### PR TITLE
fix: prevent panic when artifact service is not configured

### DIFF
--- a/internal/toolinternal/context.go
+++ b/internal/toolinternal/context.go
@@ -30,12 +30,17 @@ import (
 	"google.golang.org/adk/tool/toolconfirmation"
 )
 
+const artifactServiceNotConfiguredMsg = "artifact service is not configured: please configure ArtifactService in the runner"
+
 type internalArtifacts struct {
 	agent.Artifacts
 	eventActions *session.EventActions
 }
 
 func (ia *internalArtifacts) Save(ctx context.Context, name string, data *genai.Part) (*artifact.SaveResponse, error) {
+	if ia.Artifacts == nil {
+		return nil, fmt.Errorf(artifactServiceNotConfiguredMsg)
+	}
 	resp, err := ia.Artifacts.Save(ctx, name, data)
 	if err != nil {
 		return resp, err
@@ -48,6 +53,27 @@ func (ia *internalArtifacts) Save(ctx context.Context, name string, data *genai.
 		ia.eventActions.ArtifactDelta[name] = resp.Version
 	}
 	return resp, nil
+}
+
+func (ia *internalArtifacts) List(ctx context.Context) (*artifact.ListResponse, error) {
+	if ia.Artifacts == nil {
+		return nil, fmt.Errorf(artifactServiceNotConfiguredMsg)
+	}
+	return ia.Artifacts.List(ctx)
+}
+
+func (ia *internalArtifacts) Load(ctx context.Context, name string) (*artifact.LoadResponse, error) {
+	if ia.Artifacts == nil {
+		return nil, fmt.Errorf(artifactServiceNotConfiguredMsg)
+	}
+	return ia.Artifacts.Load(ctx, name)
+}
+
+func (ia *internalArtifacts) LoadVersion(ctx context.Context, name string, version int) (*artifact.LoadResponse, error) {
+	if ia.Artifacts == nil {
+		return nil, fmt.Errorf(artifactServiceNotConfiguredMsg)
+	}
+	return ia.Artifacts.LoadVersion(ctx, name, version)
 }
 
 func NewToolContext(ctx agent.InvocationContext, functionCallID string, actions *session.EventActions, confirmation *toolconfirmation.ToolConfirmation) tool.Context {

--- a/internal/toolinternal/context_test.go
+++ b/internal/toolinternal/context_test.go
@@ -15,6 +15,7 @@
 package toolinternal
 
 import (
+	"strings"
 	"testing"
 
 	"google.golang.org/adk/agent"
@@ -88,4 +89,58 @@ func TestRequestConfirmation_AutoGeneratesIDWhenEmpty(t *testing.T) {
 			t.Error("expected Confirmed to be false")
 		}
 	}
+}
+
+func TestInternalArtifacts_NilArtifactsService(t *testing.T) {
+	// Create a tool context with nil artifacts service
+	inv := contextinternal.NewInvocationContext(t.Context(), contextinternal.InvocationContextParams{
+		Artifacts: nil, // Explicitly set to nil to simulate misconfiguration
+	})
+	toolCtx := NewToolContext(inv, "fn1", &session.EventActions{}, nil)
+
+	artifacts := toolCtx.Artifacts()
+
+	t.Run("List returns error for nil service", func(t *testing.T) {
+		_, err := artifacts.List(t.Context())
+		if err == nil {
+			t.Fatal("expected error when calling List on nil artifacts service, got nil")
+		}
+		expectedMsg := "artifact service is not configured"
+		if !strings.Contains(err.Error(), expectedMsg) {
+			t.Errorf("expected error message to contain %q, got %q", expectedMsg, err.Error())
+		}
+	})
+
+	t.Run("Load returns error for nil service", func(t *testing.T) {
+		_, err := artifacts.Load(t.Context(), "test.txt")
+		if err == nil {
+			t.Fatal("expected error when calling Load on nil artifacts service, got nil")
+		}
+		expectedMsg := "artifact service is not configured"
+		if !strings.Contains(err.Error(), expectedMsg) {
+			t.Errorf("expected error message to contain %q, got %q", expectedMsg, err.Error())
+		}
+	})
+
+	t.Run("LoadVersion returns error for nil service", func(t *testing.T) {
+		_, err := artifacts.LoadVersion(t.Context(), "test.txt", 1)
+		if err == nil {
+			t.Fatal("expected error when calling LoadVersion on nil artifacts service, got nil")
+		}
+		expectedMsg := "artifact service is not configured"
+		if !strings.Contains(err.Error(), expectedMsg) {
+			t.Errorf("expected error message to contain %q, got %q", expectedMsg, err.Error())
+		}
+	})
+
+	t.Run("Save returns error for nil service", func(t *testing.T) {
+		_, err := artifacts.Save(t.Context(), "test.txt", nil)
+		if err == nil {
+			t.Fatal("expected error when calling Save on nil artifacts service, got nil")
+		}
+		expectedMsg := "artifact service is not configured"
+		if !strings.Contains(err.Error(), expectedMsg) {
+			t.Errorf("expected error message to contain %q, got %q", expectedMsg, err.Error())
+		}
+	})
 }

--- a/tool/loadartifactstool/load_artifacts_tool_test.go
+++ b/tool/loadartifactstool/load_artifacts_tool_test.go
@@ -293,3 +293,31 @@ func createToolContext(t *testing.T) tool.Context {
 
 	return toolinternal.NewToolContext(ctx, "", nil, nil)
 }
+
+func TestLoadArtifactsTool_ProcessRequest_NilArtifactService(t *testing.T) {
+	loadArtifactsTool := loadartifactstool.New()
+
+	// Create a tool context WITHOUT an artifact service (nil)
+	ctx := icontext.NewInvocationContext(t.Context(), icontext.InvocationContextParams{
+		Artifacts: nil, // Explicitly nil to simulate misconfiguration
+	})
+	tc := toolinternal.NewToolContext(ctx, "", nil, nil)
+
+	llmRequest := &model.LLMRequest{}
+
+	requestProcessor, ok := loadArtifactsTool.(toolinternal.RequestProcessor)
+	if !ok {
+		t.Fatal("loadArtifactsTool does not implement RequestProcessor")
+	}
+
+	// This should return an error instead of panicking
+	err := requestProcessor.ProcessRequest(tc, llmRequest)
+	if err == nil {
+		t.Fatal("expected error when artifact service is not configured, got nil")
+	}
+
+	expectedMsg := "artifact service is not configured"
+	if !strings.Contains(err.Error(), expectedMsg) {
+		t.Errorf("expected error to contain %q, got %q", expectedMsg, err.Error())
+	}
+}


### PR DESCRIPTION
# Fix: Prevent Panic When Artifact Service Is Not Configured

Fixes #283

## 🐛 Problem

When using `loadartifactstool` without properly configuring an `ArtifactService` in the runner, the application crashes with a nil pointer dereference panic:

```
panic: runtime error: invalid memory address or nil pointer dereference
[signal SIGSEGV: segmentation violation code=0x2 addr=0x18 pc=0x100a9eba0]

goroutine 1 [running]:
google.golang.org/adk/internal/toolinternal.(*internalArtifacts).List(...)
```

This provides a poor developer experience as the error is not caught early and the crash message doesn't clearly explain the misconfiguration.

## ✅ Solution

Added nil checks in the `internalArtifacts` wrapper methods to return a descriptive error when the artifact service is not configured.

### Changes Made

1. **Added nil checks in `internal/toolinternal/context.go`**:
   - `List()` - checks for nil before calling underlying service
   - `Load()` - checks for nil before calling underlying service
   - `LoadVersion()` - checks for nil before calling underlying service
   - `Save()` - checks for nil before calling underlying service

2. **Clear error message**:
   ```
   artifact service is not configured: please configure ArtifactService in the runner
   ```

3. **Comprehensive test coverage**:
   - Unit tests in `internal/toolinternal/context_test.go` verify error handling for all methods
   - Integration test in `tool/loadartifactstool/load_artifacts_tool_test.go` ensures graceful error handling

## 🧪 Testing Plan

### Unit Tests
- ✅ `TestInternalArtifacts_NilArtifactsService` - Tests all four methods (List, Load, LoadVersion, Save) return proper errors when service is nil
- ✅ Verifies error messages contain "artifact service is not configured"

### Integration Test
- ✅ `TestLoadArtifactsTool_ProcessRequest_NilArtifactService` - Ensures `ProcessRequest` returns error instead of panicking when artifact service is not configured

### Regression Testing
- ✅ All existing tests continue to pass
- ✅ Normal operation with properly configured artifact service is unaffected

## 📝 Testing Evidence

```bash
# Unit tests pass
$ cd internal/toolinternal && go test -run TestInternalArtifacts_NilArtifactsService
PASS
ok  	google.golang.org/adk/internal/toolinternal	0.691s

# Integration test passes
$ cd tool/loadartifactstool && go test -run TestLoadArtifactsTool_ProcessRequest_NilArtifactService
PASS
ok  	google.golang.org/adk/tool/loadartifactstool	0.735s
```

## 🔍 Code Review Notes

- The fix follows the existing error handling pattern used in `SearchMemory()` (line 104-106 in context.go)
- Error messages are descriptive and actionable
- No breaking changes - only adds safety checks
- Minimal code changes focused on the specific issue

## 📚 Related

- Issue #283: Panic when Artifact tool is not properly setup
- Follows Google Go Style Guide error handling best practices
