### PR TITLE
Allow function tool handlers to return errors

### DIFF
--- a/agent/llmagent/llmagent_test.go
+++ b/agent/llmagent/llmagent_test.go
@@ -313,8 +313,8 @@ func TestToolCallback(t *testing.T) {
 		Number int `json:"number"`
 	}
 
-	handler := func(_ tool.Context, input Args) Result {
-		return Result{Number: 1}
+	handler := func(_ tool.Context, input Args) (Result, error) {
+		return Result{Number: 1}, nil
 	}
 	rand, _ := functiontool.New(functiontool.Config{
 		Name:        "rand_number",
@@ -697,11 +697,11 @@ func TestFunctionTool(t *testing.T) {
 	}
 
 	prompt := "what is the sum of 1 + 2?"
-	handler := func(_ tool.Context, input Args) Result {
+	handler := func(_ tool.Context, input Args) (Result, error) {
 		if input.A != 1 || input.B != 2 {
 			t.Errorf("handler received %+v, want {a: 1, b: 2}", input)
 		}
-		return Result{Sum: input.A + input.B}
+		return Result{Sum: input.A + input.B}, nil
 	}
 	rand, _ := functiontool.New(functiontool.Config{
 		Name:        "sum",

--- a/agent/llmagent/state_agent_test.go
+++ b/agent/llmagent/state_agent_test.go
@@ -256,7 +256,7 @@ type WeatherResult struct {
 	Timestamp   time.Time `json:"timestamp"`
 }
 
-func GetWeather(ctx tool.Context, args WeatherArgs) WeatherResult {
+func GetWeather(ctx tool.Context, args WeatherArgs) (WeatherResult, error) {
 	// Simulate weather data
 	temperatures := []int{-10, -5, 0, 5, 10, 15, 20, 25, 30, 35}
 	conditions := []string{"sunny", "cloudy", "rainy", "snowy", "windy"}
@@ -267,7 +267,7 @@ func GetWeather(ctx tool.Context, args WeatherArgs) WeatherResult {
 		Condition:   conditions[rand.Intn(len(conditions))],
 		Humidity:    rand.Intn(61) + 30, // 30-90
 		Timestamp:   time.Now(),
-	}
+	}, nil
 }
 
 type CalculationArgs struct {
@@ -284,7 +284,7 @@ type CalculationResult struct {
 	Timestamp time.Time `json:"timestamp"`
 }
 
-func Calculate(ctx tool.Context, args CalculationArgs) CalculationResult {
+func Calculate(ctx tool.Context, args CalculationArgs) (CalculationResult, error) {
 	operations := map[string]float64{
 		"add":      args.X + args.Y,
 		"subtract": args.X - args.Y,
@@ -306,7 +306,7 @@ func Calculate(ctx tool.Context, args CalculationArgs) CalculationResult {
 			Y:         args.Y,
 			Result:    "Unknown operation",
 			Timestamp: time.Now(),
-		}
+		}, nil
 	}
 
 	return CalculationResult{
@@ -315,7 +315,7 @@ func Calculate(ctx tool.Context, args CalculationArgs) CalculationResult {
 		Y:         args.Y,
 		Result:    result,
 		Timestamp: time.Now(),
-	}
+	}, nil
 }
 
 type LogActivityParams struct {
@@ -334,7 +334,7 @@ type LogActivityResult struct {
 	err          error
 }
 
-func LogActivity(ctx tool.Context, params LogActivityParams) LogActivityResult {
+func LogActivity(ctx tool.Context, params LogActivityParams) (LogActivityResult, error) {
 	var activityLog []LogEntry
 	val, err := ctx.State().Get("activity_log")
 	if err == nil {
@@ -346,7 +346,7 @@ func LogActivity(ctx tool.Context, params LogActivityParams) LogActivityResult {
 	if err := ctx.State().Set("activity_log", activityLog); err != nil {
 		return LogActivityResult{
 			err: err,
-		}
+		}, err
 	}
 
 	return LogActivityResult{
@@ -354,7 +354,7 @@ func LogActivity(ctx tool.Context, params LogActivityParams) LogActivityResult {
 		Entry:        logEntry,
 		TotalEntries: len(activityLog),
 		err:          nil,
-	}
+	}, nil
 }
 
 // --- Before Tool Callbacks ---

--- a/agent/workflowagents/loopagent/agent_test.go
+++ b/agent/workflowagents/loopagent/agent_test.go
@@ -288,16 +288,16 @@ func (a *customAgent) Run(agent.InvocationContext) iter.Seq2[*session.Event, err
 
 type EmptyArgs struct{}
 
-func exampleFunctionThatEscalates(ctx tool.Context, myArgs EmptyArgs) map[string]string {
+func exampleFunctionThatEscalates(ctx tool.Context, myArgs EmptyArgs) (map[string]string, error) {
 	ctx.Actions().Escalate = true
 	ctx.Actions().SkipSummarization = false
-	return map[string]string{}
+	return map[string]string{}, nil
 }
 
-func exampleFunctionThatEscalatesAndSkips(ctx tool.Context, myArgs EmptyArgs) map[string]string {
+func exampleFunctionThatEscalatesAndSkips(ctx tool.Context, myArgs EmptyArgs) (map[string]string, error) {
 	ctx.Actions().Escalate = true
 	ctx.Actions().SkipSummarization = true
-	return map[string]string{}
+	return map[string]string{}, nil
 }
 
 func newLmmAgentWithFunctionCall(t *testing.T, id int, skipSummarization bool) agent.Agent {

--- a/examples/tools/multipletools/main.go
+++ b/examples/tools/multipletools/main.go
@@ -65,10 +65,10 @@ func main() {
 	type Output struct {
 		Poem string `json:"poem"`
 	}
-	handler := func(ctx tool.Context, input Input) Output {
+	handler := func(ctx tool.Context, input Input) (Output, error) {
 		return Output{
 			Poem: strings.Repeat("A line of a poem,", input.LineCount) + "\n",
-		}
+		}, nil
 	}
 	poemTool, err := functiontool.New(functiontool.Config{
 		Name:        "poem",

--- a/examples/web/agents/image_generator.go
+++ b/examples/web/agents/image_generator.go
@@ -29,7 +29,7 @@ import (
 	"google.golang.org/genai"
 )
 
-func generateImage(ctx tool.Context, input generateImageInput) generateImageResult {
+func generateImage(ctx tool.Context, input generateImageInput) (generateImageResult, error) {
 	client, err := genai.NewClient(ctx, &genai.ClientConfig{
 		Project:  os.Getenv("GOOGLE_CLOUD_PROJECT"),
 		Location: os.Getenv("GOOGLE_CLOUD_LOCATION"),
@@ -38,7 +38,7 @@ func generateImage(ctx tool.Context, input generateImageInput) generateImageResu
 	if err != nil {
 		return generateImageResult{
 			Status: "fail",
-		}
+		}, nil
 	}
 
 	response, err := client.Models.GenerateImages(
@@ -49,20 +49,20 @@ func generateImage(ctx tool.Context, input generateImageInput) generateImageResu
 	if err != nil {
 		return generateImageResult{
 			Status: "fail",
-		}
+		}, nil
 	}
 
 	_, err = ctx.Artifacts().Save(ctx, input.Filename, genai.NewPartFromBytes(response.GeneratedImages[0].Image.ImageBytes, "image/png"))
 	if err != nil {
 		return generateImageResult{
 			Status: "fail",
-		}
+		}, nil
 	}
 
 	return generateImageResult{
 		Status:   "success",
 		Filename: input.Filename,
-	}
+	}, nil
 }
 
 type generateImageInput struct {

--- a/internal/llminternal/agent_transfer_test.go
+++ b/internal/llminternal/agent_transfer_test.go
@@ -408,8 +408,8 @@ func TestAgentTransferRequestProcessor(t *testing.T) {
 func TestAgentTransfer_ProcessRequest(t *testing.T) {
 	// First Tool
 	var req model.LLMRequest
-	handler := func(ctx tool.Context, x int) int {
-		return x
+	handler := func(ctx tool.Context, x int) (int, error) {
+		return x, nil
 	}
 	identityTool, err := functiontool.New(functiontool.Config{
 		Name:        "identity",

--- a/internal/llminternal/base_flow.go
+++ b/internal/llminternal/base_flow.go
@@ -416,10 +416,6 @@ func (f *Flow) callTool(tool toolinternal.FunctionTool, fArgs map[string]any, to
 	}
 	if result == nil {
 		result, err = tool.Run(toolCtx, fArgs)
-		// genai.FunctionResponse expects to use "output" key to specify function output
-		// and "error" key to specify error details (if any). If "output" and "error" keys
-		// are not specified, then whole "response" is treated as function output.
-		// TODO(hakim): revisit the tool's function signature to handle error from user function better.
 		if err != nil {
 			return map[string]any{"error": fmt.Errorf("tool %q failed: %w", tool.Name(), err)}
 		}

--- a/tool/exitlooptool/tool.go
+++ b/tool/exitlooptool/tool.go
@@ -25,10 +25,10 @@ import (
 // EmptyArgs is an empty struct used as an argument for the exitLoop tool.
 type EmptyArgs struct{}
 
-func exitLoop(ctx tool.Context, myArgs EmptyArgs) map[string]string {
+func exitLoop(ctx tool.Context, myArgs EmptyArgs) (map[string]string, error) {
 	ctx.Actions().Escalate = true
 	ctx.Actions().SkipSummarization = true
-	return map[string]string{}
+	return map[string]string{}, nil
 }
 
 // New creates an instance of an exitLoop tool.

--- a/tool/functiontool/function.go
+++ b/tool/functiontool/function.go
@@ -46,7 +46,7 @@ type Config struct {
 
 // Func represents a Go function that can be wrapped in a tool.
 // It takes a tool.Context and a generic argument type, and returns a generic result type.
-type Func[TArgs, TResults any] func(tool.Context, TArgs) TResults
+type Func[TArgs, TResults any] func(tool.Context, TArgs) (TResults, error)
 
 // New creates a new tool with a name, description, and the provided handler.
 // Input schema is automatically inferred from the input and output types.
@@ -140,7 +140,10 @@ func (f *functionTool[TArgs, TResults]) Run(ctx tool.Context, args any) (map[str
 	if err != nil {
 		return nil, err
 	}
-	output := f.handler(ctx, input)
+	output, err := f.handler(ctx, input)
+	if err != nil {
+		return nil, err
+	}
 	resp, err := typeutil.ConvertToWithJSONSchema[TResults, map[string]any](output, f.outputSchema)
 	if err == nil { // all good
 		return resp, nil

--- a/tool/functiontool/function_test.go
+++ b/tool/functiontool/function_test.go
@@ -45,8 +45,8 @@ func ExampleNew() {
 		Sum int `json:"sum"` // the sum of two integers
 	}
 
-	handler := func(ctx tool.Context, input SumArgs) SumResult {
-		return SumResult{Sum: input.A + input.B}
+	handler := func(ctx tool.Context, input SumArgs) (SumResult, error) {
+		return SumResult{Sum: input.A + input.B}, nil
 	}
 	sumTool, err := functiontool.New(functiontool.Config{
 		Name:        "sum",
@@ -89,15 +89,12 @@ func TestFunctionTool_Simple(t *testing.T) {
 		},
 	}
 
-	weatherReport := func(ctx tool.Context, input Args) Result {
+	weatherReport := func(ctx tool.Context, input Args) (Result, error) {
 		city := strings.ToLower(input.City)
 		if ret, ok := resultSet[city]; ok {
-			return ret
+			return ret, nil
 		}
-		return Result{
-			Status: "error",
-			Report: fmt.Sprintf("Weather information for %q is not available.", city),
-		}
+		return Result{}, fmt.Errorf("Weather information for %q is not available.", city)
 	}
 
 	weatherReportTool, err := functiontool.New(
@@ -111,27 +108,28 @@ func TestFunctionTool_Simple(t *testing.T) {
 	}
 
 	for _, tc := range []struct {
-		name   string
-		prompt string
-		want   Result
+		name    string
+		prompt  string
+		want    Result
+		isError bool
 	}{
 		{
-			name:   "london",
-			prompt: "Report the current weather of the capital city of U.K.",
-			want:   resultSet["london"],
+			name:    "london",
+			prompt:  "Report the current weather of the capital city of U.K.",
+			want:    resultSet["london"],
+			isError: false,
 		},
 		{
-			name:   "paris",
-			prompt: "How is the weather of Paris now?",
-			want:   resultSet["paris"],
+			name:    "paris",
+			prompt:  "How is the weather of Paris now?",
+			want:    resultSet["paris"],
+			isError: false,
 		},
 		{
-			name:   "new york",
-			prompt: "Tell me about the current weather in New York",
-			want: Result{
-				Status: "error",
-				Report: `Weather information for "new york" is not available.`,
-			},
+			name:    "new york",
+			prompt:  "Tell me about the current weather in New York",
+			want:    Result{},
+			isError: true,
 		},
 	} {
 		t.Run(tc.name, func(t *testing.T) {
@@ -163,6 +161,12 @@ func TestFunctionTool_Simple(t *testing.T) {
 				t.Fatal("weatherReportTool does not implement itype.RequestProcessor")
 			}
 			callResult, err := funcTool.Run(nil, resp.Args)
+			if tc.isError {
+				if err == nil {
+					t.Fatalf("weatherReportTool.Run(%v) expected to fail but got success with result %v", resp.Args, callResult)
+				}
+				return
+			}
 			if err != nil {
 				t.Fatalf("weatherReportTool.Run failed: %v", err)
 			}
@@ -180,8 +184,8 @@ func TestFunctionTool_Simple(t *testing.T) {
 
 func TestFunctionTool_DifferentFunctionDeclarations_ConsolidatedInOneGenAiTool(t *testing.T) {
 	// First tool
-	identityFunc := func(ctx tool.Context, x int) int {
-		return x
+	identityFunc := func(ctx tool.Context, x int) (int, error) {
+		return x, nil
 	}
 	identityTool, err := functiontool.New(functiontool.Config{
 		Name:        "identity",
@@ -192,8 +196,8 @@ func TestFunctionTool_DifferentFunctionDeclarations_ConsolidatedInOneGenAiTool(t
 	}
 
 	// Second tool
-	stringIdentityFunc := func(ctx tool.Context, input string) string {
-		return input
+	stringIdentityFunc := func(ctx tool.Context, input string) (string, error) {
+		return input, nil
 	}
 	stringIdentityTool, err := functiontool.New(
 		functiontool.Config{
@@ -238,12 +242,12 @@ func TestFunctionTool_ReturnsBasicType(t *testing.T) {
 		"paris":  "The weather in Paris is sunny with a temperature of 25 derees Celsius.",
 	}
 
-	weatherReport := func(ctx tool.Context, input Args) string {
+	weatherReport := func(ctx tool.Context, input Args) (string, error) {
 		city := strings.ToLower(input.City)
 		if ret, ok := resultSet[city]; ok {
-			return ret
+			return ret, nil
 		}
-		return fmt.Sprintf("Weather information for %q is not available.", city)
+		return fmt.Sprintf("Weather information for %q is not available.", city), nil
 	}
 
 	weatherReportTool, err := functiontool.New(
@@ -396,12 +400,12 @@ func TestFunctionTool_CustomSchema(t *testing.T) {
 		Name:        "print_quantity",
 		Description: "print the remaining quantity of the given fruit.",
 		InputSchema: ischema,
-	}, func(ctx tool.Context, input Args) any {
+	}, func(ctx tool.Context, input Args) (any, error) {
 		fruit := strings.ToLower(input.Fruit)
 		if fruit != "mandarin" && fruit != "kiwi" {
 			t.Errorf("unexpected fruit: %q", fruit)
 		}
-		return nil // always return nil.
+		return nil, nil // always return nil.
 	})
 	if err != nil {
 		t.Fatalf("NewFunctionTool failed: %v", err)

--- a/tool/functiontool/long_running_function_test.go
+++ b/tool/functiontool/long_running_function_test.go
@@ -38,8 +38,8 @@ func TestNewLongRunningFunctionTool(t *testing.T) {
 		Result string `json:"result"` // the operation result
 	}
 
-	handler := func(ctx tool.Context, input SumArgs) SumResult {
-		return SumResult{Result: "Processing sum"}
+	handler := func(ctx tool.Context, input SumArgs) (SumResult, error) {
+		return SumResult{Result: "Processing sum"}, nil
 	}
 	sumTool, err := functiontool.New(functiontool.Config{
 		Name:          "sum",
@@ -80,24 +80,24 @@ type IncArgs struct {
 
 func TestLongRunningFunctionFlow(t *testing.T) {
 	functionCalled := 0
-	increaseByOne := func(ctx tool.Context, x IncArgs) map[string]string {
+	increaseByOne := func(ctx tool.Context, x IncArgs) (map[string]string, error) {
 		functionCalled++
-		return map[string]string{"status": "pending"}
+		return map[string]string{"status": "pending"}, nil
 	}
 	testLongRunningFunctionFlow(t, increaseByOne, "status", &functionCalled)
 }
 
 func TestLongRunningStringFunctionFlow(t *testing.T) {
 	functionCalled := 0
-	increaseByOne := func(ctx tool.Context, x IncArgs) string {
+	increaseByOne := func(ctx tool.Context, x IncArgs) (string, error) {
 		functionCalled++
-		return "pending"
+		return "pending", nil
 	}
 	testLongRunningFunctionFlow(t, increaseByOne, "result", &functionCalled)
 }
 
 // --- Test Suite ---
-func testLongRunningFunctionFlow[Out any](t *testing.T, increaseByOne func(ctx tool.Context, x IncArgs) Out, resultKey string, callCount *int) {
+func testLongRunningFunctionFlow[Out any](t *testing.T, increaseByOne func(ctx tool.Context, x IncArgs) (Out, error), resultKey string, callCount *int) {
 	// 1. Setup
 	responses := []*genai.Content{
 		genai.NewContentFromFunctionCall("increaseByOne", map[string]any{}, "model"),
@@ -267,9 +267,9 @@ func TestLongRunningToolIDsAreSet(t *testing.T) {
 	type IncArgs struct {
 	}
 
-	increaseByOne := func(ctx tool.Context, x IncArgs) map[string]string {
+	increaseByOne := func(ctx tool.Context, x IncArgs) (map[string]string, error) {
 		functionCalled++
-		return map[string]string{"status": "pending"}
+		return map[string]string{"status": "pending"}, nil
 	}
 
 	longRunningTool, err := functiontool.New(functiontool.Config{

--- a/tool/tool_test.go
+++ b/tool/tool_test.go
@@ -39,7 +39,7 @@ func TestTypes(t *testing.T) {
 		{
 			name: "FunctionTool",
 			constructor: func() (tool.Tool, error) {
-				return functiontool.New(functiontool.Config{}, func(tool.Context, int) int { return 0 })
+				return functiontool.New(functiontool.Config{}, func(tool.Context, int) (int, error) { return 0, nil })
 			},
 			expectedTypes: []string{requestProc, functionTool},
 		},


### PR DESCRIPTION
This change re-introduces error as a possible return value for function tools. The previous removal of this feature led to poor error-handling patterns, as functions often need to signal failures from validation, I/O, or network calls. Restoring the ability to return errors allows for conventional error handling.

Fixes #260.