### PR TITLE
Rename remoteagent.New to remoteagent.NewA2A

### DIFF
--- a/agent/remoteagent/a2a_agent.go
+++ b/agent/remoteagent/a2a_agent.go
@@ -49,9 +49,9 @@ type A2AConfig struct {
 	MessageSendConfig *a2a.MessageSendConfig
 }
 
-// New creates a RemoteAgent. A2A (Agent-To-Agent) protocol is used for communication with an
+// NewA2A creates a remote A2A agent. A2A (Agent-To-Agent) protocol is used for communication with an
 // agent which can run in a different process or on a different host.
-func New(cfg A2AConfig) (agent.Agent, error) {
+func NewA2A(cfg A2AConfig) (agent.Agent, error) {
 	if cfg.AgentCard == nil && cfg.AgentCardSource == "" {
 		return nil, fmt.Errorf("either AgentCard or AgentCardSource must be provided")
 	}

--- a/examples/a2a/main.go
+++ b/examples/a2a/main.go
@@ -111,7 +111,7 @@ func main() {
 
 	a2aServerAddress := startWeatherAgentServer()
 
-	remoteAgent, err := remoteagent.New(remoteagent.A2AConfig{
+	remoteAgent, err := remoteagent.NewA2A(remoteagent.A2AConfig{
 		Name:            "A2A Weather agent",
 		AgentCardSource: a2aServerAddress,
 	})


### PR DESCRIPTION
Beacuse there will be other protocols we will have to support soon, and implement new Agent implementations. We can provide all first class remote agent implementations from this package.