### PR TITLE
fix: Only last state change for multiple tool calls is being committed to state

### DIFF
--- a/internal/llminternal/base_flow.go
+++ b/internal/llminternal/base_flow.go
@@ -508,10 +508,23 @@ func mergeEventActions(base, other *session.EventActions) *session.EventActions 
 		base.Escalate = true
 	}
 	if other.StateDelta != nil {
-		if base.StateDelta == nil {
-			base.StateDelta = make(map[string]any)
-		}
-		maps.Copy(base.StateDelta, other.StateDelta)
+		base.StateDelta = deepMergeMap(base.StateDelta, other.StateDelta)
 	}
 	return base
+}
+
+func deepMergeMap(dst, src map[string]any) map[string]any {
+	if dst == nil {
+		dst = make(map[string]any)
+	}
+	for key, value := range src {
+		if srcMap, ok := value.(map[string]any); ok {
+			if dstMap, ok := dst[key].(map[string]any); ok {
+				dst[key] = deepMergeMap(dstMap, srcMap)
+				continue
+			}
+		}
+		dst[key] = value
+	}
+	return dst
 }

--- a/internal/llminternal/base_flow_test.go
+++ b/internal/llminternal/base_flow_test.go
@@ -333,6 +333,24 @@ func TestMergeEventActions(t *testing.T) {
 			},
 		},
 		{
+			name: "state delta merged with nested map values",
+			base: &session.EventActions{
+				StateDelta: map[string]any{
+					"outer": map[string]any{"key1": "value1", "key2": "value2"},
+				},
+			},
+			other: &session.EventActions{
+				StateDelta: map[string]any{
+					"outer": map[string]any{"key2": "updated", "key3": "value3"},
+				},
+			},
+			want: &session.EventActions{
+				StateDelta: map[string]any{
+					"outer": map[string]any{"key1": "value1", "key2": "updated", "key3": "value3"},
+				},
+			},
+		},
+		{
 			name: "state delta merged with multiple keys from multiple tools",
 			base: &session.EventActions{
 				StateDelta: map[string]any{"tool1_key": "tool1_value"},


### PR DESCRIPTION
Fixes #354

## Changes
- Use `maps.Copy` instead of assignment in `mergeEventActions` to properly merge state deltas from multiple tool calls
- Initialize `base.StateDelta` map before copying if it's nil
- Add comprehensive tests for `mergeEventActions` function