### PR TITLE
ToolConfirmations with Vertex AI sessions

### DIFF
--- a/internal/llminternal/base_flow.go
+++ b/internal/llminternal/base_flow.go
@@ -203,7 +203,11 @@ func (f *Flow) runOneStep(ctx agent.InvocationContext) iter.Seq2[*session.Event,
 				continue
 			}
 
-			toolConfirmationEvent := generateRequestConfirmationEvent(ctx, modelResponseEvent, ev)
+			toolConfirmationEvent, err := generateRequestConfirmationEvent(ctx, modelResponseEvent, ev)
+			if err != nil {
+				yield(nil, err)
+				return
+			}
 			if toolConfirmationEvent != nil {
 				if !yield(toolConfirmationEvent, nil) {
 					return

--- a/internal/llminternal/functions.go
+++ b/internal/llminternal/functions.go
@@ -15,9 +15,12 @@
 package llminternal
 
 import (
+	"fmt"
+
 	"google.golang.org/genai"
 
 	"google.golang.org/adk/agent"
+	"google.golang.org/adk/internal/converters"
 	"google.golang.org/adk/internal/utils"
 	"google.golang.org/adk/model"
 	"google.golang.org/adk/session"
@@ -33,12 +36,12 @@ func generateRequestConfirmationEvent(
 	invocationContext agent.InvocationContext,
 	functionCallEvent *session.Event,
 	functionResponseEvent *session.Event,
-) *session.Event {
+) (*session.Event, error) {
 	if functionResponseEvent == nil || len(functionResponseEvent.Actions.RequestedToolConfirmations) == 0 {
-		return nil
+		return nil, nil
 	}
 	if functionCallEvent == nil || functionCallEvent.Content == nil {
-		return nil
+		return nil, nil
 	}
 
 	parts := []*genai.Part{}
@@ -55,9 +58,17 @@ func generateRequestConfirmationEvent(
 		}
 
 		// Prepare arguments for the adk_request_confirmation call
+		originalCallMap, err := converters.ToMapStructure(originalFunctionCall)
+		if err != nil {
+			return nil, fmt.Errorf("failed to serialize original function call: %w", err)
+		}
+		confirmationMap, err := converters.ToMapStructure(confirmation)
+		if err != nil {
+			return nil, fmt.Errorf("failed to serialize tool confirmation: %w", err)
+		}
 		args := map[string]any{
-			"originalFunctionCall": originalFunctionCall,
-			"toolConfirmation":     confirmation,
+			"originalFunctionCall": originalCallMap,
+			"toolConfirmation":     confirmationMap,
 		}
 
 		requestConfirmationFC := &genai.FunctionCall{
@@ -73,7 +84,7 @@ func generateRequestConfirmationEvent(
 	}
 
 	if len(parts) == 0 {
-		return nil
+		return nil, nil
 	}
 
 	ev := session.NewEvent(invocationContext.InvocationID())
@@ -86,5 +97,5 @@ func generateRequestConfirmationEvent(
 		},
 	}
 	ev.LongRunningToolIDs = longRunningToolIDs
-	return ev
+	return ev, nil
 }

--- a/internal/llminternal/functions_test.go
+++ b/internal/llminternal/functions_test.go
@@ -158,9 +158,15 @@ func TestGenerateRequestConfirmationEvent(t *testing.T) {
 								FunctionCall: &genai.FunctionCall{
 									Name: toolconfirmation.FunctionCallName,
 									Args: map[string]any{
-										"originalFunctionCall": confirmingFunctionCall,
-										"toolConfirmation": toolconfirmation.ToolConfirmation{
-											Hint: "Are you sure?",
+										"originalFunctionCall": map[string]any{
+											"id":   "call_1",
+											"name": "test_tool",
+											"args": map[string]any{"arg": "val"},
+										},
+										"toolConfirmation": map[string]any{
+											"hint":      "Are you sure?",
+											"confirmed": false,
+											"payload":   nil,
 										},
 									},
 								},
@@ -174,7 +180,10 @@ func TestGenerateRequestConfirmationEvent(t *testing.T) {
 
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			got := generateRequestConfirmationEvent(tt.invocationContext, tt.functionCallEvent, tt.functionResponseEvent)
+			got, err := generateRequestConfirmationEvent(tt.invocationContext, tt.functionCallEvent, tt.functionResponseEvent)
+			if err != nil {
+				t.Fatalf("generateRequestConfirmationEvent() returned unexpected error: %v", err)
+			}
 
 			if diff := cmp.Diff(tt.wantEvent, got,
 				cmpopts.IgnoreFields(session.Event{}, "Timestamp", "LongRunningToolIDs", "ID"),
@@ -239,7 +248,10 @@ func TestGenerateRequestConfirmationEventHasID(t *testing.T) {
 		},
 	}
 
-	got := generateRequestConfirmationEvent(ctx, functionCallEvent, functionResponseEvent)
+	got, err := generateRequestConfirmationEvent(ctx, functionCallEvent, functionResponseEvent)
+	if err != nil {
+		t.Fatalf("generateRequestConfirmationEvent() returned unexpected error: %v", err)
+	}
 	if got == nil {
 		t.Fatal("expected non-nil event")
 	}

--- a/session/vertexai/vertexai_client.go
+++ b/session/vertexai/vertexai_client.go
@@ -443,12 +443,14 @@ func aiplatformToGenaiContent(rpcResp *aiplatformpb.SessionEvent) *genai.Content
 			case *aiplatformpb.Part_FunctionCall:
 				argsMap := v.FunctionCall.Args.AsMap() // Converts *structpb.Struct -> map[string]any
 				part.FunctionCall = &genai.FunctionCall{
+					ID:   v.FunctionCall.Id,
 					Name: v.FunctionCall.Name,
 					Args: argsMap,
 				}
 			case *aiplatformpb.Part_FunctionResponse:
 				responseMap := v.FunctionResponse.Response.AsMap() // Converts *structpb.Struct -> map[string]any
 				part.FunctionResponse = &genai.FunctionResponse{
+					ID:       v.FunctionResponse.Id,
 					Name:     v.FunctionResponse.Name,
 					Response: responseMap,
 				}

--- a/tool/functiontool/function_test.go
+++ b/tool/functiontool/function_test.go
@@ -53,6 +53,8 @@ func sumFunc(ctx tool.Context, input SumArgs) (SumResult, error) {
 	return SumResult{Sum: input.A + input.B}, nil
 }
 
+const generatedID = "adk-generated-id"
+
 func ExampleNew() {
 	sumTool, err := functiontool.New(functiontool.Config{
 		Name:        "sum",
@@ -585,12 +587,15 @@ func TestToolConfirmation(t *testing.T) {
 			want: []*genai.Content{
 				genai.NewContentFromFunctionCall("test_tool", map[string]any{"Num": 1}, "model"),
 				genai.NewContentFromFunctionCall(toolconfirmation.FunctionCallName, map[string]any{
-					"originalFunctionCall": &genai.FunctionCall{
-						Args: map[string]any{"Num": 1},
-						Name: "test_tool",
+					"originalFunctionCall": map[string]any{
+						"id":   generatedID,
+						"args": map[string]any{"Num": float64(1)},
+						"name": "test_tool",
 					},
-					"toolConfirmation": toolconfirmation.ToolConfirmation{
-						Hint: "Please approve or reject the tool call test_tool() by responding with a FunctionResponse with an expected ToolConfirmation payload.",
+					"toolConfirmation": map[string]any{
+						"hint":      "Please approve or reject the tool call test_tool() by responding with a FunctionResponse with an expected ToolConfirmation payload.",
+						"confirmed": false,
+						"payload":   nil,
 					},
 				}, "model"),
 				genai.NewContentFromFunctionResponse("test_tool", map[string]any{
@@ -609,12 +614,15 @@ func TestToolConfirmation(t *testing.T) {
 			want: []*genai.Content{
 				genai.NewContentFromFunctionCall("test_tool", map[string]any{"Num": 1}, "model"),
 				genai.NewContentFromFunctionCall(toolconfirmation.FunctionCallName, map[string]any{
-					"originalFunctionCall": &genai.FunctionCall{
-						Args: map[string]any{"Num": 1},
-						Name: "test_tool",
+					"originalFunctionCall": map[string]any{
+						"id":   generatedID,
+						"args": map[string]any{"Num": float64(1)},
+						"name": "test_tool",
 					},
-					"toolConfirmation": toolconfirmation.ToolConfirmation{
-						Hint: "Please approve or reject the tool call test_tool() by responding with a FunctionResponse with an expected ToolConfirmation payload.",
+					"toolConfirmation": map[string]any{
+						"hint":      "Please approve or reject the tool call test_tool() by responding with a FunctionResponse with an expected ToolConfirmation payload.",
+						"confirmed": false,
+						"payload":   nil,
 					},
 				}, "model"),
 				genai.NewContentFromFunctionResponse("test_tool", map[string]any{
@@ -634,12 +642,15 @@ func TestToolConfirmation(t *testing.T) {
 			want: []*genai.Content{
 				genai.NewContentFromFunctionCall("test_tool", map[string]any{"Num": 1}, "model"),
 				genai.NewContentFromFunctionCall(toolconfirmation.FunctionCallName, map[string]any{
-					"originalFunctionCall": &genai.FunctionCall{
-						Args: map[string]any{"Num": 1},
-						Name: "test_tool",
+					"originalFunctionCall": map[string]any{
+						"id":   generatedID,
+						"args": map[string]any{"Num": float64(1)},
+						"name": "test_tool",
 					},
-					"toolConfirmation": toolconfirmation.ToolConfirmation{
-						Hint: "Please approve or reject the tool call test_tool() by responding with a FunctionResponse with an expected ToolConfirmation payload.",
+					"toolConfirmation": map[string]any{
+						"hint":      "Please approve or reject the tool call test_tool() by responding with a FunctionResponse with an expected ToolConfirmation payload.",
+						"confirmed": false,
+						"payload":   nil,
 					},
 				}, "model"),
 				genai.NewContentFromFunctionResponse("test_tool", map[string]any{
@@ -676,12 +687,15 @@ func TestToolConfirmation(t *testing.T) {
 			want: []*genai.Content{
 				genai.NewContentFromFunctionCall("test_tool", map[string]any{"Num": 4}, "model"),
 				genai.NewContentFromFunctionCall(toolconfirmation.FunctionCallName, map[string]any{
-					"originalFunctionCall": &genai.FunctionCall{
-						Args: map[string]any{"Num": 4},
-						Name: "test_tool",
+					"originalFunctionCall": map[string]any{
+						"id":   generatedID,
+						"args": map[string]any{"Num": float64(4)},
+						"name": "test_tool",
 					},
-					"toolConfirmation": toolconfirmation.ToolConfirmation{
-						Hint: "Please approve or reject the tool call test_tool() by responding with a FunctionResponse with an expected ToolConfirmation payload.",
+					"toolConfirmation": map[string]any{
+						"hint":      "Please approve or reject the tool call test_tool() by responding with a FunctionResponse with an expected ToolConfirmation payload.",
+						"confirmed": false,
+						"payload":   nil,
 					},
 				}, "model"),
 				genai.NewContentFromFunctionResponse("test_tool", map[string]any{
@@ -702,12 +716,15 @@ func TestToolConfirmation(t *testing.T) {
 			want: []*genai.Content{
 				genai.NewContentFromFunctionCall("test_tool", map[string]any{"Num": 4}, "model"),
 				genai.NewContentFromFunctionCall(toolconfirmation.FunctionCallName, map[string]any{
-					"originalFunctionCall": &genai.FunctionCall{
-						Args: map[string]any{"Num": 4},
-						Name: "test_tool",
+					"originalFunctionCall": map[string]any{
+						"id":   generatedID,
+						"args": map[string]any{"Num": float64(4)},
+						"name": "test_tool",
 					},
-					"toolConfirmation": toolconfirmation.ToolConfirmation{
-						Hint: "Please approve or reject the tool call test_tool() by responding with a FunctionResponse with an expected ToolConfirmation payload.",
+					"toolConfirmation": map[string]any{
+						"hint":      "Please approve or reject the tool call test_tool() by responding with a FunctionResponse with an expected ToolConfirmation payload.",
+						"confirmed": false,
+						"payload":   nil,
 					},
 				}, "model"),
 				genai.NewContentFromFunctionResponse("test_tool", map[string]any{
@@ -729,12 +746,15 @@ func TestToolConfirmation(t *testing.T) {
 			want: []*genai.Content{
 				genai.NewContentFromFunctionCall("test_tool", map[string]any{"Num": 4}, "model"),
 				genai.NewContentFromFunctionCall(toolconfirmation.FunctionCallName, map[string]any{
-					"originalFunctionCall": &genai.FunctionCall{
-						Args: map[string]any{"Num": 4},
-						Name: "test_tool",
+					"originalFunctionCall": map[string]any{
+						"id":   generatedID,
+						"args": map[string]any{"Num": float64(4)},
+						"name": "test_tool",
 					},
-					"toolConfirmation": toolconfirmation.ToolConfirmation{
-						Hint: "Please approve or reject the tool call test_tool() by responding with a FunctionResponse with an expected ToolConfirmation payload.",
+					"toolConfirmation": map[string]any{
+						"hint":      "Please approve or reject the tool call test_tool() by responding with a FunctionResponse with an expected ToolConfirmation payload.",
+						"confirmed": false,
+						"payload":   nil,
 					},
 				}, "model"),
 				genai.NewContentFromFunctionResponse("test_tool", map[string]any{
@@ -791,12 +811,15 @@ func TestToolConfirmation(t *testing.T) {
 				}
 
 				if diff := cmp.Diff(tc.want[eventCount], got.Content, cmpopts.IgnoreFields(genai.FunctionCall{}, "ID"),
-					cmp.Transformer("StringifyMapErrors", func(m map[string]any) map[string]any {
+					cmp.Transformer("Transform", func(m map[string]any) map[string]any {
 						out := make(map[string]any, len(m))
 						for k, v := range m {
-							// Check if the value inside the map is an error
+							// Check if the value inside the map is an error, and stringify it.
 							if err, ok := v.(error); ok {
 								out[k] = err.Error() // Convert to string
+							} else if k == "id" {
+								// IDs are generated, replace with a hardcoded placeholder.
+								out[k] = generatedID
 							} else {
 								out[k] = v // Keep as is
 							}

--- a/tool/mcptoolset/set_test.go
+++ b/tool/mcptoolset/set_test.go
@@ -57,7 +57,10 @@ func weatherFunc(ctx context.Context, req *mcp.CallToolRequest, input Input) (*m
 	}, nil
 }
 
-const modelName = "gemini-2.5-flash"
+const (
+	modelName   = "gemini-2.5-flash"
+	generatedID = "adk-generated-id"
+)
 
 //go:generate go test -v -httprecord=.*
 
@@ -416,12 +419,15 @@ func TestMCPToolSetConfirmation(t *testing.T) {
 			want: []*genai.Content{
 				genai.NewContentFromFunctionCall(toolName, map[string]any{"city": "Lisbon"}, "model"),
 				genai.NewContentFromFunctionCall(toolconfirmation.FunctionCallName, map[string]any{
-					"originalFunctionCall": &genai.FunctionCall{
-						Args: map[string]any{"city": "Lisbon"},
-						Name: toolName,
+					"originalFunctionCall": map[string]any{
+						"id":   generatedID,
+						"args": map[string]any{"city": "Lisbon"},
+						"name": toolName,
 					},
-					"toolConfirmation": toolconfirmation.ToolConfirmation{
-						Hint: "Please approve or reject the tool call get_weather() by responding with a FunctionResponse with an expected ToolConfirmation payload.",
+					"toolConfirmation": map[string]any{
+						"hint":      "Please approve or reject the tool call get_weather() by responding with a FunctionResponse with an expected ToolConfirmation payload.",
+						"confirmed": false,
+						"payload":   nil,
 					},
 				}, "model"),
 				genai.NewContentFromFunctionResponse(toolName, map[string]any{
@@ -439,12 +445,15 @@ func TestMCPToolSetConfirmation(t *testing.T) {
 			want: []*genai.Content{
 				genai.NewContentFromFunctionCall(toolName, map[string]any{"city": "Lisbon"}, "model"),
 				genai.NewContentFromFunctionCall(toolconfirmation.FunctionCallName, map[string]any{
-					"originalFunctionCall": &genai.FunctionCall{
-						Args: map[string]any{"city": "Lisbon"},
-						Name: toolName,
+					"originalFunctionCall": map[string]any{
+						"id":   generatedID,
+						"args": map[string]any{"city": "Lisbon"},
+						"name": toolName,
 					},
-					"toolConfirmation": toolconfirmation.ToolConfirmation{
-						Hint: "Please approve or reject the tool call get_weather() by responding with a FunctionResponse with an expected ToolConfirmation payload.",
+					"toolConfirmation": map[string]any{
+						"hint":      "Please approve or reject the tool call get_weather() by responding with a FunctionResponse with an expected ToolConfirmation payload.",
+						"confirmed": false,
+						"payload":   nil,
 					},
 				}, "model"),
 				genai.NewContentFromFunctionResponse(toolName, map[string]any{
@@ -466,12 +475,15 @@ func TestMCPToolSetConfirmation(t *testing.T) {
 			want: []*genai.Content{
 				genai.NewContentFromFunctionCall(toolName, map[string]any{"city": "Lisbon"}, "model"),
 				genai.NewContentFromFunctionCall(toolconfirmation.FunctionCallName, map[string]any{
-					"originalFunctionCall": &genai.FunctionCall{
-						Args: map[string]any{"city": "Lisbon"},
-						Name: toolName,
+					"originalFunctionCall": map[string]any{
+						"id":   generatedID,
+						"args": map[string]any{"city": "Lisbon"},
+						"name": toolName,
 					},
-					"toolConfirmation": toolconfirmation.ToolConfirmation{
-						Hint: "Please approve or reject the tool call get_weather() by responding with a FunctionResponse with an expected ToolConfirmation payload.",
+					"toolConfirmation": map[string]any{
+						"hint":      "Please approve or reject the tool call get_weather() by responding with a FunctionResponse with an expected ToolConfirmation payload.",
+						"confirmed": false,
+						"payload":   nil,
 					},
 				}, "model"),
 				genai.NewContentFromFunctionResponse(toolName, map[string]any{
@@ -524,12 +536,15 @@ func TestMCPToolSetConfirmation(t *testing.T) {
 			want: []*genai.Content{
 				genai.NewContentFromFunctionCall(toolName, map[string]any{"city": "Lisbon"}, "model"),
 				genai.NewContentFromFunctionCall(toolconfirmation.FunctionCallName, map[string]any{
-					"originalFunctionCall": &genai.FunctionCall{
-						Args: map[string]any{"city": "Lisbon"},
-						Name: toolName,
+					"originalFunctionCall": map[string]any{
+						"id":   generatedID,
+						"args": map[string]any{"city": "Lisbon"},
+						"name": toolName,
 					},
-					"toolConfirmation": toolconfirmation.ToolConfirmation{
-						Hint: "Please approve or reject the tool call get_weather() by responding with a FunctionResponse with an expected ToolConfirmation payload.",
+					"toolConfirmation": map[string]any{
+						"hint":      "Please approve or reject the tool call get_weather() by responding with a FunctionResponse with an expected ToolConfirmation payload.",
+						"confirmed": false,
+						"payload":   nil,
 					},
 				}, "model"),
 				genai.NewContentFromFunctionResponse(toolName, map[string]any{
@@ -546,12 +561,15 @@ func TestMCPToolSetConfirmation(t *testing.T) {
 			want: []*genai.Content{
 				genai.NewContentFromFunctionCall(toolName, map[string]any{"city": "Lisbon"}, "model"),
 				genai.NewContentFromFunctionCall(toolconfirmation.FunctionCallName, map[string]any{
-					"originalFunctionCall": &genai.FunctionCall{
-						Args: map[string]any{"city": "Lisbon"},
-						Name: toolName,
+					"originalFunctionCall": map[string]any{
+						"id":   generatedID,
+						"args": map[string]any{"city": "Lisbon"},
+						"name": toolName,
 					},
-					"toolConfirmation": toolconfirmation.ToolConfirmation{
-						Hint: "Please approve or reject the tool call get_weather() by responding with a FunctionResponse with an expected ToolConfirmation payload.",
+					"toolConfirmation": map[string]any{
+						"hint":      "Please approve or reject the tool call get_weather() by responding with a FunctionResponse with an expected ToolConfirmation payload.",
+						"confirmed": false,
+						"payload":   nil,
 					},
 				}, "model"),
 				genai.NewContentFromFunctionResponse(toolName, map[string]any{
@@ -569,12 +587,15 @@ func TestMCPToolSetConfirmation(t *testing.T) {
 			want: []*genai.Content{
 				genai.NewContentFromFunctionCall(toolName, map[string]any{"city": "Lisbon"}, "model"),
 				genai.NewContentFromFunctionCall(toolconfirmation.FunctionCallName, map[string]any{
-					"originalFunctionCall": &genai.FunctionCall{
-						Args: map[string]any{"city": "Lisbon"},
-						Name: toolName,
+					"originalFunctionCall": map[string]any{
+						"id":   generatedID,
+						"args": map[string]any{"city": "Lisbon"},
+						"name": toolName,
 					},
-					"toolConfirmation": toolconfirmation.ToolConfirmation{
-						Hint: "Please approve or reject the tool call get_weather() by responding with a FunctionResponse with an expected ToolConfirmation payload.",
+					"toolConfirmation": map[string]any{
+						"hint":      "Please approve or reject the tool call get_weather() by responding with a FunctionResponse with an expected ToolConfirmation payload.",
+						"confirmed": false,
+						"payload":   nil,
 					},
 				}, "model"),
 				genai.NewContentFromFunctionResponse(toolName, map[string]any{
@@ -596,12 +617,15 @@ func TestMCPToolSetConfirmation(t *testing.T) {
 			want: []*genai.Content{
 				genai.NewContentFromFunctionCall(toolName, map[string]any{"city": "Lisbon"}, "model"),
 				genai.NewContentFromFunctionCall(toolconfirmation.FunctionCallName, map[string]any{
-					"originalFunctionCall": &genai.FunctionCall{
-						Args: map[string]any{"city": "Lisbon"},
-						Name: toolName,
+					"originalFunctionCall": map[string]any{
+						"id":   generatedID,
+						"args": map[string]any{"city": "Lisbon"},
+						"name": toolName,
 					},
-					"toolConfirmation": toolconfirmation.ToolConfirmation{
-						Hint: "Please approve or reject the tool call get_weather() by responding with a FunctionResponse with an expected ToolConfirmation payload.",
+					"toolConfirmation": map[string]any{
+						"hint":      "Please approve or reject the tool call get_weather() by responding with a FunctionResponse with an expected ToolConfirmation payload.",
+						"confirmed": false,
+						"payload":   nil,
 					},
 				}, "model"),
 				genai.NewContentFromFunctionResponse(toolName, map[string]any{
@@ -658,12 +682,15 @@ func TestMCPToolSetConfirmation(t *testing.T) {
 				cmpopts.IgnoreFields(genai.FunctionCall{}, "ID"),
 				cmpopts.IgnoreFields(genai.FunctionResponse{}, "ID"),
 				cmpopts.IgnoreFields(genai.Part{}, "ThoughtSignature"),
-				cmp.Transformer("StringifyMapErrors", func(m map[string]any) map[string]any {
+				cmp.Transformer("Transform", func(m map[string]any) map[string]any {
 					out := make(map[string]any, len(m))
 					for k, v := range m {
-						// Check if the value inside the map is an error
+						// Check if the value inside the map is an error, and stringify it.
 						if err, ok := v.(error); ok {
 							out[k] = err.Error() // Convert to string
+						} else if k == "id" {
+							// IDs are generated, replace with a hardcoded placeholder.
+							out[k] = generatedID
 						} else {
 							out[k] = v // Keep as is
 						}


### PR DESCRIPTION
**No issue exists, describe the change:**

**Problem:**

Using the `ctx.RequestConfirmation()` inside a tool doesn't work with Vertex AI Session storage. The error returned when using that is:
```
failed to add event to session: failed to append event: error creating content: failed to convert function call to structpb: proto:\u00a0invalid type: *genai.FunctionCall
```

It seems like it tries to store an actual pointer to an `genai.FunctionCall` on the session, which is not a serializable type to pass along.

The same happens with `toolconfirmation.ToolConfirmation`:
```
failed to add event to session: failed to append event: error creating content: failed to convert function call to structpb: proto:\u00a0invalid type: toolconfirmation.ToolConfirmation
```

Using confirmations together with Vertex AI is however mentioned in the [ADK docs known limitations section](https://google.github.io/adk-docs/tools-custom/confirmation/#known-limitations).

**Solution:**

Two bugs found and fixed during debugging:

1. Function call IDs are not restored when a session is restored from Vertex AI (first commit)
2. The `*genai.FunctionCall` needs to be converted to a serializable type, fixed using `converters.ToMapStructure`
3. The `toolconfirmation.ToolConfirmation` needs to be converted to a serializable type, fixed using `converters.ToMapStructure`

### Testing Plan

_Please describe the tests that you ran to verify your changes. This is required
for all PRs that are not small documentation or typo fixes._

**Unit Tests:**

- [x] I have added or updated unit tests for my change.
- [x] All unit tests pass locally.

_Please include a summary of passed go test results._

**Manual End-to-End (E2E) Tests:**

Build an agent which uses some kind of confirmation (or just HITL) tools and validate that both being presented that the tool is running works, and that the confirmation answer is received.

### Checklist

- [x] I have read the [CONTRIBUTING.md](./CONTRIBUTING.md) document.
- [x] I have performed a self-review of my own code.
- [ ] I have commented my code, particularly in hard-to-understand areas.
- [x] I have added tests that prove my fix is effective or that my feature works.
- [x] New and existing unit tests pass locally with my changes.
- [x] I have manually tested my changes end-to-end.
- [ ] Any dependent changes have been merged and published in downstream modules.

### Additional context

I am not super familiar with the code base, and I'm not sure if this change potentially breaks other usages, but I couldn't find any indication of that.

Also not sure if this should be handled in sync with similar changes to adk-python.