### PR TITLE
Feature/session service well known error

### DIFF
--- a/internal/errorutil/assertion.go
+++ b/internal/errorutil/assertion.go
@@ -1,0 +1,58 @@
+// Copyright 2025 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package errorutil
+
+import (
+	"errors"
+	"testing"
+)
+
+// AssertTestError asserts the presence or absence of an error based on expectations.
+// It can also check for a specific expected error.
+//
+// Parameters:
+//   - t: the testing instance (marked as Helper for accurate stack traces)
+//   - err: the actual error to validate
+//   - wantError: boolean indicating if an error is expected
+//   - wantSpecificErr: the specific expected error to match against (can be nil if not checking for a specific error)
+//   - funcName: descriptive name of the function being tested (for error messages)
+//
+// Example:
+//
+//	err := myService.Update(ctx, req)
+//	testutil.AssertTestError(t, err, true, session.ErrSessionExpired, "Update()")
+func AssertTestError(t *testing.T, err error, wantError bool, wantSpecificErr error, funcName string) {
+	t.Helper()
+
+	if !wantError {
+		if err != nil {
+			t.Fatalf("%s unexpected error: %v", funcName, err)
+		}
+		return
+	}
+
+	if err == nil {
+		if wantSpecificErr != nil {
+			t.Fatalf("%s expected error %v but got nil", funcName, wantSpecificErr)
+		} else {
+			t.Fatalf("%s expected an error but got nil", funcName)
+		}
+		return
+	}
+
+	if wantSpecificErr != nil && !errors.Is(err, wantSpecificErr) {
+		t.Fatalf("%s error = %v, want %v", funcName, err, wantSpecificErr)
+	}
+}

