### PR TITLE
Refactor IncludeContents in State to use internal type.

### DIFF
--- a/agent/llmagent/llmagent.go
+++ b/agent/llmagent/llmagent.go
@@ -71,7 +71,7 @@ func New(cfg Config) (agent.Agent, error) {
 			DisallowTransferToPeers:  cfg.DisallowTransferToPeers,
 			InputSchema:              cfg.InputSchema,
 			OutputSchema:             cfg.OutputSchema,
-IncludeContents:           cfg.IncludeContents,
+			IncludeContents:           cfg.IncludeContents,
 			Instruction:               cfg.Instruction,
 			InstructionProvider:       llminternal.InstructionProvider(cfg.InstructionProvider),
 			GlobalInstruction:         cfg.GlobalInstruction,

--- a/agent/llmagent/llmagent.go
+++ b/agent/llmagent/llmagent.go
@@ -71,8 +71,7 @@ func New(cfg Config) (agent.Agent, error) {
 			DisallowTransferToPeers:  cfg.DisallowTransferToPeers,
 			InputSchema:              cfg.InputSchema,
 			OutputSchema:             cfg.OutputSchema,
-			// TODO: internal type for includeContents
-			IncludeContents:           string(cfg.IncludeContents),
+			IncludeContents:           llminternal.IncludeContents(cfg.IncludeContents),
 			Instruction:               cfg.Instruction,
 			InstructionProvider:       llminternal.InstructionProvider(cfg.InstructionProvider),
 			GlobalInstruction:         cfg.GlobalInstruction,

--- a/agent/llmagent/llmagent.go
+++ b/agent/llmagent/llmagent.go
@@ -276,13 +276,13 @@ type BeforeToolCallback func(ctx tool.Context, tool tool.Tool, args map[string]a
 type AfterToolCallback func(ctx tool.Context, tool tool.Tool, args, result map[string]any, err error) (map[string]any, error)
 
 // IncludeContents controls what parts of prior conversation history is received by llmagent.
-type IncludeContents string
+type IncludeContents = llminternal.IncludeContents
 
 const (
 	// IncludeContentsNone makes the llmagent operate solely on its current turn (latest user input + any following agent events).
-	IncludeContentsNone IncludeContents = "none"
+	IncludeContentsNone = llminternal.IncludeContentsNone
 	// IncludeContentsDefault is enabled by default. The llmagent receives the relevant conversation history.
-	IncludeContentsDefault IncludeContents = "default"
+	IncludeContentsDefault = llminternal.IncludeContentsDefault
 )
 
 type llmAgent struct {

--- a/agent/llmagent/llmagent.go
+++ b/agent/llmagent/llmagent.go
@@ -71,7 +71,7 @@ func New(cfg Config) (agent.Agent, error) {
 			DisallowTransferToPeers:  cfg.DisallowTransferToPeers,
 			InputSchema:              cfg.InputSchema,
 			OutputSchema:             cfg.OutputSchema,
-			IncludeContents:           llminternal.IncludeContents(cfg.IncludeContents),
+IncludeContents:           cfg.IncludeContents,
 			Instruction:               cfg.Instruction,
 			InstructionProvider:       llminternal.InstructionProvider(cfg.InstructionProvider),
 			GlobalInstruction:         cfg.GlobalInstruction,

--- a/internal/llminternal/agent.go
+++ b/internal/llminternal/agent.go
@@ -59,7 +59,7 @@ type IncludeContents string
 const (
 	// IncludeContentsNone makes the llmagent operate solely on its current turn (latest user input + any following agent events).
 	IncludeContentsNone IncludeContents = "none"
-	// IncludeContentsDefault is enabled by default. The llmagent receives the relevant conversation history.
+	// IncludeContentsDefault is enabled by default. It will receives the relevant conversation history.
 	IncludeContentsDefault IncludeContents = "default"
 )
 

--- a/internal/llminternal/agent.go
+++ b/internal/llminternal/agent.go
@@ -33,7 +33,7 @@ type State struct {
 	Tools    []tool.Tool
 	Toolsets []tool.Toolset
 
-	IncludeContents string
+	IncludeContents IncludeContents
 
 	GenerateContentConfig *genai.GenerateContentConfig
 
@@ -52,6 +52,16 @@ type State struct {
 }
 
 type InstructionProvider func(ctx agent.ReadonlyContext) (string, error)
+
+// IncludeContents controls what parts of prior conversation history is received by llmagent.
+type IncludeContents string
+
+const (
+	// IncludeContentsNone makes the llmagent operate solely on its current turn (latest user input + any following agent events).
+	IncludeContentsNone IncludeContents = "none"
+	// IncludeContentsDefault is enabled by default. The llmagent receives the relevant conversation history.
+	IncludeContentsDefault IncludeContents = "default"
+)
 
 func (s *State) internal() *State { return s }
 

--- a/internal/llminternal/contents_processor.go
+++ b/internal/llminternal/contents_processor.go
@@ -40,7 +40,7 @@ func ContentsRequestProcessor(ctx agent.InvocationContext, req *model.LLMRequest
 		return nil // In python, no error is yielded.
 	}
 	fn := buildContentsDefault // "" or "default".
-	if llmAgent.internal().IncludeContents == "none" {
+	if llmAgent.internal().IncludeContents == IncludeContentsNone {
 		// Include current turn context only (no conversation history)
 		fn = buildContentsCurrentTurnContextOnly
 	}


### PR DESCRIPTION
Defines a new `IncludeContents` type and constants in `internal/llminternal` and updates the `State` struct to use it. This improves type safety and addresses a TODO comment.

Internal Refs:
- Defined `IncludeContents` type and constants in `internal/llminternal/agent.go`.
- Updated `State.IncludeContents` field type.
- Updated `llmagent.New` to cast config value to internal type.
- Updated `contents_processor.go` to use internal constant.