### PR TITLE
Bump genai to v1.20.0

### DIFF
--- a/agent/llmagent/testdata/TestFunctionTool.httprr
+++ b/agent/llmagent/testdata/TestFunctionTool.httprr
@@ -1,17 +1,16 @@
 httprr trace v1
-835 1141
-POST https://generativelanguage.googleapis.com//v1beta/models/gemini-2.0-flash:generateContent HTTP/1.1
+834 1082
+POST https://generativelanguage.googleapis.com/v1beta/models/gemini-2.0-flash:generateContent HTTP/1.1
 Host: generativelanguage.googleapis.com
 User-Agent: Go-http-client/1.1
 Content-Length: 602
 Content-Type: application/json
 
 {"contents":[{"parts":[{"text":"what is the sum of 1 + 2?"}],"role":"user"}],"generationConfig":{},"systemInstruction":{"parts":[{"text":"output ONLY the result computed by the provided function"}],"role":"user"},"tools":[{"functionDeclarations":[{"description":"computes the sum of two numbers","name":"sum","parametersJsonSchema":{"additionalProperties":{"not":{}},"properties":{"a":{"type":"integer"},"b":{"type":"integer"}},"required":["a","b"],"type":"object"},"responseJsonSchema":{"additionalProperties":{"not":{}},"properties":{"sum":{"type":"integer"}},"required":["sum"],"type":"object"}}]}]}HTTP/2.0 200 OK
-Alt-Svc: h3=":443"; ma=2592000,h3-29=":443"; ma=2592000
 Content-Type: application/json; charset=UTF-8
-Date: Mon, 07 Jul 2025 13:39:56 GMT
+Date: Mon, 18 Aug 2025 11:19:53 GMT
 Server: scaffolding on HTTPServer2
-Server-Timing: gfet4t7; dur=592
+Server-Timing: gfet4t7; dur=435
 Vary: Origin
 Vary: X-Origin
 Vary: Referer
@@ -28,8 +27,8 @@ X-Xss-Protection: 0
             "functionCall": {
               "name": "sum",
               "args": {
-                "b": 2,
-                "a": 1
+                "a": 1,
+                "b": 2
               }
             }
           }
@@ -37,7 +36,7 @@ X-Xss-Protection: 0
         "role": "model"
       },
       "finishReason": "STOP",
-      "avgLogprobs": -3.4829718060791491e-07
+      "avgLogprobs": -4.03114827349782e-06
     }
   ],
   "usageMetadata": {
@@ -58,21 +57,20 @@ X-Xss-Protection: 0
     ]
   },
   "modelVersion": "gemini-2.0-flash",
-  "responseId": "K85raLC0NbKm1dkPoOiKsQM"
+  "responseId": "WQyjaNWVIJXonsEP68HFyAQ"
 }
-998 1007
-POST https://generativelanguage.googleapis.com//v1beta/models/gemini-2.0-flash:generateContent HTTP/1.1
+997 950
+POST https://generativelanguage.googleapis.com/v1beta/models/gemini-2.0-flash:generateContent HTTP/1.1
 Host: generativelanguage.googleapis.com
 User-Agent: Go-http-client/1.1
 Content-Length: 765
 Content-Type: application/json
 
 {"contents":[{"parts":[{"text":"what is the sum of 1 + 2?"}],"role":"user"},{"parts":[{"functionCall":{"args":{"a":1,"b":2},"name":"sum"}}],"role":"model"},{"parts":[{"functionResponse":{"name":"sum","response":{"sum":3}}}],"role":"user"}],"generationConfig":{},"systemInstruction":{"parts":[{"text":"output ONLY the result computed by the provided function"}],"role":"user"},"tools":[{"functionDeclarations":[{"description":"computes the sum of two numbers","name":"sum","parametersJsonSchema":{"additionalProperties":{"not":{}},"properties":{"a":{"type":"integer"},"b":{"type":"integer"}},"required":["a","b"],"type":"object"},"responseJsonSchema":{"additionalProperties":{"not":{}},"properties":{"sum":{"type":"integer"}},"required":["sum"],"type":"object"}}]}]}HTTP/2.0 200 OK
-Alt-Svc: h3=":443"; ma=2592000,h3-29=":443"; ma=2592000
 Content-Type: application/json; charset=UTF-8
-Date: Mon, 07 Jul 2025 13:39:56 GMT
+Date: Mon, 18 Aug 2025 11:19:54 GMT
 Server: scaffolding on HTTPServer2
