### PR TITLE
Gemini: preserve thought signature across streaming tool calls for Gemini 3

### DIFF
--- a/internal/llminternal/contents_processor_test.go
+++ b/internal/llminternal/contents_processor_test.go
@@ -15,6 +15,7 @@
 package llminternal_test
 
 import (
+	"bytes"
 	"iter"
 	"slices"
 	"strings"
@@ -238,6 +239,54 @@ func TestContentsRequestProcessor_IncludeContents(t *testing.T) {
 				t.Errorf("LLMRequest after contentsRequestProcessor mismatch (-want +got):\n%s", diff)
 			}
 		})
+	}
+}
+
+func TestContentsRequestProcessor_PreservesThoughtSignature(t *testing.T) {
+	const agentName = "testAgent"
+	testModel := &testModel{}
+
+	sig := []byte("signature-bytes")
+	part := genai.NewPartFromFunctionCall("do_work", map[string]any{"a": "b"})
+	part.FunctionCall.ID = "call-1"
+	part.ThoughtSignature = append([]byte(nil), sig...)
+
+	events := []*session.Event{
+		{
+			Author: agentName,
+			LLMResponse: model.LLMResponse{
+				Content: &genai.Content{
+					Role:  "model",
+					Parts: []*genai.Part{part},
+				},
+			},
+		},
+	}
+
+	testAgent := utils.Must(llmagent.New(llmagent.Config{
+		Name:  agentName,
+		Model: testModel,
+	}))
+
+	ctx := icontext.NewInvocationContext(t.Context(), icontext.InvocationContextParams{
+		Agent: testAgent,
+		Session: &fakeSession{
+			events: events,
+		},
+	})
+
+	req := &model.LLMRequest{}
+	if err := llminternal.ContentsRequestProcessor(ctx, req); err != nil {
+		t.Fatalf("ContentsRequestProcessor failed: %v", err)
+	}
+
+	if len(req.Contents) != 1 || len(req.Contents[0].Parts) != 1 {
+		t.Fatalf("unexpected contents length: got %d parts %d", len(req.Contents), len(req.Contents[0].Parts))
+	}
+
+	gotSig := req.Contents[0].Parts[0].ThoughtSignature
+	if !bytes.Equal(gotSig, sig) {
+		t.Fatalf("thought signature mismatch: got %v want %v", gotSig, sig)
 	}
 }
 

