### PR TITLE
feat(otel): use synchronous span and log processors for debug endpoints

### DIFF
--- a/server/adkrest/internal/services/debugtelemetry.go
+++ b/server/adkrest/internal/services/debugtelemetry.go
@@ -44,11 +44,13 @@ func NewDebugTelemetry() *DebugTelemetry {
 }
 
 func (d *DebugTelemetry) SpanProcessor() sdktrace.SpanProcessor {
-	return sdktrace.NewBatchSpanProcessor(d.store)
+	// Use simple processor to avoid the lag between ending the span and it appearing in adk-web.
+	return sdktrace.NewSimpleSpanProcessor(d.store)
 }
 
 func (d *DebugTelemetry) LogProcessor() sdklog.Processor {
-	return sdklog.NewBatchProcessor(d.store)
+	// Use simple processor to avoid the lag between logging and it appearing in adk-web.
+	return sdklog.NewSimpleProcessor(d.store)
 }
 
 // GetSpansByEventID returns spans associated with the given event ID.


### PR DESCRIPTION
Batch processors were causing a delay between ending a span and that span being available in debug endpoints.
It was causing race conditions in adk-web - in most cases, the Trace tab didn't show the latest conversation turn.