### PR TITLE
Add sessionservice and inmemory implementation

### DIFF
--- a/sessionservice/inmemory.go
+++ b/sessionservice/inmemory.go
@@ -1,0 +1,259 @@
+// Copyright 2025 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package sessionservice
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"iter"
+	"sync"
+	"time"
+
+	"github.com/google/uuid"
+	"google.golang.org/adk/session"
+	"rsc.io/omap"
+	"rsc.io/ordered"
+)
+
+// inMemoryService is an in-memory implementation of types.SessionService.
+// It is primarily for testing and demonstration purposes.
+// Thread-safe.
+type inMemoryService struct {
+	mu       sync.RWMutex
+	sessions omap.Map[string, *storedSession] // session.ID) -> storedSession
+}
+
+func newInMemoryService() *inMemoryService {
+	return &inMemoryService{}
+}
+
+func (s *inMemoryService) Create(ctx context.Context, req *CreateRequest) (StoredSession, error) {
+	sessionID := req.SessionID
+	if sessionID == "" {
+		sessionID = uuid.NewString()
+	}
+
+	key := sessionKey{
+		AppName:   req.AppName,
+		UserID:    req.UserID,
+		SessionID: sessionID,
+	}
+
+	encodedKey := key.Encode()
+
+	val := &storedSession{
+		id:        session.ID(key),
+		state:     req.State,
+		updatedAt: time.Now(),
+	}
+
+	s.mu.Lock()
+	defer s.mu.Unlock()
+
+	s.sessions.Set(encodedKey, val)
+
+	return val, nil
+}
+
+func (s *inMemoryService) Get(ctx context.Context, req *GetRequest) (StoredSession, error) {
+	s.mu.RLock()
+	defer s.mu.RUnlock()
+
+	res, ok := s.sessions.Get(sessionKey(req.ID).Encode())
+	if !ok {
+		return nil, fmt.Errorf("session %+v not found", req.ID)
+	}
+
+	// TODO: handle req.NumRecentEvents and req.After
+	return res, nil
+}
+
+// List returns an iterator over current snapshot.
+func (s *inMemoryService) List(ctx context.Context, req *ListRequest) ([]StoredSession, error) {
+	s.mu.RLock()
+	defer s.mu.RUnlock()
+
+	lo := sessionKey{AppName: req.AppName, UserID: req.UserID}.Encode()
+	hi := sessionKey{AppName: req.AppName, UserID: req.UserID + "\x00"}.Encode()
+
+	var res []StoredSession
+	for k, storedSession := range s.sessions.Scan(lo, hi) {
+		var key sessionKey
+		if err := key.Decode(k); err != nil {
+			return nil, fmt.Errorf("failed to decode key: %w", err)
+		}
+
+		if key.AppName != req.AppName && key.UserID != req.UserID {
+			break
+		}
+
+		res = append(res, storedSession)
+	}
+	return res, nil
+}
+
+func (s *inMemoryService) Delete(ctx context.Context, req *DeleteRequest) error {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+
+	_, ok := s.sessions.Get(sessionKey(req.ID).Encode())
+	if !ok {
+		return fmt.Errorf("session %+v not found", req.ID)
+	}
+
+	s.sessions.Delete(sessionKey(req.ID).Encode())
+	return nil
+}
+
+func (s *inMemoryService) AppendEvent(ctx context.Context, session StoredSession, event *session.Event) error {
+	// TODO: no-op if event is partial.
+	// TODO: process event actions and state delta.
+
+	storedSession, ok := session.(*storedSession)
+	if !ok {
+		return errors.New("unexpected session type")
+	}
+
+	s.mu.Lock()
+	defer s.mu.Unlock()
+
+	storedSession.appendEvent(event)
+
+	s.sessions.Set(sessionKey(session.ID()).Encode(), storedSession)
+
+	return nil
+}
+
+type sessionKey session.ID
+
+func (sk sessionKey) Encode() string {
+	return string(ordered.Encode(sk.AppName, sk.UserID, sk.SessionID))
+}
+
+func (sk *sessionKey) Decode(key string) error {
+	return ordered.Decode([]byte(key), &sk.AppName, &sk.UserID, &sk.SessionID)
+}
+
+type storedSession struct {
+	id        session.ID
+	events    []*session.Event
+	state     map[string]any
+	updatedAt time.Time
+
+	// guards all mutable fields
+	mu sync.RWMutex
+}
+
+func (s *storedSession) ID() session.ID {
+	return s.id
+}
+
+func (s *storedSession) State() session.ReadOnlyState {
+	return &state{
+		mu:    &s.mu,
+		state: s.state,
+	}
+}
+
+func (s *storedSession) Events() session.Events {
+	return &events{
+		mu:     &s.mu,
+		events: s.events,
+	}
+}
+
+func (s *storedSession) Updated() time.Time {
+	s.mu.RLock()
+	defer s.mu.RUnlock()
+
+	return s.updatedAt
+}
+
+func (s *storedSession) appendEvent(event *session.Event) {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+
+	s.events = append(s.events, event)
+	s.updatedAt = event.Time
+}
+
+type events struct {
+	mu     *sync.RWMutex
+	events []*session.Event
+}
+
+func (e *events) All() iter.Seq[*session.Event] {
+	return func(yield func(*session.Event) bool) {
+		e.mu.RLock()
+
+		for _, event := range e.events {
+			e.mu.RUnlock()
+			if !yield(event) {
+				return
+			}
+			e.mu.RLock()
+		}
+
+		e.mu.RUnlock()
+	}
+}
+
+func (e *events) Len() int {
+	e.mu.RLock()
+	defer e.mu.RUnlock()
+
+	return len(e.events)
+}
+
+func (e *events) At(i int) *session.Event {
+	e.mu.RLock()
+	defer e.mu.RUnlock()
+
+	if i >= 0 && i < len(e.events) {
+		return e.events[i]
+	}
+	return nil
+}
+
+type state struct {
+	mu    *sync.RWMutex
+	state map[string]any
+}
+
+func (s *state) Get(key string) any {
+	s.mu.RLock()
+	defer s.mu.RUnlock()
+
+	return s.state[key]
+}
+
+func (s *state) All() iter.Seq2[string, any] {
+	return func(yield func(key string, val any) bool) {
+		s.mu.RLock()
+
+		for k, v := range s.state {
+			s.mu.RUnlock()
+			if !yield(k, v) {
+				return
+			}
+			s.mu.RLock()
+		}
+
+		s.mu.RUnlock()
+	}
+}
+
+var _ Service = (*inMemoryService)(nil)