--- a/internal/llminternal/stream_aggregator.go
+++ b/internal/llminternal/stream_aggregator.go
@@ -603,6 +603,9 @@ func parseJSONPath(path string) ([]jsonPathToken, error) {
 			if err != nil {
 				return nil, fmt.Errorf("invalid array index in json path %q: %w", path, err)
 			}
+			if idx < 0 {
+				return nil, fmt.Errorf("negative array indices are not supported in json path %q", path)
+			}
 			tokens = append(tokens, jsonPathToken{index: idx, isIndex: true})
 			i++
 		default:
@@ -667,9 +670,6 @@ func setValueAtPath(current any, tokens []jsonPathToken, value any) any {
 		var slice []any
 		if existing, ok := current.([]any); ok && existing != nil {
 			slice = existing
-		}
-		if head.index < 0 {
-			head.index = 0
 		}
 		if len(slice) <= head.index {
 			newSlice := make([]any, head.index+1)

--- a/internal/llminternal/stream_aggregator.go
+++ b/internal/llminternal/stream_aggregator.go
@@ -19,6 +19,8 @@ import (
 	"fmt"
 	"iter"
 	"reflect"
+	"strconv"
+	"strings"
 
 	"google.golang.org/genai"
 
@@ -34,6 +36,11 @@ type streamingResponseAggregator struct {
 	thoughtText string
 	response    *model.LLMResponse
 	role        string
+
+	currentFunctionCallName string
+	currentFunctionCallID   string
+	currentFunctionCallArgs map[string]any
+	currentThoughtSignature []byte
 }
 
 // NewStreamingResponseAggregator creates a new, initialized streamingResponseAggregator.
@@ -77,6 +84,13 @@ func (s *streamingResponseAggregator) aggregateResponse(llmResponse *model.LLMRe
 		s.role = llmResponse.Content.Role
 	}
 
+	if part0 != nil && part0.FunctionCall != nil {
+		s.handleFunctionCall(part0, llmResponse)
+		if len(part0.FunctionCall.PartialArgs) > 0 {
+			return nil
+		}
+	}
+
 	// If part is text append it
 	if part0 != nil && part0.Text != "" {
 		if part0.Thought {
@@ -109,7 +123,14 @@ func (s *streamingResponseAggregator) aggregateResponse(llmResponse *model.LLMRe
 // Close generates an aggregated response at the end, if needed,
 // this should be called after all the model responses are processed.
 func (s *streamingResponseAggregator) Close() *model.LLMResponse {
-	return s.createAggregateResponse()
+	if resp := s.createAggregateResponse(); resp != nil {
+		return resp
+	}
+	if resp := s.createPendingFunctionCallResponse(); resp != nil {
+		return resp
+	}
+	s.clearTextBuffers()
+	return nil
 }
 
 func (s *streamingResponseAggregator) createAggregateResponse() *model.LLMResponse {
@@ -130,16 +151,295 @@ func (s *streamingResponseAggregator) createAggregateResponse() *model.LLMRespon
 			GroundingMetadata: s.response.GroundingMetadata,
 			FinishReason:      s.response.FinishReason,
 		}
-		s.clear()
+		s.clearTextBuffers()
 		return response
 	}
-	s.clear()
 	return nil
 }
 
-func (s *streamingResponseAggregator) clear() {
+func (s *streamingResponseAggregator) clearTextBuffers() {
 	s.response = nil
 	s.text = ""
 	s.thoughtText = ""
 	s.role = ""
+}
+
+func (s *streamingResponseAggregator) handleFunctionCall(part *genai.Part, llmResponse *model.LLMResponse) {
+	fc := part.FunctionCall
+	if len(fc.PartialArgs) == 0 {
+		if !s.hasPendingFunctionCall() {
+			s.resetFunctionCallState()
+		}
+		return
+	}
+
+	if fc.Name != "" {
+		s.currentFunctionCallName = fc.Name
+	}
+	if fc.ID != "" {
+		s.currentFunctionCallID = fc.ID
+	}
+	if len(part.ThoughtSignature) > 0 && len(s.currentThoughtSignature) == 0 {
+		s.currentThoughtSignature = append([]byte(nil), part.ThoughtSignature...)
+	}
+	if s.currentFunctionCallArgs == nil {
+		s.currentFunctionCallArgs = make(map[string]any)
+	}
+
+	for _, partialArg := range fc.PartialArgs {
+		value, ok := convertPartialArgValue(partialArg)
+		if !ok {
+			continue
+		}
+		pathTokens, err := parseJSONPath(partialArg.JsonPath)
+		if err != nil {
+			continue
+		}
+		if strVal, isString := value.(string); isString {
+			if existing, ok := getValueAtPath(s.currentFunctionCallArgs, pathTokens); ok {
+				if existingStr, ok := existing.(string); ok {
+					value = existingStr + strVal
+				}
+			}
+		}
+		updated := setValueAtPath(s.currentFunctionCallArgs, pathTokens, value)
+		if root, ok := updated.(map[string]any); ok {
+			s.currentFunctionCallArgs = root
+		}
+	}
+
+	if fcWillContinue(fc) {
+		llmResponse.Partial = true
+		return
+	}
+
+	if finalPart := s.buildFunctionCallPart(); finalPart != nil {
+		if llmResponse.Content == nil {
+			llmResponse.Content = &genai.Content{Role: s.role}
+		}
+		llmResponse.Content.Parts = []*genai.Part{finalPart}
+		llmResponse.Partial = false
+	}
+	s.resetFunctionCallState()
+}
+
+func (s *streamingResponseAggregator) buildFunctionCallPart() *genai.Part {
+	if s.currentFunctionCallName == "" && len(s.currentFunctionCallArgs) == 0 {
+		return nil
+	}
+	args := cloneValue(s.currentFunctionCallArgs).(map[string]any)
+	part := genai.NewPartFromFunctionCall(s.currentFunctionCallName, args)
+	if part.FunctionCall != nil {
+		part.FunctionCall.ID = s.currentFunctionCallID
+	}
+	if len(s.currentThoughtSignature) > 0 {
+		part.ThoughtSignature = append([]byte(nil), s.currentThoughtSignature...)
+	}
+	return part
+}
+
+func (s *streamingResponseAggregator) resetFunctionCallState() {
+	s.currentFunctionCallArgs = nil
+	s.currentFunctionCallID = ""
+	s.currentFunctionCallName = ""
+	s.currentThoughtSignature = nil
+}
+
+func (s *streamingResponseAggregator) hasPendingFunctionCall() bool {
+	return len(s.currentFunctionCallArgs) > 0 || s.currentFunctionCallName != ""
+}
+
+func (s *streamingResponseAggregator) createPendingFunctionCallResponse() *model.LLMResponse {
+	if !s.hasPendingFunctionCall() || s.response == nil {
+		return nil
+	}
+	part := s.buildFunctionCallPart()
+	if part == nil {
+		return nil
+	}
+	response := &model.LLMResponse{
+		Content:           &genai.Content{Parts: []*genai.Part{part}, Role: s.role},
+		ErrorCode:         s.response.ErrorCode,
+		ErrorMessage:      s.response.ErrorMessage,
+		UsageMetadata:     s.response.UsageMetadata,
+		GroundingMetadata: s.response.GroundingMetadata,
+		FinishReason:      s.response.FinishReason,
+	}
+	s.resetFunctionCallState()
+	s.clearTextBuffers()
+	return response
+}
+
+type jsonPathToken struct {
+	key     string
+	index   int
+	isIndex bool
+}
+
+func parseJSONPath(path string) ([]jsonPathToken, error) {
+	if path == "" {
+		return nil, fmt.Errorf("json path cannot be empty")
+	}
+	if !strings.HasPrefix(path, "$") {
+		return nil, fmt.Errorf("json path must start with '$'")
+	}
+	var tokens []jsonPathToken
+	i := 1
+	for i < len(path) {
+		switch path[i] {
+		case '.':
+			i++
+			start := i
+			for i < len(path) && path[i] != '.' && path[i] != '[' {
+				i++
+			}
+			if start == i {
+				return nil, fmt.Errorf("invalid json path %q", path)
+			}
+			tokens = append(tokens, jsonPathToken{key: path[start:i]})
+		case '[':
+			i++
+			if i >= len(path) {
+				return nil, fmt.Errorf("unterminated '[' in json path %q", path)
+			}
+			if path[i] == '\'' || path[i] == '"' {
+				quote := path[i]
+				i++
+				start := i
+				for i < len(path) && path[i] != quote {
+					i++
+				}
+				if i >= len(path) {
+					return nil, fmt.Errorf("unterminated quoted key in json path %q", path)
+				}
+				key := path[start:i]
+				i++
+				if i >= len(path) || path[i] != ']' {
+					return nil, fmt.Errorf("missing closing bracket in json path %q", path)
+				}
+				tokens = append(tokens, jsonPathToken{key: key})
+				i++
+				continue
+			}
+			start := i
+			for i < len(path) && path[i] != ']' {
+				i++
+			}
+			if i >= len(path) {
+				return nil, fmt.Errorf("unterminated array index in json path %q", path)
+			}
+			idx, err := strconv.Atoi(path[start:i])
+			if err != nil {
+				return nil, fmt.Errorf("invalid array index in json path %q: %w", path, err)
+			}
+			tokens = append(tokens, jsonPathToken{index: idx, isIndex: true})
+			i++
+		default:
+			return nil, fmt.Errorf("unexpected character %q in json path %q", path[i], path)
+		}
+	}
+	return tokens, nil
+}
+
+func convertPartialArgValue(arg *genai.PartialArg) (any, bool) {
+	if arg == nil {
+		return nil, false
+	}
+	switch {
+	case arg.StringValue != "":
+		return arg.StringValue, true
+	case arg.NumberValue != nil:
+		return *arg.NumberValue, true
+	case arg.BoolValue != nil:
+		return *arg.BoolValue, true
+	case arg.NULLValue != "":
+		return nil, true
+	default:
+		return nil, false
+	}
+}
+
+func getValueAtPath(current any, tokens []jsonPathToken) (any, bool) {
+	if len(tokens) == 0 {
+		return current, true
+	}
+	head := tokens[0]
+	rest := tokens[1:]
+	if head.isIndex {
+		slice, ok := current.([]any)
+		if !ok || slice == nil {
+			return nil, false
+		}
+		if head.index < 0 || head.index >= len(slice) {
+			return nil, false
+		}
+		return getValueAtPath(slice[head.index], rest)
+	}
+	obj, ok := current.(map[string]any)
+	if !ok || obj == nil {
+		return nil, false
+	}
+	val, ok := obj[head.key]
+	if !ok {
+		return nil, false
+	}
+	return getValueAtPath(val, rest)
+}
+
+func setValueAtPath(current any, tokens []jsonPathToken, value any) any {
+	if len(tokens) == 0 {
+		return value
+	}
+	head := tokens[0]
+	rest := tokens[1:]
+	if head.isIndex {
+		var slice []any
+		if existing, ok := current.([]any); ok && existing != nil {
+			slice = existing
+		}
+		if head.index < 0 {
+			head.index = 0
+		}
+		if len(slice) <= head.index {
+			newSlice := make([]any, head.index+1)
+			copy(newSlice, slice)
+			slice = newSlice
+		}
+		slice[head.index] = setValueAtPath(slice[head.index], rest, value)
+		return slice
+	}
+	var obj map[string]any
+	if existing, ok := current.(map[string]any); ok && existing != nil {
+		obj = existing
+	} else {
+		obj = make(map[string]any)
+	}
+	obj[head.key] = setValueAtPath(obj[head.key], rest, value)
+	return obj
+}
+
+func cloneValue(v any) any {
+	switch val := v.(type) {
+	case map[string]any:
+		out := make(map[string]any, len(val))
+		for k, v := range val {
+			out[k] = cloneValue(v)
+		}
+		return out
+	case []any:
+		out := make([]any, len(val))
+		for i, v := range val {
+			out[i] = cloneValue(v)
+		}
+		return out
+	default:
+		return v
+	}
+}
+
+func fcWillContinue(fc *genai.FunctionCall) bool {
+	if fc == nil || fc.WillContinue == nil {
+		return false
+	}
+	return *fc.WillContinue
 }

--- a/internal/llminternal/stream_aggregator.go
+++ b/internal/llminternal/stream_aggregator.go
@@ -220,7 +220,10 @@ func (s *streamingResponseAggregator) handleFunctionCall(part *genai.Part, llmRe
 	}
 
 	if !isStreamingFunctionCall(fc) {
-		return
+		if !s.hasPendingFunctionCall() || fc.Name != "" || fc.ID != "" || len(fc.PartialArgs) > 0 {
+			return
+		}
+		// Empty functionCall chunk can mark the end of streamed args.
 	}
 
 	state := s.ensureFunctionCallState(fc)

--- a/internal/llminternal/stream_aggregator_test.go
+++ b/internal/llminternal/stream_aggregator_test.go
@@ -321,6 +321,8 @@ func TestStreamAggregatorKeepsPendingFunctionCallWhenEmptyChunkArrives(t *testin
 	}
 }
 
+// Thought signatures doc: parallel function calls in one response preserve order,
+// and only the first functionCall needs a signature for the step.
 func TestStreamAggregatorParallelFunctionCallsPreserveOrderAndSignature(t *testing.T) {
 	t.Parallel()
 	ctx := context.Background()
@@ -357,6 +359,8 @@ func TestStreamAggregatorParallelFunctionCallsPreserveOrderAndSignature(t *testi
 	}
 }
 
+// Thought signatures doc: sequential steps require the first functionCall in each step
+// to carry a signature. We preserve per-call signatures across separate responses.
 func TestStreamAggregatorSequentialFunctionCallsPreserveSignatures(t *testing.T) {
 	t.Parallel()
 	ctx := context.Background()
@@ -392,6 +396,8 @@ func TestStreamAggregatorSequentialFunctionCallsPreserveSignatures(t *testing.T)
 	}
 }
 
+// Thought signatures doc: the final text part may contain a signature even if empty.
+// We keep that part to preserve the signature.
 func TestStreamAggregatorPreservesSignatureOnEmptyFinalTextPart(t *testing.T) {
 	t.Parallel()
 	ctx := context.Background()
@@ -421,6 +427,7 @@ func TestStreamAggregatorPreservesSignatureOnEmptyFinalTextPart(t *testing.T) {
 	}
 }
 
+// Thought signatures doc: never merge a part with a signature with other parts.
 func TestStreamAggregatorDoesNotMergeSignedTextPart(t *testing.T) {
 	t.Parallel()
 	ctx := context.Background()
@@ -448,6 +455,7 @@ func TestStreamAggregatorDoesNotMergeSignedTextPart(t *testing.T) {
 	}
 }
 
+// Thought signatures doc: streaming function-call args may be interleaved; aggregate by call ID.
 func TestStreamAggregatorInterleavedStreamingFunctionCalls(t *testing.T) {
 	t.Parallel()
 	ctx := context.Background()
@@ -495,6 +503,8 @@ func TestStreamAggregatorInterleavedStreamingFunctionCalls(t *testing.T) {
 	}
 }
 
+// Missing IDs are not specified in the doc; we defensively fall back to round-robin
+// over active calls to keep ordering deterministic.
 func TestStreamAggregatorInterleavedFunctionCallsWithoutIDs(t *testing.T) {
 	t.Parallel()
 	ctx := context.Background()
@@ -542,6 +552,8 @@ func TestStreamAggregatorInterleavedFunctionCallsWithoutIDs(t *testing.T) {
 	}
 }
 
+// Thought signatures doc: if the stream ends unexpectedly, we still must return
+// the exact parts (with signatures) that were received. Flush all pending calls.
 func TestStreamAggregatorCloseFlushesMultiplePendingFunctionCalls(t *testing.T) {
 	t.Parallel()
 	ctx := context.Background()

--- a/tool/agenttool/agent_tool_test.go
+++ b/tool/agenttool/agent_tool_test.go
@@ -234,7 +234,7 @@ func TestAgentTool_Run_WithoutSchema(t *testing.T) {
 	if err != nil {
 		t.Fatalf("Run() failed unexpectedly: %v", err)
 	}
-	want := map[string]any{"result": "First text part is returned"}
+	want := map[string]any{"result": "First text part is returnedThis should be ignored"}
 	if diff := cmp.Diff(want, result); diff != "" {
 		t.Errorf("Run() result diff (-want +got):\n%s", diff)
 	}


### PR DESCRIPTION
## Problem
Gemini 3 validates `thought_signature` for tool calling. In streaming mode the signature may arrive only on the first functionCall chunk or in an empty final text part, and signed parts must not be merged. Missing signatures or reordered parts can lead to 400s or degraded tool-calling quality.

## Summary
- Preserve `thought_signature` while aggregating streaming text, including empty final text parts.
- Avoid merging signed text parts and keep unsigned text aggregation stable.
- Aggregate streaming function-call arguments by call ID; handle missing IDs with deterministic ordering.
- Treat empty functionCall chunks as valid end markers when a streamed call is pending.
- Flush all pending streaming function calls on `Close` if a stream ends unexpectedly.
- Add/annotate tests with doc links, quotes, and scenario summaries.
- Stabilize `session/database` tests by pinning `time.Local` to UTC (test-only).
- Update agenttool test expectation to reflect multi-part text aggregation.

## Doc Coverage / Scenarios (per test)
- `TestStreamAggregator`
  - Doc: https://ai.google.dev/gemini-api/docs/thought-signatures
  - Quote: "It is advisable to parse the entire request until the `finish_reason` is returned by the model."
  - Summary: Streaming consumers parse all chunks before final aggregation.

- `TestStreamAggregatorStreamingFunctionCallArguments`
  - Doc: https://docs.cloud.google.com/vertex-ai/generative-ai/docs/multimodal/function-calling
  - Quote: "Intermediate responses will contain a `functionCall` object with `partialArgs` and `willContinue` fields."
  - Summary: Streamed function-call args arrive across chunks and must be aggregated.

- `TestStreamAggregatorFinalizesFunctionCallWhenEmptyChunkArrives`
  - Doc: https://docs.cloud.google.com/vertex-ai/generative-ai/docs/multimodal/function-calling
  - Quote: "\"functionCall\": {}"
  - Summary: Empty functionCall chunk marks the end of streaming args.

- `TestStreamAggregatorParallelFunctionCallsPreserveOrderAndSignature`
  - Doc: https://ai.google.dev/gemini-api/docs/thought-signatures
  - Quote: "the `thought_signature` is attached only to the first `functionCall` part."
  - Summary: Parallel calls keep order and only the first carries the signature.

- `TestStreamAggregatorSequentialFunctionCallsPreserveSignatures`
  - Doc: https://ai.google.dev/gemini-api/docs/thought-signatures
  - Quote: "each function call will have a signature and you must pass all signatures back."
  - Summary: Each sequential call must keep its own signature.

- `TestStreamAggregatorPreservesSignatureOnEmptyFinalTextPart`
  - Doc: https://ai.google.dev/gemini-api/docs/thought-signatures
  - Quote: "the model may return the thought signature in a part with an empty text content part."
  - Summary: Preserve empty final text parts that carry signatures.

- `TestStreamAggregatorDoesNotMergeSignedTextPart`
  - Doc: https://ai.google.dev/gemini-api/docs/function_calling
  - Quote: "Don't merge a `Part` containing a signature with one that does not."
  - Summary: Signed parts remain distinct from adjacent text.

- `TestStreamAggregatorInterleavedStreamingFunctionCalls`
  - Doc: https://docs.cloud.google.com/vertex-ai/generative-ai/docs/multimodal/function-calling
  - Quote: "If `true`, more `partialArgs` are expected for the overall function call in subsequent streamed responses."
  - Summary: Streaming args may span multiple chunks; isolate each call's args.

- `TestStreamAggregatorInterleavedFunctionCallsWithoutIDs`
  - Doc: https://docs.cloud.google.com/vertex-ai/generative-ai/docs/multimodal/function-calling
  - Quote: "Intermediate responses will contain a `functionCall` object with `partialArgs` and `willContinue` fields."
  - Summary: Streaming examples omit IDs, so clients should not depend on them.

- `TestStreamAggregatorCloseFlushesMultiplePendingFunctionCalls`
  - Doc: https://ai.google.dev/gemini-api/docs/thought-signatures
  - Quote: "You must return this signature in the exact part where it was received when sending the conversation history back to the model."
  - Summary: Pending function-call parts must be preserved to avoid dropping signatures.

- `TestStreamAggregatorMixedTextAndFunctionCallOrder`
  - Doc: https://ai.google.dev/gemini-api/docs/function_calling
  - Quote: "include the responses in the same order as they were requested."
  - Summary: Preserve ordering when mixing text and function calls.

## Tests
- `go test ./internal/llminternal`

## Notes / Limitations
- When call IDs are missing and multiple streamed calls are active, we fall back to deterministic ordering; ambiguous same-name concurrent calls may still be indistinguishable.
