### PR TITLE
Avoid the unnecessary type alias

### DIFF
--- a/memory/inmemory.go
+++ b/memory/inmemory.go
@@ -36,7 +36,7 @@ type key struct {
 	appName, userID string
 }
 
-type sessionID = string
+type sessionID string
 
 type value struct {
 	content   *genai.Content
@@ -96,7 +96,8 @@ func (s *inMemoryService) AddSession(ctx context.Context, curSession session.Ses
 		s.store[k] = v
 	}
 
-	v[curSession.ID()] = values
+	sid := sessionID(curSession.ID())
+	v[sid] = values
 	return nil
 }
 


### PR DESCRIPTION
Type aliases are useful for large scale refactoring for a gradual transition. They used to be used only exceptional cases when the old code has to keep using the old type.