### PR TITLE
feat(model): add Anthropic LLM provider

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -20,3 +20,4 @@ profile.cov
 # Go workspace file
 go.work
 go.work.sum
+.env

--- a/README.md
+++ b/README.md
@@ -18,7 +18,7 @@
       <a href="https://google.github.io/adk-docs/">Docs</a> &
       <a href="https://github.com/google/adk-go/tree/main/examples">Samples</a> &
       <a href="https://github.com/google/adk-python">Python ADK</a> &
-      <a href="https://github.com/google/adk-java">Java ADK</a> & 
+      <a href="https://github.com/google/adk-java">Java ADK</a> &
       <a href="https://github.com/google/adk-web">ADK Web</a>.
     </h3>
 </html>
@@ -58,7 +58,7 @@ import (
 )
 
 func buildModel(ctx context.Context) {
-    _, _ = adkanthropic.NewModel(ctx, anthropicapi.Model("claude-sonnet-4-20250514"), &adkanthropic.Config{
+    _, _ = adkanthropic.NewModel(ctx, anthropicapi.Model(anthropic.ModelClaudeSonnet4_6), &adkanthropic.Config{
         APIKey: "${ANTHROPIC_API_KEY}",
     })
 }

--- a/README.md
+++ b/README.md
@@ -45,6 +45,27 @@ To add ADK Go to your project, run:
 go get google.golang.org/adk
 ```
 
+### Anthropic Claude model package
+
+ADK Go now includes an Anthropic provider that implements the same `model.LLM` interface used by Gemini.
+
+```go
+import (
+    "context"
+
+    anthropicapi "github.com/anthropics/anthropic-sdk-go"
+    adkanthropic "google.golang.org/adk/model/anthropic"
+)
+
+func buildModel(ctx context.Context) {
+    _, _ = adkanthropic.NewModel(ctx, anthropicapi.Model("claude-sonnet-4-20250514"), &adkanthropic.Config{
+        APIKey: "${ANTHROPIC_API_KEY}",
+    })
+}
+```
+
+See [`examples/anthropic/main.go`](examples/anthropic/main.go) for a full runnable sample.
+
 ## 📄 License
 
 This project is licensed under the Apache 2.0 License - see the

--- a/examples/README.md
+++ b/examples/README.md
@@ -4,6 +4,11 @@ This folder hosts examples to test different features. The examples are usually 
 
 **Note**: This is different from the [google/adk-samples](https://github.com/google/adk-samples) repo, which hosts more complex e2e samples for customers to use or modify directly.
 
+## Model examples
+
+- `quickstart`: basic Gemini-backed agent.
+- `anthropic`: basic Anthropic Claude-backed agent.
+
 
 # Launcher
 In many examples you can see such lines:

--- a/examples/anthropic/main.go
+++ b/examples/anthropic/main.go
@@ -1,0 +1,60 @@
+// Copyright 2025 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+// Package main provides an Anthropic-backed ADK agent example.
+package main
+
+import (
+	"context"
+	"log"
+	"os"
+
+	anthropicapi "github.com/anthropics/anthropic-sdk-go"
+
+	"google.golang.org/adk/agent"
+	"google.golang.org/adk/agent/llmagent"
+	"google.golang.org/adk/cmd/launcher"
+	"google.golang.org/adk/cmd/launcher/full"
+	adkanthropic "google.golang.org/adk/model/anthropic"
+)
+
+func main() {
+	ctx := context.Background()
+
+	model, err := adkanthropic.NewModel(ctx, anthropicapi.Model("claude-sonnet-4-20250514"), &adkanthropic.Config{
+		APIKey: os.Getenv("ANTHROPIC_API_KEY"),
+	})
+	if err != nil {
+		log.Fatalf("failed to create model: %v", err)
+	}
+
+	a, err := llmagent.New(llmagent.Config{
+		Name:        "anthropic_weather_agent",
+		Model:       model,
+		Description: "A concise assistant powered by Anthropic Claude.",
+		Instruction: "You are a helpful assistant. Respond briefly and accurately.",
+	})
+	if err != nil {
+		log.Fatalf("failed to create agent: %v", err)
+	}
+
+	config := &launcher.Config{
+		AgentLoader: agent.NewSingleLoader(a),
+	}
+
+	l := full.NewLauncher()
+	if err = l.Execute(ctx, config, os.Args[1:]); err != nil {
+		log.Fatalf("run failed: %v\n\n%s", err, l.CommandLineSyntax())
+	}
+}

--- a/examples/anthropic/main.go
+++ b/examples/anthropic/main.go
@@ -32,7 +32,7 @@ import (
 func main() {
 	ctx := context.Background()
 
-	model, err := adkanthropic.NewModel(ctx, anthropicapi.Model("claude-sonnet-4-20250514"), &adkanthropic.Config{
+	model, err := adkanthropic.NewModel(ctx, anthropicapi.ModelClaudeSonnet4_6, &adkanthropic.Config{
 		APIKey: os.Getenv("ANTHROPIC_API_KEY"),
 	})
 	if err != nil {

--- a/go.mod
+++ b/go.mod
@@ -7,7 +7,7 @@ require (
 	cloud.google.com/go/aiplatform v1.105.0
 	cloud.google.com/go/storage v1.56.1
 	github.com/a2aproject/a2a-go v0.3.3
-	github.com/anthropics/anthropic-sdk-go v1.24.0
+	github.com/anthropics/anthropic-sdk-go v1.26.0
 	github.com/awalterschulze/gographviz v2.0.3+incompatible
 	github.com/glebarez/sqlite v1.8.0
 	github.com/google/go-cmp v0.7.0

--- a/go.mod
+++ b/go.mod
@@ -7,6 +7,7 @@ require (
 	cloud.google.com/go/aiplatform v1.105.0
 	cloud.google.com/go/storage v1.56.1
 	github.com/a2aproject/a2a-go v0.3.3
+	github.com/anthropics/anthropic-sdk-go v1.24.0
 	github.com/awalterschulze/gographviz v2.0.3+incompatible
 	github.com/glebarez/sqlite v1.8.0
 	github.com/google/go-cmp v0.7.0
@@ -33,6 +34,13 @@ require (
 	gorm.io/gorm v1.31.0
 	rsc.io/omap v1.2.0
 	rsc.io/ordered v1.1.1
+)
+
+require (
+	github.com/tidwall/gjson v1.18.0 // indirect
+	github.com/tidwall/match v1.1.1 // indirect
+	github.com/tidwall/pretty v1.2.1 // indirect
+	github.com/tidwall/sjson v1.2.5 // indirect
 )
 
 require (

--- a/go.sum
+++ b/go.sum
@@ -34,6 +34,8 @@ github.com/a2aproject/a2a-go v0.3.3 h1:NqGDw2c8hCSW3/9MakeeRpw5yCZUUmW2Y/yINV15G
 github.com/a2aproject/a2a-go v0.3.3/go.mod h1:8C0O6lsfR7zWFEqVZz/+zWCoxe8gSWpknEpqm/Vgj3E=
 github.com/anthropics/anthropic-sdk-go v1.24.0 h1:SZQ2U4sknjy0t8g275zOhe/113RIo+Uynguf9YNTfGs=
 github.com/anthropics/anthropic-sdk-go v1.24.0/go.mod h1:WTz31rIUHUHqai2UslPpw5CwXrQP3geYBioRV4WOLvE=
+github.com/anthropics/anthropic-sdk-go v1.26.0 h1:oUTzFaUpAevfuELAP1sjL6CQJ9HHAfT7CoSYSac11PY=
+github.com/anthropics/anthropic-sdk-go v1.26.0/go.mod h1:qUKmaW+uuPB64iy1l+4kOSvaLqPXnHTTBKH6RVZ7q5Q=
 github.com/awalterschulze/gographviz v2.0.3+incompatible h1:9sVEXJBJLwGX7EQVhLm2elIKCm7P2YHFC8v6096G09E=
 github.com/awalterschulze/gographviz v2.0.3+incompatible/go.mod h1:GEV5wmg4YquNw7v1kkyoX9etIk8yVmXj+AkDHuuETHs=
 github.com/cenkalti/backoff/v5 v5.0.3 h1:ZN+IMa753KfX5hd8vVaMixjnqRZ3y8CuJKRKj1xcsSM=

--- a/go.sum
+++ b/go.sum
@@ -32,6 +32,8 @@ github.com/GoogleCloudPlatform/opentelemetry-operations-go/internal/resourcemapp
 github.com/GoogleCloudPlatform/opentelemetry-operations-go/internal/resourcemapping v0.53.0/go.mod h1:cSgYe11MCNYunTnRXrKiR/tHc0eoKjICUuWpNZoVCOo=
 github.com/a2aproject/a2a-go v0.3.3 h1:NqGDw2c8hCSW3/9MakeeRpw5yCZUUmW2Y/yINV15GwQ=
 github.com/a2aproject/a2a-go v0.3.3/go.mod h1:8C0O6lsfR7zWFEqVZz/+zWCoxe8gSWpknEpqm/Vgj3E=
+github.com/anthropics/anthropic-sdk-go v1.24.0 h1:SZQ2U4sknjy0t8g275zOhe/113RIo+Uynguf9YNTfGs=
+github.com/anthropics/anthropic-sdk-go v1.24.0/go.mod h1:WTz31rIUHUHqai2UslPpw5CwXrQP3geYBioRV4WOLvE=
 github.com/awalterschulze/gographviz v2.0.3+incompatible h1:9sVEXJBJLwGX7EQVhLm2elIKCm7P2YHFC8v6096G09E=
 github.com/awalterschulze/gographviz v2.0.3+incompatible/go.mod h1:GEV5wmg4YquNw7v1kkyoX9etIk8yVmXj+AkDHuuETHs=
 github.com/cenkalti/backoff/v5 v5.0.3 h1:ZN+IMa753KfX5hd8vVaMixjnqRZ3y8CuJKRKj1xcsSM=
@@ -121,6 +123,16 @@ github.com/spiffe/go-spiffe/v2 v2.6.0 h1:l+DolpxNWYgruGQVV0xsfeya3CsC7m8iBzDnMps
 github.com/spiffe/go-spiffe/v2 v2.6.0/go.mod h1:gm2SeUoMZEtpnzPNs2Csc0D/gX33k1xIx7lEzqblHEs=
 github.com/stretchr/testify v1.11.1 h1:7s2iGBzp5EwR7/aIZr8ao5+dra3wiQyKjjFuvgVKu7U=
 github.com/stretchr/testify v1.11.1/go.mod h1:wZwfW3scLgRK+23gO65QZefKpKQRnfz6sD981Nm4B6U=
+github.com/tidwall/gjson v1.14.2/go.mod h1:/wbyibRr2FHMks5tjHJ5F8dMZh3AcwJEMf5vlfC0lxk=
+github.com/tidwall/gjson v1.18.0 h1:FIDeeyB800efLX89e5a8Y0BNH+LOngJyGrIWxG2FKQY=
+github.com/tidwall/gjson v1.18.0/go.mod h1:/wbyibRr2FHMks5tjHJ5F8dMZh3AcwJEMf5vlfC0lxk=
+github.com/tidwall/match v1.1.1 h1:+Ho715JplO36QYgwN9PGYNhgZvoUSc9X2c80KVTi+GA=
+github.com/tidwall/match v1.1.1/go.mod h1:eRSPERbgtNPcGhD8UCthc6PmLEQXEWd3PRB5JTxsfmM=
+github.com/tidwall/pretty v1.2.0/go.mod h1:ITEVvHYasfjBbM0u2Pg8T2nJnzm8xPwvNhhsoaGGjNU=
+github.com/tidwall/pretty v1.2.1 h1:qjsOFOWWQl+N3RsoF5/ssm1pHmJJwhjlSbZ51I6wMl4=
+github.com/tidwall/pretty v1.2.1/go.mod h1:ITEVvHYasfjBbM0u2Pg8T2nJnzm8xPwvNhhsoaGGjNU=
+github.com/tidwall/sjson v1.2.5 h1:kLy8mja+1c9jlljvWTlSazM7cKDRfJuR/bOJhcY5NcY=
+github.com/tidwall/sjson v1.2.5/go.mod h1:Fvgq9kS/6ociJEDnK0Fk1cpYF4FIW6ZF7LAe+6jwd28=
 github.com/yosida95/uritemplate/v3 v3.0.2 h1:Ed3Oyj9yrmi9087+NczuL5BwkIc4wvTb5zIM+UJPGz4=
 github.com/yosida95/uritemplate/v3 v3.0.2/go.mod h1:ILOh0sOhIJR3+L/8afwt/kE++YT040gmv5BQTMR2HP4=
 go.opentelemetry.io/auto/sdk v1.2.1 h1:jXsnJ4Lmnqd11kwkBV2LgLoFMZKizbCi5fNZ/ipaZ64=

--- a/model/anthropic/anthropic.go
+++ b/model/anthropic/anthropic.go
@@ -1,0 +1,436 @@
+// Copyright 2025 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package anthropic
+
+import (
+	"context"
+	"fmt"
+	"iter"
+	"log/slog"
+	"os"
+	"regexp"
+	"strings"
+
+	anthropicapi "github.com/anthropics/anthropic-sdk-go"
+	"github.com/anthropics/anthropic-sdk-go/option"
+	"github.com/anthropics/anthropic-sdk-go/vertex"
+	"google.golang.org/genai"
+
+	"google.golang.org/adk/model"
+	"google.golang.org/adk/model/anthropic/internal/converters"
+)
+
+const defaultMaxTokens = 4096
+
+type anthropicModel struct {
+	client           anthropicapi.Client
+	name             anthropicapi.Model
+	variant          string
+	defaultMaxTokens int
+}
+
+// NewModel returns [model.LLM], backed by Anthropic Claude.
+//
+// It creates an Anthropic client based on the provided configuration.
+// If Variant is not specified, it checks the ANTHROPIC_USE_VERTEX environment variable.
+//
+// For direct Anthropic API, set APIKey in the config or the ANTHROPIC_API_KEY
+// environment variable.
+//
+// For Vertex AI, set VertexProjectID and VertexLocation in the config or use
+// GOOGLE_CLOUD_PROJECT and GOOGLE_CLOUD_LOCATION environment variables.
+func NewModel(ctx context.Context, modelName anthropicapi.Model, cfg *Config) (model.LLM, error) {
+	if cfg == nil {
+		cfg = &Config{}
+	}
+
+	variant := cfg.Variant
+	if variant == "" {
+		variant = GetVariant()
+	}
+
+	var client anthropicapi.Client
+
+	switch variant {
+	case VariantVertexAI:
+		projectID := cfg.VertexProjectID
+		if projectID == "" {
+			projectID = os.Getenv("GOOGLE_CLOUD_PROJECT")
+		}
+		if projectID == "" {
+			return nil, fmt.Errorf("VertexProjectID is required for Vertex AI (set GOOGLE_CLOUD_PROJECT)")
+		}
+
+		location := cfg.VertexLocation
+		if location == "" {
+			location = os.Getenv("GOOGLE_CLOUD_LOCATION")
+		}
+		if location == "" {
+			return nil, fmt.Errorf("VertexLocation is required for Vertex AI (set GOOGLE_CLOUD_LOCATION)")
+		}
+
+		client = newVertexClient(ctx, cfg)
+	default:
+		client = newAPIClient(cfg)
+	}
+
+	maxTokens := cfg.DefaultMaxTokens
+	if maxTokens == 0 {
+		maxTokens = defaultMaxTokens
+	}
+
+	return &anthropicModel{
+		client:           client,
+		name:             modelName,
+		variant:          variant,
+		defaultMaxTokens: maxTokens,
+	}, nil
+}
+
+// newAPIClient creates a client for the direct Anthropic API.
+func newAPIClient(cfg *Config) anthropicapi.Client {
+	opts := []option.RequestOption{}
+
+	apiKey := cfg.APIKey
+	if apiKey == "" {
+		apiKey = os.Getenv("ANTHROPIC_API_KEY")
+	}
+	if apiKey != "" {
+		opts = append(opts, option.WithAPIKey(apiKey))
+	}
+
+	return anthropicapi.NewClient(opts...)
+}
+
+// newVertexClient creates a client for Anthropic via Vertex AI.
+// Note: The caller must validate that projectID and region are set before calling this.
+func newVertexClient(ctx context.Context, cfg *Config) anthropicapi.Client {
+	projectID := cfg.VertexProjectID
+	if projectID == "" {
+		projectID = os.Getenv("GOOGLE_CLOUD_PROJECT")
+	}
+
+	location := cfg.VertexLocation
+	if location == "" {
+		location = os.Getenv("GOOGLE_CLOUD_LOCATION")
+	}
+
+	return anthropicapi.NewClient(
+		vertex.WithGoogleAuth(ctx, location, projectID),
+	)
+}
+
+// Name returns the model name.
+func (m *anthropicModel) Name() string {
+	return string(m.name)
+}
+
+// GenerateContent calls the Anthropic model.
+func (m *anthropicModel) GenerateContent(ctx context.Context, req *model.LLMRequest, stream bool) iter.Seq2[*model.LLMResponse, error] {
+	m.maybeAppendUserContent(req)
+
+	if stream {
+		return m.generateStream(ctx, req)
+	}
+
+	return func(yield func(*model.LLMResponse, error) bool) {
+		resp, err := m.generate(ctx, req)
+		yield(resp, err)
+	}
+}
+
+// generate calls the model synchronously.
+func (m *anthropicModel) generate(ctx context.Context, req *model.LLMRequest) (*model.LLMResponse, error) {
+	// Vertex AI doesn't support OutputConfig — fall back to prompt-based JSON.
+	if m.variant == VariantVertexAI && req.Config != nil && req.Config.ResponseSchema != nil {
+		return m.generateWithPromptBasedJSON(ctx, req)
+	}
+
+	params, err := m.convertRequest(req)
+	if err != nil {
+		return nil, fmt.Errorf("failed to convert request: %w", err)
+	}
+
+	msg, err := m.client.Messages.New(ctx, params)
+	if err != nil {
+		return nil, fmt.Errorf("failed to call model: %w", err)
+	}
+
+	resp, err := converters.MessageToLLMResponse(msg)
+	if err != nil {
+		return nil, fmt.Errorf("failed to convert response: %w", err)
+	}
+
+	return resp, nil
+}
+
+// generateWithPromptBasedJSON falls back to prompt-based JSON for Vertex AI.
+// It embeds the JSON schema in the system instruction and asks the model to respond with valid JSON.
+func (m *anthropicModel) generateWithPromptBasedJSON(ctx context.Context, req *model.LLMRequest) (*model.LLMResponse, error) {
+	req = embedSchemaAsSystemPrompt(req)
+
+	params, err := m.convertRequest(req)
+	if err != nil {
+		return nil, fmt.Errorf("failed to convert request: %w", err)
+	}
+
+	msg, err := m.client.Messages.New(ctx, params)
+	if err != nil {
+		return nil, fmt.Errorf("failed to call model: %w", err)
+	}
+
+	resp, err := converters.MessageToLLMResponse(msg)
+	if err != nil {
+		return nil, fmt.Errorf("failed to convert response: %w", err)
+	}
+
+	stripMarkdownFromResponse(ctx, resp)
+
+	return resp, nil
+}
+
+// generateStream returns a stream of responses from the model.
+func (m *anthropicModel) generateStream(ctx context.Context, req *model.LLMRequest) iter.Seq2[*model.LLMResponse, error] {
+	// Vertex AI doesn't support OutputConfig — embed schema as a system prompt instead.
+	promptBasedJSON := m.variant == VariantVertexAI && req.Config != nil && req.Config.ResponseSchema != nil
+	if promptBasedJSON {
+		req = embedSchemaAsSystemPrompt(req)
+	}
+
+	return func(yield func(*model.LLMResponse, error) bool) {
+		params, err := m.convertRequest(req)
+		if err != nil {
+			yield(nil, fmt.Errorf("failed to convert request: %w", err))
+			return
+		}
+
+		stream := m.client.Messages.NewStreaming(ctx, params)
+		message := anthropicapi.Message{}
+
+		for stream.Next() {
+			event := stream.Current()
+
+			// Accumulate the message
+			if err := message.Accumulate(event); err != nil {
+				yield(nil, fmt.Errorf("failed to accumulate message: %w", err))
+				return
+			}
+
+			// Handle different event types for streaming
+			switch ev := event.AsAny().(type) {
+			case anthropicapi.ContentBlockDeltaEvent:
+				// Handle text deltas
+				switch delta := ev.Delta.AsAny().(type) {
+				case anthropicapi.TextDelta:
+					resp := converters.StreamDeltaToPartialResponse(delta.Text)
+					if !yield(resp, nil) {
+						return
+					}
+				case anthropicapi.ThinkingDelta:
+					resp := converters.StreamThinkingDeltaToPartialResponse(delta.Thinking)
+					if !yield(resp, nil) {
+						return
+					}
+				}
+			}
+		}
+
+		if err := stream.Err(); err != nil {
+			yield(nil, fmt.Errorf("stream error: %w", err))
+			return
+		}
+
+		// Yield the final complete response
+		finalResp, err := converters.MessageToLLMResponse(&message)
+		if err != nil {
+			yield(nil, fmt.Errorf("failed to convert stream response: %w", err))
+			return
+		}
+		if promptBasedJSON {
+			stripMarkdownFromResponse(ctx, finalResp)
+		}
+		finalResp.TurnComplete = true
+		yield(finalResp, nil)
+	}
+}
+
+// convertRequest converts an LLMRequest to Anthropic MessageNewParams.
+func (m *anthropicModel) convertRequest(req *model.LLMRequest) (anthropicapi.MessageNewParams, error) {
+	messages, err := converters.ContentsToMessages(req.Contents)
+	if err != nil {
+		return anthropicapi.MessageNewParams{}, fmt.Errorf("failed to convert contents: %w", err)
+	}
+
+	params := anthropicapi.MessageNewParams{
+		Model:     anthropicapi.Model(m.name),
+		Messages:  messages,
+		MaxTokens: int64(m.defaultMaxTokens),
+	}
+
+	if req.Config != nil {
+		// System instruction
+		if req.Config.SystemInstruction != nil {
+			params.System = converters.SystemInstructionToSystem(req.Config.SystemInstruction)
+		}
+
+		// Generation parameters
+		if req.Config.Temperature != nil {
+			params.Temperature = anthropicapi.Float(float64(*req.Config.Temperature))
+		}
+		if req.Config.TopP != nil {
+			params.TopP = anthropicapi.Float(float64(*req.Config.TopP))
+		}
+		if req.Config.TopK != nil {
+			params.TopK = anthropicapi.Int(int64(*req.Config.TopK))
+		}
+		if len(req.Config.StopSequences) > 0 {
+			params.StopSequences = req.Config.StopSequences
+		}
+		if req.Config.MaxOutputTokens > 0 {
+			params.MaxTokens = int64(req.Config.MaxOutputTokens)
+		}
+
+		// Tools
+		if len(req.Config.Tools) > 0 {
+			params.Tools = converters.ToolsToAnthropicTools(req.Config.Tools)
+		}
+
+		// Tool choice from ToolConfig
+		if req.Config.ToolConfig != nil {
+			toolChoice, err := converters.ToolConfigToToolChoice(req.Config.ToolConfig)
+			if err != nil {
+				return anthropicapi.MessageNewParams{}, err
+			}
+			params.ToolChoice = toolChoice
+		}
+
+		// Structured output format (not supported on Vertex AI — handled via prompt-based fallback)
+		if req.Config.ResponseSchema != nil && m.variant != VariantVertexAI {
+			schemaMap := converters.SchemaToMap(req.Config.ResponseSchema)
+			params.OutputConfig = anthropicapi.OutputConfigParam{
+				Format: anthropicapi.JSONOutputFormatParam{
+					Schema: schemaMap,
+				},
+			}
+		}
+
+		// Thinking config
+		if req.Config.ThinkingConfig != nil {
+			params.Thinking = converters.ThinkingConfigToAnthropicThinking(req.Config.ThinkingConfig)
+		}
+	}
+
+	return params, nil
+}
+
+// maybeAppendUserContent ensures the conversation ends with a user message.
+// Anthropic requires strictly alternating user/assistant turns.
+func (m *anthropicModel) maybeAppendUserContent(req *model.LLMRequest) {
+	if len(req.Contents) == 0 {
+		req.Contents = append(req.Contents,
+			genai.NewContentFromText("Handle the requests as specified in the System Instruction.", "user"))
+		return
+	}
+
+	if last := req.Contents[len(req.Contents)-1]; last != nil && last.Role != "user" {
+		req.Contents = append(req.Contents,
+			genai.NewContentFromText("Continue processing previous requests as instructed.", "user"))
+	}
+}
+
+// embedSchemaAsSystemPrompt returns a cloned request with the JSON schema embedded
+// in the system instruction and ResponseSchema cleared. This is the prompt-based
+// fallback for Vertex AI, which doesn't support OutputConfig.
+func embedSchemaAsSystemPrompt(req *model.LLMRequest) *model.LLMRequest {
+	schemaJSON := converters.SchemaToJSONString(req.Config.ResponseSchema)
+
+	jsonInstruction := fmt.Sprintf(`You must respond with valid JSON that conforms to the following JSON schema:
+
+%s
+
+Respond ONLY with the JSON object, no markdown code fences, no explanations.`, schemaJSON)
+
+	// Clone the config to avoid mutating the original request.
+	modifiedConfig := *req.Config
+	if modifiedConfig.SystemInstruction == nil {
+		modifiedConfig.SystemInstruction = &genai.Content{
+			Parts: []*genai.Part{{Text: jsonInstruction}},
+		}
+	} else {
+		existingText := ""
+		for _, part := range modifiedConfig.SystemInstruction.Parts {
+			if part.Text != "" {
+				existingText += part.Text + "\n\n"
+			}
+		}
+		modifiedConfig.SystemInstruction = &genai.Content{
+			Parts: []*genai.Part{{Text: existingText + jsonInstruction}},
+			Role:  modifiedConfig.SystemInstruction.Role,
+		}
+	}
+	modifiedConfig.ResponseSchema = nil
+
+	return &model.LLMRequest{
+		Model:    req.Model,
+		Contents: req.Contents,
+		Config:   &modifiedConfig,
+		Tools:    req.Tools,
+	}
+}
+
+// markdownFenceRegex matches ```json ... ``` or ``` ... ``` code blocks.
+// Uses non-greedy matching to handle the first complete fence block.
+// The (?s) flag enables dotall mode so . matches newlines.
+var markdownFenceRegex = regexp.MustCompile("(?s)^\\s*```(?:json)?\\s*\n?(.*?)\\s*```\\s*$")
+
+// markdownFenceExtractRegex is a more permissive regex that extracts JSON from
+// anywhere in the response, handling cases where the model adds preamble text.
+var markdownFenceExtractRegex = regexp.MustCompile("(?s)```(?:json)?\\s*\n?(\\{.*?\\}|\\[.*?\\])\\s*```")
+
+// stripMarkdownFromResponse removes markdown code fences from text parts in the response.
+// This handles cases where the model wraps JSON in ```json ... ``` despite instructions.
+// It tries two approaches:
+// 1. First, check if the entire text is wrapped in fences (strict match)
+// 2. If not, try to extract a JSON object/array from within fences (permissive match)
+func stripMarkdownFromResponse(ctx context.Context, resp *model.LLMResponse) {
+	if resp == nil || resp.Content == nil || len(resp.Content.Parts) == 0 {
+		return
+	}
+
+	for _, part := range resp.Content.Parts {
+		if part == nil || part.Text == "" {
+			continue
+		}
+
+		original := part.Text
+
+		// First try strict match: entire text is wrapped in fences
+		if matches := markdownFenceRegex.FindStringSubmatch(part.Text); len(matches) > 1 {
+			part.Text = strings.TrimSpace(matches[1])
+			slog.DebugContext(ctx, "stripped markdown fences from JSON response (strict)",
+				"original_length", len(original),
+				"stripped_length", len(part.Text))
+			continue
+		}
+
+		// Fall back to permissive match: extract JSON from within fences
+		if matches := markdownFenceExtractRegex.FindStringSubmatch(part.Text); len(matches) > 1 {
+			part.Text = strings.TrimSpace(matches[1])
+			slog.DebugContext(ctx, "extracted JSON from markdown fences (permissive)",
+				"original_length", len(original),
+				"stripped_length", len(part.Text))
+		}
+	}
+}

--- a/model/anthropic/anthropic_test.go
+++ b/model/anthropic/anthropic_test.go
@@ -1,0 +1,287 @@
+// Copyright 2025 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package anthropic
+
+import (
+	"context"
+	"strings"
+	"testing"
+
+	"google.golang.org/adk/model"
+	"google.golang.org/genai"
+)
+
+func TestNewModel_ConfigBehavior(t *testing.T) {
+	tests := []struct {
+		name          string
+		cfg           *Config
+		wantMaxTokens int
+		wantVariant   string
+	}{
+		{
+			name: "explicit_max_tokens_and_variant",
+			cfg: &Config{
+				APIKey:           "test-api-key",
+				DefaultMaxTokens: 2048,
+				Variant:          VariantAnthropicAPI,
+			},
+			wantMaxTokens: 2048,
+			wantVariant:   VariantAnthropicAPI,
+		},
+		{
+			name: "default_max_tokens",
+			cfg: &Config{
+				APIKey:  "test-api-key",
+				Variant: VariantAnthropicAPI,
+			},
+			wantMaxTokens: defaultMaxTokens,
+			wantVariant:   VariantAnthropicAPI,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			model, err := NewModel(t.Context(), "claude-sonnet-4-20250514", tt.cfg)
+			if err != nil {
+				t.Fatalf("NewModel() error = %v", err)
+			}
+
+			if model.Name() != "claude-sonnet-4-20250514" {
+				t.Errorf("Name() = %q, want %q", model.Name(), "claude-sonnet-4-20250514")
+			}
+
+			am := model.(*anthropicModel)
+			if am.defaultMaxTokens != tt.wantMaxTokens {
+				t.Errorf("defaultMaxTokens = %d, want %d", am.defaultMaxTokens, tt.wantMaxTokens)
+			}
+			if am.variant != tt.wantVariant {
+				t.Errorf("variant = %q, want %q", am.variant, tt.wantVariant)
+			}
+		})
+	}
+}
+
+func TestNewModel_VertexAI_MissingConfig(t *testing.T) {
+	tests := []struct {
+		name      string
+		project   string
+		location  string
+		wantError string
+	}{
+		{"missing_project", "", "us-central1", "VertexProjectID is required"},
+		{"missing_location", "test-project", "", "VertexLocation is required"},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Setenv("GOOGLE_CLOUD_PROJECT", tt.project)
+			t.Setenv("GOOGLE_CLOUD_LOCATION", tt.location)
+
+			cfg := &Config{Variant: VariantVertexAI}
+			_, err := NewModel(t.Context(), "claude-sonnet-4-20250514", cfg)
+			if err == nil || !strings.Contains(err.Error(), tt.wantError) {
+				t.Fatalf("NewModel() error = %v, want contains %q", err, tt.wantError)
+			}
+		})
+	}
+}
+
+func TestConvertRequest_VertexAI_SkipsOutputConfig(t *testing.T) {
+	m := &anthropicModel{
+		name:             "claude-haiku-4-5-20251001",
+		variant:          VariantVertexAI,
+		defaultMaxTokens: defaultMaxTokens,
+	}
+
+	schema := &genai.Schema{
+		Type:     genai.TypeObject,
+		Required: []string{"name"},
+		Properties: map[string]*genai.Schema{
+			"name": {Type: genai.TypeString},
+		},
+	}
+
+	req := &model.LLMRequest{
+		Contents: []*genai.Content{
+			genai.NewContentFromText("Hello", "user"),
+		},
+		Config: &genai.GenerateContentConfig{
+			ResponseSchema: schema,
+		},
+	}
+
+	params, err := m.convertRequest(req)
+	if err != nil {
+		t.Fatalf("convertRequest() error = %v", err)
+	}
+
+	// OutputConfig must not be set for Vertex AI
+	if params.OutputConfig.Format.Schema != nil {
+		t.Error("expected OutputConfig to be empty for Vertex AI, but it was set")
+	}
+}
+
+func TestConvertRequest_DirectAPI_SetsOutputConfig(t *testing.T) {
+	m := &anthropicModel{
+		name:             "claude-haiku-4-5-20251001",
+		variant:          VariantAnthropicAPI,
+		defaultMaxTokens: defaultMaxTokens,
+	}
+
+	schema := &genai.Schema{
+		Type:     genai.TypeObject,
+		Required: []string{"name"},
+		Properties: map[string]*genai.Schema{
+			"name": {Type: genai.TypeString},
+		},
+	}
+
+	req := &model.LLMRequest{
+		Contents: []*genai.Content{
+			genai.NewContentFromText("Hello", "user"),
+		},
+		Config: &genai.GenerateContentConfig{
+			ResponseSchema: schema,
+		},
+	}
+
+	params, err := m.convertRequest(req)
+	if err != nil {
+		t.Fatalf("convertRequest() error = %v", err)
+	}
+
+	if params.OutputConfig.Format.Schema == nil {
+		t.Error("expected OutputConfig to be set for direct API, but it was empty")
+	}
+}
+
+func TestEmbedSchemaAsSystemPrompt(t *testing.T) {
+	schema := &genai.Schema{
+		Type:     genai.TypeObject,
+		Required: []string{"name"},
+		Properties: map[string]*genai.Schema{
+			"name": {Type: genai.TypeString},
+		},
+	}
+
+	t.Run("no_existing_system_instruction", func(t *testing.T) {
+		req := &model.LLMRequest{
+			Contents: []*genai.Content{
+				genai.NewContentFromText("Hello", "user"),
+			},
+			Config: &genai.GenerateContentConfig{
+				ResponseSchema: schema,
+			},
+		}
+
+		modified := embedSchemaAsSystemPrompt(req)
+
+		// ResponseSchema should be cleared
+		if modified.Config.ResponseSchema != nil {
+			t.Error("expected ResponseSchema to be nil in modified request")
+		}
+
+		// Original request should be unchanged
+		if req.Config.ResponseSchema == nil {
+			t.Error("expected original request ResponseSchema to be unchanged")
+		}
+
+		// System instruction should contain the schema
+		if modified.Config.SystemInstruction == nil {
+			t.Fatal("expected SystemInstruction to be set")
+		}
+		text := modified.Config.SystemInstruction.Parts[0].Text
+		if !strings.Contains(text, "JSON schema") {
+			t.Errorf("expected system instruction to contain schema, got: %s", text)
+		}
+	})
+
+	t.Run("with_existing_system_instruction", func(t *testing.T) {
+		req := &model.LLMRequest{
+			Contents: []*genai.Content{
+				genai.NewContentFromText("Hello", "user"),
+			},
+			Config: &genai.GenerateContentConfig{
+				SystemInstruction: &genai.Content{
+					Parts: []*genai.Part{{Text: "You are a helpful assistant."}},
+				},
+				ResponseSchema: schema,
+			},
+		}
+
+		modified := embedSchemaAsSystemPrompt(req)
+
+		text := modified.Config.SystemInstruction.Parts[0].Text
+		if !strings.Contains(text, "You are a helpful assistant.") {
+			t.Error("expected original system instruction to be preserved")
+		}
+		if !strings.Contains(text, "JSON schema") {
+			t.Error("expected schema instruction to be appended")
+		}
+	})
+}
+
+func TestStripMarkdownFromResponse(t *testing.T) {
+	tests := []struct {
+		name     string
+		text     string
+		wantText string
+	}{
+		{
+			name:     "no_fences",
+			text:     `{"name": "test"}`,
+			wantText: `{"name": "test"}`,
+		},
+		{
+			name:     "json_fence",
+			text:     "```json\n{\"name\": \"test\"}\n```",
+			wantText: `{"name": "test"}`,
+		},
+		{
+			name:     "plain_fence",
+			text:     "```\n{\"name\": \"test\"}\n```",
+			wantText: `{"name": "test"}`,
+		},
+		{
+			name:     "fence_with_preamble",
+			text:     "Here is the result:\n```json\n{\"name\": \"test\"}\n```",
+			wantText: `{"name": "test"}`,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			resp := &model.LLMResponse{
+				Content: &genai.Content{
+					Parts: []*genai.Part{{Text: tt.text}},
+				},
+			}
+
+			stripMarkdownFromResponse(context.Background(), resp)
+
+			got := resp.Content.Parts[0].Text
+			if got != tt.wantText {
+				t.Errorf("stripMarkdownFromResponse() text = %q, want %q", got, tt.wantText)
+			}
+		})
+	}
+}
+
+func TestStripMarkdownFromResponse_NilSafety(t *testing.T) {
+	// Should not panic on nil inputs
+	stripMarkdownFromResponse(context.Background(), nil)
+	stripMarkdownFromResponse(context.Background(), &model.LLMResponse{})
+	stripMarkdownFromResponse(context.Background(), &model.LLMResponse{Content: &genai.Content{}})
+}

