### PR TITLE
feat(skills):  implement experimental skill feature

### DIFF
--- a/code_executors/base_code_executor.go
+++ b/code_executors/base_code_executor.go
@@ -1,0 +1,64 @@
+// Copyright 2025 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package code_executors
+
+import "google.golang.org/adk/agent"
+
+type CodeExecutor interface {
+	ExecuteCode(ctx agent.InvocationContext, input CodeExecutionInput) (CodeExecutionResult, error)
+}
+
+// BaseCodeExecutor Abstract base class for all code executors.
+//
+//The code executor allows the agent to execute code blocks from model responses
+//and incorporate the execution results into the final response.
+//
+//Attributes:
+// 	optimize_data_file: If true, extract and process data files from the model request and attach them to the code executor. Supported data file MimeTypes are [text/csv]. Default to False.
+//	stateful: Whether the code executor is stateful. Default to False.
+//	error_retry_attempts: The number of attempts to retry on consecutive code execution errors. Default to 2.
+//	code_block_delimiters: The list of the enclosing delimiters to identify the code blocks.
+//	execution_result_delimiters: The delimiters to format the code execution result.
+
+type Delimiter struct {
+	Start string
+	End   string
+}
+type BaseCodeExecutor struct {
+	OptimizeDataFile          bool
+	Stateful                  bool
+	ErrorRetryAttempts        int
+	CodeBlockDelimiters       []Delimiter
+	ExecutionResultDelimiters [2]string
+}
+
+func (b *BaseCodeExecutor) ExecuteCode(ctx agent.InvocationContext, input CodeExecutionInput) (CodeExecutionResult, error) {
+	return CodeExecutionResult{}, nil
+}
+
+func DefaultBaseCodeExecutor() *BaseCodeExecutor {
+	return &BaseCodeExecutor{
+		OptimizeDataFile:   false,
+		Stateful:           false,
+		ErrorRetryAttempts: 2,
+		CodeBlockDelimiters: []Delimiter{
+			{Start: "```tool_code\n", End: "\n```"},
+			{Start: "```python\n", End: "\n```"},
+		},
+		ExecutionResultDelimiters: [2]string{
+			"```tool_output\n", "\n```",
+		},
+	}
+}

--- a/code_executors/code_execution_utils.go
+++ b/code_executors/code_execution_utils.go
@@ -1,0 +1,34 @@
+// Copyright 2025 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package code_executors
+
+type File struct {
+	Name     string `json:"name"`                //  A structure that contains a file name and its content.
+	Content  []byte `json:"content"`             // The base64-encoded bytes of the file content or the original bytes of the file content.
+	MimeType string `json:"mime_type,omitempty"` //  The mime type of the file (e.g., "image/png",'text/plain').
+}
+
+type CodeExecutionInput struct {
+	Args        any    `json:"args"`
+	ScriptPath  string `json:"script_path"`
+	InputFiles  []File `json:"input_files,omitempty"`  //  The input files available to the code.
+	ExecutionID string `json:"execution_id,omitempty"` //  The execution ID for the stateful code execution.
+}
+
+type CodeExecutionResult struct {
+	StdOut      string `json:"stdout"`                 // The standard output of the code execution.
+	StdErr      string `json:"stderr,omitempty"`       // The standard error of the code execution.
+	OutputFiles []File `json:"output_files,omitempty"` // The output files from the code execution.
+}

--- a/code_executors/test_scripts/args.py
+++ b/code_executors/test_scripts/args.py
@@ -1,0 +1,2 @@
+import sys
+print(f"Arguments: {sys.argv[1:]}")

--- a/code_executors/test_scripts/fail.sh
+++ b/code_executors/test_scripts/fail.sh
@@ -1,0 +1,3 @@
+#!/bin/bash
+echo "This is an error" >&2
+exit 1

--- a/code_executors/test_scripts/hello.py
+++ b/code_executors/test_scripts/hello.py
@@ -1,0 +1,1 @@
+print("Hello from Python")

--- a/code_executors/test_scripts/hello.sh
+++ b/code_executors/test_scripts/hello.sh
@@ -1,0 +1,2 @@
+#!/bin/bash
+echo "Hello from Bash"

--- a/code_executors/test_scripts/multiply.py
+++ b/code_executors/test_scripts/multiply.py
@@ -1,0 +1,40 @@
+#!/usr/bin/env python3
+import sys
+
+"""
+乘法数值计算脚本
+提供多种乘法运算功能
+"""
+
+
+def multiply_list(numbers):
+    """
+    列表中的所有数字相乘
+
+    Args:
+        numbers (list): 数字列表
+
+    Returns:
+        float: 所有数字的乘积
+
+    Raises:
+        ValueError: 如果列表为空
+    """
+    if not numbers:
+        raise ValueError("数字列表不能为空")
+
+    result = 1
+    for num in numbers:
+        result *= num
+    return result
+
+
+if __name__ == "__main__":
+    if len(sys.argv) < 2:
+        print("Usage: python multiply.py <num1> <num2> ...<numn>")
+        sys.exit(1)
+    nums = []
+    for n in sys.argv[1:]:
+        nums.append(float(n))
+    out = multiply_list(nums)
+    print(out)

--- a/code_executors/test_scripts/timeout.sh
+++ b/code_executors/test_scripts/timeout.sh
@@ -1,0 +1,3 @@
+#!/bin/bash
+sleep 2
+echo "Should have timed out"

--- a/code_executors/unsafe_local_code_executor.go
+++ b/code_executors/unsafe_local_code_executor.go
@@ -1,0 +1,132 @@
+// Copyright 2025 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package code_executors
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"log"
+	"os/exec"
+	"strings"
+	"time"
+
+	"google.golang.org/adk/agent"
+)
+
+const DEFAULT_SCRIPT_TIMEOUT = 300 * time.Second
+
+type UnsafeLocalCodeExecutor struct {
+	Timeout          time.Duration
+	BaseCodeExecutor *BaseCodeExecutor
+}
+
+func (s *UnsafeLocalCodeExecutor) ExecuteCode(ctx agent.InvocationContext, input CodeExecutionInput) (CodeExecutionResult, error) {
+	scriptPath := input.ScriptPath
+	ext := ""
+	if i := strings.LastIndex(scriptPath, "."); i >= 0 {
+		ext = strings.ToLower(scriptPath[i+1:])
+	}
+
+	if ext != "py" && ext != "sh" && ext != "bash" {
+		extMsg := "(no extension)"
+		if ext != "" {
+			extMsg = "." + ext
+		}
+		return CodeExecutionResult{
+			StdErr: fmt.Sprintf("UNSUPPORTED_SCRIPT_TYPE: Unsupported script type '%s'. Supported types: .py, .sh, .bash", extMsg),
+		}, nil
+	}
+
+	var cmd *exec.Cmd
+	excCtx := context.Background()
+	if s.Timeout > 0 {
+		var cancel context.CancelFunc
+		excCtx, cancel = context.WithTimeout(context.Background(), s.Timeout)
+		defer cancel()
+	}
+
+	argv := []string{scriptPath}
+	if input.Args != nil {
+		switch args := input.Args.(type) {
+		case []string:
+			argv = append(argv, args...)
+		case []interface{}:
+			for _, v := range args {
+				argv = append(argv, fmt.Sprint(v))
+			}
+		case map[string]string:
+			for k, v := range args {
+				argv = append(argv, "--"+k, v)
+			}
+		case map[string]interface{}:
+			for k, v := range args {
+				argv = append(argv, "--"+k, fmt.Sprint(v))
+			}
+		default:
+			return CodeExecutionResult{
+				StdErr: fmt.Sprintf("INVALID_ARGS: Unsupported args type: %T. Expected list or map.", input.Args),
+			}, nil
+		}
+	}
+
+	if ext == "py" {
+		cmd = exec.CommandContext(excCtx, "python3", argv...)
+	} else {
+		cmd = exec.CommandContext(excCtx, "bash", argv...)
+	}
+
+	log.Printf("UnsafeLocalCodeExecutor cmd  is %s", cmd.String())
+
+	var stdoutBuf, stderrBuf strings.Builder
+	cmd.Stdout = &stdoutBuf
+	cmd.Stderr = &stderrBuf
+
+	runErr := cmd.Run()
+
+	stdout := stdoutBuf.String()
+	stderr := stderrBuf.String()
+	rc := 0
+
+	if runErr != nil {
+		log.Printf("UnsafeLocalCodeExecutor cmd executed error: %s", runErr.Error())
+		var ee *exec.ExitError
+		if errors.As(runErr, &ee) {
+			rc = ee.ExitCode()
+			if rc != 0 && stderr == "" {
+				stderr += "\n" + fmt.Sprintf("Exit code %d", rc)
+			}
+		} else {
+			stderr += "\n" + fmt.Sprintf("cmd {%s} run error:%s", cmd.String(), runErr.Error())
+		}
+	}
+
+	log.Printf("UnsafeLocalCodeExecutor result: %s", stdout)
+
+	return CodeExecutionResult{
+		StdOut: stdout,
+		StdErr: stderr,
+	}, nil
+}
+
+func NewUnsafeLocalCodeExecutor(timeout time.Duration) *UnsafeLocalCodeExecutor {
+	if timeout == 0 {
+		timeout = DEFAULT_SCRIPT_TIMEOUT
+	}
+	return &UnsafeLocalCodeExecutor{
+		Timeout:          timeout,
+		BaseCodeExecutor: DefaultBaseCodeExecutor(),
+	}
+}

