### PR TITLE
fix: copy ThoughtSignature in generateRequestConfirmationEvent

### DIFF
--- a/internal/llminternal/functions.go
+++ b/internal/llminternal/functions.go
@@ -47,6 +47,12 @@ func generateRequestConfirmationEvent(
 	for _, call := range utils.FunctionCalls(functionCallEvent.Content) {
 		functionCalls[call.ID] = call
 	}
+	thoughtSignatures := make(map[string][]byte)
+	for _, p := range functionCallEvent.Content.Parts {
+		if p.FunctionCall != nil && len(p.ThoughtSignature) > 0 {
+			thoughtSignatures[p.FunctionCall.ID] = p.ThoughtSignature
+		}
+	}
 
 	for funcID, confirmation := range functionResponseEvent.Actions.RequestedToolConfirmations {
 		originalFunctionCall, ok := functionCalls[funcID]
@@ -66,9 +72,13 @@ func generateRequestConfirmationEvent(
 			Args: args,
 		}
 
-		parts = append(parts, &genai.Part{
+		newPart := &genai.Part{
 			FunctionCall: requestConfirmationFC,
-		})
+		}
+		if sig, ok := thoughtSignatures[funcID]; ok {
+			newPart.ThoughtSignature = sig
+		}
+		parts = append(parts, newPart)
 		longRunningToolIDs = append(longRunningToolIDs, requestConfirmationFC.ID)
 	}
 

--- a/internal/llminternal/functions_test.go
+++ b/internal/llminternal/functions_test.go
@@ -170,6 +170,63 @@ func TestGenerateRequestConfirmationEvent(t *testing.T) {
 				},
 			},
 		},
+		{
+			name: "confirmation requested with ThoughtSignature",
+			invocationContext: &mockInvocationContext{
+				invocationID: "inv_1",
+				agentName:    "agent_1",
+				branch:       "main",
+			},
+			functionCallEvent: &session.Event{
+				LLMResponse: model.LLMResponse{
+					Content: &genai.Content{
+						Parts: []*genai.Part{
+							{
+								FunctionCall:     confirmingFunctionCall,
+								ThoughtSignature: []byte{0x01, 0x02, 0x03},
+							},
+						},
+					},
+				},
+			},
+			functionResponseEvent: &session.Event{
+				Actions: session.EventActions{
+					RequestedToolConfirmations: map[string]toolconfirmation.ToolConfirmation{
+						"call_1": {
+							Hint: "Are you sure?",
+						},
+					},
+				},
+			},
+			wantEvent: &session.Event{
+				InvocationID: "inv_1",
+				Author:       "agent_1",
+				Branch:       "main",
+				Actions: session.EventActions{
+					StateDelta:    map[string]any{},
+					ArtifactDelta: map[string]int64{},
+				},
+				LLMResponse: model.LLMResponse{
+					Content: &genai.Content{
+						Role: genai.RoleModel,
+						Parts: []*genai.Part{
+							{
+								FunctionCall: &genai.FunctionCall{
+									Name: toolconfirmation.FunctionCallName,
+									Args: map[string]any{
+										"originalFunctionCall": confirmingFunctionCall,
+										"toolConfirmation": toolconfirmation.ToolConfirmation{
+											Hint: "Are you sure?",
+										},
+									},
+								},
+								ThoughtSignature: []byte{0x01, 0x02, 0x03},
+							},
+						},
+					},
+				},
+			},
+		},
 	}
 
 	for _, tt := range tests {


### PR DESCRIPTION
Fixes #656

`generateRequestConfirmationEvent` uses `utils.FunctionCalls()` which extracts only `*genai.FunctionCall` from parts, discarding the `ThoughtSignature` field on the parent `*genai.Part`. When building the new `adk_request_confirmation` Part, `ThoughtSignature` was never copied.

Fix: build an additional map from `FunctionCall.ID` to `ThoughtSignature` by iterating over `functionCallEvent.Content.Parts` directly. When creating the new `genai.Part`, look up and set the `ThoughtSignature` from this map.

Added test case in `TestGenerateRequestConfirmationEvent` to verify `ThoughtSignature` is preserved.