### PR TITLE
Upgrade GitHub Actions to latest versions

### DIFF
--- a/.github/workflows/go.yml
+++ b/.github/workflows/go.yml
@@ -45,7 +45,7 @@ jobs:
       uses: ./.github/actions/setup
     
     - name: Lint
-      uses: golangci/golangci-lint-action@4afd733a84b1f43292c63897423277bb7f4313a9 # v8.0.0
+      uses: golangci/golangci-lint-action@1e7e51e771db61008b38414a730f564565cf7c20  # v9.2.0
       with:
         install-mode: goinstall
         version: 5256574b81bcedfbcae9099f745f6aee9335da10 # v2.3.1


### PR DESCRIPTION
## Summary

Upgrade GitHub Actions to their latest versions for improved features, bug fixes, and security updates.

## Changes

| Action | Old Version(s) | New Version | Release | Files |
|--------|---------------|-------------|---------|-------|
| `golangci/golangci-lint-action` | [`4afd733`](https://github.com/golangci/golangci-lint-action/commit/4afd733a84b1f43292c63897423277bb7f4313a9) | [`1e7e51e`](https://github.com/golangci/golangci-lint-action/commit/1e7e51e771db61008b38414a730f564565cf7c20) | [Release](https://github.com/golangci/golangci-lint-action/releases/tag/v9) | go.yml |

## Why upgrade?

Keeping GitHub Actions up to date ensures:
- **Security**: Latest security patches and fixes
- **Features**: Access to new functionality and improvements
- **Compatibility**: Better support for current GitHub features
- **Performance**: Optimizations and efficiency improvements

### ⚠️ Breaking Changes

- **golangci/golangci-lint-action** (v8.0.0 → v9): Major version upgrade — review the [release notes](https://github.com/golangci/golangci-lint-action/releases) for breaking changes

### Security Note

Actions that were previously pinned to commit SHAs remain pinned to SHAs (updated to the latest release SHA) to maintain the security benefits of immutable references.

### Testing

These changes only affect CI/CD workflow configurations and should not impact application functionality. The workflows should be tested by running them on a branch before merging.
