### PR TITLE
agent: extend ReadonlyContext to match the change in python's

### DIFF
--- a/agent/agent.go
+++ b/agent/agent.go
@@ -208,6 +208,8 @@ func runAfterAgentCallbacks(ctx InvocationContext, agentEvent *session.Event, ag
 	return agentEvent, agentError
 }
 
+// TODO: unify with internal/context.callbackContext
+
 type callbackContext struct {
 	context.Context
 	invocationContext InvocationContext
@@ -241,6 +243,28 @@ func (c *callbackContext) InvocationID() string {
 func (c *callbackContext) UserContent() *genai.Content {
 	return c.invocationContext.UserContent()
 }
+
+// AppName implements CallbackContext.
+func (c *callbackContext) AppName() string {
+	return c.invocationContext.Session().AppName()
+}
+
+// Branch implements CallbackContext.
+func (c *callbackContext) Branch() string {
+	return c.invocationContext.Branch()
+}
+
+// SessionID implements CallbackContext.
+func (c *callbackContext) SessionID() string {
+	return c.invocationContext.Session().ID()
+}
+
+// UserID implements CallbackContext.
+func (c *callbackContext) UserID() string {
+	return c.invocationContext.Session().UserID()
+}
+
+var _ CallbackContext = (*callbackContext)(nil)
 
 type invocationContext struct {
 	context.Context

--- a/agent/context.go
+++ b/agent/context.go
@@ -45,6 +45,11 @@ type ReadonlyContext interface {
 	InvocationID() string
 	AgentName() string
 	ReadonlyState() session.ReadonlyState
+
+	UserID() string
+	AppName() string
+	SessionID() string
+	Branch() string
 }
 
 type CallbackContext interface {

--- a/internal/context/callback_context.go
+++ b/internal/context/callback_context.go
@@ -15,23 +15,28 @@
 package context
 
 import (
-	"context"
-
 	"google.golang.org/adk/agent"
 	"google.golang.org/adk/session"
 	"google.golang.org/genai"
 )
 
 func NewCallbackContext(ctx agent.InvocationContext) agent.CallbackContext {
+	return newCallbackContext(ctx)
+}
+
+func newCallbackContext(ctx agent.InvocationContext) *callbackContext {
+	rCtx := NewReadonlyContext(ctx)
 	return &callbackContext{
-		Context:       ctx,
-		invocationCtx: ctx,
-		eventActions:  &session.EventActions{},
+		ReadonlyContext: rCtx,
+		invocationCtx:   ctx,
+		eventActions:    &session.EventActions{},
 	}
 }
 
+// TODO: unify with agent.callbackContext
+
 type callbackContext struct {
-	context.Context
+	agent.ReadonlyContext
 	invocationCtx agent.InvocationContext
 	eventActions  *session.EventActions
 }

--- a/internal/context/context_test.go
+++ b/internal/context/context_test.go
@@ -1,0 +1,42 @@
+// Copyright 2025 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package context
+
+import (
+	"testing"
+
+	"google.golang.org/adk/agent"
+)
+
+func TestReadonlyContext(t *testing.T) {
+	inv := NewInvocationContext(t.Context(), InvocationContextParams{})
+	readonly := NewReadonlyContext(inv)
+
+	if got, ok := readonly.(agent.InvocationContext); ok {
+		t.Errorf("ReadonlyContext(%+T) is unexpectedly an InvocationContext", got)
+	}
+}
+
+func TestCallbackContext(t *testing.T) {
+	inv := NewInvocationContext(t.Context(), InvocationContextParams{})
+	callback := NewCallbackContext(inv)
+
+	if _, ok := callback.(agent.ReadonlyContext); !ok {
+		t.Errorf("CallbackContext(%+T) is unexpectedly not a ReadonlyContext", callback)
+	}
+	if got, ok := callback.(agent.InvocationContext); ok {
+		t.Errorf("CallbackContext(%+T) is unexpectedly an InvocationContext", got)
+	}
+}

--- a/internal/context/readonly_context.go
+++ b/internal/context/readonly_context.go
@@ -34,6 +34,26 @@ type readonlyContext struct {
 	invocationContext agent.InvocationContext
 }
 
+// AppName implements agent.ReadonlyContext.
+func (c *readonlyContext) AppName() string {
+	return c.invocationContext.Session().AppName()
+}
+
+// Branch implements agent.ReadonlyContext.
+func (c *readonlyContext) Branch() string {
+	return c.invocationContext.Branch()
+}
+
+// SessionID implements agent.ReadonlyContext.
+func (c *readonlyContext) SessionID() string {
+	return c.invocationContext.Session().ID()
+}
+
+// UserID implements agent.ReadonlyContext.
+func (c *readonlyContext) UserID() string {
+	return c.invocationContext.Session().UserID()
+}
+
 func (c *readonlyContext) AgentName() string {
 	return c.invocationContext.Agent().Name()
 }

--- a/internal/toolinternal/context.go
+++ b/internal/toolinternal/context.go
@@ -19,6 +19,7 @@ import (
 
 	"github.com/google/uuid"
 	"google.golang.org/adk/agent"
+	contextinternal "google.golang.org/adk/internal/context"
 	"google.golang.org/adk/memory"
 	"google.golang.org/adk/session"
 	"google.golang.org/adk/tool"
@@ -28,17 +29,20 @@ func NewToolContext(ctx agent.InvocationContext, functionCallID string, actions 
 	if functionCallID == "" {
 		functionCallID = uuid.NewString()
 	}
+	cbCtx := contextinternal.NewCallbackContext(ctx)
 	return &toolContext{
-		InvocationContext: ctx,
+		CallbackContext:   cbCtx,
+		invocationContext: ctx,
 		functionCallID:    functionCallID,
 		eventActions:      actions,
 	}
 }
 
 type toolContext struct {
-	agent.InvocationContext
-	functionCallID string
-	eventActions   *session.EventActions
+	agent.CallbackContext
+	invocationContext agent.InvocationContext
+	functionCallID    string
+	eventActions      *session.EventActions
 }
 
 func (c *toolContext) FunctionCallID() string {
@@ -50,17 +54,9 @@ func (c *toolContext) Actions() *session.EventActions {
 }
 
 func (c *toolContext) AgentName() string {
-	return c.Agent().Name()
-}
-
-func (c *toolContext) ReadonlyState() session.ReadonlyState {
-	return c.Session().State()
+	return c.invocationContext.Agent().Name()
 }
 
 func (c *toolContext) SearchMemory(ctx context.Context, query string) ([]memory.Entry, error) {
-	return c.Memory().Search(query)
-}
-
-func (c *toolContext) State() session.State {
-	return c.Session().State()
+	return c.invocationContext.Memory().Search(query)
 }

--- a/internal/toolinternal/context_test.go
+++ b/internal/toolinternal/context_test.go
@@ -1,0 +1,38 @@
+// Copyright 2025 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package toolinternal
+
+import (
+	"testing"
+
+	"google.golang.org/adk/agent"
+	contextinternal "google.golang.org/adk/internal/context"
+	"google.golang.org/adk/session"
+)
+
+func TestToolContext(t *testing.T) {
+	inv := contextinternal.NewInvocationContext(t.Context(), contextinternal.InvocationContextParams{})
+	toolCtx := NewToolContext(inv, "fn1", &session.EventActions{})
+
+	if _, ok := toolCtx.(agent.ReadonlyContext); !ok {
+		t.Errorf("ToolContext(%+T) is unexpectedly not a ReadonlyContext", toolCtx)
+	}
+	if _, ok := toolCtx.(agent.CallbackContext); !ok {
+		t.Errorf("ToolContext(%+T) is unexpectedly not a CallbackContext", toolCtx)
+	}
+	if got, ok := toolCtx.(agent.InvocationContext); ok {
+		t.Errorf("ToolContext(%+T) is unexpectedly an InvocationContext", got)
+	}
+}


### PR DESCRIPTION
Python's ReadonlyContext/CallbackContext/ToolContext will allow to access user id, branch, etc.

In the mean time, fix the tool.Context so it doesn't allow to access to InvocationContext.

And add tests.