### PR TITLE
all: change Agent Run to return only the event stream

### DIFF
--- a/agent.go
+++ b/agent.go
@@ -16,6 +16,7 @@ package adk
 
 import (
 	"context"
+	"iter"
 
 	"github.com/google/uuid"
 	"google.golang.org/genai"
@@ -27,7 +28,7 @@ type Agent interface {
 	Description() string
 
 	// Run runs the agent with the invocation context.
-	Run(ctx context.Context, parentCtx *InvocationContext) (EventStream, error)
+	Run(ctx context.Context, parentCtx *InvocationContext) iter.Seq2[*Event, error]
 	// TODO: finalize the interface.
 }
 

--- a/agent/agent_transfer_test.go
+++ b/agent/agent_transfer_test.go
@@ -16,6 +16,7 @@ package agent
 
 import (
 	"context"
+	"iter"
 	"slices"
 	"strings"
 	"testing"
@@ -31,8 +32,8 @@ var _ adk.Agent = mockAgent("")
 
 func (a mockAgent) Name() string        { return string(a) }
 func (a mockAgent) Description() string { return "" }
-func (a mockAgent) Run(ctx context.Context, invCtx *adk.InvocationContext) (adk.EventStream, error) {
-	return func(yield func(*adk.Event, error) bool) {}, nil
+func (a mockAgent) Run(ctx context.Context, invCtx *adk.InvocationContext) iter.Seq2[*adk.Event, error] {
+	return func(yield func(*adk.Event, error) bool) {}
 }
 
 func TestAgentTransferRequestProcessor(t *testing.T) {

--- a/event.go
+++ b/event.go
@@ -15,13 +15,10 @@
 package adk
 
 import (
-	"iter"
 	"time"
 
 	"github.com/google/uuid"
 )
-
-type EventStream = iter.Seq2[*Event, error]
 
 // NewEvent creates a new event.
 func NewEvent(invocationID string) *Event {

--- a/internal/runner/runner.go
+++ b/internal/runner/runner.go
@@ -16,6 +16,7 @@ package runner
 
 import (
 	"context"
+	"iter"
 
 	"github.com/google/adk-go"
 
@@ -29,7 +30,7 @@ type Runner struct {
 }
 
 // Run runs the agent.
-func (r *Runner) Run(ctx context.Context, userID, sessionID string, msg *genai.Content, cfg *adk.AgentRunConfig) (adk.EventStream, error) {
+func (r *Runner) Run(ctx context.Context, userID, sessionID string, msg *genai.Content, cfg *adk.AgentRunConfig) (iter.Seq2[*adk.Event, error], error) {
 	// TODO(hakim): we need to validate whether cfg is compatible with the Agent.
 	//   see adk-python/src/google/adk/runners.py Runner._new_invocation_context.
 	//


### PR DESCRIPTION
The error is not useful.

And drop adk.EventStream, and use iter.Seq2[*adk.Event, error]