### PR TITLE
Make the type comparison case insensitive

### DIFF
--- a/internal/utils/schema_test.go
+++ b/internal/utils/schema_test.go
@@ -172,7 +172,7 @@ func TestMatchType(t *testing.T) {
 			schema:    &genai.Schema{Type: genai.TypeObject, Properties: map[string]*genai.Schema{"foo": {Type: genai.TypeString}}},
 			isInput:   true,
 			wantMatch: false,
-			wantErr:   true, //This will fail ValidateMapOnSchema, which returns error
+			wantErr:   true, // This will fail ValidateMapOnSchema, which returns error
 		},
 		{
 			name:      "unsupported type",

--- a/internal/utils/schema_utils.go
+++ b/internal/utils/schema_utils.go
@@ -35,11 +35,7 @@ func matchType(value any, schema *genai.Schema, isInput bool) (bool, error) {
 	}
 
 	// Convert type to upper case to match the type in the schema.
-	localSchema := *schema
-	localSchema.Type = genai.Type(strings.ToUpper(string(schema.Type)))
-	schema = &localSchema
-
-	switch schema.Type {
+	switch genai.Type(strings.ToUpper(string(schema.Type))) {
 	case genai.TypeString:
 		_, ok := value.(string)
 		return ok, nil


### PR DESCRIPTION
Otherwise schema validation that uses lowercase values of enums such as "object" or "string" fails.