### PR TITLE
fix: update time truncation in database session service

### DIFF
--- a/session/database/service.go
+++ b/session/database/service.go
@@ -329,7 +329,7 @@ func (s *databaseService) AppendEvent(ctx context.Context, curSession session.Se
 	}
 
 	// Truncate timestamp to microsecond precision to match database precision and prevent rounding errors.
-	event.Timestamp = time.UnixMicro(event.Timestamp.UnixMicro())
+	event.Timestamp = event.Timestamp.Truncate(time.Microsecond)
 
 	// Trim temp state before persisting
 	event = trimTempDeltaState(event)


### PR DESCRIPTION
When truncating to microseconds (to match db max allowed precision) we need to keep the location of the event. Right now it's overwritten here.

That's the fix for tests mostly, because in real world scenario the event is created and overwritten here by the same library code, thus it will be the same location anyway.