### PR TITLE
fix: Apply temp state deltas to local session object.

### DIFF
--- a/agent/workflowagents/loopagent/agent.go
+++ b/agent/workflowagents/loopagent/agent.go
@@ -85,7 +85,7 @@ func (a *loopAgent) Run(ctx agent.InvocationContext) iter.Seq2[*session.Event, e
 						return
 					}
 
-					if event.Actions.Escalate {
+					if event != nil && event.Actions.Escalate {
 						shouldExit = true
 					}
 				}

--- a/examples/workflowagents/sequentialCode/main.go
+++ b/examples/workflowagents/sequentialCode/main.go
@@ -81,7 +81,7 @@ Provide your feedback as a concise, bulleted list. Focus on the most important p
 If the code is excellent and requires no changes, simply state: "No major issues found."
 Output *only* the review comments or the "No major issues" statement.`,
 		Description: "Reviews code and provides feedback.",
-		OutputKey:   "review_comments", // Stores output in state["review_comments"]
+		OutputKey:   "temp:review_comments", // Stores output in state["temp:review_comments"]
 	})
 	if err != nil {
 		log.Fatalf("failed to create codeReviewerAgent: %s", err)
@@ -101,7 +101,7 @@ Your goal is to improve the given Python code based on the provided review comme
 '''
 
 **Review Comments:**
-{review_comments}
+{temp:review_comments}
 
 **Task:**
 Carefully apply the suggestions from the review comments to refactor the original code.

--- a/session/database/service.go
+++ b/session/database/service.go
@@ -331,22 +331,26 @@ func (s *databaseService) AppendEvent(ctx context.Context, curSession session.Se
 	// Truncate timestamp to microsecond precision to match database precision and prevent rounding errors.
 	event.Timestamp = event.Timestamp.Truncate(time.Microsecond)
 
-	// Trim temp state before persisting
-	event = trimTempDeltaState(event)
-
 	sess, ok := curSession.(*localSession)
 	if !ok {
 		return fmt.Errorf("unexpected session type %T", sess)
 	}
+	// append it to session
+	if err := sess.appendEvent(event); err != nil {
+		return err
+	}
 
+	// Trim temp state before persisting
+	event = trimTempDeltaState(event)
 	// applyChanges and persist them
 	err := s.applyEvent(ctx, sess, event)
 	if err != nil {
 		return err
 	}
 
-	// append it to session
-	return sess.appendEvent(event)
+	// update local session last update time
+	sess.updatedAt = event.Timestamp
+	return nil
 }
 
 // applyEvent fetches the session, validates it, applies state changes from an

--- a/session/database/service_test.go
+++ b/session/database/service_test.go
@@ -862,6 +862,12 @@ func Test_databaseService_StateManagement(t *testing.T) {
 		if err != nil {
 			t.Fatalf("Failed to appendEvent: %v", err)
 		}
+		invocationSession := s1.Session.(*localSession)
+		wantInvocationState := map[string]any{"sk": "v2", "temp:k1": "v1"}
+		gotInvocationState := maps.Collect(invocationSession.State().All())
+		if diff := cmp.Diff(wantInvocationState, gotInvocationState); diff != "" {
+			t.Errorf("Invocation session state mismatch (-want +got):\n%s", diff)
+		}
 
 		s1_got, _ := s.Get(ctx, &session.GetRequest{AppName: appName, UserID: "u1", SessionID: "s1"})
 		wantState := map[string]any{"sk": "v2"}
@@ -1010,8 +1016,5 @@ func emptyService(t *testing.T) *databaseService {
 		}
 	})
 
-	if err != nil {
-		t.Fatalf("Failed to open GORM connection: %v", err)
-	}
 	return dbservice
 }

--- a/session/database/session.go
+++ b/session/database/session.go
@@ -17,6 +17,7 @@ package database
 import (
 	"fmt"
 	"iter"
+	"maps"
 	"strings"
 	"sync"
 	"time"
@@ -75,13 +76,12 @@ func (s *localSession) appendEvent(event *session.Event) error {
 	s.mu.Lock()
 	defer s.mu.Unlock()
 
-	processedEvent := trimTempDeltaState(event)
-	if err := updateSessionState(s, processedEvent); err != nil {
+	if err := updateSessionState(s, event); err != nil {
 		return fmt.Errorf("failed to update localSession state: %w", err)
 	}
 
-	s.events = append(s.events, event)
-	s.updatedAt = event.Timestamp
+	processedEvent := trimTempDeltaState(event)
+	s.events = append(s.events, processedEvent)
 	return nil
 }
 
@@ -180,12 +180,7 @@ func updateSessionState(sess *localSession, event *session.Event) error {
 		sess.state = make(map[string]any)
 	}
 
-	for key, value := range event.Actions.StateDelta {
-		if strings.HasPrefix(key, session.KeyPrefixTemp) {
-			continue
-		}
-		sess.state[key] = value
-	}
+	maps.Copy(sess.state, event.Actions.StateDelta)
 
 	return nil
 }

--- a/session/inmemory.go
+++ b/session/inmemory.go
@@ -329,12 +329,12 @@ func (s *session) appendEvent(event *Event) error {
 		return nil
 	}
 
-	processedEvent := trimTempDeltaState(event)
-	if err := updateSessionState(s, processedEvent); err != nil {
+	if err := updateSessionState(s, event); err != nil {
 		return fmt.Errorf("error on appendEvent: %w", err)
 	}
+	processedEvent := trimTempDeltaState(event)
 
-	s.events = append(s.events, event)
+	s.events = append(s.events, processedEvent)
 	s.updatedAt = event.Timestamp
 	return nil
 }
@@ -436,9 +436,6 @@ func updateSessionState(session *session, event *Event) error {
 
 	state := session.State()
 	for key, value := range event.Actions.StateDelta {
-		if strings.HasPrefix(key, KeyPrefixTemp) {
-			continue
-		}
 		err := state.Set(key, value)
 		if err != nil {
 			return fmt.Errorf("error on updateSessionState state: %w", err)

--- a/session/vertexai/service_test.go
+++ b/session/vertexai/service_test.go
@@ -1085,6 +1085,12 @@ func Test_vertexaiService_StateManagement(t *testing.T) {
 		if err != nil {
 			t.Fatalf("Failed to appendEvent: %v", err)
 		}
+		invocationSession := s1.Session.(*localSession)
+		wantInvocationState := map[string]any{"sk": "v2", "temp:k1": "v1"}
+		gotInvocationState := maps.Collect(invocationSession.State().All())
+		if diff := cmp.Diff(wantInvocationState, gotInvocationState); diff != "" {
+			t.Errorf("Invocation session state mismatch (-want +got):\n%s", diff)
+		}
 
 		s1_got, _ := s.Get(ctx, &session.GetRequest{AppName: appName, UserID: s1.Session.UserID(), SessionID: s1.Session.ID()})
 		wantState := map[string]any{"sk": "v2"}


### PR DESCRIPTION
Temp states created via eventaction.stateDelta were not being applied to local session object.
As such it was not possible to use temp states for outputKey.
The temp values should not be persisted but should still apply to the local session object, and be present throughout the invocation.