### PR TITLE
refactor: update memory req/resp names

### DIFF
--- a/agent/agent.go
+++ b/agent/agent.go
@@ -117,7 +117,7 @@ type Artifacts interface {
 // sessions of the current user_id.
 type Memory interface {
 	AddSessionToMemory(context.Context, session.Session) error
-	SearchMemory(ctx context.Context, query string) (*memory.SearchMemoryResponse, error)
+	SearchMemory(ctx context.Context, query string) (*memory.SearchResponse, error)
 }
 
 // BeforeAgentCallback is a function that is called before the agent starts

--- a/internal/configurable/conformance/replayplugin/replay_plugin_test.go
+++ b/internal/configurable/conformance/replayplugin/replay_plugin_test.go
@@ -440,7 +440,7 @@ func (m *MockToolContext) InvocationID() string                 { return m.invoc
 func (m *MockToolContext) AgentName() string                    { return m.agentName }
 func (m *MockToolContext) FunctionCallID() string               { return "mock-function-call-id" }
 func (m *MockToolContext) Actions() *session.EventActions       { return nil }
-func (m *MockToolContext) SearchMemory(ctx context.Context, query string) (*memory.SearchMemoryResponse, error) {
+func (m *MockToolContext) SearchMemory(ctx context.Context, query string) (*memory.SearchResponse, error) {
 	return nil, nil
 }
 func (m *MockToolContext) ToolConfirmation() *toolconfirmation.ToolConfirmation { return nil }

--- a/internal/memory/memory.go
+++ b/internal/memory/memory.go
@@ -32,8 +32,8 @@ func (a *Memory) AddSessionToMemory(ctx context.Context, session session.Session
 	return a.Service.AddSessionToMemory(ctx, session)
 }
 
-func (a *Memory) SearchMemory(ctx context.Context, query string) (*memory.SearchMemoryResponse, error) {
-	return a.Service.SearchMemory(ctx, &memory.SearchMemoryRequest{
+func (a *Memory) SearchMemory(ctx context.Context, query string) (*memory.SearchResponse, error) {
+	return a.Service.SearchMemory(ctx, &memory.SearchRequest{
 		AppName: a.AppName,
 		UserID:  a.UserID,
 		Query:   query,

--- a/internal/memory/memory_test.go
+++ b/internal/memory/memory_test.go
@@ -91,45 +91,45 @@ func TestMemory_AddAndSearch(t *testing.T) {
 	tests := []struct {
 		name  string
 		query string
-		want  *memory.SearchMemoryResponse
+		want  *memory.SearchResponse
 	}{
 		{
 			name:  "match first entry",
 			query: "fox",
-			want: &memory.SearchMemoryResponse{
+			want: &memory.SearchResponse{
 				Memories: []memory.Entry{entry1},
 			},
 		},
 		{
 			name:  "match second entry",
 			query: "DOG", // Search should be case-insensitive
-			want: &memory.SearchMemoryResponse{
+			want: &memory.SearchResponse{
 				Memories: []memory.Entry{entry2},
 			},
 		},
 		{
 			name:  "match both entries (any word)",
 			query: "quick dog",
-			want: &memory.SearchMemoryResponse{
+			want: &memory.SearchResponse{
 				Memories: []memory.Entry{entry1, entry2},
 			},
 		},
 		{
 			name:  "match word in both",
 			query: "the",
-			want: &memory.SearchMemoryResponse{
+			want: &memory.SearchResponse{
 				Memories: []memory.Entry{entry1, entry2},
 			},
 		},
 		{
 			name:  "no match",
 			query: "unrelated",
-			want:  &memory.SearchMemoryResponse{},
+			want:  &memory.SearchResponse{},
 		},
 		{
 			name:  "empty query",
 			query: "",
-			want:  &memory.SearchMemoryResponse{},
+			want:  &memory.SearchResponse{},
 		},
 	}
 

--- a/internal/toolinternal/context.go
+++ b/internal/toolinternal/context.go
@@ -103,7 +103,7 @@ func (c *toolContext) AgentName() string {
 	return c.invocationContext.Agent().Name()
 }
 
-func (c *toolContext) SearchMemory(ctx context.Context, query string) (*memory.SearchMemoryResponse, error) {
+func (c *toolContext) SearchMemory(ctx context.Context, query string) (*memory.SearchResponse, error) {
 	if c.invocationContext.Memory() == nil {
 		return nil, fmt.Errorf("memory service is not set")
 	}

--- a/memory/inmemory.go
+++ b/memory/inmemory.go
@@ -106,7 +106,7 @@ func (s *inMemoryService) AddSessionToMemory(ctx context.Context, curSession ses
 	return nil
 }
 
-func (s *inMemoryService) SearchMemory(ctx context.Context, req *SearchMemoryRequest) (*SearchMemoryResponse, error) {
+func (s *inMemoryService) SearchMemory(ctx context.Context, req *SearchRequest) (*SearchResponse, error) {
 	queryWords := extractWords(req.Query)
 
 	k := key{
@@ -118,10 +118,10 @@ func (s *inMemoryService) SearchMemory(ctx context.Context, req *SearchMemoryReq
 	values, ok := s.store[k]
 	s.mu.RUnlock()
 	if !ok {
-		return &SearchMemoryResponse{}, nil
+		return &SearchResponse{}, nil
 	}
 
-	res := &SearchMemoryResponse{}
+	res := &SearchResponse{}
 
 	for _, events := range values {
 		for _, e := range events {

--- a/memory/inmemory_test.go
+++ b/memory/inmemory_test.go
@@ -32,8 +32,8 @@ func Test_inMemoryService_SearchMemory(t *testing.T) {
 	tests := []struct {
 		name         string
 		initSessions []session.Session
-		req          *memory.SearchMemoryRequest
-		wantResp     *memory.SearchMemoryResponse
+		req          *memory.SearchRequest
+		wantResp     *memory.SearchResponse
 		wantErr      bool
 	}{
 		{
@@ -66,12 +66,12 @@ func Test_inMemoryService_SearchMemory(t *testing.T) {
 					{LLMResponse: model.LLMResponse{Content: genai.NewContentFromText("test text", genai.RoleUser)}},
 				}),
 			},
-			req: &memory.SearchMemoryRequest{
+			req: &memory.SearchRequest{
 				AppName: "app1",
 				UserID:  "user1",
 				Query:   "quick hello",
 			},
-			wantResp: &memory.SearchMemoryResponse{
+			wantResp: &memory.SearchResponse{
 				Memories: []memory.Entry{
 					{
 						ID:             "event1",
@@ -95,12 +95,12 @@ func Test_inMemoryService_SearchMemory(t *testing.T) {
 					{LLMResponse: model.LLMResponse{Content: genai.NewContentFromText("test text", genai.RoleUser)}},
 				}),
 			},
-			req: &memory.SearchMemoryRequest{
+			req: &memory.SearchRequest{
 				AppName: "other_app",
 				UserID:  "user1",
 				Query:   "test text",
 			},
-			wantResp: &memory.SearchMemoryResponse{},
+			wantResp: &memory.SearchResponse{},
 		},
 		{
 			name: "no leakage for different user",
@@ -109,12 +109,12 @@ func Test_inMemoryService_SearchMemory(t *testing.T) {
 					{LLMResponse: model.LLMResponse{Content: genai.NewContentFromText("test text", genai.RoleUser)}},
 				}),
 			},
-			req: &memory.SearchMemoryRequest{
+			req: &memory.SearchRequest{
 				AppName: "app1",
 				UserID:  "test_user",
 				Query:   "test text",
 			},
-			wantResp: &memory.SearchMemoryResponse{},
+			wantResp: &memory.SearchResponse{},
 		},
 		{
 			name: "no matches",
@@ -123,21 +123,21 @@ func Test_inMemoryService_SearchMemory(t *testing.T) {
 					{LLMResponse: model.LLMResponse{Content: genai.NewContentFromText("test text", genai.RoleUser)}},
 				}),
 			},
-			req: &memory.SearchMemoryRequest{
+			req: &memory.SearchRequest{
 				AppName: "app1",
 				UserID:  "test_user",
 				Query:   "something different",
 			},
-			wantResp: &memory.SearchMemoryResponse{},
+			wantResp: &memory.SearchResponse{},
 		},
 		{
 			name: "lookup on empty store",
-			req: &memory.SearchMemoryRequest{
+			req: &memory.SearchRequest{
 				AppName: "app1",
 				UserID:  "test_user",
 				Query:   "something different",
 			},
-			wantResp: &memory.SearchMemoryResponse{},
+			wantResp: &memory.SearchResponse{},
 		},
 	}
 	for _, tt := range tests {
@@ -172,7 +172,7 @@ func makeSession(t *testing.T, appName, userID, sessionID string, events []*sess
 	}
 }
 
-var sortMemories = cmp.Transformer("Sort", func(in *memory.SearchMemoryResponse) *memory.SearchMemoryResponse {
+var sortMemories = cmp.Transformer("Sort", func(in *memory.SearchResponse) *memory.SearchResponse {
 	slices.SortFunc(in.Memories, func(m1, m2 memory.Entry) int {
 		return m1.Timestamp.Compare(m2.Timestamp)
 	})

--- a/memory/service.go
+++ b/memory/service.go
@@ -35,18 +35,18 @@ type Service interface {
 	AddSessionToMemory(ctx context.Context, s session.Session) error
 	// SearchMemory returns memory entries relevant to the given query.
 	// Empty slice is returned if there are no matches.
-	SearchMemory(ctx context.Context, req *SearchMemoryRequest) (*SearchMemoryResponse, error)
+	SearchMemory(ctx context.Context, req *SearchRequest) (*SearchResponse, error)
 }
 
-// SearchMemoryRequest represents a request for memory search.
-type SearchMemoryRequest struct {
+// SearchRequest represents a request for memory search.
+type SearchRequest struct {
 	Query   string
 	UserID  string
 	AppName string
 }
 
-// SearchMemoryResponse represents the response from a memory search.
-type SearchMemoryResponse struct {
+// SearchResponse represents the response from a memory search.
+type SearchResponse struct {
 	Memories []Entry
 }
 

--- a/tool/exampletool/tool_test.go
+++ b/tool/exampletool/tool_test.go
@@ -47,7 +47,7 @@ func (m *mockToolContext) Actions() *session.EventActions {
 	return &session.EventActions{}
 }
 
-func (m *mockToolContext) SearchMemory(ctx context.Context, query string) (*memory.SearchMemoryResponse, error) {
+func (m *mockToolContext) SearchMemory(ctx context.Context, query string) (*memory.SearchResponse, error) {
 	return nil, nil
 }
 func (m *mockToolContext) ToolConfirmation() *toolconfirmation.ToolConfirmation { return nil }

--- a/tool/loadmemorytool/tool_test.go
+++ b/tool/loadmemorytool/tool_test.go
@@ -40,11 +40,11 @@ func (m *mockMemory) AddSessionToMemory(ctx context.Context, s session.Session) 
 	return nil
 }
 
-func (m *mockMemory) SearchMemory(ctx context.Context, query string) (*memory.SearchMemoryResponse, error) {
+func (m *mockMemory) SearchMemory(ctx context.Context, query string) (*memory.SearchResponse, error) {
 	if m.err != nil {
 		return nil, m.err
 	}
-	return &memory.SearchMemoryResponse{Memories: m.memories}, nil
+	return &memory.SearchResponse{Memories: m.memories}, nil
 }
 
 func TestLoadMemoryTool_BasicProperties(t *testing.T) {

--- a/tool/preloadmemorytool/tool_test.go
+++ b/tool/preloadmemorytool/tool_test.go
@@ -41,11 +41,11 @@ func (m *mockMemory) AddSessionToMemory(ctx context.Context, s session.Session) 
 	return nil
 }
 
-func (m *mockMemory) SearchMemory(ctx context.Context, query string) (*memory.SearchMemoryResponse, error) {
+func (m *mockMemory) SearchMemory(ctx context.Context, query string) (*memory.SearchResponse, error) {
 	if m.err != nil {
 		return nil, m.err
 	}
-	return &memory.SearchMemoryResponse{Memories: m.memories}, nil
+	return &memory.SearchResponse{Memories: m.memories}, nil
 }
 
 func TestPreloadMemoryTool_BasicProperties(t *testing.T) {

--- a/tool/tool.go
+++ b/tool/tool.go
@@ -63,7 +63,7 @@ type Context interface {
 	// agent, or perform other actions.
 	Actions() *session.EventActions
 	// SearchMemory performs a semantic search on the agent's memory.
-	SearchMemory(context.Context, string) (*memory.SearchMemoryResponse, error)
+	SearchMemory(context.Context, string) (*memory.SearchResponse, error)
 
 	// ToolConfirmation returns a handler for checking the Human-in-the-Loop
 	// confirmation status for the current tool context. This should be used within a tool's logic

--- a/tool/tool_test.go
+++ b/tool/tool_test.go
@@ -135,7 +135,7 @@ func (c *testContext) Actions() *session.EventActions {
 	return c.eventActions
 }
 func (c *testContext) FunctionCallID() string { return "test-function-call-id" }
-func (c *testContext) SearchMemory(context.Context, string) (*memory.SearchMemoryResponse, error) {
+func (c *testContext) SearchMemory(context.Context, string) (*memory.SearchResponse, error) {
 	return nil, nil
 }
 func (c *testContext) AgentName() string                    { return "test-agent" }


### PR DESCRIPTION
BREAKING CHANGE:

We decided to keep the new name for the memory service method: `SearchMemory` so it's a consistent naming across ADKs.

While for the req/resp we already have to keep the original naming `memory.SearchRequest` and `memory.SearchResponse`. These structs are used in ToolContext and many users already rely and use them (e.g in their tests), so this is a large breaking change, not worth it.