### PR TITLE
agent: implement actual agent transfer logic

### DIFF
--- a/agent/agent_transfer.go
+++ b/agent/agent_transfer.go
@@ -47,18 +47,16 @@ import (
 //
 // Peer-agent transfers are only enabled when all the following conditions are met:
 //
-//  - The parent agent also uses AutoFlow.
+//  - The parent agent is also an LLMAgent.
 //  - This agent has DisallowTransferToPeers set to false (default).
 //
-// Depending on the target agent's flow type, the transfer may be automatically
-// reversed. The conditions are as follows:
+// Depending on the target agent type, the transfer may be automatically
+// reversed. See python's Runner._find_agent_to_run method for which
+// agent will remain active to handle the next user message.
+// (src/google/adk/runners.py)
 //
-//  - If the flow type of the transferee agent is also AutoFlow, the transferee agent will
-//    remain the active agent and respond to the user's next message directly.
-//  - If the flow type of the transferee agent is not AutoFlow, the active agent will
-//    be reverted to the previous agent.
-//
-// TODO(hakim): implement.
+// TODO: implement it in the runners package and update this doc.
+
 
 func agentTransferRequestProcessor(ctx context.Context, parentCtx *adk.InvocationContext, req *adk.LLMRequest) error {
 	agent := asLLMAgent(parentCtx.Agent)


### PR DESCRIPTION
The previous PR #30 defined a custom transfer_to_agent function tool which updates ToolContext
so the agent can know what agent it should transfer to. This is a follow-up change, that made the agent
actually transfer to the requested agent.

The transfer is done by looking up the agent by the agent name, and then invoking the agent's Run.
(Note: this results in recursive Run calls)

Depending on the last agent type, the transfer can be automatically reversed. The reverse logic
is implemented in Runner's _find_agent_to_run.

Since runner implementation is work-in-progress, this change temporarily extends testAgentRunner
(in adk/llm_agent_test.go) to implement the relevant part of _find_agent_to_run needed for
testing. Once we have the full runner implementation we can remove much of testAgentRunner.