### PR TITLE
feat: Add HeaderProvider to mcptoolset

### DIFF
--- a/tool/mcptoolset/session_manager.go
+++ b/tool/mcptoolset/session_manager.go
@@ -28,7 +28,10 @@ import (
 	"github.com/modelcontextprotocol/go-sdk/mcp"
 )
 
-const defaultSessionKey = "default"
+const (
+	defaultSessionKey  = "default"
+	defaultPingTimeout = 2 * time.Second
+)
 
 // sessionManager manages MCP client sessions with header-based pooling
 type sessionManager struct {
@@ -134,7 +137,7 @@ func (sm *sessionManager) isSessionValid(ctx context.Context, session *mcp.Clien
 	pingCtx := ctx
 	if _, hasDeadline := ctx.Deadline(); !hasDeadline {
 		var cancel context.CancelFunc
-		pingCtx, cancel = context.WithTimeout(ctx, 2*time.Second)
+		pingCtx, cancel = context.WithTimeout(ctx, defaultPingTimeout)
 		defer cancel()
 	}
 

--- a/tool/mcptoolset/session_manager.go
+++ b/tool/mcptoolset/session_manager.go
@@ -204,7 +204,6 @@ func (sm *sessionManager) Close() error {
 	return nil
 }
 
-// headerTransport that uses fixed headers instead of context
 type headerTransport struct {
 	Base    http.RoundTripper
 	Headers map[string]string

--- a/tool/mcptoolset/session_manager.go
+++ b/tool/mcptoolset/session_manager.go
@@ -94,14 +94,11 @@ func (sm *sessionManager) GetSession(ctx context.Context, headers map[string]str
 	key := sm.generateSessionKey(headers)
 
 	sm.mu.RLock()
-	if entry, ok := sm.sessions[key]; ok {
-		if sm.isSessionValid(ctx, entry.session) {
-			sm.mu.RUnlock()
-			return entry.session, nil
-		}
-		sm.mu.RUnlock()
-	} else {
-		sm.mu.RUnlock()
+	entry, ok := sm.sessions[key]
+	sm.mu.RUnlock()
+
+	if ok && sm.isSessionValid(ctx, entry.session) {
+		return entry.session, nil
 	}
 
 	sm.mu.Lock()

--- a/tool/mcptoolset/session_manager.go
+++ b/tool/mcptoolset/session_manager.go
@@ -210,17 +210,7 @@ type headerTransport struct {
 
 // RoundTrip adds the configured headers to the request.
 func (t *headerTransport) RoundTrip(req *http.Request) (*http.Response, error) {
-	reqBodyClosed := false
-	if req.Body != nil {
-		defer func() {
-			if !reqBodyClosed {
-				req.Body.Close()
-			}
-		}()
-	}
-
 	if len(t.Headers) == 0 {
-		reqBodyClosed = true
 		return t.base().RoundTrip(req)
 	}
 
@@ -228,8 +218,6 @@ func (t *headerTransport) RoundTrip(req *http.Request) (*http.Response, error) {
 	for key, value := range t.Headers {
 		req2.Header.Set(key, value)
 	}
-
-	reqBodyClosed = true
 	return t.base().RoundTrip(req2)
 }
 

--- a/tool/mcptoolset/session_manager.go
+++ b/tool/mcptoolset/session_manager.go
@@ -1,0 +1,225 @@
+// Copyright 2025 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package mcptoolset
+
+import (
+	"context"
+	"crypto/md5"
+	"encoding/hex"
+	"fmt"
+	"net/http"
+	"sort"
+	"strings"
+	"sync"
+	"time"
+
+	"github.com/modelcontextprotocol/go-sdk/mcp"
+)
+
+// SessionManager manages MCP client sessions with header-based pooling
+type SessionManager struct {
+	client    *mcp.Client
+	transport mcp.Transport
+
+	mu       sync.RWMutex
+	sessions map[string]*sessionEntry
+}
+
+type sessionEntry struct {
+	session *mcp.ClientSession
+	headers map[string]string
+}
+
+// NewSessionManager creates a new session manager
+func NewSessionManager(client *mcp.Client, transport mcp.Transport) *SessionManager {
+	return &SessionManager{
+		client:    client,
+		transport: transport,
+		sessions:  make(map[string]*sessionEntry),
+	}
+}
+
+// generateSessionKey creates a hash-based key from headers
+func (sm *SessionManager) generateSessionKey(headers map[string]string) string {
+	if len(headers) == 0 {
+		return "default"
+	}
+
+	keys := make([]string, 0, len(headers))
+	for k := range headers {
+		keys = append(keys, k)
+	}
+	sort.Strings(keys)
+
+	var pairs []string
+	for _, k := range keys {
+		pairs = append(pairs, fmt.Sprintf("%q:%q", k, headers[k]))
+	}
+	jsonStr := "{" + strings.Join(pairs, ",") + "}"
+
+	h := md5.Sum([]byte(jsonStr))
+	return hex.EncodeToString(h[:])
+}
+
+// GetSession returns a session for the given headers, creating if necessary
+func (sm *SessionManager) GetSession(ctx context.Context, headers map[string]string) (*mcp.ClientSession, error) {
+	key := sm.generateSessionKey(headers)
+
+	sm.mu.RLock()
+	if entry, ok := sm.sessions[key]; ok {
+		if sm.isSessionValid(ctx, entry.session) {
+			sm.mu.RUnlock()
+			return entry.session, nil
+		}
+		sm.mu.RUnlock()
+	} else {
+		sm.mu.RUnlock()
+	}
+
+	sm.mu.Lock()
+	defer sm.mu.Unlock()
+
+	if entry, ok := sm.sessions[key]; ok && sm.isSessionValid(ctx, entry.session) {
+		return entry.session, nil
+	}
+
+	wrappedTransport := sm.wrapTransportWithHeaders(headers)
+
+	session, err := sm.client.Connect(ctx, wrappedTransport, nil)
+	if err != nil {
+		return nil, fmt.Errorf("failed to create session: %w", err)
+	}
+
+	sm.sessions[key] = &sessionEntry{
+		session: session,
+		headers: headers,
+	}
+
+	return session, nil
+}
+
+// isSessionValid checks if a session is still usable
+func (sm *SessionManager) isSessionValid(ctx context.Context, session *mcp.ClientSession) bool {
+	if session == nil {
+		return false
+	}
+
+	pingCtx := ctx
+	if _, hasDeadline := ctx.Deadline(); !hasDeadline {
+		var cancel context.CancelFunc
+		pingCtx, cancel = context.WithTimeout(ctx, 2*time.Second)
+		defer cancel()
+	}
+
+	if err := session.Ping(pingCtx, nil); err != nil {
+		return false
+	}
+	return true
+}
+
+// wrapTransportWithHeaders creates a transport that injects headers
+func (sm *SessionManager) wrapTransportWithHeaders(headers map[string]string) mcp.Transport {
+	switch t := sm.transport.(type) {
+
+	case *mcp.SSEClientTransport:
+		return &mcp.SSEClientTransport{
+			Endpoint:   t.Endpoint,
+			HTTPClient: wrapHTTPClient(t.HTTPClient, headers),
+		}
+
+	case *mcp.StreamableClientTransport:
+		return &mcp.StreamableClientTransport{
+			Endpoint:   t.Endpoint,
+			HTTPClient: wrapHTTPClient(t.HTTPClient, headers),
+		}
+
+	default:
+		return sm.transport
+	}
+}
+
+func wrapHTTPClient(httpClient *http.Client, headers map[string]string) *http.Client {
+	if httpClient == nil {
+		httpClient = &http.Client{}
+	}
+
+	return &http.Client{
+		Transport: &headerTransport{
+			Base:    httpClient.Transport,
+			Headers: headers,
+		},
+		CheckRedirect: httpClient.CheckRedirect,
+		Jar:           httpClient.Jar,
+		Timeout:       httpClient.Timeout,
+	}
+}
+
+// Close closes all sessions
+func (sm *SessionManager) Close() error {
+	sm.mu.Lock()
+	defer sm.mu.Unlock()
+
+	var errs []error
+	for _, entry := range sm.sessions {
+		if err := entry.session.Close(); err != nil {
+			errs = append(errs, err)
+		}
+	}
+
+	sm.sessions = make(map[string]*sessionEntry)
+
+	if len(errs) > 0 {
+		return fmt.Errorf("errors closing sessions: %v", errs)
+	}
+	return nil
+}
+
+// headerTransport that uses fixed headers instead of context
+type headerTransport struct {
+	Base    http.RoundTripper
+	Headers map[string]string
+}
+
+// RoundTrip adds the configured headers to the request.
+func (t *headerTransport) RoundTrip(req *http.Request) (*http.Response, error) {
+	reqBodyClosed := false
+	if req.Body != nil {
+		defer func() {
+			if !reqBodyClosed {
+				req.Body.Close()
+			}
+		}()
+	}
+
+	if len(t.Headers) == 0 {
+		reqBodyClosed = true
+		return t.base().RoundTrip(req)
+	}
+
+	req2 := req.Clone(req.Context())
+	for key, value := range t.Headers {
+		req2.Header.Set(key, value)
+	}
+
+	reqBodyClosed = true
+	return t.base().RoundTrip(req2)
+}
+
+func (t *headerTransport) base() http.RoundTripper {
+	if t.Base != nil {
+		return t.Base
+	}
+	return http.DefaultTransport
+}

--- a/tool/mcptoolset/session_manager.go
+++ b/tool/mcptoolset/session_manager.go
@@ -28,6 +28,8 @@ import (
 	"github.com/modelcontextprotocol/go-sdk/mcp"
 )
 
+const defaultSessionKey = "default"
+
 // sessionManager manages MCP client sessions with header-based pooling
 type sessionManager struct {
 	client    *mcp.Client
@@ -67,10 +69,10 @@ func (sm *sessionManager) generateSessionKey(headers map[string]string) string {
 	// For non-HTTP transports (e.g., stdio, in-memory), headers don't apply,
 	// so we always pool into the same session.
 	if !sm.headersAffectSession() {
-		return "default"
+		return defaultSessionKey
 	}
 	if len(headers) == 0 {
-		return "default"
+		return defaultSessionKey
 	}
 
 	keys := make([]string, 0, len(headers))

--- a/tool/mcptoolset/session_manager_test.go
+++ b/tool/mcptoolset/session_manager_test.go
@@ -81,7 +81,7 @@ func TestGenerateSessionKey(t *testing.T) {
 			clientTransport := &mcp.SSEClientTransport{}
 
 			client := mcp.NewClient(&mcp.Implementation{Name: "test_client", Version: "v1.0.0"}, nil)
-			sm := NewSessionManager(client, clientTransport)
+			sm := newSessionManager(client, clientTransport)
 
 			key1 := sm.generateSessionKey(tt.headers1)
 			key2 := sm.generateSessionKey(tt.headers2)
@@ -101,7 +101,7 @@ func TestGenerateSessionKey_IgnoresHeadersForNonHTTPTransport(t *testing.T) {
 	clientTransport, _ := mcp.NewInMemoryTransports()
 
 	client := mcp.NewClient(&mcp.Implementation{Name: "test_client", Version: "v1.0.0"}, nil)
-	sm := NewSessionManager(client, clientTransport)
+	sm := newSessionManager(client, clientTransport)
 
 	key1 := sm.generateSessionKey(map[string]string{"Authorization": "Bearer token123"})
 	key2 := sm.generateSessionKey(map[string]string{"Authorization": "Bearer token456"})
@@ -119,7 +119,7 @@ func TestDefaultKey(t *testing.T) {
 	clientTransport, _ := mcp.NewInMemoryTransports()
 
 	client := mcp.NewClient(&mcp.Implementation{Name: "test_client", Version: "v1.0.0"}, nil)
-	sm := NewSessionManager(client, clientTransport)
+	sm := newSessionManager(client, clientTransport)
 
 	emptyKey := sm.generateSessionKey(map[string]string{})
 	nilKey := sm.generateSessionKey(nil)
@@ -143,7 +143,7 @@ func TestGetSession(t *testing.T) {
 	}
 
 	client := mcp.NewClient(&mcp.Implementation{Name: "test_client", Version: "v1.0.0"}, nil)
-	sm := NewSessionManager(client, clientTransport)
+	sm := newSessionManager(client, clientTransport)
 	defer sm.Close()
 
 	headers := map[string]string{"Authorization": "Bearer token123"}
@@ -183,7 +183,7 @@ func TestGetSessionWithNilHeaders(t *testing.T) {
 	}
 
 	client := mcp.NewClient(&mcp.Implementation{Name: "test_client", Version: "v1.0.0"}, nil)
-	sm := NewSessionManager(client, clientTransport)
+	sm := newSessionManager(client, clientTransport)
 	defer sm.Close()
 
 	session, err := sm.GetSession(ctx, nil)
@@ -211,7 +211,7 @@ func TestClose(t *testing.T) {
 	}
 
 	client := mcp.NewClient(&mcp.Implementation{Name: "test_client", Version: "v1.0.0"}, nil)
-	sm := NewSessionManager(client, clientTransport)
+	sm := newSessionManager(client, clientTransport)
 
 	headers := map[string]string{"Authorization": "Bearer token123"}
 
@@ -250,7 +250,7 @@ func TestIsSessionValid(t *testing.T) {
 	}
 
 	client := mcp.NewClient(&mcp.Implementation{Name: "test_client", Version: "v1.0.0"}, nil)
-	sm := NewSessionManager(client, clientTransport)
+	sm := newSessionManager(client, clientTransport)
 	defer sm.Close()
 
 	session, err := sm.GetSession(ctx, nil)

--- a/tool/mcptoolset/session_manager_test.go
+++ b/tool/mcptoolset/session_manager_test.go
@@ -439,7 +439,7 @@ func TestWrapHTTPClient(t *testing.T) {
 			if diff := cmp.Diff(tt.headers, ht.Headers); diff != "" {
 				t.Errorf("headers mismatch (-want +got):\n%s", diff)
 			}
-			// Verify timeout is preserved
+
 			if tt.httpClient != nil && wrapped.Timeout != tt.httpClient.Timeout {
 				t.Errorf("timeout mismatch: got %v, want %v", wrapped.Timeout, tt.httpClient.Timeout)
 			}

--- a/tool/mcptoolset/session_manager_test.go
+++ b/tool/mcptoolset/session_manager_test.go
@@ -1,0 +1,436 @@
+// Copyright 2025 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package mcptoolset
+
+import (
+	"io"
+	"net/http"
+	"strings"
+	"testing"
+
+	"github.com/google/go-cmp/cmp"
+	"github.com/modelcontextprotocol/go-sdk/mcp"
+)
+
+func TestGenerateSessionKey(t *testing.T) {
+	tests := []struct {
+		name     string
+		headers1 map[string]string
+		headers2 map[string]string
+		wantSame bool
+	}{
+		{
+			name:     "empty headers produce default key",
+			headers1: map[string]string{},
+			headers2: map[string]string{},
+			wantSame: true,
+		},
+		{
+			name:     "nil headers produce default key",
+			headers1: nil,
+			headers2: nil,
+			wantSame: true,
+		},
+		{
+			name:     "identical headers produce same key",
+			headers1: map[string]string{"Authorization": "Bearer token123"},
+			headers2: map[string]string{"Authorization": "Bearer token123"},
+			wantSame: true,
+		},
+		{
+			name:     "different header values produce different keys",
+			headers1: map[string]string{"Authorization": "Bearer token123"},
+			headers2: map[string]string{"Authorization": "Bearer token456"},
+			wantSame: false,
+		},
+		{
+			name:     "different header names produce different keys",
+			headers1: map[string]string{"Authorization": "Bearer token123"},
+			headers2: map[string]string{"X-API-Key": "Bearer token123"},
+			wantSame: false,
+		},
+		{
+			name:     "multiple headers in different order produce same key",
+			headers1: map[string]string{"Authorization": "Bearer token", "X-API-Key": "key123"},
+			headers2: map[string]string{"X-API-Key": "key123", "Authorization": "Bearer token"},
+			wantSame: true,
+		},
+		{
+			name:     "subset of headers produces different key",
+			headers1: map[string]string{"Authorization": "Bearer token", "X-API-Key": "key123"},
+			headers2: map[string]string{"Authorization": "Bearer token"},
+			wantSame: false,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			clientTransport, _ := mcp.NewInMemoryTransports()
+
+			client := mcp.NewClient(&mcp.Implementation{Name: "test_client", Version: "v1.0.0"}, nil)
+			sm := NewSessionManager(client, clientTransport)
+
+			key1 := sm.generateSessionKey(tt.headers1)
+			key2 := sm.generateSessionKey(tt.headers2)
+
+			if tt.wantSame && key1 != key2 {
+				t.Errorf("expected same keys, got %q and %q", key1, key2)
+			}
+			if !tt.wantSame && key1 == key2 {
+				t.Errorf("expected different keys, got %q for both", key1)
+			}
+		})
+	}
+}
+
+func TestDefaultKey(t *testing.T) {
+	clientTransport, _ := mcp.NewInMemoryTransports()
+
+	client := mcp.NewClient(&mcp.Implementation{Name: "test_client", Version: "v1.0.0"}, nil)
+	sm := NewSessionManager(client, clientTransport)
+
+	emptyKey := sm.generateSessionKey(map[string]string{})
+	nilKey := sm.generateSessionKey(nil)
+
+	if emptyKey != "default" {
+		t.Errorf("expected 'default' key for empty headers, got %q", emptyKey)
+	}
+	if nilKey != "default" {
+		t.Errorf("expected 'default' key for nil headers, got %q", nilKey)
+	}
+}
+
+func TestGetSession(t *testing.T) {
+	ctx := t.Context()
+
+	clientTransport, serverTransport := mcp.NewInMemoryTransports()
+	server := mcp.NewServer(&mcp.Implementation{Name: "test_server", Version: "v1.0.0"}, nil)
+	_, err := server.Connect(ctx, serverTransport, nil)
+	if err != nil {
+		t.Fatalf("failed to connect server: %v", err)
+	}
+
+	client := mcp.NewClient(&mcp.Implementation{Name: "test_client", Version: "v1.0.0"}, nil)
+	sm := NewSessionManager(client, clientTransport)
+	defer sm.Close()
+
+	headers := map[string]string{"Authorization": "Bearer token123"}
+
+	session1, err := sm.GetSession(ctx, headers)
+	if err != nil {
+		t.Fatalf("failed to get session: %v", err)
+	}
+	if session1 == nil {
+		t.Fatal("expected non-nil session")
+	}
+
+	session2, err := sm.GetSession(ctx, headers)
+	if err != nil {
+		t.Fatalf("failed to get session again: %v", err)
+	}
+	if session2 != session1 {
+		t.Error("expected same session instance for identical headers")
+	}
+
+	sm.mu.RLock()
+	sessionCount := len(sm.sessions)
+	sm.mu.RUnlock()
+	if sessionCount != 1 {
+		t.Errorf("expected 1 session, got %d", sessionCount)
+	}
+}
+
+func TestGetSessionWithNilHeaders(t *testing.T) {
+	ctx := t.Context()
+
+	clientTransport, serverTransport := mcp.NewInMemoryTransports()
+	server := mcp.NewServer(&mcp.Implementation{Name: "test_server", Version: "v1.0.0"}, nil)
+	_, err := server.Connect(ctx, serverTransport, nil)
+	if err != nil {
+		t.Fatalf("failed to connect server: %v", err)
+	}
+
+	client := mcp.NewClient(&mcp.Implementation{Name: "test_client", Version: "v1.0.0"}, nil)
+	sm := NewSessionManager(client, clientTransport)
+	defer sm.Close()
+
+	session, err := sm.GetSession(ctx, nil)
+	if err != nil {
+		t.Fatalf("failed to get session with nil headers: %v", err)
+	}
+	if session == nil {
+		t.Fatal("expected non-nil session")
+	}
+
+	key := sm.generateSessionKey(nil)
+	if key != "default" {
+		t.Errorf("expected default key for nil headers, got %q", key)
+	}
+}
+
+func TestClose(t *testing.T) {
+	ctx := t.Context()
+
+	clientTransport, serverTransport := mcp.NewInMemoryTransports()
+	server := mcp.NewServer(&mcp.Implementation{Name: "test_server", Version: "v1.0.0"}, nil)
+	_, err := server.Connect(ctx, serverTransport, nil)
+	if err != nil {
+		t.Fatalf("failed to connect server: %v", err)
+	}
+
+	client := mcp.NewClient(&mcp.Implementation{Name: "test_client", Version: "v1.0.0"}, nil)
+	sm := NewSessionManager(client, clientTransport)
+
+	headers := map[string]string{"Authorization": "Bearer token123"}
+
+	_, err = sm.GetSession(ctx, headers)
+	if err != nil {
+		t.Fatalf("failed to create session: %v", err)
+	}
+
+	sm.mu.RLock()
+	sessionCount := len(sm.sessions)
+	sm.mu.RUnlock()
+	if sessionCount != 1 {
+		t.Errorf("expected 1 session before close, got %d", sessionCount)
+	}
+
+	err = sm.Close()
+	if err != nil {
+		t.Errorf("Close() returned error: %v", err)
+	}
+
+	sm.mu.RLock()
+	sessionCount = len(sm.sessions)
+	sm.mu.RUnlock()
+	if sessionCount != 0 {
+		t.Errorf("expected 0 sessions after close, got %d", sessionCount)
+	}
+}
+
+func TestIsSessionValid(t *testing.T) {
+	ctx := t.Context()
+
+	clientTransport, serverTransport := mcp.NewInMemoryTransports()
+	server := mcp.NewServer(&mcp.Implementation{Name: "test_server", Version: "v1.0.0"}, nil)
+	if _, err := server.Connect(ctx, serverTransport, nil); err != nil {
+		t.Fatalf("failed to connect server: %v", err)
+	}
+
+	client := mcp.NewClient(&mcp.Implementation{Name: "test_client", Version: "v1.0.0"}, nil)
+	sm := NewSessionManager(client, clientTransport)
+	defer sm.Close()
+
+	session, err := sm.GetSession(ctx, nil)
+	if err != nil {
+		t.Fatalf("failed to get session: %v", err)
+	}
+
+	if !sm.isSessionValid(ctx, session) {
+		t.Fatal("expected active session to be valid")
+	}
+
+	if err := session.Close(); err != nil {
+		t.Fatalf("failed to close session: %v", err)
+	}
+
+	if sm.isSessionValid(ctx, session) {
+		t.Fatal("expected closed session to be invalid")
+	}
+}
+
+func TestHeaderTransport(t *testing.T) {
+	tests := []struct {
+		name           string
+		headers        map[string]string
+		wantHeaders    map[string]string
+		existingHeader map[string]string
+	}{
+		{
+			name:        "adds single header",
+			headers:     map[string]string{"Authorization": "Bearer token123"},
+			wantHeaders: map[string]string{"Authorization": "Bearer token123"},
+		},
+		{
+			name: "adds multiple headers",
+			headers: map[string]string{
+				"Authorization": "Bearer token123",
+				"X-API-Key":     "key456",
+			},
+			wantHeaders: map[string]string{
+				"Authorization": "Bearer token123",
+				"X-API-Key":     "key456",
+			},
+		},
+		{
+			name:        "no headers added when empty",
+			headers:     map[string]string{},
+			wantHeaders: map[string]string{},
+		},
+		{
+			name:           "overwrites existing header",
+			headers:        map[string]string{"Authorization": "Bearer new-token"},
+			existingHeader: map[string]string{"Authorization": "Bearer old-token"},
+			wantHeaders:    map[string]string{"Authorization": "Bearer new-token"},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			var capturedReq *http.Request
+			baseTransport := &mockRoundTripper{
+				roundTripFunc: func(req *http.Request) (*http.Response, error) {
+					capturedReq = req
+					return &http.Response{
+						StatusCode: http.StatusOK,
+						Body:       io.NopCloser(strings.NewReader("OK")),
+						Header:     make(http.Header),
+					}, nil
+				},
+			}
+
+			ht := &headerTransport{
+				Base:    baseTransport,
+				Headers: tt.headers,
+			}
+
+			req, err := http.NewRequest("GET", "http://example.com", nil)
+			if err != nil {
+				t.Fatalf("failed to create request: %v", err)
+			}
+
+			for k, v := range tt.existingHeader {
+				req.Header.Set(k, v)
+			}
+
+			_, err = ht.RoundTrip(req)
+			if err != nil {
+				t.Fatalf("RoundTrip failed: %v", err)
+			}
+
+			for key, wantValue := range tt.wantHeaders {
+				gotValue := capturedReq.Header.Get(key)
+				if gotValue != wantValue {
+					t.Errorf("header %q: got %q, want %q", key, gotValue, wantValue)
+				}
+			}
+
+			if len(tt.headers) == 0 && len(tt.existingHeader) == 0 {
+				if len(capturedReq.Header) > 0 {
+					t.Errorf("expected no headers, got %v", capturedReq.Header)
+				}
+			}
+		})
+	}
+}
+
+func TestHeaderTransportBase(t *testing.T) {
+	tests := []struct {
+		name          string
+		baseTransport http.RoundTripper
+		wantDefault   bool
+	}{
+		{
+			name: "uses provided base transport",
+			baseTransport: &mockRoundTripper{
+				roundTripFunc: func(req *http.Request) (*http.Response, error) {
+					return &http.Response{StatusCode: http.StatusOK, Body: io.NopCloser(strings.NewReader("custom"))}, nil
+				},
+			},
+			wantDefault: false,
+		},
+		{
+			name:          "uses default transport when nil",
+			baseTransport: nil,
+			wantDefault:   true,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			ht := &headerTransport{
+				Base:    tt.baseTransport,
+				Headers: map[string]string{},
+			}
+
+			baseRT := ht.base()
+			if tt.wantDefault && baseRT != http.DefaultTransport {
+				t.Error("expected default transport when Base is nil")
+			}
+			if !tt.wantDefault && baseRT == http.DefaultTransport {
+				t.Error("expected custom transport, got default")
+			}
+		})
+	}
+}
+
+func TestWrapHTTPClient(t *testing.T) {
+	tests := []struct {
+		name       string
+		httpClient *http.Client
+		headers    map[string]string
+	}{
+		{
+			name:       "wraps nil client",
+			httpClient: nil,
+			headers:    map[string]string{"Authorization": "Bearer token"},
+		},
+		{
+			name: "wraps existing client",
+			httpClient: &http.Client{
+				Timeout: 30,
+			},
+			headers: map[string]string{"X-API-Key": "key123"},
+		},
+		{
+			name: "preserves client settings",
+			httpClient: &http.Client{
+				Timeout: 60,
+			},
+			headers: map[string]string{"Authorization": "Bearer token"},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			wrapped := wrapHTTPClient(tt.httpClient, tt.headers)
+
+			if wrapped == nil {
+				t.Fatal("expected non-nil wrapped client")
+			}
+
+			ht, ok := wrapped.Transport.(*headerTransport)
+			if !ok {
+				t.Fatal("expected Transport to be *headerTransport")
+			}
+
+			if diff := cmp.Diff(tt.headers, ht.Headers); diff != "" {
+				t.Errorf("headers mismatch (-want +got):\n%s", diff)
+			}
+			// Verify timeout is preserved
+			if tt.httpClient != nil && wrapped.Timeout != tt.httpClient.Timeout {
+				t.Errorf("timeout mismatch: got %v, want %v", wrapped.Timeout, tt.httpClient.Timeout)
+			}
+		})
+	}
+}
+
+type mockRoundTripper struct {
+	roundTripFunc func(*http.Request) (*http.Response, error)
+}
+
+func (m *mockRoundTripper) RoundTrip(req *http.Request) (*http.Response, error) {
+	return m.roundTripFunc(req)
+}

--- a/tool/mcptoolset/set.go
+++ b/tool/mcptoolset/set.go
@@ -139,13 +139,10 @@ func (s *set) Tools(ctx agent.ReadonlyContext) ([]tool.Tool, error) {
 }
 
 func (s *set) getSession(ctx agent.ReadonlyContext) (*mcp.ClientSession, error) {
-	headers := make(map[string]string)
+	var headers map[string]string
 
 	if s.headerProvider != nil {
-		providerHeaders := s.headerProvider(ctx)
-		for k, v := range providerHeaders {
-			headers[k] = v
-		}
+		headers = s.headerProvider(ctx)
 	}
 
 	return s.sessionManager.GetSession(ctx, headers)

--- a/tool/mcptoolset/set.go
+++ b/tool/mcptoolset/set.go
@@ -57,7 +57,7 @@ func New(cfg Config) (tool.Toolset, error) {
 		transport:      cfg.Transport,
 		toolFilter:     cfg.ToolFilter,
 		headerProvider: cfg.HeaderProvider,
-		sessionManager: NewSessionManager(client, cfg.Transport),
+		sessionManager: newSessionManager(client, cfg.Transport),
 	}, nil
 }
 
@@ -83,7 +83,7 @@ type set struct {
 	toolFilter     tool.Predicate
 	headerProvider func(agent.ReadonlyContext) map[string]string
 
-	sessionManager *SessionManager
+	sessionManager *sessionManager
 }
 
 func (*set) Name() string {

--- a/tool/mcptoolset/tool.go
+++ b/tool/mcptoolset/tool.go
@@ -15,7 +15,6 @@
 package mcptoolset
 
 import (
-	"context"
 	"errors"
 	"fmt"
 	"strings"
@@ -23,13 +22,14 @@ import (
 	"github.com/modelcontextprotocol/go-sdk/mcp"
 	"google.golang.org/genai"
 
+	"google.golang.org/adk/agent"
 	"google.golang.org/adk/internal/toolinternal"
 	"google.golang.org/adk/internal/toolinternal/toolutils"
 	"google.golang.org/adk/model"
 	"google.golang.org/adk/tool"
 )
 
-type getSessionFunc func(ctx context.Context) (*mcp.ClientSession, error)
+type getSessionFunc func(ctx agent.ReadonlyContext) (*mcp.ClientSession, error)
 
 func convertTool(t *mcp.Tool, getSessionFunc getSessionFunc) (tool.Tool, error) {
 	return &mcpTool{


### PR DESCRIPTION
## Overview

This PR aligns the Go MCP toolset with the adk-python implementation by introducing:

### 1. HeaderProvider support  
Allows tool calls to attach context-aware HTTP headers (auth tokens, user/session IDs, tenant headers, etc).  Headers are generated per call with `agent.ReadonlyContext` context.

### 2. Session pooling keyed by headers  
Adds a new `sessionManager` that reuses MCP sessions when headers are identical and creates new ones only when necessary.

### 3. Updated example:
`examples/mcp/main.go` now supports a third mode (`AGENT_MODE=custom-headers`) that uses `HeaderProvider` to attach a GitHub PAT + optional context headers.

## Summary of Changes

### `mcptoolset/set.go`
- Added `HeaderProvider` to `Config`
- Added a `sessionManager` instance to `set`
- `getSession` now:
  - accepts `agent.ReadonlyContext`
  - gathers provider headers
  - requests a pooled session for those headers

### `mcptoolset/session_manager.go` (new)
- Pools sessions keyed by deterministic header hash
- Wraps HTTP transports with a custom `RoundTripper` for static header injection
- Validates sessions using `Ping`
- Implements `Close()` to cleanly shut down all sessions

### `mcptoolset/session_manager_test.go` (new)
- Tests for:
  - session key stability
  - pooling behavior
  - header injection
  - cleanup
  - asserts that headers do *not* change session key for stdio/in-memory

### `examples/mcp/main.go`
- Added “custom-headers” mode demonstrating HeaderProvider usage.

## Alignment with Python

This matches the adk-python behavior in:

- per-call dynamic headers
- session pooling keyed by headers
- stdio/in-memory = "single session regardless of headers"

## Example
```go
headerProvider := func(ctx agent.ReadonlyContext) map[string]string {
	return map[string]string{
		"Authorization": "Bearer " + os.Getenv("GITHUB_PAT"),
		"X-User-ID":     ctx.UserID(),
	}
}

ts, _ := mcptoolset.New(mcptoolset.Config{
	Transport: &mcp.StreamableClientTransport{Endpoint: "https://api.githubcopilot.com/mcp/"},
	HeaderProvider: headerProvider,
})
```

## Known Limitation

Sessions are pooled based on headers from `HeaderProvider` only. Headers added by custom `HTTPClient` transports (e.g., `oauth2.NewClient`) are not visible to the session manager and do not affect pooling.