-Server-Timing: gfet4t7; dur=417
+Server-Timing: gfet4t7; dur=397
 Vary: Origin
 Vary: X-Origin
 Vary: Referer
@@ -92,7 +90,7 @@ X-Xss-Protection: 0
         "role": "model"
       },
       "finishReason": "STOP",
-      "avgLogprobs": -8.2294456660747528e-05
+      "avgLogprobs": -0.00032072281464934349
     }
   ],
   "usageMetadata": {
@@ -113,5 +111,5 @@ X-Xss-Protection: 0
     ]
   },
   "modelVersion": "gemini-2.0-flash",
-  "responseId": "LM5raOKMI52vgLUPiKvesAc"
+  "responseId": "WQyjaPjzOei4kdUP29P4oAc"
 }

--- a/agent/llmagent/testdata/TestLLMAgent_healthy_backend.httprr
+++ b/agent/llmagent/testdata/TestLLMAgent_healthy_backend.httprr
@@ -1,17 +1,16 @@
 httprr trace v1
-501 1004
-POST https://generativelanguage.googleapis.com//v1beta/models/gemini-2.0-flash:generateContent HTTP/1.1
+500 947
+POST https://generativelanguage.googleapis.com/v1beta/models/gemini-2.0-flash:generateContent HTTP/1.1
 Host: generativelanguage.googleapis.com
 User-Agent: Go-http-client/1.1
 Content-Length: 268
 Content-Type: application/json
 
 {"contents":[{"parts":[{"text":"Handle the requests as specified in the System Instruction."}],"role":"user"}],"generationConfig":{},"systemInstruction":{"parts":[{"text":"Answer as precisely as possible.\n\nRoll the dice and report only the result."}],"role":"user"}}HTTP/2.0 200 OK
-Alt-Svc: h3=":443"; ma=2592000,h3-29=":443"; ma=2592000
 Content-Type: application/json; charset=UTF-8
-Date: Sun, 22 Jun 2025 17:10:04 GMT
+Date: Mon, 18 Aug 2025 11:19:53 GMT
 Server: scaffolding on HTTPServer2
-Server-Timing: gfet4t7; dur=357
+Server-Timing: gfet4t7; dur=402
 Vary: Origin
 Vary: X-Origin
 Vary: Referer
@@ -31,7 +30,7 @@ X-Xss-Protection: 0
         "role": "model"
       },
       "finishReason": "STOP",
-      "avgLogprobs": -0.50234735012054443
+      "avgLogprobs": -0.50080591440200806
     }
   ],
   "usageMetadata": {
@@ -52,5 +51,5 @@ X-Xss-Protection: 0
     ]
   },
   "modelVersion": "gemini-2.0-flash",
-  "responseId": "7DhYaNXJAv_bgLUPvdfCsQU"
+  "responseId": "WQyjaLX3BpewkdUPnIf6qAc"
 }

--- a/go.mod
+++ b/go.mod
@@ -5,7 +5,7 @@ go 1.24.3
 require (
 	github.com/google/go-cmp v0.7.0
 	github.com/google/uuid v1.6.0
-	google.golang.org/genai v1.13.0
+	google.golang.org/genai v1.20.0
 	rsc.io/omap v1.2.0
 	rsc.io/ordered v1.1.1
 )

--- a/go.sum
+++ b/go.sum
@@ -98,8 +98,8 @@ golang.org/x/tools v0.0.0-20190524140312-2c0ae7006135/go.mod h1:RgjU9mgBXZiqYHBn
 golang.org/x/xerrors v0.0.0-20191204190536-9bdfabe68543/go.mod h1:I/5z698sn9Ka8TeJc9MKroUUfqBBauWjQqLJ2OPfmY0=
 google.golang.org/appengine v1.1.0/go.mod h1:EbEs0AVv82hx2wNQdGPgUI5lhzA/G0D9YwlJXL52JkM=
 google.golang.org/appengine v1.4.0/go.mod h1:xpcJRLb0r/rnEns0DIKYYv+WjYCduHsrkT7/EB5XEv4=
