### PR TITLE
fix: align and correct eventBelongsToBranch to match adk-python

### DIFF
--- a/internal/llminternal/contents_processor.go
+++ b/internal/llminternal/contents_processor.go
@@ -123,7 +123,7 @@ func buildContentsDefault(agentName, invocationBranch string, events []*session.
 }
 
 func eventBelongsToBranch(invocationBranch string, event *session.Event) bool {
-	if invocationBranch == "" {
+	if invocationBranch == "" || event.Branch == "" {
 		return true
 	}
 	if event.Branch == invocationBranch {

--- a/internal/llminternal/contents_processor_test.go
+++ b/internal/llminternal/contents_processor_test.go
@@ -335,10 +335,18 @@ func TestContentsRequestProcessor(t *testing.T) {
 						Content: genai.NewContentFromText("In branch 2", "user"),
 					},
 				},
+				{
+					Author: "user",
+					Branch: "",
+					LLMResponse: model.LLMResponse{
+						Content: genai.NewContentFromText("empty branch", "user"),
+					},
+				},
 			},
 			want: []*genai.Content{
 				genai.NewContentFromText("In branch 1", "user"),
 				genai.NewContentFromText("In branch 1 and task 1", "user"),
+				genai.NewContentFromText("empty branch", "user"),
 			},
 		},
 		{


### PR DESCRIPTION
Fixes #436 

Description

This PR resolves the issue where sub-agents of parallel agents cannot receive user inputs.
﻿
Reference
adk-python/src/google/adk/flows/llm_flows/content.py _is_event_belongs_to_branch

Optimized the method
/adk-go/internal/llminternal/contents_processor.go eventBelongsToBranch
﻿
The alignment of the judgment logic has been made