### PR TITLE
fix run mode config ineffective issue in a2a remote agent

### DIFF
--- a/agent/remoteagent/a2a_agent.go
+++ b/agent/remoteagent/a2a_agent.go
@@ -170,38 +170,49 @@ func (a *a2aAgent) run(ctx agent.InvocationContext, cfg A2AConfig) iter.Seq2[*se
 			return
 		}
 
-		for a2aEvent, a2aErr := range client.SendStreamingMessage(ctx, req) {
+		processEvent := func(aEvent a2a.Event, aErr error) bool {
 			var err error
 			var event *session.Event
 			if cfg.Converter != nil {
-				event, err = cfg.Converter(icontext.NewReadonlyContext(ctx), req, a2aEvent, a2aErr)
+				event, err = cfg.Converter(icontext.NewReadonlyContext(ctx), req, aEvent, aErr)
 			} else {
-				event, err = processor.convertToSessionEvent(ctx, a2aEvent, a2aErr)
+				event, err = processor.convertToSessionEvent(ctx, aEvent, aErr)
 			}
 
 			if cbResp, cbErr := processor.runAfterA2ARequestCallbacks(ctx, event, err); cbResp != nil || cbErr != nil {
 				if cbErr != nil {
-					yield(nil, cbErr)
-					return
+					return yield(nil, cbErr)
 				}
 				event = cbResp
 				err = nil
 			}
 
 			if err != nil {
-				yield(nil, err)
-				return
+				return yield(nil, err)
 			}
 
 			if event != nil { // an event might be skipped
 				if intermediate := processor.aggregatePartial(ctx, event); intermediate != nil {
 					if !yield(intermediate, nil) {
-						return
+						return false
 					}
 				}
 				if !yield(event, nil) {
-					return
+					return false
 				}
+			}
+			return true
+		}
+
+		if ctx.RunConfig().StreamingMode == agent.StreamingModeNone {
+			a2aEvent, a2aErr := client.SendMessage(ctx, req)
+			processEvent(a2aEvent, a2aErr)
+			return
+		}
+
+		for a2aEvent, a2aErr := range client.SendStreamingMessage(ctx, req) {
+			if !processEvent(a2aEvent, a2aErr) {
+				return
 			}
 		}
 	}


### PR DESCRIPTION
Resolved the problem that the Run method of the remote agent does not verify the StreamingMode parameter in the external run configuration, which resulted in non-streaming requests failing to take effect.

Fixes #486 