### PR TITLE
Change function context argument with tool context

### DIFF
--- a/agent/llmagent/llmagent_test.go
+++ b/agent/llmagent/llmagent_test.go
@@ -15,7 +15,6 @@
 package llmagent_test
 
 import (
-	"context"
 	"errors"
 	"fmt"
 	"iter"
@@ -269,7 +268,7 @@ func TestFunctionTool(t *testing.T) {
 	}
 
 	prompt := "what is the sum of 1 + 2?"
-	handler := func(_ context.Context, input Args) Result {
+	handler := func(_ tool.Context, input Args) Result {
 		if input.A != 1 || input.B != 2 {
 			t.Errorf("handler received %+v, want {a: 1, b: 2}", input)
 		}

--- a/tool/function.go
+++ b/tool/function.go
@@ -15,7 +15,6 @@
 package tool
 
 import (
-	"context"
 	"fmt"
 
 	"github.com/google/jsonschema-go/jsonschema"
@@ -53,7 +52,7 @@ type FunctionToolConfig struct {
 }
 
 // Funtion represents a Go function.
-type Function[TArgs, TResults any] func(context.Context, TArgs) TResults
+type Function[TArgs, TResults any] func(Context, TArgs) TResults
 
 // NewFunctionTool creates a new tool with a name, description, and the provided handler.
 // Input schema is automatically inferred from the input and output types.

--- a/tool/function_test.go
+++ b/tool/function_test.go
@@ -15,7 +15,6 @@
 package tool_test
 
 import (
-	"context"
 	"encoding/json"
 	"fmt"
 	"iter"
@@ -45,7 +44,7 @@ func ExampleNewFunctionTool() {
 		Sum int `json:"sum"` // the sum of two integers
 	}
 
-	handler := func(ctx context.Context, input SumArgs) SumResult {
+	handler := func(ctx tool.Context, input SumArgs) SumResult {
 		return SumResult{Sum: input.A + input.B}
 	}
 	sumTool, err := tool.NewFunctionTool(tool.FunctionToolConfig{
@@ -89,7 +88,7 @@ func TestFunctionTool_Simple(t *testing.T) {
 		},
 	}
 
-	weatherReport := func(ctx context.Context, input Args) Result {
+	weatherReport := func(ctx tool.Context, input Args) Result {
 		city := strings.ToLower(input.City)
 		if ret, ok := resultSet[city]; ok {
 			return ret
@@ -195,7 +194,7 @@ func TestFunctionTool_ReturnsBasicType(t *testing.T) {
 		"paris":  "The weather in Paris is sunny with a temperature of 25 derees Celsius.",
 	}
 
-	weatherReport := func(ctx context.Context, input Args) string {
+	weatherReport := func(ctx tool.Context, input Args) string {
 		city := strings.ToLower(input.City)
 		if ret, ok := resultSet[city]; ok {
 			return ret
@@ -357,7 +356,7 @@ func TestFunctionTool_CustomSchema(t *testing.T) {
 		Name:        "print_quantity",
 		Description: "print the remaining quantity of the given fruit.",
 		InputSchema: ischema,
-	}, func(ctx context.Context, input Args) any {
+	}, func(ctx tool.Context, input Args) any {
 		fruit := strings.ToLower(input.Fruit)
 		if fruit != "mandarin" && fruit != "kiwi" {
 			t.Errorf("unexpected fruit: %q", fruit)

--- a/tool/long_running_function_test.go
+++ b/tool/long_running_function_test.go
@@ -15,7 +15,6 @@
 package tool_test
 
 import (
-	"context"
 	"strings"
 	"testing"
 
@@ -35,7 +34,7 @@ func TestNewLongRunningFunctionTool(t *testing.T) {
 		Result string `json:"result"` // the operation result
 	}
 
-	handler := func(ctx context.Context, input SumArgs) SumResult {
+	handler := func(ctx tool.Context, input SumArgs) SumResult {
 		return SumResult{Result: "Processing sum"}
 	}
 	sumTool, err := tool.NewLongRunningFunctionTool(tool.FunctionToolConfig{
@@ -83,7 +82,7 @@ func TestAsyncFunction(t *testing.T) {
 	type IncArgs struct {
 	}
 
-	increaseByOne := func(ctx context.Context, x IncArgs) map[string]string {
+	increaseByOne := func(ctx tool.Context, x IncArgs) map[string]string {
 		functionCalled++
 		return map[string]string{"status": "pending"}
 	}

--- a/tool/tool_test.go
+++ b/tool/tool_test.go
@@ -15,7 +15,6 @@
 package tool_test
 
 import (
-	"context"
 	"testing"
 
 	"google.golang.org/adk/internal/toolinternal"
@@ -37,7 +36,7 @@ func TestTypes(t *testing.T) {
 		{
 			name: "FunctionTool",
 			constructor: func() (tool.Tool, error) {
-				return tool.NewFunctionTool(tool.FunctionToolConfig{}, func(context.Context, int) int { return 0 })
+				return tool.NewFunctionTool(tool.FunctionToolConfig{}, func(tool.Context, int) int { return 0 })
 			},
 			expectedTypes: []string{requestProc, functionTool},
 		},


### PR DESCRIPTION
Function tool without tool context is not that powerful, I was trying to write a tool where I wanted to use artifacts but couldn't without it. Also it's consistent with other adks.