### PR TITLE
fix: always include events with empty branch

### DIFF
--- a/internal/llminternal/contents_processor.go
+++ b/internal/llminternal/contents_processor.go
@@ -123,7 +123,7 @@ func buildContentsDefault(agentName, invocationBranch string, events []*session.
 }
 
 func eventBelongsToBranch(invocationBranch string, event *session.Event) bool {
-	if invocationBranch == "" {
+	if invocationBranch == "" || event.Branch == "" {
 		return true
 	}
 	if event.Branch == invocationBranch {

--- a/internal/llminternal/contents_processor_test.go
+++ b/internal/llminternal/contents_processor_test.go
@@ -323,6 +323,13 @@ func TestContentsRequestProcessor(t *testing.T) {
 				},
 				{
 					Author: "user",
+					Branch: "",
+					LLMResponse: model.LLMResponse{
+						Content: genai.NewContentFromText("empty branch", "user"),
+					},
+				},
+				{
+					Author: "user",
 					Branch: "branch12",
 					LLMResponse: model.LLMResponse{
 						Content: genai.NewContentFromText("In branch 12", "user"),
@@ -339,6 +346,7 @@ func TestContentsRequestProcessor(t *testing.T) {
 			want: []*genai.Content{
 				genai.NewContentFromText("In branch 1", "user"),
 				genai.NewContentFromText("In branch 1 and task 1", "user"),
+				genai.NewContentFromText("empty branch", "user"),
 			},
 		},
 		{


### PR DESCRIPTION
When there's this setup: LLMAgent1 -> ParallelAgent -> LLMAgent2

Then invocation_branch is: llmagent1.llmagent2
But event.branch is "" because it's the event generated from first user input.

python ref: https://github.com/google/adk-python/blob/0b1cff2976d1c04acf3863f76107b05d1cec448f/src/google/adk/flows/llm_flows/contents.py#L634