--- a/model/anthropic/anthropic_test.go
+++ b/model/anthropic/anthropic_test.go
@@ -19,6 +19,7 @@ import (
 	"strings"
 	"testing"
 
+	"github.com/anthropics/anthropic-sdk-go"
 	"google.golang.org/adk/model"
 	"google.golang.org/genai"
 )
@@ -53,13 +54,13 @@ func TestNewModel_ConfigBehavior(t *testing.T) {
 
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			model, err := NewModel(t.Context(), "claude-sonnet-4-20250514", tt.cfg)
+			model, err := NewModel(t.Context(), anthropic.ModelClaudeSonnet4_6, tt.cfg)
 			if err != nil {
 				t.Fatalf("NewModel() error = %v", err)
 			}
 
-			if model.Name() != "claude-sonnet-4-20250514" {
-				t.Errorf("Name() = %q, want %q", model.Name(), "claude-sonnet-4-20250514")
+			if model.Name() != string(anthropic.ModelClaudeSonnet4_6) {
+				t.Errorf("Name() = %q, want %q", model.Name(), anthropic.ModelClaudeSonnet4_6)
 			}
 
 			am := model.(*anthropicModel)
@@ -90,7 +91,7 @@ func TestNewModel_VertexAI_MissingConfig(t *testing.T) {
 			t.Setenv("GOOGLE_CLOUD_LOCATION", tt.location)
 
 			cfg := &Config{Variant: VariantVertexAI}
-			_, err := NewModel(t.Context(), "claude-sonnet-4-20250514", cfg)
+			_, err := NewModel(t.Context(), anthropic.ModelClaudeSonnet4_6, cfg)
 			if err == nil || !strings.Contains(err.Error(), tt.wantError) {
 				t.Fatalf("NewModel() error = %v, want contains %q", err, tt.wantError)
 			}

--- a/model/anthropic/config.go
+++ b/model/anthropic/config.go
@@ -1,0 +1,44 @@
+// Copyright 2025 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package anthropic
+
+// Config holds configuration for creating an Anthropic Claude model.
+type Config struct {
+	// APIKey is the Anthropic API key for direct API access.
+	// If not provided, it will be read from the ANTHROPIC_API_KEY environment variable.
+	// This is only used when Variant is VariantAnthropicAPI.
+	APIKey string
+
+	// VertexProjectID is the Google Cloud project ID for Vertex AI access.
+	// If not provided, it will be read from the GOOGLE_CLOUD_PROJECT environment variable.
+	// This is only used when Variant is VariantVertexAI.
+	VertexProjectID string
+
+	// VertexLocation is the Google Cloud location for Vertex AI access.
+	// If not provided, it will be read from the GOOGLE_CLOUD_LOCATION environment variable.
+	// Common locations include "us-central1", "us-east5", "europe-west1", and "global".
+	// This is only used when Variant is VariantVertexAI.
+	VertexLocation string
+
+	// Variant determines which backend to use for API calls.
+	// Valid values are VariantAnthropicAPI and VariantVertexAI.
+	// If empty, the variant is determined from the ANTHROPIC_USE_VERTEX environment variable.
+	Variant string
+
+	// DefaultMaxTokens is the default maximum number of tokens to generate.
+	// Anthropic requires max_tokens to be explicitly set for all requests.
+	// If not provided, defaults to 4096.
+	DefaultMaxTokens int
+}

--- a/model/anthropic/doc.go
+++ b/model/anthropic/doc.go
@@ -1,0 +1,18 @@
+// Copyright 2025 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+// Package anthropic implements the model.LLM interface for Anthropic Claude models.
+//
+// It supports direct Anthropic API usage and Anthropic models served via Vertex AI.
+package anthropic

--- a/model/anthropic/internal/converters/converters_test.go
+++ b/model/anthropic/internal/converters/converters_test.go
@@ -1,0 +1,1114 @@
+// Copyright 2025 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package converters_test
+
+import (
+	"strings"
+	"testing"
+
+	"github.com/anthropics/anthropic-sdk-go"
+	"github.com/google/go-cmp/cmp"
+	"github.com/google/jsonschema-go/jsonschema"
+	"google.golang.org/genai"
+
+	"google.golang.org/adk/model/anthropic/internal/converters"
+)
+
+func TestContentsToMessages_SimpleText(t *testing.T) {
+	contents := []*genai.Content{
+		genai.NewContentFromText("Hello", "user"),
+	}
+
+	messages, err := converters.ContentsToMessages(contents)
+	if err != nil {
+		t.Fatalf("ContentsToMessages() error = %v", err)
+	}
+
+	if len(messages) != 1 {
+		t.Fatalf("expected 1 message, got %d", len(messages))
+	}
+
+	if messages[0].Role != "user" {
+		t.Errorf("expected role 'user', got %q", messages[0].Role)
+	}
+}
+
+func TestContentsToMessages_MultiTurn(t *testing.T) {
+	contents := []*genai.Content{
+		genai.NewContentFromText("Hello", "user"),
+		genai.NewContentFromText("Hi there!", "model"),
+		genai.NewContentFromText("How are you?", "user"),
+	}
+
+	messages, err := converters.ContentsToMessages(contents)
+	if err != nil {
+		t.Fatalf("ContentsToMessages() error = %v", err)
+	}
+
+	if len(messages) != 3 {
+		t.Fatalf("expected 3 messages, got %d", len(messages))
+	}
+
+	expectedRoles := []string{"user", "assistant", "user"}
+	for i, msg := range messages {
+		if string(msg.Role) != expectedRoles[i] {
+			t.Errorf("message %d: expected role %q, got %q", i, expectedRoles[i], msg.Role)
+		}
+	}
+}
+
+func TestContentsToMessages_MergesConsecutiveRoles(t *testing.T) {
+	contents := []*genai.Content{
+		genai.NewContentFromText("Hello", "user"),
+		genai.NewContentFromText("How are you?", "user"),
+	}
+
+	messages, err := converters.ContentsToMessages(contents)
+	if err != nil {
+		t.Fatalf("ContentsToMessages() error = %v", err)
+	}
+
+	// Should merge consecutive user messages
+	if len(messages) != 1 {
+		t.Fatalf("expected 1 merged message, got %d", len(messages))
+	}
+
+	// Should have 2 content blocks
+	if len(messages[0].Content) != 2 {
+		t.Errorf("expected 2 content blocks, got %d", len(messages[0].Content))
+	}
+}
+
+func TestContentsToMessages_Empty(t *testing.T) {
+	messages, err := converters.ContentsToMessages(nil)
+	if err != nil {
+		t.Fatalf("ContentsToMessages() error = %v", err)
+	}
+
+	if messages != nil {
+		t.Errorf("expected nil messages, got %v", messages)
+	}
+}
+
+func TestSystemInstructionToSystem(t *testing.T) {
+	tests := []struct {
+		name        string
+		instruction *genai.Content
+		wantLen     int
+	}{
+		{
+			name:        "nil instruction",
+			instruction: nil,
+			wantLen:     0,
+		},
+		{
+			name:        "single text part",
+			instruction: genai.NewContentFromText("You are a helpful assistant.", "system"),
+			wantLen:     1,
+		},
+		{
+			name: "multiple text parts",
+			instruction: &genai.Content{
+				Role: "system",
+				Parts: []*genai.Part{
+					{Text: "You are a helpful assistant."},
+					{Text: "Be concise."},
+				},
+			},
+			wantLen: 2,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			blocks := converters.SystemInstructionToSystem(tt.instruction)
+			if len(blocks) != tt.wantLen {
+				t.Errorf("SystemInstructionToSystem() returned %d blocks, want %d", len(blocks), tt.wantLen)
+			}
+		})
+	}
+}
+
+func TestStopReasonToFinishReason(t *testing.T) {
+	tests := []struct {
+		name string
+		stop anthropic.StopReason
+		want genai.FinishReason
+	}{
+		{"end_turn", anthropic.StopReasonEndTurn, genai.FinishReasonStop},
+		{"max_tokens", anthropic.StopReasonMaxTokens, genai.FinishReasonMaxTokens},
+		{"stop_sequence", anthropic.StopReasonStopSequence, genai.FinishReasonStop},
+		{"tool_use", anthropic.StopReasonToolUse, genai.FinishReasonStop},
+		{"unknown", anthropic.StopReason("unknown"), genai.FinishReasonUnspecified},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got := converters.StopReasonToFinishReason(tt.stop)
+			if got != tt.want {
+				t.Errorf("StopReasonToFinishReason(%q) = %v, want %v", tt.stop, got, tt.want)
+			}
+		})
+	}
+}
+
+func TestUsageToMetadata(t *testing.T) {
+	usage := anthropic.Usage{InputTokens: 10, OutputTokens: 20}
+	want := &genai.GenerateContentResponseUsageMetadata{
+		PromptTokenCount:     10,
+		CandidatesTokenCount: 20,
+		TotalTokenCount:      30,
+	}
+	got := converters.UsageToMetadata(usage)
+	if diff := cmp.Diff(want, got); diff != "" {
+		t.Errorf("UsageToMetadata() mismatch (-want +got):\n%s", diff)
+	}
+}
+
+func TestToolsToAnthropicTools(t *testing.T) {
+	tests := []struct {
+		name    string
+		tools   []*genai.Tool
+		wantLen int
+	}{
+		{
+			name:    "nil tools",
+			tools:   nil,
+			wantLen: 0,
+		},
+		{
+			name: "single tool with one function",
+			tools: []*genai.Tool{
+				{
+					FunctionDeclarations: []*genai.FunctionDeclaration{
+						{
+							Name:        "get_weather",
+							Description: "Get the weather for a location",
+							Parameters: &genai.Schema{
+								Type: "object",
+								Properties: map[string]*genai.Schema{
+									"location": {Type: "string", Description: "The city name"},
+								},
+								Required: []string{"location"},
+							},
+						},
+					},
+				},
+			},
+			wantLen: 1,
+		},
+		{
+			name: "tool with multiple functions",
+			tools: []*genai.Tool{
+				{
+					FunctionDeclarations: []*genai.FunctionDeclaration{
+						{Name: "func1", Description: "Function 1"},
+						{Name: "func2", Description: "Function 2"},
+					},
+				},
+			},
+			wantLen: 2,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			result := converters.ToolsToAnthropicTools(tt.tools)
+			if len(result) != tt.wantLen {
+				t.Errorf("ToolsToAnthropicTools() returned %d tools, want %d", len(result), tt.wantLen)
+			}
+		})
+	}
+}
+
+func TestSchemaConversion(t *testing.T) {
+	tool := &genai.Tool{
+		FunctionDeclarations: []*genai.FunctionDeclaration{
+			{
+				Name:        "complex_func",
+				Description: "A function with complex schema",
+				Parameters: &genai.Schema{
+					Type: "object",
+					Properties: map[string]*genai.Schema{
+						"name":  {Type: "string"},
+						"count": {Type: "integer"},
+						"items": {
+							Type: "array",
+							Items: &genai.Schema{
+								Type: "string",
+							},
+						},
+						"nested": {
+							Type: "object",
+							Properties: map[string]*genai.Schema{
+								"inner": {Type: "boolean"},
+							},
+						},
+					},
+					Required: []string{"name"},
+				},
+			},
+		},
+	}
+
+	result := converters.ToolsToAnthropicTools([]*genai.Tool{tool})
+	if len(result) != 1 {
+		t.Fatalf("expected 1 tool, got %d", len(result))
+	}
+}
+
+func TestPartToContentBlock_UnsupportedTypes(t *testing.T) {
+	part := &genai.Part{
+		ExecutableCode: &genai.ExecutableCode{
+			Code:     "print('hello')",
+			Language: "python",
+		},
+	}
+
+	_, err := converters.PartToContentBlock(part)
+	if err == nil {
+		t.Error("expected error for ExecutableCode, got nil")
+	}
+}
+
+func TestFunctionResponseToBlock(t *testing.T) {
+	content := &genai.Content{
+		Role: "user",
+		Parts: []*genai.Part{
+			{
+				FunctionResponse: &genai.FunctionResponse{
+					ID:       "call_123",
+					Name:     "get_weather",
+					Response: map[string]any{"temperature": 72, "condition": "sunny"},
+				},
+			},
+		},
+	}
+
+	messages, err := converters.ContentsToMessages([]*genai.Content{content})
+	if err != nil {
+		t.Fatalf("ContentsToMessages() error = %v", err)
+	}
+
+	if len(messages) != 1 {
+		t.Fatalf("expected 1 message, got %d", len(messages))
+	}
+
+	if len(messages[0].Content) != 1 {
+		t.Fatalf("expected 1 content block, got %d", len(messages[0].Content))
+	}
+}
+
+func TestFunctionResponseToBlock_RequiresID(t *testing.T) {
+	content := &genai.Content{
+		Role: "user",
+		Parts: []*genai.Part{
+			{
+				FunctionResponse: &genai.FunctionResponse{
+					Name:     "get_weather",
+					Response: map[string]any{"temperature": 72},
+				},
+			},
+		},
+	}
+
+	_, err := converters.ContentsToMessages([]*genai.Content{content})
+	if err == nil {
+		t.Fatal("expected error for FunctionResponse without ID, got nil")
+	}
+
+	if !strings.Contains(err.Error(), "FunctionResponse.ID is required") {
+		t.Errorf("expected error about missing ID, got: %v", err)
+	}
+}
+
+func TestFunctionResponse_ForcesUserRole(t *testing.T) {
+	content := &genai.Content{
+		Role: "model",
+		Parts: []*genai.Part{
+			{
+				FunctionResponse: &genai.FunctionResponse{
+					ID:       "toolu_abc123",
+					Name:     "get_weather",
+					Response: map[string]any{"temperature": 22},
+				},
+			},
+		},
+	}
+
+	messages, err := converters.ContentsToMessages([]*genai.Content{content})
+	if err != nil {
+		t.Fatalf("ContentsToMessages() error = %v", err)
+	}
+
+	if len(messages) != 1 {
+		t.Fatalf("expected 1 message, got %d", len(messages))
+	}
+
+	if messages[0].Role != "user" {
+		t.Errorf("expected role 'user' for tool result, got %q", messages[0].Role)
+	}
+}
+
+func TestFunctionCall_ForcesAssistantRole(t *testing.T) {
+	content := &genai.Content{
+		Role: "user",
+		Parts: []*genai.Part{
+			{
+				FunctionCall: &genai.FunctionCall{
+					ID:   "toolu_abc123",
+					Name: "get_weather",
+					Args: map[string]any{"location": "London"},
+				},
+			},
+		},
+	}
+
+	messages, err := converters.ContentsToMessages([]*genai.Content{content})
+	if err != nil {
+		t.Fatalf("ContentsToMessages() error = %v", err)
+	}
+
+	if len(messages) != 1 {
+		t.Fatalf("expected 1 message, got %d", len(messages))
+	}
+
+	if messages[0].Role != "assistant" {
+		t.Errorf("expected role 'assistant' for tool call, got %q", messages[0].Role)
+	}
+}
+
+func TestToolCallAndResult_Correlation(t *testing.T) {
+	contents := []*genai.Content{
+		genai.NewContentFromText("What's the weather in London?", "user"),
+		{
+			Role: "model",
+			Parts: []*genai.Part{
+				{
+					FunctionCall: &genai.FunctionCall{
+						ID:   "toolu_weather_123",
+						Name: "get_weather",
+						Args: map[string]any{"location": "London"},
+					},
+				},
+			},
+		},
+		{
+			Role: "user",
+			Parts: []*genai.Part{
+				{
+					FunctionResponse: &genai.FunctionResponse{
+						ID:       "toolu_weather_123",
+						Name:     "get_weather",
+						Response: map[string]any{"temperature": 15, "condition": "cloudy"},
+					},
+				},
+			},
+		},
+	}
+
+	messages, err := converters.ContentsToMessages(contents)
+	if err != nil {
+		t.Fatalf("ContentsToMessages() error = %v", err)
+	}
+
+	if len(messages) != 3 {
+		t.Fatalf("expected 3 messages, got %d", len(messages))
+	}
+
+	expectedRoles := []string{"user", "assistant", "user"}
+	for i, msg := range messages {
+		if string(msg.Role) != expectedRoles[i] {
+			t.Errorf("message %d: expected role %q, got %q", i, expectedRoles[i], msg.Role)
+		}
+	}
+}
+
+var cmpOpts = []cmp.Option{
+	cmp.AllowUnexported(),
+}
+
+var _ = cmpOpts
+
+func TestFunctionDeclarationToTool_JsonSchemaNoRequired(t *testing.T) {
+	fd := &genai.FunctionDeclaration{
+		Name:        "test_func",
+		Description: "A test function",
+		ParametersJsonSchema: &jsonschema.Schema{
+			Properties: map[string]*jsonschema.Schema{
+				"name": {Type: "string"},
+			},
+			// Required intentionally omitted (nil)
+		},
+	}
+
+	result := converters.FunctionDeclarationToTool(fd)
+	if result.OfTool == nil {
+		t.Fatal("expected OfTool to be non-nil")
+	}
+
+	if result.OfTool.InputSchema.Required != nil {
+		t.Errorf("expected Required to be nil when jsonschema.Schema has no required fields, got %v",
+			result.OfTool.InputSchema.Required)
+	}
+
+	props, ok := result.OfTool.InputSchema.Properties.(map[string]any)
+	if !ok {
+		t.Fatalf("expected Properties to be map[string]any, got %T", result.OfTool.InputSchema.Properties)
+	}
+	if _, ok := props["name"]; !ok {
+		t.Error("expected 'name' property to be present")
+	}
+}
+
+func TestFunctionDeclarationToTool_ParametersJsonSchemaMap(t *testing.T) {
+	tests := []struct {
+		name         string
+		fd           *genai.FunctionDeclaration
+		wantProps    map[string]any
+		wantRequired []string
+	}{
+		{
+			name: "map with []any required (JSON unmarshalled)",
+			fd: &genai.FunctionDeclaration{
+				Name:        "test_func",
+				Description: "A test function",
+				ParametersJsonSchema: map[string]any{
+					"properties": map[string]any{
+						"location": map[string]any{
+							"type":        "string",
+							"description": "The city name",
+						},
+					},
+					"required": []any{"location"},
+				},
+			},
+			wantProps: map[string]any{
+				"location": map[string]any{
+					"type":        "string",
+					"description": "The city name",
+				},
+			},
+			wantRequired: []string{"location"},
+		},
+		{
+			name: "map with []string required (manually constructed)",
+			fd: &genai.FunctionDeclaration{
+				Name:        "test_func",
+				Description: "A test function",
+				ParametersJsonSchema: map[string]any{
+					"properties": map[string]any{
+						"name": map[string]any{"type": "string"},
+						"age":  map[string]any{"type": "integer"},
+					},
+					"required": []string{"name", "age"},
+				},
+			},
+			wantProps: map[string]any{
+				"name": map[string]any{"type": "string"},
+				"age":  map[string]any{"type": "integer"},
+			},
+			wantRequired: []string{"name", "age"},
+		},
+		{
+			name: "map with no required field",
+			fd: &genai.FunctionDeclaration{
+				Name: "optional_func",
+				ParametersJsonSchema: map[string]any{
+					"properties": map[string]any{
+						"optional": map[string]any{"type": "string"},
+					},
+				},
+			},
+			wantProps: map[string]any{
+				"optional": map[string]any{"type": "string"},
+			},
+			wantRequired: nil,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			result := converters.FunctionDeclarationToTool(tt.fd)
+
+			if result.OfTool == nil {
+				t.Fatal("expected OfTool to be non-nil")
+			}
+
+			is := result.OfTool.InputSchema
+
+			if diff := cmp.Diff(tt.wantProps, is.Properties); diff != "" {
+				t.Errorf("Properties mismatch (-want +got):\n%s", diff)
+			}
+
+			if diff := cmp.Diff(tt.wantRequired, is.Required); diff != "" {
+				t.Errorf("Required mismatch (-want +got):\n%s", diff)
+			}
+		})
+	}
+}
+
+func TestFunctionDeclarationToTool_ParametersPrecedence(t *testing.T) {
+	fd := &genai.FunctionDeclaration{
+		Name: "test_func",
+		Parameters: &genai.Schema{
+			Type: "object",
+			Properties: map[string]*genai.Schema{
+				"from_parameters": {Type: "string"},
+			},
+			Required: []string{"from_parameters"},
+		},
+		ParametersJsonSchema: map[string]any{
+			"properties": map[string]any{
+				"from_json_schema": map[string]any{"type": "string"},
+			},
+			"required": []any{"from_json_schema"},
+		},
+	}
+
+	result := converters.FunctionDeclarationToTool(fd)
+
+	if result.OfTool == nil {
+		t.Fatal("expected OfTool to be non-nil")
+	}
+
+	is := result.OfTool.InputSchema
+	props, ok := is.Properties.(map[string]any)
+	if !ok {
+		t.Fatalf("expected Properties to be map[string]any, got %T", is.Properties)
+	}
+
+	if _, ok := props["from_parameters"]; !ok {
+		t.Error("expected 'from_parameters' property from Parameters (should take precedence)")
+	}
+	if _, ok := props["from_json_schema"]; ok {
+		t.Error("unexpected 'from_json_schema' property - Parameters should take precedence")
+	}
+}
+
+func TestSchemaToMap_AllFields(t *testing.T) {
+	min, max := 1.0, 100.0
+	minLen, maxLen := int64(1), int64(50)
+	minItems, maxItems := int64(1), int64(10)
+	nullable := true
+
+	tool := &genai.Tool{
+		FunctionDeclarations: []*genai.FunctionDeclaration{
+			{
+				Name:        "full_schema_func",
+				Description: "Function with all schema fields",
+				Parameters: &genai.Schema{
+					Type:        "object",
+					Description: "Root object",
+					Properties: map[string]*genai.Schema{
+						"name": {
+							Type:        "STRING",
+							Description: "User name",
+							MinLength:   &minLen,
+							MaxLength:   &maxLen,
+							Pattern:     "^[a-zA-Z]+$",
+						},
+						"age": {
+							Type:     "INTEGER",
+							Minimum:  &min,
+							Maximum:  &max,
+							Nullable: &nullable,
+						},
+						"tags": {
+							Type:     "ARRAY",
+							MinItems: &minItems,
+							MaxItems: &maxItems,
+							Items:    &genai.Schema{Type: "STRING"},
+						},
+						"status": {
+							Type: "STRING",
+							Enum: []string{"active", "inactive"},
+						},
+						"metadata": {
+							Type: "OBJECT",
+							Properties: map[string]*genai.Schema{
+								"created": {Type: "STRING", Format: "date-time"},
+							},
+						},
+					},
+					Required: []string{"name"},
+				},
+			},
+		},
+	}
+
+	result := converters.ToolsToAnthropicTools([]*genai.Tool{tool})
+	if len(result) != 1 {
+		t.Fatalf("expected 1 tool, got %d", len(result))
+	}
+
+	is := result[0].OfTool.InputSchema
+	props, ok := is.Properties.(map[string]any)
+	if !ok {
+		t.Fatalf("expected Properties to be map[string]any, got %T", is.Properties)
+	}
+
+	nameSchema, ok := props["name"].(map[string]any)
+	if !ok {
+		t.Fatal("expected 'name' property")
+	}
+	if nameSchema["type"] != "string" {
+		t.Errorf("name.type = %v, want 'string'", nameSchema["type"])
+	}
+	if nameSchema["minLength"] != minLen {
+		t.Errorf("name.minLength = %v, want %v", nameSchema["minLength"], minLen)
+	}
+	if nameSchema["pattern"] != "^[a-zA-Z]+$" {
+		t.Errorf("name.pattern = %v, want '^[a-zA-Z]+$'", nameSchema["pattern"])
+	}
+
+	ageSchema, ok := props["age"].(map[string]any)
+	if !ok {
+		t.Fatal("expected 'age' property")
+	}
+	if ageSchema["nullable"] != true {
+		t.Errorf("age.nullable = %v, want true", ageSchema["nullable"])
+	}
+	if ageSchema["minimum"] != min {
+		t.Errorf("age.minimum = %v, want %v", ageSchema["minimum"], min)
+	}
+
+	tagsSchema, ok := props["tags"].(map[string]any)
+	if !ok {
+		t.Fatal("expected 'tags' property")
+	}
+	if tagsSchema["minItems"] != minItems {
+		t.Errorf("tags.minItems = %v, want %v", tagsSchema["minItems"], minItems)
+	}
+	items, ok := tagsSchema["items"].(map[string]any)
+	if !ok {
+		t.Fatal("expected 'tags.items'")
+	}
+	if items["type"] != "string" {
+		t.Errorf("tags.items.type = %v, want 'string'", items["type"])
+	}
+
+	statusSchema, ok := props["status"].(map[string]any)
+	if !ok {
+		t.Fatal("expected 'status' property")
+	}
+	if statusSchema["enum"] == nil {
+		t.Error("expected 'status.enum' to be set")
+	}
+
+	metaSchema, ok := props["metadata"].(map[string]any)
+	if !ok {
+		t.Fatal("expected 'metadata' property")
+	}
+	metaProps, ok := metaSchema["properties"].(map[string]any)
+	if !ok {
+		t.Fatal("expected 'metadata.properties'")
+	}
+	createdSchema, ok := metaProps["created"].(map[string]any)
+	if !ok {
+		t.Fatal("expected 'metadata.properties.created'")
+	}
+	if createdSchema["format"] != "date-time" {
+		t.Errorf("created.format = %v, want 'date-time'", createdSchema["format"])
+	}
+}
+
+func TestSchemaToMap_AnyOf(t *testing.T) {
+	tool := &genai.Tool{
+		FunctionDeclarations: []*genai.FunctionDeclaration{
+			{
+				Name: "anyof_func",
+				Parameters: &genai.Schema{
+					Type: "object",
+					Properties: map[string]*genai.Schema{
+						"value": {
+							AnyOf: []*genai.Schema{
+								{Type: "STRING"},
+								{Type: "INTEGER"},
+							},
+						},
+					},
+				},
+			},
+		},
+	}
+
+	result := converters.ToolsToAnthropicTools([]*genai.Tool{tool})
+	if len(result) != 1 {
+		t.Fatalf("expected 1 tool, got %d", len(result))
+	}
+
+	props, ok := result[0].OfTool.InputSchema.Properties.(map[string]any)
+	if !ok {
+		t.Fatalf("expected Properties to be map[string]any, got %T", result[0].OfTool.InputSchema.Properties)
+	}
+	valueSchema, ok := props["value"].(map[string]any)
+	if !ok {
+		t.Fatal("expected 'value' property")
+	}
+
+	anyOf, ok := valueSchema["anyOf"].([]map[string]any)
+	if !ok {
+		t.Fatalf("expected 'anyOf' to be []map[string]any, got %T", valueSchema["anyOf"])
+	}
+	if len(anyOf) != 2 {
+		t.Errorf("expected 2 anyOf entries, got %d", len(anyOf))
+	}
+}
+
+func TestMessageToLLMResponse_WithCitations(t *testing.T) {
+	msgJSON := `{
+		"content": [{
+			"type": "text",
+			"text": "According to the documentation...",
+			"citations": [
+				{
+					"type": "char_location",
+					"document_title": "API Reference",
+					"start_char_index": 0,
+					"end_char_index": 50,
+					"cited_text": "some text"
+				},
+				{
+					"type": "web_search_result_location",
+					"title": "Official Docs",
+					"url": "https://example.com/docs",
+					"cited_text": "other text"
+				}
+			]
+		}],
+		"stop_reason": "end_turn",
+		"usage": {"input_tokens": 10, "output_tokens": 20}
+	}`
+
+	var msg anthropic.Message
+	if err := msg.UnmarshalJSON([]byte(msgJSON)); err != nil {
+		t.Fatalf("failed to unmarshal message: %v", err)
+	}
+
+	resp, err := converters.MessageToLLMResponse(&msg)
+	if err != nil {
+		t.Fatalf("MessageToLLMResponse() error = %v", err)
+	}
+
+	if resp.CitationMetadata == nil {
+		t.Fatal("expected CitationMetadata to be set")
+	}
+	if len(resp.CitationMetadata.Citations) != 2 {
+		t.Fatalf("expected 2 citations, got %d", len(resp.CitationMetadata.Citations))
+	}
+
+	c0 := resp.CitationMetadata.Citations[0]
+	if c0.Title != "API Reference" {
+		t.Errorf("citation[0].Title = %q, want 'API Reference'", c0.Title)
+	}
+	if c0.StartIndex != 0 || c0.EndIndex != 50 {
+		t.Errorf("citation[0] indices = (%d, %d), want (0, 50)", c0.StartIndex, c0.EndIndex)
+	}
+
+	c1 := resp.CitationMetadata.Citations[1]
+	if c1.Title != "Official Docs" {
+		t.Errorf("citation[1].Title = %q, want 'Official Docs'", c1.Title)
+	}
+	if c1.URI != "https://example.com/docs" {
+		t.Errorf("citation[1].URI = %q, want 'https://example.com/docs'", c1.URI)
+	}
+}
+
+func TestContentBlockToGenaiPart_WebSearchToolResult(t *testing.T) {
+	blockJSON := `{
+		"type": "web_search_tool_result",
+		"tool_use_id": "toolu_search_123",
+		"content": [
+			{
+				"type": "web_search_result",
+				"title": "Example Page",
+				"url": "https://example.com",
+				"page_age": "2 days ago",
+				"encrypted_content": "abc123"
+			},
+			{
+				"type": "web_search_result",
+				"title": "Another Page",
+				"url": "https://another.com",
+				"page_age": "1 week ago",
+				"encrypted_content": "def456"
+			}
+		]
+	}`
+
+	var block anthropic.ContentBlockUnion
+	if err := block.UnmarshalJSON([]byte(blockJSON)); err != nil {
+		t.Fatalf("failed to unmarshal block: %v", err)
+	}
+
+	part, err := converters.ContentBlockToGenaiPart(block)
+	if err != nil {
+		t.Fatalf("ContentBlockToGenaiPart() error = %v", err)
+	}
+
+	if part == nil {
+		t.Fatal("expected part to be non-nil")
+	}
+	if part.FunctionResponse == nil {
+		t.Fatal("expected FunctionResponse to be set")
+	}
+	if part.FunctionResponse.ID != "toolu_search_123" {
+		t.Errorf("FunctionResponse.ID = %q, want 'toolu_search_123'", part.FunctionResponse.ID)
+	}
+	if part.FunctionResponse.Name != "web_search" {
+		t.Errorf("FunctionResponse.Name = %q, want 'web_search'", part.FunctionResponse.Name)
+	}
+
+	results, ok := part.FunctionResponse.Response["results"].([]map[string]any)
+	if !ok {
+		t.Fatalf("expected results to be []map[string]any, got %T", part.FunctionResponse.Response["results"])
+	}
+	if len(results) != 2 {
+		t.Fatalf("expected 2 results, got %d", len(results))
+	}
+	if results[0]["title"] != "Example Page" {
+		t.Errorf("results[0].title = %q, want 'Example Page'", results[0]["title"])
+	}
+	if results[0]["url"] != "https://example.com" {
+		t.Errorf("results[0].url = %q, want 'https://example.com'", results[0]["url"])
+	}
+}
+
+func int32Ptr(v int32) *int32 { return &v }
+
+func TestThinkingConfigToAnthropicThinking(t *testing.T) {
+	tests := []struct {
+		name       string
+		cfg        *genai.ThinkingConfig
+		wantNil    bool // expect zero value (no thinking)
+		wantBudget int64
+	}{
+		{
+			name:    "nil config",
+			cfg:     nil,
+			wantNil: true,
+		},
+		{
+			name:       "HIGH level without budget",
+			cfg:        &genai.ThinkingConfig{ThinkingLevel: genai.ThinkingLevelHigh},
+			wantBudget: 10000,
+		},
+		{
+			name:       "LOW level without budget",
+			cfg:        &genai.ThinkingConfig{ThinkingLevel: genai.ThinkingLevelLow},
+			wantBudget: 1024,
+		},
+		{
+			name:       "explicit budget",
+			cfg:        &genai.ThinkingConfig{ThinkingBudget: int32Ptr(5000)},
+			wantBudget: 5000,
+		},
+		{
+			name:       "level with explicit budget - budget wins",
+			cfg:        &genai.ThinkingConfig{ThinkingLevel: genai.ThinkingLevelLow, ThinkingBudget: int32Ptr(8000)},
+			wantBudget: 8000,
+		},
+		{
+			name:       "IncludeThoughts alone",
+			cfg:        &genai.ThinkingConfig{IncludeThoughts: true},
+			wantBudget: 10000,
+		},
+		{
+			name:    "unspecified level no budget no include",
+			cfg:     &genai.ThinkingConfig{ThinkingLevel: genai.ThinkingLevelUnspecified},
+			wantNil: true,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got := converters.ThinkingConfigToAnthropicThinking(tt.cfg)
+			if tt.wantNil {
+				if got.OfEnabled != nil {
+					t.Errorf("expected zero value, got OfEnabled with budget %d", got.OfEnabled.BudgetTokens)
+				}
+				return
+			}
+			if got.OfEnabled == nil {
+				t.Fatal("expected OfEnabled to be non-nil")
+			}
+			if got.OfEnabled.BudgetTokens != tt.wantBudget {
+				t.Errorf("BudgetTokens = %d, want %d", got.OfEnabled.BudgetTokens, tt.wantBudget)
+			}
+		})
+	}
+}
+
+func TestToolConfigToToolChoice(t *testing.T) {
+	tests := []struct {
+		name      string
+		config    *genai.ToolConfig
+		wantAuto  bool
+		wantAny   bool
+		wantTool  string
+		wantZero  bool
+		wantError bool
+	}{
+		{
+			name:     "nil config",
+			config:   nil,
+			wantZero: true,
+		},
+		{
+			name:     "nil FunctionCallingConfig",
+			config:   &genai.ToolConfig{},
+			wantZero: true,
+		},
+		{
+			name: "ModeNone",
+			config: &genai.ToolConfig{
+				FunctionCallingConfig: &genai.FunctionCallingConfig{
+					Mode: genai.FunctionCallingConfigModeNone,
+				},
+			},
+			wantZero: true,
+		},
+		{
+			name: "ModeAuto",
+			config: &genai.ToolConfig{
+				FunctionCallingConfig: &genai.FunctionCallingConfig{
+					Mode: genai.FunctionCallingConfigModeAuto,
+				},
+			},
+			wantAuto: true,
+		},
+		{
+			name: "ModeAny",
+			config: &genai.ToolConfig{
+				FunctionCallingConfig: &genai.FunctionCallingConfig{
+					Mode: genai.FunctionCallingConfigModeAny,
+				},
+			},
+			wantAny: true,
+		},
+		{
+			name: "ModeAny with single AllowedFunctionNames",
+			config: &genai.ToolConfig{
+				FunctionCallingConfig: &genai.FunctionCallingConfig{
+					Mode:                 genai.FunctionCallingConfigModeAny,
+					AllowedFunctionNames: []string{"get_weather"},
+				},
+			},
+			wantTool: "get_weather",
+		},
+		{
+			name: "multiple AllowedFunctionNames returns error",
+			config: &genai.ToolConfig{
+				FunctionCallingConfig: &genai.FunctionCallingConfig{
+					Mode:                 genai.FunctionCallingConfigModeAny,
+					AllowedFunctionNames: []string{"func1", "func2"},
+				},
+			},
+			wantError: true,
+		},
+		{
+			name: "unknown mode returns error",
+			config: &genai.ToolConfig{
+				FunctionCallingConfig: &genai.FunctionCallingConfig{
+					Mode: genai.FunctionCallingConfigMode("UNKNOWN"),
+				},
+			},
+			wantError: true,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			result, err := converters.ToolConfigToToolChoice(tt.config)
+
+			if tt.wantError {
+				if err == nil {
+					t.Fatal("expected error, got nil")
+				}
+				return
+			}
+			if err != nil {
+				t.Fatalf("unexpected error: %v", err)
+			}
+
+			if tt.wantZero {
+				if result.OfAuto != nil || result.OfAny != nil || result.OfTool != nil {
+					t.Error("expected zero-value result")
+				}
+				return
+			}
+			if tt.wantAuto && result.OfAuto == nil {
+				t.Error("expected OfAuto to be set")
+			}
+			if tt.wantAny && result.OfAny == nil {
+				t.Error("expected OfAny to be set")
+			}
+			if tt.wantTool != "" {
+				if result.OfTool == nil {
+					t.Fatal("expected OfTool to be set")
+				}
+				if result.OfTool.Name != tt.wantTool {
+					t.Errorf("OfTool.Name = %q, want %q", result.OfTool.Name, tt.wantTool)
+				}
+			}
+		})
+	}
+}
+
+func TestSchemaToJSONString(t *testing.T) {
+	tests := []struct {
+		name     string
+		schema   *genai.Schema
+		contains []string
+	}{
+		{
+			name:     "nil_schema",
+			schema:   nil,
+			contains: []string{"null"},
+		},
+		{
+			name: "simple_object",
+			schema: &genai.Schema{
+				Type: genai.TypeObject,
+				Properties: map[string]*genai.Schema{
+					"name": {Type: genai.TypeString},
+				},
+				Required: []string{"name"},
+			},
+			contains: []string{`"type": "object"`, `"properties"`, `"name"`, `"required"`},
+		},
+		{
+			name: "with_description",
+			schema: &genai.Schema{
+				Type:        genai.TypeString,
+				Description: "A user name",
+			},
+			contains: []string{`"type": "string"`, `"description": "A user name"`},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			result := converters.SchemaToJSONString(tt.schema)
+
+			for _, want := range tt.contains {
+				if !strings.Contains(result, want) {
+					t.Errorf("SchemaToJSONString() = %q, want to contain %q", result, want)
+				}
+			}
+		})
+	}
+}

