### PR TITLE
fix: prevent panic when LLMAgent has no Model configured

### DIFF
--- a/internal/llminternal/base_flow.go
+++ b/internal/llminternal/base_flow.go
@@ -248,6 +248,11 @@ func (f *Flow) callLLM(ctx agent.InvocationContext, req *model.LLMRequest, state
 			}
 		}
 
+		if f.Model == nil {
+			yield(nil, fmt.Errorf("agent %q has no Model configured; ensure Model is set in llmagent.Config", ctx.Agent().Name()))
+			return
+		}
+
 		// TODO: Set _ADK_AGENT_NAME_LABEL_KEY in req.GenerateConfig.Labels
 		// to help with slicing the billing reports on a per-agent basis.
 


### PR DESCRIPTION
Fixes https://github.com/google/adk-go/issues/279

Since there is a valid use-case to initiate without providing a model, it did not make sense to validate during initialization. Added a lazy validation. 