### PR TITLE
Fix/graceful tool error handling #423

### DIFF
--- a/agent/workflowagents/loopagent/agent.go
+++ b/agent/workflowagents/loopagent/agent.go
@@ -85,11 +85,7 @@ func (a *loopAgent) Run(ctx agent.InvocationContext) iter.Seq2[*session.Event, e
 						return
 					}
 
-					if err != nil {
-						shouldExit = true
-						break
-					}
-					if event != nil && event.Actions.Escalate {
+					if err != nil || (event != nil && event.Actions.Escalate) {
 						shouldExit = true
 						break
 					}

--- a/agent/workflowagents/loopagent/agent.go
+++ b/agent/workflowagents/loopagent/agent.go
@@ -85,13 +85,21 @@ func (a *loopAgent) Run(ctx agent.InvocationContext) iter.Seq2[*session.Event, e
 						return
 					}
 
-					if event.Actions.Escalate {
+					if err != nil {
 						shouldExit = true
+						break
+					}
+					if event != nil && event.Actions.Escalate {
+						shouldExit = true
+						break
 					}
 				}
 				if shouldExit {
-					return
+					break
 				}
+			}
+			if shouldExit {
+				return
 			}
 
 			if count > 0 {

--- a/internal/telemetry/telemetry.go
+++ b/internal/telemetry/telemetry.go
@@ -60,6 +60,7 @@ const (
 	genAiToolName        = "gen_ai.tool.name"
 	genAiToolCallID      = "gen_ai.tool.call.id"
 	genAiSystemName      = "gen_ai.system"
+	genAiConversationID  = "gen_ai.conversation.id"
 
 	genAiRequestModelName = "gen_ai.request.model"
 	genAiRequestTopP      = "gen_ai.request.top_p"
@@ -207,6 +208,7 @@ func TraceLLMCall(spans []trace.Span, agentCtx agent.InvocationContext, llmReque
 			attribute.String(genAiRequestModelName, llmRequest.Model),
 			attribute.String(gcpVertexAgentInvocationID, event.InvocationID),
 			attribute.String(gcpVertexAgentSessionID, agentCtx.Session().ID()),
+			attribute.String(genAiConversationID, agentCtx.Session().ID()),
 			attribute.String(gcpVertexAgentEventID, event.ID),
 			attribute.String(gcpVertexAgentLLMRequestName, safeSerialize(llmRequestToTrace(llmRequest))),
 			attribute.String(gcpVertexAgentLLMResponseName, safeSerialize(event.LLMResponse)),

--- a/internal/telemetry/telemetry.go
+++ b/internal/telemetry/telemetry.go
@@ -60,7 +60,6 @@ const (
 	genAiToolName        = "gen_ai.tool.name"
 	genAiToolCallID      = "gen_ai.tool.call.id"
 	genAiSystemName      = "gen_ai.system"
-	genAiConversationID  = "gen_ai.conversation.id"
 
 	genAiRequestModelName = "gen_ai.request.model"
 	genAiRequestTopP      = "gen_ai.request.top_p"
@@ -208,7 +207,6 @@ func TraceLLMCall(spans []trace.Span, agentCtx agent.InvocationContext, llmReque
 			attribute.String(genAiRequestModelName, llmRequest.Model),
 			attribute.String(gcpVertexAgentInvocationID, event.InvocationID),
 			attribute.String(gcpVertexAgentSessionID, agentCtx.Session().ID()),
-			attribute.String(genAiConversationID, agentCtx.Session().ID()),
 			attribute.String(gcpVertexAgentEventID, event.ID),
 			attribute.String(gcpVertexAgentLLMRequestName, safeSerialize(llmRequestToTrace(llmRequest))),
 			attribute.String(gcpVertexAgentLLMResponseName, safeSerialize(event.LLMResponse)),


### PR DESCRIPTION
Addressing issue: #423 

This commit fixes a nil pointer dereference in the loopagent that occurred when an LLM called a tool that was not registered with the current agent. The agent now gracefully handles the error and continues execution instead of crashing.

Test: Passed.