### PR TITLE
feat: add opt-in content capture to GenerateContent spans

### DIFF
--- a/internal/llminternal/base_flow.go
+++ b/internal/llminternal/base_flow.go
@@ -380,6 +380,7 @@ func generateContent(ctx agent.InvocationContext, m model.LLM, req *model.LLMReq
 		spanCtx, span := telemetry.StartGenerateContentSpan(ctx, telemetry.StartGenerateContentSpanParams{
 			ModelName:    m.Name(),
 			InvocationID: ctx.InvocationID(),
+			LLMRequest:   req,
 		})
 		ctx = ctx.WithContext(spanCtx)
 		backend := googlellm.GetGoogleLLMVariant(m)

--- a/internal/telemetry/logger.go
+++ b/internal/telemetry/logger.go
@@ -17,6 +17,7 @@ package telemetry
 import (
 	"context"
 	"encoding/json"
+	"os"
 	"strings"
 	"sync/atomic"
 
@@ -29,17 +30,25 @@ import (
 	"google.golang.org/adk/model"
 )
 
-// genAICaptureMessageContent is true if message content should be elided. False by default.
+// genAICaptureMessageContent is true if message content should be captured. False by default.
 var genAICaptureMessageContent atomic.Bool
 
-// SetGenAICaptureMessageContent sets whether message content should be elided.
+// SetGenAICaptureMessageContent sets whether message content should be captured.
 func SetGenAICaptureMessageContent(capture bool) {
 	genAICaptureMessageContent.Store(capture)
 }
 
-// getGenAICaptureMessageContent returns whether message content should be elided.
+// getGenAICaptureMessageContent returns whether message content should be captured.
+// It checks the programmatic flag first, then falls back to the standard OTel env var.
 func getGenAICaptureMessageContent() bool {
-	return genAICaptureMessageContent.Load()
+	if genAICaptureMessageContent.Load() {
+		return true
+	}
+	// Fall back to the standard OTel env var for content capture.
+	// Any non-empty value is treated as enabling content capture for now.
+	// In the future, this will support the full mode set (EVENT_ONLY, SPAN_ONLY, SPAN_AND_EVENT).
+	v := os.Getenv("OTEL_INSTRUMENTATION_GENAI_CAPTURE_MESSAGE_CONTENT")
+	return v != ""
 }
 
 const elidedContent = "<elided>"

--- a/internal/telemetry/telemetry.go
+++ b/internal/telemetry/telemetry.go
@@ -22,6 +22,7 @@ import (
 	"context"
 	"encoding/json"
 	"fmt"
+	"strings"
 
 	"go.opentelemetry.io/otel"
 	"go.opentelemetry.io/otel/attribute"
@@ -46,6 +47,12 @@ var (
 	gcpVertexAgentEventID          = attribute.Key("gcp.vertex.agent.event_id")
 	gcpVertexAgentToolResponseName = attribute.Key("gcp.vertex.agent.tool_response")
 	gcpVertexAgentInvocationID     = attribute.Key("gcp.vertex.agent.invocation_id")
+
+	// Content capture attribute keys per OTel Semantic Conventions for GenAI.
+	// See: https://opentelemetry.io/docs/specs/semconv/gen-ai/gen-ai-spans/#capturing-instructions-inputs-and-outputs
+	genAISystemInstructions = attribute.Key("gen_ai.system_instructions")
+	genAIInputMessages      = attribute.Key("gen_ai.input.messages")
+	genAIOutputMessages     = attribute.Key("gen_ai.output.messages")
 )
 
 // tracer is the tracer instance for ADK go.
@@ -91,6 +98,8 @@ type StartGenerateContentSpanParams struct {
 	ModelName string
 	// InvocationID is the ID of the invocation.
 	InvocationID string
+	// LLMRequest is the full LLM request, used for content capture when enabled via SetGenAICaptureMessageContent.
+	LLMRequest *model.LLMRequest
 }
 
 // StartGenerateContentSpan starts a new semconv generate_content span.
@@ -102,6 +111,14 @@ func StartGenerateContentSpan(ctx context.Context, params StartGenerateContentSp
 		semconv.GenAIOperationNameGenerateContent,
 		semconv.GenAIRequestModel(modelName),
 	))
+	if getGenAICaptureMessageContent() && params.LLMRequest != nil {
+		if si := serializeSystemInstructions(params.LLMRequest); si != "" {
+			span.SetAttributes(genAISystemInstructions.String(si))
+		}
+		if im := serializeInputMessages(params.LLMRequest); im != "" {
+			span.SetAttributes(genAIInputMessages.String(im))
+		}
+	}
 	return spanCtx, span
 }
 
@@ -126,6 +143,9 @@ func TraceGenerateContentResult(span trace.Span, params TraceGenerateContentResu
 			semconv.GenAIUsageInputTokens(int(params.Response.UsageMetadata.PromptTokenCount)),
 			semconv.GenAIUsageOutputTokens(int(params.Response.UsageMetadata.CandidatesTokenCount)),
 		)
+	}
+	if getGenAICaptureMessageContent() && params.Response != nil && params.Response.Content != nil {
+		span.SetAttributes(genAIOutputMessages.String(safeSerialize(params.Response.Content)))
 	}
 }
 
