### PR TITLE
artifact: don't allow file names with path separators

### DIFF
--- a/artifact/gcsartifact/service.go
+++ b/artifact/gcsartifact/service.go
@@ -267,9 +267,9 @@ func (s *gcsService) fetchFilenamesFromPrefix(ctx context.Context, prefix string
 		if len(segments) < 2 {
 			return fmt.Errorf("error iterating blobs: incorrect number of segments in path %q", blob.Name)
 		}
-		// TODO agent can create files with multiple segments for example file a/b.txt
-		// This a/b.txt file will show as b.txt when listed and trying to load it will fail.
-		filename := segments[len(segments)-2] // appName/userId/sessionId/filename/version or appName/userId/user/filename/version
+		// Extract filename from path: appName/userId/sessionId/filename/version or appName/userId/user/filename/version
+		// Note: filenames with path separators are rejected during validation (see service.go Validate methods)
+		filename := segments[len(segments)-2]
 		filenamesSet[filename] = true
 	}
 

--- a/artifact/request_validation_test.go
+++ b/artifact/request_validation_test.go
@@ -110,6 +110,18 @@ func TestSaveRequest_Validate(t *testing.T) {
 			wantErr:    true,
 			wantErrMsg: "invalid save request: missing required fields: AppName, UserID, SessionID, FileName, Part",
 		},
+		{
+			name: "FileName with path separator",
+			req: &SaveRequest{
+				AppName:   "MyApp",
+				UserID:    "user-123",
+				SessionID: "sess-abc",
+				FileName:  "path/to/file.txt",
+				Part:      genai.NewPartFromBytes([]byte("data"), "text/plain"),
+			},
+			wantErr:    true,
+			wantErrMsg: "invalid name: filename cannot contain path separators",
+		},
 	}
 	executeValidatorTestCases(t, "SaveRequest", testCases)
 }
@@ -152,6 +164,17 @@ func TestLoadRequest_Validate(t *testing.T) {
 			wantErr:    true,
 			wantErrMsg: "invalid load request: missing required fields: AppName, UserID, SessionID, FileName",
 		},
+		{
+			name: "FileName with path separator",
+			req: &LoadRequest{
+				AppName:   "MyApp",
+				UserID:    "user-123",
+				SessionID: "sess-abc",
+				FileName:  "a/b.txt",
+			},
+			wantErr:    true,
+			wantErrMsg: "invalid name: filename cannot contain path separators",
+		},
 	}
 	executeValidatorTestCases(t, "LoadRequest", testCases)
 }
@@ -193,6 +216,17 @@ func TestDeleteRequest_Validate(t *testing.T) {
 			req:        &DeleteRequest{},
 			wantErr:    true,
 			wantErrMsg: "invalid delete request: missing required fields: AppName, UserID, SessionID, FileName",
+		},
+		{
+			name: "FileName with path separator",
+			req: &DeleteRequest{
+				AppName:   "MyApp",
+				UserID:    "user-123",
+				SessionID: "sess-abc",
+				FileName:  "dir/file.txt",
+			},
+			wantErr:    true,
+			wantErrMsg: "invalid name: filename cannot contain path separators",
 		},
 	}
 	executeValidatorTestCases(t, "DeleteRequest", testCases)
@@ -275,6 +309,17 @@ func TestVersionsRequest_Validate(t *testing.T) {
 			req:        &VersionsRequest{},
 			wantErr:    true,
 			wantErrMsg: "invalid versions request: missing required fields: AppName, UserID, SessionID, FileName",
+		},
+		{
+			name: "FileName with path separator",
+			req: &VersionsRequest{
+				AppName:   "MyApp",
+				UserID:    "user-123",
+				SessionID: "sess-abc",
+				FileName:  "folder/file.txt",
+			},
+			wantErr:    true,
+			wantErrMsg: "invalid name: filename cannot contain path separators",
 		},
 	}
 	executeValidatorTestCases(t, "VersionsRequest", testCases)

--- a/artifact/service.go
+++ b/artifact/service.go
@@ -101,6 +101,18 @@ func (req *SaveRequest) Validate() error {
 	if req.Part.Text == "" && req.Part.InlineData == nil {
 		return fmt.Errorf("invalid save request: Part.InlineData or Part.Text has to be set")
 	}
+
+	// Validate that FileName doesn't contain path separators
+	if err := validateFileName(req.FileName); err != nil {
+		return err
+	}
+	return nil
+}
+
+func validateFileName(name string) error {
+	if strings.Contains(name, "/") || strings.Contains(name, "\\") {
+		return fmt.Errorf("invalid name: filename cannot contain path separators")
+	}
 	return nil
 }
 
@@ -134,6 +146,12 @@ func (req *LoadRequest) Validate() error {
 	if len(missingFields) > 0 {
 		return fmt.Errorf("invalid load request: missing required fields: %s", strings.Join(missingFields, ", "))
 	}
+
+	// Validate that FileName doesn't contain path separators
+	if err := validateFileName(req.FileName); err != nil {
+		return err
+	}
+
 	return nil
 }
 
@@ -168,6 +186,12 @@ func (req *DeleteRequest) Validate() error {
 	if len(missingFields) > 0 {
 		return fmt.Errorf("invalid delete request: missing required fields: %s", strings.Join(missingFields, ", "))
 	}
+
+	// Validate that FileName doesn't contain path separators
+	if err := validateFileName(req.FileName); err != nil {
+		return err
+	}
+
 	return nil
 }
 
@@ -222,6 +246,12 @@ func (req *VersionsRequest) Validate() error {
 	if len(missingFields) > 0 {
 		return fmt.Errorf("invalid versions request: missing required fields: %s", strings.Join(missingFields, ", "))
 	}
+
+	// Validate that FileName doesn't contain path separators
+	if err := validateFileName(req.FileName); err != nil {
+		return err
+	}
+
 	return nil
 }
 


### PR DESCRIPTION
File separators as filename breaks the layout of the object name. Reject file names that contain any separators.