### PR TITLE
adk: clarify SessionService interface and change AppendEvent semantic

### DIFF
--- a/session.go
+++ b/session.go
@@ -21,11 +21,24 @@ import (
 
 // SessionService abstracts the session storage.
 type SessionService interface {
+	// Create creates and returns a new session.
+	// If the session already exists, it returns an error.
 	Create(ctx context.Context, req *SessionCreateRequest) (*Session, error)
+	// Get returns the requested session.
+	// It returns an error if the requested session does not exist.
 	Get(ctx context.Context, req *SessionGetRequest) (*Session, error)
+	// List lists the requested sessions.
+	// It returns an empty list if no session matches.
 	List(ctx context.Context, req *SessionListRequest) ([]*Session, error)
+	// Delete deletes the requested session.
+	// It reports an error if the requested session does not exist.
 	Delete(ctx context.Context, req *SessionDeleteRequest) error
-	AppendEvent(ctx context.Context, req *SessionAppendEventRequest) error
+
+	// AppendEvent appends the event to the session object.
+	// The change is reflected both in the session storage and
+	// the provided Session object's Events field.
+	// If the event is marked as partial, it is a no-op.
+	AppendEvent(ctx context.Context, session *Session, ev *Event) error
 }
 
 // Session represents a series of interaction between a user and agents.
@@ -68,11 +81,4 @@ type SessionListRequest struct {
 type SessionDeleteRequest struct {
 	// Identifies a unique session object. Required.
 	AppName, UserID, SessionID string
-}
-
-// SessionAppendEventRequest is the request for SesssionService's AppendEvent.
-type SessionAppendEventRequest struct {
-	// Required.
-	Session *Session // TODO: why not just AppName/UserID/SessionID?
-	Event   *Event
 }

--- a/session/session.go
+++ b/session/session.go
@@ -108,12 +108,15 @@ func (s *InMemorySessionService) get(appName, userID, sessionID string) (*sessio
 }
 
 // AppendEvent implements adk.SessionService.
-func (s *InMemorySessionService) AppendEvent(ctx context.Context, req *adk.SessionAppendEventRequest) error {
-	sess, ok := s.get(req.Session.AppName, req.Session.UserID, req.Session.ID)
+func (s *InMemorySessionService) AppendEvent(ctx context.Context, session *adk.Session, event *adk.Event) error {
+	// TODO: no-op if event is partial.
+	// TODO: process event actions and state delta.
+	sess, ok := s.get(session.AppName, session.UserID, session.ID)
 	if !ok {
 		return fmt.Errorf("session not found")
 	}
-	sess.AppendEvent(ctx, req.Event)
+	sess.AppendEvent(ctx, event)
+	session.Events = append(session.Events, event)
 	return nil
 }
 


### PR DESCRIPTION
AppendEvent takes *Session and *Event directly
(I cannot think of any other options we want to add in the future) and also modifies the provided Session object's Events field to match the python and java's SDK.

For example, in Java, the doc for Appends explicitely states BaseSessionService's Appends appends an event to an in-memory session object.

https://google.github.io/adk-docs/api-reference/java/com/google/adk/sessions/BaseSessionService.html#appendEvent(com.google.adk.sessions.Session,com.google.adk.events.Event)