### PR TITLE
Rename tool.Set -> tool.Toolset

### DIFF
--- a/agent/llmagent/llmagent.go
+++ b/agent/llmagent/llmagent.go
@@ -140,7 +140,7 @@ type Config struct {
 	Tools []tool.Tool
 	// Toolsets will be used by llmagent to extract tools and pass to the
 	// underlying LLM.
-	Toolsets []tool.Set
+	Toolsets []tool.Toolset
 
 	// OutputKey is an optional parameter to specify the key in session state for the agent output.
 	//

--- a/examples/mcp/main.go
+++ b/examples/mcp/main.go
@@ -112,7 +112,7 @@ func main() {
 		Model:       model,
 		Description: "Helper agent.",
 		Instruction: "You are a helpful assistant that helps users with various tasks.",
-		Toolsets: []tool.Set{
+		Toolsets: []tool.Toolset{
 			mcpToolSet,
 		},
 	})

--- a/internal/llminternal/agent.go
+++ b/internal/llminternal/agent.go
@@ -29,7 +29,7 @@ type State struct {
 	Model model.LLM
 
 	Tools    []tool.Tool
-	Toolsets []tool.Set
+	Toolsets []tool.Toolset
 
 	IncludeContents string
 

--- a/tool/mcptoolset/set.go
+++ b/tool/mcptoolset/set.go
@@ -47,7 +47,7 @@ import (
 //			}),
 //		},
 //	})
-func New(cfg Config) (tool.Set, error) {
+func New(cfg Config) (tool.Toolset, error) {
 	return &set{
 		client:     mcp.NewClient(&mcp.Implementation{Name: "adk-mcp-client", Version: "v1.0.0"}, nil),
 		transport:  cfg.Transport,

--- a/tool/mcptoolset/set_test.go
+++ b/tool/mcptoolset/set_test.go
@@ -87,7 +87,7 @@ func TestMCPToolSet(t *testing.T) {
 		Model:       newGeminiModel(t, modelName),
 		Description: "Agent to answer questions about the time and weather in a city.",
 		Instruction: "I can answer your questions about the time and weather in a city.",
-		Toolsets: []tool.Set{
+		Toolsets: []tool.Toolset{
 			ts,
 		},
 	})

--- a/tool/tool.go
+++ b/tool/tool.go
@@ -41,7 +41,7 @@ type Context interface {
 	SearchMemory(context.Context, string) (*memory.SearchResponse, error)
 }
 
-type Set interface {
+type Toolset interface {
 	Name() string
 	Tools(ctx agent.ReadonlyContext) ([]Tool, error)
 }


### PR DESCRIPTION
From the feedback of ADK team, Toolset is one word so it should be named as Toolset.