--- a/model/anthropic/internal/converters/request.go
+++ b/model/anthropic/internal/converters/request.go
@@ -1,0 +1,403 @@
+// Copyright 2025 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+// Package converters provides conversion functions between genai types and Anthropic SDK types.
+package converters
+
+import (
+	"encoding/base64"
+	"encoding/json"
+	"fmt"
+	"strings"
+
+	"github.com/anthropics/anthropic-sdk-go"
+	"google.golang.org/genai"
+)
+
+// ContentsToMessages converts genai Contents to Anthropic MessageParams.
+// It handles role mapping and content part conversion.
+func ContentsToMessages(contents []*genai.Content) ([]anthropic.MessageParam, error) {
+	if len(contents) == 0 {
+		return nil, nil
+	}
+
+	var messages []anthropic.MessageParam
+	for _, content := range contents {
+		if content == nil {
+			continue
+		}
+
+		msg, err := contentToMessage(content)
+		if err != nil {
+			return nil, fmt.Errorf("failed to convert content: %w", err)
+		}
+		if msg != nil {
+			messages = append(messages, *msg)
+		}
+	}
+
+	// Merge consecutive messages with the same role (Anthropic requires alternating roles)
+	messages = mergeConsecutiveMessages(messages)
+
+	return messages, nil
+}
+
+// contentToMessage converts a single genai.Content to an Anthropic MessageParam.
+func contentToMessage(content *genai.Content) (*anthropic.MessageParam, error) {
+	if content == nil || len(content.Parts) == 0 {
+		return nil, nil
+	}
+
+	// Check if this content contains tool results (FunctionResponse).
+	// Anthropic requires tool results to be in user messages.
+	hasFunctionResponse := false
+	hasFunctionCall := false
+	for _, part := range content.Parts {
+		if part != nil {
+			if part.FunctionResponse != nil {
+				hasFunctionResponse = true
+			}
+			if part.FunctionCall != nil {
+				hasFunctionCall = true
+			}
+		}
+	}
+
+	// Determine the role - tool results must be user, tool calls must be assistant
+	var role anthropic.MessageParamRole
+	if hasFunctionResponse {
+		// Tool results MUST be in user messages per Anthropic API requirements
+		role = anthropic.MessageParamRoleUser
+	} else if hasFunctionCall {
+		// Tool calls (from model) MUST be in assistant messages
+		role = anthropic.MessageParamRoleAssistant
+	} else {
+		var err error
+		role, err = mapRole(content.Role)
+		if err != nil {
+			return nil, err
+		}
+	}
+
+	var blocks []anthropic.ContentBlockParamUnion
+	for _, part := range content.Parts {
+		if part == nil {
+			continue
+		}
+		block, err := PartToContentBlock(part)
+		if err != nil {
+			return nil, fmt.Errorf("failed to convert part: %w", err)
+		}
+		if block != nil {
+			blocks = append(blocks, *block)
+		}
+	}
+
+	if len(blocks) == 0 {
+		return nil, nil
+	}
+
+	msg := anthropic.MessageParam{
+		Role:    role,
+		Content: blocks,
+	}
+	return &msg, nil
+}
+
+// mapRole maps genai role to Anthropic MessageParamRole.
+func mapRole(role string) (anthropic.MessageParamRole, error) {
+	switch strings.ToLower(role) {
+	case "user":
+		return anthropic.MessageParamRoleUser, nil
+	case "model", "assistant":
+		return anthropic.MessageParamRoleAssistant, nil
+	default:
+		return "", fmt.Errorf("unsupported role: %s", role)
+	}
+}
+
+// PartToContentBlock converts a genai Part to an Anthropic ContentBlockParamUnion.
+func PartToContentBlock(part *genai.Part) (*anthropic.ContentBlockParamUnion, error) {
+	if part == nil {
+		return nil, nil
+	}
+
+	// Text content
+	if part.Text != "" {
+		// Check if this is a thought block
+		if part.Thought {
+			// Thoughts from model responses need to be passed back with signature
+			if len(part.ThoughtSignature) > 0 {
+				block := anthropic.ContentBlockParamUnion{
+					OfThinking: &anthropic.ThinkingBlockParam{
+						Thinking:  part.Text,
+						Signature: base64.StdEncoding.EncodeToString(part.ThoughtSignature),
+					},
+				}
+				return &block, nil
+			}
+			// If no signature, treat as regular text (shouldn't happen in valid flow)
+		}
+		block := anthropic.NewTextBlock(part.Text)
+		return &block, nil
+	}
+
+	// Inline binary data (images, PDFs)
+	if part.InlineData != nil {
+		return inlineDataToBlock(part.InlineData)
+	}
+
+	// File data (URI-based)
+	if part.FileData != nil {
+		return fileDataToBlock(part.FileData)
+	}
+
+	// Function response (tool result)
+	if part.FunctionResponse != nil {
+		return functionResponseToBlock(part.FunctionResponse)
+	}
+
+	// Function call - these should only appear in model responses, not requests
+	// We return nil for these as they shouldn't be in user messages
+	if part.FunctionCall != nil {
+		return functionCallToBlock(part.FunctionCall)
+	}
+
+	// Executable code and CodeExecutionResult are Gemini-specific features
+	// that don't have direct Anthropic equivalents
+	if part.ExecutableCode != nil || part.CodeExecutionResult != nil {
+		return nil, fmt.Errorf("ExecutableCode and CodeExecutionResult are not supported by Anthropic")
+	}
+
+	return nil, nil
+}
+
+// inlineDataToBlock converts inline binary data to an Anthropic content block.
+func inlineDataToBlock(blob *genai.Blob) (*anthropic.ContentBlockParamUnion, error) {
+	if blob == nil {
+		return nil, nil
+	}
+
+	mimeType := strings.ToLower(blob.MIMEType)
+
+	// Handle images
+	if strings.HasPrefix(mimeType, "image/") {
+		mediaType, err := mapImageMediaType(mimeType)
+		if err != nil {
+			return nil, err
+		}
+		block := anthropic.ContentBlockParamUnion{
+			OfImage: &anthropic.ImageBlockParam{
+				Source: anthropic.ImageBlockParamSourceUnion{
+					OfBase64: &anthropic.Base64ImageSourceParam{
+						Data:      base64.StdEncoding.EncodeToString(blob.Data),
+						MediaType: mediaType,
+					},
+				},
+			},
+		}
+		return &block, nil
+	}
+
+	// Handle PDFs (beta feature)
+	if mimeType == "application/pdf" {
+		block := anthropic.ContentBlockParamUnion{
+			OfDocument: &anthropic.DocumentBlockParam{
+				Source: anthropic.DocumentBlockParamSourceUnion{
+					OfBase64: &anthropic.Base64PDFSourceParam{
+						Data: base64.StdEncoding.EncodeToString(blob.Data),
+					},
+				},
+			},
+		}
+		return &block, nil
+	}
+
+	return nil, fmt.Errorf("unsupported MIME type for inline data: %s", mimeType)
+}
+
+// mapImageMediaType maps MIME types to Anthropic Base64ImageSourceMediaType.
+func mapImageMediaType(mimeType string) (anthropic.Base64ImageSourceMediaType, error) {
+	switch mimeType {
+	case "image/jpeg":
+		return anthropic.Base64ImageSourceMediaTypeImageJPEG, nil
+	case "image/png":
+		return anthropic.Base64ImageSourceMediaTypeImagePNG, nil
+	case "image/gif":
+		return anthropic.Base64ImageSourceMediaTypeImageGIF, nil
+	case "image/webp":
+		return anthropic.Base64ImageSourceMediaTypeImageWebP, nil
+	default:
+		return "", fmt.Errorf("unsupported image media type: %s", mimeType)
+	}
+}
+
+// fileDataToBlock converts URI-based file data to an Anthropic content block.
+func fileDataToBlock(fileData *genai.FileData) (*anthropic.ContentBlockParamUnion, error) {
+	if fileData == nil {
+		return nil, nil
+	}
+
+	mimeType := strings.ToLower(fileData.MIMEType)
+
+	// Handle images via URL
+	if strings.HasPrefix(mimeType, "image/") {
+		block := anthropic.ContentBlockParamUnion{
+			OfImage: &anthropic.ImageBlockParam{
+				Source: anthropic.ImageBlockParamSourceUnion{
+					OfURL: &anthropic.URLImageSourceParam{
+						URL: fileData.FileURI,
+					},
+				},
+			},
+		}
+		return &block, nil
+	}
+
+	// Handle PDFs via URL (beta feature)
+	if mimeType == "application/pdf" {
+		block := anthropic.ContentBlockParamUnion{
+			OfDocument: &anthropic.DocumentBlockParam{
+				Source: anthropic.DocumentBlockParamSourceUnion{
+					OfURL: &anthropic.URLPDFSourceParam{
+						URL: fileData.FileURI,
+					},
+				},
+			},
+		}
+		return &block, nil
+	}
+
+	return nil, fmt.Errorf("unsupported MIME type for file data: %s", mimeType)
+}
+
+// functionResponseToBlock converts a FunctionResponse to an Anthropic tool result block.
+func functionResponseToBlock(resp *genai.FunctionResponse) (*anthropic.ContentBlockParamUnion, error) {
+	if resp == nil {
+		return nil, nil
+	}
+
+	// The function ID is required for proper tool call correlation.
+	// Without it, Anthropic cannot match tool results to their originating tool calls.
+	if resp.ID == "" {
+		return nil, fmt.Errorf("FunctionResponse.ID is required for tool call correlation (function: %s)", resp.Name)
+	}
+
+	// Convert the response to JSON string
+	var content string
+	if resp.Response != nil {
+		jsonBytes, err := json.Marshal(resp.Response)
+		if err != nil {
+			return nil, fmt.Errorf("failed to marshal function response: %w", err)
+		}
+		content = string(jsonBytes)
+	}
+
+	block := anthropic.NewToolResultBlock(resp.ID, content, false)
+	return &block, nil
+}
+
+// functionCallToBlock converts a FunctionCall to an Anthropic tool use block.
+// This is used when passing model responses back (e.g., in conversation history).
+func functionCallToBlock(call *genai.FunctionCall) (*anthropic.ContentBlockParamUnion, error) {
+	if call == nil {
+		return nil, nil
+	}
+
+	// Anthropic requires input to be a dictionary - ensure we have a valid map
+	// After JSON round-trip, nil maps stay nil, so we must always provide a valid map
+	var input any = call.Args
+	if call.Args == nil || len(call.Args) == 0 {
+		input = map[string]any{}
+	}
+
+	block := anthropic.NewToolUseBlock(call.ID, input, call.Name)
+	return &block, nil
+}
+
+// SystemInstructionToSystem converts a genai SystemInstruction to Anthropic system text blocks.
+func SystemInstructionToSystem(instruction *genai.Content) []anthropic.TextBlockParam {
+	if instruction == nil || len(instruction.Parts) == 0 {
+		return nil
+	}
+
+	var blocks []anthropic.TextBlockParam
+	for _, part := range instruction.Parts {
+		if part != nil && part.Text != "" {
+			blocks = append(blocks, anthropic.TextBlockParam{
+				Text: part.Text,
+			})
+		}
+	}
+	return blocks
+}
+
+// mergeConsecutiveMessages merges consecutive messages with the same role.
+// Anthropic requires strictly alternating user/assistant messages.
+func mergeConsecutiveMessages(messages []anthropic.MessageParam) []anthropic.MessageParam {
+	if len(messages) <= 1 {
+		return messages
+	}
+
+	var merged []anthropic.MessageParam
+	for i, msg := range messages {
+		if i == 0 {
+			merged = append(merged, msg)
+			continue
+		}
+
+		last := &merged[len(merged)-1]
+		if last.Role == msg.Role {
+			// Merge content blocks
+			last.Content = append(last.Content, msg.Content...)
+		} else {
+			merged = append(merged, msg)
+		}
+	}
+	return merged
+}
+
+// resolveThinkingBudget returns the thinking token budget for a ThinkingConfig,
+// or -1 if thinking should not be enabled.
+func resolveThinkingBudget(cfg *genai.ThinkingConfig) int64 {
+	if cfg == nil {
+		return -1
+	}
+
+	// Explicit budget always takes precedence.
+	if cfg.ThinkingBudget != nil {
+		return int64(*cfg.ThinkingBudget)
+	}
+
+	// Map thinking level to a default budget.
+	switch cfg.ThinkingLevel {
+	case genai.ThinkingLevelHigh:
+		return 10000
+	case genai.ThinkingLevelLow:
+		return 1024
+	default:
+		if cfg.IncludeThoughts {
+			return 10000
+		}
+		return -1
+	}
+}
+
+// ThinkingConfigToAnthropicThinking converts a genai ThinkingConfig to an Anthropic ThinkingConfigParamUnion.
+func ThinkingConfigToAnthropicThinking(cfg *genai.ThinkingConfig) anthropic.ThinkingConfigParamUnion {
+	if budget := resolveThinkingBudget(cfg); budget >= 0 {
+		return anthropic.ThinkingConfigParamOfEnabled(budget)
+	}
+	return anthropic.ThinkingConfigParamUnion{}
+}

