### PR TITLE
Add custom part converters to ADK Executor.

### DIFF
--- a/server/adka2a/executor_test.go
+++ b/server/adka2a/executor_test.go
@@ -542,7 +542,7 @@ func TestExecutor_Converters(t *testing.T) {
 	task := &a2a.Task{ID: a2a.NewTaskID(), ContextID: a2a.NewContextID()}
 	hiMsg := a2a.NewMessageForTask(a2a.MessageRoleUser, task, a2a.TextPart{Text: "hi"})
 
-	t.Run("A2AToGenAIPartConverter", func(t *testing.T) {
+	t.Run("A2APartConverter", func(t *testing.T) {
 		t.Run("modify input", func(t *testing.T) {
 			var receivedText string
 			agent, err := agent.New(agent.Config{
@@ -560,7 +560,7 @@ func TestExecutor_Converters(t *testing.T) {
 
 			executor := NewExecutor(ExecutorConfig{
 				RunnerConfig: runner.Config{AppName: agent.Name(), Agent: agent, SessionService: session.InMemoryService()},
-				A2AToGenAIPartConverter: func(ctx context.Context, evt a2a.Event, part a2a.Part) (*genai.Part, error) {
+				A2APartConverter: func(ctx context.Context, evt a2a.Event, part a2a.Part) (*genai.Part, error) {
 					if p, ok := part.(a2a.TextPart); ok && p.Text == "hi" {
 						return genai.NewPartFromText("HELLO"), nil
 					}
@@ -593,7 +593,7 @@ func TestExecutor_Converters(t *testing.T) {
 
 			executor := NewExecutor(ExecutorConfig{
 				RunnerConfig: runner.Config{AppName: agent.Name(), Agent: agent, SessionService: session.InMemoryService()},
-				A2AToGenAIPartConverter: func(ctx context.Context, evt a2a.Event, part a2a.Part) (*genai.Part, error) {
+				A2APartConverter: func(ctx context.Context, evt a2a.Event, part a2a.Part) (*genai.Part, error) {
 					return nil, nil
 				},
 			})
@@ -609,7 +609,7 @@ func TestExecutor_Converters(t *testing.T) {
 		})
 	})
 
-	t.Run("GenAIToA2APartConverter", func(t *testing.T) {
+	t.Run("GenAIPartConverter", func(t *testing.T) {
 		agentEvents := []*session.Event{
 			{LLMResponse: model.LLMResponse{
 				Content: &genai.Content{Parts: []*genai.Part{genai.NewPartFromText("world")}},
@@ -624,7 +624,7 @@ func TestExecutor_Converters(t *testing.T) {
 
 			executor := NewExecutor(ExecutorConfig{
 				RunnerConfig: runner.Config{AppName: agent.Name(), Agent: agent, SessionService: session.InMemoryService()},
-				GenAIToA2APartConverter: func(ctx context.Context, evt *session.Event, part *genai.Part) (a2a.Part, error) {
+				GenAIPartConverter: func(ctx context.Context, evt *session.Event, part *genai.Part) (a2a.Part, error) {
 					if part.Text == "world" {
 						return a2a.TextPart{Text: "WORLD"}, nil
 					}
@@ -661,7 +661,7 @@ func TestExecutor_Converters(t *testing.T) {
 
 			executor := NewExecutor(ExecutorConfig{
 				RunnerConfig: runner.Config{AppName: agent.Name(), Agent: agent, SessionService: session.InMemoryService()},
-				GenAIToA2APartConverter: func(ctx context.Context, evt *session.Event, part *genai.Part) (a2a.Part, error) {
+				GenAIPartConverter: func(ctx context.Context, evt *session.Event, part *genai.Part) (a2a.Part, error) {
 					return nil, nil
 				},
 			})

--- a/server/adka2a/processor.go
+++ b/server/adka2a/processor.go
@@ -27,8 +27,9 @@ import (
 )
 
 type eventProcessor struct {
-	reqCtx *a2asrv.RequestContext
-	meta   invocationMeta
+	reqCtx        *a2asrv.RequestContext
+	meta          invocationMeta
+	partConverter GenAIPartConverter
 
 	// terminalActions is used to keep track of escalate and agent transfer actions on processed events.
 	// It is then gets passed to caller through with metadata of a terminal event.
@@ -47,19 +48,20 @@ type eventProcessor struct {
 	inputRequiredProcessor *inputRequiredProcessor
 }
 
-func newEventProcessor(reqCtx *a2asrv.RequestContext, meta invocationMeta) *eventProcessor {
+func newEventProcessor(
+	reqCtx *a2asrv.RequestContext,
+	meta invocationMeta,
+	converter GenAIPartConverter,
+) *eventProcessor {
 	return &eventProcessor{
 		inputRequiredProcessor: newInputRequiredProcessor(reqCtx),
+		partConverter:          converter,
 		reqCtx:                 reqCtx,
 		meta:                   meta,
 	}
 }
 
 func (p *eventProcessor) process(ctx context.Context, event *session.Event) (*a2a.TaskArtifactUpdateEvent, error) {
-	return p.processWithConverter(ctx, event, nil)
-}
-
-func (p *eventProcessor) processWithConverter(ctx context.Context, event *session.Event, converter GenAIToA2APartConverter) (*a2a.TaskArtifactUpdateEvent, error) {
 	if event == nil {
 		return nil, nil
 	}
@@ -82,17 +84,16 @@ func (p *eventProcessor) processWithConverter(ctx context.Context, event *sessio
 		}
 	}
 
-	if resp.Content == nil || len(resp.Content.Parts) == 0 {
-		return nil, nil
-	}
-
 	if err := p.inputRequiredProcessor.process(event); err != nil {
 		return nil, fmt.Errorf("input required processing failed: %w", err)
 	}
 
-	parts, err := ToA2APartsWithConverter(ctx, event, converter, resp.Content.Parts, event.LongRunningToolIDs)
+	parts, err := p.convertParts(ctx, event)
 	if err != nil {
 		return nil, err
+	}
+	if len(parts) == 0 {
+		return nil, nil
 	}
 
 	if event.Partial {
@@ -156,6 +157,28 @@ func (p *eventProcessor) updateTerminalActions(event *session.Event) {
 	if event.Actions.TransferToAgent != "" {
 		p.terminalActions.TransferToAgent = event.Actions.TransferToAgent
 	}
+}
+
+func (p *eventProcessor) convertParts(ctx context.Context, event *session.Event) ([]a2a.Part, error) {
+	if event.Content == nil || len(event.Content.Parts) == 0 {
+		return nil, nil
+	}
+	parts := event.Content.Parts
+	if p.partConverter == nil {
+		return ToA2AParts(parts, event.LongRunningToolIDs)
+	}
+	converted := make([]a2a.Part, 0, len(parts))
+	for _, part := range parts {
+		cp, err := p.partConverter(ctx, event, part)
+		if err != nil {
+			return nil, err
+		}
+		if cp == nil {
+			continue
+		}
+		converted = append(converted, cp)
+	}
+	return converted, nil
 }
 
 func toTaskFailedUpdateEvent(task a2a.TaskInfoProvider, cause error, meta map[string]any) *a2a.TaskStatusUpdateEvent {

--- a/server/adka2a/processor_test.go
+++ b/server/adka2a/processor_test.go
@@ -427,7 +427,7 @@ func TestEventProcessor_Process(t *testing.T) {
 		}
 		t.Run(tc.name, func(t *testing.T) {
 			reqCtx := &a2asrv.RequestContext{TaskID: task.ID, ContextID: task.ContextID}
-			processor := newEventProcessor(reqCtx, invocationMeta{})
+			processor := newEventProcessor(reqCtx, invocationMeta{}, nil)
 
 			var gotEvents []*a2a.TaskArtifactUpdateEvent
 			for _, event := range tc.events {
@@ -474,7 +474,7 @@ func TestEventProcessor_ArtifactUpdates(t *testing.T) {
 	}
 
 	reqCtx := &a2asrv.RequestContext{TaskID: task.ID, ContextID: task.ContextID}
-	processor := newEventProcessor(reqCtx, invocationMeta{})
+	processor := newEventProcessor(reqCtx, invocationMeta{}, nil)
 	got := make([]*a2a.TaskArtifactUpdateEvent, len(events))
 	for i, event := range events {
 		processed, err := processor.process(t.Context(), event)


### PR DESCRIPTION
This change essentially mirrors the functionality available in the Python A2A implementation at https://github.com/google/adk-python/blob/main/src/google/adk/a2a/executor/a2a_agent_executor.py#L62-L67.

The use case here is to allow conversion of specific A2A Data parts into something slightly structured (or annotated in some way) for ADK consumption. Currently data parts which are not Function or ExecutableCode related get converted to Text parts (https://github.com/google/adk-go/blob/main/server/adka2a/parts.go#L253). Conceptually these could become InlineData parts (which do tend to overlap with the model of File parts) or extra processing could be applied to make them more consumable by ADK agents. Similarly semi-structured output from ADK agents are returned as TextParts, this just gives us the responsible to marshal these as typed data parts based on whatever signifies we include.