-google.golang.org/genai v1.13.0 h1:LRhwx5PU+bXhfnXyPEHu2kt9yc+MpvuYbajxSorOJjg=
-google.golang.org/genai v1.13.0/go.mod h1:QPj5NGJw+3wEOHg+PrsWwJKvG6UC84ex5FR7qAYsN/M=
+google.golang.org/genai v1.20.0 h1:nmDZSJjXwBvSXcdOohz7pzTVGP9yuNITY8kZ2Ta24xY=
+google.golang.org/genai v1.20.0/go.mod h1:QPj5NGJw+3wEOHg+PrsWwJKvG6UC84ex5FR7qAYsN/M=
 google.golang.org/genproto v0.0.0-20180817151627-c66870c02cf8/go.mod h1:JiN7NxoALGmiZfu7CAH4rXhgtRTLTxftemlI0sWmxmc=
 google.golang.org/genproto v0.0.0-20190819201941-24fa4b261c55/go.mod h1:DMBHOl98Agz4BDEuKkezgsaosCRResVns1a3J2ZsMNc=
 google.golang.org/genproto v0.0.0-20200526211855-cb27e3aa2013/go.mod h1:NbSheEEYHJ7i3ixzK3sjbqSGDJWnxyFXZblF3eUsNvo=

--- a/model/testdata/TestNewGeminiModel.httprr
+++ b/model/testdata/TestNewGeminiModel.httprr
@@ -1,17 +1,16 @@
 httprr trace v1
-314 1037
-POST https://generativelanguage.googleapis.com//v1beta/models/gemini-2.0-flash:generateContent HTTP/1.1
+313 980
+POST https://generativelanguage.googleapis.com/v1beta/models/gemini-2.0-flash:generateContent HTTP/1.1
 Host: generativelanguage.googleapis.com
 User-Agent: Go-http-client/1.1
 Content-Length: 82
 Content-Type: application/json
 
 {"contents":[{"parts":[{"text":"What is the capital of France?"}],"role":"user"}]}HTTP/2.0 200 OK
-Alt-Svc: h3=":443"; ma=2592000,h3-29=":443"; ma=2592000
 Content-Type: application/json; charset=UTF-8
-Date: Tue, 17 Jun 2025 01:57:29 GMT
+Date: Mon, 18 Aug 2025 11:19:55 GMT
 Server: scaffolding on HTTPServer2
-Server-Timing: gfet4t7; dur=393
+Server-Timing: gfet4t7; dur=365
 Vary: Origin
 Vary: X-Origin
 Vary: Referer
@@ -31,7 +30,7 @@ X-Xss-Protection: 0
         "role": "model"
       },
       "finishReason": "STOP",
-      "avgLogprobs": -0.021610861023267109
+      "avgLogprobs": -0.064053091737959117
     }
   ],
   "usageMetadata": {
@@ -52,10 +51,10 @@ X-Xss-Protection: 0
     ]
   },
   "modelVersion": "gemini-2.0-flash",
-  "responseId": "ictQaKDzD_6ShMIPm7P8iAY"
+  "responseId": "WwyjaN-4D7vxnsEPtbymsAU"
 }
-328 1387
-POST https://generativelanguage.googleapis.com//v1beta/models/gemini-2.0-flash:streamGenerateContent?alt=sse HTTP/1.1
+327 1330
+POST https://generativelanguage.googleapis.com/v1beta/models/gemini-2.0-flash:streamGenerateContent?alt=sse HTTP/1.1
 Host: generativelanguage.googleapis.com
 User-Agent: Go-http-client/1.1
 Content-Length: 82
@@ -63,12 +62,11 @@ Content-Type: application/json
 
 {"contents":[{"parts":[{"text":"What is the capital of France?"}],"role":"user"}]}HTTP/2.0 200 OK
 Connection: close
-Alt-Svc: h3=":443"; ma=2592000,h3-29=":443"; ma=2592000
 Content-Disposition: attachment
 Content-Type: text/event-stream
-Date: Tue, 17 Jun 2025 01:57:29 GMT
+Date: Mon, 18 Aug 2025 11:19:55 GMT
 Server: scaffolding on HTTPServer2
-Server-Timing: gfet4t7; dur=366
+Server-Timing: gfet4t7; dur=268
 Vary: Origin
 Vary: X-Origin
 Vary: Referer
@@ -76,9 +74,9 @@ X-Content-Type-Options: nosniff
 X-Frame-Options: SAMEORIGIN
 X-Xss-Protection: 0
 
-data: {"candidates": [{"content": {"parts": [{"text": "The"}],"role": "model"}}],"usageMetadata": {"promptTokenCount": 8,"totalTokenCount": 8,"promptTokensDetails": [{"modality": "TEXT","tokenCount": 8}]},"modelVersion": "gemini-2.0-flash","responseId": "ictQaOn0MeeDmNAP8OOwqA0"}
+data: {"candidates": [{"content": {"parts": [{"text": "The"}],"role": "model"}}],"usageMetadata": {"promptTokenCount": 8,"totalTokenCount": 8,"promptTokensDetails": [{"modality": "TEXT","tokenCount": 8}]},"modelVersion": "gemini-2.0-flash","responseId": "WwyjaOzEJ-Cyx_APyabouQ0"}
 
