### PR TITLE
docs: revamp README with comprehensive example usage and guidance

### DIFF
--- a/examples/README.md
+++ b/examples/README.md
@@ -23,17 +23,19 @@ Most examples can be run using the Go command:
 go run ./examples/<example-name>/main.go console
 
 # Run with REST API server
-go run ./examples/<example-name>/main.go restapi
+go run ./examples/<example-name>/main.go web api
 
-# Run with Agent-to-Agent (A2A) protocol
-go run ./examples/<example-name>/main.go a2a
+# Run with Agent-to-Agent (A2A) protocol server
+go run ./examples/<example-name>/main.go web a2a
 
-# Run with Web UI
-go run ./examples/<example-name>/main.go webui
+# Run with the Web UI (served alongside the REST API)
+go run ./examples/<example-name>/main.go web api webui
 
 # Get help for available commands
 go run ./examples/<example-name>/main.go help
 ```
+
+The `web` launcher hosts one or more sub-servers (`api`, `a2a`, `webui`). The Web UI is served by the `api` server, so `web api webui` is required to bring it up.
 
 Before running examples, ensure you have:
 
@@ -60,20 +62,23 @@ go run ./examples/quickstart/main.go console
 
 ### [a2a](./a2a)
 
-Demonstrates the Agent-to-Agent (A2A) protocol integration. Shows:
+Demonstrates the Agent-to-Agent (A2A) protocol integration. The example
+internally starts an A2A server exposing a weather agent, then connects to it
+as a remote agent. Shows:
 
-- Setting up A2A server and client
-- Remote agent communication
+- Serving an agent over the A2A protocol
+- Consuming a remote agent through `remoteagent.NewA2A`
 - Multi-agent collaboration
 
-**Run it:**
+**Run it** (the in-process A2A server starts automatically; run it in any mode):
 
 ```bash
-# Start the A2A server
-go run ./examples/a2a/main.go a2a
+# Interactive console talking to the remote agent
+go run ./examples/a2a/main.go console
 
-# In another terminal, connect as client
-go run ./examples/a2a/main.go a2a --client
+# Or expose the remote agent over A2A / the Web UI
+go run ./examples/a2a/main.go web a2a
+go run ./examples/a2a/main.go web api webui
 ```
 
 ### [mcp](./mcp)
@@ -90,16 +95,19 @@ Model Context Protocol (MCP) integration example. Features:
 
 Web-based agent interface example. Demonstrates:
 
-- Building web UI for agents
+- Building a web UI for agents
 - Artifact handling (code, text, images)
 - Interactive agent conversations
 
 **Run it:**
 
 ```bash
-go run ./examples/web/main.go webui
+go run ./examples/web/main.go web api webui
 # Open http://localhost:8080 in your browser
 ```
+
+> **Note:** The Web UI is not unique to this example — any example can be
+> launched with `web api webui` to get the same interface.
 
 ## Tool Examples
 
@@ -147,9 +155,11 @@ Iterative workflow pattern with loops.
 
 ### [workflowagents/sequentialCode](./workflowagents/sequentialCode)
 
-Code-defined sequential workflow (vs configuration-based).
+A sequential workflow that writes code, chaining sub-agents that generate,
+review, and refactor code in order.
 
-**Use case:** Complex workflows requiring programmatic control.
+**Use case:** Multi-stage code-generation pipelines where each agent builds on
+the previous agent's output (writer → reviewer → refactorer).
 
 ## Advanced Examples
 
@@ -174,18 +184,17 @@ The ADK launcher provides a flexible way to run agents in different modes. Most 
 
 ```go
 l := full.NewLauncher()
