### PR TITLE
feat: implement identityRequestProcessor in llminternal

### DIFF
--- a/internal/llminternal/other_processors.go
+++ b/internal/llminternal/other_processors.go
@@ -16,11 +16,31 @@ package llminternal
 
 import (
 	"google.golang.org/adk/agent"
+	"google.golang.org/adk/internal/utils"
 	"google.golang.org/adk/model"
 )
 
+// identityRequestProcessor sets up identity context for LLM agents in the LLM request.
+// It adds system instructions that inform the LLM about the agent's name and description.
 func identityRequestProcessor(ctx agent.InvocationContext, req *model.LLMRequest) error {
-	// TODO: implement (adk-python src/google/adk/flows/llm_flows/identity.py)
+	// reference: adk-python src/google/adk/flows/llm_flows/identity.py
+
+	llmAgent := asLLMAgent(ctx.Agent())
+	if llmAgent == nil {
+		return nil // do nothing.
+	}
+
+	// Add identity information to system instructions.
+	var identityInstructions []string
+	if name := ctx.Agent().Name(); name != "" {
+		identityInstructions = append(identityInstructions, `You are an agent. Your internal name is "`+name+`".`)
+	}
+	if description := ctx.Agent().Description(); description != "" {
+		identityInstructions = append(identityInstructions, `The description about you is "`+description+`".`)
+	}
+
+	// Append identity instructions to the system instruction.
+	utils.AppendInstructions(req, identityInstructions...)
 	return nil
 }
 

