### PR TITLE
fix(style): support windows line endings and paths in copyright check

### DIFF
--- a/internal/style_test.go
+++ b/internal/style_test.go
@@ -56,7 +56,7 @@ func TestCopyrightHeader(t *testing.T) {
 			return err
 		}
 		if info.IsDir() {
-			if ignore[path] {
+			if ignore[filepath.ToSlash(path)] {
 				return filepath.SkipDir
 			}
 			return nil
@@ -85,7 +85,10 @@ func hasCopyrightHeader(path string) (bool, error) {
 	if err != nil {
 		return false, err
 	}
-	return strings.HasPrefix(string(content), copyrightHeader), nil
+	// Normalize line endings to LF to support Windows (CRLF)
+	fileContent := strings.ReplaceAll(string(content), "\r\n", "\n")
+	header := strings.ReplaceAll(copyrightHeader, "\r\n", "\n")
+	return strings.HasPrefix(fileContent, header), nil
 }
 
 func addCopyrightHeader(path string) error {


### PR DESCRIPTION
## Description
Fixes [TestCopyrightHeader](cci:1://file:///c:/Users/arc4e/source/AG/OpenSource/ProjectNovember/adk-go/internal/style_test.go:41:0-80:1) failures on Windows environments.

The [style_test.go](cci:7://file:///c:/Users/arc4e/source/AG/OpenSource/ProjectNovember/adk-go/internal/style_test.go:0:0-0:0) was failing on Windows due to two issues:
1. **Line Endings:** Source files checked out on Windows often have CRLF line endings (depending on git config), but the test expected exact LF matches for the copyright header.
2. **Path Separators:** `filepath.Walk` returns paths with backslashes (`\`) on Windows, but the [ignore](cci:7://file:///c:/Users/arc4e/source/AG/OpenSource/ProjectNovember/adk-go/.gitignore:0:0-0:0) map used forward slashes (`/`), causing ignored directories like `internal/httprr` to be checked erroneously.

## Changes
- Normalized file content to LF before checking for the copyright header.
- Normalized file paths using `filepath.ToSlash` before checking against the ignore list.

## Testing Plan
Ran `go test -v ./internal` on a Windows machine.

**Before Fix:**
```text
--- FAIL: TestCopyrightHeader (0.11s)
    style_test.go:72: file "internal\httprr\rr.go" does not have the copyright header