### PR TITLE
fix: use session.NewEvent in generateRequestConfirmationEvent

### DIFF
--- a/internal/llminternal/functions.go
+++ b/internal/llminternal/functions.go
@@ -15,8 +15,6 @@
 package llminternal
 
 import (
-	"time"
-
 	"google.golang.org/genai"
 
 	"google.golang.org/adk/agent"
@@ -78,18 +76,15 @@ func generateRequestConfirmationEvent(
 		return nil
 	}
 
-	return &session.Event{
-		InvocationID: invocationContext.InvocationID(),
-		Author:       invocationContext.Agent().Name(),
-		Branch:       invocationContext.Branch(),
-		LLMResponse: model.LLMResponse{
-			Content: &genai.Content{
-				Parts: parts,
-				Role:  genai.RoleModel,
-			},
+	event := session.NewEvent(invocationContext.InvocationID())
+	event.Author = invocationContext.Agent().Name()
+	event.Branch = invocationContext.Branch()
+	event.LLMResponse = model.LLMResponse{
+		Content: &genai.Content{
+			Parts: parts,
+			Role:  genai.RoleModel,
 		},
-		Timestamp:          time.Now(),
-		LongRunningToolIDs: longRunningToolIDs,
-		Actions:            session.EventActions{},
 	}
+	event.LongRunningToolIDs = longRunningToolIDs
+	return event
 }

--- a/internal/llminternal/functions_test.go
+++ b/internal/llminternal/functions_test.go
@@ -146,6 +146,7 @@ func TestGenerateRequestConfirmationEvent(t *testing.T) {
 				InvocationID: "inv_1",
 				Author:       "agent_1",
 				Branch:       "main",
+				Actions:      session.EventActions{StateDelta: map[string]any{}},
 				LLMResponse: model.LLMResponse{
 					Content: &genai.Content{
 						Role: genai.RoleModel,
@@ -180,6 +181,12 @@ func TestGenerateRequestConfirmationEvent(t *testing.T) {
 			}
 
 			if got != nil {
+				if got.ID == "" {
+					t.Errorf("expected event ID to be set, got empty string")
+				}
+				if got.Timestamp.IsZero() {
+					t.Errorf("expected event Timestamp to be set, got zero value")
+				}
 				for _, s := range got.LongRunningToolIDs {
 					if s == "" {
 						t.Errorf("empty long running tool id")


### PR DESCRIPTION
Fixes #590

## Description

`generateRequestConfirmationEvent` in `internal/llminternal/functions.go` constructs an `Event` using a raw struct literal, bypassing `session.NewEvent()`. This results in:

1. **Missing `ID`** — empty string instead of a UUID. Any downstream logic relying on event IDs for deduplication, ordering, tracing, or correlation will break.
2. **Uninitialized `StateDelta`** — nil map instead of `map[string]any{}`, which could cause nil map panics if anything writes to it.

### Root Cause

The function was written as a raw struct literal `&session.Event{...}` instead of calling `session.NewEvent()`. The `NewEvent` constructor sets:
- `ID: uuid.NewString()`
- `Timestamp: time.Now()`
- `Actions: EventActions{StateDelta: make(map[string]any)}`

The raw literal only set `Timestamp` and left `ID` empty and `StateDelta` nil.

### Fix

Replace the raw struct literal with `session.NewEvent()` and set the remaining fields (`Author`, `Branch`, `LLMResponse`, `LongRunningToolIDs`) on the returned object. This is consistent with how events are created elsewhere in the codebase.

## Testing Plan

### Unit Tests

Updated tests in `internal/llminternal/functions_test.go`:

- Added assertions verifying that the returned event has a non-empty `ID` and a non-zero `Timestamp`.
- Updated existing test expectation to match the properly initialized `StateDelta` from `NewEvent`.

### Manual E2E Test

Verified with `go test ./internal/llminternal/...` — all tests pass with no regressions.