### PR TITLE
Add logging for GORM expression in stateMap and dynamicJSON

### DIFF
--- a/session/database/gorm_datatypes.go
+++ b/session/database/gorm_datatypes.go
@@ -90,7 +90,9 @@ func (sm *stateMap) Scan(value any) error {
 
 func (sm stateMap) GormValue(ctx context.Context, db *gorm.DB) clause.Expr {
 	data, _ := json.Marshal(sm)
-	// TODO log the expression result
+	if db.Logger != nil {
+		db.Logger.Info(ctx, "GormValue expression result: %s", string(data))
+	}
 	return gorm.Expr("?", string(data))
 }
 
@@ -163,6 +165,8 @@ func (js dynamicJSON) GormValue(ctx context.Context, db *gorm.DB) clause.Expr {
 	if len(js) == 0 {
 		return gorm.Expr("NULL")
 	}
-	// TODO log the expression result
+	if db.Logger != nil {
+		db.Logger.Info(ctx, "GormValue expression result: %s", string(js))
+	}
 	return gorm.Expr("?", string(js))
 }

--- a/session/database/gorm_datatypes.go
+++ b/session/database/gorm_datatypes.go
@@ -89,9 +89,13 @@ func (sm *stateMap) Scan(value any) error {
 }
 
 func (sm stateMap) GormValue(ctx context.Context, db *gorm.DB) clause.Expr {
-	data, _ := json.Marshal(sm)
+	data, err := json.Marshal(sm)
 	if db.Logger != nil {
-		db.Logger.Info(ctx, "GormValue expression result: %s", string(data))
+		if err != nil {
+			db.Logger.Error(ctx, "GormValue json.Marshal error: %v", err)
+		} else {
+			db.Logger.Info(ctx, "GormValue expression result: %s", string(data))
+		}
 	}
 	return gorm.Expr("?", string(data))
 }


### PR DESCRIPTION
This commit adds logging of the expression result in `GormValue` for both `stateMap` and `dynamicJSON` types in `session/database/gorm_datatypes.go`. It uses `db.Logger.Info` to log the result if a logger is configured. This resolves the TODOs in the code.