### PR TITLE
fix(server): prevent panic in SSE handler on error

### DIFF
--- a/server/adkrest/controllers/runtime.go
+++ b/server/adkrest/controllers/runtime.go
@@ -126,7 +126,7 @@ func (c *RuntimeAPIController) RunSSEHandler(rw http.ResponseWriter, req *http.R
 				return newStatusError(fmt.Errorf("failed to flush: %w", err), http.StatusInternalServerError)
 			}
 
-			continue
+			return nil
 		}
 		err := flashEvent(rc, rw, *event)
 		if err != nil {


### PR DESCRIPTION
Fixes #383

Description
This PR addresses a stability issue in RunSSEHandler where the server would panic or enter an infinite loop if the LLM provider returned an error (e.g., invalid API key) during streaming.

The Bug: The error handling logic inside the event loop used continue after encountering a stream error. This caused the loop to attempt reading from a broken or closed stream repeatedly, causing a panic.

The Fix: Replaced continue with return nil in server/adkrest/controllers/runtime.go. This ensures the handler exits the request loop gracefully when a fatal error occurs.

Verification
Before Fix (Panic/Crash): The server crashes with a panic when an invalid API key is used. <img width="958" height="439" alt="Image" src="https://github.com/user-attachments/assets/cefd5405-3338-4f6b-b7b1-2d7fdef2ef3c" /> <img width="955" height="479" alt="Image" src="https://github.com/user-attachments/assets/bbef7d12-f777-41b3-a3d3-081deaec7be8" />

After Fix (Graceful Exit): The server returns the error to the client and remains stable without crashing. <img width="953" height="273" alt="Image" src="https://github.com/user-attachments/assets/598a09f5-f1c3-45bb-bc86-ab4b82bcc099" />