### PR TITLE
Introduce jsonschema based tools

### DIFF
--- a/tool.go
+++ b/tool.go
@@ -14,7 +14,12 @@
 
 package adk
 
-import "context"
+import (
+	"context"
+	"fmt"
+
+	"github.com/google/adk-go/internal/jsonschema"
+)
 
 // ToolContext is the tool invocation context.
 type ToolContext struct {
@@ -31,19 +36,48 @@ type ToolContext struct {
 	EventActions *EventActions
 }
 
-// Tool is the ADK tool interface.
-type Tool interface {
-	Name() string
-	Description() string
+// TODO: Implement an MCP client as a tool to validate whether
+// a concrete type is sufficient for tool use.
 
-	// ProcessRequest processes the outgoing LLM request for this tool.
-	// Use cases:
-	//  * Adding this tool to the LLM request.
-	//  * Preprocess the LLM request before it's sent out.
-	ProcessRequest(ctx context.Context, tc *ToolContext, req *LLMRequest) error
+// Tool is an ADK tool.
+type Tool struct {
+	Name        string
+	Description string
+	InputSchema *jsonschema.Schema
+	// TODO: OutputSchema
 
-	// TODO: IsLongRunning, or LongRunningTool interface?
-	// TODO: interface vs concrete (golang.org/x/tools/internal/mcp.Tool)
+	rawHandler rawToolHandler
 }
 
-// TODO: func Declaration(Tool) JSONSchema?
+// Run executes the tool with the provided context and yields events.
+func (t *Tool) Run(ctx context.Context, tc *ToolContext, args map[string]any) (map[string]any, error) {
+	return t.rawHandler(ctx, tc, args)
+}
+
+// ToolHandler is the execution handler of a tool.
+type ToolHandler[In, Out any] func(ctx context.Context, input In) (output Out, err error)
+
+type rawToolHandler func(ctx context.Context, tc *ToolContext, args map[string]any) (map[string]any, error)
+
+// NewTool creates a new tool with a name, description, and the provided handler.
+// Input schema is automatically inferred from the input and output types.
+func NewTool[In, Out any](name string, description string, handler ToolHandler[In, Out]) *Tool {
+	// TODO(jbd): Add ToolOption as variadic arguments to NewTool.
+	ischema, err := jsonschema.For[In]()
+	if err != nil {
+		panic(fmt.Errorf("NewTool(%q): %w", name, err))
+	}
+	rawHandler := func(ctx context.Context, tc *ToolContext, args map[string]any) (map[string]any, error) {
+		panic("not yet implemented")
+		// TODO: Handle function call request from tc.InvocationContext.
+		// TODO: Unmarshal into input.
+		// TODO: Make a call to handler.
+		// TODO: Yield events with the output.
+	}
+	return &Tool{
+		Name:        name,
+		Description: description,
+		InputSchema: ischema,
+		rawHandler:  rawHandler,
+	}
+}

--- a/tool_test.go
+++ b/tool_test.go
@@ -1,0 +1,37 @@
+// Copyright 2025 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package adk_test
+
+import (
+	"context"
+
+	"github.com/google/adk-go"
+)
+
+func ExampleNewTool() {
+	type SumArgs struct {
+		A int `json:"a"` // an integer to sum
+		B int `json:"b"` // another integer to sum
+	}
+	type SumResult struct {
+		Sum int `json:"sum"` // the sum of two integers
+	}
+
+	handler := func(ctx context.Context, input SumArgs) (SumResult, error) {
+		return SumResult{Sum: input.A + input.B}, nil
+	}
+	tool := adk.NewTool("sum", "sums two integers", handler)
+	_ = tool // use the tool
+}


### PR DESCRIPTION
This changes replaces the Tool interface with a concrete tool type, that is represented with jsonschema. Callers provide a name, a description and a handler with custom argument and return types.

In the agentic loop, name, description and the input schema are used to supply tool schema to the model. The model can determine the arguments from the context. Model can request to execute the tool. Upon execution, events will be yielded from Tool.Run for the caller to handle.