### PR TITLE
feat(session): add CreatedTime to Session interface and implementations 

### DIFF
--- a/internal/llminternal/contents_processor_test.go
+++ b/internal/llminternal/contents_processor_test.go
@@ -932,6 +932,10 @@ func (s *fakeSession) UserID() string {
 	return ""
 }
 
+func (s *fakeSession) CreatedTime() time.Time {
+	return time.Time{}
+}
+
 func (s *fakeSession) LastUpdateTime() time.Time {
 	return time.Time{}
 }

--- a/internal/sessioninternal/mutablesession.go
+++ b/internal/sessioninternal/mutablesession.go
@@ -56,6 +56,10 @@ func (s *MutableSession) Events() session.Events {
 	return s.storedSession.Events()
 }
 
+func (s *MutableSession) CreatedTime() time.Time {
+	return s.storedSession.CreatedTime()
+}
+
 func (s *MutableSession) LastUpdateTime() time.Time {
 	return s.storedSession.LastUpdateTime()
 }

--- a/memory/inmemory_test.go
+++ b/memory/inmemory_test.go
@@ -212,6 +212,10 @@ func (s *testSession) State() session.State {
 	panic("not implemented")
 }
 
+func (s *testSession) CreatedTime() time.Time {
+	panic("not implemented")
+}
+
 func (s *testSession) LastUpdateTime() time.Time {
 	panic("not implemented")
 }

--- a/server/adkrest/internal/fakes/testsessionservice.go
+++ b/server/adkrest/internal/fakes/testsessionservice.go
@@ -71,6 +71,7 @@ type TestSession struct {
 	SessionState  TestState
 	SessionEvents TestEvents
 	UpdatedAt     time.Time
+	CreatedAt     time.Time
 }
 
 func (s TestSession) ID() string {
@@ -91,6 +92,10 @@ func (s TestSession) State() session.State {
 
 func (s TestSession) Events() session.Events {
 	return s.SessionEvents
+}
+
+func (s TestSession) CreatedTime() time.Time {
+	return s.CreatedAt
 }
 
 func (s TestSession) LastUpdateTime() time.Time {

--- a/session/database/service.go
+++ b/session/database/service.go
@@ -88,6 +88,7 @@ func (s *databaseService) Create(ctx context.Context, req *session.CreateRequest
 		sessionID: sessionID,
 		state:     stateMap,
 		updatedAt: time.Now(),
+		createdAt: time.Now(),
 	}
 	createdSession, err := createStorageSession(val)
 	if err != nil {
@@ -127,6 +128,7 @@ func (s *databaseService) Create(ctx context.Context, req *session.CreateRequest
 
 		val.state = mergeStates(storageApp.State, storageUser.State, sessionState)
 		val.updatedAt = createdSession.UpdateTime
+		val.createdAt = createdSession.CreateTime
 		return nil
 	})
 	if err != nil {

--- a/session/database/session.go
+++ b/session/database/session.go
@@ -34,6 +34,7 @@ type localSession struct {
 	mu        sync.RWMutex
 	events    []*session.Event
 	state     map[string]any
+	createdAt time.Time
 	updatedAt time.Time
 }
 
@@ -58,6 +59,13 @@ func (s *localSession) State() session.State {
 
 func (s *localSession) Events() session.Events {
 	return events(s.events)
+}
+
+func (s *localSession) CreatedTime() time.Time {
+	s.mu.RLock()
+	defer s.mu.RUnlock()
+
+	return s.createdAt
 }
 
 func (s *localSession) LastUpdateTime() time.Time {

--- a/session/database/storage_session.go
+++ b/session/database/storage_session.go
@@ -63,6 +63,7 @@ func createSessionFromStorageSession(storage *storageSession) (*localSession, er
 		sessionID: storage.ID,
 		state:     storage.State,
 		updatedAt: storage.UpdateTime,
+		createdAt: storage.CreateTime,
 	}, nil
 }
 

--- a/session/inmemory_test.go
+++ b/session/inmemory_test.go
@@ -78,6 +78,7 @@ func Test_databaseService_Create(t *testing.T) {
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
 			s := tt.setup(t)
+			st := time.Now()
 
 			got, err := s.Create(t.Context(), tt.req)
 			if (err != nil) != tt.wantErr {
@@ -95,6 +96,14 @@ func Test_databaseService_Create(t *testing.T) {
 
 			if got.Session.UserID() != tt.req.UserID {
 				t.Errorf("UserID got: %v, want: %v", got.Session.UserID(), tt.wantErr)
+			}
+
+			if got.Session.CreatedTime().Before(st) {
+				t.Errorf("CreatedTime got: %v, want after: %v", got.Session.CreatedTime(), st)
+			}
+
+			if got.Session.LastUpdateTime().Before(st) {
+				t.Errorf("LastUpdateTime got: %v, want after: %v", got.Session.CreatedTime(), st)
 			}
 
 			if tt.req.SessionID != "" {
@@ -355,7 +364,7 @@ func Test_databaseService_Get(t *testing.T) {
 				if diff := cmp.Diff(tt.wantResponse, got,
 					cmp.AllowUnexported(session{}),
 					cmp.AllowUnexported(id{}),
-					cmpopts.IgnoreFields(session{}, "mu", "updatedAt")); diff != "" {
+					cmpopts.IgnoreFields(session{}, "mu", "createdAt", "updatedAt")); diff != "" {
 					t.Errorf("Get session mismatch: (-want +got):\n%s", diff)
 				}
 			}

--- a/session/session.go
+++ b/session/session.go
@@ -42,6 +42,8 @@ type Session interface {
 	Events() Events
 	// LastUpdateTime returns the time of the last update.
 	LastUpdateTime() time.Time
+	// CreatedTime returns the time of the session creation.
+	CreatedTime() time.Time
 }
 
 // State defines a standard interface for a key-value store.


### PR DESCRIPTION
- Introduce `CreatedTime() time.Time` to the `Session` interface.
- Implement `CreatedTime` for all session types: in-memory, database, and test fakes.
- Store and propagate `createdAt` timestamps in session structs.
- Update session creation logic to set `createdAt` appropriately.
- Extend tests to verify correct `CreatedTime` behavior and comparisons.