### PR TITLE
Handle errors in Runner Artifacts Service

### DIFF
--- a/runner/artifacts.go
+++ b/runner/artifacts.go
@@ -47,7 +47,10 @@ func (a *artifacts) Load(name string) (genai.Part, error) {
 		SessionID: a.id.SessionID,
 		FileName:  name,
 	})
-	return *loadResponse.Part, err
+	if err != nil {
+		return genai.Part{}, err
+	}
+	return *loadResponse.Part, nil
 }
 
 func (a *artifacts) LoadVersion(name string, version int) (genai.Part, error) {
@@ -58,7 +61,10 @@ func (a *artifacts) LoadVersion(name string, version int) (genai.Part, error) {
 		FileName:  name,
 		Version:   int64(version),
 	})
-	return *loadResponse.Part, err
+	if err != nil {
+		return genai.Part{}, err
+	}
+	return *loadResponse.Part, nil
 }
 
 func (a *artifacts) List() ([]string, error) {
@@ -67,7 +73,10 @@ func (a *artifacts) List() ([]string, error) {
 		UserID:    a.id.UserID,
 		SessionID: a.id.SessionID,
 	})
-	return ListResponse.FileNames, err
+	if err != nil {
+		return nil, err
+	}
+	return ListResponse.FileNames, nil
 }
 
 var _ agent.Artifacts = (*artifacts)(nil)

--- a/runner/artifacts_test.go
+++ b/runner/artifacts_test.go
@@ -98,3 +98,41 @@ func TestArtifacts_WithLoadVersion(t *testing.T) {
 		t.Errorf("Loaded part differs from saved part (-want +got):\n%s", diff)
 	}
 }
+
+func TestArtifacts_Errors(t *testing.T) {
+	inMemoryArtifactService := artifactservice.Mem()
+
+	testSessionID := session.ID{
+		AppName:   "testApp",
+		UserID:    "testUser",
+		SessionID: "testSession",
+	}
+	a := artifacts{
+		service: inMemoryArtifactService,
+		id:      testSessionID,
+	}
+
+	// Attempt to Load non-existent artifact
+	_, err := a.Load("nonExistentArtifact")
+	if err == nil {
+		t.Errorf("Load(\"nonExistentArtifact\") succeeded, want error")
+	}
+
+	// Attempt to LoadVersion non-existent artifact
+	_, err = a.LoadVersion("nonExistentArtifact", 0)
+	if err == nil {
+		t.Errorf("LoadVersion(\"nonExistentArtifact\", 0) succeeded, want error")
+	}
+
+	// Save an artifact to test LoadVersion with an invalid version
+	part := *genai.NewPartFromText("test data")
+	if err := a.Save("existsArtifact", part); err != nil {
+		t.Fatalf("Save(\"existsArtifact\") failed: %v", err)
+	}
+
+	// Attempt to LoadVersion with a version number that doesn't exist
+	_, err = a.LoadVersion("existsArtifact", 99)
+	if err == nil {
+		t.Errorf("LoadVersion(\"existsArtifact\", 99) succeeded, want error")
+	}
+}


### PR DESCRIPTION
Ideally there's should be a test for List as well but hard to make artifactservice.Mem() implementation throw an error for List().