### PR TITLE
fix: return error instead of panic when ArtifactService is nil (#283)

### DIFF
--- a/internal/context/callback_context.go
+++ b/internal/context/callback_context.go
@@ -56,14 +56,20 @@ func NewCallbackContextWithDelta(ctx agent.InvocationContext, stateDelta map[str
 func newCallbackContext(ctx agent.InvocationContext, stateDelta map[string]any) *callbackContext {
 	rCtx := NewReadonlyContext(ctx)
 	eventActions := &session.EventActions{StateDelta: stateDelta}
+
+	var artifacts *internalArtifacts
+	if ctx.Artifacts() != nil {
+		artifacts = &internalArtifacts{
+			Artifacts:    ctx.Artifacts(),
+			eventActions: eventActions,
+		}
+	}
+
 	return &callbackContext{
 		ReadonlyContext: rCtx,
 		invocationCtx:   ctx,
 		eventActions:    eventActions,
-		artifacts: &internalArtifacts{
-			Artifacts:    ctx.Artifacts(),
-			eventActions: eventActions,
-		},
+		artifacts:       artifacts,
 	}
 }
 
@@ -77,6 +83,9 @@ type callbackContext struct {
 }
 
 func (c *callbackContext) Artifacts() agent.Artifacts {
+	if c.artifacts == nil {
+		return nil
+	}
 	return c.artifacts
 }
 

--- a/internal/toolinternal/context.go
+++ b/internal/toolinternal/context.go
@@ -60,15 +60,20 @@ func NewToolContext(ctx agent.InvocationContext, functionCallID string, actions 
 	}
 	cbCtx := contextinternal.NewCallbackContextWithDelta(ctx, actions.StateDelta)
 
+	var artifacts *internalArtifacts
+	if ctx.Artifacts() != nil {
+		artifacts = &internalArtifacts{
+			Artifacts:    ctx.Artifacts(),
+			eventActions: actions,
+		}
+	}
+
 	return &toolContext{
 		CallbackContext:   cbCtx,
 		invocationContext: ctx,
 		functionCallID:    functionCallID,
 		eventActions:      actions,
-		artifacts: &internalArtifacts{
-			Artifacts:    ctx.Artifacts(),
-			eventActions: actions,
-		},
+		artifacts:         artifacts,
 	}
 }
 
@@ -81,6 +86,9 @@ type toolContext struct {
 }
 
 func (c *toolContext) Artifacts() agent.Artifacts {
+	if c.artifacts == nil {
+		return nil
+	}
 	return c.artifacts
 }
 

--- a/tool/loadartifactstool/load_artifacts_tool.go
+++ b/tool/loadartifactstool/load_artifacts_tool.go
@@ -20,6 +20,7 @@ package loadartifactstool
 import (
 	"context"
 	"encoding/json"
+	"errors"
 	"fmt"
 
 	"golang.org/x/sync/errgroup"
@@ -31,6 +32,8 @@ import (
 	"google.golang.org/adk/model"
 	"google.golang.org/adk/tool"
 )
+
+var ErrArtifactServiceNotInitialized = errors.New("artifact service is not initialized")
 
 // artifactsTool is a tool that loads artifacts and adds them to the session.
 type artifactsTool struct {
@@ -118,6 +121,9 @@ func (t *artifactsTool) Run(ctx tool.Context, args any) (map[string]any, error) 
 // ProcessRequest processes the LLM request. It packs the tool, appends initial
 // instructions, and processes any load artifacts function calls.
 func (t *artifactsTool) ProcessRequest(ctx tool.Context, req *model.LLMRequest) error {
+	if ctx.Artifacts() == nil {
+		return ErrArtifactServiceNotInitialized
+	}
 	if err := toolutils.PackTool(req, t); err != nil {
 		return err
 	}

--- a/tool/loadartifactstool/load_artifacts_tool_test.go
+++ b/tool/loadartifactstool/load_artifacts_tool_test.go
@@ -15,6 +15,7 @@
 package loadartifactstool_test
 
 import (
+	"errors"
 	"strings"
 	"testing"
 
@@ -292,4 +293,28 @@ func createToolContext(t *testing.T) tool.Context {
 	})
 
 	return toolinternal.NewToolContext(ctx, "", nil)
+}
+
+func TestLoadArtifactsTool_ProcessRequest_NilArtifactService(t *testing.T) {
+	loadArtifactsTool := loadartifactstool.New()
+
+	ctx := icontext.NewInvocationContext(t.Context(), icontext.InvocationContextParams{
+		Artifacts: nil,
+	})
+	tc := toolinternal.NewToolContext(ctx, "", nil)
+
+	llmRequest := &model.LLMRequest{}
+
+	requestProcessor, ok := loadArtifactsTool.(toolinternal.RequestProcessor)
+	if !ok {
+		t.Fatal("loadArtifactsTool does not implement RequestProcessor")
+	}
+
+	err := requestProcessor.ProcessRequest(tc, llmRequest)
+	if err == nil {
+		t.Fatal("Expected error when artifact service is nil, got nil")
+	}
+	if !errors.Is(err, loadartifactstool.ErrArtifactServiceNotInitialized) {
+		t.Errorf("Expected ErrArtifactServiceNotInitialized, got: %v", err)
+	}
 }

--- a/tool/loadartifactstool/load_artifacts_tool_test.go
+++ b/tool/loadartifactstool/load_artifacts_tool_test.go
@@ -311,10 +311,7 @@ func TestLoadArtifactsTool_ProcessRequest_NilArtifactService(t *testing.T) {
 	}
 
 	err := requestProcessor.ProcessRequest(tc, llmRequest)
-	if err == nil {
-		t.Fatal("Expected error when artifact service is nil, got nil")
-	}
-	if !errors.Is(err, loadartifactstool.ErrArtifactServiceNotInitialized) {
-		t.Errorf("Expected ErrArtifactServiceNotInitialized, got: %v", err)
+if !errors.Is(err, loadartifactstool.ErrArtifactServiceNotInitialized) {
+		t.Errorf("ProcessRequest() with nil artifact service returned error = %v, want %v", err, loadartifactstool.ErrArtifactServiceNotInitialized)
 	}
 }


### PR DESCRIPTION
Addressing issue: #283

Fixes a nil pointer dereference panic in loadartifactstool that occurred when the tool was used without configuring an ArtifactService in the Runner. The tool now returns `ErrArtifactServiceNotInitialized` instead of panicking.

**Changes:**
  - Added `ErrArtifactServiceNotInitialized` error in loadartifactstool
  - Added nil check in `ProcessRequest()`
  - Fixed context wrappers to return nil when underlying ArtifactService is nil

  **Test:** Added `TestLoadArtifactsTool_ProcessRequest_NilArtifactService`.

