### PR TITLE
feat: add script for updating embedded adk-web

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -122,6 +122,15 @@ Depending on your change:
     -   Include the command used and console output showing test results.
     -   Highlight sections of the log that directly relate to your change.
 
+# ADK Web
+
+## Updating ADK web version to latest
+
+-   Run `./scripts/adk-web/update-adk-web.sh` to update the web UI to the latest version from [GitHub](https://github.com/google/adk-web).
+-   Run `docker run -it adk-web-builder:latest sh -c "<COMMAND>"` to start the container and debug the build, e.g.:
+    -   `docker run -it adk-web-builder:latest sh -c "ls -alh dist/agent_framework_web/browser"` to view the built files.
+    -   `docker run -it adk-web-builder:latest sh -c "npm run build"` to debug the build output.
+
 ### Documentation
 
 For any changes that impact user-facing documentation (guides, API reference,

--- a/scripts/adk-web/Dockerfile
+++ b/scripts/adk-web/Dockerfile
@@ -1,0 +1,23 @@
+# Stage 1: Clone the repository
+FROM node:iron-trixie AS downloader
+RUN apt-get update && apt-get install -y git
+
+# Trigger re-clone when the main branch changes.
+ADD https://api.github.com/repos/google/adk-web/git/refs/heads/main version.json
+RUN git clone -b main https://github.com/google/adk-web /adk-web && rm version.json
+
+# Stage 2: Build the application
+FROM node:iron-trixie AS builder
+
+WORKDIR /adk-web
+
+# Copy package files first to leverage Docker cache for npm install.
+# This ensures that npm install is only re-run if package.json or package-lock.json changes,
+# and not when other source files change.
+COPY --from=downloader /adk-web/package*.json ./
+RUN npm install
+
+# Copy the rest of the source code
+COPY --from=downloader /adk-web ./
+
+RUN npm run build

--- a/scripts/adk-web/update-adk-web.sh
+++ b/scripts/adk-web/update-adk-web.sh
@@ -1,0 +1,30 @@
+#!/bin/sh
+
+# This scripts pulls the latest version of adk-web.
+# It uses the latest version from https://github.com/google/adk-web and builds it in a docker container.
+
+
+# Use directory of the script for references
+SCRIPT_DIR="$(dirname "$0")"
+
+OUTPUT_DIR="${SCRIPT_DIR}/../../cmd/launcher/web/webui/distr/"
+CONTAINER_BUILD_DIR="adk-web/dist/agent_framework_web/browser"
+
+if ! docker build -t adk-web-builder:latest "${SCRIPT_DIR}"; then
+    echo "Failed to build container. Stopping the update."
+    exit 1
+fi
+
+CONTAINER_ID=$(docker create adk-web-builder:latest)
+if [ $? -ne 0 ]; then
+    echo "Failed to create container. Stopping the update."
+    exit 1
+fi
+trap "docker rm -f ${CONTAINER_ID}" EXIT
+
+echo "Cleaning up the output directory."
+rm -rf "${OUTPUT_DIR}"
+echo "Copying the built files from the container to the output directory."
+docker cp "${CONTAINER_ID}":/${CONTAINER_BUILD_DIR}/. "${OUTPUT_DIR}"
+
+echo "Done."


### PR DESCRIPTION
This PR adds script to update adk-web to the latest version available on github.

* it fetches the latest version from github, builds it in docker and replaces the assets embedded in adk-go.
* adk-web doesn't support tagging at the moment, so the script fetches the latest version from main
* Dockerfile is structured to avoid rebuilds and installing dependencies if there are no changes:
```sh
$ ./scripts/adk-web/update-adk-web.sh 
[+] Building 0.5s (14/14) FINISHED                                                                                                                                                                                                   docker:default
 => [internal] load build definition from Dockerfile                                                                                                                                                                                           0.0s
 => => transferring dockerfile: 812B                                                                                                                                                                                                           0.0s
 => [internal] load metadata for docker.io/library/node:iron-trixie                                                                                                                                                                            0.1s
 => [internal] load .dockerignore                                                                                                                                                                                                              0.0s
 => => transferring context: 2B                                                                                                                                                                                                                0.0s
 => [downloader 1/4] FROM docker.io/library/node:iron-trixie@sha256:4cfff88a78683696d48e15badf98f90bf80bc8015254fbad30ed945d989463ff                                                                                                           0.0s
 => [downloader 3/4] ADD https://api.github.com/repos/google/adk-web/git/refs/heads/main version.json                                                                                                                                          0.2s
 => CACHED [builder 2/6] WORKDIR /adk-web                                                                                                                                                                                                      0.0s
 => CACHED [downloader 2/4] RUN apt-get update && apt-get install -y git                                                                                                                                                                       0.0s
 => CACHED [downloader 3/4] ADD https://api.github.com/repos/google/adk-web/git/refs/heads/main version.json                                                                                                                                   0.0s
 => CACHED [downloader 4/4] RUN git clone -b main https://github.com/google/adk-web /adk-web && rm version.json                                                                                                                                0.0s
 => CACHED [builder 3/6] COPY --from=downloader /adk-web/package*.json ./                                                                                                                                                                      0.0s
 => CACHED [builder 4/6] RUN npm install                                                                                                                                                                                                       0.0s
 => CACHED [builder 5/6] COPY --from=downloader /adk-web ./                                                                                                                                                                                    0.0s
 => CACHED [builder 6/6] RUN npm run build                                                                                                                                                                                                     0.0s
 => exporting to image                                                                                                                                                                                                                         0.0s
 => => exporting layers                                                                                                                                                                                                                        0.0s
 => => writing image sha256:ea3231cc674a02f61cf90526791ef88c038885c505228dea2d7fd7018b71b3c5                                                                                                                                                   0.0s
 => => naming to docker.io/library/adk-web-builder:latest                                                                                                                                                                                      0.0s
Cleaning up the output directory.
Copying the built files from the container to the output directory.
Successfully copied 4.84MB to /usr/local/google/home/pmaciejczek/git-repos/adk-go/cmd/launcher/web/webui/distr/
Done.
```

Inspired by #387 by @caglar10ur