### PR TITLE
fix: Introduce `ExitLoop` action and tool for `LoopAgent` to exit loo…

### DIFF
--- a/internal/llminternal/base_flow.go
+++ b/internal/llminternal/base_flow.go
@@ -714,6 +714,9 @@ func mergeEventActions(base, other *session.EventActions) *session.EventActions 
 	if other.Escalate {
 		base.Escalate = true
 	}
+	if other.ExitLoop {
+		base.ExitLoop = true
+	}
 	if other.StateDelta != nil {
 		base.StateDelta = deepMergeMap(base.StateDelta, other.StateDelta)
 	}

--- a/session/session.go
+++ b/session/session.go
@@ -157,6 +157,10 @@ type EventActions struct {
 	TransferToAgent string
 	// The agent is escalating to a higher level agent.
 	Escalate bool
+	// If true, signals that the current loop should exit.
+	// Used by the exit_loop tool to break out of a LoopAgent without
+	// propagating to parent agents (unlike Escalate).
+	ExitLoop bool
 }
 
 // Prefixes for defining session's state scopes

--- a/tool/exitlooptool/tool.go
+++ b/tool/exitlooptool/tool.go
@@ -26,7 +26,7 @@ import (
 type EmptyArgs struct{}
 
 func exitLoop(ctx tool.Context, myArgs EmptyArgs) (map[string]string, error) {
-	ctx.Actions().Escalate = true
+	ctx.Actions().ExitLoop = true
 	ctx.Actions().SkipSummarization = true
 	return map[string]string{}, nil
 }


### PR DESCRIPTION
# Summary

- Fixes #522: exit_loop with Escalate=true was propagating to parent agents, causing SequentialAgent (which is internally a LoopAgent) to also exit and skip
remaining sub-agents
- Introduces a dedicated ExitLoop field on EventActions, decoupling loop exit from the Escalate flag
- LoopAgent consumes the ExitLoop flag before yielding events upstream, so parent agents are unaffected
- Escalate retains its original semantics ("escalate to a higher level agent") and passes through loops without triggering exit

# Test plan

- Updated loopagent tests to use ExitLoop instead of Escalate
- Added TestSequentialAgentWithNestedLoop verifying Sequential(Loop(..., exit_loop), Summary) continues to Summary
- All existing tests pass (go test ./...)