-err = l.ParseAndRun(ctx, config, os.Args[1:], universal.ErrorOnUnparsedArgs)
-if err != nil {
-    log.Fatalf("run failed: %v\n\n%s", err, l.FormatSyntax())
+if err = l.Execute(ctx, config, os.Args[1:]); err != nil {
+    log.Fatalf("run failed: %v\n\n%s", err, l.CommandLineSyntax())
 }
 ```
 
 The `full.NewLauncher()` includes all major launch modes:
 
 - **console**: Interactive command-line interface
-- **restapi**: REST API server for HTTP requests
-- **a2a**: Agent-to-Agent protocol server
-- **webui**: Web-based user interface (can run standalone or with restapi/a2a)
+- **web api**: REST API server for HTTP requests
+- **web a2a**: Agent-to-Agent protocol server
+- **web api webui**: Web-based user interface (served by the `api` server)
 
 ### Production Launcher
 
@@ -195,10 +204,10 @@ l := prod.NewLauncher()
 
 The `prod.NewLauncher()` includes only production-ready modes:
 
-- **restapi**: REST API server
-- **a2a**: Agent-to-Agent protocol
+- **web api**: REST API server
+- **web a2a**: Agent-to-Agent protocol
 
-Use this for production deployments where console and webui are not needed.
+Use this for production deployments where console and the Web UI are not needed.
 
 ### Getting Help
 
@@ -216,25 +225,31 @@ Many examples use these environment variables:
 
 - `GOOGLE_API_KEY`: Gemini API key for model access
 - `GOOGLE_CLOUD_PROJECT`: GCP project ID (for Vertex AI)
-- `PORT`: Server port (default: 8080)
+
+The server port is not read from an environment variable. Instead, pass the
+`-port` flag to the `web` launcher (default: `8080`):
+
+```bash
+go run ./examples/<example-name>/main.go web api -port 9090
+```
 
 ### Configuration
 
 Examples typically follow this structure:
 
 ```go
-// 1. Create agent configuration
-config := adk.Config{
-    AgentCreator: func(ctx context.Context) (agent.Agent, error) {
-        // Agent setup
-    },
+// 1. Create your agent, then wrap it in a launcher config
+config := &launcher.Config{
+    AgentLoader: agent.NewSingleLoader(myAgent),
 }
 
 // 2. Create and configure launcher
 l := full.NewLauncher()
 
-// 3. Parse and run
-err := l.ParseAndRun(ctx, config, os.Args[1:], universal.ErrorOnUnparsedArgs)
+// 3. Parse arguments and run
+if err := l.Execute(ctx, config, os.Args[1:]); err != nil {
+    log.Fatalf("run failed: %v\n\n%s", err, l.CommandLineSyntax())
+}
 ```
 
 ## Contributing

--- a/examples/README.md
+++ b/examples/README.md
@@ -1,12 +1,177 @@
-# ADK GO samples
-This folder hosts examples to test different features. The examples are usually minimal and simplistic to test one or a few scenarios.
+# ADK Go Examples
 
+This directory contains examples demonstrating various features and capabilities of the ADK (Agent Development Kit) for Go. The examples are designed to be minimal and focused, each showcasing specific scenarios or features.
 
-**Note**: This is different from the [google/adk-samples](https://github.com/google/adk-samples) repo, which hosts more complex e2e samples for customers to use or modify directly.
+**Note**: This is different from the [google/adk-samples](https://github.com/google/adk-samples) repository, which hosts more complex end-to-end samples for production use.
 
+## Table of Contents
 
-# Launcher
-In many examples you can see such lines:
+- [Getting Started](#getting-started)
+- [Basic Examples](#basic-examples)
+- [Integration Examples](#integration-examples)
+- [Tool Examples](#tool-examples)
+- [Workflow Agent Examples](#workflow-agent-examples)
+- [Advanced Examples](#advanced-examples)
+- [Launcher System](#launcher-system)
+
+## Getting Started
+
+Most examples can be run using the Go command:
+
+```bash
+# Run in console mode (interactive)
+go run ./examples/<example-name>/main.go console
+
+# Run with REST API server
+go run ./examples/<example-name>/main.go restapi
+
+# Run with Agent-to-Agent (A2A) protocol
+go run ./examples/<example-name>/main.go a2a
+
+# Run with Web UI
+go run ./examples/<example-name>/main.go webui
+
+# Get help for available commands
+go run ./examples/<example-name>/main.go help
+```
+
+Before running examples, ensure you have:
+
+- Set up your `GOOGLE_API_KEY` or Google Cloud credentials
+- Installed required dependencies (`go mod download`)
+
+## Basic Examples
+
+### [quickstart](./quickstart)
+
+A minimal example to get started with ADK Go. Demonstrates:
+
+- Creating a simple LLM agent
+- Using Gemini tools (code execution, search)
+- Basic launcher configuration
+
+**Run it:**
+
+```bash
+go run ./examples/quickstart/main.go console
+```
+
+## Integration Examples
+
+### [a2a](./a2a)
+
+Demonstrates the Agent-to-Agent (A2A) protocol integration. Shows:
+
+- Setting up A2A server and client
+- Remote agent communication
+- Multi-agent collaboration
+
+**Run it:**
+
+```bash
+# Start the A2A server
+go run ./examples/a2a/main.go a2a
+
+# In another terminal, connect as client
+go run ./examples/a2a/main.go a2a --client
+```
+
+### [mcp](./mcp)
+
+Model Context Protocol (MCP) integration example. Features:
+
+- Connecting to MCP servers
+- Using MCP tools with ADK agents
+- GitHub integration via MCP
+
+**Prerequisites:** Configure MCP server settings before running.
+
+### [web](./web)
+
+Web-based agent interface example. Demonstrates:
+
+- Building web UI for agents
+- Artifact handling (code, text, images)
+- Interactive agent conversations
+
+**Run it:**
+
+```bash
+go run ./examples/web/main.go webui
+# Open http://localhost:8080 in your browser
+```
+
+## Tool Examples
+
+### [tools/multipletools](./tools/multipletools)
+
+Shows how to register and use multiple custom tools with an agent.
+
+**Key concepts:**
+
+- Tool registration
+- Tool parameter handling
+- Multiple tool coordination
+
+### [tools/loadartifacts](./tools/loadartifacts)
+
+Demonstrates artifact loading and manipulation.
+
+**Key concepts:**
+
+- Artifact creation and storage
+- Loading artifacts into agent context
+- Artifact type handling
+
+## Workflow Agent Examples
+
+These examples demonstrate different agent workflow patterns.
+
+### [workflowagents/sequential](./workflowagents/sequential)
+
+Sequential workflow execution pattern.
+
+**Use case:** Tasks that must be executed in order, where each step depends on the previous one.
+
+### [workflowagents/parallel](./workflowagents/parallel)
+
+Parallel workflow execution pattern.
+
+**Use case:** Independent tasks that can run simultaneously for better performance.
+
+### [workflowagents/loop](./workflowagents/loop)
+
+Iterative workflow pattern with loops.
+
+**Use case:** Repetitive tasks or retry logic until a condition is met.
+
+### [workflowagents/sequentialCode](./workflowagents/sequentialCode)
+
+Code-defined sequential workflow (vs configuration-based).
+
+**Use case:** Complex workflows requiring programmatic control.
+
+## Advanced Examples
+
+### [vertexai](./vertexai)
+
+Google Cloud Vertex AI integration examples.
+
+**Subdirectories:**
+
+- `imagegenerator`: Generate images using Vertex AI models
+
+**Prerequisites:**
+
+- Google Cloud project with Vertex AI API enabled
+- Application Default Credentials (ADC) configured
+
+## Launcher System
+
+The ADK launcher provides a flexible way to run agents in different modes. Most examples use one of two launcher configurations:
+
+### Full Launcher
+
 ```go
 l := full.NewLauncher()
 err = l.ParseAndRun(ctx, config, os.Args[1:], universal.ErrorOnUnparsedArgs)
@@ -15,13 +180,75 @@ if err != nil {
 }
 ```
 
-it allows to decide, which launching options are supported in the run-time. 
-`full.NewLauncher()` includes all major ways you can run the example:
-* console
-* restapi
-* a2a
-* webui (it can run standalone or with restapi or a2a).
+The `full.NewLauncher()` includes all major launch modes:
 
-Run `go run ./example/quickstart/main.go help` for details
+- **console**: Interactive command-line interface
+- **restapi**: REST API server for HTTP requests
+- **a2a**: Agent-to-Agent protocol server
+- **webui**: Web-based user interface (can run standalone or with restapi/a2a)
 
-As an alternative, you may want to use `prod.NewLauncher()` which only builds-in restapi and a2a launchers.
+### Production Launcher
+
+```go
+l := prod.NewLauncher()
+```
+
+The `prod.NewLauncher()` includes only production-ready modes:
+
+- **restapi**: REST API server
+- **a2a**: Agent-to-Agent protocol
+
+Use this for production deployments where console and webui are not needed.
+
+### Getting Help
+
+Run any example with `help` to see available options:
+
+```bash
+go run ./examples/quickstart/main.go help
+```
+
+## Common Patterns
+
+### Environment Variables
+
+Many examples use these environment variables:
+
+- `GOOGLE_API_KEY`: Gemini API key for model access
+- `GOOGLE_CLOUD_PROJECT`: GCP project ID (for Vertex AI)
+- `PORT`: Server port (default: 8080)
+
+### Configuration
+
+Examples typically follow this structure:
+
+```go
+// 1. Create agent configuration
+config := adk.Config{
+    AgentCreator: func(ctx context.Context) (agent.Agent, error) {
+        // Agent setup
+    },
+}
+
+// 2. Create and configure launcher
+l := full.NewLauncher()
+
+// 3. Parse and run
+err := l.ParseAndRun(ctx, config, os.Args[1:], universal.ErrorOnUnparsedArgs)
+```
+
+## Contributing
+
+When adding new examples:
+
+1. Keep them focused on specific features
+2. Include comments explaining key concepts
+3. Follow the existing launcher pattern
+4. Update this README with your example
+5. Test in at least one launch mode
+
+## Additional Resources
+
+- [ADK Go Documentation](https://pkg.go.dev/google.golang.org/adk)
+- [Google AI for Developers](https://ai.google.dev/)
+- [Vertex AI Documentation](https://cloud.google.com/vertex-ai/docs)


### PR DESCRIPTION
- Rewrite and expand the README to provide a detailed overview of the example categories, launch options, and usage instructions
- Add an extensive table of contents with clear links to all major example types
- Document step-by-step instructions for running examples in various modes (console, restapi, a2a, webui)
- Clarify environment variable requirements and configuration patterns across examples
- Distinguish between full and production launchers, specifying their supported modes
- Add sections on contributing, common patterns, and integration prerequisites for advanced examples
- Improve consistency, clarity, and completeness throughout the guide