--- a/model/anthropic/internal/converters/response.go
+++ b/model/anthropic/internal/converters/response.go
@@ -1,0 +1,250 @@
+// Copyright 2025 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package converters
+
+import (
+	"encoding/base64"
+	"encoding/json"
+	"fmt"
+
+	"github.com/anthropics/anthropic-sdk-go"
+	"google.golang.org/genai"
+
+	"google.golang.org/adk/model"
+)
+
+// MessageToLLMResponse converts an Anthropic Message to a model.LLMResponse.
+func MessageToLLMResponse(msg *anthropic.Message) (*model.LLMResponse, error) {
+	if msg == nil {
+		return nil, fmt.Errorf("nil message received")
+	}
+
+	content := &genai.Content{
+		Role:  "model",
+		Parts: make([]*genai.Part, 0, len(msg.Content)),
+	}
+
+	var allCitations []*genai.Citation
+	for _, block := range msg.Content {
+		part, err := ContentBlockToGenaiPart(block)
+		if err != nil {
+			return nil, fmt.Errorf("failed to convert content block: %w", err)
+		}
+		if part != nil {
+			content.Parts = append(content.Parts, part)
+		}
+		// Collect citations from text blocks
+		if textBlock, ok := block.AsAny().(anthropic.TextBlock); ok {
+			if citations := textCitationsToSlice(textBlock.Citations); len(citations) > 0 {
+				allCitations = append(allCitations, citations...)
+			}
+		}
+	}
+
+	resp := &model.LLMResponse{
+		Content:       content,
+		UsageMetadata: UsageToMetadata(msg.Usage),
+		FinishReason:  StopReasonToFinishReason(msg.StopReason),
+	}
+
+	if len(allCitations) > 0 {
+		resp.CitationMetadata = &genai.CitationMetadata{Citations: allCitations}
+	}
+
+	return resp, nil
+}
+
+// ContentBlockToGenaiPart converts an Anthropic ContentBlockUnion to a genai.Part.
+func ContentBlockToGenaiPart(block anthropic.ContentBlockUnion) (*genai.Part, error) {
+	switch variant := block.AsAny().(type) {
+	case anthropic.TextBlock:
+		return &genai.Part{Text: variant.Text}, nil
+
+	case anthropic.ThinkingBlock:
+		// Map thinking blocks to genai.Part with Thought=true
+		signature, _ := base64.StdEncoding.DecodeString(variant.Signature)
+		return &genai.Part{
+			Text:             variant.Thinking,
+			Thought:          true,
+			ThoughtSignature: signature,
+		}, nil
+
+	case anthropic.RedactedThinkingBlock:
+		// Redacted thinking - we can't see the content but preserve the marker
+		return &genai.Part{
+			Text:    "[thinking redacted]",
+			Thought: true,
+		}, nil
+
+	case anthropic.ToolUseBlock:
+		// Convert to FunctionCall
+		args := make(map[string]any)
+		if variant.Input != nil {
+			// Input is json.RawMessage, unmarshal it
+			if err := json.Unmarshal(variant.Input, &args); err != nil {
+				return nil, fmt.Errorf("failed to unmarshal tool input for %q (id=%s): %w", variant.Name, variant.ID, err)
+			}
+		}
+		return &genai.Part{
+			FunctionCall: &genai.FunctionCall{
+				ID:   variant.ID,
+				Name: variant.Name,
+				Args: args,
+			},
+		}, nil
+
+	case anthropic.ServerToolUseBlock:
+		// Server-side tool use (web search, etc.)
+		args := make(map[string]any)
+		if variant.Input != nil {
+			// Input is an any type, convert through JSON
+			inputBytes, err := json.Marshal(variant.Input)
+			if err != nil {
+				return nil, fmt.Errorf("failed to marshal server tool input for %q (id=%s): %w", variant.Name, variant.ID, err)
+			}
+			if err := json.Unmarshal(inputBytes, &args); err != nil {
+				return nil, fmt.Errorf("failed to unmarshal server tool input for %q (id=%s): %w", variant.Name, variant.ID, err)
+			}
+		}
+		return &genai.Part{
+			FunctionCall: &genai.FunctionCall{
+				ID:   variant.ID,
+				Name: string(variant.Name),
+				Args: args,
+			},
+		}, nil
+
+	case anthropic.WebSearchToolResultBlock:
+		// Web search results from Anthropic's built-in web search tool
+		return webSearchResultToFunctionResponse(variant), nil
+
+	default:
+		// Unknown block type - skip
+		return nil, nil
+	}
+}
+
+// webSearchResultToFunctionResponse converts a WebSearchToolResultBlock to a FunctionResponse Part.
+func webSearchResultToFunctionResponse(block anthropic.WebSearchToolResultBlock) *genai.Part {
+	response := make(map[string]any)
+
+	// Check if it's an error or results
+	if results := block.Content.AsWebSearchResultBlockArray(); len(results) > 0 {
+		searchResults := make([]map[string]any, 0, len(results))
+		for _, result := range results {
+			searchResults = append(searchResults, map[string]any{
+				"title":   result.Title,
+				"url":     result.URL,
+				"pageAge": result.PageAge,
+			})
+		}
+		response["results"] = searchResults
+	} else if errBlock := block.Content.AsResponseWebSearchToolResultError(); errBlock.ErrorCode != "" {
+		response["error"] = string(errBlock.ErrorCode)
+	}
+
+	return &genai.Part{
+		FunctionResponse: &genai.FunctionResponse{
+			ID:       block.ToolUseID,
+			Name:     "web_search",
+			Response: response,
+		},
+	}
+}
+
+// textCitationsToSlice converts Anthropic text citations to a slice of genai.Citation.
+func textCitationsToSlice(citations []anthropic.TextCitationUnion) []*genai.Citation {
+	if len(citations) == 0 {
+		return nil
+	}
+
+	result := make([]*genai.Citation, 0, len(citations))
+	for _, c := range citations {
+		citation := &genai.Citation{
+			Title: c.DocumentTitle,
+		}
+
+		// Map based on citation type
+		switch c.Type {
+		case "char_location":
+			citation.StartIndex = int32(c.StartCharIndex)
+			citation.EndIndex = int32(c.EndCharIndex)
+		case "web_search_result_location":
+			citation.Title = c.Title
+			citation.URI = c.URL
+		case "search_result_location":
+			citation.Title = c.Title
+		}
+
+		result = append(result, citation)
+	}
+
+	return result
+}
+
+// UsageToMetadata converts Anthropic Usage to genai UsageMetadata.
+func UsageToMetadata(usage anthropic.Usage) *genai.GenerateContentResponseUsageMetadata {
+	return &genai.GenerateContentResponseUsageMetadata{
+		PromptTokenCount:     int32(usage.InputTokens),
+		CandidatesTokenCount: int32(usage.OutputTokens),
+		TotalTokenCount:      int32(usage.InputTokens + usage.OutputTokens),
+	}
+}
+
+// StopReasonToFinishReason maps Anthropic StopReason to genai FinishReason.
+func StopReasonToFinishReason(sr anthropic.StopReason) genai.FinishReason {
+	switch sr {
+	case anthropic.StopReasonEndTurn:
+		return genai.FinishReasonStop
+	case anthropic.StopReasonMaxTokens:
+		return genai.FinishReasonMaxTokens
+	case anthropic.StopReasonStopSequence:
+		return genai.FinishReasonStop
+	case anthropic.StopReasonToolUse:
+		return genai.FinishReasonStop
+	default:
+		return genai.FinishReasonUnspecified
+	}
+}
+
+// StreamDeltaToPartialResponse converts a streaming content block delta to a partial LLMResponse.
+// Used for streaming text updates.
+func StreamDeltaToPartialResponse(text string) *model.LLMResponse {
+	return &model.LLMResponse{
+		Content: &genai.Content{
+			Role: "model",
+			Parts: []*genai.Part{
+				{Text: text},
+			},
+		},
+		Partial: true,
+	}
+}
+
+// StreamThinkingDeltaToPartialResponse converts a streaming thinking delta to a partial LLMResponse.
+func StreamThinkingDeltaToPartialResponse(thinking string) *model.LLMResponse {
+	return &model.LLMResponse{
+		Content: &genai.Content{
+			Role: "model",
+			Parts: []*genai.Part{
+				{
+					Text:    thinking,
+					Thought: true,
+				},
+			},
+		},
+		Partial: true,
+	}
+}

