### PR TITLE
Fix MCP reconnection on EOF error

### DIFF
--- a/tool/mcptoolset/client.go
+++ b/tool/mcptoolset/client.go
@@ -49,6 +49,7 @@ type connectionRefresher struct {
 var refreshableErrors = []error{
 	mcp.ErrConnectionClosed,
 	io.ErrClosedPipe,
+	io.EOF,
 }
 
 // newConnectionRefresher creates a new connectionRefresher with the given client and transport.


### PR DESCRIPTION
Related to https://github.com/google/adk-go/pull/417#issuecomment-3783796150. We now trigger reconnect on io.EOF.

