### PR TITLE
Pass RunConfig with value instead of reference

### DIFF
--- a/agent/llmagent/llmagent_test.go
+++ b/agent/llmagent/llmagent_test.go
@@ -105,7 +105,7 @@ func TestLLMAgentStreamingModeSSE(t *testing.T) {
 		t.Fatalf("NewLLMAgent failed: %v", err)
 	}
 	testRunner := testutil.NewTestAgentRunner(t, a)
-	stream := testRunner.RunContentWithConfig(t, "test_session", genai.NewContentFromText("What is the sum of the first 50 prime numbers?", "user"), &agent.RunConfig{StreamingMode: agent.StreamingModeSSE})
+	stream := testRunner.RunContentWithConfig(t, "test_session", genai.NewContentFromText("What is the sum of the first 50 prime numbers?", "user"), agent.RunConfig{StreamingMode: agent.StreamingModeSSE})
 	events, err := testutil.CollectEvents(stream)
 	gotThought := false
 	numContents := 0

--- a/agent/workflowagents/loopagent/agent_test.go
+++ b/agent/workflowagents/loopagent/agent_test.go
@@ -122,7 +122,7 @@ func TestNewLoopAgent(t *testing.T) {
 				t.Fatal(err)
 			}
 
-			for event, err := range agentRunner.Run(ctx, "user_id", "session_id", genai.NewContentFromText("user input", genai.RoleUser), &agent.RunConfig{}) {
+			for event, err := range agentRunner.Run(ctx, "user_id", "session_id", genai.NewContentFromText("user input", genai.RoleUser), agent.RunConfig{}) {
 				if err != nil {
 					t.Errorf("got unexpected error: %v", err)
 				}

--- a/agent/workflowagents/parallelagent/agent_test.go
+++ b/agent/workflowagents/parallelagent/agent_test.go
@@ -123,7 +123,7 @@ func TestNewParallelAgent(t *testing.T) {
 				}()
 			}
 
-			for event, err := range agentRunner.Run(ctx, "user_id", "session_id", genai.NewContentFromText("user input", genai.RoleUser), &agent.RunConfig{}) {
+			for event, err := range agentRunner.Run(ctx, "user_id", "session_id", genai.NewContentFromText("user input", genai.RoleUser), agent.RunConfig{}) {
 				if tt.wantErr != (err != nil) {
 					if tt.cancelContext && err == nil {
 						// In case of context cancellation some events can be processed before cancel is applied.

--- a/agent/workflowagents/sequentialagent/agent_test.go
+++ b/agent/workflowagents/sequentialagent/agent_test.go
@@ -111,7 +111,7 @@ func TestNewSequentialAgent(t *testing.T) {
 				t.Fatal(err)
 			}
 
-			for event, err := range agentRunner.Run(ctx, "user_id", "session_id", genai.NewContentFromText("user input", genai.RoleUser), &agent.RunConfig{}) {
+			for event, err := range agentRunner.Run(ctx, "user_id", "session_id", genai.NewContentFromText("user input", genai.RoleUser), agent.RunConfig{}) {
 				if err != nil {
 					t.Errorf("got unexpected error: %v", err)
 				}

--- a/cmd/restapi/handlers/runtime.go
+++ b/cmd/restapi/handlers/runtime.go
@@ -70,7 +70,7 @@ func (c *RuntimeAPIController) runAgent(ctx context.Context, runAgentRequest mod
 		return nil, err
 	}
 
-	resp := r.Run(ctx, runAgentRequest.UserId, runAgentRequest.SessionId, &runAgentRequest.NewMessage, rCfg)
+	resp := r.Run(ctx, runAgentRequest.UserId, runAgentRequest.SessionId, &runAgentRequest.NewMessage, *rCfg)
 
 	var events []*session.Event
 	for event, err := range resp {
@@ -108,7 +108,7 @@ func (c *RuntimeAPIController) RunAgentSSE(rw http.ResponseWriter, req *http.Req
 		return err
 	}
 
-	resp := r.Run(req.Context(), runAgentRequest.UserId, runAgentRequest.SessionId, &runAgentRequest.NewMessage, rCfg)
+	resp := r.Run(req.Context(), runAgentRequest.UserId, runAgentRequest.SessionId, &runAgentRequest.NewMessage, *rCfg)
 
 	rw.WriteHeader(http.StatusOK)
 	for event, err := range resp {

--- a/examples/tools/loadartifacts/main.go
+++ b/examples/tools/loadartifacts/main.go
@@ -124,7 +124,7 @@ func main() {
 
 		fmt.Print("\nAgent -> ")
 		streamingMode := agent.StreamingModeSSE
-		for event, err := range r.Run(ctx, userID, session.ID(), userMsg, &agent.RunConfig{
+		for event, err := range r.Run(ctx, userID, session.ID(), userMsg, agent.RunConfig{
 			StreamingMode: streamingMode,
 		}) {
 			if err != nil {

--- a/examples/userloop.go
+++ b/examples/userloop.go
@@ -83,7 +83,7 @@ func Run(ctx context.Context, rootAgent agent.Agent, runConfig *RunConfig) {
 			streamingMode = agent.StreamingModeSSE
 		}
 		fmt.Print("\nAgent -> ")
-		for event, err := range r.Run(ctx, userID, session.ID(), userMsg, &agent.RunConfig{
+		for event, err := range r.Run(ctx, userID, session.ID(), userMsg, agent.RunConfig{
 			StreamingMode: streamingMode,
 		}) {
 			if err != nil {

--- a/internal/testutil/test_agent_runner.go
+++ b/internal/testutil/test_agent_runner.go
@@ -70,10 +70,10 @@ func (r *TestAgentRunner) Run(t *testing.T, sessionID, newMessage string) iter.S
 
 func (r *TestAgentRunner) RunContent(t *testing.T, sessionID string, content *genai.Content) iter.Seq2[*session.Event, error] {
 	t.Helper()
-	return r.RunContentWithConfig(t, sessionID, content, &agent.RunConfig{})
+	return r.RunContentWithConfig(t, sessionID, content, agent.RunConfig{})
 }
 
-func (r *TestAgentRunner) RunContentWithConfig(t *testing.T, sessionID string, content *genai.Content, cfg *agent.RunConfig) iter.Seq2[*session.Event, error] {
+func (r *TestAgentRunner) RunContentWithConfig(t *testing.T, sessionID string, content *genai.Content, cfg agent.RunConfig) iter.Seq2[*session.Event, error] {
 	t.Helper()
 	ctx := t.Context()
 

--- a/runner/runner.go
+++ b/runner/runner.go
@@ -71,7 +71,7 @@ type Runner struct {
 }
 
 // Run runs the agent.
-func (r *Runner) Run(ctx context.Context, userID, sessionID string, msg *genai.Content, cfg *agent.RunConfig) iter.Seq2[*session.Event, error] {
+func (r *Runner) Run(ctx context.Context, userID, sessionID string, msg *genai.Content, cfg agent.RunConfig) iter.Seq2[*session.Event, error] {
 	// TODO(hakim): we need to validate whether cfg is compatible with the Agent.
 	//   see adk-python/src/google/adk/runners.py Runner._new_invocation_context.
 	// TODO: setup tracer.
@@ -94,7 +94,7 @@ func (r *Runner) Run(ctx context.Context, userID, sessionID string, msg *genai.C
 			return
 		}
 
-		if cfg != nil && cfg.SupportCFC {
+		if cfg.SupportCFC {
 			if err := r.setupCFC(agentToRun); err != nil {
 				yield(nil, fmt.Errorf("failed to setup CFC: %w", err))
 				return

--- a/runner/runner_test.go
+++ b/runner/runner_test.go
@@ -238,7 +238,7 @@ func TestRunner_SaveInputBlobsAsArtifacts(t *testing.T) {
 		Role: genai.RoleUser,
 	}
 
-	cfg := &agent.RunConfig{
+	cfg := agent.RunConfig{
 		SaveInputBlobsAsArtifacts: true,
 	}
 

--- a/tool/agenttool/agent_tool.go
+++ b/tool/agenttool/agent_tool.go
@@ -187,7 +187,7 @@ func (t *agentTool) Run(toolCtx tool.Context, args any) (any, error) {
 	}
 
 	// TODO(dpasiukevich): verify agent loop termination.
-	eventCh := r.Run(toolCtx, subSession.Session.UserID(), subSession.Session.ID(), content, &agent.RunConfig{
+	eventCh := r.Run(toolCtx, subSession.Session.UserID(), subSession.Session.ID(), content, agent.RunConfig{
 		StreamingMode: agent.StreamingModeSSE,
 	})
 

--- a/tool/mcptool/set_test.go
+++ b/tool/mcptool/set_test.go
@@ -260,5 +260,5 @@ func (r *testAgentRunner) Run(t *testing.T, sessionID, newMessage string) iter.S
 		content = genai.NewContentFromText(newMessage, genai.RoleUser)
 	}
 
-	return r.runner.Run(ctx, userID, session.ID(), content, &agent.RunConfig{})
+	return r.runner.Run(ctx, userID, session.ID(), content, agent.RunConfig{})
 }


### PR DESCRIPTION
If RunConfig is nill, then it fails with panic in the run method. Since we never want nil, we might as well pass it by value, so it will be enforced by the compiler. 