### PR TITLE
fix: parse events with errors in agenttool

### DIFF
--- a/cmd/launcher/web/web.go
+++ b/cmd/launcher/web/web.go
@@ -132,7 +132,7 @@ func (w *webLauncher) Parse(args []string) ([]string, error) {
 			// skip the keyword and move on
 			restArgs, err = sublauncher.Parse(restArgs[1:])
 			if err != nil {
-				return nil, fmt.Errorf("tha %q launcher cannot parse arguments: %v", keyword, err)
+				return nil, fmt.Errorf("the %q launcher cannot parse arguments: %v", keyword, err)
 			}
 			w.activeSublaunchers[keyword] = sublauncher
 		} else {

--- a/tool/agenttool/agent_tool.go
+++ b/tool/agenttool/agent_tool.go
@@ -206,6 +206,9 @@ func (t *agentTool) Run(toolCtx tool.Context, args any) (map[string]any, error) 
 		if err != nil {
 			return nil, fmt.Errorf("error during execution of sub-agent %s: %w", t.agent.Name(), err)
 		}
+		if event.ErrorCode != "" || event.ErrorMessage != "" {
+			return nil, fmt.Errorf("error from sub-agent %q (code: %q, message: %q)", t.agent.Name(), event.ErrorCode, event.ErrorMessage)
+		}
 		if event.LLMResponse.Content != nil {
 			lastEvent = event
 		}


### PR DESCRIPTION
Right now agenttool for error flow only handles go errors (e.g. when ADK Go agent is wrapped).

But agenttool can also wrap remoteagent which may return events with error_code and/or error_message. Currently agenttool would return {} because may not have a content, which hides the error.