### PR TITLE
Add check parent is llmagent in transfer agent targets.

### DIFF
--- a/internal/llminternal/agent_transfer.go
+++ b/internal/llminternal/agent_transfer.go
@@ -151,7 +151,7 @@ func transferTargets(agent, parent agent.Agent) []agent.Agent {
 	llmAgent := asLLMAgent(agent)
 	llmParent := asLLMAgent(parent)
 
-	if parent == nil || llmParent == nil {
+	if llmParent == nil {
 		return targets
 	}
 

--- a/internal/llminternal/agent_transfer_test.go
+++ b/internal/llminternal/agent_transfer_test.go
@@ -358,7 +358,7 @@ func TestAgentTransferRequestProcessor(t *testing.T) {
 		check(t, curAgent, root, "", nil, []string{"Parent", "Peer", "Current"})
 	})
 
-	t.Run("AgentWithSequetialParent", func(t *testing.T) {
+	t.Run("AgentWithSequentialParent", func(t *testing.T) {
 		curAgent := utils.Must(llmagent.New(llmagent.Config{
 			Name:                     "Current",
 			Model:                    llm,
@@ -377,6 +377,30 @@ func TestAgentTransferRequestProcessor(t *testing.T) {
 		}))
 
 		check(t, curAgent, root, "", nil, []string{"Parent", "Peer", "Current"})
+	})
+
+	t.Run("AgentWithSequentialSubagent", func(t *testing.T) {
+		seqSub := utils.Must(llmagent.New(llmagent.Config{
+			Name:  "Sub3",
+			Model: llm,
+		}))
+		agent := utils.Must(llmagent.New(llmagent.Config{
+			Name:  "Current",
+			Model: llm,
+			SubAgents: []agent.Agent{
+				utils.Must(sequentialagent.New(sequentialagent.Config{
+					AgentConfig: agent.Config{
+						Name:      "Sub1",
+						SubAgents: []agent.Agent{seqSub},
+					},
+				})),
+				utils.Must(llmagent.New(llmagent.Config{
+					Name:  "Sub2",
+					Model: llm,
+				})),
+			},
+		}))
+		check(t, agent, agent, "", []string{"Sub1", "Sub2"}, []string{"Current"})
 	})
 }
 


### PR DESCRIPTION
Added same logic as https://github.com/google/adk-python/blob/55aa6f669b0c0a47d630db6740a8310da87d43e9/src/google/adk/flows/llm_flows/agent_transfer.py#L131 to verify if parent is an llmagent. Transferring to sequential parent resulted in recursive loop.