### PR TITLE
Update model.LLM interface to be ADK conformant

### DIFF
--- a/internal/testutil/test_agent_runner.go
+++ b/internal/testutil/test_agent_runner.go
@@ -119,6 +119,16 @@ type MockModel struct {
 
 var errNoModelData = errors.New("no data")
 
+func (m *MockModel) GenerateContent(ctx context.Context, req *model.LLMRequest, stream bool) iter.Seq2[*model.LLMResponse, error] {
+	if stream {
+		return m.GenerateStream(ctx, req)
+	}
+	return func(yield func(*model.LLMResponse, error) bool) {
+		resp, err := m.Generate(ctx, req)
+		yield(resp, err)
+	}
+}
+
 // GenerateContent implements llm.Model.
 func (m *MockModel) Generate(ctx context.Context, req *model.LLMRequest) (*model.LLMResponse, error) {
 	m.Requests = append(m.Requests, req)

--- a/model/gemini/gemini_test.go
+++ b/model/gemini/gemini_test.go
@@ -71,13 +71,14 @@ func TestModel_Generate(t *testing.T) {
 				t.Fatal(err)
 			}
 
-			got, err := testModel.Generate(t.Context(), tt.req)
-			if (err != nil) != tt.wantErr {
-				t.Errorf("Model.Generate() error = %v, wantErr %v", err, tt.wantErr)
-				return
-			}
-			if diff := cmp.Diff(tt.want, got, cmpopts.IgnoreFields(model.LLMResponse{}, "AvgLogprobs")); diff != "" {
-				t.Errorf("Model.Generate() = %v, want %v\ndiff(-want +got):\n%v", got, tt.want, diff)
+			for got, err := range testModel.GenerateContent(t.Context(), tt.req, false) {
+				if (err != nil) != tt.wantErr {
+					t.Errorf("Model.Generate() error = %v, wantErr %v", err, tt.wantErr)
+					return
+				}
+				if diff := cmp.Diff(tt.want, got, cmpopts.IgnoreFields(model.LLMResponse{}, "AvgLogprobs")); diff != "" {
+					t.Errorf("Model.Generate() = %v, want %v\ndiff(-want +got):\n%v", got, tt.want, diff)
+				}
 			}
 		})
 	}
@@ -113,7 +114,7 @@ func TestModel_GenerateStream(t *testing.T) {
 			}
 
 			// Transforms the stream into strings, concating the text value of the response parts
-			got, err := readResponse(model.GenerateStream(t.Context(), tt.req))
+			got, err := readResponse(model.GenerateContent(t.Context(), tt.req, true))
 			if (err != nil) != tt.wantErr {
 				t.Errorf("Model.GenerateStream() error = %v, wantErr %v", err, tt.wantErr)
 				return

--- a/model/llm.go
+++ b/model/llm.go
@@ -24,8 +24,7 @@ import (
 // LLM provides the access to the underlying LLM.
 type LLM interface {
 	Name() string
-	Generate(ctx context.Context, req *LLMRequest) (*LLMResponse, error)
-	GenerateStream(ctx context.Context, req *LLMRequest) iter.Seq2[*LLMResponse, error]
+	GenerateContent(ctx context.Context, req *LLMRequest, stream bool) iter.Seq2[*LLMResponse, error]
 }
 
 // LLMRequest is the raw LLM request.

--- a/tool/function_test.go
+++ b/tool/function_test.go
@@ -147,13 +147,9 @@ func TestFunctionTool_Simple(t *testing.T) {
 				t.Fatalf("weatherReportTool.ProcessRequest did not configure tool info in LLMRequest: %v", req)
 			}
 			req.Contents = genai.Text(tc.prompt)
-			f := func() iter.Seq2[*model.LLMResponse, error] {
-				return func(yield func(*model.LLMResponse, error) bool) {
-					resp, err := m.Generate(ctx, &req)
-					yield(resp, err)
-				}
-			}
-			resp, err := readFirstResponse[*genai.FunctionCall](f())
+			resp, err := readFirstResponse[*genai.FunctionCall](
+				m.GenerateContent(ctx, &req, false),
+			)
 			if err != nil {
 				t.Fatalf("GenerateContent(%v) failed: %v", req, err)
 			}


### PR DESCRIPTION
Other ADKs' BaseLLM class exposes only one method: generate_content(req, stream) -> iterator