### PR TITLE
Minor fixes

### DIFF
--- a/internal/utils/utils_test.go
+++ b/internal/utils/utils_test.go
@@ -13,3 +13,9 @@
 // limitations under the License.
 
 package utils_test
+
+import "testing"
+
+func TestNothing(t *testing.T) {
+	// To make it buildable.
+}

--- a/tool/function.go
+++ b/tool/function.go
@@ -167,7 +167,7 @@ func (f *functionTool[TArgs, TResults]) Run(ctx Context, args any) (any, error) 
 	// 		function_result = {'result': function_result}
 	if f.outputSchema != nil {
 		if err1 := f.outputSchema.Validate(output); err1 != nil {
-			return resp, err //if it fails propagate original err.
+			return resp, err // if it fails propagate original err.
 		}
 	}
 	wrappedOutput := map[string]any{"result": output}


### PR DESCRIPTION
When using copybara to update g3, test doesn't build without one test and it also complains that the comment doesn't start with space. I'll address other linter complains in another pr (Lots of exported fields doesn't have comments e.g.)