### PR TITLE
session: add NewSessionServiceGorm and make NewSessionService a wrapp……er (deprecated)

### DIFF
--- a/session/database/service.go
+++ b/session/database/service.go
@@ -60,7 +60,7 @@ func NewSessionService(dialector gorm.Dialector, opts ...gorm.Option) (session.S
 // service will not attempt to open or close the database connection.
 func NewSessionServiceGorm(db *gorm.DB) (session.Service, error) {
 	if db == nil {
-		return nil, fmt.Errorf("db cannot be nil")
+return nil, fmt.Errorf("gorm.DB cannot be nil")
 	}
 	return &databaseService{db: db}, nil
 }


### PR DESCRIPTION
New GORM-based Session Service Constructor: Introduced NewSessionServiceGorm, a new constructor that accepts an already initialized *gorm.DB instance, allowing callers to manage their database connection lifecycle directly.
Deprecation of Existing Constructor: The NewSessionService function has been deprecated. It now acts as a backward-compatible wrapper, internally opening a GORM database connection and then calling NewSessionServiceGorm.
Improved Database Connection Management: The new approach encourages callers to manage shared database connections, providing more control over resource lifecycle and preventing the session service from opening or closing the connection itself.