--- a/model/anthropic/internal/converters/tools.go
+++ b/model/anthropic/internal/converters/tools.go
@@ -1,0 +1,379 @@
+// Copyright 2025 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package converters
+
+import (
+	"encoding/json"
+	"fmt"
+	"strings"
+
+	"github.com/anthropics/anthropic-sdk-go"
+	"github.com/google/jsonschema-go/jsonschema"
+	"google.golang.org/genai"
+)
+
+// ToolsToAnthropicTools converts genai Tools to Anthropic ToolUnionParams.
+func ToolsToAnthropicTools(tools []*genai.Tool) []anthropic.ToolUnionParam {
+	if len(tools) == 0 {
+		return nil
+	}
+
+	var result []anthropic.ToolUnionParam
+	for _, tool := range tools {
+		if tool == nil || len(tool.FunctionDeclarations) == 0 {
+			continue
+		}
+		for _, fd := range tool.FunctionDeclarations {
+			if fd == nil {
+				continue
+			}
+			toolParam := FunctionDeclarationToTool(fd)
+			result = append(result, toolParam)
+		}
+	}
+	return result
+}
+
+// extractFunctionParams extracts properties and required fields from a FunctionDeclaration.
+// Parameters takes precedence over ParametersJsonSchema.
+// ParametersJsonSchema currently supports:
+//   - map[string]any with "properties" and "required" keys
+//   - *jsonschema.Schema
+//
+// Other ParametersJsonSchema types are ignored.
+func extractFunctionParams(fd *genai.FunctionDeclaration) (properties map[string]any, required []string) {
+	properties = map[string]any{}
+
+	if fd.Parameters != nil {
+		if props := schemaPropertiesToMap(fd.Parameters.Properties); props != nil {
+			properties = props
+		}
+		required = fd.Parameters.Required
+	} else if fd.ParametersJsonSchema != nil {
+		switch schema := fd.ParametersJsonSchema.(type) {
+		case map[string]any:
+			if props, ok := schema["properties"].(map[string]any); ok {
+				properties = props
+			}
+			required = extractRequiredFields(schema["required"])
+		case *jsonschema.Schema:
+			if props := jsonSchemaToProperties(schema); props != nil {
+				properties = props
+			}
+			if len(schema.Required) > 0 {
+				required = schema.Required
+			}
+		}
+	}
+
+	return properties, required
+}
+
+// FunctionDeclarationToTool converts a genai FunctionDeclaration to an Anthropic ToolUnionParam.
+func FunctionDeclarationToTool(fd *genai.FunctionDeclaration) anthropic.ToolUnionParam {
+	properties, required := extractFunctionParams(fd)
+
+	return anthropic.ToolUnionParam{
+		OfTool: &anthropic.ToolParam{
+			Name:        fd.Name,
+			Description: anthropic.String(fd.Description),
+			InputSchema: anthropic.ToolInputSchemaParam{
+				Properties: properties,
+				Required:   required,
+			},
+		},
+	}
+}
+
+// extractRequiredFields extracts required field names from various input types.
+// Supports []any (from JSON unmarshalling) and []string (from manual construction).
+func extractRequiredFields(v any) []string {
+	if v == nil {
+		return nil
+	}
+	switch req := v.(type) {
+	case []string:
+		return req
+	case []any:
+		result := make([]string, 0, len(req))
+		for _, r := range req {
+			if s, ok := r.(string); ok {
+				result = append(result, s)
+			}
+		}
+		return result
+	default:
+		return nil
+	}
+}
+
+// jsonSchemaToProperties converts a jsonschema.Schema to a properties map.
+// Returns nil if schema or its properties are nil, consistent with schemaPropertiesToMap.
+func jsonSchemaToProperties(schema *jsonschema.Schema) map[string]any {
+	if schema == nil || schema.Properties == nil {
+		return nil
+	}
+
+	props := make(map[string]any)
+	for name, propSchema := range schema.Properties {
+		props[name] = jsonSchemaPropertyToMap(propSchema)
+	}
+	return props
+}
+
+// jsonSchemaPropertyToMap converts a single jsonschema.Schema property to a map.
+func jsonSchemaPropertyToMap(schema *jsonschema.Schema) map[string]any {
+	if schema == nil {
+		return nil
+	}
+
+	result := make(map[string]any)
+
+	if schema.Type != "" {
+		result["type"] = string(schema.Type)
+	}
+	if schema.Description != "" {
+		result["description"] = schema.Description
+	}
+	if len(schema.Enum) > 0 {
+		result["enum"] = schema.Enum
+	}
+	if schema.Items != nil {
+		result["items"] = jsonSchemaPropertyToMap(schema.Items)
+	}
+	if schema.Properties != nil {
+		result["properties"] = jsonSchemaToProperties(schema)
+	}
+	if len(schema.Required) > 0 {
+		result["required"] = schema.Required
+	}
+
+	return result
+}
+
+// schemaPropertiesToMap converts genai Schema properties to a map for Anthropic.
+func schemaPropertiesToMap(props map[string]*genai.Schema) map[string]any {
+	if props == nil {
+		return nil
+	}
+
+	result := make(map[string]any)
+	for name, schema := range props {
+		if schema == nil {
+			continue
+		}
+		result[name] = SchemaToMap(schema)
+	}
+	return result
+}
+
+// SchemaToMap converts a genai.Schema to a map[string]any suitable for Anthropic.
+func SchemaToMap(schema *genai.Schema) map[string]any {
+	if schema == nil {
+		return nil
+	}
+
+	result := make(map[string]any)
+
+	// Type
+	if schema.Type != "" {
+		result["type"] = strings.ToLower(string(schema.Type))
+	}
+
+	// Description
+	if schema.Description != "" {
+		result["description"] = schema.Description
+	}
+
+	// Enum
+	if len(schema.Enum) > 0 {
+		result["enum"] = schema.Enum
+	}
+
+	// Format
+	if schema.Format != "" {
+		result["format"] = schema.Format
+	}
+
+	// Items (for arrays)
+	if schema.Items != nil {
+		result["items"] = SchemaToMap(schema.Items)
+	}
+
+	// Properties (for objects)
+	if len(schema.Properties) > 0 {
+		result["properties"] = schemaPropertiesToMap(schema.Properties)
+	}
+
+	// Required
+	if len(schema.Required) > 0 {
+		result["required"] = schema.Required
+	}
+
+	// Nullable
+	if schema.Nullable != nil && *schema.Nullable {
+		result["nullable"] = true
+	}
+
+	// Default
+	if schema.Default != nil {
+		result["default"] = schema.Default
+	}
+
+	// Min/Max constraints
+	if schema.Minimum != nil {
+		result["minimum"] = *schema.Minimum
+	}
+	if schema.Maximum != nil {
+		result["maximum"] = *schema.Maximum
+	}
+	if schema.MinLength != nil {
+		result["minLength"] = *schema.MinLength
+	}
+	if schema.MaxLength != nil {
+		result["maxLength"] = *schema.MaxLength
+	}
+	if schema.MinItems != nil {
+		result["minItems"] = *schema.MinItems
+	}
+	if schema.MaxItems != nil {
+		result["maxItems"] = *schema.MaxItems
+	}
+
+	// Pattern
+	if schema.Pattern != "" {
+		result["pattern"] = schema.Pattern
+	}
+
+	// AnyOf
+	if len(schema.AnyOf) > 0 {
+		anyOf := make([]map[string]any, 0, len(schema.AnyOf))
+		for _, s := range schema.AnyOf {
+			if m := SchemaToMap(s); m != nil {
+				anyOf = append(anyOf, m)
+			}
+		}
+		if len(anyOf) > 0 {
+			result["anyOf"] = anyOf
+		}
+	}
+
+	return result
+}
+
+// SchemaToJSONString converts a genai.Schema to a pretty-printed JSON string.
+// Used for prompt-based JSON output fallback on Vertex AI.
+func SchemaToJSONString(schema *genai.Schema) string {
+	m := SchemaToMap(schema)
+	b, err := json.MarshalIndent(m, "", "  ")
+	if err != nil {
+		return "{}"
+	}
+	return string(b)
+}
+
+// toolChoiceKind represents the resolved tool choice type.
+type toolChoiceKind int
+
+const (
+	toolChoiceNone toolChoiceKind = iota // omit tool_choice
+	toolChoiceAuto
+	toolChoiceAny
+	toolChoiceTool
+)
+
+// resolvedToolChoice holds the result of resolving a ToolConfig into a tool choice decision.
+type resolvedToolChoice struct {
+	kind     toolChoiceKind
+	toolName string // populated when kind == toolChoiceTool
+}
+
+// resolveToolChoice extracts the tool choice decision from a ToolConfig.
+// Returns an error for unsupported configurations (multiple AllowedFunctionNames,
+// unknown FunctionCallingConfig modes).
+func resolveToolChoice(config *genai.ToolConfig) (resolvedToolChoice, error) {
+	if config == nil || config.FunctionCallingConfig == nil {
+		return resolvedToolChoice{kind: toolChoiceNone}, nil
+	}
+
+	fcc := config.FunctionCallingConfig
+
+	if len(fcc.AllowedFunctionNames) > 1 {
+		return resolvedToolChoice{}, fmt.Errorf(
+			"Anthropic does not support multiple AllowedFunctionNames (got %d); use a single function name or remove the restriction",
+			len(fcc.AllowedFunctionNames),
+		)
+	}
+
+	switch fcc.Mode {
+	case genai.FunctionCallingConfigModeNone:
+		return resolvedToolChoice{kind: toolChoiceNone}, nil
+
+	case genai.FunctionCallingConfigModeAuto:
+		return resolvedToolChoice{kind: toolChoiceAuto}, nil
+
+	case genai.FunctionCallingConfigModeAny:
+		if len(fcc.AllowedFunctionNames) == 1 {
+			return resolvedToolChoice{kind: toolChoiceTool, toolName: fcc.AllowedFunctionNames[0]}, nil
+		}
+		return resolvedToolChoice{kind: toolChoiceAny}, nil
+
+	default:
+		return resolvedToolChoice{}, fmt.Errorf(
+			"unsupported FunctionCallingConfig mode %q; supported modes are: ModeNone, ModeAuto, ModeAny",
+			fcc.Mode,
+		)
+	}
+}
+
+// ToolConfigToToolChoice converts a genai.ToolConfig to Anthropic's tool_choice parameter.
+// Returns a zero-value union param when no tool_choice should be set (nil config, ModeNone),
+// which is safe to assign unconditionally as the SDK omits it during serialization.
+//
+// Mapping:
+//   - ModeNone -> zero value (omitted)
+//   - ModeAuto -> "auto" (model decides whether to use tools)
+//   - ModeAny -> "any" (model must use a tool)
+//   - ModeAny + single AllowedFunctionNames -> "tool" with specific name
+//
+// Returns an error if AllowedFunctionNames contains more than one function name,
+// or if the FunctionCallingConfig mode is not recognized.
+func ToolConfigToToolChoice(config *genai.ToolConfig) (anthropic.ToolChoiceUnionParam, error) {
+	resolved, err := resolveToolChoice(config)
+	if err != nil {
+		return anthropic.ToolChoiceUnionParam{}, err
+	}
+
+	switch resolved.kind {
+	case toolChoiceNone:
+		return anthropic.ToolChoiceUnionParam{}, nil
+	case toolChoiceAuto:
+		return anthropic.ToolChoiceUnionParam{
+			OfAuto: &anthropic.ToolChoiceAutoParam{},
+		}, nil
+	case toolChoiceAny:
+		return anthropic.ToolChoiceUnionParam{
+			OfAny: &anthropic.ToolChoiceAnyParam{},
+		}, nil
+	case toolChoiceTool:
+		return anthropic.ToolChoiceUnionParam{
+			OfTool: &anthropic.ToolChoiceToolParam{
+				Name: resolved.toolName,
+			},
+		}, nil
+	default:
+		return anthropic.ToolChoiceUnionParam{}, fmt.Errorf("unexpected tool choice kind: %d", resolved.kind)
+	}
+}