@@ -255,4 +275,29 @@ func safeSerialize(obj any) string {
 		return "<not serializable>"
 	}
 	return string(dump)
+}
+
+// serializeSystemInstructions extracts and serializes the system instructions from the request.
+func serializeSystemInstructions(req *model.LLMRequest) string {
+	if req.Config == nil || req.Config.SystemInstruction == nil {
+		return ""
+	}
+	var texts []string
+	for _, p := range req.Config.SystemInstruction.Parts {
+		if p.Text != "" {
+			texts = append(texts, p.Text)
+		}
+	}
+	if len(texts) == 0 {
+		return ""
+	}
+	return strings.Join(texts, "\n")
+}
+
+// serializeInputMessages serializes the input messages (contents) from the request.
+func serializeInputMessages(req *model.LLMRequest) string {
+	if len(req.Contents) == 0 {
+		return ""
+	}
+	return safeSerialize(req.Contents)
 }

--- a/internal/telemetry/telemetry.go
+++ b/internal/telemetry/telemetry.go
@@ -112,11 +112,15 @@ func StartGenerateContentSpan(ctx context.Context, params StartGenerateContentSp
 		semconv.GenAIRequestModel(modelName),
 	))
 	if getGenAICaptureMessageContent() && params.LLMRequest != nil {
+		var attrs []attribute.KeyValue
 		if si := serializeSystemInstructions(params.LLMRequest); si != "" {
-			span.SetAttributes(genAISystemInstructions.String(si))
+			attrs = append(attrs, genAISystemInstructions.String(si))
 		}
 		if im := serializeInputMessages(params.LLMRequest); im != "" {
-			span.SetAttributes(genAIInputMessages.String(im))
+			attrs = append(attrs, genAIInputMessages.String(im))
+		}
+		if len(attrs) > 0 {
+			span.SetAttributes(attrs...)
 		}
 	}
 	return spanCtx, span
@@ -144,7 +148,7 @@ func TraceGenerateContentResult(span trace.Span, params TraceGenerateContentResu
 			semconv.GenAIUsageOutputTokens(int(params.Response.UsageMetadata.CandidatesTokenCount)),
 		)
 	}
-	if getGenAICaptureMessageContent() && params.Response != nil && params.Response.Content != nil {
+	if getGenAICaptureMessageContent() && params.Response.Content != nil {
 		span.SetAttributes(genAIOutputMessages.String(safeSerialize(params.Response.Content)))
 	}
 }
@@ -287,9 +291,6 @@ func serializeSystemInstructions(req *model.LLMRequest) string {
 		if p.Text != "" {
 			texts = append(texts, p.Text)
 		}
-	}
-	if len(texts) == 0 {
-		return ""
 	}
 	return strings.Join(texts, "\n")
 }

--- a/internal/telemetry/telemetry_test.go
+++ b/internal/telemetry/telemetry_test.go
@@ -291,6 +291,112 @@ func TestGenerateContent(t *testing.T) {
 	}
 }
 
