### PR TITLE
Implement session.Session in agentContext

### DIFF
--- a/internal/sessioninternal/session.go
+++ b/internal/sessioninternal/session.go
@@ -1,0 +1,20 @@
+// Copyright 2025 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+// Package tool defines internal-only interfaces and logic for tools.
+package sessioninternal
+
+type MutableState interface {
+	Set(string, any) error
+}

--- a/runner/session_test.go
+++ b/runner/session_test.go
@@ -1,0 +1,192 @@
+// Copyright 2025 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package runner
+
+import (
+	"context"
+	"fmt"
+	"reflect"
+	"testing"
+
+	"github.com/google/go-cmp/cmp"
+
+	"google.golang.org/adk/session"
+	"google.golang.org/adk/sessionservice"
+)
+
+func createMutableSession(ctx context.Context, t *testing.T, sessionID string, initialData map[string]any) (*mutableSession, sessionservice.Service) {
+	t.Helper()
+	service := sessionservice.Mem()
+	req := &sessionservice.CreateRequest{
+		AppName:   "testApp",
+		UserID:    "testUser",
+		SessionID: sessionID,
+		State:     initialData,
+	}
+	createResp, err := service.Create(ctx, req)
+	if err != nil {
+		t.Fatalf("Failed to create session %q: %v", sessionID, err)
+	}
+
+	return &mutableSession{
+		service:       service,
+		storedSession: createResp.Session,
+	}, service
+}
+
+func TestMutableSession_SetGet(t *testing.T) {
+	ctx := context.Background()
+
+	tests := []struct {
+		name    string
+		key     string
+		value   any
+		initial map[string]any
+	}{
+		{name: "string", key: "myKey", value: "myValue"},
+		{name: "int", key: "count", value: 123},
+		{name: "bool", key: "enabled", value: true},
+		{name: "overwrite", key: "myKey", value: "newValue", initial: map[string]any{"myKey": "oldValue"}},
+		{name: "new_key", key: "newKey", value: 456, initial: map[string]any{"existing": "val"}},
+	}
+
+	for i, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			sessionID := fmt.Sprintf("testSetGet-%d", i)
+			ms, _ := createMutableSession(ctx, t, sessionID, tc.initial)
+
+			if err := ms.Set(tc.key, tc.value); err != nil {
+				t.Fatalf("Set(%q, %v) failed unexpectedly: %v", tc.key, tc.value, err)
+			}
+
+			got, err := ms.Get(tc.key)
+			if err != nil {
+				t.Fatalf("Get(%q) failed unexpectedly: %v", tc.key, err)
+			}
+			if diff := cmp.Diff(tc.value, got); diff != "" {
+				t.Errorf("Get(%q) returned diff (-want +got):\n%s", tc.key, diff)
+			}
+		})
+	}
+}
+
+func TestMutableSession_Set_Persistence(t *testing.T) {
+	ctx := context.Background()
+	sessionID := "testSetPersistence"
+	ms, service := createMutableSession(ctx, t, sessionID, nil)
+
+	testKey := "persistKey"
+	testValue := "persistValue"
+
+	if err := ms.Set(testKey, testValue); err != nil {
+		t.Fatalf("Set(%q, %v) failed: %v", testKey, testValue, err)
+	}
+
+	req := &sessionservice.GetRequest{ID: ms.ID()}
+	getResp, err := service.Get(ctx, req)
+	if err != nil {
+		t.Fatalf("service.Get failed: %v", err)
+	}
+
+	val, err := getResp.Session.State().Get(testKey)
+	if err != nil {
+		t.Fatalf("storedSess.State().Get(%q) failed: %v", testKey, err)
+	}
+	if diff := cmp.Diff(testValue, val); diff != "" {
+		t.Errorf("Persisted state diff (-want +got):\n%s", diff)
+	}
+}
+
+func TestMutableSession_All(t *testing.T) {
+	ctx := context.Background()
+
+	tests := []struct {
+		name    string
+		initial map[string]any
+	}{
+		{
+			name: "multiple",
+			initial: map[string]any{
+				"key1": "value1",
+				"key2": 100,
+				"key3": true,
+			},
+		},
+		{
+			name:    "empty",
+			initial: nil,
+		},
+	}
+
+	for i, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			sessionID := fmt.Sprintf("testAll-%d", i)
+			ms, _ := createMutableSession(ctx, t, sessionID, tc.initial)
+
+			gotMap := make(map[string]any)
+			for k, v := range ms.All() {
+				gotMap[k] = v
+			}
+
+			wantMap := tc.initial
+			if wantMap == nil {
+				wantMap = map[string]any{}
+			}
+
+			if diff := cmp.Diff(wantMap, gotMap); diff != "" {
+				t.Errorf("All() returned diff (-want +got):\n%s", diff)
+			}
+		})
+	}
+}
+
+func TestMutableSession_PassthroughMethods(t *testing.T) {
+	ctx := context.Background()
+	sessionID := "testPassthrough"
+	testID := session.ID{AppName: "testApp", UserID: "testUser", SessionID: sessionID}
+
+	service := sessionservice.Mem()
+	createReq := &sessionservice.CreateRequest{AppName: testID.AppName, UserID: testID.UserID, SessionID: sessionID}
+	createResp, err := service.Create(ctx, createReq)
+	if err != nil {
+		t.Fatalf("Failed to create session: %v", err)
+	}
+
+	ms := &mutableSession{
+		service:       service,
+		storedSession: createResp.Session,
+	}
+
+	if got := ms.ID(); !reflect.DeepEqual(got, testID) {
+		t.Errorf("ID() = %v, want %v", got, testID)
+	}
+
+	wantUpdatedTime := createResp.Session.Updated()
+	if got := ms.Updated(); !got.Equal(wantUpdatedTime) || got.IsZero() {
+		t.Errorf("Updated() = %v, want %v (non-zero)", got, wantUpdatedTime)
+	}
+
+	if ms.Events() == nil {
+		t.Errorf("Events() = nil, want non-nil")
+	}
+
+	state := ms.State()
+	if state == nil {
+		t.Fatalf("State() returned nil")
+	}
+	if _, ok := state.(*mutableSession); !ok {
+		t.Errorf("State() did not return *mutableSession as expected")
+	}
+}

--- a/session/session.go
+++ b/session/session.go
@@ -36,14 +36,14 @@ type ID struct {
 }
 
 type State interface {
-	Get(string) any
-	Set(string, any)
+	Get(string) (any, error)
+	Set(string, any) error
 	All() iter.Seq2[string, any]
 }
 
 // TODO: It is provided for use by SessionService, and perhaps it should move there.
 type ReadOnlyState interface {
-	Get(string) any
+	Get(string) (any, error)
 	All() iter.Seq2[string, any]
 }
 


### PR DESCRIPTION
I've added "error" as return value for Set and Get as proposed in the api doc, obviously this can change in the future. Probably it makes sense to move this thing to internal folder.

Also I made a small change in sessionservice/inmemory.go to create empty map for state if it's nil in the request, similar thing is done in java: https://github.com/google/adk-java/blob/main/core/src/main/java/com/google/adk/sessions/InMemorySessionService.java#L88-L89

Lots of things might change, just doing it right now to make it ready for fishfood