### PR TITLE
Fix test cases failure due to the time zone

### DIFF
--- a/session/database/service_test.go
+++ b/session/database/service_test.go
@@ -190,7 +190,7 @@ func Test_databaseService_Get(t *testing.T) {
 		return s
 	}
 
-	now := time.Now()
+	now := time.Date(2025, time.January, 1, 12, 0, 0, 0, time.Local)
 	setupGetWithConfig := func(t *testing.T) *databaseService {
 		t.Helper()
 		s := emptyService(t)


### PR DESCRIPTION
Currently, the following test case is failing on my side due to using `time.UnixMicro` to truncate the precision:

```shell
    service_test.go:363: Get session events mismatch: (-want +got):
          database.events{
                &{
                        LLMResponse:  {},
        -               ID:           "4",
        +               ID:           "3",
        -               Timestamp:    s"0001-01-01 00:00:00.000004 +0000 UTC",
        +               Timestamp:    s"0001-01-01 08:05:43.000003 +0805 +0805",
                        InvocationID: "",
                        Branch:       "",
                        ... // 3 identical fields
                },
```

The root cause should be `time.UnixMicro` will change the time.Time to the local timezone. To work around this, use the fixed time with the local timezone instead of UTC.

It's related to the change in PR #414.