+func TestGenerateContentContentCapture(t *testing.T) {
+	invocationID := "test-invocation-id"
+
+	llmRequest := &model.LLMRequest{
+		Model: "test-model",
+		Contents: []*genai.Content{
+			{
+				Role:  "user",
+				Parts: []*genai.Part{{Text: "Hello, world!"}},
+			},
+		},
+		Config: &genai.GenerateContentConfig{
+			SystemInstruction: &genai.Content{
+				Parts: []*genai.Part{
+					{Text: "You are a helpful assistant."},
+					{Text: "Be concise."},
+				},
+			},
+		},
+	}
+
+	llmResponse := &model.LLMResponse{
+		Content: &genai.Content{
+			Role:  "model",
+			Parts: []*genai.Part{{Text: "Hi there!"}},
+		},
+		UsageMetadata: &genai.GenerateContentResponseUsageMetadata{
+			PromptTokenCount:     5,
+			CandidatesTokenCount: 3,
+		},
+		FinishReason: genai.FinishReasonStop,
+	}
+
+	t.Run("ContentCaptureDisabled", func(t *testing.T) {
+		// Ensure content capture is disabled (default).
+		SetGenAICaptureMessageContent(false)
+		t.Cleanup(func() { SetGenAICaptureMessageContent(false) })
+
+		exporter := setupTestTracer(t)
+		ctx := t.Context()
+
+		_, span := StartGenerateContentSpan(ctx, StartGenerateContentSpanParams{
+			ModelName:    "test-model",
+			InvocationID: invocationID,
+			LLMRequest:   llmRequest,
+		})
+		TraceGenerateContentResult(span, TraceGenerateContentResultParams{
+			Response: llmResponse,
+		})
+		span.End()
+
+		spans := exporter.GetSpans()
+		if len(spans) != 1 {
+			t.Fatalf("expected 1 span, got %d", len(spans))
+		}
+		gotAttrs := attributesToMap(spans[0].Attributes)
+
+		// Content capture attributes should NOT be present.
+		for _, key := range []attribute.Key{"gen_ai.system_instructions", "gen_ai.input.messages", "gen_ai.output.messages"} {
+			if _, found := gotAttrs[key]; found {
+				t.Errorf("attribute %q should not be present when content capture is disabled", key)
+			}
+		}
+	})
+
+	t.Run("ContentCaptureEnabled", func(t *testing.T) {
+		SetGenAICaptureMessageContent(true)
+		t.Cleanup(func() { SetGenAICaptureMessageContent(false) })
+
+		exporter := setupTestTracer(t)
+		ctx := t.Context()
+
+		_, span := StartGenerateContentSpan(ctx, StartGenerateContentSpanParams{
+			ModelName:    "test-model",
+			InvocationID: invocationID,
+			LLMRequest:   llmRequest,
+		})
+		TraceGenerateContentResult(span, TraceGenerateContentResultParams{
+			Response: llmResponse,
+		})
+		span.End()
+
+		spans := exporter.GetSpans()
+		if len(spans) != 1 {
+			t.Fatalf("expected 1 span, got %d", len(spans))
+		}
+		gotAttrs := attributesToMap(spans[0].Attributes)
+
+		// System instructions should be present.
+		wantSysInstr := "You are a helpful assistant.\nBe concise."
+		if got := gotAttrs["gen_ai.system_instructions"]; got != wantSysInstr {
+			t.Errorf("gen_ai.system_instructions: got %q, want %q", got, wantSysInstr)
+		}
+
+		// Input messages should be present (JSON serialized).
+		if got, found := gotAttrs["gen_ai.input.messages"]; !found || got == "" {
+			t.Error("gen_ai.input.messages should be present and non-empty when content capture is enabled")
+		}
+
+		// Output messages should be present (JSON serialized).
+		if got, found := gotAttrs["gen_ai.output.messages"]; !found || got == "" {
+			t.Error("gen_ai.output.messages should be present and non-empty when content capture is enabled")
+		}
+	})
+}
+
 func TestExecuteTool(t *testing.T) {
 	tests := []struct {
 		name         string


### PR DESCRIPTION
## Description

Fixes #608

In the migration from v0.4.0 to v0.5.0, the telemetry package moved to standard OpenTelemetry Semantic Conventions for GenAI, but dropped the ability to capture LLM request/response content in spans. This PR restores that capability as an opt-in feature, aligned with the [OTel spec recommendation](https://opentelemetry.io/docs/specs/semconv/gen-ai/gen-ai-spans/#capturing-instructions-inputs-and-outputs).

When `SetGenAICaptureMessageContent(true)` is called (the same flag already used by the OTel log events in `logger.go`), the following span attributes are populated on `generate_content` spans:

| Attribute | Source | Format |
|---|---|---|
| `gen_ai.system_instructions` | `LLMRequest.Config.SystemInstruction` | Plain text (newline-joined) |
| `gen_ai.input.messages` | `LLMRequest.Contents` | JSON |
| `gen_ai.output.messages` | `LLMResponse.Content` | JSON |

Content is **not captured by default** — the existing behavior is preserved.

## Changes

- **`internal/telemetry/telemetry.go`**: Added content capture attribute keys, extended `StartGenerateContentSpanParams` with `LLMRequest`, and conditionally populate content attributes in `StartGenerateContentSpan` and `TraceGenerateContentResult`.
- **`internal/llminternal/base_flow.go`**: Pass `LLMRequest` to `StartGenerateContentSpanParams`.
- **`internal/telemetry/telemetry_test.go`**: Added `TestGenerateContentContentCapture` with sub-tests for disabled (default) and enabled content capture.

## Testing Plan

### Unit Tests
```
=== RUN   TestGenerateContentContentCapture
=== RUN   TestGenerateContentContentCapture/ContentCaptureDisabled
=== RUN   TestGenerateContentContentCapture/ContentCaptureEnabled
--- PASS: TestGenerateContentContentCapture (0.00s)
```

### Full Verification
- `go test ./internal/telemetry/...` — all tests pass
- `go vet ./internal/telemetry/... ./internal/llminternal/...` — clean
- `gofmt -l` — clean
- `go build ./...` — clean