--- a/model/anthropic/variant.go
+++ b/model/anthropic/variant.go
@@ -1,0 +1,42 @@
+// Copyright 2025 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package anthropic
+
+import (
+	"os"
+	"strconv"
+	"strings"
+)
+
+// Backend variant constants.
+const (
+	// VariantAnthropicAPI uses the direct Anthropic API.
+	VariantAnthropicAPI = "ANTHROPIC_API"
+
+	// VariantVertexAI uses Anthropic models via Google Cloud Vertex AI.
+	VariantVertexAI = "VERTEX_AI"
+)
+
+// GetVariant returns the configured variant for the Anthropic backend.
+// It checks the ANTHROPIC_USE_VERTEX environment variable.
+// If set to "1" or "true" (case-insensitive), it returns VariantVertexAI.
+// Otherwise, it returns VariantAnthropicAPI.
+func GetVariant() string {
+	b, _ := strconv.ParseBool(strings.TrimSpace(os.Getenv("ANTHROPIC_USE_VERTEX")))
+	if b {
+		return VariantVertexAI
+	}
+	return VariantAnthropicAPI
+}


### PR DESCRIPTION
**Please ensure you have read the [contribution guide](./CONTRIBUTING.md) before creating a pull request.**

### Link to Issue or Description of Change

