### PR TITLE
Align to New(Config) for consistency

### DIFF
--- a/agent/workflowagents/loopagent/agent_test.go
+++ b/agent/workflowagents/loopagent/agent_test.go
@@ -104,7 +104,7 @@ func TestNewLoopAgent(t *testing.T) {
 
 			sessionService := session.InMemoryService()
 
-			agentRunner, err := runner.New(&runner.Config{
+			agentRunner, err := runner.New(runner.Config{
 				AppName:        "test_app",
 				Agent:          agent,
 				SessionService: sessionService,

--- a/agent/workflowagents/parallelagent/agent_test.go
+++ b/agent/workflowagents/parallelagent/agent_test.go
@@ -95,7 +95,7 @@ func TestNewParallelAgent(t *testing.T) {
 
 			sessionService := session.InMemoryService()
 
-			agentRunner, err := runner.New(&runner.Config{
+			agentRunner, err := runner.New(runner.Config{
 				AppName:        "test_app",
 				Agent:          agent,
 				SessionService: sessionService,

--- a/agent/workflowagents/sequentialagent/agent_test.go
+++ b/agent/workflowagents/sequentialagent/agent_test.go
@@ -93,7 +93,7 @@ func TestNewSequentialAgent(t *testing.T) {
 
 			sessionService := session.InMemoryService()
 
-			agentRunner, err := runner.New(&runner.Config{
+			agentRunner, err := runner.New(runner.Config{
 				AppName:        "test_app",
 				Agent:          agent,
 				SessionService: sessionService,

--- a/cmd/restapi/handlers/runtime.go
+++ b/cmd/restapi/handlers/runtime.go
@@ -162,13 +162,12 @@ func (c *RuntimeAPIController) getRunner(req models.RunAgentRequest) (*runner.Ru
 		return nil, nil, errors.NewStatusError(fmt.Errorf("load agent: %w", err), http.StatusInternalServerError)
 	}
 
-	r, err := runner.New(
-		&runner.Config{
-			AppName:         req.AppName,
-			Agent:           agent,
-			SessionService:  c.sessionService,
-			ArtifactService: c.artifactService,
-		},
+	r, err := runner.New(runner.Config{
+		AppName:         req.AppName,
+		Agent:           agent,
+		SessionService:  c.sessionService,
+		ArtifactService: c.artifactService,
+	},
 	)
 	if err != nil {
 		return nil, nil, errors.NewStatusError(fmt.Errorf("create runner: %w", err), http.StatusInternalServerError)

--- a/examples/tools/loadartifacts/main.go
+++ b/examples/tools/loadartifacts/main.go
@@ -100,7 +100,7 @@ func main() {
 		log.Fatalf("Failed to save artifact: %v", err)
 	}
 
-	r, err := runner.New(&runner.Config{
+	r, err := runner.New(runner.Config{
 		AppName:         appName,
 		Agent:           agent,
 		SessionService:  sessionService,

--- a/examples/userloop.go
+++ b/examples/userloop.go
@@ -56,7 +56,7 @@ func Run(ctx context.Context, rootAgent agent.Agent, runConfig *RunConfig) {
 
 	session := resp.Session
 
-	r, err := runner.New(&runner.Config{
+	r, err := runner.New(runner.Config{
 		AppName:         appName,
 		Agent:           rootAgent,
 		SessionService:  sessionService,

--- a/internal/testutil/test_agent_runner.go
+++ b/internal/testutil/test_agent_runner.go
@@ -91,7 +91,7 @@ func NewTestAgentRunner(t *testing.T, agent agent.Agent) *TestAgentRunner {
 	appName := "test_app"
 	sessionService := session.InMemoryService()
 
-	runner, err := runner.New(&runner.Config{
+	runner, err := runner.New(runner.Config{
 		AppName:        appName,
 		Agent:          agent,
 		SessionService: sessionService,

--- a/runner/runner.go
+++ b/runner/runner.go
@@ -43,7 +43,7 @@ type Config struct {
 	MemoryService   memoryservice.Service
 }
 
-func New(cfg *Config) (*Runner, error) {
+func New(cfg Config) (*Runner, error) {
 	parents, err := parentmap.New(cfg.Agent)
 	if err != nil {
 		return nil, fmt.Errorf("failed to create agent tree: %w", err)

--- a/runner/runner_test.go
+++ b/runner/runner_test.go
@@ -176,7 +176,7 @@ func Test_isTransferrableAcrossAgentTree(t *testing.T) {
 	}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			runner, err := New(&Config{
+			runner, err := New(Config{
 				AppName:        "testApp",
 				Agent:          tt.agent,
 				SessionService: session.InMemoryService(),
@@ -209,7 +209,7 @@ func TestRunner_SaveInputBlobsAsArtifacts(t *testing.T) {
 		},
 	}))
 
-	r, err := New(&Config{
+	r, err := New(Config{
 		AppName:        appName,
 		Agent:          testAgent,
 		SessionService: sessionService,

--- a/tool/mcptool/set_test.go
+++ b/tool/mcptool/set_test.go
@@ -198,7 +198,7 @@ func newTestAgentRunner(t *testing.T, agent agent.Agent) *testAgentRunner {
 	appName := "test_app"
 	sessionService := session.InMemoryService()
 
-	runner, err := runner.New(&runner.Config{
+	runner, err := runner.New(runner.Config{
 		AppName:        appName,
 		Agent:          agent,
 		SessionService: sessionService,


### PR DESCRIPTION
In all places we use New(Config). The runner had New(*Config). Updating it to align to one consistent approach.