### PR TITLE
fix(adkrest): apply stateDelta from /api/run before agent run

### DIFF
--- a/server/adkrest/controllers/runtime.go
+++ b/server/adkrest/controllers/runtime.go
@@ -18,6 +18,7 @@ import (
 	"context"
 	"encoding/json"
 	"fmt"
+	"maps"
 	"net/http"
 	"time"
 
@@ -167,6 +168,10 @@ func flashEvent(rc *http.ResponseController, rw http.ResponseWriter, event sessi
 	return nil
 }
 
+// validateSessionExists fetches the session by appName, userID, and sessionID from the request.
+// Security: userID and sessionID are taken from the request body and are not verified against
+// the authenticated user. When authentication is enabled, callers should ensure the request's
+// userId matches the identity from the auth token/session before invoking this handler.
 func (c *RuntimeAPIController) validateSessionExists(ctx context.Context, appName, userID, sessionID string) (session.Session, error) {
 	resp, err := c.sessionService.Get(ctx, &session.GetRequest{
 		AppName:   appName,
@@ -180,20 +185,19 @@ func (c *RuntimeAPIController) validateSessionExists(ctx context.Context, appNam
 }
 
 // applyStateDeltaIfPresent appends a state_delta event to the session when the request
-// includes a non-empty StateDelta. The map is shallow-copied so the event does not
-// share the request's map.
+// includes a non-empty StateDelta. The map is shallow-copied via maps.Clone so the
+// event does not share the request's map.
+//
+// Security: stateDelta keys are not validated here; the request can include app-scoped
+// (app:) and user-scoped (user:) keys. Callers or the session service should sanitize
+// to allowed keys or enforce access control to prevent injection of arbitrary state.
 func (c *RuntimeAPIController) applyStateDeltaIfPresent(ctx context.Context, ssn session.Session, stateDelta *map[string]any) error {
 	if stateDelta == nil || len(*stateDelta) == 0 {
 		return nil
 	}
 	ev := session.NewEvent(uuid.New().String())
 	ev.Author = "system"
-
-	deltaCopy := make(map[string]any, len(*stateDelta))
-	for k, v := range *stateDelta {
-		deltaCopy[k] = v
-	}
-	ev.Actions.StateDelta = deltaCopy
+	ev.Actions.StateDelta = maps.Clone(*stateDelta)
 	return c.sessionService.AppendEvent(ctx, ssn, ev)
 }
 

--- a/server/adkrest/controllers/runtime.go
+++ b/server/adkrest/controllers/runtime.go
@@ -21,6 +21,7 @@ import (
 	"net/http"
 	"time"
 
+	"github.com/google/uuid"
 	"google.golang.org/adk/agent"
 	"google.golang.org/adk/artifact"
 	"google.golang.org/adk/memory"
@@ -64,9 +65,13 @@ func (c *RuntimeAPIController) RunHandler(rw http.ResponseWriter, req *http.Requ
 
 // RunAgent executes a non-streaming agent run for a given session and message.
 func (c *RuntimeAPIController) runAgent(ctx context.Context, runAgentRequest models.RunAgentRequest) ([]*session.Event, error) {
-	err := c.validateSessionExists(ctx, runAgentRequest.AppName, runAgentRequest.UserId, runAgentRequest.SessionId)
+	ssn, err := c.validateSessionExists(ctx, runAgentRequest.AppName, runAgentRequest.UserId, runAgentRequest.SessionId)
 	if err != nil {
 		return nil, err
+	}
+
+	if err := c.applyStateDeltaIfPresent(ctx, ssn, runAgentRequest.StateDelta); err != nil {
+		return nil, newStatusError(fmt.Errorf("failed to append event: %w", err), http.StatusInternalServerError)
 	}
 
 	r, rCfg, err := c.getRunner(runAgentRequest)
@@ -105,9 +110,13 @@ func (c *RuntimeAPIController) RunSSEHandler(rw http.ResponseWriter, req *http.R
 		return err
 	}
 
-	err = c.validateSessionExists(req.Context(), runAgentRequest.AppName, runAgentRequest.UserId, runAgentRequest.SessionId)
+	ssn, err := c.validateSessionExists(req.Context(), runAgentRequest.AppName, runAgentRequest.UserId, runAgentRequest.SessionId)
 	if err != nil {
 		return err
+	}
+
+	if err := c.applyStateDeltaIfPresent(req.Context(), ssn, runAgentRequest.StateDelta); err != nil {
+		return newStatusError(fmt.Errorf("failed to append event: %w", err), http.StatusInternalServerError)
 	}
 
 	r, rCfg, err := c.getRunner(runAgentRequest)
@@ -158,16 +167,34 @@ func flashEvent(rc *http.ResponseController, rw http.ResponseWriter, event sessi
 	return nil
 }
 
-func (c *RuntimeAPIController) validateSessionExists(ctx context.Context, appName, userID, sessionID string) error {
-	_, err := c.sessionService.Get(ctx, &session.GetRequest{
+func (c *RuntimeAPIController) validateSessionExists(ctx context.Context, appName, userID, sessionID string) (session.Session, error) {
+	resp, err := c.sessionService.Get(ctx, &session.GetRequest{
 		AppName:   appName,
 		UserID:    userID,
 		SessionID: sessionID,
 	})
 	if err != nil {
-		return newStatusError(fmt.Errorf("failed to get session: %w", err), http.StatusNotFound)
+		return nil, newStatusError(fmt.Errorf("failed to get session: %w", err), http.StatusNotFound)
 	}
-	return nil
+	return resp.Session, nil
+}
+
+// applyStateDeltaIfPresent appends a state_delta event to the session when the request
+// includes a non-empty StateDelta. The map is shallow-copied so the event does not
+// share the request's map.
+func (c *RuntimeAPIController) applyStateDeltaIfPresent(ctx context.Context, ssn session.Session, stateDelta *map[string]any) error {
+	if stateDelta == nil || len(*stateDelta) == 0 {
+		return nil
+	}
+	ev := session.NewEvent(uuid.New().String())
+	ev.Author = "system"
+
+	deltaCopy := make(map[string]any, len(*stateDelta))
+	for k, v := range *stateDelta {
+		deltaCopy[k] = v
+	}
+	ev.Actions.StateDelta = deltaCopy
+	return c.sessionService.AppendEvent(ctx, ssn, ev)
 }
 
 func (c *RuntimeAPIController) getRunner(req models.RunAgentRequest) (*runner.Runner, *agent.RunConfig, error) {

--- a/server/adkrest/controllers/runtime_test.go
+++ b/server/adkrest/controllers/runtime_test.go
@@ -15,11 +15,13 @@
 package controllers
 
 import (
+	"context"
 	"testing"
 	"time"
 
 	"google.golang.org/adk/plugin"
 	"google.golang.org/adk/runner"
+	"google.golang.org/adk/session"
 )
 
 func TestNewRuntimeAPIController_PluginsAssignment(t *testing.T) {
@@ -75,4 +77,111 @@ func TestNewRuntimeAPIController_PluginsAssignment(t *testing.T) {
 			}
 		})
 	}
+}
+
+// recordingSessionService wraps a session.Service and records each AppendEvent call.
+type recordingSessionService struct {
+	session.Service
+	appendEventCalls []*session.Event
+}
+
+func (r *recordingSessionService) AppendEvent(ctx context.Context, s session.Session, ev *session.Event) error {
+	r.appendEventCalls = append(r.appendEventCalls, ev)
+	return r.Service.AppendEvent(ctx, s, ev)
+}
+
+func TestRuntimeAPIController_applyStateDeltaIfPresent(t *testing.T) {
+	ctx := context.Background()
+	base := session.InMemoryService()
+	rec := &recordingSessionService{Service: base}
+
+	createResp, err := base.Create(ctx, &session.CreateRequest{
+		AppName:   "app",
+		UserID:    "user",
+		SessionID: "sess",
+	})
+	if err != nil {
+		t.Fatalf("Create session: %v", err)
+	}
+	ssn := createResp.Session
+
+	c := NewRuntimeAPIController(rec, nil, nil, nil, 10*time.Second, runner.PluginConfig{})
+
+	t.Run("nil stateDelta does not call AppendEvent", func(t *testing.T) {
+		rec.appendEventCalls = nil
+		if err := c.applyStateDeltaIfPresent(ctx, ssn, nil); err != nil {
+			t.Errorf("applyStateDeltaIfPresent(nil): %v", err)
+		}
+		if n := len(rec.appendEventCalls); n != 0 {
+			t.Errorf("AppendEvent called %d times, want 0", n)
+		}
+		// Validate from session perspective: no new events.
+		getResp, err := rec.Get(ctx, &session.GetRequest{AppName: "app", UserID: "user", SessionID: "sess"})
+		if err != nil {
+			t.Fatalf("Get session: %v", err)
+		}
+		if n := getResp.Session.Events().Len(); n != 0 {
+			t.Errorf("session Events().Len() = %d, want 0 after nil stateDelta", n)
+		}
+	})
+
+	t.Run("empty stateDelta does not call AppendEvent", func(t *testing.T) {
+		rec.appendEventCalls = nil
+		empty := map[string]any{}
+		if err := c.applyStateDeltaIfPresent(ctx, ssn, &empty); err != nil {
+			t.Errorf("applyStateDeltaIfPresent(empty): %v", err)
+		}
+		if n := len(rec.appendEventCalls); n != 0 {
+			t.Errorf("AppendEvent called %d times, want 0", n)
+		}
+		// Validate from session perspective: no new events.
+		getResp, err := rec.Get(ctx, &session.GetRequest{AppName: "app", UserID: "user", SessionID: "sess"})
+		if err != nil {
+			t.Fatalf("Get session: %v", err)
+		}
+		if n := getResp.Session.Events().Len(); n != 0 {
+			t.Errorf("session Events().Len() = %d, want 0 after empty stateDelta", n)
+		}
+	})
+
+	t.Run("non-empty stateDelta appends event with Author system and shallow-copied delta", func(t *testing.T) {
+		rec.appendEventCalls = nil
+		delta := map[string]any{"user:key": "value", "user:other": 42}
+		if err := c.applyStateDeltaIfPresent(ctx, ssn, &delta); err != nil {
+			t.Errorf("applyStateDeltaIfPresent: %v", err)
+		}
+		if n := len(rec.appendEventCalls); n != 1 {
+			t.Fatalf("AppendEvent called %d times, want 1", n)
+		}
+		ev := rec.appendEventCalls[0]
+		if ev.Author != "system" {
+			t.Errorf("event.Author = %q, want %q", ev.Author, "system")
+		}
+		if ev.Actions.StateDelta == nil {
+			t.Fatal("event.Actions.StateDelta is nil")
+		}
+		if got := ev.Actions.StateDelta["user:key"]; got != "value" {
+			t.Errorf("StateDelta[user:key] = %v, want value", got)
+		}
+		if got := ev.Actions.StateDelta["user:other"]; got != 42 {
+			t.Errorf("StateDelta[user:other] = %v, want 42", got)
+		}
+		// Shallow copy: mutating the request map after the call must not change the stored event.
+		delta["user:key"] = "mutated"
+		if got := ev.Actions.StateDelta["user:key"]; got != "value" {
+			t.Errorf("after mutating request map, StateDelta[user:key] = %v, want value (stored event must be a copy)", got)
+		}
+		// Validate from session perspective: state was merged.
+		getResp, err := rec.Get(ctx, &session.GetRequest{AppName: "app", UserID: "user", SessionID: "sess"})
+		if err != nil {
+			t.Fatalf("Get session: %v", err)
+		}
+		state := getResp.Session.State()
+		if got, err := state.Get("user:key"); err != nil || got != "value" {
+			t.Errorf("session state user:key = %v, err = %v; want value", got, err)
+		}
+		if got, err := state.Get("user:other"); err != nil || got != 42 {
+			t.Errorf("session state user:other = %v, err = %v; want 42", got, err)
+		}
+	})
 }


### PR DESCRIPTION
**Please ensure you have read the [contribution guide](./CONTRIBUTING.md) before creating a pull request.**

### Link to Issue or Description of Change

**1. Link to an existing issue (if applicable):**

- Closes: #632

**2. Or, if no issue exists, describe the change:**

N/A — see issue #632.

**Problem:**
The `/api/run` REST endpoint accepts a `stateDelta` field in the JSON body (`RunAgentRequest.StateDelta`), but the runtime controller never applied it to the session. The value was decoded and then ignored, so callers (e.g. LRO resume flows sending a state delta) saw no change in session state and the agent run did not see the updated state.

**Solution:**
Apply the request’s `stateDelta` to the session before running the agent, in line with the [ADK state docs](https://google.github.io/adk-docs/sessions/state/#how-state-is-updated-recommended-methods): when `StateDelta` is non-nil and non-empty, append a single event with `EventActions.state_delta` via `sessionService.AppendEvent`, then run the agent so the runner’s subsequent `Get()` sees the merged state. The delta map is shallow-copied before attaching it to the event so the stored event does not share the request’s map. This logic is centralized in a new helper `applyStateDeltaIfPresent` and used from both `RunHandler` and `RunSSEHandler`.

### Testing Plan

_Please describe the tests that you ran to verify your changes. This is required for all PRs that are not small documentation or typo fixes._

**Unit Tests:**

- [x] I have added or updated unit tests for my change.
- [x] All unit tests pass locally.

Added `TestRuntimeAPIController_applyStateDeltaIfPresent` in `server/adkrest/controllers/runtime_test.go`. It uses a recording session service to assert: (1) nil or empty `stateDelta` does not call `AppendEvent` and session event count stays 0 (validated via Get); (2) non-empty `stateDelta` causes one `AppendEvent` with Author `"system"`, correct `StateDelta` content, and a shallow copy (mutating the request map after the call does not change the stored event); (3) after applying a non-empty delta, Get session and verify state contains the merged keys (`user:key`, `user:other`).

```text
go test ./server/adkrest/controllers/ -run TestRuntimeAPIController_applyStateDeltaIfPresent -v
# PASS (all subtests: nil, empty, non-empty + Get validation)
```

**Manual End-to-End (E2E) Tests:**

1. Run an ADK app with the REST API launcher serving `/api/run`.
2. Create a session and run the agent at least once.
3. POST to `/api/run` with a JSON body that includes `stateDelta` (e.g. `"stateDelta": { "user:test_key": "test_value" }`) along with `appName`, `userId`, `sessionId`, and `newMessage`.
4. After the run completes, inspect the session (e.g. via session service or a follow-up run that reads state). The keys from `stateDelta` should be present in the session state.
5. Repeat with the SSE run endpoint if applicable; behavior should be the same.

_Provide logs or screenshots showing session state before/after the request with `stateDelta` to confirm the merge._

### Checklist

- [x] I have read the [CONTRIBUTING.md](./CONTRIBUTING.md) document.
- [x] I have performed a self-review of my own code.
- [x] I have commented my code, particularly in hard-to-understand areas.
- [x] I have added tests that prove my fix is effective or that my feature works.
- [x] New and existing unit tests pass locally with my changes.
- [x] I have manually tested my changes end-to-end.
- [ ] Any dependent changes have been merged and published in downstream modules.

### Additional context

- Affected code: `server/adkrest/controllers/runtime.go` — `runAgent`, `RunSSEHandler`, and new helper `applyStateDeltaIfPresent`. Tests in `server/adkrest/controllers/runtime_test.go` (`TestRuntimeAPIController_applyStateDeltaIfPresent`).
- No new dependencies; uses existing `session` package and `sessionService.AppendEvent`.
- Bug report and expected behaviour are documented in the project’s `state_delta_bug.md` for reference.