--- a/session/database/service.go
+++ b/session/database/service.go
@@ -156,7 +156,7 @@ func (s *databaseService) Get(ctx context.Context, req *session.GetRequest) (*se
 		First(&foundSession).Error
 	if err != nil {
 		if errors.Is(err, gorm.ErrRecordNotFound) {
-			return nil, fmt.Errorf("%w with id %+v ", session.ErrSessionNotFound, sessionID)
+			return nil, fmt.Errorf("%w with id %q", session.ErrSessionNotFound, sessionID)
 		}
 
 		// For any error including ErrRecordNotFound, return it as a system error.
@@ -317,7 +317,7 @@ func (s *databaseService) Delete(ctx context.Context, req *session.DeleteRequest
 		}
 
 		if result.RowsAffected == 0 {
-			return fmt.Errorf("%w with id %+v ", session.ErrSessionNotFound, sessionID)
+			return fmt.Errorf("%w with id %q", session.ErrSessionNotFound, sessionID)
 		}
 
 		return nil // Returning nil commits the transaction

--- a/session/database/service.go
+++ b/session/database/service.go
@@ -159,7 +159,7 @@ func (s *databaseService) Get(ctx context.Context, req *session.GetRequest) (*se
 			return nil, fmt.Errorf("%w with id %q", session.ErrSessionNotFound, sessionID)
 		}
 
-		// For any error including ErrRecordNotFound, return it as a system error.
+		// For any other database error, return it as a system error.
 		return nil, fmt.Errorf("database error while fetching session: %w", err)
 	}
 

--- a/session/database/service.go
+++ b/session/database/service.go
@@ -356,16 +356,16 @@ func (s *databaseService) AppendEvent(ctx context.Context, curSession session.Se
 
 // applyEvent fetches the session, validates it, applies state changes from an
 // event, and saves the event atomically.
-func (s *databaseService) applyEvent(ctx context.Context, session *localSession, event *session.Event) error {
+func (s *databaseService) applyEvent(ctx context.Context, localSession *localSession, event *session.Event) error {
 	// Wrap database operations in a single transaction.
 	err := s.db.WithContext(ctx).Transaction(func(tx *gorm.DB) error {
 		// Fetch the session object from storage.
 		var storageSess storageSession
-		err := tx.Where(&storageSession{AppName: session.AppName(), UserID: session.UserID(), ID: session.ID()}).
+		err := tx.Where(&storageSession{AppName: localSession.AppName(), UserID: localSession.UserID(), ID: localSession.ID()}).
 			First(&storageSess).Error
 		if err != nil {
 			if errors.Is(err, gorm.ErrRecordNotFound) {
-				return fmt.Errorf("session not found, cannot apply event")
+				return fmt.Errorf("%w with id %q", session.ErrSessionNotFound, localSession.ID())
 			}
 			return fmt.Errorf("failed to get session: %w", err)
 		}
@@ -373,7 +373,7 @@ func (s *databaseService) applyEvent(ctx context.Context, session *localSession,
 		// Ensure the session object is not stale.
 		// We use UnixNano() for microsecond-level precision, matching the Python code.
 		storageUpdateTime := storageSess.UpdateTime.UnixNano()
-		sessionUpdateTime := session.updatedAt.UnixNano()
+		sessionUpdateTime := localSession.updatedAt.UnixNano()
 		if storageUpdateTime > sessionUpdateTime {
 			return fmt.Errorf(
 				"stale session error: last update time from request (%s) is older than in database (%s)",
@@ -383,11 +383,11 @@ func (s *databaseService) applyEvent(ctx context.Context, session *localSession,
 		}
 
 		// Fetch App and User states.
-		storageApp, err := fetchStorageAppState(tx, session.AppName())
+		storageApp, err := fetchStorageAppState(tx, localSession.AppName())
 		if err != nil {
 			return err
 		}
-		storageUser, err := fetchStorageUserState(tx, session.AppName(), session.UserID())
+		storageUser, err := fetchStorageUserState(tx, localSession.AppName(), localSession.UserID())
 		if err != nil {
 			return err
 		}
@@ -414,7 +414,7 @@ func (s *databaseService) applyEvent(ctx context.Context, session *localSession,
 		}
 
 		// Create the new event record in the database.
-		storageEv, err := createStorageEvent(session, event)
+		storageEv, err := createStorageEvent(localSession, event)
 		if err != nil {
 			return fmt.Errorf("failed to map event to storage model: %w", err)
 		}
@@ -428,7 +428,7 @@ func (s *databaseService) applyEvent(ctx context.Context, session *localSession,
 			return fmt.Errorf("failed to save session state: %w", err)
 		}
 
-		session.updatedAt = storageSess.UpdateTime
+		localSession.updatedAt = storageSess.UpdateTime
 
 		return nil // Returning nil commits the transaction.
 	})

--- a/session/database/service_test.go
+++ b/session/database/service_test.go
@@ -31,15 +31,6 @@ import (
 	"google.golang.org/adk/session"
 )
 
-// checkTestError is a test helper that validates error conditions.
-// It fails the test immediately if the error state doesn't match expectations.
-func checkTestError(t *testing.T, err error, wantErr bool, format string, args ...any) {
-	t.Helper()
-	if (err != nil) != wantErr {
-		t.Fatalf(format, append(args, err, wantErr)...)
-	}
-}
-
 func Test_databaseService_Create(t *testing.T) {
 	tests := []struct {
 		name    string
@@ -90,7 +81,11 @@ func Test_databaseService_Create(t *testing.T) {
 			s := tt.setup(t)
 
 			got, err := s.Create(t.Context(), tt.req)
-			checkTestError(t, err, tt.wantErr, "databaseService.Create() error = %v, wantErr %v")
+
+			if (err != nil) != tt.wantErr {
+				t.Fatalf("databaseService.Create() error = %v, wantErr %v", err, tt.wantErr)
+				return
+			}
 
 			if err != nil {
 				return
@@ -357,7 +352,18 @@ func Test_databaseService_Get(t *testing.T) {
 			s := tt.setup(t)
 
 			got, err := s.Get(t.Context(), tt.req)
-			checkTestError(t, err, tt.wantErr, "databaseService.Get() error = %v, wantErr %v")
+
+			if (err != nil) != tt.wantErr {
+				t.Fatalf("databaseService.Get() error = %v, wantErr %v", err, tt.wantErr)
+				return
+			}
+
+			if tt.wantNotFoundErr {
+				if !errors.Is(err, session.ErrSessionNotFound) {
+					t.Fatalf("databaseService.Get() error = %v, want ErrSessionNotFound", err)
+				}
+				return
+			}
 
 			if err != nil {
 				return
@@ -743,7 +749,18 @@ func Test_databaseService_AppendEvent(t *testing.T) {
 
 			tt.session.updatedAt = time.Now() // set updatedAt value to pass stale validation
 			err := s.AppendEvent(ctx, tt.session, tt.event)
-			checkTestError(t, err, tt.wantErr, "databaseService.AppendEvent() error = %v, wantErr %v")
+
+			if (err != nil) != tt.wantErr {
+				t.Fatalf("databaseService.AppendEvent() error = %v, wantErr %v", err, tt.wantErr)
+				return
+			}
+
+			if tt.wantNotFoundErr {
+				if !errors.Is(err, session.ErrSessionNotFound) {
+					t.Fatalf("databaseService.AppendEvent() error = %v, want ErrSessionNotFound", err)
+				}
+				return
+			}
 
 			if err != nil {
 				return

--- a/session/database/service_test.go
+++ b/session/database/service_test.go
@@ -15,6 +15,7 @@
 package database
 
 import (
+	"errors"
 	"maps"
 	"strconv"
 	"testing"
@@ -29,6 +30,15 @@ import (
 	"google.golang.org/adk/model"
 	"google.golang.org/adk/session"
 )
+
+// checkTestError is a test helper that validates error conditions.
+// It fails the test immediately if the error state doesn't match expectations.
+func checkTestError(t *testing.T, err error, wantErr bool, format string, args ...any) {
+	t.Helper()
+	if (err != nil) != wantErr {
+		t.Fatalf(format, append(args, err, wantErr)...)
+	}
+}
 
 func Test_databaseService_Create(t *testing.T) {
 	tests := []struct {
@@ -80,10 +90,7 @@ func Test_databaseService_Create(t *testing.T) {
 			s := tt.setup(t)
 
 			got, err := s.Create(t.Context(), tt.req)
-			if (err != nil) != tt.wantErr {
-				t.Fatalf("databaseService.Create() error = %v, wantErr %v", err, tt.wantErr)
-				return
-			}
+			checkTestError(t, err, tt.wantErr, "databaseService.Create() error = %v, wantErr %v")
 
 			if err != nil {
 				return
@@ -119,10 +126,11 @@ func Test_databaseService_Create(t *testing.T) {
 
 func Test_databaseService_Delete(t *testing.T) {
 	tests := []struct {
-		name    string
-		req     *session.DeleteRequest
-		setup   func(t *testing.T) *databaseService
-		wantErr bool
+		name            string
+		req             *session.DeleteRequest
+		setup           func(t *testing.T) *databaseService
+		wantErr         bool
+		wantNotFoundErr bool
 	}{
 		{
 			name:  "delete ok",
@@ -134,20 +142,29 @@ func Test_databaseService_Delete(t *testing.T) {
 			},
 		},
 		{
-			name:  "no error when not found",
+			name:  "error when session not found",
 			setup: serviceDbWithData,
 			req: &session.DeleteRequest{
 				AppName:   "appTest",
 				UserID:    "user1",
 				SessionID: "session1",
 			},
+			wantErr:         true,
+			wantNotFoundErr: true,
 		},
 	}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
 			s := tt.setup(t)
-			if err := s.Delete(t.Context(), tt.req); (err != nil) != tt.wantErr {
-				t.Errorf("databaseService.Delete() error = %v, wantErr %v", err, tt.wantErr)
+			err := s.Delete(t.Context(), tt.req)
+			if tt.wantNotFoundErr {
+				if !errors.Is(err, session.ErrSessionNotFound) {
+					t.Fatalf("databaseService.Delete() error = %v, want ErrSessionNotFound", err)
+				}
+				return
+			}
+			if (err != nil) != tt.wantErr {
+				t.Fatalf("databaseService.Delete() error = %v, wantErr %v", err, tt.wantErr)
 			}
 		})
 	}
@@ -220,12 +237,13 @@ func Test_databaseService_Get(t *testing.T) {
 	}
 
 	tests := []struct {
-		name         string
-		req          *session.GetRequest
-		setup        func(t *testing.T) *databaseService
-		wantResponse *session.GetResponse
-		wantEvents   []*session.Event
-		wantErr      bool
+		name            string
+		req             *session.GetRequest
+		setup           func(t *testing.T) *databaseService
+		wantResponse    *session.GetResponse
+		wantEvents      []*session.Event
+		wantErr         bool
+		wantNotFoundErr bool
 	}{
 		{
 			name:  "ok",
@@ -255,7 +273,8 @@ func Test_databaseService_Get(t *testing.T) {
 				UserID:    "user1",
 				SessionID: "session1",
 			},
-			wantErr: true,
+			wantErr:         true,
+			wantNotFoundErr: true,
 		},
 		{
 			name:  "get session respects user id",
@@ -338,10 +357,7 @@ func Test_databaseService_Get(t *testing.T) {
 			s := tt.setup(t)
 
 			got, err := s.Get(t.Context(), tt.req)
-			if (err != nil) != tt.wantErr {
-				t.Fatalf("databaseService.Get() error = %v, wantErr %v", err, tt.wantErr)
-				return
-			}
+			checkTestError(t, err, tt.wantErr, "databaseService.Get() error = %v, wantErr %v")
 
 			if err != nil {
 				return
@@ -482,6 +498,7 @@ func Test_databaseService_AppendEvent(t *testing.T) {
 		wantStoredSession *localSession // State of the session after Get
 		wantEventCount    int           // Expected event count in storage
 		wantErr           bool
+		wantNotFoundErr   bool
 	}{
 		{
 			name:  "append event to the session and overwrite in storage",
@@ -567,7 +584,8 @@ func Test_databaseService_AppendEvent(t *testing.T) {
 					Partial: false,
 				},
 			},
-			wantErr: true,
+			wantErr:         true,
+			wantNotFoundErr: true,
 		},
 		{
 			name:  "append event with bytes content",
@@ -725,9 +743,7 @@ func Test_databaseService_AppendEvent(t *testing.T) {
 
 			tt.session.updatedAt = time.Now() // set updatedAt value to pass stale validation
 			err := s.AppendEvent(ctx, tt.session, tt.event)
-			if (err != nil) != tt.wantErr {
-				t.Errorf("databaseService.AppendEvent() error = %v, wantErr %v", err, tt.wantErr)
-			}
+			checkTestError(t, err, tt.wantErr, "databaseService.AppendEvent() error = %v, wantErr %v")
 
 			if err != nil {
 				return

--- a/session/database/service_test.go
+++ b/session/database/service_test.go
@@ -15,7 +15,6 @@
 package database
 
 import (
-	"errors"
 	"maps"
 	"strconv"
 	"testing"
@@ -27,6 +26,7 @@ import (
 	"gorm.io/driver/sqlite"
 	"gorm.io/gorm"
 
+	"google.golang.org/adk/internal/errorutil"
 	"google.golang.org/adk/model"
 	"google.golang.org/adk/session"
 )
@@ -82,10 +82,7 @@ func Test_databaseService_Create(t *testing.T) {
 
 			got, err := s.Create(t.Context(), tt.req)
 
-			if (err != nil) != tt.wantErr {
-				t.Fatalf("databaseService.Create() error = %v, wantErr %v", err, tt.wantErr)
-				return
-			}
+			errorutil.AssertTestError(t, err, tt.wantErr, nil, "databaseService.Create()")
 
 			if err != nil {
 				return
@@ -152,15 +149,12 @@ func Test_databaseService_Delete(t *testing.T) {
 		t.Run(tt.name, func(t *testing.T) {
 			s := tt.setup(t)
 			err := s.Delete(t.Context(), tt.req)
-			if (err != nil) != tt.wantErr {
-				t.Fatalf("databaseService.Delete() error = %v, wantErr %v", err, tt.wantErr)
-				return
-			}
-
+			var wantSpecificErr error
 			if tt.wantNotFoundErr {
-				if !errors.Is(err, session.ErrSessionNotFound) {
-					t.Fatalf("databaseService.Delete() error = %v, want ErrSessionNotFound", err)
-				}
+				wantSpecificErr = session.ErrSessionNotFound
+			}
+			errorutil.AssertTestError(t, err, tt.wantErr, wantSpecificErr, "databaseService.Delete()")
+			if err != nil {
 				return
 			}
 		})
@@ -355,18 +349,11 @@ func Test_databaseService_Get(t *testing.T) {
 
 			got, err := s.Get(t.Context(), tt.req)
 
-			if (err != nil) != tt.wantErr {
-				t.Fatalf("databaseService.Get() error = %v, wantErr %v", err, tt.wantErr)
-				return
-			}
-
+			var wantSpecificErr error
 			if tt.wantNotFoundErr {
-				if !errors.Is(err, session.ErrSessionNotFound) {
-					t.Fatalf("databaseService.Get() error = %v, want ErrSessionNotFound", err)
-				}
-				return
+				wantSpecificErr = session.ErrSessionNotFound
 			}
-
+			errorutil.AssertTestError(t, err, tt.wantErr, wantSpecificErr, "databaseService.Get()")
 			if err != nil {
 				return
 			}
@@ -752,18 +739,11 @@ func Test_databaseService_AppendEvent(t *testing.T) {
 			tt.session.updatedAt = time.Now() // set updatedAt value to pass stale validation
 			err := s.AppendEvent(ctx, tt.session, tt.event)
 
-			if (err != nil) != tt.wantErr {
-				t.Fatalf("databaseService.AppendEvent() error = %v, wantErr %v", err, tt.wantErr)
-				return
-			}
-
+			var wantSpecificErr error
 			if tt.wantNotFoundErr {
-				if !errors.Is(err, session.ErrSessionNotFound) {
-					t.Fatalf("databaseService.AppendEvent() error = %v, want ErrSessionNotFound", err)
-				}
-				return
+				wantSpecificErr = session.ErrSessionNotFound
 			}
-
+			errorutil.AssertTestError(t, err, tt.wantErr, wantSpecificErr, "databaseService.AppendEvent()")
 			if err != nil {
 				return
 			}

--- a/session/database/service_test.go
+++ b/session/database/service_test.go
@@ -152,14 +152,16 @@ func Test_databaseService_Delete(t *testing.T) {
 		t.Run(tt.name, func(t *testing.T) {
 			s := tt.setup(t)
 			err := s.Delete(t.Context(), tt.req)
+			if (err != nil) != tt.wantErr {
+				t.Fatalf("databaseService.Delete() error = %v, wantErr %v", err, tt.wantErr)
+				return
+			}
+
 			if tt.wantNotFoundErr {
 				if !errors.Is(err, session.ErrSessionNotFound) {
 					t.Fatalf("databaseService.Delete() error = %v, want ErrSessionNotFound", err)
 				}
 				return
-			}
-			if (err != nil) != tt.wantErr {
-				t.Fatalf("databaseService.Delete() error = %v, wantErr %v", err, tt.wantErr)
 			}
 		})
 	}

--- a/session/errors.go
+++ b/session/errors.go
@@ -1,0 +1,24 @@
+// Copyright 2025 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package session
+
+import "errors"
+
+var (
+	// ErrSessionNotFound is returned when a session is not found.
+	ErrSessionNotFound = errors.New("session not found")
+	// ErrStateKeyNotExist is the error thrown when key does not exist.
+	ErrStateKeyNotExist = errors.New("state key does not exist")
+)

--- a/session/inmemory.go
+++ b/session/inmemory.go
@@ -191,7 +191,13 @@ func (s *inMemoryService) Delete(ctx context.Context, req *DeleteRequest) error 
 		sessionID: sessionID,
 	}
 
-	s.sessions.Delete(id.Encode())
+	encodedKey := id.Encode()
+	_, ok := s.sessions.Get(encodedKey)
+	if !ok {
+		return fmt.Errorf("%w with id %+v ", ErrSessionNotFound, req.SessionID)
+	}
+
+	s.sessions.Delete(encodedKey)
 	return nil
 }
 

--- a/session/inmemory.go
+++ b/session/inmemory.go
@@ -216,7 +216,7 @@ func (s *inMemoryService) AppendEvent(ctx context.Context, curSession Session, e
 
 	stored_session, ok := s.sessions.Get(sess.id.Encode())
 	if !ok {
-		return fmt.Errorf("%w with id %+v ", ErrSessionNotFound, sess.ID())
+return fmt.Errorf("%w with id %q", ErrSessionNotFound, sess.ID())
 	}
 
 	// update the in-memory session

--- a/session/inmemory.go
+++ b/session/inmemory.go
@@ -110,7 +110,7 @@ func (s *inMemoryService) Get(ctx context.Context, req *GetRequest) (*GetRespons
 
 	res, ok := s.sessions.Get(id.Encode())
 	if !ok {
-		return nil, fmt.Errorf("%w with id %+v ", ErrSessionNotFound, req.SessionID)
+return nil, fmt.Errorf("%w with id %q", ErrSessionNotFound, req.SessionID)
 	}
 
 	copiedSession := copySessionWithoutStateAndEvents(res)

--- a/session/inmemory.go
+++ b/session/inmemory.go
@@ -110,7 +110,7 @@ func (s *inMemoryService) Get(ctx context.Context, req *GetRequest) (*GetRespons
 
 	res, ok := s.sessions.Get(id.Encode())
 	if !ok {
-		return nil, fmt.Errorf("session %+v not found", req.SessionID)
+		return nil, fmt.Errorf("%w with id %+v ", ErrSessionNotFound, req.SessionID)
 	}
 
 	copiedSession := copySessionWithoutStateAndEvents(res)
@@ -216,7 +216,7 @@ func (s *inMemoryService) AppendEvent(ctx context.Context, curSession Session, e
 
 	stored_session, ok := s.sessions.Get(sess.id.Encode())
 	if !ok {
-		return fmt.Errorf("session not found, cannot apply event")
+		return fmt.Errorf("%w with id %+v ", ErrSessionNotFound, sess.ID())
 	}
 
 	// update the in-memory session

--- a/session/inmemory.go
+++ b/session/inmemory.go
@@ -110,7 +110,7 @@ func (s *inMemoryService) Get(ctx context.Context, req *GetRequest) (*GetRespons
 
 	res, ok := s.sessions.Get(id.Encode())
 	if !ok {
-return nil, fmt.Errorf("%w with id %q", ErrSessionNotFound, req.SessionID)
+		return nil, fmt.Errorf("%w with id %q", ErrSessionNotFound, req.SessionID)
 	}
 
 	copiedSession := copySessionWithoutStateAndEvents(res)
@@ -194,7 +194,7 @@ func (s *inMemoryService) Delete(ctx context.Context, req *DeleteRequest) error 
 	encodedKey := id.Encode()
 	_, ok := s.sessions.Get(encodedKey)
 	if !ok {
-		return fmt.Errorf("%w with id %+v ", ErrSessionNotFound, req.SessionID)
+		return fmt.Errorf("%w with id %q", ErrSessionNotFound, req.SessionID)
 	}
 
 	s.sessions.Delete(encodedKey)
@@ -222,7 +222,7 @@ func (s *inMemoryService) AppendEvent(ctx context.Context, curSession Session, e
 
 	stored_session, ok := s.sessions.Get(sess.id.Encode())
 	if !ok {
-return fmt.Errorf("%w with id %q", ErrSessionNotFound, sess.ID())
+		return fmt.Errorf("%w with id %q", ErrSessionNotFound, sess.ID())
 	}
 
 	// update the in-memory session

--- a/session/inmemory_test.go
+++ b/session/inmemory_test.go
@@ -151,11 +151,13 @@ func Test_inMemoryService_Delete(t *testing.T) {
 
 			if (err != nil) != tt.wantErr {
 				t.Fatalf("inMemoryService.Delete() error = %v, wantErr %v", err, tt.wantErr)
+				return
 			}
 
 			if tt.wantNotFoundErr {
 				if !errors.Is(err, ErrSessionNotFound) {
 					t.Fatalf("inMemoryService.Delete() expected ErrSessionNotFound, got %v", err)
+					return
 				}
 			}
 
@@ -360,11 +362,13 @@ func Test_inMemoryService_Get(t *testing.T) {
 
 			if (err != nil) != tt.wantErr {
 				t.Fatalf("inMemoryService.Get() error = %v, wantErr %v", err, tt.wantErr)
+				return
 			}
 
 			if tt.wantNotFoundErr {
 				if !errors.Is(err, ErrSessionNotFound) {
 					t.Fatalf("inMemoryService.Get() expected ErrSessionNotFound, got %v", err)
+					return
 				}
 			}
 
@@ -815,11 +819,13 @@ func Test_inMemoryService_AppendEvent(t *testing.T) {
 
 			if (err != nil) != tt.wantErr {
 				t.Fatalf("inMemoryService.AppendEvent() error = %v, wantErr %v", err, tt.wantErr)
+				return
 			}
 
 			if tt.wantNotFoundErr {
 				if !errors.Is(err, ErrSessionNotFound) {
 					t.Fatalf("inMemoryService.AppendEvent() expected ErrSessionNotFound, got %v", err)
+					return
 				}
 			}
 

--- a/session/inmemory_test.go
+++ b/session/inmemory_test.go
@@ -26,7 +26,6 @@ import (
 	"google.golang.org/genai"
 
 	"google.golang.org/adk/model"
-	"google.golang.org/adk/session"
 )
 
 func Test_inMemoryService_Create(t *testing.T) {
@@ -116,7 +115,7 @@ func Test_inMemoryService_Create(t *testing.T) {
 	}
 }
 
-func Test_databaseService_Delete(t *testing.T) {
+func Test_inMemoryService_Delete(t *testing.T) {
 	tests := []struct {
 		name            string
 		req             *DeleteRequest
@@ -155,7 +154,7 @@ func Test_databaseService_Delete(t *testing.T) {
 			}
 
 			if tt.wantNotFoundErr {
-				if !errors.Is(err, session.ErrSessionNotFound) {
+				if !errors.Is(err, ErrSessionNotFound) {
 					t.Fatalf("inMemoryService.Delete() expected ErrSessionNotFound, got %v", err)
 				}
 			}
@@ -167,7 +166,7 @@ func Test_databaseService_Delete(t *testing.T) {
 	}
 }
 
-func Test_databaseService_Get(t *testing.T) {
+func Test_inMemoryService_Get(t *testing.T) {
 	// This setup function is required for a test case.
 	// It creates the specific scenario from 'test_get_session_respects_user_id'.
 	setupGetRespectsUserID := func(t *testing.T) Service {
@@ -364,7 +363,7 @@ func Test_databaseService_Get(t *testing.T) {
 			}
 
 			if tt.wantNotFoundErr {
-				if !errors.Is(err, session.ErrSessionNotFound) {
+				if !errors.Is(err, ErrSessionNotFound) {
 					t.Fatalf("inMemoryService.Get() expected ErrSessionNotFound, got %v", err)
 				}
 			}
@@ -394,7 +393,7 @@ func Test_databaseService_Get(t *testing.T) {
 	}
 }
 
-func Test_databaseService_List(t *testing.T) {
+func Test_inMemoryService_List(t *testing.T) {
 	tests := []struct {
 		name         string
 		req          *ListRequest
@@ -528,7 +527,7 @@ func Test_databaseService_List(t *testing.T) {
 	}
 }
 
-func Test_databaseService_AppendEvent(t *testing.T) {
+func Test_inMemoryService_AppendEvent(t *testing.T) {
 	tests := []struct {
 		name              string
 		setup             func(t *testing.T) Service
@@ -819,7 +818,7 @@ func Test_databaseService_AppendEvent(t *testing.T) {
 			}
 
 			if tt.wantNotFoundErr {
-				if !errors.Is(err, session.ErrSessionNotFound) {
+				if !errors.Is(err, ErrSessionNotFound) {
 					t.Fatalf("inMemoryService.AppendEvent() expected ErrSessionNotFound, got %v", err)
 				}
 			}
@@ -862,7 +861,7 @@ func Test_databaseService_AppendEvent(t *testing.T) {
 	}
 }
 
-func Test_databaseService_StateManagement(t *testing.T) {
+func Test_inMemoryService_StateManagement(t *testing.T) {
 	ctx := t.Context()
 	appName := "my_app"
 

--- a/session/inmemory_test.go
+++ b/session/inmemory_test.go
@@ -36,7 +36,7 @@ func checkTestError(t *testing.T, err error, wantErr bool, format string, args .
 	}
 }
 
-func Test_databaseService_Create(t *testing.T) {
+func Test_inMemoryService_Create(t *testing.T) {
 	tests := []struct {
 		name    string
 		setup   func(t *testing.T) Service

--- a/session/inmemory_test.go
+++ b/session/inmemory_test.go
@@ -15,7 +15,6 @@
 package session
 
 import (
-	"errors"
 	"maps"
 	"strconv"
 	"testing"
@@ -25,6 +24,7 @@ import (
 	"github.com/google/go-cmp/cmp/cmpopts"
 	"google.golang.org/genai"
 
+	"google.golang.org/adk/internal/errorutil"
 	"google.golang.org/adk/model"
 )
 
@@ -79,9 +79,7 @@ func Test_inMemoryService_Create(t *testing.T) {
 
 			got, err := s.Create(t.Context(), tt.req)
 
-			if (err != nil) != tt.wantErr {
-				t.Fatalf("inMemoryService.Create() error = %v, wantErr %v", err, tt.wantErr)
-			}
+			errorutil.AssertTestError(t, err, tt.wantErr, nil, "inMemoryService.Create()")
 
 			if err != nil {
 				return
@@ -149,21 +147,11 @@ func Test_inMemoryService_Delete(t *testing.T) {
 			s := tt.setup(t)
 			err := s.Delete(t.Context(), tt.req)
 
-			if (err != nil) != tt.wantErr {
-				t.Fatalf("inMemoryService.Delete() error = %v, wantErr %v", err, tt.wantErr)
-				return
-			}
-
+			var wantSpecificErr error
 			if tt.wantNotFoundErr {
-				if !errors.Is(err, ErrSessionNotFound) {
-					t.Fatalf("inMemoryService.Delete() expected ErrSessionNotFound, got %v", err)
-					return
-				}
+				wantSpecificErr = ErrSessionNotFound
 			}
-
-			if err != nil {
-				return
-			}
+			errorutil.AssertTestError(t, err, tt.wantErr, wantSpecificErr, "inMemoryService.Delete()")
 		})
 	}
 }
@@ -360,18 +348,11 @@ func Test_inMemoryService_Get(t *testing.T) {
 
 			got, err := s.Get(t.Context(), tt.req)
 
-			if (err != nil) != tt.wantErr {
-				t.Fatalf("inMemoryService.Get() error = %v, wantErr %v", err, tt.wantErr)
-				return
-			}
-
+			var wantSpecificErr error
 			if tt.wantNotFoundErr {
-				if !errors.Is(err, ErrSessionNotFound) {
-					t.Fatalf("inMemoryService.Get() expected ErrSessionNotFound, got %v", err)
-					return
-				}
+				wantSpecificErr = ErrSessionNotFound
 			}
-
+			errorutil.AssertTestError(t, err, tt.wantErr, wantSpecificErr, "inMemoryService.Get()")
 			if err != nil {
 				return
 			}
@@ -817,18 +798,11 @@ func Test_inMemoryService_AppendEvent(t *testing.T) {
 			tt.session.updatedAt = time.Now() // set updatedAt value to pass stale validation
 			err := s.AppendEvent(ctx, tt.session, tt.event)
 
-			if (err != nil) != tt.wantErr {
-				t.Fatalf("inMemoryService.AppendEvent() error = %v, wantErr %v", err, tt.wantErr)
-				return
-			}
-
+			var wantSpecificErr error
 			if tt.wantNotFoundErr {
-				if !errors.Is(err, ErrSessionNotFound) {
-					t.Fatalf("inMemoryService.AppendEvent() expected ErrSessionNotFound, got %v", err)
-					return
-				}
+				wantSpecificErr = ErrSessionNotFound
 			}
-
+			errorutil.AssertTestError(t, err, tt.wantErr, wantSpecificErr, "inMemoryService.AppendEvent()")
 			if err != nil {
 				return
 			}

--- a/session/session.go
+++ b/session/session.go
@@ -15,7 +15,6 @@
 package session
 
 import (
-	"errors"
 	"iter"
 	"time"
 
@@ -171,9 +170,6 @@ const (
 	// (within the same app_name).
 	KeyPrefixUser string = "user:"
 )
-
-// ErrStateKeyNotExist is the error thrown when key does not exist.
-var ErrStateKeyNotExist = errors.New("state key does not exist")
 
 func hasFunctionCalls(resp *model.LLMResponse) bool {
 	if resp == nil || resp.Content == nil {


### PR DESCRIPTION
# Session Service: Well-Known Error Handling

Resolves #85 

This PR introduces standardized error handling for the session service by creating well-known errors and updating both in-memory and database implementations to use them consistently.

## Changes Made

### 1. Created Well-Known Errors (`session/errors.go`)
- Added `ErrSessionNotFound` - returned when a session cannot be found
- Moved `ErrStateKeyNotExist` - returned when a state key doesn't exist

### 2. Updated Session Service Implementations

#### Database Service (`session/database/service.go`)
- Modified `Get()` to return `ErrSessionNotFound` when `gorm.ErrRecordNotFound` is encountered
- Modified `Delete()` to return `ErrSessionNotFound` when no rows are affected (session doesn't exist)
- Improved error messages with contextual information (session ID)

#### In-Memory Service (`session/inmemory.go`)
- Updated `Get()` to return `ErrSessionNotFound` instead of generic error
- Updated `AppendEvent()` to return `ErrSessionNotFound` when session is not found
- Improved error messages with contextual information (session ID)

### 3. Test Improvements

#### Added Test Helper Function
- Created `checkTestError()` helper to eliminate code duplication across test files
- Uses `t.Fatalf()` for immediate test termination on error, ensuring consistent error handling
- Applied to both `service_test.go` and `inmemory_test.go`

## Breaking Change Note
This changes the error behavior for `Delete()` operations - previously, deleting a non-existent session returned no error, but now returns `ErrSessionNotFound`. This aligns the behavior between database and in-memory implementations.