### PR TITLE
feat: include gen_ai.conversation.id in OTEL spans (#421)

### DIFF
--- a/internal/telemetry/telemetry.go
+++ b/internal/telemetry/telemetry.go
@@ -70,6 +70,7 @@ const (
 	genAiResponseCandidatesTokenCount    = "gen_ai.response.candidates_token_count"
 	genAiResponseCachedContentTokenCount = "gen_ai.response.cached_content_token_count"
 	genAiResponseTotalTokenCount         = "gen_ai.response.total_token_count"
+	genAiConversationID                  = "gen_ai.conversation.id"
 
 	gcpVertexAgentLLMRequestName   = "gcp.vertex.agent.llm_request"
 	gcpVertexAgentToolCallArgsName = "gcp.vertex.agent.tool_call_args"
@@ -201,12 +202,14 @@ func TraceToolCall(spans []trace.Span, tool tool.Tool, fnArgs map[string]any, fn
 
 // TraceLLMCall fills the call_llm event details.
 func TraceLLMCall(spans []trace.Span, agentCtx agent.InvocationContext, llmRequest *model.LLMRequest, event *session.Event) {
+	sessionID := agentCtx.Session().ID()
 	for _, span := range spans {
 		attributes := []attribute.KeyValue{
 			attribute.String(genAiSystemName, systemName),
 			attribute.String(genAiRequestModelName, llmRequest.Model),
 			attribute.String(gcpVertexAgentInvocationID, event.InvocationID),
-			attribute.String(gcpVertexAgentSessionID, agentCtx.Session().ID()),
+			attribute.String(gcpVertexAgentSessionID, sessionID),
+			attribute.String(genAiConversationID, sessionID),
 			attribute.String(gcpVertexAgentEventID, event.ID),
 			attribute.String(gcpVertexAgentLLMRequestName, safeSerialize(llmRequestToTrace(llmRequest))),
 			attribute.String(gcpVertexAgentLLMResponseName, safeSerialize(event.LLMResponse)),


### PR DESCRIPTION
Ref #421

This change adds the `gen_ai.conversation.id` attribute to OTEL spans, allowing messages within the same conversation to be linked in AI evaluation and observability platforms.

## Changes

- Added `genAiConversationID` constant
- Stored `sessionID` in variable to avoid duplicate method calls
- Added `gen_ai.conversation.id` attribute to `TraceLLMCall`

## Testing Plan

- All existing tests pass (`go test ./...`)
- Verified with `go build` and `golangci-lint run`
- New attribute appears in OTEL spans alongside `gcp.vertex.agent.session_id`

## Reference

- OTEL GenAI Semantic Conventions: https://opentelemetry.io/docs/specs/semconv/gen-ai/gen-ai-spans/

