### PR TITLE
Fix mcp tool convert, null responseJsonSchema

### DIFF
--- a/tool/mcptoolset/tool.go
+++ b/tool/mcptoolset/tool.go
@@ -36,18 +36,20 @@ func convertTool(t *mcp.Tool, getSessionFunc getSessionFunc) (tool.Tool, error) 
 		name:        t.Name,
 		description: t.Description,
 		funcDeclaration: &genai.FunctionDeclaration{
-			Name:                 t.Name,
-			Description:          t.Description,
-			ParametersJsonSchema: t.InputSchema,
+			Name:        t.Name,
+			Description: t.Description,
 		},
 		getSessionFunc: getSessionFunc,
 	}
 
-	// Since t.OutputSchema is a pointer (*jsonschema.Schema) and the destination ResponseJsonSchema
+	// Since t.InputSchema and t.OutputSchema are pointers (*jsonschema.Schema) and the destination ResponseJsonSchema
 	// is an interface (any), we have encountered the type nil problem.
 	// This will make the omitempty not work since ResponseJsonSchema becomes an interface wrapper
 	// to a nil pointer and genai converter includes "responseJsonSchema": null in the json sent to the llm which causes it to crash.
 	// we need the following "if" check to keep ResponseJsonSchema (nil,nil) instead of (*jsonschema.Schema, nil)
+	if t.InputSchema != nil {
+		mcp.funcDeclaration.ParametersJsonSchema = t.InputSchema
+	}
 	if t.OutputSchema != nil {
 		mcp.funcDeclaration.ResponseJsonSchema = t.OutputSchema
 	}


### PR DESCRIPTION
Fix mcp tool convert to only set responseJsonSchema if mcp tool has output schema.