### PR TITLE
fix: prevent decode error from being overwritten by Body.Close in decodeRequestBody

### DIFF
--- a/server/adkrest/controllers/runtime.go
+++ b/server/adkrest/controllers/runtime.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/server/adkrest/controllers/runtime.go
+++ b/server/adkrest/controllers/runtime.go
@@ -197,7 +197,9 @@ func (c *RuntimeAPIController) getRunner(req models.RunAgentRequest) (*runner.Ru
 func decodeRequestBody(req *http.Request) (decodedReq models.RunAgentRequest, err error) {
 	var runAgentRequest models.RunAgentRequest
 	defer func() {
-		err = req.Body.Close()
+		if cerr := req.Body.Close(); err == nil && cerr != nil {
+			err = cerr
+		}
 	}()
 	d := json.NewDecoder(req.Body)
 	d.DisallowUnknownFields()

--- a/server/adkrest/controllers/runtime_test.go
+++ b/server/adkrest/controllers/runtime_test.go
@@ -1,0 +1,33 @@
+// Copyright 2025 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//	http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+package controllers
+
+import (
+	"io"
+	"net/http/httptest"
+	"strings"
+	"testing"
+)
+
+func TestDecodeRequestBody_DoesNotOverwriteDecodeErrorOnClose(t *testing.T) {
+	// Invalid JSON should produce a 400 error from decodeRequestBody.
+	// This test reproduces a bug where a deferred Body.Close() overwrites
+	// the decode error (named return value) and causes err to become nil.
+	req := httptest.NewRequest("POST", "http://example/runtime", io.NopCloser(strings.NewReader("{")))
+
+	_, err := decodeRequestBody(req)
+	if err == nil {
+		t.Fatalf("expected decodeRequestBody to return an error for invalid JSON, got nil")
+	}
+}


### PR DESCRIPTION
**Problem:**
In runtime.go, the function decodeRequestBody is declared with named return values.Inside it, the request body is closed using a defer that assigns to the named return variable err.This creates a bug because the deferred closure runs after the function has already decided what to return, but before the return values are actually returned to the caller. If JSON decoding fails, the function intends to return a non-nil error.However, when the deferred Close() runs, it overwrites the return variable err with the result of req.Body.Close().
**fix:**
The fix changes the defer to only propagate a Close() error if no earlier error is being returned:

If decoding (or any earlier step) already set err, we keep that error.
If err is still nil and Close() fails, we return the close error.
**old code:**
<img width="1328" height="358" alt="image" src="https://github.com/user-attachments/assets/55de2f03-4427-40fd-849c-acdaeda45761" />
**new code:**
<img width="1480" height="470" alt="image" src="https://github.com/user-attachments/assets/221124a9-ef6e-4f06-8750-05a1f0eb4ad4" />
