### PR TITLE
Basic LLMAgent implementation based on the restruct proposal.

### DIFF
--- a/agent/llmagent/llmagent.go
+++ b/agent/llmagent/llmagent.go
@@ -1,0 +1,110 @@
+// Copyright 2025 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package llmagent
+
+import (
+	"iter"
+
+	"google.golang.org/adk/agent"
+	"google.golang.org/adk/llm"
+	"google.golang.org/adk/session"
+	"google.golang.org/adk/tool"
+	"google.golang.org/genai"
+)
+
+type Builder struct {
+	Name        string
+	Description string
+	SubAgents   []agent.Agent
+
+	BeforeAgent []agent.Callback
+	AfterAgent  []agent.Callback
+
+	BeforeModel []agent.BeforeModelCallback
+	Model       llm.Model
+	AfterModel  []agent.AfterModelCallback
+
+	Instruction       string
+	GlobalInstruction string
+
+	DisallowTransferToParent bool
+	DisallowTransferToPeers  bool
+
+	IncludeContents string
+
+	InputSchema  *genai.Schema
+	OutputSchema *genai.Schema
+
+	// TODO: BeforeTool and AfterTool callbacks
+	Tools []tool.Tool
+}
+
+type BeforeModelCallback func(ctx agent.Context, llmRequest *llm.Request) (*llm.Response, error)
+
+type AfterModelCallback func(ctx agent.Context, llmResponse *llm.Response, llmResponseError error) (*llm.Response, error)
+
+func (b Builder) Agent() agent.Agent {
+	llmAgent := &llmAgent{
+		model:       b.Model,
+		instruction: b.Instruction,
+	}
+
+	a := agent.Builder{
+		Name:        b.Name,
+		Description: b.Description,
+		SubAgents:   b.SubAgents,
+		BeforeAgent: b.BeforeAgent,
+		AfterAgent:  b.AfterAgent,
+		Run:         llmAgent.Run,
+	}.Agent()
+
+	return a
+}
+
+type llmAgent struct {
+	model       llm.Model
+	instruction string
+}
+
+func (a *llmAgent) Run(ctx agent.Context) iter.Seq2[*session.Event, error] {
+	req := &llm.Request{
+		Contents: []*genai.Content{
+			ctx.UserContent(),
+		},
+		GenerateConfig: &genai.GenerateContentConfig{
+			SystemInstruction: genai.NewContentFromText(a.instruction, ""),
+		},
+	}
+
+	return func(yield func(*session.Event, error) bool) {
+		// TODO: right now it's generateStream only, we'd need to propagate this from the AgentRunConfig or equivalent.
+		for resp, err := range a.model.GenerateStream(ctx, req) {
+			// TODO: check if we should stop iterator on the first error from stream or continue yielding next results.
+			if err != nil {
+				yield(nil, err)
+				return
+			}
+
+			// TODO: proper event initialization, function calls handling etc.
+			ev := session.NewEvent(ctx.InvocationID())
+			ev.LLMResponse = resp
+			ev.Author = genai.RoleModel
+
+			if !yield(ev, nil) {
+				return
+			}
+		}
+	}
+}

--- a/examples/restruct/main.go
+++ b/examples/restruct/main.go
@@ -1,0 +1,114 @@
+// Copyright 2025 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package main
+
+import (
+	"bufio"
+	"context"
+	"fmt"
+	"log"
+	"os"
+
+	"google.golang.org/adk/agent"
+	"google.golang.org/adk/agent/llmagent"
+	"google.golang.org/adk/llm/gemini"
+	"google.golang.org/adk/session"
+	"google.golang.org/genai"
+)
+
+func main() {
+	ctx := context.Background()
+
+	model, err := gemini.NewModel(ctx, "gemini-2.5-flash", &genai.ClientConfig{
+		APIKey: os.Getenv("GEMINI_API_KEY"),
+	})
+	if err != nil {
+		panic(err)
+	}
+
+	runAgent(llmagent.Builder{
+		Name:        "weather_time_agent",
+		Model:       model,
+		Description: "Agent to answer questions about the time and weather in a city.",
+		Instruction: "I can answer your questions about the time and weather in a city.",
+	}.Agent())
+}
+
+func runAgent(agent agent.Agent) {
+	reader := bufio.NewReader(os.Stdin)
+
+	for {
+		fmt.Print("\nUser -> ")
+
+		userInput, err := reader.ReadString('\n')
+		if err != nil {
+			log.Fatal(err)
+		}
+
+		ctx := &agentContext{
+			Context:     context.Background(),
+			userContent: genai.NewContentFromText(userInput, genai.RoleUser),
+		}
+
+		fmt.Print("\nAgent -> ")
+		for event, err := range agent.Run(ctx) {
+			if err != nil {
+				fmt.Printf("\nAGENT_ERROR: %v\n", err)
+			} else {
+				for _, p := range event.LLMResponse.Content.Parts {
+					fmt.Print(p.Text)
+				}
+			}
+		}
+	}
+}
+
+// TODO: move to runner
+type agentContext struct {
+	context.Context
+	ended        bool
+	userContent  *genai.Content
+	invocationID string
+	branch       string
+	agentName    string
+	artifacts    agent.Artifacts
+	session      session.Session
+}
+
+func (c *agentContext) UserContent() *genai.Content {
+	return c.userContent
+}
+func (c *agentContext) InvocationID() string {
+	return c.invocationID
+}
+func (c *agentContext) Branch() string {
+	return c.branch
+}
+func (c *agentContext) AgentName() string {
+	return c.agentName
+}
+func (c *agentContext) Session() session.Session {
+	return c.session
+}
+func (c *agentContext) Artifacts() agent.Artifacts {
+	return c.artifacts
+}
+func (c *agentContext) End() {
+	c.ended = true
+}
+func (c *agentContext) Ended() bool {
+	return c.ended
+}
+func (c *agentContext) Report(*session.Event) {}

