### PR TITLE
Extract ProcessRequest from tools

### DIFF
--- a/internal/toolinternal/toolutils/toolutils.go
+++ b/internal/toolinternal/toolutils/toolutils.go
@@ -1,0 +1,68 @@
+// Copyright 2025 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+// Package tool defines internal-only interfaces and logic for tools.
+package toolutils
+
+import (
+	"fmt"
+
+	"google.golang.org/adk/model"
+	"google.golang.org/genai"
+)
+
+type Tool interface {
+	Name() string
+	Declaration() *genai.FunctionDeclaration
+}
+
+// The PackTool ensures that in case there is a usage of multiple function tools,
+// all of them are consolidated into one genai tool that has all the function declarations
+// provided by the tools. So, if there is already a tool with a function declaration,
+// it appends another to it; otherwise, it creates a new genai tool.
+func PackTool(req *model.LLMRequest, tool Tool) error {
+	if req.Tools == nil {
+		req.Tools = make(map[string]any)
+	}
+
+	name := tool.Name()
+
+	if _, ok := req.Tools[name]; ok {
+		return fmt.Errorf("duplicate tool: %q", name)
+	}
+	req.Tools[name] = tool
+
+	if req.Config == nil {
+		req.Config = &genai.GenerateContentConfig{}
+	}
+	if decl := tool.Declaration(); decl == nil {
+		return nil
+	}
+	// Find an existing genai.Tool with FunctionDeclarations
+	var funcTool *genai.Tool
+	for _, tool := range req.Config.Tools {
+		if tool != nil && tool.FunctionDeclarations != nil {
+			funcTool = tool
+			break
+		}
+	}
+	if funcTool == nil {
+		req.Config.Tools = append(req.Config.Tools, &genai.Tool{
+			FunctionDeclarations: []*genai.FunctionDeclaration{tool.Declaration()},
+		})
+	} else {
+		funcTool.FunctionDeclarations = append(funcTool.FunctionDeclarations, tool.Declaration())
+	}
+	return nil
+}

--- a/tool/mcptool/tool.go
+++ b/tool/mcptool/tool.go
@@ -22,6 +22,7 @@ import (
 
 	"github.com/modelcontextprotocol/go-sdk/mcp"
 	"google.golang.org/adk/internal/toolinternal"
+	"google.golang.org/adk/internal/toolinternal/toolutils"
 	"google.golang.org/adk/model"
 	"google.golang.org/adk/tool"
 	"google.golang.org/genai"
@@ -64,26 +65,7 @@ func (t *mcpTool) IsLongRunning() bool {
 }
 
 func (t *mcpTool) ProcessRequest(ctx tool.Context, req *model.LLMRequest) error {
-	if req.Tools == nil {
-		req.Tools = make(map[string]any)
-	}
-
-	name := t.Name()
-	if _, ok := req.Tools[name]; ok {
-		return fmt.Errorf("duplicate tool: %q", name)
-	}
-	req.Tools[name] = t
-
-	if req.Config == nil {
-		req.Config = &genai.GenerateContentConfig{}
-	}
-	req.Config.Tools = append(req.Config.Tools, &genai.Tool{
-		FunctionDeclarations: []*genai.FunctionDeclaration{
-			t.funcDeclaration,
-		},
-	})
-
-	return nil
+	return toolutils.PackTool(req, t)
 }
 
 func (t *mcpTool) Declaration() *genai.FunctionDeclaration {


### PR DESCRIPTION
Some implementations still append function tools a new genai tools, this will block the ability to have different function tools in one agent for vertex models (because of genai limitation).

The correct way to consolidate the tools by combining the function declarations. Therefore extracting processRequest from tools so its logic is in one place, it will make it less error prone.