### PR TITLE
Filter function calls

### DIFF
--- a/agent/llmagent/llmagent.go
+++ b/agent/llmagent/llmagent.go
@@ -67,6 +67,7 @@ func New(cfg Config) (agent.Agent, error) {
 			GenerateContentConfig:    cfg.GenerateContentConfig,
 			Tools:                    cfg.Tools,
 			Toolsets:                 cfg.Toolsets,
+			Filter:                   cfg.Filter,
 			DisallowTransferToParent: cfg.DisallowTransferToParent,
 			DisallowTransferToPeers:  cfg.DisallowTransferToPeers,
 			InputSchema:              cfg.InputSchema,
@@ -248,6 +249,9 @@ type Config struct {
 	// Toolsets will be used by llmagent to extract tools and pass to the
 	// underlying LLM.
 	Toolsets []tool.Toolset
+
+	// Filter will be used by llmagent to filter tools that will not be used by this specific agent
+	Filter map[string]bool
 
 	// OutputKey is an optional parameter to specify the key in session state for the agent output.
 	//

--- a/agent/llmagent/llmagent_test.go
+++ b/agent/llmagent/llmagent_test.go
@@ -968,7 +968,8 @@ func TestToolFiltering(t *testing.T) {
 		DisallowTransferToParent: true,
 		DisallowTransferToPeers:  true,
 		Tools:                    []tool.Tool{sumTool},
-		Filter:                   map[string]bool{sumTool.Name(): false},
+		// The Filter's map values are ignored, but it has to be boolean.
+		Filter: map[string]bool{sumTool.Name(): true},
 	})
 	if err != nil {
 		t.Fatalf("failed to create LLM Agent: %v", err)

--- a/agent/llmagent/llmagent_test.go
+++ b/agent/llmagent/llmagent_test.go
@@ -932,6 +932,65 @@ func TestAgentTransfer(t *testing.T) {
 	//   - test_auto_to_loop
 }
 
+func TestToolFiltering(t *testing.T) {
+	model := newGeminiModel(t, modelName, nil)
+
+	type Args struct {
+		Int1 int `json:"int1"`
+		Int2 int `json:"int2"`
+	}
+	type Result struct {
+		Sum int `json:"sum"`
+	}
+
+	prompt := "what tools do you have?"
+	handlerCalled := false
+	handler := func(_ tool.Context, input Args) (Result, error) {
+		handlerCalled = true
+		return Result{Sum: input.Int1 + input.Int2}, nil
+	}
+
+	sumTool, _ := functiontool.New(functiontool.Config{
+		Name:        "sum",
+		Description: "Adds 2 numbers together",
+	}, handler)
+
+	agent, err := llmagent.New(llmagent.Config{
+		Name:        "agent",
+		Description: "math agent",
+		Model:       model,
+		Instruction: "only use the tools provided to output results",
+		// TODO(hakim): set to false when autoflow is implemented.
+		DisallowTransferToParent: true,
+		DisallowTransferToPeers:  true,
+		Tools:                    []tool.Tool{sumTool},
+		Filter:                   map[string]bool{sumTool.Name(): false},
+	})
+	if err != nil {
+		t.Fatalf("failed to create LLM Agent: %v", err)
+	}
+
+	runner := testutil.NewTestAgentRunner(t, agent)
+	stream := runner.Run(t, "session1", prompt)
+
+	ans, err := testutil.CollectTextParts(stream)
+	if err != nil {
+		t.Fatalf("failed to collect response: %v", err)
+	}
+
+	// Assert the handler was NOT called
+	if handlerCalled {
+		t.Fatalf("tool handler should NOT be called when filtered")
+	}
+
+	// Assert the LLM returned a normal text response
+	if len(ans) == 0 {
+		t.Fatalf("expected a text response, got nothing")
+	}
+
+	t.Logf("The agent returned: %v", ans)
+}
+
 func newGeminiModel(t *testing.T, modelName string, transport http.RoundTripper) model.LLM {
 	apiKey := "fakeKey"
 	if transport == nil { // use httprr
@@ -939,7 +998,7 @@ func newGeminiModel(t *testing.T, modelName string, transport http.RoundTripper)
 		recording := false
 		transport, recording = newGeminiTestClientConfig(t, trace)
 		if recording { // if we are recording httprr trace, don't use the fakeKey.
-			apiKey = ""
+			apiKey = "AIzaSyBq8uw1Gff6ZAfbEIEVGv-mOs4FFFoGhMw"
 		}
 	}
 	model, err := gemini.NewModel(t.Context(), modelName, &genai.ClientConfig{

--- a/agent/llmagent/llmagent_test.go
+++ b/agent/llmagent/llmagent_test.go
@@ -1002,7 +1002,7 @@ func newGeminiModel(t *testing.T, modelName string, transport http.RoundTripper)
 		recording := false
 		transport, recording = newGeminiTestClientConfig(t, trace)
 		if recording { // if we are recording httprr trace, don't use the fakeKey.
-			apiKey = "AIzaSyBq8uw1Gff6ZAfbEIEVGv-mOs4FFFoGhMw"
+			apiKey = ""
 		}
 	}
 	model, err := gemini.NewModel(t.Context(), modelName, &genai.ClientConfig{

--- a/agent/llmagent/testdata/TestToolFiltering.httprr
+++ b/agent/llmagent/testdata/TestToolFiltering.httprr
@@ -1,0 +1,56 @@
+httprr trace v1
+432 1173
+POST https://generativelanguage.googleapis.com/v1beta/models/gemini-2.0-flash:generateContent HTTP/1.1
+Host: generativelanguage.googleapis.com
+User-Agent: Go-http-client/1.1
+Content-Length: 200
+Content-Type: application/json
+
+{"contents":[{"parts":[{"text":"what tools do you have?"}],"role":"user"}],"generationConfig":{},"systemInstruction":{"parts":[{"text":"only use the tools provided to output results"}],"role":"user"}}HTTP/2.0 200 OK
+Alt-Svc: h3=":443"; ma=2592000,h3-29=":443"; ma=2592000
+Content-Type: application/json; charset=UTF-8
+Date: Tue, 02 Dec 2025 09:13:17 GMT
+Server: scaffolding on HTTPServer2
+Server-Timing: gfet4t7; dur=1085
+Vary: Origin
+Vary: X-Origin
+Vary: Referer
+X-Content-Type-Options: nosniff
+X-Frame-Options: SAMEORIGIN
+X-Xss-Protection: 0
+
+{
+  "candidates": [
+    {
+      "content": {
+        "parts": [
+          {
+            "text": "I have access to the following tools:\n\n*   **Calculator:** I can perform calculations.\n*   **Web Browser:** I can access and retrieve information from the internet.\n"
+          }
+        ],
+        "role": "model"
+      },
+      "finishReason": "STOP",
+      "avgLogprobs": -0.10833433512094859
+    }
+  ],
+  "usageMetadata": {
+    "promptTokenCount": 14,
+    "candidatesTokenCount": 37,
+    "totalTokenCount": 51,
+    "promptTokensDetails": [
+      {
+        "modality": "TEXT",
+        "tokenCount": 14
+      }
+    ],
+    "candidatesTokensDetails": [
+      {
+        "modality": "TEXT",
+        "tokenCount": 37
+      }
+    ]
+  },
+  "modelVersion": "gemini-2.0-flash",
+  "responseId": "rK0uafnEFcaM4-EPt-m4qQw"
+}

--- a/internal/llminternal/agent.go
+++ b/internal/llminternal/agent.go
@@ -32,7 +32,7 @@ type State struct {
 
 	Tools    []tool.Tool
 	Toolsets []tool.Toolset
-	Filter	 map[string]bool
+	Filter   map[string]bool
 
 	IncludeContents string
 

--- a/internal/llminternal/agent.go
+++ b/internal/llminternal/agent.go
@@ -32,6 +32,7 @@ type State struct {
 
 	Tools    []tool.Tool
 	Toolsets []tool.Toolset
+	Filter	 map[string]bool
 
 	IncludeContents string
 


### PR DESCRIPTION
## Filter Function Calls

Developers using ADK-go can now add filters when they create a new LLM agent as such:
```go
	agent, err := llmagent.New(llmagent.Config{
		Name:        "agent",
		Description: "math agent",
		Model:       model,
		Instruction: "only use the tools provided to output results",
		// TODO(hakim): set to false when autoflow is implemented.
		DisallowTransferToParent: true,
		DisallowTransferToPeers:  true,
		Tools:                    []tool.Tool{sumTool},
		Filter:                   map[string]bool{sumTool.Name(): false},  <================ Added filter field
	})
```
The Filter field accepts a map where the `Key` is the tool's name and the `Value` is a boolean on whether the tool is allowed or not.
True = Tool is allowed.
False = Tool is NOT allowed.

- Added Filter field to the `Config` struct.
- Added filter field to the `State` struct.
- Implemented filter logic in `base_flow.go`
- Added tests for testing if filtered tools are still called.

## Notes
I have decided to start on developer declared filter first as the use cases can include tool prohibition based on user roles.
For example, if a user has no premium access account, developers could create a conditional check and initialize the agent without access to specific tools.
The current implementation will impose a permanent tool filter on all requests after agent initialization, meaning we cannot change the filter once the agent has been initialized.

## TODO
 - Implement filter changes per request.
 - Agent defined filters to pass to sub-agents.

This PR references this [Issue ](https://github.com/google/adk-go/issues/356)