### PR TITLE
Add thought signature propagation to avoid hard crashes

### DIFF
--- a/internal/llminternal/functions.go
+++ b/internal/llminternal/functions.go
@@ -43,20 +43,33 @@ func generateRequestConfirmationEvent(
 
 	parts := []*genai.Part{}
 	longRunningToolIDs := []string{}
-	functionCalls := make(map[string]*genai.FunctionCall, len(functionCallEvent.Content.Parts))
-	for _, call := range utils.FunctionCalls(functionCallEvent.Content) {
-		functionCalls[call.ID] = call
+
+	// Index the original Parts by function call ID so we can carry over
+	// ThoughtSignature. Gemini thinking models require every model-role
+	// function call Part to include its thought signature; without it the
+	// API returns INVALID_ARGUMENT.
+	type originalCall struct {
+		call             *genai.FunctionCall
+		thoughtSignature []byte
+	}
+	originals := make(map[string]originalCall, len(functionCallEvent.Content.Parts))
+	for _, p := range functionCallEvent.Content.Parts {
+		if p.FunctionCall != nil {
+			originals[p.FunctionCall.ID] = originalCall{
+				call:             p.FunctionCall,
+				thoughtSignature: p.ThoughtSignature,
+			}
+		}
 	}
 
 	for funcID, confirmation := range functionResponseEvent.Actions.RequestedToolConfirmations {
-		originalFunctionCall, ok := functionCalls[funcID]
-		if !ok || originalFunctionCall == nil {
+		orig, ok := originals[funcID]
+		if !ok || orig.call == nil {
 			continue
 		}
 
-		// Prepare arguments for the adk_request_confirmation call
 		args := map[string]any{
-			"originalFunctionCall": originalFunctionCall,
+			"originalFunctionCall": orig.call,
 			"toolConfirmation":     confirmation,
 		}
 
@@ -67,7 +80,8 @@ func generateRequestConfirmationEvent(
 		}
 
 		parts = append(parts, &genai.Part{
-			FunctionCall: requestConfirmationFC,
+			FunctionCall:     requestConfirmationFC,
+			ThoughtSignature: orig.thoughtSignature,
 		})
 		longRunningToolIDs = append(longRunningToolIDs, requestConfirmationFC.ID)
 	}

--- a/internal/llminternal/functions_test.go
+++ b/internal/llminternal/functions_test.go
@@ -194,6 +194,104 @@ func TestGenerateRequestConfirmationEvent(t *testing.T) {
 	}
 }
 
+// TestGenerateRequestConfirmationEventPreservesThoughtSignature verifies that
+// ThoughtSignature from the original function call Part is carried over to the
+// adk_request_confirmation Part. Gemini thinking models require every model-role
+// function call Part to include a thought_signature — without it the API returns
+// INVALID_ARGUMENT.
+func TestGenerateRequestConfirmationEventPreservesThoughtSignature(t *testing.T) {
+	sig := []byte("opaque-thought-signature")
+
+	ctx := &mockInvocationContext{
+		invocationID: "inv_1",
+		agentName:    "agent_1",
+		branch:       "main",
+	}
+
+	functionCallEvent := &session.Event{
+		LLMResponse: model.LLMResponse{
+			Content: &genai.Content{
+				Parts: []*genai.Part{
+					{
+						FunctionCall: &genai.FunctionCall{
+							ID:   "call_1",
+							Name: "test_tool",
+							Args: map[string]any{"arg": "val"},
+						},
+						ThoughtSignature: sig,
+					},
+				},
+			},
+		},
+	}
+
+	functionResponseEvent := &session.Event{
+		Actions: session.EventActions{
+			RequestedToolConfirmations: map[string]toolconfirmation.ToolConfirmation{
+				"call_1": {Hint: "confirm?"},
+			},
+		},
+	}
+
+	got := generateRequestConfirmationEvent(ctx, functionCallEvent, functionResponseEvent)
+	if got == nil {
+		t.Fatal("expected non-nil event")
+	}
+	if len(got.Content.Parts) != 1 {
+		t.Fatalf("expected 1 part, got %d", len(got.Content.Parts))
+	}
+
+	part := got.Content.Parts[0]
+	if part.FunctionCall == nil || part.FunctionCall.Name != toolconfirmation.FunctionCallName {
+		t.Fatal("expected adk_request_confirmation function call")
+	}
+	if string(part.ThoughtSignature) != string(sig) {
+		t.Errorf("ThoughtSignature not preserved: got %q, want %q", part.ThoughtSignature, sig)
+	}
+}
+
+// TestGenerateRequestConfirmationEventNoThoughtSignature verifies the function
+// works normally when the original Part has no ThoughtSignature.
+func TestGenerateRequestConfirmationEventNoThoughtSignature(t *testing.T) {
+	ctx := &mockInvocationContext{
+		invocationID: "inv_1",
+		agentName:    "agent_1",
+	}
+
+	functionCallEvent := &session.Event{
+		LLMResponse: model.LLMResponse{
+			Content: &genai.Content{
+				Parts: []*genai.Part{
+					{
+						FunctionCall: &genai.FunctionCall{
+							ID:   "call_1",
+							Name: "test_tool",
+						},
+					},
+				},
+			},
+		},
+	}
+
+	functionResponseEvent := &session.Event{
+		Actions: session.EventActions{
+			RequestedToolConfirmations: map[string]toolconfirmation.ToolConfirmation{
+				"call_1": {Hint: "confirm?"},
+			},
+		},
+	}
+
+	got := generateRequestConfirmationEvent(ctx, functionCallEvent, functionResponseEvent)
+	if got == nil {
+		t.Fatal("expected non-nil event")
+	}
+
+	part := got.Content.Parts[0]
+	if len(part.ThoughtSignature) != 0 {
+		t.Errorf("expected no ThoughtSignature, got %q", part.ThoughtSignature)
+	}
+}
+
 // TestGenerateRequestConfirmationEventHasID verifies that the event returned
 // by generateRequestConfirmationEvent always has a non-empty ID.
 //


### PR DESCRIPTION
### Link to Issue or Description of Change

**1. Link to an existing issue (if applicable):**

- Closes: #656

**2. Or, if no issue exists, describe the change:**

**Problem:**
`generateRequestConfirmationEvent` created synthetic `adk_request_confirmation` function-call parts without preserving the original model-generated part's `ThoughtSignature`.

Gemini thinking models require every replayed model-role function-call part to carry its thought signature. When the confirmation flow appended a synthetic `adk_request_confirmation` part without that signature, subsequent requests could fail with `400 INVALID_ARGUMENT` complaining that the function call was missing a `thought_signature`.

**Solution:**
This PR fixes the confirmation-path bug by preserving the original `ThoughtSignature` when constructing synthetic `adk_request_confirmation` function-call parts in `generateRequestConfirmationEvent`.

The implementation indexes the original function-call parts by call ID, captures the corresponding `ThoughtSignature`, and copies it onto the synthetic confirmation part when present.

This PR is intentionally scoped to the `#656` confirmation bug only. It does **not** include:
- parallel streaming thought-signature propagation
- confirmation-event history filtering
- Vertex AI session persistence / serialization changes

These should be addressed in separate PRs to keep scope small.

### Testing Plan

**Unit Tests:**

- [x] I have added or updated unit tests for my change.
- [x] Relevant tests pass locally.

New/updated tests:
- `TestGenerateRequestConfirmationEventPreservesThoughtSignature` -- verifies the original thought signature is copied to the synthetic confirmation part
- `TestGenerateRequestConfirmationEventNoThoughtSignature` -- verifies normal behavior when the original function-call part has no thought signature

```sh
go test ./internal/llminternal
ok  	google.golang.org/adk/internal/llminternal
```