### PR TITLE
Implement Artifacts for agent context

### DIFF
--- a/agent/agent.go
+++ b/agent/agent.go
@@ -103,7 +103,7 @@ func (a *agent) SubAgents() []Agent {
 func (a *agent) Run(ctx Context) iter.Seq2[*session.Event, error] {
 	return func(yield func(*session.Event, error) bool) {
 		// TODO: verify&update the setup here. Should we branch etc.
-		ctx := NewContext(ctx, a, ctx.UserContent(), ctx.Session(), ctx.Branch())
+		ctx := NewContext(ctx, a, ctx.UserContent(), ctx.Artifacts(), ctx.Session(), ctx.Branch())
 
 		event, err := runBeforeAgentCallbacks(ctx)
 		if event != nil || err != nil {

--- a/agent/agent_test.go
+++ b/agent/agent_test.go
@@ -108,7 +108,7 @@ func TestAgentCallbacks(t *testing.T) {
 				t.Fatalf("failed to create agent: %v", err)
 			}
 
-			ctx := NewContext(ctx, testAgent, genai.NewContentFromText("", genai.RoleUser), nil, "")
+			ctx := NewContext(ctx, testAgent, genai.NewContentFromText("", genai.RoleUser), nil, nil, "")
 			var gotEvents []*session.Event
 			for event, err := range testAgent.Run(ctx) {
 				if err != nil {

--- a/agent/context.go
+++ b/agent/context.go
@@ -29,12 +29,14 @@ type agentContext struct {
 	invocationID string
 	agent        Agent
 	session      session.Session
-	userContent  *genai.Content
-	branch       string
+	artifacts    Artifacts
+
+	userContent *genai.Content
+	branch      string
 }
 
 // TODO: see if needed or possible to make internal
-func NewContext(ctx context.Context, agent Agent, userContent *genai.Content, session session.Session, branch string) *agentContext {
+func NewContext(ctx context.Context, agent Agent, userContent *genai.Content, artifacts Artifacts, session session.Session, branch string) *agentContext {
 	ctx, cancel := context.WithCancel(ctx)
 
 	return &agentContext{
@@ -43,6 +45,7 @@ func NewContext(ctx context.Context, agent Agent, userContent *genai.Content, se
 
 		invocationID: "e-" + uuid.NewString(),
 		agent:        agent,
+		artifacts:    artifacts,
 		session:      session,
 		userContent:  userContent,
 		branch:       branch,
@@ -69,8 +72,8 @@ func (a *agentContext) Session() session.Session {
 	return a.session
 }
 
-func (*agentContext) Artifacts() Artifacts {
-	return nil
+func (a *agentContext) Artifacts() Artifacts {
+	return a.artifacts
 }
 
 func (*agentContext) Report(*session.Event) {

--- a/agent/llmagent/llmagent.go
+++ b/agent/llmagent/llmagent.go
@@ -153,7 +153,7 @@ type llmAgent struct {
 
 func (a *llmAgent) run(ctx agent.Context) iter.Seq2[*session.Event, error] {
 	// TODO: branch context?
-	ctx = agent.NewContext(ctx, a, ctx.UserContent(), ctx.Session(), ctx.Branch())
+	ctx = agent.NewContext(ctx, a, ctx.UserContent(), ctx.Artifacts(), ctx.Session(), ctx.Branch())
 
 	f := &llminternal.Flow{
 		Model:                a.model,

--- a/agent/workflowagents/parallelagent/agent.go
+++ b/agent/workflowagents/parallelagent/agent.go
@@ -62,7 +62,7 @@ func run(ctx agent.Context) iter.Seq2[*session.Event, error] {
 		}
 
 		errGroup.Go(func() error {
-			ctx := agent.NewContext(errGroupCtx, subAgent, ctx.UserContent(), ctx.Session(), branch)
+			ctx := agent.NewContext(errGroupCtx, subAgent, ctx.UserContent(), ctx.Artifacts(), ctx.Session(), branch)
 
 			if err := runSubAgent(ctx, subAgent, resultsChan, doneChan); err != nil {
 				return fmt.Errorf("failed to run sub-agent %q: %w", subAgent.Name(), err)

--- a/internal/llminternal/agent_transfer_test.go
+++ b/internal/llminternal/agent_transfer_test.go
@@ -48,7 +48,7 @@ func TestAgentTransferRequestProcessor(t *testing.T) {
 			t.Fatal(err)
 		}
 
-		ctx := agent.NewContext(parentmap.ToContext(t.Context(), parents), curAgent, nil, nil, "")
+		ctx := agent.NewContext(parentmap.ToContext(t.Context(), parents), curAgent, nil, nil, nil, "")
 
 		if err := llminternal.AgentTransferRequestProcessor(ctx, req); err != nil {
 			t.Fatalf("AgentTransferRequestProcessor() = %v, want success", err)
@@ -335,7 +335,7 @@ func TestAgentTransferRequestProcessor(t *testing.T) {
 func TestTransferToAgentToolRun(t *testing.T) {
 	t.Run("Success", func(t *testing.T) {
 		curTool := &llminternal.TransferToAgentTool{}
-		ctx := tool.NewContext(agent.NewContext(t.Context(), nil, nil, nil, ""), "", &session.Actions{})
+		ctx := tool.NewContext(agent.NewContext(t.Context(), nil, nil, nil, nil, ""), "", &session.Actions{})
 		wantAgentName := "TestAgent"
 		args := map[string]any{"agent_name": wantAgentName}
 		if _, err := curTool.Run(ctx, args); err != nil {
@@ -360,7 +360,7 @@ func TestTransferToAgentToolRun(t *testing.T) {
 		for _, tc := range testCases {
 			t.Run(tc.name, func(t *testing.T) {
 				curTool := &llminternal.TransferToAgentTool{}
-				ctx := tool.NewContext(agent.NewContext(t.Context(), nil, nil, nil, ""), "", &session.Actions{})
+				ctx := tool.NewContext(agent.NewContext(t.Context(), nil, nil, nil, nil, ""), "", &session.Actions{})
 				if got, err := curTool.Run(ctx, tc.args); err == nil {
 					t.Fatalf("Run(%v) = (%v, %v), want error", tc.args, got, err)
 				}

--- a/internal/llminternal/contents_processor_test.go
+++ b/internal/llminternal/contents_processor_test.go
@@ -219,7 +219,7 @@ func TestContentsRequestProcessor_IncludeContents(t *testing.T) {
 				IncludeContents: tc.includeContents,
 			}))
 
-			ctx := agent.NewContext(t.Context(), testAgent, nil, &fakeSession{
+			ctx := agent.NewContext(t.Context(), testAgent, nil, nil, &fakeSession{
 				events: tc.events,
 			}, "")
 
@@ -368,7 +368,7 @@ func TestContentsRequestProcessor(t *testing.T) {
 				Model: model,
 			}))
 
-			ctx := agent.NewContext(t.Context(), testAgent, nil, &fakeSession{
+			ctx := agent.NewContext(t.Context(), testAgent, nil, nil, &fakeSession{
 				events: tc.events,
 			}, tc.branch)
 
@@ -494,7 +494,7 @@ func TestContentsRequestProcessor_NonLLMAgent(t *testing.T) {
 		Name: "test_agent",
 	}))
 
-	ctx := agent.NewContext(t.Context(), testAgent, nil, nil, "")
+	ctx := agent.NewContext(t.Context(), testAgent, nil, nil, nil, "")
 
 	req := &llm.Request{}
 	if err := llminternal.ContentsRequestProcessor(ctx, req); err != nil {

--- a/runner/artifacts.go
+++ b/runner/artifacts.go
@@ -1,0 +1,73 @@
+// Copyright 2025 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package runner
+
+import (
+	"context"
+
+	"google.golang.org/adk/agent"
+	"google.golang.org/adk/artifactservice"
+	"google.golang.org/adk/session"
+	"google.golang.org/genai"
+)
+
+// artifacts implements Artifacts
+type artifacts struct {
+	service artifactservice.Service
+	id      session.ID
+}
+
+func (a *artifacts) Save(name string, data genai.Part) error {
+	_, err := a.service.Save(context.Background(), &artifactservice.SaveRequest{
+		AppName:   a.id.AppName,
+		UserID:    a.id.UserID,
+		SessionID: a.id.SessionID,
+		FileName:  name,
+		Part:      &data,
+	})
+	return err
+}
+
+func (a *artifacts) Load(name string) (genai.Part, error) {
+	loadResponse, err := a.service.Load(context.Background(), &artifactservice.LoadRequest{
+		AppName:   a.id.AppName,
+		UserID:    a.id.UserID,
+		SessionID: a.id.SessionID,
+		FileName:  name,
+	})
+	return *loadResponse.Part, err
+}
+
+func (a *artifacts) LoadVersion(name string, version int) (genai.Part, error) {
+	loadResponse, err := a.service.Load(context.Background(), &artifactservice.LoadRequest{
+		AppName:   a.id.AppName,
+		UserID:    a.id.UserID,
+		SessionID: a.id.SessionID,
+		FileName:  name,
+		Version:   int64(version),
+	})
+	return *loadResponse.Part, err
+}
+
+func (a *artifacts) List() ([]string, error) {
+	ListResponse, err := a.service.List(context.Background(), &artifactservice.ListRequest{
+		AppName:   a.id.AppName,
+		UserID:    a.id.UserID,
+		SessionID: a.id.SessionID,
+	})
+	return ListResponse.FileNames, err
+}
+
+var _ agent.Artifacts = (*artifacts)(nil)

--- a/runner/artifacts_test.go
+++ b/runner/artifacts_test.go
@@ -1,0 +1,100 @@
+// Copyright 2025 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package runner
+
+import (
+	"testing"
+
+	"github.com/google/go-cmp/cmp"
+	"google.golang.org/adk/artifactservice"
+	"google.golang.org/adk/session"
+	"google.golang.org/genai"
+)
+
+func TestArtifacts(t *testing.T) {
+	inMemoryArtifactService := artifactservice.Mem()
+
+	testSessionID := session.ID{
+		AppName:   "testApp",
+		UserID:    "testUser",
+		SessionID: "testSession",
+	}
+	a := artifacts{
+		service: inMemoryArtifactService,
+		id:      testSessionID,
+	}
+
+	// Save
+	part := *genai.NewPartFromText("test data")
+	err := a.Save("testArtifact", part)
+	if err != nil {
+		t.Fatalf("Save failed: %v", err)
+	}
+
+	// Load
+	loadedPart, err := a.Load("testArtifact")
+	if err != nil {
+		t.Fatalf("Load failed: %v", err)
+	}
+
+	if diff := cmp.Diff(part, loadedPart); diff != "" {
+		t.Errorf("Loaded part differs from saved part (-want +got):\n%s", diff)
+	}
+
+	// List
+	fileNames, err := a.List()
+	if err != nil {
+		t.Fatalf("List failed: %v", err)
+	}
+
+	expectedFileNames := []string{"testArtifact"}
+	if diff := cmp.Diff(expectedFileNames, fileNames); diff != "" {
+		t.Errorf("List returned unexpected file names (-want +got):\n%s", diff)
+	}
+}
+
+func TestArtifacts_WithLoadVersion(t *testing.T) {
+	inMemoryArtifactService := artifactservice.Mem()
+
+	testSessionID := session.ID{
+		AppName:   "testApp",
+		UserID:    "testUser",
+		SessionID: "testSession",
+	}
+	a := artifacts{
+		service: inMemoryArtifactService,
+		id:      testSessionID,
+	}
+
+	part := *genai.NewPartFromText("test data")
+	err := a.Save("testArtifact", part)
+	if err != nil {
+		t.Fatalf("Save failed: %v", err)
+	}
+	part2 := *genai.NewPartFromText("test data 2")
+	err = a.Save("testArtifact", part2)
+	if err != nil {
+		t.Fatalf("Save failed: %v", err)
+	}
+
+	loadedPart, err := a.LoadVersion("testArtifact", 0)
+	if err != nil {
+		t.Fatalf("Load failed: %v", err)
+	}
+
+	if diff := cmp.Diff(part2, loadedPart); diff != "" {
+		t.Errorf("Loaded part differs from saved part (-want +got):\n%s", diff)
+	}
+}


### PR DESCRIPTION
In the following PRs I will replace load_artifacts_tool tests with real implementation and also add artifacts service logic (to save appended messages) to the runner. 