--- a/code_executors/unsafe_local_code_executor_test.go
+++ b/code_executors/unsafe_local_code_executor_test.go
@@ -1,0 +1,134 @@
+// Copyright 2025 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package code_executors
+
+import (
+	"os"
+	"path/filepath"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/assert"
+)
+
+func TestUnsafeLocalCodeExecutor(t *testing.T) {
+	// Setup paths
+	cwd, _ := os.Getwd()
+	scriptsDir := filepath.Join(cwd, "test_scripts")
+	input := CodeExecutionInput{
+		ScriptPath: filepath.Join(scriptsDir, "multiply.py"),
+		Args:       []string{"2", "3", "4"},
+	}
+	executor := NewUnsafeLocalCodeExecutor(300 * time.Second)
+	// Invoke
+	result, err := executor.ExecuteCode(nil, input)
+	if err != nil {
+		t.Errorf("UnsafeLocalCodeExecutor should not return an error: %s", err.Error())
+		return
+	}
+	t.Logf("UnsafeLocalCodeExecutor result: %s", result.StdOut)
+}
+
+func TestSkillScriptExecutor_ExecuteCode(t *testing.T) {
+	// Setup paths
+	cwd, _ := os.Getwd()
+	scriptsDir := filepath.Join(cwd, "test_scripts")
+
+	tests := []struct {
+		name           string
+		scriptPath     string
+		args           any
+		timeout        time.Duration
+		expectedStdout string
+		expectedStderr string
+		expectError    bool
+	}{
+		{
+			name:           "Python Hello",
+			scriptPath:     filepath.Join(scriptsDir, "hello.py"),
+			expectedStdout: "Hello from Python",
+		},
+		{
+			name:           "Bash Hello",
+			scriptPath:     filepath.Join(scriptsDir, "hello.sh"),
+			expectedStdout: "Hello from Bash",
+		},
+		{
+			name:           "Python Args List",
+			scriptPath:     filepath.Join(scriptsDir, "args.py"),
+			args:           []string{"arg1", "arg2"},
+			expectedStdout: "Arguments: ['arg1', 'arg2']",
+		},
+		{
+			name:           "Python Args Interface List",
+			scriptPath:     filepath.Join(scriptsDir, "args.py"),
+			args:           []interface{}{"arg1", 123},
+			expectedStdout: "Arguments: ['arg1', '123']",
+		},
+		{
+			name:           "Python Args Map",
+			scriptPath:     filepath.Join(scriptsDir, "args.py"),
+			args:           map[string]string{"key": "value"},
+			expectedStdout: "Arguments: ['--key', 'value']",
+		},
+		{
+			name:           "Fail Script",
+			scriptPath:     filepath.Join(scriptsDir, "fail.sh"),
+			expectedStderr: "This is an error",
+		},
+		{
+			name:       "Timeout Script",
+			scriptPath: filepath.Join(scriptsDir, "timeout.sh"),
+			timeout:    1 * time.Second,
+		},
+		{
+			name:           "Unsupported Extension",
+			scriptPath:     "test.txt",
+			expectedStderr: "UNSUPPORTED_SCRIPT_TYPE: Unsupported script type '.txt'. Supported types: .py, .sh, .bash",
+		},
+		{
+			name:           "Args List",
+			scriptPath:     filepath.Join(scriptsDir, "multiply.py"),
+			args:           []string{"2", "3", "4"},
+			expectedStdout: "24.0",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			executor := NewUnsafeLocalCodeExecutor(tt.timeout)
+			input := CodeExecutionInput{
+				ScriptPath: tt.scriptPath,
+				Args:       tt.args,
+			}
+
+			// Invoke
+			result, err := executor.ExecuteCode(nil, input)
+
+			if tt.expectError {
+				assert.Error(t, err)
+			} else {
+				assert.NoError(t, err)
+			}
+
+			if tt.expectedStdout != "" {
+				assert.Contains(t, result.StdOut, tt.expectedStdout)
+			}
+			if tt.expectedStderr != "" {
+				assert.Contains(t, result.StdErr, tt.expectedStderr)
+			}
+		})
+	}
+}

--- a/examples/skill/main.go
+++ b/examples/skill/main.go
@@ -1,0 +1,84 @@
+// Copyright 2025 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package main
+
+import (
+	"context"
+	"log"
+	"os"
+	"time"
+
+	"google.golang.org/genai"
+
+	"google.golang.org/adk/agent"
+	"google.golang.org/adk/agent/llmagent"
+	"google.golang.org/adk/cmd/launcher"
+	"google.golang.org/adk/cmd/launcher/full"
+	"google.golang.org/adk/code_executors"
+	"google.golang.org/adk/model/gemini"
+	"google.golang.org/adk/skills"
+	"google.golang.org/adk/tool"
+	"google.golang.org/adk/tool/skilltool"
+)
+
+func main() {
+	ctx := context.Background()
+
+	skillPathList := []string{
+		"You Skill Path",
+	}
+	var skillList []*skills.Skill
+	for _, path := range skillPathList {
+		skill, err := skills.LoadSkillFromDir(path)
+		if err != nil {
+			panic(err)
+		}
+		skillList = append(skillList, skill)
+	}
+
+	skillToolset, err := skilltool.NewSkillToolset(skillList, code_executors.NewUnsafeLocalCodeExecutor(300*time.Second))
+	if err != nil {
+		panic(err)
+	}
+
+	model, err := gemini.NewModel(ctx, "gemini-2.5-flash", &genai.ClientConfig{
+		APIKey: os.Getenv("GOOGLE_API_KEY"),
+	})
+	if err != nil {
+		log.Fatalf("Failed to create model: %v", err)
+	}
+
+	a, err := llmagent.New(llmagent.Config{
+		Name:        "skill_agent",
+		Model:       model,
+		Description: "Agent to answer questions.",
+		Instruction: "Your SOLE purpose is to answer questions. You can use the skill tool when necessary.",
+		Toolsets: []tool.Toolset{
+			skillToolset,
+		},
+	})
+	if err != nil {
+		log.Fatalf("Failed to create agent: %v", err)
+	}
+
+	config := &launcher.Config{
+		AgentLoader: agent.NewSingleLoader(a),
+	}
+
+	l := full.NewLauncher()
+	if err = l.Execute(ctx, config, os.Args[1:]); err != nil {
+		log.Fatalf("Run failed: %v\n\n%s", err, l.CommandLineSyntax())
+	}
+}

