### PR TITLE
Use real Artifacts implementation in load artifacts tool tests

### DIFF
--- a/internal/artifactsinternal/artifacts.go
+++ b/internal/artifactsinternal/artifacts.go
@@ -12,7 +12,7 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-package runner
+package artifactsinternal
 
 import (
 	"context"
@@ -23,13 +23,21 @@ import (
 	"google.golang.org/genai"
 )
 
-// artifacts implements Artifacts
-type artifacts struct {
+// Artifacts implements Artifacts
+type Artifacts struct {
 	service artifactservice.Service
 	id      session.ID
 }
 
-func (a *artifacts) Save(name string, data genai.Part) error {
+// NewArtifacts creates and returns Artifacts implementation.
+func NewArtifacts(service artifactservice.Service, id session.ID) *Artifacts {
+	return &Artifacts{
+		service: service,
+		id:      id,
+	}
+}
+
+func (a *Artifacts) Save(name string, data genai.Part) error {
 	_, err := a.service.Save(context.Background(), &artifactservice.SaveRequest{
 		AppName:   a.id.AppName,
 		UserID:    a.id.UserID,
@@ -40,7 +48,7 @@ func (a *artifacts) Save(name string, data genai.Part) error {
 	return err
 }
 
-func (a *artifacts) Load(name string) (genai.Part, error) {
+func (a *Artifacts) Load(name string) (genai.Part, error) {
 	loadResponse, err := a.service.Load(context.Background(), &artifactservice.LoadRequest{
 		AppName:   a.id.AppName,
 		UserID:    a.id.UserID,
@@ -53,7 +61,7 @@ func (a *artifacts) Load(name string) (genai.Part, error) {
 	return *loadResponse.Part, nil
 }
 
-func (a *artifacts) LoadVersion(name string, version int) (genai.Part, error) {
+func (a *Artifacts) LoadVersion(name string, version int) (genai.Part, error) {
 	loadResponse, err := a.service.Load(context.Background(), &artifactservice.LoadRequest{
 		AppName:   a.id.AppName,
 		UserID:    a.id.UserID,
@@ -67,7 +75,7 @@ func (a *artifacts) LoadVersion(name string, version int) (genai.Part, error) {
 	return *loadResponse.Part, nil
 }
 
-func (a *artifacts) List() ([]string, error) {
+func (a *Artifacts) List() ([]string, error) {
 	ListResponse, err := a.service.List(context.Background(), &artifactservice.ListRequest{
 		AppName:   a.id.AppName,
 		UserID:    a.id.UserID,
@@ -79,4 +87,4 @@ func (a *artifacts) List() ([]string, error) {
 	return ListResponse.FileNames, nil
 }
 
-var _ agent.Artifacts = (*artifacts)(nil)
+var _ agent.Artifacts = (*Artifacts)(nil)

--- a/internal/artifactsinternal/artifacts_test.go
+++ b/internal/artifactsinternal/artifacts_test.go
@@ -12,13 +12,14 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-package runner
+package artifactsinternal_test
 
 import (
 	"testing"
 
 	"github.com/google/go-cmp/cmp"
 	"google.golang.org/adk/artifactservice"
+	"google.golang.org/adk/internal/artifactsinternal"
 	"google.golang.org/adk/session"
 	"google.golang.org/genai"
 )
@@ -31,10 +32,7 @@ func TestArtifacts(t *testing.T) {
 		UserID:    "testUser",
 		SessionID: "testSession",
 	}
-	a := artifacts{
-		service: inMemoryArtifactService,
-		id:      testSessionID,
-	}
+	a := artifactsinternal.NewArtifacts(inMemoryArtifactService, testSessionID)
 
 	// Save
 	part := *genai.NewPartFromText("test data")
@@ -73,10 +71,8 @@ func TestArtifacts_WithLoadVersion(t *testing.T) {
 		UserID:    "testUser",
 		SessionID: "testSession",
 	}
-	a := artifacts{
-		service: inMemoryArtifactService,
-		id:      testSessionID,
-	}
+
+	a := artifactsinternal.NewArtifacts(inMemoryArtifactService, testSessionID)
 
 	part := *genai.NewPartFromText("test data")
 	err := a.Save("testArtifact", part)
@@ -107,10 +103,7 @@ func TestArtifacts_Errors(t *testing.T) {
 		UserID:    "testUser",
 		SessionID: "testSession",
 	}
-	a := artifacts{
-		service: inMemoryArtifactService,
-		id:      testSessionID,
-	}
+	a := artifactsinternal.NewArtifacts(inMemoryArtifactService, testSessionID)
 
 	// Attempt to Load non-existent artifact
 	_, err := a.Load("nonExistentArtifact")

--- a/runner/runner.go
+++ b/runner/runner.go
@@ -25,6 +25,7 @@ import (
 	"google.golang.org/adk/artifactservice"
 	"google.golang.org/adk/internal/agent/parentmap"
 	"google.golang.org/adk/internal/agent/runconfig"
+	"google.golang.org/adk/internal/artifactsinternal"
 	"google.golang.org/adk/internal/llminternal"
 	"google.golang.org/adk/llm"
 	"google.golang.org/adk/session"
@@ -103,10 +104,7 @@ func (r *Runner) Run(ctx context.Context, userID, sessionID string, msg *genai.C
 
 		var artifactsImpl agent.Artifacts = nil
 		if r.artifactService != nil {
-			artifactsImpl = &artifacts{
-				service: r.artifactService,
-				id:      session.ID(),
-			}
+			artifactsImpl = artifactsinternal.NewArtifacts(r.artifactService, session.ID())
 		}
 
 		ctx := agent.NewContext(ctx, agentToRun, msg, artifactsImpl, &mutableSession{


### PR DESCRIPTION
Before Artifacts (in agent context) was implemented, we used mocking to unblock the load artifacts tool implementation, since now it's implemented we can update the tests.

Also added NewArtifacts method to artifacts, now it's easier to create Artifacts service in artifacts_test and it can be created outside of the package for testing as well. Otherwise I will need to create Runner and call run method to test things outside of the package (Because that's where Artifacts is initialized and put in AgentContext).