-data: {"candidates": [{"content": {"parts": [{"text": " capital of France"}],"role": "model"}}],"usageMetadata": {"promptTokenCount": 8,"totalTokenCount": 8,"promptTokensDetails": [{"modality": "TEXT","tokenCount": 8}]},"modelVersion": "gemini-2.0-flash","responseId": "ictQaOn0MeeDmNAP8OOwqA0"}
+data: {"candidates": [{"content": {"parts": [{"text": " capital of France"}],"role": "model"}}],"usageMetadata": {"promptTokenCount": 8,"totalTokenCount": 8,"promptTokensDetails": [{"modality": "TEXT","tokenCount": 8}]},"modelVersion": "gemini-2.0-flash","responseId": "WwyjaOzEJ-Cyx_APyabouQ0"}
 
-data: {"candidates": [{"content": {"parts": [{"text": " is Paris.\n"}],"role": "model"},"finishReason": "STOP"}],"usageMetadata": {"promptTokenCount": 7,"candidatesTokenCount": 8,"totalTokenCount": 15,"promptTokensDetails": [{"modality": "TEXT","tokenCount": 7}],"candidatesTokensDetails": [{"modality": "TEXT","tokenCount": 8}]},"modelVersion": "gemini-2.0-flash","responseId": "ictQaOn0MeeDmNAP8OOwqA0"}
+data: {"candidates": [{"content": {"parts": [{"text": " is Paris.\n"}],"role": "model"},"finishReason": "STOP"}],"usageMetadata": {"promptTokenCount": 7,"candidatesTokenCount": 8,"totalTokenCount": 15,"promptTokensDetails": [{"modality": "TEXT","tokenCount": 7}],"candidatesTokensDetails": [{"modality": "TEXT","tokenCount": 8}]},"modelVersion": "gemini-2.0-flash","responseId": "WwyjaOzEJ-Cyx_APyabouQ0"}
 

--- a/tool/testdata/TestFunctionTool_Simple.httprr
+++ b/tool/testdata/TestFunctionTool_Simple.httprr
@@ -1,17 +1,16 @@
 httprr trace v1
-811 1141
-POST https://generativelanguage.googleapis.com//v1beta/models/gemini-2.0-flash:generateContent HTTP/1.1
+810 1085
+POST https://generativelanguage.googleapis.com/v1beta/models/gemini-2.0-flash:generateContent HTTP/1.1
 Host: generativelanguage.googleapis.com
 User-Agent: Go-http-client/1.1
 Content-Length: 578
 Content-Type: application/json
 
 {"contents":[{"parts":[{"text":"Report the current weather of the capital city of U.K."}],"role":"user"}],"generationConfig":{},"tools":[{"functionDeclarations":[{"description":"Retrieves the current weather report for a specified city.","name":"get_weather_report","parametersJsonSchema":{"additionalProperties":{"not":{}},"properties":{"city":{"type":"string"}},"required":["city"],"type":"object"},"responseJsonSchema":{"additionalProperties":{"not":{}},"properties":{"report":{"type":"string"},"status":{"type":"string"}},"required":["report","status"],"type":"object"}}]}]}HTTP/2.0 200 OK
-Alt-Svc: h3=":443"; ma=2592000,h3-29=":443"; ma=2592000
 Content-Type: application/json; charset=UTF-8
-Date: Tue, 01 Jul 2025 01:49:23 GMT
+Date: Mon, 18 Aug 2025 11:19:57 GMT
 Server: scaffolding on HTTPServer2
-Server-Timing: gfet4t7; dur=547
+Server-Timing: gfet4t7; dur=440
 Vary: Origin
 Vary: X-Origin
 Vary: Referer
@@ -36,7 +35,7 @@ X-Xss-Protection: 0
         "role": "model"
       },
       "finishReason": "STOP",
-      "avgLogprobs": -0.0001656591027442898
+      "avgLogprobs": -0.00042905209452978203
     }
   ],
   "usageMetadata": {
@@ -57,21 +56,20 @@ X-Xss-Protection: 0
     ]
   },
   "modelVersion": "gemini-2.0-flash",
-  "responseId": "oj5jaM37OaizxfcPvo3h8QI"
+  "responseId": "XAyjaNy_MdKqkdUP1bGNqQc"
 }
