### PR TITLE
Integrate Memory Service into ADK runtime

### DIFF
--- a/agent/agent_test.go
+++ b/agent/agent_test.go
@@ -108,7 +108,7 @@ func TestAgentCallbacks(t *testing.T) {
 				t.Fatalf("failed to create agent: %v", err)
 			}
 
-			ctx := NewContext(ctx, testAgent, genai.NewContentFromText("", genai.RoleUser), nil, nil, "")
+			ctx := NewContext(ctx, testAgent, genai.NewContentFromText("", genai.RoleUser), nil, nil, nil, "")
 			var gotEvents []*session.Event
 			for event, err := range testAgent.Run(ctx) {
 				if err != nil {

--- a/agent/context.go
+++ b/agent/context.go
@@ -30,13 +30,14 @@ type agentContext struct {
 	agent        Agent
 	session      session.Session
 	artifacts    Artifacts
+	memory       Memory
 
 	userContent *genai.Content
 	branch      string
 }
 
 // TODO: see if needed or possible to make internal
-func NewContext(ctx context.Context, agent Agent, userContent *genai.Content, artifacts Artifacts, session session.Session, branch string) *agentContext {
+func NewContext(ctx context.Context, agent Agent, userContent *genai.Content, artifacts Artifacts, session session.Session, memory Memory, branch string) *agentContext {
 	ctx, cancel := context.WithCancel(ctx)
 
 	return &agentContext{
@@ -47,6 +48,7 @@ func NewContext(ctx context.Context, agent Agent, userContent *genai.Content, ar
 		agent:        agent,
 		artifacts:    artifacts,
 		session:      session,
+		memory:       memory,
 		userContent:  userContent,
 		branch:       branch,
 	}
@@ -74,6 +76,10 @@ func (a *agentContext) Session() session.Session {
 
 func (a *agentContext) Artifacts() Artifacts {
 	return a.artifacts
+}
+
+func (a *agentContext) Memory() Memory {
+	return a.memory
 }
 
 func (*agentContext) Report(*session.Event) {

--- a/agent/llmagent/llmagent.go
+++ b/agent/llmagent/llmagent.go
@@ -153,7 +153,7 @@ type llmAgent struct {
 
 func (a *llmAgent) run(ctx agent.Context) iter.Seq2[*session.Event, error] {
 	// TODO: branch context?
-	ctx = agent.NewContext(ctx, a, ctx.UserContent(), ctx.Artifacts(), ctx.Session(), ctx.Branch())
+	ctx = agent.NewContext(ctx, a, ctx.UserContent(), ctx.Artifacts(), ctx.Session(), ctx.Memory(), ctx.Branch())
 
 	f := &llminternal.Flow{
 		Model:                a.model,

--- a/agent/workflowagents/parallelagent/agent.go
+++ b/agent/workflowagents/parallelagent/agent.go
@@ -62,7 +62,7 @@ func run(ctx agent.Context) iter.Seq2[*session.Event, error] {
 		}
 
 		errGroup.Go(func() error {
-			ctx := agent.NewContext(errGroupCtx, subAgent, ctx.UserContent(), ctx.Artifacts(), ctx.Session(), branch)
+			ctx := agent.NewContext(errGroupCtx, subAgent, ctx.UserContent(), ctx.Artifacts(), ctx.Session(), ctx.Memory(), branch)
 
 			if err := runSubAgent(ctx, subAgent, resultsChan, doneChan); err != nil {
 				return fmt.Errorf("failed to run sub-agent %q: %w", subAgent.Name(), err)

--- a/internal/llminternal/agent_transfer_test.go
+++ b/internal/llminternal/agent_transfer_test.go
@@ -48,7 +48,7 @@ func TestAgentTransferRequestProcessor(t *testing.T) {
 			t.Fatal(err)
 		}
 
-		ctx := agent.NewContext(parentmap.ToContext(t.Context(), parents), curAgent, nil, nil, nil, "")
+		ctx := agent.NewContext(parentmap.ToContext(t.Context(), parents), curAgent, nil, nil, nil, nil, "")
 
 		if err := llminternal.AgentTransferRequestProcessor(ctx, req); err != nil {
 			t.Fatalf("AgentTransferRequestProcessor() = %v, want success", err)
@@ -335,7 +335,7 @@ func TestAgentTransferRequestProcessor(t *testing.T) {
 func TestTransferToAgentToolRun(t *testing.T) {
 	t.Run("Success", func(t *testing.T) {
 		curTool := &llminternal.TransferToAgentTool{}
-		ctx := tool.NewContext(agent.NewContext(t.Context(), nil, nil, nil, nil, ""), "", &session.Actions{})
+		ctx := tool.NewContext(agent.NewContext(t.Context(), nil, nil, nil, nil, nil, ""), "", &session.Actions{})
 		wantAgentName := "TestAgent"
 		args := map[string]any{"agent_name": wantAgentName}
 		if _, err := curTool.Run(ctx, args); err != nil {
@@ -360,7 +360,7 @@ func TestTransferToAgentToolRun(t *testing.T) {
 		for _, tc := range testCases {
 			t.Run(tc.name, func(t *testing.T) {
 				curTool := &llminternal.TransferToAgentTool{}
-				ctx := tool.NewContext(agent.NewContext(t.Context(), nil, nil, nil, nil, ""), "", &session.Actions{})
+				ctx := tool.NewContext(agent.NewContext(t.Context(), nil, nil, nil, nil, nil, ""), "", &session.Actions{})
 				if got, err := curTool.Run(ctx, tc.args); err == nil {
 					t.Fatalf("Run(%v) = (%v, %v), want error", tc.args, got, err)
 				}

--- a/internal/llminternal/contents_processor_test.go
+++ b/internal/llminternal/contents_processor_test.go
@@ -221,7 +221,7 @@ func TestContentsRequestProcessor_IncludeContents(t *testing.T) {
 
 			ctx := agent.NewContext(t.Context(), testAgent, nil, nil, &fakeSession{
 				events: tc.events,
-			}, "")
+			}, nil, "")
 
 			req := &llm.Request{}
 			if err := llminternal.ContentsRequestProcessor(ctx, req); err != nil {
@@ -370,7 +370,7 @@ func TestContentsRequestProcessor(t *testing.T) {
 
 			ctx := agent.NewContext(t.Context(), testAgent, nil, nil, &fakeSession{
 				events: tc.events,
-			}, tc.branch)
+			}, nil, tc.branch)
 
 			req := &llm.Request{}
 			if err := llminternal.ContentsRequestProcessor(ctx, req); err != nil {
@@ -494,7 +494,7 @@ func TestContentsRequestProcessor_NonLLMAgent(t *testing.T) {
 		Name: "test_agent",
 	}))
 
-	ctx := agent.NewContext(t.Context(), testAgent, nil, nil, nil, "")
+	ctx := agent.NewContext(t.Context(), testAgent, nil, nil, nil, nil, "")
 
 	req := &llm.Request{}
 	if err := llminternal.ContentsRequestProcessor(ctx, req); err != nil {

--- a/internal/memoryinternal/memory.go
+++ b/internal/memoryinternal/memory.go
@@ -1,0 +1,57 @@
+// Copyright 2025 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package memoryinternal
+
+import (
+	"context"
+	"fmt"
+
+	"google.golang.org/adk/memoryservice"
+	"google.golang.org/adk/session"
+)
+
+// Memory implements Memory
+type Memory struct {
+	service memoryservice.Service
+	id      session.ID
+}
+
+// NewMemory creates and returns Memory implementation.
+func NewMemory(service memoryservice.Service, id session.ID) *Memory {
+	return &Memory{
+		service: service,
+		id:      id,
+	}
+}
+
+func (a *Memory) AddSession(session session.Session) error {
+	err := a.service.AddSession(context.Background(), session)
+	if err != nil {
+		return fmt.Errorf("could not add session to memory service: %w", err)
+	}
+	return nil
+}
+
+func (a *Memory) Search(query string) ([]memoryservice.MemoryEntry, error) {
+	searchResponse, err := a.service.Search(context.Background(), &memoryservice.SearchRequest{
+		AppName: a.id.AppName,
+		UserID:  a.id.UserID,
+		Query:   query,
+	})
+	if err != nil {
+		return nil, err
+	}
+	return searchResponse.Memories, nil
+}

--- a/internal/memoryinternal/memory_test.go
+++ b/internal/memoryinternal/memory_test.go
@@ -1,0 +1,249 @@
+// Copyright 2025 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package memoryinternal_test
+
+import (
+	"testing"
+	"time"
+
+	"github.com/google/go-cmp/cmp"
+	"github.com/google/go-cmp/cmp/cmpopts"
+
+	"google.golang.org/adk/internal/memoryinternal"
+	"google.golang.org/adk/internal/sessioninternal"
+	"google.golang.org/adk/llm"
+	"google.golang.org/adk/memoryservice"
+	"google.golang.org/adk/session"
+	"google.golang.org/adk/sessionservice"
+	"google.golang.org/genai"
+)
+
+func TestMemory_AddAndSearch(t *testing.T) {
+	memService := memoryservice.Mem()
+	testID := session.ID{
+		AppName:   "testApp",
+		UserID:    "testUser",
+		SessionID: "sess1",
+	}
+	memory := memoryinternal.NewMemory(memService, testID)
+
+	content1 := genai.NewContentFromText("The quick brown fox", genai.RoleUser)
+	content2 := genai.NewContentFromText("jumps over the lazy dog", genai.RoleUser)
+
+	events := []*session.Event{
+		{
+			Time:   time.Date(2025, 1, 1, 10, 0, 0, 0, time.UTC),
+			Author: "user1",
+			LLMResponse: &llm.Response{
+				Content: content1,
+			},
+		},
+		{
+			Time:   time.Date(2025, 1, 1, 10, 5, 0, 0, time.UTC),
+			Author: "user1",
+			LLMResponse: &llm.Response{
+				Content: content2,
+			},
+		},
+	}
+	sessionService := sessionservice.Mem()
+	createResponse, err := sessionService.Create(t.Context(), &sessionservice.CreateRequest{
+		AppName:   testID.AppName,
+		UserID:    testID.UserID,
+		SessionID: testID.SessionID,
+	})
+	if err != nil {
+		t.Fatalf("Failed to create session: %v", err)
+	}
+	session := createResponse.Session
+	for _, event := range events {
+		if err := sessionService.AppendEvent(t.Context(), session, event); err != nil {
+			t.Fatalf("Failed to append event: %v", err)
+		}
+	}
+
+	if err := memory.AddSession(sessioninternal.NewMutableSession(sessionService, session)); err != nil {
+		t.Fatalf("AddSession failed: %v", err)
+	}
+
+	// Expected MemoryEntry items
+	entry1 := memoryservice.MemoryEntry{
+		Content:   content1,
+		Author:    "user1",
+		Timestamp: time.Date(2025, 1, 1, 10, 0, 0, 0, time.UTC),
+	}
+	entry2 := memoryservice.MemoryEntry{
+		Content:   content2,
+		Author:    "user1",
+		Timestamp: time.Date(2025, 1, 1, 10, 5, 0, 0, time.UTC),
+	}
+
+	tests := []struct {
+		name  string
+		query string
+		want  []memoryservice.MemoryEntry
+	}{
+		{
+			name:  "match first entry",
+			query: "fox",
+			want:  []memoryservice.MemoryEntry{entry1},
+		},
+		{
+			name:  "match second entry",
+			query: "DOG", // Search should be case-insensitive
+			want:  []memoryservice.MemoryEntry{entry2},
+		},
+		{
+			name:  "match both entries (any word)",
+			query: "quick dog",
+			want:  []memoryservice.MemoryEntry{entry1, entry2},
+		},
+		{
+			name:  "match word in both",
+			query: "the",
+			want:  []memoryservice.MemoryEntry{entry1, entry2},
+		},
+		{
+			name:  "no match",
+			query: "unrelated",
+			want:  nil,
+		},
+		{
+			name:  "empty query",
+			query: "",
+			want:  nil,
+		},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			got, err := memory.Search(tc.query)
+			if err != nil {
+				t.Fatalf("Search(%q) failed: %v", tc.query, err)
+			}
+
+			sortOpt := cmpopts.SortSlices(func(a, b memoryservice.MemoryEntry) bool {
+				return a.Timestamp.Before(b.Timestamp)
+			})
+
+			if diff := cmp.Diff(tc.want, got, sortOpt, cmpopts.EquateEmpty()); diff != "" {
+				t.Errorf("Search(%q) returned diff (-want +got):\n%s", tc.query, diff)
+			}
+		})
+	}
+}
+
+func TestMemory_Search_NoData(t *testing.T) {
+	memService := memoryservice.Mem()
+	testID := session.ID{
+		AppName:   "testApp",
+		UserID:    "testUser",
+		SessionID: "sess2",
+	}
+	memory := memoryinternal.NewMemory(memService, testID)
+
+	got, err := memory.Search("any query")
+	if err != nil {
+		t.Fatalf("Search() failed: %v", err)
+	}
+	if len(got) != 0 {
+		t.Errorf("Search() on empty memory returned %d items, want 0", len(got))
+	}
+}
+
+func TestMemory_Search_Isolation(t *testing.T) {
+	memService := memoryservice.Mem()
+
+	// Add data for User1
+	testID1 := session.ID{
+		AppName:   "testApp",
+		UserID:    "user1",
+		SessionID: "sess1",
+	}
+	memory1 := memoryinternal.NewMemory(memService, testID1)
+	content1 := genai.NewContentFromText("Content for user1", genai.RoleUser)
+	sessionService := sessionservice.Mem()
+	createResponse, err := sessionService.Create(t.Context(), &sessionservice.CreateRequest{
+		AppName:   testID1.AppName,
+		UserID:    testID1.UserID,
+		SessionID: testID1.SessionID,
+	})
+	if err != nil {
+		t.Fatalf("Failed to create session: %v", err)
+	}
+	storedSession := createResponse.Session
+	if err := sessionService.AppendEvent(t.Context(), storedSession, &session.Event{
+		Time:        time.Now(),
+		Author:      "user1",
+		LLMResponse: &llm.Response{Content: content1},
+	}); err != nil {
+		t.Fatalf("Failed to append event: %v", err)
+	}
+
+	if err := memory1.AddSession(sessioninternal.NewMutableSession(sessionService, storedSession)); err != nil {
+		t.Fatalf("AddSession failed: %v", err)
+	}
+
+	// Add data for User2
+	testID2 := session.ID{
+		AppName:   "testApp",
+		UserID:    "user2",
+		SessionID: "sess2",
+	}
+	memory2 := memoryinternal.NewMemory(memService, testID2)
+	content2 := genai.NewContentFromText("Content for user2", genai.RoleUser)
+	createResponse2, err := sessionService.Create(t.Context(), &sessionservice.CreateRequest{
+		AppName:   testID2.AppName,
+		UserID:    testID2.UserID,
+		SessionID: testID2.SessionID,
+	})
+	if err != nil {
+		t.Fatalf("Failed to create session: %v", err)
+	}
+	storedSession2 := createResponse2.Session
+	if err := sessionService.AppendEvent(t.Context(), storedSession2, &session.Event{
+		Time:        time.Now(),
+		Author:      "user2",
+		LLMResponse: &llm.Response{Content: content2},
+	}); err != nil {
+		t.Fatalf("Failed to append event: %v", err)
+	}
+
+	if err := memory2.AddSession(sessioninternal.NewMutableSession(sessionService, storedSession2)); err != nil {
+		t.Fatalf("AddSession failed: %v", err)
+	}
+
+	// User1 search should only find user1's content
+	got1, err := memory1.Search("Content")
+	if err != nil {
+		t.Fatalf("memory1.Search failed: %v", err)
+	}
+	if len(got1) != 1 {
+		t.Errorf("memory1.Search returned %d items, want 1", len(got1))
+	} else if diff := cmp.Diff(content1, got1[0].Content); diff != "" {
+		t.Errorf("memory1.Search returned diff (-want +got):\n%s", diff)
+	}
+
+	// User2 search should only find user2's content
+	got2, err := memory2.Search("Content")
+	if err != nil {
+		t.Fatalf("memory2.Search failed: %v", err)
+	}
+	if len(got2) != 1 {
+		t.Errorf("memory2.Search returned %d items, want 1", len(got2))
+	} else if diff := cmp.Diff(content2, got2[0].Content); diff != "" {
+		t.Errorf("memory2.Search returned diff (-want +got):\n%s", diff)
+	}
+}

--- a/internal/sessioninternal/mutablesession.go
+++ b/internal/sessioninternal/mutablesession.go
@@ -12,41 +12,48 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-package runner
+package sessioninternal
 
 import (
 	"fmt"
 	"iter"
 	"time"
 
-	"google.golang.org/adk/internal/sessioninternal"
 	"google.golang.org/adk/session"
 	"google.golang.org/adk/sessionservice"
 )
 
-// mutableSession implements session.Session
-type mutableSession struct {
+// MutableSession implements session.Session
+type MutableSession struct {
 	service       sessionservice.Service
 	storedSession sessionservice.StoredSession
 }
 
-func (s *mutableSession) State() session.State {
+// NewMutableSession creates and returns session.Session implementation.
+func NewMutableSession(service sessionservice.Service, storedSession sessionservice.StoredSession) *MutableSession {
+	return &MutableSession{
+		service:       service,
+		storedSession: storedSession,
+	}
+}
+
+func (s *MutableSession) State() session.State {
 	return s
 }
 
-func (s *mutableSession) ID() session.ID {
+func (s *MutableSession) ID() session.ID {
 	return s.storedSession.ID()
 }
 
-func (s *mutableSession) Events() session.Events {
+func (s *MutableSession) Events() session.Events {
 	return s.storedSession.Events()
 }
 
-func (s *mutableSession) Updated() time.Time {
+func (s *MutableSession) Updated() time.Time {
 	return s.storedSession.Updated()
 }
 
-func (s *mutableSession) Get(key string) (any, error) {
+func (s *MutableSession) Get(key string) (any, error) {
 	value, err := s.storedSession.State().Get(key)
 	if err != nil {
 		return nil, fmt.Errorf("failed to get key %q from state: %w", key, err)
@@ -54,12 +61,12 @@ func (s *mutableSession) Get(key string) (any, error) {
 	return value, nil
 }
 
-func (s *mutableSession) All() iter.Seq2[string, any] {
+func (s *MutableSession) All() iter.Seq2[string, any] {
 	return s.storedSession.State().All()
 }
 
-func (s *mutableSession) Set(key string, value any) error {
-	mutableState, ok := s.storedSession.State().(sessioninternal.MutableState)
+func (s *MutableSession) Set(key string, value any) error {
+	mutableState, ok := s.storedSession.State().(MutableState)
 	if !ok {
 		return fmt.Errorf("this session state is not mutable")
 

--- a/internal/sessioninternal/mutablesession_test.go
+++ b/internal/sessioninternal/mutablesession_test.go
@@ -12,7 +12,7 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-package runner
+package sessioninternal_test
 
 import (
 	"context"
@@ -22,11 +22,12 @@ import (
 
 	"github.com/google/go-cmp/cmp"
 
+	"google.golang.org/adk/internal/sessioninternal"
 	"google.golang.org/adk/session"
 	"google.golang.org/adk/sessionservice"
 )
 
-func createMutableSession(ctx context.Context, t *testing.T, sessionID string, initialData map[string]any) (*mutableSession, sessionservice.Service) {
+func createMutableSession(ctx context.Context, t *testing.T, sessionID string, initialData map[string]any) (*sessioninternal.MutableSession, sessionservice.Service) {
 	t.Helper()
 	service := sessionservice.Mem()
 	req := &sessionservice.CreateRequest{
@@ -40,10 +41,7 @@ func createMutableSession(ctx context.Context, t *testing.T, sessionID string, i
 		t.Fatalf("Failed to create session %q: %v", sessionID, err)
 	}
 
-	return &mutableSession{
-		service:       service,
-		storedSession: createResp.Session,
-	}, service
+	return sessioninternal.NewMutableSession(service, createResp.Session), service
 }
 
 func TestMutableSession_SetGet(t *testing.T) {
@@ -164,10 +162,7 @@ func TestMutableSession_PassthroughMethods(t *testing.T) {
 		t.Fatalf("Failed to create session: %v", err)
 	}
 
-	ms := &mutableSession{
-		service:       service,
-		storedSession: createResp.Session,
-	}
+	ms := sessioninternal.NewMutableSession(service, createResp.Session)
 
 	if got := ms.ID(); !reflect.DeepEqual(got, testID) {
 		t.Errorf("ID() = %v, want %v", got, testID)
@@ -186,7 +181,7 @@ func TestMutableSession_PassthroughMethods(t *testing.T) {
 	if state == nil {
 		t.Fatalf("State() returned nil")
 	}
-	if _, ok := state.(*mutableSession); !ok {
+	if _, ok := state.(*sessioninternal.MutableSession); !ok {
 		t.Errorf("State() did not return *mutableSession as expected")
 	}
 }

--- a/tool/load_artifacts_tool_test.go
+++ b/tool/load_artifacts_tool_test.go
@@ -227,7 +227,7 @@ func createToolContext(t *testing.T) tool.Context {
 
 	artifactsImpl := artifactsinternal.NewArtifacts(artifactservice.Mem(), sessionId)
 
-	agentCtx := agent.NewContext(t.Context(), nil, nil, artifactsImpl, nil, "")
+	agentCtx := agent.NewContext(t.Context(), nil, nil, artifactsImpl, nil, nil, "")
 
 	return tool.NewContext(agentCtx, "", nil)
 }


### PR DESCRIPTION
I moved mutable session implementation to internal package for testing.

Also I've made interface of Memory as simple as possible, not same as in the doc, but similar to the Artifacts interface. This is just to make things running and we can modify it later.