### PR TITLE
Fix examples to ignore aggregated event

### DIFF
--- a/cmd/restapi/models/event.go
+++ b/cmd/restapi/models/event.go
@@ -46,7 +46,6 @@ func ToSessionEvent(event Event) *session.Event {
 		InvocationID:       event.InvocationID,
 		Branch:             event.Branch,
 		Author:             event.Author,
-		Partial:            event.Partial,
 		LongRunningToolIDs: event.LongRunningToolIDs,
 		LLMResponse: &model.LLMResponse{
 			Content:           event.Content,

--- a/examples/tools/loadartifacts/main.go
+++ b/examples/tools/loadartifacts/main.go
@@ -122,14 +122,18 @@ func main() {
 		userMsg := genai.NewContentFromText(userInput, genai.RoleUser)
 
 		fmt.Print("\nAgent -> ")
+		streamingMode := runner.StreamingModeSSE
 		for event, err := range r.Run(ctx, userID, session.ID(), userMsg, &runner.RunConfig{
-			StreamingMode: runner.StreamingModeSSE,
+			StreamingMode: streamingMode,
 		}) {
 			if err != nil {
 				fmt.Printf("\nAGENT_ERROR: %v\n", err)
 			} else {
 				for _, p := range event.LLMResponse.Content.Parts {
-					fmt.Print(p.Text)
+					// if its running in streaming mode, don't print the non partial llmResponses
+					if streamingMode != runner.StreamingModeSSE || event.LLMResponse.Partial {
+						fmt.Print(p.Text)
+					}
 				}
 			}
 		}

--- a/examples/userloop.go
+++ b/examples/userloop.go
@@ -90,7 +90,10 @@ func Run(ctx context.Context, rootAgent agent.Agent, runConfig *RunConfig) {
 				fmt.Printf("\nAGENT_ERROR: %v\n", err)
 			} else {
 				for _, p := range event.LLMResponse.Content.Parts {
-					fmt.Print(p.Text)
+					// if its running in streaming mode, don't print the non partial llmResponses
+					if streamingMode != runner.StreamingModeSSE || event.LLMResponse.Partial {
+						fmt.Print(p.Text)
+					}
 				}
 			}
 		}

--- a/internal/llminternal/contents_processor.go
+++ b/internal/llminternal/contents_processor.go
@@ -522,7 +522,6 @@ func cloneEvent(e *session.Event) *session.Event {
 		InvocationID: e.InvocationID,
 		Branch:       e.Branch,
 		Author:       e.Author,
-		Partial:      e.Partial,
 		Actions:      e.Actions,
 	}
 

--- a/session/session.go
+++ b/session/session.go
@@ -75,7 +75,6 @@ type Event struct {
 	Branch string
 	Author string
 
-	Partial bool
 	// The actions taken by the agent.
 	Actions EventActions
 	// Set of IDs of the long running function calls.


### PR DESCRIPTION
Fix examples to ignore aggregated event and also removed unused Partial property from event.