### PR TITLE
Implement runner.Config

### DIFF
--- a/agent/llmagent/llmagent_test.go
+++ b/agent/llmagent/llmagent_test.go
@@ -562,7 +562,11 @@ func newTestAgentRunner(t *testing.T, agent agent.Agent) *testAgentRunner {
 	appName := "test_app"
 	sessionService := sessionservice.Mem()
 
-	runner, err := runner.New(appName, agent, sessionService)
+	runner, err := runner.New(&runner.Config{
+		AppName:        appName,
+		Agent:          agent,
+		SessionService: sessionService,
+	})
 	if err != nil {
 		t.Fatal(err)
 	}

--- a/agent/workflowagents/loopagent/agent_test.go
+++ b/agent/workflowagents/loopagent/agent_test.go
@@ -105,7 +105,11 @@ func TestNewLoopAgent(t *testing.T) {
 
 			sessionService := sessionservice.Mem()
 
-			agentRunner, err := runner.New("test_app", agent, sessionService)
+			agentRunner, err := runner.New(&runner.Config{
+				AppName:        "test_app",
+				Agent:          agent,
+				SessionService: sessionService,
+			})
 			if err != nil {
 				t.Fatal(err)
 			}

--- a/agent/workflowagents/parallelagent/agent_test.go
+++ b/agent/workflowagents/parallelagent/agent_test.go
@@ -96,7 +96,11 @@ func TestNewParallelAgent(t *testing.T) {
 
 			sessionService := sessionservice.Mem()
 
-			agentRunner, err := runner.New("test_app", agent, sessionService)
+			agentRunner, err := runner.New(&runner.Config{
+				AppName:        "test_app",
+				Agent:          agent,
+				SessionService: sessionService,
+			})
 			if err != nil {
 				t.Fatal(err)
 			}

--- a/agent/workflowagents/sequentialagent/agent_test.go
+++ b/agent/workflowagents/sequentialagent/agent_test.go
@@ -94,7 +94,11 @@ func TestNewSequentialAgent(t *testing.T) {
 
 			sessionService := sessionservice.Mem()
 
-			agentRunner, err := runner.New("test_app", agent, sessionService)
+			agentRunner, err := runner.New(&runner.Config{
+				AppName:        "test_app",
+				Agent:          agent,
+				SessionService: sessionService,
+			})
 			if err != nil {
 				t.Fatal(err)
 			}

--- a/examples/userloop.go
+++ b/examples/userloop.go
@@ -42,7 +42,11 @@ func Run(ctx context.Context, rootAgent agent.Agent) {
 
 	session := resp.Session
 
-	r, err := runner.New(appName, rootAgent, sessionService)
+	r, err := runner.New(&runner.Config{
+		AppName:        appName,
+		Agent:          rootAgent,
+		SessionService: sessionService,
+	})
 	if err != nil {
 		log.Fatalf("Failed to create runner: %v", err)
 	}

--- a/runner/runner.go
+++ b/runner/runner.go
@@ -32,17 +32,25 @@ import (
 	"google.golang.org/genai"
 )
 
-func New(appName string, rootAgent agent.Agent, sessionService sessionservice.Service) (*Runner, error) {
-	parents, err := parentmap.New(rootAgent)
+type Config struct {
+	AppName         string
+	Agent           agent.Agent
+	SessionService  sessionservice.Service
+	ArtifactService artifactservice.Service
+}
+
+func New(cfg *Config) (*Runner, error) {
+	parents, err := parentmap.New(cfg.Agent)
 	if err != nil {
 		return nil, fmt.Errorf("failed to create agent tree: %w", err)
 	}
 
 	return &Runner{
-		appName:        appName,
-		rootAgent:      rootAgent,
-		sessionService: sessionService,
-		parents:        parents,
+		appName:         cfg.AppName,
+		rootAgent:       cfg.Agent,
+		sessionService:  cfg.SessionService,
+		artifactService: cfg.ArtifactService,
+		parents:         parents,
 	}, nil
 }
 

--- a/runner/runner_test.go
+++ b/runner/runner_test.go
@@ -181,7 +181,11 @@ func Test_isTransferrableAcrossAgentTree(t *testing.T) {
 	}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			runner, err := New("testApp", tt.agent, sessionservice.Mem())
+			runner, err := New(&Config{
+				AppName:        "testApp",
+				Agent:          tt.agent,
+				SessionService: sessionservice.Mem(),
+			})
 			if err != nil {
 				t.Fatal(err)
 			}
@@ -210,7 +214,11 @@ func TestRunner_SaveInputBlobsAsArtifacts(t *testing.T) {
 		},
 	}))
 
-	r, err := New(appName, testAgent, sessionService)
+	r, err := New(&Config{
+		AppName:        appName,
+		Agent:          testAgent,
+		SessionService: sessionService,
+	})
 	if err != nil {
 		t.Fatalf("New() error = %v", err)
 	}


### PR DESCRIPTION
With this change, we will be able to provide only required arguments to the runner. No more need to provide `nil` for optional fields.