### PR TITLE
Plumb part converter to input required processor

### DIFF
--- a/server/adka2a/input_required.go
+++ b/server/adka2a/input_required.go
@@ -28,20 +28,21 @@ import (
 )
 
 type inputRequiredProcessor struct {
-	reqCtx *a2asrv.RequestContext
-	event  *a2a.TaskStatusUpdateEvent
+	reqCtx        *a2asrv.RequestContext
+	event         *a2a.TaskStatusUpdateEvent
+	partConverter GenAIPartConverter
 	// handles possible duplication in partial and non-partial events
 	addedParts []*genai.Part
 }
 
-func newInputRequiredProcessor(reqCtx *a2asrv.RequestContext) *inputRequiredProcessor {
-	return &inputRequiredProcessor{reqCtx: reqCtx}
+func newInputRequiredProcessor(reqCtx *a2asrv.RequestContext, partConverter GenAIPartConverter) *inputRequiredProcessor {
+	return &inputRequiredProcessor{reqCtx: reqCtx, partConverter: partConverter}
 }
 
 // process handles long-running function tool calls by accumulating them for the final task status update.
 // If a part was incorporated into the final task status update the original event is modified to not include it,
 // so that parts are not duplicated in the response.
-func (p *inputRequiredProcessor) process(event *session.Event) (*session.Event, error) {
+func (p *inputRequiredProcessor) process(ctx context.Context, event *session.Event) (*session.Event, error) {
 	resp := event.LLMResponse
 	if resp.Content == nil {
 		return event, nil
@@ -77,7 +78,7 @@ func (p *inputRequiredProcessor) process(event *session.Event) (*session.Event, 
 	}
 
 	if len(inputRequiredParts) > 0 {
-		a2aParts, err := ToA2AParts(inputRequiredParts, longRunningCallIDs)
+		a2aParts, err := p.convertParts(ctx, event, inputRequiredParts, longRunningCallIDs)
 		if err != nil {
 			return nil, fmt.Errorf("failed to convert input required parts to A2A parts: %w", err)
 		}
@@ -102,6 +103,24 @@ func (p *inputRequiredProcessor) process(event *session.Event) (*session.Event, 
 	modifiedEvent.LLMResponse.Content = &newContent
 
 	return &modifiedEvent, nil
+}
+
+func (p *inputRequiredProcessor) convertParts(ctx context.Context, event *session.Event, parts []*genai.Part, longRunningCallIDs []string) ([]a2a.Part, error) {
+	if p.partConverter == nil {
+		return ToA2AParts(parts, longRunningCallIDs)
+	}
+	converted := make([]a2a.Part, 0, len(parts))
+	for _, part := range parts {
+		cp, err := p.partConverter(ctx, event, part)
+		if err != nil {
+			return nil, err
+		}
+		if cp == nil {
+			continue
+		}
+		converted = append(converted, cp)
+	}
+	return converted, nil
 }
 
 func (p *inputRequiredProcessor) isLongRunningResponse(event *session.Event, part *genai.Part) bool {

--- a/server/adka2a/processor.go
+++ b/server/adka2a/processor.go
@@ -60,7 +60,7 @@ func newEventProcessor(
 	transform eventToArtifactTransform,
 ) *eventProcessor {
 	return &eventProcessor{
-		inputRequiredProcessor: newInputRequiredProcessor(reqCtx),
+		inputRequiredProcessor: newInputRequiredProcessor(reqCtx, converter),
 		partConverter:          converter,
 		reqCtx:                 reqCtx,
 		meta:                   meta,
@@ -91,7 +91,7 @@ func (p *eventProcessor) process(ctx context.Context, event *session.Event) (*a2
 		}
 	}
 
-	event, err = p.inputRequiredProcessor.process(event)
+	event, err = p.inputRequiredProcessor.process(ctx, event)
 	if err != nil {
 		return nil, fmt.Errorf("input required processing failed: %w", err)
 	}


### PR DESCRIPTION
The main event processing pipeline checks for a part converter in processor.go just after handling the inputRequiredProcessor.  If any parts are found to be "input required" parts they are sliced off of the content and put onto a new A2A message that is returned after the main A2A message. Unfortunately that means that if there are any special converters that would affect those parts they do not get the chance to be invoked.

This change just plumbs through the existing converter and makes sure it gets a chance to run.

### Testing Plan

Manual verification in an environment with a part converter which affects FunctionResponse parts marked as IsLongRunning

### Checklist

- [x] I have read the [CONTRIBUTING.md](./CONTRIBUTING.md) document.
- [x] I have performed a self-review of my own code.
- [ ] I have commented my code, particularly in hard-to-understand areas.
- [ ] I have added tests that prove my fix is effective or that my feature works.
- [x] New and existing unit tests pass locally with my changes.
- [x] I have manually tested my changes end-to-end.
- [x] Any dependent changes have been merged and published in downstream modules.

