### PR TITLE
fix(database): cascade delete events when deleting session

### DIFF
--- a/session/database/storage_session.go
+++ b/session/database/storage_session.go
@@ -35,7 +35,7 @@ type storageSession struct {
 	UpdateTime time.Time `gorm:"precision:6"`
 
 	// Has-Many relationship: A session has many events.
-	Events []storageEvent `gorm:"foreignKey:AppName,UserID,SessionID;references:AppName,UserID,ID"`
+	Events []storageEvent `gorm:"foreignKey:AppName,UserID,SessionID;references:AppName,UserID,ID;constraint:OnDelete:CASCADE"`
 }
 
 // TableName explicitly sets the table name for the storageSession struct.


### PR DESCRIPTION
Previously, attempting to delete a session with related events failed on Postgres due to a foreign key constraint violation. This commit adds `OnDelete:CASCADE` to the GORM relationship between sessions and events, ensuring that deleting a session will also remove its associated events. This resolves errors encountered during session deletion and allows safe cleanup of sessions with related events. Related to ~> https://github.com/google/adk-go/issues/482 

```
database error during session deletion: 
ERROR: update or delete on table "sessions" violates foreign key constraint "fk_sessions_events" on table "events" (SQLSTATE 23503)
```