### PR TITLE
fix: generate UUID for request confirmation events

### DIFF
--- a/internal/llminternal/functions.go
+++ b/internal/llminternal/functions.go
@@ -17,6 +17,7 @@ package llminternal
 import (
 	"time"
 
+	"github.com/google/uuid"
 	"google.golang.org/genai"
 
 	"google.golang.org/adk/agent"
@@ -84,6 +85,7 @@ func generateRequestConfirmationEvent(
 	utils.PopulateClientFunctionCallID(content)
 
 	return &session.Event{
+		ID:           uuid.NewString(),
 		InvocationID: invocationContext.InvocationID(),
 		Author:       invocationContext.Agent().Name(),
 		Branch:       invocationContext.Branch(),


### PR DESCRIPTION
Fixes #558

## Summary

`generateRequestConfirmationEvent()` creates `session.Event` structs without setting the `ID` field, resulting in empty string IDs. When persisted to a database backend, the composite primary key `(ID, AppName, UserID, SessionID)` causes a duplicate key violation on the second HITL confirmation event within the same session.

**Fix:** Add `ID: uuid.NewString()` to the Event struct initialization, consistent with `session.NewEvent()`.

## Changes

- `internal/llminternal/functions.go`: Add `ID: uuid.NewString()` and `uuid` import
- `internal/llminternal/base_flow_test.go`: Add test verifying generated events have non-empty, unique IDs

## Testing Plan

**Unit test added:**
- `TestGenerateRequestConfirmationEvent_SetsEventID` — verifies the generated event has a non-empty ID, and calling twice produces unique IDs

**Manual E2E verification:**
- Configured ADK with `database.NewSessionService` (PostgreSQL via GORM)
- Triggered multiple HITL confirmation flows within the same session
- Before fix: second confirmation fails with `duplicate key value violates unique constraint "events_pkey"`
- After fix: all confirmation events persist successfully with unique UUIDs

```text
$ go test ./internal/llminternal/ -run TestGenerateRequestConfirmationEvent -v
=== RUN   TestGenerateRequestConfirmationEvent_SetsEventID
--- PASS: TestGenerateRequestConfirmationEvent_SetsEventID (0.00s)
PASS
```