### PR TITLE
fix: filter adk_request_confirmation events from LLM history

### DIFF
--- a/internal/llminternal/contents_processor.go
+++ b/internal/llminternal/contents_processor.go
@@ -29,6 +29,7 @@ import (
 	"google.golang.org/adk/internal/utils"
 	"google.golang.org/adk/model"
 	"google.golang.org/adk/session"
+	"google.golang.org/adk/tool/toolconfirmation"
 )
 
 // ContentRequestProcessor populates the LLMRequest's Contents based on
@@ -83,6 +84,9 @@ func buildContentsDefault(agentName, invocationBranch string, events []*session.
 			continue
 		}
 		if isAuthEvent(ev) {
+			continue
+		}
+		if isConfirmationEvent(ev) {
 			continue
 		}
 		if isOtherAgentReply(agentName, ev) {
@@ -519,6 +523,26 @@ func isAuthEvent(ev *session.Event) bool {
 			return true
 		}
 		if p.FunctionResponse != nil && p.FunctionResponse.Name == requestEUCFunctionCallName {
+			return true
+		}
+	}
+	return false
+}
+
+// isConfirmationEvent returns true if the event contains an adk_request_confirmation
+// FunctionCall or FunctionResponse. These are ADK-internal events used for the tool
+// confirmation (HITL) flow and must be filtered from LLM history — the model never
+// declared this function and cannot interpret it.
+func isConfirmationEvent(ev *session.Event) bool {
+	c := utils.Content(ev)
+	if c == nil {
+		return false
+	}
+	for _, p := range c.Parts {
+		if p.FunctionCall != nil && p.FunctionCall.Name == toolconfirmation.FunctionCallName {
+			return true
+		}
+		if p.FunctionResponse != nil && p.FunctionResponse.Name == toolconfirmation.FunctionCallName {
 			return true
 		}
 	}

--- a/internal/llminternal/contents_processor_test.go
+++ b/internal/llminternal/contents_processor_test.go
@@ -372,6 +372,111 @@ func TestContentsRequestProcessor(t *testing.T) {
 			want: nil,
 		},
 		{
+			name: "ConfirmationFunctionCallEvent",
+			events: []*session.Event{
+				{
+					Author: agentName,
+					LLMResponse: model.LLMResponse{
+						Content: &genai.Content{
+							Role: "model",
+							Parts: []*genai.Part{
+								{FunctionCall: &genai.FunctionCall{Name: "adk_request_confirmation"}},
+							},
+						},
+					},
+				},
+			},
+			want: nil,
+		},
+		{
+			name: "ConfirmationFunctionResponseEvent",
+			events: []*session.Event{
+				{
+					Author: "user",
+					LLMResponse: model.LLMResponse{
+						Content: &genai.Content{
+							Role: "user",
+							Parts: []*genai.Part{
+								{FunctionResponse: &genai.FunctionResponse{Name: "adk_request_confirmation"}},
+							},
+						},
+					},
+				},
+			},
+			want: nil,
+		},
+		{
+			name: "ConfirmationEventsFilteredFromHistory",
+			events: []*session.Event{
+				{
+					Author: "user",
+					LLMResponse: model.LLMResponse{
+						Content: genai.NewContentFromText("Create a vehicle", "user"),
+					},
+				},
+				{
+					Author: agentName,
+					LLMResponse: model.LLMResponse{
+						Content: &genai.Content{
+							Role: "model",
+							Parts: []*genai.Part{
+								{FunctionCall: &genai.FunctionCall{Name: "batch_create_vehicles", ID: "call-1"}},
+							},
+						},
+					},
+				},
+				{
+					Author: agentName,
+					LLMResponse: model.LLMResponse{
+						Content: &genai.Content{
+							Role: "user",
+							Parts: []*genai.Part{
+								{FunctionResponse: &genai.FunctionResponse{Name: "batch_create_vehicles", ID: "call-1", Response: map[string]any{"status": "pending"}}},
+							},
+						},
+					},
+				},
+				// These confirmation events should be filtered out:
+				{
+					Author: agentName,
+					LLMResponse: model.LLMResponse{
+						Content: &genai.Content{
+							Role: "model",
+							Parts: []*genai.Part{
+								{FunctionCall: &genai.FunctionCall{Name: "adk_request_confirmation", ID: "confirm-1"}},
+							},
+						},
+					},
+				},
+				{
+					Author: "user",
+					LLMResponse: model.LLMResponse{
+						Content: &genai.Content{
+							Role: "user",
+							Parts: []*genai.Part{
+								{FunctionResponse: &genai.FunctionResponse{Name: "adk_request_confirmation", ID: "confirm-1", Response: map[string]any{"confirmed": true}}},
+							},
+						},
+					},
+				},
+			},
+			want: []*genai.Content{
+				genai.NewContentFromText("Create a vehicle", "user"),
+				{
+					Role: "model",
+					Parts: []*genai.Part{
+						{FunctionCall: &genai.FunctionCall{Name: "batch_create_vehicles", ID: "call-1"}},
+					},
+				},
+				{
+					Role: "user",
+					Parts: []*genai.Part{
+						{FunctionResponse: &genai.FunctionResponse{Name: "batch_create_vehicles", ID: "call-1", Response: map[string]any{"status": "pending"}}},
+					},
+				},
+			},
+		},
+		{
 			name: "EventWithoutContent",
 			events: []*session.Event{
 				{Author: "user"},


### PR DESCRIPTION
## Description

`buildContentsDefault` in `contents_processor.go` filters `adk_request_credential` events from LLM history via `isAuthEvent()`, but has no equivalent for `adk_request_confirmation` events.

When using a persistent session store (anything other than `InMemorySessionService`), confirmation events are replayed into the Gemini context on the next turn, causing a 400 error — Gemini sees FunctionCall/FunctionResponse parts for `adk_request_confirmation`, a function it never declared.

## Changes

- Add `isConfirmationEvent()` function in `contents_processor.go`, mirroring `isAuthEvent()`
- Wire it into `buildContentsDefault` to skip confirmation events
- Add 3 test cases: FunctionCall event, FunctionResponse event, and mixed history with confirmation events interleaved

## Testing

```
go test ./internal/llminternal/ -run "TestContentsRequestProcessor$" -v
```

All existing tests pass. New tests:
- `ConfirmationFunctionCallEvent` — verifies FunctionCall with `adk_request_confirmation` is filtered
- `ConfirmationFunctionResponseEvent` — verifies FunctionResponse with `adk_request_confirmation` is filtered
- `ConfirmationEventsFilteredFromHistory` — verifies confirmation events are stripped while regular tool call events are preserved

Fixes #682