### PR TITLE
cleanup: remove `call_llm` spans after adding semconv tracing

### DIFF
--- a/server/adkrest/internal/services/apiserverspanexporter.go
+++ b/server/adkrest/internal/services/apiserverspanexporter.go
@@ -22,7 +22,7 @@ import (
 )
 
 // APIServerSpanExporter is a custom SpanExporter that stores relevant span data.
-// Stores attributes of specific spans (call_llm, send_data, execute_tool) keyed by `gcp.vertex.agent.event_id`.
+// Stores attributes of specific spans (send_data, execute_tool) keyed by `gcp.vertex.agent.event_id`.
 // This is used for debugging individual events.
 // APIServerSpanExporter implements sdktrace.SpanExporter interface.
 type APIServerSpanExporter struct {
@@ -44,7 +44,7 @@ func (s *APIServerSpanExporter) GetTraceDict() map[string]map[string]string {
 // ExportSpans implements custom export function for sdktrace.SpanExporter.
 func (s *APIServerSpanExporter) ExportSpans(ctx context.Context, spans []sdktrace.ReadOnlySpan) error {
 	for _, span := range spans {
-		if span.Name() == "call_llm" || span.Name() == "send_data" || strings.HasPrefix(span.Name(), "execute_tool") {
+		if span.Name() == "send_data" || strings.HasPrefix(span.Name(), "execute_tool") {
 			spanAttributes := span.Attributes()
 			attributes := make(map[string]string)
 			for _, attribute := range spanAttributes {

--- a/server/adkrest/internal/services/apiserverspanexporter_test.go
+++ b/server/adkrest/internal/services/apiserverspanexporter_test.go
@@ -55,14 +55,6 @@ func TestAPIServerSpanExporterExportSpans(t *testing.T) {
 		expectedEvent bool
 	}{
 		{
-			name:     "call_llm-with-event-id-saved",
-			spanName: "call_llm",
-			attributes: []attribute.KeyValue{
-				attribute.String("gcp.vertex.agent.event_id", "event-id"),
-			},
-			expectedEvent: true,
-		},
-		{
 			name:     "send_data-with-event-id-saved",
 			spanName: "send_data",
 			attributes: []attribute.KeyValue{
@@ -84,12 +76,6 @@ func TestAPIServerSpanExporterExportSpans(t *testing.T) {
 			attributes: []attribute.KeyValue{
 				attribute.String("gcp.vertex.agent.event_id", "event-id"),
 			},
-			expectedEvent: false,
-		},
-		{
-			name:          "call_llm-missing-event-id-ignored",
-			spanName:      "call_llm",
-			attributes:    []attribute.KeyValue{},
 			expectedEvent: false,
 		},
 	}


### PR DESCRIPTION
This PR removes the obsolete `call_llm` span after adding semconv traces in #548