### PR TITLE
fix: use background context for MCP session and add test

### DIFF
--- a/tool/mcptoolset/set.go
+++ b/tool/mcptoolset/set.go
@@ -142,7 +142,7 @@ func (s *set) getSession(ctx context.Context) (*mcp.ClientSession, error) {
 		return s.session, nil
 	}
 
-	session, err := s.client.Connect(ctx, s.transport, nil)
+	session, err := s.client.Connect(context.Background(), s.transport, nil)
 	if err != nil {
 		return nil, fmt.Errorf("failed to init MCP session: %w", err)
 	}


### PR DESCRIPTION
The MCP session was being initialized using the request-scoped context passed to Tools(ctx). When this context was cancelled the underlying MCP connection was closed. However, the session remained cached in the mcptoolset struct, causing subsequent calls to fail.

Changed the Connect call in getSession to use context.Background().

Added TestSessionContextCancellation to verify that the context passed to connect is not cancelled.

For questions related to executing Ping as well to confirm the status of the connection, please see https://github.com/google/adk-go/issues/399#issuecomment-3643981984