### PR TITLE
Update agent constructors.

### DIFF
--- a/examples/restruct/main.go
+++ b/examples/restruct/main.go
@@ -38,12 +38,17 @@ func main() {
 		panic(err)
 	}
 
-	runAgent(llmagent.Builder{
+	agent, err := llmagent.New(llmagent.Config{
 		Name:        "weather_time_agent",
 		Model:       model,
 		Description: "Agent to answer questions about the time and weather in a city.",
 		Instruction: "I can answer your questions about the time and weather in a city.",
-	}.Agent())
+	})
+	if err != nil {
+		panic(err)
+	}
+
+	runAgent(agent)
 }
 
 func runAgent(agent agent.Agent) {

--- a/internal/llminternal/agent.go
+++ b/internal/llminternal/agent.go
@@ -1,0 +1,27 @@
+// Copyright 2025 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package llminternal
+
+type Agent interface {
+	internal() *State
+}
+
+type State struct {
+	DisallowTransferToParent bool
+}
+
+func (s *State) internal() *State { return s }
+
+func Reveal(a Agent) *State { return a.internal() }


### PR DESCRIPTION
From Builder{}.Agent() to more agent.New(agent.Config{}) and similarly for LLMAgent.

Introduce internal/llmagent package to allow reading LLMAgent properties in adk (e.g. runner).

There's a discussion regarding the naming:
https://docs.google.com/document/d/1MgmRln4aLYpN1m3Jdn4_0bpeB43t944rX9qIKYISC7o/edit?resourcekey=0-DhFFZ9fssrJBoTY0s3DAKA&pli=1&disco=AAABnr5_LVU

I'd continue migrating to session, llmagent packages etc.