--- a/internal/llminternal/other_processors.go
+++ b/internal/llminternal/other_processors.go
@@ -15,6 +15,8 @@
 package llminternal
 
 import (
+	"fmt"
+
 	"google.golang.org/adk/agent"
 	"google.golang.org/adk/internal/utils"
 	"google.golang.org/adk/model"
@@ -31,12 +33,12 @@ func identityRequestProcessor(ctx agent.InvocationContext, req *model.LLMRequest
 	}
 
 	// Add identity information to system instructions.
-	var identityInstructions []string
+	identityInstructions := make([]string, 0, 2)
 	if name := ctx.Agent().Name(); name != "" {
-		identityInstructions = append(identityInstructions, `You are an agent. Your internal name is "`+name+`".`)
+		identityInstructions = append(identityInstructions, fmt.Sprintf(`You are an agent. Your internal name is %q.`, name))
 	}
 	if description := ctx.Agent().Description(); description != "" {
-		identityInstructions = append(identityInstructions, `The description about you is "`+description+`".`)
+		identityInstructions = append(identityInstructions, fmt.Sprintf(`The description about you is %q.`, description))
 	}
 
 	// Append identity instructions to the system instruction.

--- a/internal/llminternal/other_processors_test.go
+++ b/internal/llminternal/other_processors_test.go
@@ -1,0 +1,171 @@
+// Copyright 2025 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package llminternal
+
+import (
+	"testing"
+
+	"github.com/google/go-cmp/cmp"
+	"google.golang.org/genai"
+
+	"google.golang.org/adk/agent"
+	icontext "google.golang.org/adk/internal/context"
+	"google.golang.org/adk/internal/utils"
+	"google.golang.org/adk/model"
+)
+
+func Test_identityRequestProcessor(t *testing.T) {
+	testCases := []struct {
+		name           string
+		agentConfig    agent.Config
+		req            *model.LLMRequest
+		wantErr        bool
+		wantSystemInst string
+	}{
+		{
+			name: "LLM agent with name only - adds name instruction",
+			agentConfig: agent.Config{
+				Name: "TestAgent",
+			},
+			req:            &model.LLMRequest{},
+			wantErr:        false,
+			wantSystemInst: `You are an agent. Your internal name is "TestAgent".`,
+		},
+		{
+			name: "LLM agent with description only - adds description instruction",
+			agentConfig: agent.Config{
+				Name:        "",
+				Description: "A helpful assistant that answers questions",
+			},
+			req:            &model.LLMRequest{},
+			wantErr:        false,
+			wantSystemInst: `The description about you is: "A helpful assistant that answers questions".`,
+		},
+		{
+			name: "LLM agent with both name and description - adds both instructions",
+			agentConfig: agent.Config{
+				Name:        "HelperBot",
+				Description: "A friendly assistant that helps users with their tasks",
+			},
+			req:            &model.LLMRequest{},
+			wantErr:        false,
+			wantSystemInst: `You are an agent. Your internal name is "HelperBot".` + "\n\n" + `The description about you is: "A friendly assistant that helps users with their tasks".`,
+		},
+		{
+			name: "LLM agent with existing system instruction - appends to existing",
+			agentConfig: agent.Config{
+				Name:        "ExistingAgent",
+				Description: "Agent with existing instructions",
+			},
+			req: &model.LLMRequest{
+				Config: &genai.GenerateContentConfig{
+					SystemInstruction: genai.NewContentFromText("Existing system instruction", genai.RoleUser),
+				},
+			},
+			wantErr: false,
+			wantSystemInst: "Existing system instruction\n\n" +
+				`You are an agent. Your internal name is "ExistingAgent".` + "\n\n" +
+				`The description about you is: "Agent with existing instructions".`,
+		},
+		{
+			name: "LLM agent with existing config but no system instruction - creates new",
+			agentConfig: agent.Config{
+				Name:        "ConfigAgent",
+				Description: "Agent with existing config",
+			},
+			req: &model.LLMRequest{
+				Config: &genai.GenerateContentConfig{
+					// No SystemInstruction
+				},
+			},
+			wantErr: false,
+			wantSystemInst: `You are an agent. Your internal name is "ConfigAgent".` + "\n\n" +
+				`The description about you is: "Agent with existing config".`,
+		},
+		{
+			name:           "Non-LLM agent - does nothing and returns no error",
+			agentConfig:    agent.Config{},
+			req:            &model.LLMRequest{},
+			wantErr:        false,
+			wantSystemInst: "",
+		},
+	}
+
+	for _, tc := range testCases {
+		t.Run(tc.name, func(t *testing.T) {
+			var testAgent agent.Agent
+
+			// Create a test agent implementing the Agent interface and llmagent state
+			// if name or description is empty, we use a nil agent to simulate non-LLM agent.
+			if tc.agentConfig.Name != "" || tc.agentConfig.Description != "" {
+				testAgent = &struct {
+					agent.Agent
+					State
+				}{
+					Agent: utils.Must(agent.New(tc.agentConfig)),
+					State: State{},
+				}
+			}
+
+			// Create real invocation context
+			ctx := icontext.NewInvocationContext(t.Context(), icontext.InvocationContextParams{
+				Agent: testAgent,
+			})
+
+			// Call the function under test
+			err := identityRequestProcessor(ctx, tc.req)
+			if (err != nil) != tc.wantErr {
+				t.Fatalf("identityRequestProcessor() error = %v, wantErr %v", err, tc.wantErr)
+			}
+
+			// Check the system instruction
+			if tc.wantSystemInst != "" {
+				if tc.req.Config == nil || tc.req.Config.SystemInstruction == nil {
+					t.Errorf("expected system instruction to be set")
+					return
+				}
+
+				gotText := ""
+				for _, part := range tc.req.Config.SystemInstruction.Parts {
+					if part.Text != "" {
+						if gotText != "" {
+							gotText += "\n\n"
+						}
+						gotText += part.Text
+					}
+				}
+
+				if diff := cmp.Diff(tc.wantSystemInst, gotText); diff != "" {
+					t.Errorf("system instruction mismatch (-want +got):\n%s", diff)
+				}
+			} else {
+				if tc.req.Config != nil && tc.req.Config.SystemInstruction != nil {
+					gotText := ""
+					for _, part := range tc.req.Config.SystemInstruction.Parts {
+						if part.Text != "" {
+							if gotText != "" {
+								gotText += "\n\n"
+							}
+							gotText += part.Text
+						}
+					}
+					if gotText != "" {
+						t.Errorf("expected no system instruction, got: %s", gotText)
+					}
+				}
+			}
+		})
+	}
+}

--- a/internal/llminternal/other_processors_test.go
+++ b/internal/llminternal/other_processors_test.go
@@ -51,7 +51,7 @@ func Test_identityRequestProcessor(t *testing.T) {
 			},
 			req:            &model.LLMRequest{},
 			wantErr:        false,
-			wantSystemInst: `The description about you is: "A helpful assistant that answers questions".`,
+			wantSystemInst: `The description about you is "A helpful assistant that answers questions".`,
 		},
 		{
 			name: "LLM agent with both name and description - adds both instructions",
@@ -61,7 +61,7 @@ func Test_identityRequestProcessor(t *testing.T) {
 			},
 			req:            &model.LLMRequest{},
 			wantErr:        false,
-			wantSystemInst: `You are an agent. Your internal name is "HelperBot".` + "\n\n" + `The description about you is: "A friendly assistant that helps users with their tasks".`,
+			wantSystemInst: `You are an agent. Your internal name is "HelperBot".` + "\n\n" + `The description about you is "A friendly assistant that helps users with their tasks".`,
 		},
 		{
 			name: "LLM agent with existing system instruction - appends to existing",
@@ -77,7 +77,7 @@ func Test_identityRequestProcessor(t *testing.T) {
 			wantErr: false,
 			wantSystemInst: "Existing system instruction\n\n" +
 				`You are an agent. Your internal name is "ExistingAgent".` + "\n\n" +
-				`The description about you is: "Agent with existing instructions".`,
+				`The description about you is "Agent with existing instructions".`,
 		},
 		{
 			name: "LLM agent with existing config but no system instruction - creates new",
@@ -92,7 +92,7 @@ func Test_identityRequestProcessor(t *testing.T) {
 			},
 			wantErr: false,
 			wantSystemInst: `You are an agent. Your internal name is "ConfigAgent".` + "\n\n" +
-				`The description about you is: "Agent with existing config".`,
+				`The description about you is "Agent with existing config".`,
 		},
 		{
 			name:           "Non-LLM agent - does nothing and returns no error",


### PR DESCRIPTION
## Summary
Implement identityRequestProcessor in **llminternal** pkg, referencing the **adk-python** `src/google/adk/flows/llm_flows/identity.py` identity flow implementation.

## Changes
- Added `identityRequestProcessor` function in `other_processors.go`
- Implemented request processing logic following Python ADK patterns
- Added corresponding test cases in `other_processors_test.go`

## Testing
- Added unit tests that cover 100% of the basic functionality
- All tests pass with expected behavior