**1. Link to an existing issue (if applicable):**

- Closes: #225
- Related: N/A

**2. Or, if no issue exists, describe the change:**

N/A (issue exists)

**Problem:**
ADK Go was model-agnostic in design, but there was no first-party Anthropic provider package in this repository. Users wanting Claude support had to rely on external integrations.

**Solution:**
Added a new additive provider package at `model/anthropic` that implements the existing `model.LLM` interface without changing any existing API surface.  
The implementation includes:

- direct Anthropic API support and Vertex AI variant support,
- streaming and non-streaming generation paths,
- tool/function calling conversions,
- thinking config and structured output handling (including Vertex fallback),
- dedicated tests for the provider and converters.

Also added docs and a runnable example:

- `examples/anthropic/main.go`
- README updates documenting package usage.

### Testing Plan

_Please describe the tests that you ran to verify your changes. This is required
for all PRs that are not small documentation or typo fixes._

**Unit Tests:**

- [x] I have added or updated unit tests for my change.
- [x] All unit tests pass locally.

_Please include a summary of passed go test results._

Commands run:

- `go test ./model/anthropic/...`
- `go test ./model/...`
- `go test ./...`

Result summary:

- All tests passed locally, including the full repository test sweep.

**Manual End-to-End (E2E) Tests:**