--- a/sessionservice/inmemory_test.go
+++ b/sessionservice/inmemory_test.go
@@ -1,0 +1,400 @@
+// Copyright 2025 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package sessionservice
+
+import (
+	"context"
+	"maps"
+	"testing"
+
+	"github.com/google/go-cmp/cmp"
+	"github.com/google/go-cmp/cmp/cmpopts"
+	"google.golang.org/adk/session"
+)
+
+func Test_inMemoryService_Create(t *testing.T) {
+	tests := []struct {
+		name            string
+		inMemoryService *inMemoryService
+		req             *CreateRequest
+		want            StoredSession
+		wantErr         bool
+	}{
+		{
+			name:            "full key",
+			inMemoryService: newInMemoryService(),
+			req: &CreateRequest{
+				AppName:   "testApp",
+				UserID:    "testUserID",
+				SessionID: "testSessionID",
+				State: map[string]any{
+					"k": 5,
+				},
+			},
+		},
+		{
+			name:            "generated session id",
+			inMemoryService: newInMemoryService(),
+			req: &CreateRequest{
+				AppName: "testApp",
+				UserID:  "testUserID",
+				State: map[string]any{
+					"k": 5,
+				},
+			},
+		},
+		{
+			name:            "when already exists, it's overwritten", // to be consistent with python/java
+			inMemoryService: serviceWithData(t),
+			req: &CreateRequest{
+				AppName:   "app1",
+				UserID:    "user1",
+				SessionID: "session1",
+				State: map[string]any{
+					"k": 10,
+				},
+			},
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			ctx := context.Background()
+
+			s := tt.inMemoryService
+
+			got, err := s.Create(ctx, tt.req)
+			if (err != nil) != tt.wantErr {
+				t.Fatalf("inMemoryService.Create() error = %v, wantErr %v", err, tt.wantErr)
+				return
+			}
+
+			if err != nil {
+				return
+			}
+
+			if got.ID().AppName != tt.req.AppName {
+				t.Errorf("AppName got: %v, want: %v", got.ID().AppName, tt.wantErr)
+			}
+
+			if got.ID().UserID != tt.req.UserID {
+				t.Errorf("UserID got: %v, want: %v", got.ID().AppName, tt.wantErr)
+			}
+
+			if tt.req.SessionID != "" {
+				if got.ID().SessionID != tt.req.SessionID {
+					t.Errorf("SessionID got: %v, want: %v", got.ID().AppName, tt.wantErr)
+				}
+			} else {
+				if got.ID().SessionID == "" {
+					t.Errorf("SessionID was not generated on empty user input.")
+				}
+			}
+
+			gotState := maps.Collect(got.State().All())
+			wantState := tt.req.State
+
+			if diff := cmp.Diff(wantState, gotState); diff != "" {
+				t.Errorf("Create State mismatch: (-want +got):\n%s", diff)
+			}
+		})
+	}
+}
+
+func Test_inMemoryService_Get(t *testing.T) {
+	tests := []struct {
+		name              string
+		req               *GetRequest
+		inMemoryService   *inMemoryService
+		wantStoredSession *storedSession
+		wantErr           bool
+	}{
+		{
+			name:            "ok",
+			inMemoryService: serviceWithData(t),
+			req: &GetRequest{
+				ID: session.ID{
+					AppName:   "app1",
+					UserID:    "user1",
+					SessionID: "session1",
+				},
+			},
+			wantStoredSession: &storedSession{
+				id: session.ID{
+					AppName:   "app1",
+					UserID:    "user1",
+					SessionID: "session1",
+				},
+				state: map[string]any{
+					"k1": "v1",
+				},
+			},
+		},
+		{
+			name:            "error when not found",
+			inMemoryService: serviceWithData(t),
+			req: &GetRequest{
+				ID: session.ID{
+					AppName:   "testApp",
+					UserID:    "user1",
+					SessionID: "session1",
+				},
+			},
+			wantErr: true,
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			ctx := context.Background()
+
+			s := tt.inMemoryService
+
+			got, err := s.Get(ctx, tt.req)
+			if (err != nil) != tt.wantErr {
+				t.Fatalf("inMemoryService.Get() error = %v, wantErr %v", err, tt.wantErr)
+				return
+			}
+
+			if err != nil {
+				return
+			}
+
+			if diff := cmp.Diff(tt.wantStoredSession, got,
+				cmp.AllowUnexported(storedSession{}),
+				cmpopts.IgnoreFields(storedSession{}, "mu")); diff != "" {
+				t.Errorf("Create session mismatch: (-want +got):\n%s", diff)
+			}
+		})
+	}
+}
+
+func Test_inMemoryService_List(t *testing.T) {
+	tests := []struct {
+		name               string
+		req                *ListRequest
+		inMemoryService    *inMemoryService
+		wantStoredSessions []StoredSession
+		wantErr            bool
+	}{
+		{
+			name:            "ok",
+			inMemoryService: serviceWithData(t),
+			req: &ListRequest{
+				AppName: "app1",
+				UserID:  "user1",
+			},
+			wantStoredSessions: []StoredSession{
+				&storedSession{
+					id: session.ID{
+						AppName:   "app1",
+						UserID:    "user1",
+						SessionID: "session1",
+					},
+					state: map[string]any{
+						"k1": "v1",
+					},
+				},
+				&storedSession{
+					id: session.ID{
+						AppName:   "app1",
+						UserID:    "user1",
+						SessionID: "session2",
+					},
+					state: map[string]any{
+						"k1": "v2",
+					},
+				},
+			},
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			ctx := context.Background()
+
+			s := tt.inMemoryService
+			got, err := s.List(ctx, tt.req)
+			if (err != nil) != tt.wantErr {
+				t.Errorf("inMemoryService.List() error = %v, wantErr %v", err, tt.wantErr)
+				return
+			}
+
+			if err == nil {
+				if diff := cmp.Diff(tt.wantStoredSessions, got,
+					cmp.AllowUnexported(storedSession{}),
+					cmpopts.IgnoreFields(storedSession{}, "mu")); diff != "" {
+					t.Errorf("inMemoryService.List() = %v (-want +got):\n%s", got, diff)
+				}
+			}
+		})
+	}
+}
+
+func Test_inMemoryService_Delete(t *testing.T) {
+	tests := []struct {
+		name            string
+		req             *DeleteRequest
+		inMemoryService *inMemoryService
+		wantErr         bool
+	}{
+		{
+			name:            "delete ok",
+			inMemoryService: serviceWithData(t),
+			req: &DeleteRequest{
+				ID: session.ID{
+					AppName:   "app1",
+					UserID:    "user1",
+					SessionID: "session1",
+				},
+			},
+		},
+		{
+			name:            "error when not found",
+			inMemoryService: serviceWithData(t),
+			req: &DeleteRequest{
+				ID: session.ID{
+					AppName:   "appTest",
+					UserID:    "user1",
+					SessionID: "session1",
+				},
+			},
+			wantErr: true,
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			ctx := context.Background()
+
+			s := tt.inMemoryService
+			if err := s.Delete(ctx, tt.req); (err != nil) != tt.wantErr {
+				t.Errorf("inMemoryService.Delete() error = %v, wantErr %v", err, tt.wantErr)
+			}
+		})
+	}
+}
+
+func Test_inMemoryService_AppendEvent(t *testing.T) {
+	tests := []struct {
+		name              string
+		inMemoryService   *inMemoryService
+		session           *storedSession
+		event             *session.Event
+		wantStoredSession *storedSession
+		wantErr           bool
+	}{
+		{
+			name:            "append event to the session and overwrite in storage",
+			inMemoryService: serviceWithData(t),
+			session: &storedSession{
+				id: session.ID{
+					AppName:   "app1",
+					UserID:    "user1",
+					SessionID: "session1",
+				},
+			},
+			event: &session.Event{
+				ID: "new_event",
+			},
+			wantStoredSession: &storedSession{
+				id: session.ID{
+					AppName:   "app1",
+					UserID:    "user1",
+					SessionID: "session1",
+				},
+				events: []*session.Event{
+					{
+						ID: "new_event",
+					},
+				},
+			},
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			ctx := context.Background()
+
+			s := tt.inMemoryService
+
+			err := s.AppendEvent(ctx, tt.session, tt.event)
+			if (err != nil) != tt.wantErr {
+				t.Errorf("inMemoryService.AppendEvent() error = %v, wantErr %v", err, tt.wantErr)
+			}
+
+			if err != nil {
+				return
+			}
+
+			got, err := s.Get(ctx, &GetRequest{
+				ID: tt.session.ID(),
+			})
+			if (err != nil) != tt.wantErr {
+				t.Fatalf("inMemoryService.Get() error = %v, wantErr %v", err, tt.wantErr)
+				return
+			}
+
+			if err != nil {
+				return
+			}
+
+			if diff := cmp.Diff(tt.wantStoredSession, got,
+				cmp.AllowUnexported(storedSession{}),
+				cmpopts.IgnoreFields(storedSession{}, "mu")); diff != "" {
+				t.Errorf("Create session mismatch: (-want +got):\n%s", diff)
+			}
+
+		})
+	}
+}
+
+func serviceWithData(t *testing.T) *inMemoryService {
+	t.Helper()
+
+	service := newInMemoryService()
+
+	for _, storedSession := range []*storedSession{
+		{
+			id: session.ID{
+				AppName:   "app1",
+				UserID:    "user1",
+				SessionID: "session1",
+			},
+			state: map[string]any{
+				"k1": "v1",
+			},
+		},
+		{
+			id: session.ID{
+				AppName:   "app1",
+				UserID:    "user1",
+				SessionID: "session2",
+			},
+			state: map[string]any{
+				"k1": "v2",
+			},
+		},
+		{
+			id: session.ID{
+				AppName:   "app2",
+				UserID:    "user2",
+				SessionID: "session2",
+			},
+			state: map[string]any{
+				"k2": "v2",
+			},
+		},
+	} {
+		service.sessions.Set(sessionKey(storedSession.id).Encode(), storedSession)
+	}
+
+	return service
+}

--- a/sessionservice/service.go
+++ b/sessionservice/service.go
@@ -29,6 +29,10 @@ type Service interface {
 	AppendEvent(context.Context, StoredSession, *session.Event) error
 }
 
+func Mem() Service {
+	return newInMemoryService()
+}
+
 type StoredSession interface {
 	ID() session.ID
 	State() session.ReadOnlyState


### PR DESCRIPTION
1. I've made the in-memory implementation thread safe (i think).
If you'd consider we should better provide non-thread safe and remove mutex/copy overhead, I can update the PR.

2. stored session has `updated_at` field. Both python&java set it to `event.time` during `append_event` call. So theoretically updated_at may jump forward and backward.
We may make it non-decreasing as least: `if event.Time.After(session.UpdatedAt`. Or use `time.Now()` to reflect when the stored session was actually updated.
For now I've kept as python/java implemented this.