--- a/go.mod
+++ b/go.mod
@@ -17,6 +17,7 @@ require (
 	github.com/mitchellh/mapstructure v1.5.0
 	github.com/modelcontextprotocol/go-sdk v1.4.1
 	github.com/spf13/cobra v1.8.1
+	github.com/stretchr/testify v1.11.1
 	go.opentelemetry.io/contrib/detectors/gcp v1.40.0
 	go.opentelemetry.io/otel v1.40.0
 	go.opentelemetry.io/otel/exporters/otlp/otlplog/otlploghttp v0.16.0
@@ -34,6 +35,11 @@ require (
 	gorm.io/gorm v1.31.0
 	rsc.io/omap v1.2.0
 	rsc.io/ordered v1.1.1
+)
+
+require (
+	github.com/davecgh/go-spew v1.1.2-0.20180830191138-d8f796af33cc // indirect
+	github.com/pmezard/go-difflib v1.0.1-0.20181226105442-5d4384ee4fb2 // indirect
 )
 
 require (

--- a/skills/models.go
+++ b/skills/models.go
@@ -1,0 +1,292 @@
+// Copyright 2025 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package skills
+
+import (
+	"encoding/json"
+	"fmt"
+	"os"
+	"path/filepath"
+	"regexp"
+	"strings"
+
+	"gopkg.in/yaml.v3"
+)
+
+// Skill from https://github.com/agentskills/agentskills
+// https://agentskills.io/specification
+
+var validNameRegex = regexp.MustCompile(`^[a-z0-9]+(-[a-z0-9]+)*$`)
+
+// Frontmatter L1 skill content: metadata parsed from SKILL.md frontmatter for skill discovery.
+// Attributes:
+//
+//	name: Skill name in kebab-case (required).
+//	description: What the skill does and when the model should use it (required).
+//	license: License for the skill (optional).
+//	compatibility: Compatibility information for the skill (optional).
+//	allowed_tools: Tool patterns the skill requires (optional, experimental).
+//		Accepts both ``allowed_tools`` and the YAML-friendly ``allowed-tools`` key.
+//	metadata: Key-value pairs for client-specific properties (defaults to empty dict).
+type Frontmatter struct {
+	Name          string            `yaml:"name"`
+	Description   string            `yaml:"description"`
+	License       string            `yaml:"license,omitempty"`
+	Compatibility string            `yaml:"compatibility,omitempty"`
+	AllowedTools  string            `yaml:"allowed_tools,omitempty"`
+	Metadata      map[string]string `yaml:"metadata,omitempty"`
+}
+
+func (f *Frontmatter) UnmarshalYAML(node *yaml.Node) error {
+	type tempFrontmatter struct {
+		Name          string            `yaml:"name"`
+		Description   string            `yaml:"description"`
+		License       string            `yaml:"license,omitempty"`
+		Compatibility string            `yaml:"compatibility,omitempty"`
+		AllowedTools  string            `yaml:"allowed_tools,omitempty"`
+		AllowedTools2 string            `yaml:"allowed-tools,omitempty"`
+		Metadata      map[string]string `yaml:"metadata,omitempty"`
+	}
+
+	var temp tempFrontmatter
+	if err := node.Decode(&temp); err != nil {
+		return err
+	}
+
+	if temp.AllowedTools != "" {
+		f.AllowedTools = temp.AllowedTools
+	} else {
+		f.AllowedTools = temp.AllowedTools2
+	}
+
+	f.Name = temp.Name
+	f.Description = temp.Description
+	f.License = temp.License
+	f.Compatibility = temp.Compatibility
+	f.Metadata = temp.Metadata
+
+	return nil
+}
+
+func (f *Frontmatter) Validate() error {
+	if len(f.Name) < 1 || len(f.Name) > 64 {
+		return fmt.Errorf("name must be 1-64 characters")
+	}
+	if !validNameRegex.MatchString(f.Name) {
+		return fmt.Errorf("name must be lowercase kebab-case (a-z, 0-9, hyphens), with no leading, trailing, or consecutive hyphens")
+	}
+
+	// Note: The rule "Must match the parent directory name" cannot be validated here
+	// as the Skill struct does not contain information about its file path.
+	// This validation should be performed by the caller when loading the skill.
+
+	if strings.TrimSpace(f.Description) == "" {
+		return fmt.Errorf("description must not be empty")
+	}
+	if len(f.Description) > 1024 {
+		return fmt.Errorf("description must be at most 1024 characters")
+	}
+
+	if f.Compatibility != "" && len(f.Compatibility) > 500 {
+		return fmt.Errorf("compatibility must be 1-500 characters")
+	}
+
+	return nil
+}
+
+func (f *Frontmatter) SkillPromptEntry() string {
+	return fmt.Sprintf("- name: %s, description: %s", f.Name, f.Description)
+}
+
+func (f *Frontmatter) ToJsonString() string {
+	bytes, _ := json.Marshal(f)
+	return string(bytes)
+}
+
+type Script struct {
+	Src string
+}
+
+func (s *Script) String() string {
+	return s.Src
+}
+
+// Resources L3 skill content: additional instructions, assets, and scripts, loaded as needed.
+// Attributes:
+//
+//	references: Additional markdown files with instructions, workflows, or guidance.
+//	assets: Resource materials like database schemas, API documentation, templates, or examples.
+//	scripts: Executable scripts that can be run via bash.
+type Resources struct {
+	References map[string]string
+	Assets     map[string]string
+	Scripts    map[string]*Script
+}
+
+func (r *Resources) GetReference(referenceId string) (string, bool) {
+	if r.References == nil {
+		return "", false
+	}
+	v, ok := r.References[referenceId]
+	return v, ok
+}
+
+func (r *Resources) GetAsset(assetId string) (string, bool) {
+	if r.Assets == nil {
+		return "", false
+	}
+	v, ok := r.Assets[assetId]
+	return v, ok
+}
+
+func (r *Resources) GetScript(scriptId string) (*Script, bool) {
+	if r.Scripts == nil {
+		return nil, false
+	}
+	v, ok := r.Scripts[scriptId]
+	return v, ok
+}
+
+func (r *Resources) ListReferences() []string {
+	out := make([]string, 0, len(r.References))
+	for k := range r.References {
+		out = append(out, k)
+	}
+	return out
+}
+
+func (r *Resources) ListAssets() []string {
+	out := make([]string, 0, len(r.Assets))
+	for k := range r.Assets {
+		out = append(out, k)
+	}
+	return out
+}
+
+func (r *Resources) ListScripts() []string {
+	out := make([]string, 0, len(r.Scripts))
+	for k := range r.Scripts {
+		out = append(out, k)
+	}
+	return out
+}
+
+type Skill struct {
+	Frontmatter  *Frontmatter
+	Instructions string
+	Resources    *Resources
+	SkillMDPath  string
+}
+
+func (s *Skill) Name() string {
+	return s.Frontmatter.Name
+}
+
+func (s *Skill) Description() string {
+	return s.Frontmatter.Description
+}
+
+func (s *Skill) GetSkillPath() string {
+	return filepath.Dir(s.SkillMDPath)
+}
+
+func (s *Skill) WriteSkill(path string) error {
+	if path == "" {
+		return fmt.Errorf("path must not be empty")
+	}
+	info, err := os.Stat(path)
+	if err != nil {
+		return fmt.Errorf("path invalid: %w", err)
+	}
+	if !info.IsDir() {
+		return fmt.Errorf("path must be a directory")
+	}
+
+	if s.Frontmatter == nil || s.Frontmatter.Name == "" {
+		return fmt.Errorf("skill name is missing")
+	}
+
+	skillDir := filepath.Join(path, s.Frontmatter.Name)
+	if err := os.MkdirAll(skillDir, 0o755); err != nil {
+		return fmt.Errorf("failed to create skill directory: %w", err)
+	}
+
+	// Write SKILL.md
+	if err := os.WriteFile(filepath.Join(skillDir, "SKILL.md"), []byte(s.Instructions), 0o644); err != nil {
+		return fmt.Errorf("failed to write SKILL.md: %w", err)
+	}
+
+	if s.Resources == nil {
+		return nil
+	}
+
+	// References
+	if len(s.Resources.References) > 0 {
+		refDir := filepath.Join(skillDir, "references")
+		if err := os.MkdirAll(refDir, 0o755); err != nil {
+			return fmt.Errorf("failed to create references directory: %w", err)
+		}
+		for name, content := range s.Resources.References {
+			targetPath := filepath.Join(refDir, name)
+			if err := os.MkdirAll(filepath.Dir(targetPath), 0o755); err != nil {
+				return fmt.Errorf("failed to create directory for reference %s: %w", name, err)
+			}
+			if err := os.WriteFile(targetPath, []byte(content), 0o644); err != nil {
+				return fmt.Errorf("failed to write reference %s: %w", name, err)
+			}
+		}
+	}
+
+	// Assets
+	if len(s.Resources.Assets) > 0 {
+		assetsDir := filepath.Join(skillDir, "assets")
+		if err := os.MkdirAll(assetsDir, 0o755); err != nil {
+			return fmt.Errorf("failed to create assets directory: %w", err)
+		}
+		for name, content := range s.Resources.Assets {
+			targetPath := filepath.Join(assetsDir, name)
+			if err := os.MkdirAll(filepath.Dir(targetPath), 0o755); err != nil {
+				return fmt.Errorf("failed to create directory for asset %s: %w", name, err)
+			}
+			if err := os.WriteFile(targetPath, []byte(content), 0o644); err != nil {
+				return fmt.Errorf("failed to write asset %s: %w", name, err)
+			}
+		}
+	}
+
+	// Scripts
+	if len(s.Resources.Scripts) > 0 {
+		scriptsDir := filepath.Join(skillDir, "scripts")
+		if err := os.MkdirAll(scriptsDir, 0o755); err != nil {
+			return fmt.Errorf("failed to create scripts directory: %w", err)
+		}
+		for name, script := range s.Resources.Scripts {
+			if script == nil {
+				continue
+			}
+			targetPath := filepath.Join(scriptsDir, name)
+			if err := os.MkdirAll(filepath.Dir(targetPath), 0o755); err != nil {
+				return fmt.Errorf("failed to create directory for script %s: %w", name, err)
+			}
+			if err := os.WriteFile(targetPath, []byte(script.Src), 0o755); err != nil {
+				return fmt.Errorf("failed to write script %s: %w", name, err)
+			}
+		}
+	}
+
+	s.SkillMDPath = filepath.Join(skillDir, "SKILL.md")
+
+	return nil
+}

--- a/skills/models_test.go
+++ b/skills/models_test.go
@@ -1,0 +1,157 @@
+// Copyright 2025 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package skills
+
+import (
+	"strings"
+	"testing"
+)
+
+func TestSkill_Valid(t *testing.T) {
+	tests := []struct {
+		name    string
+		skill   Frontmatter
+		wantErr bool
+	}{
+		{
+			name: "valid skill",
+			skill: Frontmatter{
+				Name:        "pdf-processing",
+				Description: "Extracts text and tables from PDF files.",
+			},
+			wantErr: false,
+		},
+		{
+			name: "valid skill with compatibility",
+			skill: Frontmatter{
+				Name:          "data-analysis",
+				Description:   "Analyzes data.",
+				Compatibility: "Requires python 3.9",
+			},
+			wantErr: false,
+		},
+		{
+			name: "invalid name - empty",
+			skill: Frontmatter{
+				Name:        "",
+				Description: "Valid description",
+			},
+			wantErr: true,
+		},
+		{
+			name: "invalid name - too long",
+			skill: Frontmatter{
+				Name:        strings.Repeat("a", 65),
+				Description: "Valid description",
+			},
+			wantErr: true,
+		},
+		{
+			name: "invalid name - uppercase",
+			skill: Frontmatter{
+				Name:        "PDF-Processing",
+				Description: "Valid description",
+			},
+			wantErr: true,
+		},
+		{
+			name: "invalid name - starts with hyphen",
+			skill: Frontmatter{
+				Name:        "-pdf",
+				Description: "Valid description",
+			},
+			wantErr: true,
+		},
+		{
+			name: "invalid name - ends with hyphen",
+			skill: Frontmatter{
+				Name:        "pdf-",
+				Description: "Valid description",
+			},
+			wantErr: true,
+		},
+		{
+			name: "invalid name - consecutive hyphens",
+			skill: Frontmatter{
+				Name:        "pdf--processing",
+				Description: "Valid description",
+			},
+			wantErr: true,
+		},
+		{
+			name: "invalid description - empty",
+			skill: Frontmatter{
+				Name:        "valid-name",
+				Description: "",
+			},
+			wantErr: true,
+		},
+		{
+			name: "invalid description - too long",
+			skill: Frontmatter{
+				Name:        "valid-name",
+				Description: strings.Repeat("a", 1025),
+			},
+			wantErr: true,
+		},
+		{
+			name: "invalid compatibility - too long",
+			skill: Frontmatter{
+				Name:          "valid-name",
+				Description:   "Valid description",
+				Compatibility: strings.Repeat("a", 501),
+			},
+			wantErr: true,
+		},
+		{
+			name: "valid skill with license",
+			skill: Frontmatter{
+				Name:        "valid-name",
+				Description: "Valid description",
+				License:     "MIT",
+			},
+			wantErr: false,
+		},
+		{
+			name: "valid skill with metadata",
+			skill: Frontmatter{
+				Name:        "valid-name",
+				Description: "Valid description",
+				Metadata: map[string]string{
+					"author":  "example-org",
+					"version": "1.0",
+				},
+			},
+			wantErr: false,
+		},
+		{
+			name: "valid skill with allowed tools",
+			skill: Frontmatter{
+				Name:         "valid-name",
+				Description:  "Valid description",
+				AllowedTools: "Bash(git:*) Bash(jq:*) Read",
+			},
+			wantErr: false,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			if err := tt.skill.Validate(); (err != nil) != tt.wantErr {
+				t.Errorf("Skill.Valid() error = %v, wantErr %v", err, tt.wantErr)
+			}
+		})
+	}
+}

--- a/skills/prompt.go
+++ b/skills/prompt.go
@@ -1,0 +1,48 @@
+// Copyright 2025 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package skills
+
+import (
+	"html"
+	"strings"
+)
+
+//type SkillLike interface {
+//	Name() string
+//	Description() string
+//}
+
+func FormatSkillsAsXML(skills []*Skill) string {
+	if len(skills) == 0 {
+		return "<available_skills>\n</available_skills>"
+	}
+
+	var b strings.Builder
+	b.WriteString("<available_skills>\n")
+
+	for _, item := range skills {
+		b.WriteString("<skill>\n")
+		b.WriteString("<name>\n")
+		b.WriteString(html.EscapeString(item.Name()))
+		b.WriteString("\n</name>\n")
+		b.WriteString("<description>\n")
+		b.WriteString(html.EscapeString(item.Description()))
+		b.WriteString("\n</description>\n")
+		b.WriteString("</skill>\n")
+	}
+
+	b.WriteString("</available_skills>")
+	return b.String()
+}

--- a/skills/utils.go
+++ b/skills/utils.go
@@ -1,0 +1,226 @@
+// Copyright 2025 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package skills
+
+import (
+	"bufio"
+	"errors"
+	"fmt"
+	"io/fs"
+	"log"
+	"os"
+	"path/filepath"
+	"strings"
+	"unicode/utf8"
+
+	"gopkg.in/yaml.v3"
+)
+
+// loadDir Recursively load files from a directory into a dictionary.
+// Args:
+//
+//	directory: Path to the directory to load.
+//
+// Returns:
+//
+//	Dictionary mapping relative file paths to their string content.
+func loadDir(directory string) (map[string]string, error) {
+	files := make(map[string]string)
+	info, err := os.Stat(directory)
+	if err != nil {
+		return files, nil
+	}
+	if !info.IsDir() {
+		return files, nil
+	}
+	err = filepath.WalkDir(directory, func(path string, d fs.DirEntry, err error) error {
+		if err != nil {
+			return err
+		}
+		for _, part := range strings.Split(path, string(filepath.Separator)) {
+			if part == "__pycache__" {
+				if d.IsDir() {
+					return fs.SkipDir
+				}
+				return nil
+			}
+		}
+		if d.IsDir() {
+			return nil
+		}
+		b, err := os.ReadFile(path)
+		if err != nil {
+			return fmt.Errorf("read file %s: %w", path, err)
+		}
+		if !utf8.Valid(b) {
+			return errors.New("invalid UTF-8")
+		}
+		rel, err := filepath.Rel(directory, path)
+		if err != nil {
+			return fmt.Errorf("get relative path: %w", err)
+		}
+		rel = filepath.ToSlash(rel)
+		files[rel] = string(b)
+		return nil
+	})
+	if err != nil {
+		return files, err
+	}
+	return files, nil
+}
+
+func parseFrontmatter(text []byte) (*Frontmatter, error) {
+	var skillMeta Frontmatter
+
+	if err := yaml.Unmarshal(text, &skillMeta); err != nil {
+		return nil, fmt.Errorf("failed to parse frontmatter {%s} error: %v", text, err)
+	}
+
+	if skillMeta.Name == "" || skillMeta.Description == "" {
+		return nil, fmt.Errorf("skill %s frontmatter is missing name or description. Please check the SKILL.md file", text)
+	}
+
+	log.Printf("Successfully loaded skill frontmatter ,name = %s,description=%s", skillMeta.Name, skillMeta.Description)
+	return &skillMeta, nil
+}
+
+func parseSkillMD(skillDir string) (*Skill, error) {
+	skill := &Skill{}
+	info, err := os.Stat(skillDir)
+	if err != nil {
+		return skill, fmt.Errorf("skill directory '%s' stat error:%w", skillDir, err)
+	}
+	if !info.IsDir() {
+		return skill, fmt.Errorf("skill directory '%s' is not a directory", skillDir)
+	}
+
+	var skillMD string
+	for _, name := range []string{"SKILL.md", "skill.md"} {
+		p := filepath.Join(skillDir, name)
+		if _, err := os.Stat(p); err == nil {
+			skillMD = p
+			break
+		}
+	}
+	if skillMD == "" {
+		return skill, fmt.Errorf("SKILL.md not found in '%s'", skillDir)
+	}
+
+	file, err := os.Open(skillMD)
+	if err != nil {
+		return skill, fmt.Errorf("open skill file '%s' error:%w", skillMD, err)
+	}
+	defer func() {
+		_ = file.Close()
+	}()
+	sc := bufio.NewScanner(file)
+	if !sc.Scan() {
+		return skill, err
+	}
+
+	if strings.TrimSpace(sc.Text()) != "---" {
+		return skill, fmt.Errorf("failed to parse %s, invalid frontmatter", skillMD)
+	}
+
+	var frontmatterLines []string
+	var contextLines []string
+	isFrontmatterLines := true
+
+	for sc.Scan() {
+		line := sc.Text()
+		if isFrontmatterLines && strings.TrimSpace(line) == "---" {
+			if len(frontmatterLines) == 0 {
+				return nil, fmt.Errorf("failed to parse %s, empty frontmatter", skillMD)
+			}
+			isFrontmatterLines = false
+			frontmatterStr := strings.Join(frontmatterLines, "\n")
+			skill.Frontmatter, err = parseFrontmatter([]byte(frontmatterStr))
+			if err != nil {
+				return skill, fmt.Errorf("failed to parse frontmatter '%s', %w", skillMD, err)
+			}
+			if err := skill.Frontmatter.Validate(); err != nil {
+				return skill, fmt.Errorf("skill %s frontmatter invalid :%w", skillDir, err)
+			}
+			continue
+		}
+		if isFrontmatterLines {
+			frontmatterLines = append(frontmatterLines, line)
+		} else {
+			contextLines = append(contextLines, line)
+		}
+	}
+
+	if isFrontmatterLines {
+		return skill, fmt.Errorf("failed to parse %s, missing closing frontmatter separator", skillMD)
+	}
+
+	skill.Instructions = strings.Join(contextLines, "\n")
+	skill.SkillMDPath = skillMD
+
+	log.Printf("Successfully loaded skill %s locally from %s", skill.Frontmatter.Name, skillDir)
+	return skill, nil
+}
+
+func LoadSkillFromDir(skillDir string) (*Skill, error) {
+	var skill *Skill
+	var err error
+	abs, err := filepath.Abs(skillDir)
+	if err != nil {
+		return skill, err
+	}
+	skill, err = parseSkillMD(abs)
+	if err != nil {
+		return skill, fmt.Errorf("failed to parse skill directory '%s' error:%w", skillDir, err)
+	}
+
+	if base := filepath.Base(abs); base != skill.Name() {
+		return skill, fmt.Errorf("skill name '%s' does not match directory name '%s'", skill.Name(), base)
+	}
+	refs, err := loadDir(filepath.Join(abs, "references"))
+	if err != nil {
+		return skill, fmt.Errorf("failed to load references dir '%s' error:%w", abs, err)
+	}
+	assets, err := loadDir(filepath.Join(abs, "assets"))
+	if err != nil {
+		return skill, fmt.Errorf("failed to load assets dir '%s' error:%w", abs, err)
+	}
+	rawScripts, err := loadDir(filepath.Join(abs, "scripts"))
+	if err != nil {
+		return skill, fmt.Errorf("failed to load scripts dir '%s' error:%w", abs, err)
+	}
+	scripts := make(map[string]*Script, len(rawScripts))
+	for k, v := range rawScripts {
+		scripts[k] = &Script{Src: v}
+	}
+	skill.Resources = &Resources{
+		References: refs,
+		Assets:     assets,
+		Scripts:    scripts,
+	}
+
+	return skill, nil
+}
+
+func ReadSkillProperties(skillDir string) (*Frontmatter, error) {
+	abs, err := filepath.Abs(skillDir)
+	if err != nil {
+		return nil, err
+	}
+	skill, err := parseSkillMD(abs)
+	if err != nil {
+		return nil, err
+	}
+	return skill.Frontmatter, nil
+}

--- a/skills/utils_test.go
+++ b/skills/utils_test.go
@@ -1,0 +1,134 @@
+// Copyright 2025 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package skills
+
+import (
+	"os"
+	"path/filepath"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+var mockSkill = &Skill{
+	Frontmatter: &Frontmatter{
+		Name:        "test-skill",
+		Description: "A test skill for unit testing",
+		Metadata: map[string]string{
+			"version": "1.0.0",
+		},
+	},
+	Instructions: "---\nname: test-skill\ndescription: A test skill for unit testing\n---\n\n# Test Skill\n\nThis is a test skill.",
+	Resources: &Resources{
+		Scripts: map[string]*Script{
+			"test_script.py": {
+				Src: `print("Hello World")`,
+			},
+		},
+		References: map[string]string{
+			"ref.md": "# Reference\nThis is a reference file.",
+		},
+		Assets: map[string]string{
+			"data.json":       `{"key": "value"}`,
+			"subdir/file.txt": "content in subdir",
+		},
+	},
+}
+
+func TestLoadSkillFromDir(t *testing.T) {
+	// 1. Create a temporary directory
+	tmpDir := t.TempDir()
+
+	// 2. Write the mock skill to the temporary directory
+	err := mockSkill.WriteSkill(tmpDir)
+	require.NoError(t, err)
+
+	// The skill is written to tmpDir/test-skill
+	skillDir := filepath.Join(tmpDir, mockSkill.Name())
+
+	// 3. Test LoadSkillFromDir
+	loadedSkill, err := LoadSkillFromDir(skillDir)
+	require.NoError(t, err)
+	require.NotNil(t, loadedSkill)
+
+	// Verify Frontmatter
+	assert.Equal(t, mockSkill.Frontmatter.Name, loadedSkill.Frontmatter.Name)
+	assert.Equal(t, mockSkill.Frontmatter.Description, loadedSkill.Frontmatter.Description)
+
+	// Verify Instructions
+	// Note: parseSkillMD separates frontmatter and content.
+	// The original Instructions string includes frontmatter, but loadedSkill.Instructions should only have the content.
+	expectedInstructions := "\n# Test Skill\n\nThis is a test skill."
+	assert.Equal(t, expectedInstructions, loadedSkill.Instructions)
+
+	// Verify Resources
+	require.NotNil(t, loadedSkill.Resources)
+
+	// Verify Scripts
+	script, ok := loadedSkill.Resources.GetScript("test_script.py")
+	assert.True(t, ok)
+	assert.Equal(t, mockSkill.Resources.Scripts["test_script.py"].Src, script.Src)
+
+	// Verify References
+	ref, ok := loadedSkill.Resources.GetReference("ref.md")
+	assert.True(t, ok)
+	assert.Equal(t, mockSkill.Resources.References["ref.md"], ref)
+
+	// Verify Assets
+	asset, ok := loadedSkill.Resources.GetAsset("data.json")
+	assert.True(t, ok)
+	assert.Equal(t, mockSkill.Resources.Assets["data.json"], asset)
+
+	// Verify Assets in subdir (loadDir is recursive)
+	assetSub, ok := loadedSkill.Resources.GetAsset("subdir/file.txt")
+	assert.True(t, ok)
+	assert.Equal(t, mockSkill.Resources.Assets["subdir/file.txt"], assetSub)
+}
+
+func TestReadSkillProperties(t *testing.T) {
+	tmpDir := t.TempDir()
+	err := mockSkill.WriteSkill(tmpDir)
+	require.NoError(t, err)
+
+	skillDir := filepath.Join(tmpDir, mockSkill.Name())
+
+	frontmatter, err := ReadSkillProperties(skillDir)
+	require.NoError(t, err)
+	require.NotNil(t, frontmatter)
+
+	assert.Equal(t, mockSkill.Frontmatter.Name, frontmatter.Name)
+	assert.Equal(t, mockSkill.Frontmatter.Description, frontmatter.Description)
+}
+
+func TestLoadSkillFromDir_Errors(t *testing.T) {
+	tmpDir := t.TempDir()
+
+	// Test non-existent directory
+	_, err := LoadSkillFromDir(filepath.Join(tmpDir, "non-existent"))
+	assert.Error(t, err)
+
+	// Test empty directory (no SKILL.md)
+	emptyDir := filepath.Join(tmpDir, "empty-skill")
+	_ = mockSkill.WriteSkill(tmpDir) // write normal skill first
+	// overwrite with empty dir
+	// actually let's just make a new dir
+	err = os.Mkdir(emptyDir, 0o755)
+	require.NoError(t, err)
+
+	_, err = LoadSkillFromDir(emptyDir)
+	assert.Error(t, err)
+	assert.Contains(t, err.Error(), "SKILL.md not found")
+}

--- a/tool/skilltool/skill_toolset.go
+++ b/tool/skilltool/skill_toolset.go
@@ -1,0 +1,303 @@
+// Copyright 2025 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package skilltool
+
+import (
+	"encoding/json"
+	"fmt"
+	"log"
+	"path/filepath"
+	"sort"
+	"strings"
+
+	"google.golang.org/genai"
+
+	"google.golang.org/adk/agent"
+	"google.golang.org/adk/code_executors"
+	"google.golang.org/adk/model"
+	"google.golang.org/adk/skills"
+	"google.golang.org/adk/tool"
+	"google.golang.org/adk/tool/functiontool"
+)
+
+const (
+	DEFAULT_SKILL_SYSTEM_INSTRUCTION = "" +
+		"You can use specialized 'skills' to help you with complex tasks. You MUST use the skill tools to interact with these skills.\n\n" +
+		"Skills are folders of instructions and resources that extend your capabilities for specialized tasks. Each skill folder contains:\n" +
+		"- **SKILL.md** (required): The main instruction file with skill metadata and detailed markdown instructions.\n" +
+		"- **references/** (Optional): Additional documentation or examples for skill usage.\n" +
+		"- **assets/** (Optional): Templates, scripts or other resources used by the skill.\n" +
+		"- **scripts/** (Optional): Executable scripts that can be run via bash.\n\n" +
+		"This is very important:\n\n" +
+		"1. If a skill seems relevant to the current user query, you MUST use the `load_skill` tool with `name=\"<SKILL_NAME>\"` to read its full instructions before proceeding.\n" +
+		"2. Once you have read the instructions, follow them exactly as documented before replying to the user. For example, If the instruction lists multiple steps, please make sure you complete all of them in order.\n" +
+		"3. The `load_skill_resource` tool is for viewing files within a skill's directory (e.g., `references/*`, `assets/*`, `scripts/*`). Do NOT use other tools to access these files.\n" +
+		"4. Use `run_skill_script` to run scripts from a skill's `scripts/` directory. Use `load_skill_resource` to view script content first if needed.\n"
+)
+
+// SkillToolset A toolset for managing and interacting with agent skills.
+type SkillToolset struct {
+	skills       map[string]*skills.Skill
+	tools        []tool.Tool
+	codeExecutor code_executors.CodeExecutor
+}
+
+func NewSkillToolset(skillList []*skills.Skill, codeExecutor code_executors.CodeExecutor) (*SkillToolset, error) {
+	m := make(map[string]*skills.Skill, len(skillList))
+	for _, s := range skillList {
+		if _, dup := m[s.Name()]; dup {
+			return nil, fmt.Errorf("duplicate skill name '%s'", s.Name())
+		}
+		m[s.Name()] = s
+	}
+	st := &SkillToolset{
+		skills:       m,
+		codeExecutor: codeExecutor,
+	}
+	st.tools = []tool.Tool{
+		st.listSkillsTool(),
+		st.loadSkillTool(),
+		st.loadSkillResourceTool(),
+		st.runSkillScriptTool(),
+	}
+	return st, nil
+}
+
+func (s *SkillToolset) Name() string {
+	return "SkillToolset"
+}
+
+func (s *SkillToolset) Tools(ctx agent.ReadonlyContext) ([]tool.Tool, error) {
+	return s.tools, nil
+}
+
+//func (s *SkillToolset) GetTools() []tool.Tool {
+//	return s.tools
+//}
+
+func (s *SkillToolset) ProcessRequest(ctx tool.Context, req *model.LLMRequest) error {
+	skillList := s.listSkills()
+	skillXML := skills.FormatSkillsAsXML(skillList)
+	instruction := []string{DEFAULT_SKILL_SYSTEM_INSTRUCTION, skillXML}
+	if req.Config.SystemInstruction == nil {
+		req.Config.SystemInstruction = &genai.Content{
+			Parts: []*genai.Part{
+				{
+					Text: strings.Join(instruction, "\n\n"),
+				},
+			},
+			Role: "user",
+		}
+	} else {
+		req.Config.SystemInstruction.Parts = append(req.Config.SystemInstruction.Parts,
+			&genai.Part{
+				Text: strings.Join(instruction, "\n\n"),
+			},
+		)
+	}
+	systemInstructionStr, _ := json.Marshal(req.Config.SystemInstruction)
+	log.Printf("SkillToolset After ProcessRequest SystemInstruction is %s", systemInstructionStr)
+	return nil
+}
+
+func (s *SkillToolset) getSkill(name string) (*skills.Skill, bool) {
+	sk, ok := s.skills[name]
+	return sk, ok
+}
+
+func (s *SkillToolset) listSkills() []*skills.Skill {
+	out := make([]*skills.Skill, 0, len(s.skills))
+	for _, v := range s.skills {
+		out = append(out, v)
+	}
+	sort.Slice(out, func(i, j int) bool { return out[i].Name() < out[j].Name() })
+	return out
+}
+
+type listSkillsArgs struct{}
+
+func (s *SkillToolset) listSkillsToolHandler(ctx tool.Context, args listSkillsArgs) (map[string]any, error) {
+	xml := skills.FormatSkillsAsXML(s.listSkills())
+	return map[string]any{"result": xml}, nil
+}
+
+// listSkillsTool Tool to list all available skills.
+func (s *SkillToolset) listSkillsTool() tool.Tool {
+	t, _ := functiontool.New(functiontool.Config{
+		Name:        "list_skills",
+		Description: "Lists all available skills with their names and descriptions.",
+	}, s.listSkillsToolHandler)
+	return t
+}
+
+type loadSkillArgs struct {
+	Name string `json:"name" jsonschema:"The name of the skill to load."`
+}
+
+func (s *SkillToolset) loadSkillToolHandler(ctx tool.Context, args loadSkillArgs) (map[string]any, error) {
+	if strings.TrimSpace(args.Name) == "" {
+		return map[string]any{
+			"error":      "Skill name is required.",
+			"error_code": "MISSING_SKILL_NAME",
+		}, nil
+	}
+	sk, ok := s.getSkill(args.Name)
+	if !ok {
+		return map[string]any{
+			"error":      fmt.Sprintf("Skill '%s' not found.", args.Name),
+			"error_code": "SKILL_NOT_FOUND",
+		}, nil
+	}
+
+	return map[string]any{
+		"skill_name":   sk.Name(),
+		"instructions": sk.Instructions,
+		"frontmatter":  sk.Frontmatter.ToJsonString(),
+	}, nil
+}
+
+// loadSkillTool Tool to load a skill's instructions."""
+func (s *SkillToolset) loadSkillTool() tool.Tool {
+	t, _ := functiontool.New(functiontool.Config{
+		Name:        "load_skill",
+		Description: "Loads the SKILL.md instructions for a given skill.",
+	}, s.loadSkillToolHandler)
+	return t
+}
+
+type loadSkillResourceArgs struct {
+	SkillName string `json:"skill_name" jsonschema:"The name of the skill."`
+	Path      string `json:"path" jsonschema:"The relative path to the resource (e.g., 'references/x.md', 'assets/template.txt', 'scripts/setup.sh')."`
+}
+
+func (s *SkillToolset) loadSkillResourceToolHandler(ctx tool.Context, args loadSkillResourceArgs) (map[string]any, error) {
+	if strings.TrimSpace(args.SkillName) == "" {
+		return map[string]any{"error": "Skill name is required.", "error_code": "MISSING_SKILL_NAME"}, nil
+	}
+	if strings.TrimSpace(args.Path) == "" {
+		return map[string]any{"error": "Resource path is required.", "error_code": "MISSING_RESOURCE_PATH"}, nil
+	}
+	sk, ok := s.getSkill(args.SkillName)
+	if !ok {
+		return map[string]any{"error": fmt.Sprintf("Skill '%s' not found.", args.SkillName), "error_code": "SKILL_NOT_FOUND"}, nil
+	}
+	var content string
+	var found bool
+	if strings.HasPrefix(args.Path, "references/") {
+		name := strings.TrimPrefix(args.Path, "references/")
+		content, found = sk.Resources.GetReference(name)
+	} else if strings.HasPrefix(args.Path, "assets/") {
+		name := strings.TrimPrefix(args.Path, "assets/")
+		content, found = sk.Resources.GetAsset(name)
+	} else if strings.HasPrefix(args.Path, "scripts/") {
+		name := strings.TrimPrefix(args.Path, "scripts/")
+		scr, ok2 := sk.Resources.GetScript(name)
+		if ok2 && scr != nil {
+			content, found = scr.Src, true
+		}
+	} else {
+		return map[string]any{
+			"error":      "Path must start with 'references/', 'assets/', or 'scripts/'.",
+			"error_code": "INVALID_RESOURCE_PATH",
+		}, nil
+	}
+	if !found {
+		return map[string]any{
+			"error":      fmt.Sprintf("Resource '%s' not found in skill '%s'.", args.Path, args.SkillName),
+			"error_code": "RESOURCE_NOT_FOUND",
+		}, nil
+	}
+	return map[string]any{
+		"skill_name": sk.Name(),
+		"path":       args.Path,
+		"content":    content,
+	}, nil
+}
+
+// loadSkillResourceTool Tool to load resources (references, assets, or scripts) from a skill."""
+func (s *SkillToolset) loadSkillResourceTool() tool.Tool {
+	t, _ := functiontool.New(functiontool.Config{
+		Name:        "load_skill_resource",
+		Description: "Loads a resource file (from references/, assets/, or scripts/) from within a skill.",
+	}, s.loadSkillResourceToolHandler)
+	return t
+}
+
+type runSkillScriptArgs struct {
+	SkillName  string   `json:"skill_name" jsonschema:"The name of the skill."`
+	ScriptPath string   `json:"script_path" jsonschema:"The relative path to the script (e.g., 'scripts/setup.py')."`
+	Args       []string `json:"args_list" jsonschema:"Optional arguments to pass to the script as list."`
+}
+
+func (s *SkillToolset) runSkillScriptToolHandler(ctx tool.Context, args runSkillScriptArgs) (map[string]any, error) {
+	if strings.TrimSpace(args.SkillName) == "" {
+		return map[string]any{"error": "Skill name is required.", "error_code": "MISSING_SKILL_NAME"}, nil
+	}
+	if strings.TrimSpace(args.ScriptPath) == "" {
+		return map[string]any{"error": "Script path is required.", "error_code": "MISSING_SCRIPT_PATH"}, nil
+	}
+	sk, ok := s.getSkill(args.SkillName)
+	if !ok {
+		return map[string]any{"error": fmt.Sprintf("Skill '%s' not found.", args.SkillName), "error_code": "SKILL_NOT_FOUND"}, nil
+	}
+	name := args.ScriptPath
+	if strings.HasPrefix(args.ScriptPath, "scripts/") {
+		name = strings.TrimPrefix(args.ScriptPath, "scripts/")
+	}
+
+	if scr, ok := sk.Resources.GetScript(name); !ok || scr == nil {
+		return map[string]any{"error": fmt.Sprintf("Script '%s' not found in skill '%s'.", args.ScriptPath, args.SkillName), "error_code": "SCRIPT_NOT_FOUND"}, nil
+	}
+	if s.codeExecutor == nil {
+		return map[string]any{
+			"error":      "No code executor configured. A code executor is required to run scripts.",
+			"error_code": "NO_CODE_EXECUTOR",
+		}, nil
+	}
+	argsStr, _ := json.Marshal(args)
+	log.Printf("runSkillScriptToolHandler args is %s", string(argsStr))
+	codeExecutorResult, err := s.codeExecutor.ExecuteCode(nil, code_executors.CodeExecutionInput{
+		Args:        args.Args,
+		ScriptPath:  filepath.Join(sk.GetSkillPath(), "scripts", name),
+		InputFiles:  nil,
+		ExecutionID: ctx.InvocationID(),
+	})
+	resultStr, _ := json.Marshal(codeExecutorResult)
+	log.Printf("codeExecutor result is %s", string(resultStr))
+	if err != nil {
+		return map[string]any{
+			"error":      fmt.Sprintf("Failed to execute script '%s':\n%s", args.ScriptPath, err.Error()),
+			"error_code": "EXECUTION_ERROR",
+		}, nil
+	}
+	status := "success"
+
+	return map[string]any{
+		"skill_name":  sk.Name(),
+		"script_path": args.ScriptPath,
+		"stdout":      codeExecutorResult.StdOut,
+		"stderr":      codeExecutorResult.StdErr,
+		"status":      status,
+	}, nil
+}
+
+// runSkillScriptTool Tool to execute scripts from a skill's scripts/ directory."""
+func (s *SkillToolset) runSkillScriptTool() tool.Tool {
+	t, _ := functiontool.New(functiontool.Config{
+		Name:        "run_skill_script",
+		Description: "Executes a script from a skill's scripts/ directory.",
+	}, s.runSkillScriptToolHandler)
+	return t
+}

--- a/tool/skilltool/skill_toolset_test.go
+++ b/tool/skilltool/skill_toolset_test.go
@@ -1,0 +1,225 @@
+// Copyright 2025 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package skilltool
+
+import (
+	"encoding/json"
+	"log"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/assert"
+
+	"google.golang.org/adk/code_executors"
+	"google.golang.org/adk/skills"
+	"google.golang.org/adk/tool"
+)
+
+var mockSkills = map[string]*skills.Skill{
+	"multiplication-calculator": {
+		Frontmatter: &skills.Frontmatter{
+			Name:        "multiplication-calculator",
+			Description: "提供乘法数值计算功能。当需要执行乘法运算任务时使用此技能。",
+		},
+		Instructions: "---\nname: multiplication-calculator\ndescription: 提供乘法数值计算功能。当需要执行乘法运算任务时使用此技能。\n---\n\n# 乘法数值计算器\n\n## 概述\n\n乘法数值计算器技能提供简单的数字相乘能力。该技能包含Python脚本，可用于执行乘法计算任务。\n\n## 快速开始\n\n要使用乘法计算功能，可以直接调用提供的Python脚本：\n\n```bash\n# 运行演示脚本\npython scripts/multiply.py <num1> <num2> ... <numn>\n```",
+		Resources: &skills.Resources{
+			Scripts: map[string]*skills.Script{
+				"multiply.py": {
+					Src: `#!/usr/bin/env python3
+import sys
+
+"""
+乘法数值计算脚本
+提供多种乘法运算功能
+"""
+
+
+def multiply_list(numbers):
+    """
+    列表中的所有数字相乘
+
+    Args:
+        numbers (list): 数字列表
+
+    Returns:
+        float: 所有数字的乘积
+
+    Raises:
+        ValueError: 如果列表为空
+    """
+    if not numbers:
+        raise ValueError("数字列表不能为空")
+
+    result = 1
+    for num in numbers:
+        result *= num
+    return result
+
+
+if __name__ == "__main__":
+    if len(sys.argv) < 2:
+        print("Usage: python multiply.py <num1> <num2> ...<numn>")
+        sys.exit(1)
+    nums = []
+    for n in sys.argv[1:]:
+        nums.append(float(n))
+    out = multiply_list(nums)
+    print(out)
+`,
+				},
+			},
+		},
+	},
+}
+
+func createMockSkill(t *testing.T) []*skills.Skill {
+	tmpDir := t.TempDir()
+	log.Print("Created temp dir: " + tmpDir)
+	var skillList []*skills.Skill
+	for _, sk := range mockSkills {
+		err := sk.WriteSkill(tmpDir)
+		if err != nil {
+			t.Fatalf("write skill %s to %s error:%s", sk.Name(), tmpDir, err)
+		}
+		skillList = append(skillList, sk)
+	}
+	return skillList
+}
+
+func TestListSkillsTool(t *testing.T) {
+	skillList := createMockSkill(t)
+	toolset, err := NewSkillToolset(skillList, code_executors.NewUnsafeLocalCodeExecutor(300*time.Second))
+	assert.NoError(t, err)
+
+	listTool := toolset.listSkillsTool()
+	assert.Equal(t, "list_skills", listTool.Name())
+
+	result, err := toolset.listSkillsToolHandler(nil, listSkillsArgs{})
+	assert.NoError(t, err)
+
+	outputMap := result
+	xmlResult, ok := outputMap["result"].(string)
+	assert.True(t, ok)
+	assert.Contains(t, xmlResult, "multiplication-calculator")
+	assert.Contains(t, xmlResult, "提供乘法数值计算功能。当需要执行乘法运算任务时使用此技能。")
+}
+
+func TestLoadSkillTool(t *testing.T) {
+	skillList := createMockSkill(t)
+	toolset, err := NewSkillToolset(skillList, nil)
+	assert.NoError(t, err)
+
+	loadTool := toolset.loadSkillTool()
+	assert.Equal(t, "load_skill", loadTool.Name())
+
+	// Test missing name
+	result, err := toolset.loadSkillToolHandler(nil, loadSkillArgs{})
+	assert.NoError(t, err)
+	outputMap := result
+	assert.Equal(t, "MISSING_SKILL_NAME", outputMap["error_code"])
+
+	// Test skill not found
+	result, err = toolset.loadSkillToolHandler(nil, loadSkillArgs{Name: "unknown-skill"})
+	assert.NoError(t, err)
+	outputMap = result
+	assert.Equal(t, "SKILL_NOT_FOUND", outputMap["error_code"])
+
+	// Test success
+	result, err = toolset.loadSkillToolHandler(nil, loadSkillArgs{Name: "multiplication-calculator"})
+	assert.NoError(t, err)
+	outputMap = result
+	assert.Equal(t, "multiplication-calculator", outputMap["skill_name"])
+	assert.Equal(t, mockSkills["multiplication-calculator"].Instructions, outputMap["instructions"])
+	assert.NotEmpty(t, outputMap["frontmatter"])
+}
+
+func TestLoadSkillResourceTool(t *testing.T) {
+	skillList := createMockSkill(t)
+	toolset, err := NewSkillToolset(skillList, nil)
+	assert.NoError(t, err)
+
+	resourceTool := toolset.loadSkillResourceTool()
+	assert.Equal(t, "load_skill_resource", resourceTool.Name())
+
+	// Test missing params
+	result, err := toolset.loadSkillResourceToolHandler(nil, loadSkillResourceArgs{})
+	assert.NoError(t, err)
+	outputMap := result
+	assert.Equal(t, "MISSING_SKILL_NAME", outputMap["error_code"])
+
+	result, err = toolset.loadSkillResourceToolHandler(nil, loadSkillResourceArgs{SkillName: "multiplication-calculator"})
+	assert.NoError(t, err)
+	outputMap = result
+	assert.Equal(t, "MISSING_RESOURCE_PATH", outputMap["error_code"])
+
+	// Test success
+	result, err = toolset.loadSkillResourceToolHandler(nil, loadSkillResourceArgs{
+		SkillName: "multiplication-calculator",
+		Path:      "scripts/multiply.py",
+	})
+	assert.NoError(t, err)
+	outputMap = result
+	assert.Equal(t, "multiplication-calculator", outputMap["skill_name"])
+	assert.Equal(t, "scripts/multiply.py", outputMap["path"])
+	assert.Equal(t, mockSkills["multiplication-calculator"].Resources.Scripts["multiply.py"].String(), outputMap["content"])
+
+	// Test not found
+	result, err = toolset.loadSkillResourceToolHandler(nil, loadSkillResourceArgs{
+		SkillName: "multiplication-calculator",
+		Path:      "scripts/unknown.py",
+	})
+	assert.NoError(t, err)
+	outputMap = result
+	assert.Equal(t, "RESOURCE_NOT_FOUND", outputMap["error_code"])
+}
+
+type mockToolContext struct {
+	tool.Context
+}
+
+func (m *mockToolContext) InvocationID() string {
+	return "test-invocation-id"
+}
+
+func TestRunSkillScriptTool(t *testing.T) {
+	skillList := createMockSkill(t)
+
+	mockExecutor := code_executors.NewUnsafeLocalCodeExecutor(300 * time.Second)
+
+	toolset, err := NewSkillToolset(skillList, mockExecutor)
+	assert.NoError(t, err)
+
+	runTool := toolset.runSkillScriptTool()
+	assert.Equal(t, "run_skill_script", runTool.Name())
+
+	// Test missing params
+	result, err := toolset.runSkillScriptToolHandler(&mockToolContext{}, runSkillScriptArgs{})
+	assert.NoError(t, err)
+	outputMap := result
+	assert.Equal(t, "MISSING_SKILL_NAME", outputMap["error_code"])
+
+	// Test success
+	result, err = toolset.runSkillScriptToolHandler(&mockToolContext{}, runSkillScriptArgs{
+		SkillName:  "multiplication-calculator",
+		ScriptPath: "scripts/multiply.py",
+		Args:       []string{"2", "3", "4"},
+	})
+	assert.NoError(t, err)
+	outputMap = result
+	str, _ := json.Marshal(outputMap)
+	println(string(str))
+	assert.Equal(t, "success", outputMap["status"])
+	assert.Equal(t, "24.0\n", outputMap["stdout"])
+}


### PR DESCRIPTION
### Link to Issue or Description of Change

**1. Link to an existing issue (if applicable):**

- Related: #540 

**2. Or, if no issue exists, describe the change:**

**Problem:**
The agent currently lacks a standardized, modular way to extend its capabilities using file-based "skills" (collections of instructions, resources, and executable scripts). There is also no built-in mechanism to execute local scripts provided by these skills, which limits the agent's ability to perform specialized tasks defined in external skill repositories.

**Solution:**
I have implemented an experimental "Skill" feature . The changes include:

1.  **Core Model (`skills` package):** Defined the data structures for `Skill`, `Frontmatter`, `Resources`, and `Script` to parse and validate skill directories.
2.  **Skill Toolset (`tool/skilltool`):** Implemented `SkillToolset` which exposes the following tools to the agent:
    *   `list_skills`: Discover available skills.
    *   `load_skill`: Read skill instructions (`SKILL.md`).
    *   `load_skill_resource`: Access auxiliary files (references, assets).
    *   `run_skill_script`: Execute scripts contained within a skill.
3.  **Code Executor (`code_executors`):** Added `UnsafeLocalCodeExecutor` to support running Python and Bash scripts locally via `os/exec`.
4.  **Example (`examples/skill`):** Added a `main.go` example demonstrating how to initialize an agent with the `SkillToolset` and load skills from a directory.

### Testing Plan

**Unit Tests:**

- I have added or updated unit tests for my change.
- All unit tests pass locally.

*   **`tool/skilltool`**: Added `skill_toolset_test.go` which tests all tool handlers (`list_skills`, `load_skill`, etc.) using mock skills.
*   **`code_executors`**: Added `unsafe_local_code_executor_test.go` which verifies script execution (Python/Bash), argument passing, and timeout handling.

**Manual End-to-End (E2E) Tests:**

1.  Navigate to the example directory: `cd examples/skill`.
2.  Ensure you have a valid `GOOGLE_API_KEY` environment variable set.
3.  Prepare a sample skill directory (or use a mock one).
4.  Run the example agent:
    ```bash
    go run main.go
    ```
5.  Interact with the agent and ask it to perform a task that requires a skill (e.g., "use the multiplication skill to calculate 5 * 5").
6.  Verify that the agent correctly calls `load_skill` and `run_skill_script`, and returns the correct result.

### Additional context

_Add any other context or screenshots about the feature request here._

This feature is currently experimental. The `UnsafeLocalCodeExecutor` executes code directly on the host machine and should be used with caution. Future improvements may include sandboxed execution environments.
