### PR TITLE
ADK Rest API: Log any non-user errors

### DIFF
--- a/server/adkrest/controllers/artifacts.go
+++ b/server/adkrest/controllers/artifacts.go
@@ -15,6 +15,7 @@
 package controllers
 
 import (
+	"log/slog"
 	"net/http"
 	"strconv"
 
@@ -38,6 +39,7 @@ func (c *ArtifactsAPIController) ListArtifactsHandler(rw http.ResponseWriter, re
 	vars := mux.Vars(req)
 	sessionID, err := models.SessionIDFromHTTPParameters(vars)
 	if err != nil {
+		slog.ErrorContext(req.Context(), "Error while getting session ID", slog.Any("err", err))
 		http.Error(rw, err.Error(), http.StatusBadRequest)
 		return
 	}
@@ -51,6 +53,7 @@ func (c *ArtifactsAPIController) ListArtifactsHandler(rw http.ResponseWriter, re
 		SessionID: sessionID.ID,
 	})
 	if err != nil {
+		slog.ErrorContext(req.Context(), "Error while listing artifacts", slog.Any("err", err))
 		http.Error(rw, err.Error(), http.StatusInternalServerError)
 		return
 	}
@@ -66,6 +69,7 @@ func (c *ArtifactsAPIController) LoadArtifactHandler(rw http.ResponseWriter, req
 	vars := mux.Vars(req)
 	sessionID, err := models.SessionIDFromHTTPParameters(vars)
 	if err != nil {
+		slog.ErrorContext(req.Context(), "Error while getting session ID", slog.Any("err", err))
 		http.Error(rw, err.Error(), http.StatusBadRequest)
 		return
 	}
@@ -98,6 +102,7 @@ func (c *ArtifactsAPIController) LoadArtifactHandler(rw http.ResponseWriter, req
 
 	resp, err := c.artifactService.Load(req.Context(), loadReq)
 	if err != nil {
+		slog.ErrorContext(req.Context(), "Error while loading artifact", slog.Any("err", err))
 		http.Error(rw, err.Error(), http.StatusInternalServerError)
 		return
 	}
@@ -109,6 +114,7 @@ func (c *ArtifactsAPIController) LoadArtifactVersionHandler(rw http.ResponseWrit
 	vars := mux.Vars(req)
 	sessionID, err := models.SessionIDFromHTTPParameters(vars)
 	if err != nil {
+		slog.ErrorContext(req.Context(), "Error while getting session ID", slog.Any("err", err))
 		http.Error(rw, err.Error(), http.StatusBadRequest)
 		return
 	}
@@ -144,6 +150,7 @@ func (c *ArtifactsAPIController) LoadArtifactVersionHandler(rw http.ResponseWrit
 
 	resp, err := c.artifactService.Load(req.Context(), loadReq)
 	if err != nil {
+		slog.ErrorContext(req.Context(), "Error while loading artifact at version", slog.Any("err", err))
 		http.Error(rw, err.Error(), http.StatusInternalServerError)
 		return
 	}
@@ -155,6 +162,7 @@ func (c *ArtifactsAPIController) DeleteArtifactHandler(rw http.ResponseWriter, r
 	vars := mux.Vars(req)
 	sessionID, err := models.SessionIDFromHTTPParameters(vars)
 	if err != nil {
+		slog.ErrorContext(req.Context(), "Error while getting session ID", slog.Any("err", err))
 		http.Error(rw, err.Error(), http.StatusBadRequest)
 		return
 	}
@@ -174,6 +182,7 @@ func (c *ArtifactsAPIController) DeleteArtifactHandler(rw http.ResponseWriter, r
 		FileName:  artifactName,
 	})
 	if err != nil {
+		slog.ErrorContext(req.Context(), "Error while deleting artifact", slog.Any("err", err))
 		http.Error(rw, err.Error(), http.StatusInternalServerError)
 		return
 	}

--- a/server/adkrest/controllers/debug.go
+++ b/server/adkrest/controllers/debug.go
@@ -16,6 +16,7 @@ package controllers
 
 import (
 	"fmt"
+	"log/slog"
 	"net/http"
 	"slices"
 
@@ -104,6 +105,7 @@ func (c *DebugAPIController) EventGraphHandler(rw http.ResponseWriter, req *http
 	vars := mux.Vars(req)
 	sessionID, err := models.SessionIDFromHTTPParameters(vars)
 	if err != nil {
+		slog.ErrorContext(req.Context(), "Error while getting session ID", slog.Any("err", err))
 		http.Error(rw, err.Error(), http.StatusBadRequest)
 		return
 	}
@@ -113,6 +115,7 @@ func (c *DebugAPIController) EventGraphHandler(rw http.ResponseWriter, req *http
 		SessionID: sessionID.ID,
 	})
 	if err != nil {
+		slog.ErrorContext(req.Context(), "Error while getting session", slog.Any("err", err))
 		http.Error(rw, err.Error(), http.StatusBadRequest)
 		return
 	}
@@ -157,11 +160,13 @@ func (c *DebugAPIController) EventGraphHandler(rw http.ResponseWriter, req *http
 
 	agent, err := c.agentloader.LoadAgent(sessionID.AppName)
 	if err != nil {
+		slog.ErrorContext(req.Context(), "Error while loading agent", slog.Any("err", err))
 		http.Error(rw, err.Error(), http.StatusInternalServerError)
 		return
 	}
 	graph, err := services.GetAgentGraph(req.Context(), agent, highlightedPairs)
 	if err != nil {
+		slog.ErrorContext(req.Context(), "Error while getting agent graph", slog.Any("err", err))
 		http.Error(rw, err.Error(), http.StatusInternalServerError)
 		return
 	}

--- a/server/adkrest/controllers/sessions.go
+++ b/server/adkrest/controllers/sessions.go
@@ -17,6 +17,7 @@ package controllers
 import (
 	"context"
 	"encoding/json"
+	"log/slog"
 	"net/http"
 
 	"github.com/gorilla/mux"
@@ -42,6 +43,7 @@ func (c *SessionsAPIController) CreateSessionHandler(rw http.ResponseWriter, req
 	params := mux.Vars(req)
 	sessionID, err := models.SessionIDFromHTTPParameters(params)
 	if err != nil {
+		slog.ErrorContext(req.Context(), "Error while getting session ID", slog.Any("err", err))
 		http.Error(rw, err.Error(), http.StatusBadRequest)
 		return
 	}
@@ -50,12 +52,14 @@ func (c *SessionsAPIController) CreateSessionHandler(rw http.ResponseWriter, req
 	if req.ContentLength > 0 {
 		err := json.NewDecoder(req.Body).Decode(&createSessionRequest)
 		if err != nil {
+			slog.ErrorContext(req.Context(), "Error while parsing body", slog.Any("err", err))
 			http.Error(rw, err.Error(), http.StatusBadRequest)
 			return
 		}
 	}
 	respSession, err := c.createSession(req.Context(), sessionID, createSessionRequest)
 	if err != nil {
+		slog.ErrorContext(req.Context(), "Error while creating session", slog.Any("err", err))
 		http.Error(rw, err.Error(), http.StatusInternalServerError)
 		return
 	}
@@ -86,6 +90,7 @@ func (c *SessionsAPIController) DeleteSessionHandler(rw http.ResponseWriter, req
 	params := mux.Vars(req)
 	sessionID, err := models.SessionIDFromHTTPParameters(params)
 	if err != nil {
+		slog.ErrorContext(req.Context(), "Error while getting session ID", slog.Any("err", err))
 		http.Error(rw, err.Error(), http.StatusBadRequest)
 		return
 	}
@@ -100,6 +105,7 @@ func (c *SessionsAPIController) DeleteSessionHandler(rw http.ResponseWriter, req
 		SessionID: sessionID.ID,
 	})
 	if err != nil {
+		slog.ErrorContext(req.Context(), "Error while deleting session", slog.Any("err", err))
 		http.Error(rw, err.Error(), http.StatusInternalServerError)
 		return
 	}
@@ -111,6 +117,7 @@ func (c *SessionsAPIController) GetSessionHandler(rw http.ResponseWriter, req *h
 	params := mux.Vars(req)
 	sessionID, err := models.SessionIDFromHTTPParameters(params)
 	if err != nil {
+		slog.ErrorContext(req.Context(), "Error while getting session ID", slog.Any("err", err))
 		http.Error(rw, err.Error(), http.StatusBadRequest)
 		return
 	}
@@ -124,11 +131,13 @@ func (c *SessionsAPIController) GetSessionHandler(rw http.ResponseWriter, req *h
 		SessionID: sessionID.ID,
 	})
 	if err != nil {
+		slog.ErrorContext(req.Context(), "Error while getting session", slog.Any("err", err))
 		http.Error(rw, err.Error(), http.StatusInternalServerError)
 		return
 	}
 	session, err := models.FromSession(storedSession.Session)
 	if err != nil {
+		slog.ErrorContext(req.Context(), "Error while converting session to wire format", slog.Any("err", err))
 		http.Error(rw, err.Error(), http.StatusInternalServerError)
 		return
 	}
@@ -140,6 +149,7 @@ func (c *SessionsAPIController) ListSessionsHandler(rw http.ResponseWriter, req 
 	params := mux.Vars(req)
 	sessionID, err := models.SessionIDFromHTTPParameters(params)
 	if err != nil {
+		slog.ErrorContext(req.Context(), "Error while getting session ID", slog.Any("err", err))
 		http.Error(rw, err.Error(), http.StatusBadRequest)
 		return
 	}
@@ -149,12 +159,14 @@ func (c *SessionsAPIController) ListSessionsHandler(rw http.ResponseWriter, req 
 		UserID:  sessionID.UserID,
 	})
 	if err != nil {
+		slog.ErrorContext(req.Context(), "Error while listing sessions", slog.Any("err", err))
 		http.Error(rw, err.Error(), http.StatusInternalServerError)
 		return
 	}
 	for _, session := range resp.Sessions {
 		respSession, err := models.FromSession(session)
 		if err != nil {
+			slog.ErrorContext(req.Context(), "Error while converting session to wire format", slog.Any("err", err))
 			http.Error(rw, err.Error(), http.StatusInternalServerError)
 			return
 		}


### PR DESCRIPTION
I hit this while developing a custom agent with a custom session storage service.  Conventionally, errors that occur during HTTP handlers need to be logged, so that the server operator can see them for observability and debugging.

Just dumping the error to the response risks over-sharing error details with the client, and also the ADK Web UI doesn't surface them.

No unit tests for logging, typically.

### Checklist

- [x] I have read the [CONTRIBUTING.md](./CONTRIBUTING.md) document.
- [x] I have performed a self-review of my own code.
- [x] I have commented my code, particularly in hard-to-understand areas.
- [x] I have added tests that prove my fix is effective or that my feature works.
- [x] New and existing unit tests pass locally with my changes.
- [x] I have manually tested my changes end-to-end.
- [x] Any dependent changes have been merged and published in downstream modules.