-789 1140
-POST https://generativelanguage.googleapis.com//v1beta/models/gemini-2.0-flash:generateContent HTTP/1.1
+788 1083
+POST https://generativelanguage.googleapis.com/v1beta/models/gemini-2.0-flash:generateContent HTTP/1.1
 Host: generativelanguage.googleapis.com
 User-Agent: Go-http-client/1.1
 Content-Length: 556
 Content-Type: application/json
 
 {"contents":[{"parts":[{"text":"How is the weather of Paris now?"}],"role":"user"}],"generationConfig":{},"tools":[{"functionDeclarations":[{"description":"Retrieves the current weather report for a specified city.","name":"get_weather_report","parametersJsonSchema":{"additionalProperties":{"not":{}},"properties":{"city":{"type":"string"}},"required":["city"],"type":"object"},"responseJsonSchema":{"additionalProperties":{"not":{}},"properties":{"report":{"type":"string"},"status":{"type":"string"}},"required":["report","status"],"type":"object"}}]}]}HTTP/2.0 200 OK
-Alt-Svc: h3=":443"; ma=2592000,h3-29=":443"; ma=2592000
 Content-Type: application/json; charset=UTF-8
-Date: Tue, 01 Jul 2025 01:49:23 GMT
+Date: Mon, 18 Aug 2025 11:19:57 GMT
 Server: scaffolding on HTTPServer2
-Server-Timing: gfet4t7; dur=535
+Server-Timing: gfet4t7; dur=649
 Vary: Origin
 Vary: X-Origin
 Vary: Referer
@@ -96,7 +94,7 @@ X-Xss-Protection: 0
         "role": "model"
       },
       "finishReason": "STOP",
-      "avgLogprobs": 2.4634563097996372e-06
+      "avgLogprobs": 3.4654814433971685e-06
     }
   ],
   "usageMetadata": {
@@ -117,21 +115,20 @@ X-Xss-Protection: 0
     ]
   },
   "modelVersion": "gemini-2.0-flash",
-  "responseId": "oz5jaMyGHvLhmNAPpebBuQM"
+  "responseId": "XQyjaMrMD_KbkdUP_ITnqQc"
 }
-802 1143
-POST https://generativelanguage.googleapis.com//v1beta/models/gemini-2.0-flash:generateContent HTTP/1.1
+801 1086
+POST https://generativelanguage.googleapis.com/v1beta/models/gemini-2.0-flash:generateContent HTTP/1.1
 Host: generativelanguage.googleapis.com
 User-Agent: Go-http-client/1.1
 Content-Length: 569
 Content-Type: application/json
 
 {"contents":[{"parts":[{"text":"Tell me about the current weather in New York"}],"role":"user"}],"generationConfig":{},"tools":[{"functionDeclarations":[{"description":"Retrieves the current weather report for a specified city.","name":"get_weather_report","parametersJsonSchema":{"additionalProperties":{"not":{}},"properties":{"city":{"type":"string"}},"required":["city"],"type":"object"},"responseJsonSchema":{"additionalProperties":{"not":{}},"properties":{"report":{"type":"string"},"status":{"type":"string"}},"required":["report","status"],"type":"object"}}]}]}HTTP/2.0 200 OK
-Alt-Svc: h3=":443"; ma=2592000,h3-29=":443"; ma=2592000
 Content-Type: application/json; charset=UTF-8
-Date: Tue, 01 Jul 2025 01:49:24 GMT
+Date: Mon, 18 Aug 2025 11:19:58 GMT
 Server: scaffolding on HTTPServer2
-Server-Timing: gfet4t7; dur=817
+Server-Timing: gfet4t7; dur=490
 Vary: Origin
 Vary: X-Origin
 Vary: Referer
@@ -156,7 +153,7 @@ X-Xss-Protection: 0
         "role": "model"
       },
       "finishReason": "STOP",
-      "avgLogprobs": 9.3482958618551493e-07
+      "avgLogprobs": 1.7310030671069399e-06
     }
   ],
   "usageMetadata": {
@@ -177,5 +174,5 @@ X-Xss-Protection: 0
     ]
   },
   "modelVersion": "gemini-2.0-flash",
-  "responseId": "oz5jaOm-PL7Bld8P2ZeQgQ8"
+  "responseId": "XQyjaPSENrvxnsEPtbymsAU"
 }


### PR DESCRIPTION
genai v1.13 client generated URLs with double //. This was captured by httprr.

But internally we use version genai 1.20 and its client has proper one / in the URLs.
This diff caused test failures internally due to httprr URL mismatch.