### PR TITLE
Update code for AgentSpec

### DIFF
--- a/agent.go
+++ b/agent.go
@@ -16,7 +16,6 @@ package adk
 
 import (
 	"context"
-	"fmt"
 	"iter"
 
 	"github.com/google/uuid"
@@ -32,6 +31,74 @@ type Agent interface {
 	Run(ctx context.Context, invocationCtx *InvocationContext) iter.Seq2[*Event, error]
 
 	// TODO: RunLive.
+}
+
+type AgentSpec struct {
+	// Agent name.
+	// It must be unique within the agent tree.
+	// Agent name cannot be "user" since it is reserved for user input.
+	Name string
+
+	// Description about the agent's capability.
+	// The model uses this to determine whether to delegate control to the agent.
+	// One-line description is enough and preferred.
+	Description string
+
+	// The parent agent of this agent.
+	// Note that an agent can ONLY be added as sub-agent once.
+	// If you want to add one agent twice as sub-agent, consider to create two agent
+	// instances with identical config, but with different name and add them to the
+	// agent tree.
+	Parent Agent
+
+	// The sub-agents of this agent.
+	SubAgents []Agent
+
+	// Configuration for the agent backed by LLM.
+	LLMAgent *LLMAgentSpec
+
+	// TODO:
+	//  BeforeAgentCallback
+	//  AfterAgentCallback
+}
+
+type LLMAgentSpec struct {
+	Model Model
+
+	Instruction       string
+	GlobalInstruction string
+
+	Tools []Tool
+
+	GenerateContentConfig *genai.GenerateContentConfig
+
+	// LLM-based agent transfer configs.
+	DisallowTransferToParent bool
+	DisallowTransferToPeers  bool
+
+	// Whether to include contents in the model request.
+	// When set to 'none', the model request will not include any contents, such as
+	// user messages, tool requests, etc.
+	IncludeContents string
+
+	// The input schema when agent is used as a tool.
+	InputSchema *genai.Schema
+
+	// The output schema when agent replies.
+	//
+	// NOTE: when this is set, agent can only reply and cannot use any tools,
+	// such as function tools, RAGs, agent transfer, etc.
+	OutputSchema *genai.Schema
+
+	// OutputKey
+	// Planner
+	// CodeExecutor
+	// Examples
+
+	// BeforeModelCallback
+	// AfterModelCallback
+	// BeforeToolCallback
+	// AfterToolCallback
 }
 
 // An InvocationContext represents the data of a single invocation of an agent.
@@ -151,76 +218,4 @@ type AgentRunConfig struct {
 	//    calls is enforced, if the value is set in this range.
 	//  - Less than or equal to 0: This allows for unbounded number of llm calls.
 	MaxLLMCalls int
-}
-
-// AgentSpec defines the common properties all ADK agents must holds.
-// [Agent.Spec] must return its AgentSpec, that is bound to it.
-/*
-	type MyAgent struct {
-		agentSpec *adk.AgentSpec
-		...
-	}
-	var _ adk.Agent = (*MyAgent)(nil)
-
-	func NewMyAgent(name string) *MyAgent {
-		spec := &adk.AgentSpec{Name: name}
-		a := &MyAgent{agentSpec: spec}
-		_ = spec.Init(a) // spec must be initialized before the agent is used.
-		return a
-	}
-*/
-type AgentSpec struct {
-	Name        string
-	Description string
-	SubAgents   []Agent
-
-	// TODO:
-	//  BeforeAgentCallback
-	//  AfterAgentCallback
-
-	// the followings are set by Init.
-	parentAgent Agent
-	self        Agent
-}
-
-// Init initializes the AgentSpec by binding the AgentSpec and its containing [Agent].
-// It also validates the subagents and update their parents to point to the agent.
-// All subagents must be fully initialized before the agent is being used and
-// its parent agent's AgentSpec is initialized.
-func (s *AgentSpec) Init(self Agent) error {
-	if self == nil {
-		return fmt.Errorf("Agent is undefined")
-	}
-	if s.self != nil {
-		return fmt.Errorf("AgentSpec %q is already initialized with another agent", s.Name)
-	}
-	s.self = self
-	return s.validateSubAgents()
-}
-
-// validateSubAgents validates [AgentSpec.SubAgents]
-// and updates the subagents' parents.
-func (s *AgentSpec) validateSubAgents() error {
-	names := map[string]bool{}
-	// run sanity check (no duplicate name, no multiple parents)
-	for i, subagent := range s.SubAgents {
-		subagentSpec := subagent.Spec()
-		if subagentSpec == nil || subagentSpec.Name == "" {
-			return fmt.Errorf("%d-th Agent does not have a valid Spec", i)
-		}
-		name := subagentSpec.Name
-		if names[name] {
-			return fmt.Errorf("multiple subagents with the same name (%q) are not allowed", name)
-		}
-		if parent := subagentSpec.Parent(); parent != nil {
-			return fmt.Errorf("agent %q already has parent %q", name, parent.Spec().Name)
-		}
-		subagentSpec.parentAgent = s.self
-		names[name] = true
-	}
-	return nil
-}
-
-func (s *AgentSpec) Parent() Agent {
-	return s.parentAgent
 }

--- a/agent/basic_processor.go
+++ b/agent/basic_processor.go
@@ -27,33 +27,22 @@ import (
 // with the agent's LLM generation configs.
 func basicRequestProcessor(ctx context.Context, parentCtx *adk.InvocationContext, req *adk.LLMRequest) error {
 	// reference: adk-python src/google/adk/flows/llm_flows/basic.py
-
-	llmAgent := asLLMAgent(parentCtx.Agent)
-	if llmAgent == nil {
+	spec := parentCtx.Agent.Spec()
+	if spec.LLMAgent == nil {
 		return nil // do nothing.
 	}
-	req.Model = llmAgent.Model
-	req.GenerateConfig = clone(llmAgent.GenerateContentConfig)
+
+	req.Model = spec.LLMAgent.Model
+	req.GenerateConfig = clone(spec.LLMAgent.GenerateContentConfig)
 	if req.GenerateConfig == nil {
 		req.GenerateConfig = &genai.GenerateContentConfig{}
 	}
-	if llmAgent.OutputSchema != nil {
-		req.GenerateConfig.ResponseSchema = llmAgent.OutputSchema
+	if spec.LLMAgent.OutputSchema != nil {
+		req.GenerateConfig.ResponseSchema = spec.LLMAgent.OutputSchema
 		req.GenerateConfig.ResponseMIMEType = "application/json"
 	}
 	// TODO: missing features
 	//  populate LLMRequest LiveConnectConfig setting
-	return nil
-}
-
-// asLLMAgent returns LLMAgent if agent is LLMAgent. Otherwise, nil.
-func asLLMAgent(agent adk.Agent) *LLMAgent {
-	if agent == nil {
-		return nil
-	}
-	if llmAgent, ok := agent.(*LLMAgent); ok {
-		return llmAgent
-	}
 	return nil
 }
 

--- a/agent/contents_processor.go
+++ b/agent/contents_processor.go
@@ -28,13 +28,13 @@ import (
 // the InvocationContext that includes the previous events.
 func contentsRequestProcessor(ctx context.Context, parentCtx *adk.InvocationContext, req *adk.LLMRequest) error {
 	// TODO: implement (adk-python src/google/adk/flows/llm_flows/contents.py) - extract function call results, etc.
-	llmAgent := asLLMAgent(parentCtx.Agent)
-	if llmAgent == nil {
+	agentSpec := parentCtx.Agent.Spec()
+	if agentSpec.LLMAgent == nil {
 		// Do nothing.
 		return nil // In python, no error is yielded.
 	}
 	fn := buildContentsDefault // "" or "default".
-	if llmAgent.IncludeContents == "none" {
+	if agentSpec.LLMAgent.IncludeContents == "none" {
 		// Include current turn context only (no conversation history)
 		fn = buildContentsCurrentTurnContextOnly
 	}
@@ -42,7 +42,7 @@ func contentsRequestProcessor(ctx context.Context, parentCtx *adk.InvocationCont
 	if parentCtx.Session != nil {
 		events = parentCtx.Session.Events
 	}
-	contents, err := fn(llmAgent.Spec().Name, parentCtx.Branch, events)
+	contents, err := fn(agentSpec.Name, parentCtx.Branch, events)
 	if err != nil {
 		return err
 	}

--- a/agent/instruction_processor.go
+++ b/agent/instruction_processor.go
@@ -24,25 +24,25 @@ import (
 func instructionsRequestProcessor(ctx context.Context, parentCtx *adk.InvocationContext, req *adk.LLMRequest) error {
 	// reference: adk-python src/google/adk/flows/llm_flows/instructions.py
 
-	llmAgent := asLLMAgent(parentCtx.Agent)
-	if llmAgent == nil {
+	agent := parentCtx.Agent
+	if agent.Spec().LLMAgent == nil {
 		return nil // do nothing.
 	}
-	rootAgent := asLLMAgent(rootAgent(llmAgent))
-	if rootAgent == nil {
-		rootAgent = llmAgent
+	rootAgent := rootAgent(agent)
+	if rootAgent.Spec().LLMAgent == nil {
+		rootAgent = agent
 	}
 
 	// Append global instructions if set.
-	if rootAgent != nil && rootAgent.GlobalInstruction != "" {
+	if rootAgent != nil && rootAgent.Spec().LLMAgent.GlobalInstruction != "" {
 		// TODO: apply instructions_utils.inject_session_state
-		req.AppendInstructions(rootAgent.GlobalInstruction)
+		req.AppendInstructions(rootAgent.Spec().LLMAgent.GlobalInstruction)
 	}
 
 	// Append agent's instruction
-	if llmAgent.Instruction != "" {
+	if rootAgent.Spec().LLMAgent.Instruction != "" {
 		// TODO: apply instructions_utils.inject_session_state
-		req.AppendInstructions(llmAgent.Instruction)
+		req.AppendInstructions(rootAgent.Spec().LLMAgent.Instruction)
 	}
 
 	return nil

--- a/agent/llm_agent.go
+++ b/agent/llm_agent.go
@@ -23,196 +23,26 @@ import (
 	"google.golang.org/genai"
 )
 
-// AgentOption configures the AgentSpec.
-type AgentOption interface {
-	apply2AgentSpec(adk.Agent) error
-}
-
-// LLMAgentOption is an AgentOption that configures an LLMAgent.
-// Passing this option to other types of Agent is an error.
-type LLMAgentOption interface {
-	AgentOption
-	apply2LLMAgent(adk.Agent) error
-}
-
-type optionFunc func(*adk.AgentSpec) error
-
-func (o optionFunc) apply2AgentSpec(a adk.Agent) error {
-	s := a.Spec()
-	if s == nil {
-		return fmt.Errorf("agent's spec is not configured")
-	}
-	return o(s)
-}
-
-func WithDescription(desc string) AgentOption {
-	return optionFunc(func(s *adk.AgentSpec) error {
-		s.Description = desc
-		return nil
-	})
-}
-
-func WithSubAgents(agents ...adk.Agent) AgentOption {
-	return optionFunc(func(s *adk.AgentSpec) error {
-		s.SubAgents = agents
-		return nil
-	})
-}
-
-type llmOptionFunc func(*LLMAgent) error
-
-func (o llmOptionFunc) apply2LLMAgent(a adk.Agent) error {
-	llmAgent, ok := a.(*LLMAgent)
-	if !ok {
-		return fmt.Errorf("cannot apply to non-LLMAgent")
-	}
-	return o(llmAgent)
-}
-
-func (o llmOptionFunc) apply2AgentSpec(a adk.Agent) error {
-	if _, ok := a.(*LLMAgent); !ok {
-		return fmt.Errorf("option cannot apply to non-LLMAgent")
-	}
-	return nil
-}
-
-func WithInstruction(inst string) LLMAgentOption {
-	return llmOptionFunc(func(a *LLMAgent) error {
-		a.Instruction = inst
-		return nil
-	})
-}
-
-func WithGlobalInstruction(inst string) LLMAgentOption {
-	return llmOptionFunc(func(a *LLMAgent) error {
-		a.GlobalInstruction = inst
-		return nil
-	})
-}
-
-func WithTools(tools ...adk.Tool) LLMAgentOption {
-	return llmOptionFunc(func(a *LLMAgent) error {
-		a.Tools = tools
-		// TODO: check if tools names don't conflict or include reserved names.
-		return nil
-	})
-}
-
-func WithDisallowTransferToParent() LLMAgentOption {
-	return llmOptionFunc(func(a *LLMAgent) error {
-		a.DisallowTransferToParent = true
-		return nil
-	})
-}
-
-func WithDisallowTransferToPeers() LLMAgentOption {
-	return llmOptionFunc(func(a *LLMAgent) error {
-		a.DisallowTransferToPeers = true
-		return nil
-	})
-}
-
-func WithIncludeContents(v string) LLMAgentOption {
-	return llmOptionFunc(func(a *LLMAgent) error {
-		a.IncludeContents = v
-		return nil
-	})
-}
-
-func WithInputSchema(s *genai.Schema) LLMAgentOption {
-	return llmOptionFunc(func(a *LLMAgent) error {
-		a.InputSchema = s
-		return nil
-	})
-}
-
-func WithOutputSchema(s *genai.Schema) LLMAgentOption {
-	return llmOptionFunc(func(a *LLMAgent) error {
-		a.OutputSchema = s
-		return nil
-	})
-}
-
 // NewLLMAgent returns a new LLMAgent configured with the provided options.
-func NewLLMAgent(name string, model adk.Model, opts ...AgentOption) (*LLMAgent, error) {
-	agentSpec := &adk.AgentSpec{Name: name}
-	a := &LLMAgent{Model: model, agentSpec: agentSpec}
-
-	// apply Options that are not llmOptions to initialize agentSpec.
-	for _, o := range opts {
-		if _, ok := o.(LLMAgentOption); ok {
-			continue
-		}
-		if err := o.apply2AgentSpec(a); err != nil {
-			return nil, err
-		}
+func NewLLMAgent(spec *adk.AgentSpec) (*LLMAgent, error) {
+	agent := &LLMAgent{
+		agentSpec: spec,
 	}
-	// fully initialize agentSpec.
-	agentSpec.Init(a)
 
-	// apply Options that are llmOptions.
-	for _, o := range opts {
-		llmOption, ok := o.(llmOptionFunc)
-		if !ok {
-			continue
-		}
-		if err := llmOption.apply2LLMAgent(a); err != nil {
-			return nil, err
-		}
+	if err := validateSubAgents(agent); err != nil {
+		return nil, fmt.Errorf("failed to validate subagents: %w", err)
 	}
-	return a, nil
+
+	return agent, nil
 }
 
 // LLMAgent is an LLM-based Agent.
 type LLMAgent struct {
 	agentSpec *adk.AgentSpec
-
-	Model adk.Model
-
-	Instruction           string
-	GlobalInstruction     string
-	Tools                 []adk.Tool
-	GenerateContentConfig *genai.GenerateContentConfig
-
-	// LLM-based agent transfer configs.
-	DisallowTransferToParent bool
-	DisallowTransferToPeers  bool
-
-	// Whether to include contents in the model request.
-	// When set to 'none', the model request will not include any contents, such as
-	// user messages, tool requests, etc.
-	IncludeContents string
-
-	// The input schema when agent is used as a tool.
-	InputSchema *genai.Schema
-
-	// The output schema when agent replies.
-	//
-	// NOTE: when this is set, agent can only reply and cannot use any tools,
-	// such as function tools, RAGs, agent transfer, etc.
-	OutputSchema *genai.Schema
-
-	// OutputKey
-	// Planner
-	// CodeExecutor
-	// Examples
-
-	// BeforeModelCallback
-	// AfterModelCallback
-	// BeforeToolCallback
-	// AfterToolCallback
 }
 
 func (a *LLMAgent) Spec() *adk.AgentSpec {
 	return a.agentSpec
-}
-
-func (a *LLMAgent) Name() string {
-	return a.agentSpec.Name
-}
-
-func (a *LLMAgent) Description() string {
-	return a.agentSpec.Description
 }
 
 func (a *LLMAgent) newInvocationContext(ctx context.Context, p *adk.InvocationContext) (context.Context, *adk.InvocationContext) {
@@ -233,15 +63,15 @@ func (a *LLMAgent) Run(ctx context.Context, parentCtx *adk.InvocationContext) it
 	// TODO: Select model (LlmAgent.canonical_model)
 	ctx, parentCtx = a.newInvocationContext(ctx, parentCtx)
 	flow := &baseFlow{
-		Model:              a.Model,
+		Model:              a.Spec().LLMAgent.Model,
 		RequestProcessors:  defaultRequestProcessors,
 		ResponseProcessors: defaultResponseProcessors,
 	}
 	return flow.Run(ctx, parentCtx)
 }
 
-func (a *LLMAgent) useAutoFlow() bool {
-	return len(a.Spec().SubAgents) != 0 || !a.DisallowTransferToParent || !a.DisallowTransferToPeers
+func useAutoFlow(spec *adk.AgentSpec) bool {
+	return len(spec.SubAgents) != 0 || !spec.LLMAgent.DisallowTransferToParent || !spec.LLMAgent.DisallowTransferToPeers
 }
 
 var _ adk.Agent = (*LLMAgent)(nil)
@@ -388,8 +218,8 @@ func (f *baseFlow) finalizeModelResponseEvent(parentCtx *adk.InvocationContext, 
 }
 
 func (f *baseFlow) preprocess(ctx context.Context, parentCtx *adk.InvocationContext, req *adk.LLMRequest) error {
-	llmAgent := asLLMAgent(parentCtx.Agent)
-	if llmAgent == nil {
+	llmAgentSpec := parentCtx.Agent.Spec().LLMAgent
+	if llmAgentSpec == nil {
 		return nil
 	}
 	// apply request processor functions to the request in the configured order.
@@ -400,7 +230,7 @@ func (f *baseFlow) preprocess(ctx context.Context, parentCtx *adk.InvocationCont
 	}
 	// run processors for tools.
 	// TODO: check need/feasibility of running this concurrently.
-	for _, t := range llmAgent.Tools {
+	for _, t := range llmAgentSpec.Tools {
 		toolCtx := &adk.ToolContext{
 			InvocationContext: parentCtx, // TODO: how to prevent mutation on this?
 			EventActions:      &adk.EventActions{},
@@ -454,7 +284,7 @@ func (f *baseFlow) agentToRun(parentCtx *adk.InvocationContext, agentName string
 	// NOTE: in python, BaseLlmFlow._get_gent_to_run searches the entire agent
 	// tree from the root_agent when processing _postprocess_handle_function_calls_async.
 	// I think that is strange. In our version, we check the agents included in transferTarget.
-	agents := transferTarget(asLLMAgent(parentCtx.Agent))
+	agents := transferTarget(parentCtx.Agent)
 	for _, agent := range agents {
 		if agent.Spec().Name == agentName {
 			return agent

--- a/agent/utils_test.go
+++ b/agent/utils_test.go
@@ -21,14 +21,28 @@ import (
 )
 
 func TestRootAgent(t *testing.T) {
-	model := struct {
-		adk.Model
-	}{}
-
 	nonLLM := newMockAgent("mock")
-	b := must(NewLLMAgent("b", model, WithSubAgents(nonLLM)))
-	a := must(NewLLMAgent("a", model, WithSubAgents(b)))
-	root := must(NewLLMAgent("root", model, WithSubAgents(a)))
+	b := must(NewLLMAgent(&adk.AgentSpec{
+		Name:      "b",
+		SubAgents: []adk.Agent{nonLLM},
+		LLMAgent: &adk.LLMAgentSpec{
+			Model: &model{},
+		},
+	}))
+	a := must(NewLLMAgent(&adk.AgentSpec{
+		Name:      "a",
+		SubAgents: []adk.Agent{b},
+		LLMAgent: &adk.LLMAgentSpec{
+			Model: &model{},
+		},
+	}))
+	root := must(NewLLMAgent(&adk.AgentSpec{
+		Name:      "root",
+		SubAgents: []adk.Agent{a},
+		LLMAgent: &adk.LLMAgentSpec{
+			Model: &model{},
+		},
+	}))
 
 	agentName := func(a adk.Agent) string {
 		if a == nil {
@@ -44,7 +58,7 @@ func TestRootAgent(t *testing.T) {
 		{root, root},
 		{a, root},
 		{b, root},
-		{nonLLM, nonLLM}, // TODO: nonLLM agent should be able to have root.
+		{nonLLM, root},
 		{nil, nil},
 	} {
 		t.Run("agent="+agentName(tc.agent), func(t *testing.T) {

--- a/runner/runner.go
+++ b/runner/runner.go
@@ -21,12 +21,12 @@ import (
 	"strings"
 
 	"github.com/google/adk-go"
-	"github.com/google/adk-go/agent"
 
 	"google.golang.org/genai"
 )
 
 func NewRunner(appName string, rootAgent adk.Agent, sessionService adk.SessionService) *Runner {
+	// TODO: potentially validate the whole agent tree here.
 	return &Runner{
 		AppName:        appName,
 		RootAgent:      rootAgent,
@@ -89,17 +89,17 @@ func (r *Runner) newInvocationContext(ctx context.Context, session *adk.Session,
 }
 
 func (r *Runner) setupCFC(rootAgent adk.Agent) error {
-	llmAgent, ok := r.RootAgent.(*agent.LLMAgent)
-	if !ok {
-		return fmt.Errorf("cannot setup cfc for non-LLMAgent")
+	spec := rootAgent.Spec()
+	if spec.LLMAgent == nil {
+		return fmt.Errorf("root agent %s has no LLMAgent spec", spec.Name)
 	}
 
-	if llmAgent.Model == nil {
+	if spec.LLMAgent.Model == nil {
 		return fmt.Errorf("LLMAgent has no model")
 	}
 
-	if !strings.HasPrefix(llmAgent.Model.Name(), "gemini-2") {
-		return fmt.Errorf("CFC is not supported for model: %v", llmAgent.Model.Name())
+	if !strings.HasPrefix(spec.LLMAgent.Model.Name(), "gemini-2") {
+		return fmt.Errorf("CFC is not supported for model: %v", spec.LLMAgent.Model.Name())
 	}
 
 	// TODO: handle CFC setup for LLMAgent, e.g. setting code_executor


### PR DESCRIPTION
This removes need to embed/cast between agent types. And a `self` back-reference is not needed as well.

Currently all fields are exported but if we decide it would be easy to hide them behind constructor and accessors.