--- a/llm/gemini/gemini.go
+++ b/llm/gemini/gemini.go
@@ -1,3 +1,17 @@
+// Copyright 2025 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
 package gemini
 
 import (

--- a/llm/llm.go
+++ b/llm/llm.go
@@ -1,3 +1,17 @@
+// Copyright 2025 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
 package llm
 
 import (

--- a/session/session.go
+++ b/session/session.go
@@ -22,6 +22,7 @@ import (
 	"sync"
 	"time"
 
+	"github.com/google/uuid"
 	"google.golang.org/adk/llm"
 	"google.golang.org/adk/types"
 	"rsc.io/omap"
@@ -78,7 +79,16 @@ type Event struct {
 	LLMResponse        *llm.Response
 }
 
-func (e *Event) Clone() *Event
+// NewEvent creates a new event.
+func NewEvent(invocationID string) *Event {
+	return &Event{
+		ID:           uuid.NewString(),
+		InvocationID: invocationID,
+		Time:         time.Now(),
+	}
+}
+
+func (e *Event) Clone() *Event { return nil }
 
 type Actions struct {
 	// Set by agent.Context implementation.

--- a/tool/tool.go
+++ b/tool/tool.go
@@ -35,4 +35,4 @@ type Context interface {
 // TODO: implement
 type Set struct{}
 
-func NewSet(t ...Tool) Set
+func NewSet(t ...Tool) Set { return Set{} }


### PR DESCRIPTION
I've also added a temporary `examples/restruct/main.go` to run the agent locally.

I've added 2 diffs from the doc. Let me know if that should be updated. Once we submit the PR, I will proceed and wire up the existing code to the new entities.

The diffs:
1. I've added the internal method to `Agent` interface.
```
setParent(parent Agent)
```

As we'd need to set a parent field for the provided subAgents when they are added.

Another approach is create a wrapper Agent each time (as @rakyll have:
```
type hierarchicalAgent struct {
	agent  agent.Agent
	subs   []agent.Agent
	parent agent.Agent
}
func (a *hierarchicalAgent) Name() string {
	return a.agent.Name()
}
func (a *hierarchicalAgent) Description() string {
	return a.agent.Description()
}
func (a *hierarchicalAgent) Run(ctx agent.Context) iter.Seq2[session.Event, error] {
	return a.agent.Run(ctx)
}
func (a *hierarchicalAgent) Subs() []agent.Agent {
	return a.subs
}
func (a *hierarchicalAgent) Parent() agent.Agent {
	return a.parent
}
// NewAgent provides an agent with the provided parent and sub agents.
// It doesn't change the behavior of the underlying agent otherwise.
func NewAgent(agent agent.Agent, parent agent.Agent, subs ...agent.Agent) agent.Agent {
	return &hierarchicalAgent{
		agent:  agent,
		subs:   subs,
		parent: parent,
	}
}
```

I suspect this will not enforce the agent **tree.** Because semantically the agent may have multiple parents then. 
e.g. `a1 with subAgent(a) and a2 with subAgent(a)`. Ideally we need to error when a2 wants to add subAgent `a`. But with `hierarchicalAgent` it won't error and both `a1` and `a2` will have a subAgent `a`.
Moreover if you run just `a` it won't have a parent.

If I'm wrong here, I can briefly add `hierarchicalAgent` and remove `setParent(parent Agent)` from the interface.

2. Renamed `subs` to `subAgents`.