### PR TITLE
fix(functiontool): recover from panics in user functions

### DIFF
--- a/tool/functiontool/function.go
+++ b/tool/functiontool/function.go
@@ -17,6 +17,7 @@ package functiontool
 
 import (
 	"fmt"
+	"runtime/debug"
 
 	"github.com/google/jsonschema-go/jsonschema"
 	"google.golang.org/genai"
@@ -130,9 +131,14 @@ func (f *functionTool[TArgs, TResults]) Declaration() *genai.FunctionDeclaration
 }
 
 // Run executes the tool with the provided context and yields events.
-func (f *functionTool[TArgs, TResults]) Run(ctx tool.Context, args any) (map[string]any, error) {
+func (f *functionTool[TArgs, TResults]) Run(ctx tool.Context, args any) (result map[string]any, err error) {
 	// TODO: Handle function call request from tc.InvocationContext.
-	// TODO: Handle panic -> convert to error.
+	defer func() {
+		if r := recover(); r != nil {
+			err = fmt.Errorf("panic in tool %q: %v\nstack: %s", f.Name(), r, debug.Stack())
+		}
+	}()
+
 	m, ok := args.(map[string]any)
 	if !ok {
 		return nil, fmt.Errorf("unexpected args type, got: %T", args)

--- a/tool/functiontool/function_test.go
+++ b/tool/functiontool/function_test.go
@@ -508,3 +508,46 @@ func stringify(v any) string {
 	}
 	return string(x)
 }
+
+func TestFunctionTool_PanicRecovery(t *testing.T) {
+	type Args struct {
+		Value string `json:"value"`
+	}
+
+	panicHandler := func(ctx tool.Context, input Args) (string, error) {
+		panic("intentional panic for testing")
+	}
+
+	panicTool, err := functiontool.New(functiontool.Config{
+		Name:        "panic_tool",
+		Description: "a tool that always panics",
+	}, panicHandler)
+	if err != nil {
+		t.Fatalf("NewFunctionTool failed: %v", err)
+	}
+
+	funcTool, ok := panicTool.(toolinternal.FunctionTool)
+	if !ok {
+		t.Fatal("panicTool does not implement toolinternal.FunctionTool")
+	}
+
+	result, err := funcTool.Run(nil, map[string]any{"value": "test"})
+	if err == nil {
+		t.Fatal("expected error from panic recovery, got nil")
+	}
+	if result != nil {
+		t.Errorf("expected nil result, got %v", result)
+	}
+
+	expectedErrParts := []string{
+		"panic in tool",
+		"panic_tool",
+		"intentional panic for testing",
+		"stack:",
+	}
+	for _, part := range expectedErrParts {
+		if !strings.Contains(err.Error(), part) {
+			t.Errorf("expected error to contain %q, but it did not. Error: %v", part, err)
+		}
+	}
+}


### PR DESCRIPTION
## Summary
  - Add panic recovery to `functionTool.Run()` to prevent agent crashes when user-provided functions panic
  - Panics are converted to errors with descriptive messages including the tool name
  - Add test case to verify panic recovery behavior

  Resolves the TODO at `tool/functiontool/function.go:135`:
  ```go
  // TODO: Handle panic -> convert to error.

  Test plan

  - Added TestFunctionTool_PanicRecovery unit test
  - Test creates a function that intentionally panics and verifies:
    - Error is returned (not nil)
    - Result is nil
    - Error message contains "panic in tool" and the tool name
  - Ran locally: go test ./tool/functiontool/... -run TestFunctionTool_PanicRecovery -v → PASS