Manual steps to verify locally:

1. Export `ANTHROPIC_API_KEY`.
2. Run: `go run ./examples/anthropic/main.go --help` (launcher wiring check).
3. Run the example via console mode and prompt the agent (for example, “Give a short summary of Sydney weather patterns in summer.”).
4. Optionally validate Vertex mode by setting:
   - `ANTHROPIC_USE_VERTEX=1`
   - `GOOGLE_CLOUD_PROJECT`
   - `GOOGLE_CLOUD_LOCATION`

Notes:

- Full automated test suite passed.
- Live Anthropic API behaviour depends on local credentials and environment.

### Checklist

- [x] I have read the [CONTRIBUTING.md](./CONTRIBUTING.md) document.
- [x] I have performed a self-review of my own code.
- [x] I have commented my code, particularly in hard-to-understand areas.
- [x] I have added tests that prove my fix is effective or that my feature works.
- [x] New and existing unit tests pass locally with my changes.
- [x] I have manually tested my changes end-to-end.
- [x] Any dependent changes have been merged and published in downstream modules.

### Additional context

This PR keeps change surface minimal and idiomatic to existing repo patterns:

- no modifications to existing public interfaces,
- provider is opt-in via package import (`google.golang.org/adk/model/anthropic`),
- converter logic is internal to the provider package to avoid unnecessary exported surface.
