### PR TITLE
Rename package memoryservice -> memory

### DIFF
--- a/agent/agent.go
+++ b/agent/agent.go
@@ -20,7 +20,7 @@ import (
 	"iter"
 
 	agentinternal "google.golang.org/adk/internal/agent"
-	"google.golang.org/adk/memoryservice"
+	"google.golang.org/adk/memory"
 	"google.golang.org/adk/model"
 	"google.golang.org/adk/session"
 	"google.golang.org/genai"
@@ -68,7 +68,7 @@ type Artifacts interface {
 
 type Memory interface {
 	AddSession(session session.Session) error
-	Search(query string) ([]memoryservice.MemoryEntry, error)
+	Search(query string) ([]memory.Entry, error)
 }
 
 type BeforeAgentCallback func(CallbackContext) (*genai.Content, error)

--- a/internal/memory/memory.go
+++ b/internal/memory/memory.go
@@ -12,18 +12,18 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-package memoryinternal
+package memory
 
 import (
 	"context"
 	"fmt"
 
-	"google.golang.org/adk/memoryservice"
+	"google.golang.org/adk/memory"
 	"google.golang.org/adk/session"
 )
 
 type Memory struct {
-	Service   memoryservice.Service
+	Service   memory.Service
 	SessionID string
 	UserID    string
 	AppName   string
@@ -37,8 +37,8 @@ func (a *Memory) AddSession(session session.Session) error {
 	return nil
 }
 
-func (a *Memory) Search(query string) ([]memoryservice.MemoryEntry, error) {
-	searchResponse, err := a.Service.Search(context.Background(), &memoryservice.SearchRequest{
+func (a *Memory) Search(query string) ([]memory.Entry, error) {
+	searchResponse, err := a.Service.Search(context.Background(), &memory.SearchRequest{
 		AppName: a.AppName,
 		UserID:  a.UserID,
 		Query:   query,

--- a/internal/toolinternal/context.go
+++ b/internal/toolinternal/context.go
@@ -19,7 +19,7 @@ import (
 
 	"github.com/google/uuid"
 	"google.golang.org/adk/agent"
-	"google.golang.org/adk/memoryservice"
+	"google.golang.org/adk/memory"
 	"google.golang.org/adk/session"
 	"google.golang.org/adk/tool"
 )
@@ -57,7 +57,7 @@ func (c *toolContext) ReadonlyState() session.ReadonlyState {
 	return c.Session().State()
 }
 
-func (c *toolContext) SearchMemory(ctx context.Context, query string) ([]memoryservice.MemoryEntry, error) {
+func (c *toolContext) SearchMemory(ctx context.Context, query string) ([]memory.Entry, error) {
 	return c.Memory().Search(query)
 }
 

--- a/memory/inmemory.go
+++ b/memory/inmemory.go
@@ -12,7 +12,7 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-package memoryservice
+package memory
 
 import (
 	"context"
@@ -25,8 +25,8 @@ import (
 	"google.golang.org/genai"
 )
 
-// Mem returns a new in-memory implementation of the memory service. Thread-safe.
-func Mem() Service {
+// InMemoryService returns a new in-memory implementation of the memory service. Thread-safe.
+func InMemoryService() Service {
 	return &inMemoryService{
 		store: make(map[key]map[sessionID][]value),
 	}
@@ -120,7 +120,7 @@ func (s *inMemoryService) Search(ctx context.Context, req *SearchRequest) (*Sear
 	for _, events := range values {
 		for _, e := range events {
 			if checkMapsIntersect(e.words, queryWords) {
-				res.Memories = append(res.Memories, MemoryEntry{
+				res.Memories = append(res.Memories, Entry{
 					Content:   e.content,
 					Author:    e.author,
 					Timestamp: e.timestamp,

--- a/memory/inmemory_test.go
+++ b/memory/inmemory_test.go
@@ -12,7 +12,7 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-package memoryservice_test
+package memory_test
 
 import (
 	"iter"
@@ -21,7 +21,7 @@ import (
 	"time"
 
 	"github.com/google/go-cmp/cmp"
-	"google.golang.org/adk/memoryservice"
+	"google.golang.org/adk/memory"
 	"google.golang.org/adk/model"
 	"google.golang.org/adk/session"
 	"google.golang.org/genai"
@@ -31,8 +31,8 @@ func Test_inMemoryService_SearchMemory(t *testing.T) {
 	tests := []struct {
 		name         string
 		initSessions []session.Session
-		req          *memoryservice.SearchRequest
-		wantResp     *memoryservice.SearchResponse
+		req          *memory.SearchRequest
+		wantResp     *memory.SearchResponse
 		wantErr      bool
 	}{
 		{
@@ -63,13 +63,13 @@ func Test_inMemoryService_SearchMemory(t *testing.T) {
 					{LLMResponse: &model.LLMResponse{Content: genai.NewContentFromText("test text", genai.RoleUser)}},
 				}),
 			},
-			req: &memoryservice.SearchRequest{
+			req: &memory.SearchRequest{
 				AppName: "app1",
 				UserID:  "user1",
 				Query:   "quick hello",
 			},
-			wantResp: &memoryservice.SearchResponse{
-				Memories: []memoryservice.MemoryEntry{
+			wantResp: &memory.SearchResponse{
+				Memories: []memory.Entry{
 					{
 						Content:   genai.NewContentFromText("The Quick brown fox", genai.RoleUser),
 						Author:    "user1",
@@ -90,12 +90,12 @@ func Test_inMemoryService_SearchMemory(t *testing.T) {
 					{LLMResponse: &model.LLMResponse{Content: genai.NewContentFromText("test text", genai.RoleUser)}},
 				}),
 			},
-			req: &memoryservice.SearchRequest{
+			req: &memory.SearchRequest{
 				AppName: "other_app",
 				UserID:  "user1",
 				Query:   "test text",
 			},
-			wantResp: &memoryservice.SearchResponse{},
+			wantResp: &memory.SearchResponse{},
 		},
 		{
 			name: "no leakage for different user",
@@ -104,12 +104,12 @@ func Test_inMemoryService_SearchMemory(t *testing.T) {
 					{LLMResponse: &model.LLMResponse{Content: genai.NewContentFromText("test text", genai.RoleUser)}},
 				}),
 			},
-			req: &memoryservice.SearchRequest{
+			req: &memory.SearchRequest{
 				AppName: "app1",
 				UserID:  "test_user",
 				Query:   "test text",
 			},
-			wantResp: &memoryservice.SearchResponse{},
+			wantResp: &memory.SearchResponse{},
 		},
 		{
 			name: "no matches",
@@ -118,26 +118,26 @@ func Test_inMemoryService_SearchMemory(t *testing.T) {
 					{LLMResponse: &model.LLMResponse{Content: genai.NewContentFromText("test text", genai.RoleUser)}},
 				}),
 			},
-			req: &memoryservice.SearchRequest{
+			req: &memory.SearchRequest{
 				AppName: "app1",
 				UserID:  "test_user",
 				Query:   "something different",
 			},
-			wantResp: &memoryservice.SearchResponse{},
+			wantResp: &memory.SearchResponse{},
 		},
 		{
 			name: "lookup on empty store",
-			req: &memoryservice.SearchRequest{
+			req: &memory.SearchRequest{
 				AppName: "app1",
 				UserID:  "test_user",
 				Query:   "something different",
 			},
-			wantResp: &memoryservice.SearchResponse{},
+			wantResp: &memory.SearchResponse{},
 		},
 	}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			s := memoryservice.Mem()
+			s := memory.InMemoryService()
 
 			for _, session := range tt.initSessions {
 				if err := s.AddSession(t.Context(), session); err != nil {
@@ -167,8 +167,8 @@ func makeSession(t *testing.T, appName, userID, sessionID string, events []*sess
 	}
 }
 
-var sortMemories = cmp.Transformer("Sort", func(in *memoryservice.SearchResponse) *memoryservice.SearchResponse {
-	slices.SortFunc(in.Memories, func(m1, m2 memoryservice.MemoryEntry) int {
+var sortMemories = cmp.Transformer("Sort", func(in *memory.SearchResponse) *memory.SearchResponse {
+	slices.SortFunc(in.Memories, func(m1, m2 memory.Entry) int {
 		return m1.Timestamp.Compare(m2.Timestamp)
 	})
 	return in

--- a/memory/service.go
+++ b/memory/service.go
@@ -12,7 +12,7 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-package memoryservice
+package memory
 
 import (
 	"context"
@@ -45,11 +45,11 @@ type SearchRequest struct {
 
 // SearchResponse represents the response from a memory search.
 type SearchResponse struct {
-	Memories []MemoryEntry
+	Memories []Entry
 }
 
-// MemoryEntry represents a single memory entry.
-type MemoryEntry struct {
+// Entry represents a single memory entry.
+type Entry struct {
 	// Content contains the main content of the memory.
 	Content *genai.Content
 	// Author of the memory.

--- a/runner/runner.go
+++ b/runner/runner.go
@@ -28,9 +28,9 @@ import (
 	artifactinternal "google.golang.org/adk/internal/artifact"
 	icontext "google.golang.org/adk/internal/context"
 	"google.golang.org/adk/internal/llminternal"
-	"google.golang.org/adk/internal/memoryinternal"
+	imemory "google.golang.org/adk/internal/memory"
 	"google.golang.org/adk/internal/sessioninternal"
-	"google.golang.org/adk/memoryservice"
+	"google.golang.org/adk/memory"
 	"google.golang.org/adk/model"
 	"google.golang.org/adk/session"
 	"google.golang.org/genai"
@@ -41,7 +41,7 @@ type Config struct {
 	Agent           agent.Agent
 	SessionService  session.Service
 	ArtifactService artifact.Service
-	MemoryService   memoryservice.Service
+	MemoryService   memory.Service
 }
 
 func New(cfg Config) (*Runner, error) {
@@ -65,7 +65,7 @@ type Runner struct {
 	rootAgent       agent.Agent
 	sessionService  session.Service
 	artifactService artifact.Service
-	memoryService   memoryservice.Service
+	memoryService   memory.Service
 
 	parents parentmap.Map
 }
@@ -118,7 +118,7 @@ func (r *Runner) Run(ctx context.Context, userID, sessionID string, msg *genai.C
 
 		var memoryImpl agent.Memory = nil
 		if r.memoryService != nil {
-			memoryImpl = &memoryinternal.Memory{
+			memoryImpl = &imemory.Memory{
 				Service:   r.memoryService,
 				SessionID: session.ID(),
 				UserID:    session.UserID(),

--- a/tool/tool.go
+++ b/tool/tool.go
@@ -18,7 +18,7 @@ import (
 	"context"
 
 	"google.golang.org/adk/agent"
-	"google.golang.org/adk/memoryservice"
+	"google.golang.org/adk/memory"
 	"google.golang.org/adk/session"
 )
 
@@ -38,7 +38,7 @@ type Context interface {
 	FunctionCallID() string
 
 	Actions() *session.EventActions
-	SearchMemory(context.Context, string) ([]memoryservice.MemoryEntry, error)
+	SearchMemory(context.Context, string) ([]memory.Entry, error)
 }
 
 type Set interface {


### PR DESCRIPTION
For naming consistency.

It includes:
* Updates package name memoryservice -> memory
* Update the struct name: memoryservice.MemoryEntry -> memory.Entry
* Update the internal package name: internal/memoryinternal ->
  internal/memory (with imemory import name) to make the internal package naming consistent.

Fixes #142 