### PR TITLE
Document reasoning for omitting ctx.EndInvocation()

### DIFF
--- a/agent/agent.go
+++ b/agent/agent.go
@@ -285,20 +285,14 @@ func runAfterAgentCallbacks(ctx InvocationContext) (*session.Event, error) {
 		event.Branch = ctx.Branch()
 		event.Actions = *callbackCtx.actions
 		
-		// NOTE:
-        //  intentionally do NOT call ctx.EndInvocation() here.
-        //
-        // Reason:
-        // - After-agent callbacks do not check ctx.Ended(), so marking the
-        //   invocation as ended has no effect on execution flow.
-        // - The Python ADK implementation also omits ending the invocation here,
-        //   so matching that behavior ensures cross-language consistency.
-        // - The invocation end flag is local to the current subagent and is not
-        //   used by anything after runAfterAgentCallbacks, so setting it would
-        //   be misleading to future contributors.
-        //
-        // Leaving this unimplemented is intentional.
-        // TODO: revisit only if the after-callback flow changes in future.
+// NOTE: Intentionally not calling ctx.EndInvocation() here.
+//
+// Rationale:
+// - After-agent callbacks do not check ctx.Ended(), so ending the invocation here has no effect on the execution flow.
+// - This behavior is consistent with the Python ADK implementation.
+// - The invocation end flag is local to this subagent's context and is not used after this function returns, so setting it could be misleading.
+//
+// TODO: Revisit this decision if the after-callback flow changes in the future.
 
 		return event, nil
 	}

--- a/agent/agent.go
+++ b/agent/agent.go
@@ -389,10 +389,10 @@ func (c *callbackContextState) All() iter.Seq2[string, any] {
 type invocationContext struct {
 	context.Context
 
-	agent     Agent
-	artifacts Artifacts
-	memory    Memory
-	session   session.Session
+	agent         Agent
+	artifacts     Artifacts
+	memory        Memory
+	session       session.Session
 
 	invocationID  string
 	branch        string

--- a/agent/agent.go
+++ b/agent/agent.go
@@ -284,8 +284,22 @@ func runAfterAgentCallbacks(ctx InvocationContext) (*session.Event, error) {
 		event.Author = agent.Name()
 		event.Branch = ctx.Branch()
 		event.Actions = *callbackCtx.actions
-		// TODO set context invocation ended
-		// ctx.invocationEnded = true
+		
+		// NOTE:
+        //  intentionally do NOT call ctx.EndInvocation() here.
+        //
+        // Reason:
+        // - After-agent callbacks do not check ctx.Ended(), so marking the
+        //   invocation as ended has no effect on execution flow.
+        // - The Python ADK implementation also omits ending the invocation here,
+        //   so matching that behavior ensures cross-language consistency.
+        // - The invocation end flag is local to the current subagent and is not
+        //   used by anything after runAfterAgentCallbacks, so setting it would
+        //   be misleading to future contributors.
+        //
+        // Leaving this unimplemented is intentional.
+        // TODO: revisit only if the after-callback flow changes in future.
+
 		return event, nil
 	}
 


### PR DESCRIPTION
Added detailed comments explaining the intentional omission of ctx.EndInvocation() and its implications for cross-language consistency.