### PR TITLE
agent: make Agent a concrete type

### DIFF
--- a/agent/base/base.go
+++ b/agent/base/base.go
@@ -1,0 +1,39 @@
+// Copyright 2025 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package base
+
+import (
+	"fmt"
+
+	"github.com/google/adk-go"
+	"github.com/google/adk-go/internal/itype"
+)
+
+type Config = itype.AgentConfig
+
+// NewAgent returns a BaseAgent that can be the base of the implementation agent.
+func NewAgent(cfg Config) (*adk.Agent, error) {
+	if cfg.Name == "" {
+		return nil, fmt.Errorf("agent requires name")
+	}
+	a, err := itype.NewAgent(cfg)
+	if err != nil {
+		return nil, err
+	}
+	if agent, ok := a.(*adk.Agent); ok {
+		return agent, nil
+	}
+	panic(fmt.Sprintf("itype.ConfigureAgent returned unexpected type %T instead of *adk.Agent", a))
+}

--- a/agent/basic_processor.go
+++ b/agent/basic_processor.go
@@ -25,12 +25,11 @@ import (
 
 // basicRequestProcessor populates the LLMRequest
 // with the agent's LLM generation configs.
-func basicRequestProcessor(ctx context.Context, parentCtx *adk.InvocationContext, req *adk.LLMRequest) error {
+func basicRequestProcessor(ctx context.Context, parentCtx *adk.InvocationContext, agent *adk.Agent, req *adk.LLMRequest) error {
+	llmAgent := asLLMAgent(agent)
 	// reference: adk-python src/google/adk/flows/llm_flows/basic.py
-
-	llmAgent := asLLMAgent(parentCtx.Agent)
 	if llmAgent == nil {
-		return nil // do nothing.
+		return nil
 	}
 	req.Model = llmAgent.Model
 	req.GenerateConfig = clone(llmAgent.GenerateContentConfig)
@@ -47,11 +46,11 @@ func basicRequestProcessor(ctx context.Context, parentCtx *adk.InvocationContext
 }
 
 // asLLMAgent returns LLMAgent if agent is LLMAgent. Otherwise, nil.
-func asLLMAgent(agent adk.Agent) *LLMAgent {
-	if agent == nil {
+func asLLMAgent(agent *adk.Agent) *LLMAgent {
+	if agent == nil || agent.Impl() == nil {
 		return nil
 	}
-	if llmAgent, ok := agent.(*LLMAgent); ok {
+	if llmAgent, ok := agent.Impl().(*LLMAgent); ok {
 		return llmAgent
 	}
 	return nil

--- a/agent/contents_processor.go
+++ b/agent/contents_processor.go
@@ -26,9 +26,9 @@ import (
 
 // contentRequestProcessor populates the LLMRequest's Contents based on
 // the InvocationContext that includes the previous events.
-func contentsRequestProcessor(ctx context.Context, parentCtx *adk.InvocationContext, req *adk.LLMRequest) error {
+func contentsRequestProcessor(ctx context.Context, parentCtx *adk.InvocationContext, agent *adk.Agent, req *adk.LLMRequest) error {
 	// TODO: implement (adk-python src/google/adk/flows/llm_flows/contents.py) - extract function call results, etc.
-	llmAgent := asLLMAgent(parentCtx.Agent)
+	llmAgent := asLLMAgent(agent)
 	if llmAgent == nil {
 		// Do nothing.
 		return nil // In python, no error is yielded.
@@ -42,7 +42,7 @@ func contentsRequestProcessor(ctx context.Context, parentCtx *adk.InvocationCont
 	if parentCtx.Session != nil {
 		events = parentCtx.Session.Events
 	}
-	contents, err := fn(llmAgent.Name(), parentCtx.Branch, events)
+	contents, err := fn(agent.Name(), parentCtx.Branch, events)
 	if err != nil {
 		return err
 	}

--- a/agent/contents_processor_test.go
+++ b/agent/contents_processor_test.go
@@ -206,11 +206,8 @@ func TestContentsRequestProcessor_IncludeContents(t *testing.T) {
 
 	for _, tc := range testCases {
 		t.Run(tc.name+"/include_contents="+tc.includeContents, func(t *testing.T) {
-			agent := &LLMAgent{
-				AgentName:       agentName,
-				Model:           model,
-				IncludeContents: tc.includeContents,
-			}
+			agent := must(NewLLMAgent(LLMAgentConfig{Name: agentName, Model: model}))
+			agent.Impl().(*LLMAgent).IncludeContents = tc.includeContents
 			invCtx := &adk.InvocationContext{
 				InvocationID: "12345",
 				Agent:        agent,
@@ -218,7 +215,7 @@ func TestContentsRequestProcessor_IncludeContents(t *testing.T) {
 			}
 
 			req := &adk.LLMRequest{Model: model}
-			if err := contentsRequestProcessor(t.Context(), invCtx, req); err != nil {
+			if err := contentsRequestProcessor(t.Context(), invCtx, agent, req); err != nil {
 				t.Fatalf("contentsRequestProcessor failed: %v", err)
 			}
 			got := req.Contents
@@ -357,10 +354,7 @@ func TestContentsRequestProcessor(t *testing.T) {
 
 	for _, tc := range testCases {
 		t.Run(tc.name, func(t *testing.T) {
-			agent := &LLMAgent{
-				AgentName: agentName,
-				Model:     model,
-			}
+			agent := must(NewLLMAgent(LLMAgentConfig{Name: "testAgent", Model: model}))
 			invCtx := &adk.InvocationContext{
 				InvocationID: "12345",
 				Agent:        agent,
@@ -369,7 +363,7 @@ func TestContentsRequestProcessor(t *testing.T) {
 			}
 
 			req := &adk.LLMRequest{Model: model}
-			if err := contentsRequestProcessor(t.Context(), invCtx, req); err != nil {
+			if err := contentsRequestProcessor(t.Context(), invCtx, agent, req); err != nil {
 				t.Fatalf("contentRequestProcessor failed: %v", err)
 			}
 			got := req.Contents
@@ -485,6 +479,7 @@ func TestConvertForeignEvent(t *testing.T) {
 	}
 }
 
+/*
 func TestContentsRequestProcessor_NonLLMAgent(t *testing.T) {
 	type customAgent struct {
 		adk.Agent
@@ -514,3 +509,4 @@ func TestContentsRequestProcessor_NonLLMAgent(t *testing.T) {
 		t.Errorf("LLMRequest after contentRequestProcessor mismatch (-want +got):\n%s", diff)
 	}
 }
+*/

--- a/agent/instruction_processor.go
+++ b/agent/instruction_processor.go
@@ -21,14 +21,13 @@ import (
 )
 
 // instructionsRequestProcessor configures req's instructions and global instructions for LLM flow.
-func instructionsRequestProcessor(ctx context.Context, parentCtx *adk.InvocationContext, req *adk.LLMRequest) error {
+func instructionsRequestProcessor(ctx context.Context, parentCtx *adk.InvocationContext, agent *adk.Agent, req *adk.LLMRequest) error {
 	// reference: adk-python src/google/adk/flows/llm_flows/instructions.py
-
-	llmAgent := asLLMAgent(parentCtx.Agent)
+	llmAgent := asLLMAgent(agent)
 	if llmAgent == nil {
 		return nil // do nothing.
 	}
-	rootAgent := asLLMAgent(rootAgent(llmAgent))
+	rootAgent := asLLMAgent(rootAgent(agent))
 	if rootAgent == nil {
 		rootAgent = llmAgent
 	}

--- a/agent/other_processors.go
+++ b/agent/other_processors.go
@@ -20,32 +20,32 @@ import (
 	"github.com/google/adk-go"
 )
 
-func identityRequestProcessor(ctx context.Context, parentCtx *adk.InvocationContext, req *adk.LLMRequest) error {
+func identityRequestProcessor(ctx context.Context, parentCtx *adk.InvocationContext, current *adk.Agent, req *adk.LLMRequest) error {
 	// TODO: implement (adk-python src/google/adk/flows/llm_flows/identity.py)
 	return nil
 }
 
-func nlPlanningRequestProcessor(ctx context.Context, parentCtx *adk.InvocationContext, req *adk.LLMRequest) error {
+func nlPlanningRequestProcessor(ctx context.Context, parentCtx *adk.InvocationContext, current *adk.Agent, req *adk.LLMRequest) error {
 	// TODO: implement (adk-python src/google/adk/flows/llm_flows/_nl_plnning.py)
 	return nil
 }
 
-func codeExecutionRequestProcessor(ctx context.Context, parentCtx *adk.InvocationContext, req *adk.LLMRequest) error {
+func codeExecutionRequestProcessor(ctx context.Context, parentCtx *adk.InvocationContext, current *adk.Agent, req *adk.LLMRequest) error {
 	// TODO: implement (adk-python src/google/adk/flows/llm_flows/_code_execution.py)
 	return nil
 }
 
-func authPreprocesssor(ctx context.Context, parentCtx *adk.InvocationContext, req *adk.LLMRequest) error {
+func authPreprocesssor(ctx context.Context, parentCtx *adk.InvocationContext, current *adk.Agent, req *adk.LLMRequest) error {
 	// TODO: implement (adk-python src/google/adk/auth/auth_preprocessor.py)
 	return nil
 }
 
-func nlPlanningResponseProcessor(ctx context.Context, parentCtx *adk.InvocationContext, req *adk.LLMRequest, resp *adk.LLMResponse) error {
+func nlPlanningResponseProcessor(ctx context.Context, parentCtx *adk.InvocationContext, current *adk.Agent, req *adk.LLMRequest, resp *adk.LLMResponse) error {
 	// TODO: implement (adk-python src/google/adk/_nl_planning.py)
 	return nil
 }
 
-func codeExecutionResponseProcessor(ctx context.Context, parentCtx *adk.InvocationContext, req *adk.LLMRequest, resp *adk.LLMResponse) error {
+func codeExecutionResponseProcessor(ctx context.Context, parentCtx *adk.InvocationContext, current *adk.Agent, req *adk.LLMRequest, resp *adk.LLMResponse) error {
 	// TODO: implement (adk-python src/google/adk_code_execution.py)
 	return nil
 }

--- a/agent/utils.go
+++ b/agent/utils.go
@@ -118,25 +118,23 @@ func content(ev *adk.Event) *genai.Content {
 }
 
 // rootAgent returns the root of the agent tree.
-func rootAgent(agent adk.Agent) adk.Agent {
-	findParent := func(agent adk.Agent) adk.Agent {
-		// this test is because ParentAgent/SubAgents are implemented only in LLMAgent.
-		// TODO: Parent/SubAgents should be part of Agent interface. Then, this is not needed.
-		a := asLLMAgent(agent)
-		if a == nil {
-			return nil
-		}
-		if p := asLLMAgent(a.ParentAgent); p != nil {
-			return p
-		}
+func rootAgent(agent *adk.Agent) *adk.Agent {
+	if agent == nil {
 		return nil
 	}
 	current := agent
 	for {
-		parent := findParent(current)
+		parent := current.Parent()
 		if parent == nil {
 			return current
 		}
 		current = parent
 	}
+}
+
+func must[T *adk.Agent](a T, err error) T {
+	if err != nil {
+		panic(err)
+	}
+	return a
 }

--- a/agent_test.go
+++ b/agent_test.go
@@ -21,14 +21,13 @@ import (
 	"testing"
 
 	"github.com/google/adk-go"
+	"github.com/google/adk-go/agent/base"
 )
 
 type testAgent struct {
 	run func(ctx context.Context, parentCtx *adk.InvocationContext) iter.Seq2[*adk.Event, error]
 }
 
-func (m *testAgent) Name() string        { return "TestAgent" }
-func (m *testAgent) Description() string { return "" }
 func (m *testAgent) Run(ctx context.Context, parentCtx *adk.InvocationContext) iter.Seq2[*adk.Event, error] {
 	return m.run(ctx, parentCtx)
 }
@@ -42,7 +41,8 @@ func TestNewInvocationContext_End(t *testing.T) {
 			yield(nil, ctx.Err())
 		}
 	}
-	agent := &testAgent{run: waitForCancel}
+	agent, _ := base.NewAgent(base.Config{Name: "TestAgent"})
+	agent.SetImpl(&testAgent{run: waitForCancel})
 
 	ctx, ic := adk.NewInvocationContext(ctx, agent)
 	// schedule cancellation to happen after the agent starts running.

--- a/internal/itype/agent.go
+++ b/internal/itype/agent.go
@@ -1,0 +1,37 @@
+// Copyright 2025 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package itype
+
+type AgentConfig struct {
+	Name        string
+	Description string
+	SubAgents   []any // should be *adk.Agent
+}
+
+// RegisterNewAgent registers the internal constructor function for adk.Agent.
+func RegisterNewAgent(fn func(cfg AgentConfig) (any, error)) {
+	configureAgent = fn
+}
+
+var configureAgent func(cfg AgentConfig) (any, error)
+
+// NewAgent returns a new adk.Agent.
+// The return type is untyped, because this package is imported by the adk package.
+func NewAgent(cfg AgentConfig) (any, error) {
+	if configureAgent == nil {
+		panic("configureAgent is not set")
+	}
+	return configureAgent(cfg)
+}

--- a/internal/runner/runner.go
+++ b/internal/runner/runner.go
@@ -25,7 +25,7 @@ import (
 
 type Runner struct {
 	AppName        string
-	Agent          adk.Agent
+	Agent          *adk.Agent
 	SessionService adk.SessionService
 }
 


### PR DESCRIPTION
This is the prototype of making the adk.Agent a concrete type and
moving the shared logic to ensure the consistency of Parent/SubAgents relationship.

Start from "agent.go" and look at how agent/llm_agent.go and agent/base/base.go are connected.

Keeping the constructor of adk.Agent in the separate package (agent/base) made things a bit complicated. Will take another pass tomorrow with fresh minds.

cc @rakyll @dpasiukevich 