### PR TITLE
Fix: gracefully handle sub-agent errors in loopagent

### DIFF
--- a/agent/workflowagents/loopagent/agent.go
+++ b/agent/workflowagents/loopagent/agent.go
@@ -80,7 +80,11 @@ func (a *loopAgent) Run(ctx agent.InvocationContext) iter.Seq2[*session.Event, e
 			shouldExit := false
 			for _, subAgent := range ctx.Agent().SubAgents() {
 				for event, err := range subAgent.Run(ctx) {
-					// TODO: ensure consistency -- if there's an error, return and close iterator, verify everywhere in ADK.
+					if err != nil {
+						yield(nil, err)
+						return
+					}
+
 					if !yield(event, err) {
 						return
 					}

--- a/agent/workflowagents/loopagent/agent_test.go
+++ b/agent/workflowagents/loopagent/agent_test.go
@@ -45,6 +45,7 @@ func TestNewLoopAgent(t *testing.T) {
 		args       args
 		wantEvents []*session.Event
 		wantErr    bool
+		wantRunErr bool
 	}{
 		{
 			name: "infinite loop",
@@ -197,6 +198,15 @@ func TestNewLoopAgent(t *testing.T) {
 				},
 			},
 		},
+		{
+			name: "loop agent which always yields an error",
+			args: args{
+				maxIterations: 1,
+				subAgents:     []agent.Agent{newErrorAgent(t)},
+			},
+			wantEvents: nil,
+			wantRunErr: true,
+		},
 	}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
@@ -238,7 +248,10 @@ func TestNewLoopAgent(t *testing.T) {
 
 			for event, err := range agentRunner.Run(ctx, "user_id", "session_id", genai.NewContentFromText("user input", genai.RoleUser), agent.RunConfig{}) {
 				if err != nil {
-					t.Errorf("got unexpected error: %v", err)
+					if !tt.wantRunErr {
+						t.Errorf("got unexpected error: %v", err)
+					}
+					break
 				}
 
 				if tt.args.maxIterations == 0 && len(gotEvents) == len(tt.wantEvents) {
@@ -375,4 +388,20 @@ func (f *FakeLLM) GenerateContent(ctx context.Context, req *model.LLMRequest, st
 			}
 		}
 	}
+}
+
+func newErrorAgent(t *testing.T) agent.Agent {
+	t.Helper()
+	a, err := agent.New(agent.Config{
+		Name: "error_agent",
+		Run: func(ctx agent.InvocationContext) iter.Seq2[*session.Event, error] {
+			return func(yield func(*session.Event, error) bool) {
+				yield(nil, fmt.Errorf("something went wrong"))
+			}
+		},
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+	return a
 }


### PR DESCRIPTION
**Please ensure you have read the [contribution guide](./CONTRIBUTING.md) before creating a pull request.**

### Link to Issue or Description of Change

**1. Link to an existing issue (if applicable):**

- Closes: #423 
- Related: #427 

**Problem:**
_When a sub-agent yields an error in `loopagent`, the error was silently swallowed. `shouldExit` was set to `true` but the error was never propagated to the caller, making it impossible to distinguish between a normal escalation and a sub-agent failure. This caused a nil pointer dereference panic upstream._

**Solution:**
_Return early and yield the error to the caller when a sub-agent returns a non-nil error. This is consistent with how `Flow.Run` handles errors in `llmagent` and follows the TODO comment left in the original code._

### Testing Plan
**Unit Tests:**

- [x] I have added or updated unit tests for my change.
- [x] All unit tests pass locally.

_Added a new test case `loop agent which always yields an error` that creates a sub-agent that returns an error and verifies the loop agent propagates it correctly without panicking._

**Manual End-to-End (E2E) Tests:**

_The original panic can be reproduced by registering an unknown tool name in the prompt. After this fix the agent returns an error instead of crashing._

### Checklist

- [x] I have read the [CONTRIBUTING.md](./CONTRIBUTING.md) document.
- [x] I have performed a self-review of my own code.
- [x] I have commented my code, particularly in hard-to-understand areas.
- [x] I have added tests that prove my fix is effective or that my feature works.
- [x] New and existing unit tests pass locally with my changes.
- [ ] I have manually tested my changes end-to-end.
- [ ] Any dependent changes have been merged and published in downstream modules.

### Additional Context
Alternative approach to #427 which has been inactive. This fix also propagates the error to the caller rather than swallowing it.