### PR TITLE
runssehandler-causes-superfluous-responsewriteheader-on-errors

### DIFF
--- a/server/adkrest/controllers/runtime.go
+++ b/server/adkrest/controllers/runtime.go
@@ -117,7 +117,6 @@ func (c *RuntimeAPIController) RunSSEHandler(rw http.ResponseWriter, req *http.R
 
 	resp := r.Run(req.Context(), runAgentRequest.UserId, runAgentRequest.SessionId, &runAgentRequest.NewMessage, *rCfg)
 
-	rw.WriteHeader(http.StatusOK)
 	for event, err := range resp {
 		if err != nil {
 			_, err := fmt.Fprintf(rw, "Error while running agent: %v\n", err)


### PR DESCRIPTION
Fixed a "superfluous response.WriteHeader" warning occurring in the RunSSEHandler. The handler was explicitly setting a 200 OK status before entering the event stream loop, which caused conflicts if an error occurred early and the error middleware attempted to write a 500 status.