### PR TITLE
feat(telemetry): add configurable LRU cache in debug telemetry to avoid memory leaks

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -36,6 +36,8 @@ require (
 	rsc.io/ordered v1.1.1
 )
 
+require github.com/hashicorp/golang-lru/v2 v2.0.7
+
 require (
 	cel.dev/expr v0.25.1 // indirect
 	cloud.google.com/go/auth v0.17.0 // indirect

--- a/go.sum
+++ b/go.sum
@@ -94,6 +94,8 @@ github.com/gorilla/websocket v1.5.3 h1:saDtZ6Pbx/0u+bgYQ3q96pZgCzfhKXGPqt7kZ72aN
 github.com/gorilla/websocket v1.5.3/go.mod h1:YR8l580nyteQvAITg2hZ9XVh4b55+EU/adAjf1fMHhE=
 github.com/grpc-ecosystem/grpc-gateway/v2 v2.27.7 h1:X+2YciYSxvMQK0UZ7sg45ZVabVZBeBuvMkmuI2V3Fak=
 github.com/grpc-ecosystem/grpc-gateway/v2 v2.27.7/go.mod h1:lW34nIZuQ8UDPdkon5fmfp2l3+ZkQ2me/+oecHYLOII=
+github.com/hashicorp/golang-lru/v2 v2.0.7 h1:a+bsQ5rvGLjzHuww6tVxozPZFVghXaHOwFs4luLUK2k=
+github.com/hashicorp/golang-lru/v2 v2.0.7/go.mod h1:QeFd9opnmA6QUJc5vARoKUSoFhyfM2/ZepoAG6RGpeM=
 github.com/inconshreveable/mousetrap v1.1.0 h1:wN+x4NVGpMsO7ErUn/mUI3vEoE6Jt13X2s0bqwp9tc8=
 github.com/inconshreveable/mousetrap v1.1.0/go.mod h1:vpF70FUmC8bwa3OWnCshd2FqLfsEA9PFc4w1p2J65bw=
 github.com/jinzhu/inflection v1.0.0 h1:K317FqzuhWc8YvSVlFMCCUb36O/S9MCKRDI7QkRKD/E=

--- a/server/adkrest/controllers/debug_test.go
+++ b/server/adkrest/controllers/debug_test.go
@@ -259,7 +259,7 @@ type testTelemetry struct {
 }
 
 func setupTestTelemetry() *testTelemetry {
-	dt := services.NewDebugTelemetry()
+	dt := services.NewDebugTelemetry(nil)
 
 	tp := sdktrace.NewTracerProvider(sdktrace.WithSpanProcessor(dt.SpanProcessor()))
 	lp := sdklog.NewLoggerProvider(sdklog.WithProcessor(dt.LogProcessor()))

--- a/server/adkrest/controllers/debug_test.go
+++ b/server/adkrest/controllers/debug_test.go
@@ -92,7 +92,7 @@ func TestSessionSpansHandler(t *testing.T) {
 		t.Run(tt.name, func(t *testing.T) {
 			eventID := "test-event"
 			opName := semconv.GenAIOperationNameExecuteTool.Value.AsString()
-			testTelemetry := setupTestTelemetry()
+			testTelemetry := setupTestTelemetry(t)
 
 			apiController := controllers.NewDebugAPIController(nil, nil, testTelemetry.dt)
 			req, err := http.NewRequest(http.MethodGet, "/debug/sessions/"+tt.reqSessionID+"/spans", nil)
@@ -204,7 +204,7 @@ func TestEventSpanHandler(t *testing.T) {
 	for _, tt := range tc {
 		t.Run(tt.name, func(t *testing.T) {
 			sessionID := "test-session"
-			testTelemetry := setupTestTelemetry()
+			testTelemetry := setupTestTelemetry(t)
 
 			apiController := controllers.NewDebugAPIController(nil, nil, testTelemetry.dt)
 			req, err := http.NewRequest(http.MethodGet, "/debug/events/"+tt.reqEventID+"/span", nil)
@@ -258,8 +258,11 @@ type testTelemetry struct {
 	lp     *sdklog.LoggerProvider
 }
 
-func setupTestTelemetry() *testTelemetry {
-	dt := services.NewDebugTelemetry(nil)
+func setupTestTelemetry(t *testing.T) *testTelemetry {
+	dt, err := services.NewDebugTelemetryWithConfig(nil)
+	if err != nil {
+		t.Fatalf("failed to create debug telemetry: %v", err)
+	}
 
 	tp := sdktrace.NewTracerProvider(sdktrace.WithSpanProcessor(dt.SpanProcessor()))
 	lp := sdklog.NewLoggerProvider(sdklog.WithProcessor(dt.LogProcessor()))

--- a/server/adkrest/handler.go
+++ b/server/adkrest/handler.go
@@ -34,7 +34,9 @@ import (
 
 // NewServer creates a new ADK REST API server which implements [http.Handler] interface.
 func NewServer(cfg ServerConfig) (*Server, error) {
-	debugTelemetry := services.NewDebugTelemetry()
+	debugTelemetry := services.NewDebugTelemetry(&services.DebugTelemetryConfig{
+		TraceCapacity: cfg.DebugConfig.TraceCapacity,
+	})
 
 	router := mux.NewRouter().StrictSlash(true)
 	// TODO: Allow taking a prefix to allow customizing the path
@@ -61,6 +63,14 @@ type ServerConfig struct {
 	ArtifactService artifact.Service
 	SSEWriteTimeout time.Duration
 	PluginConfig    runner.PluginConfig
+	DebugConfig     *DebugTelemetryConfig
+}
+
+// DebugTelemetryConfig contains parameters for the debug telemetry.
+type DebugTelemetryConfig struct {
+	// Maximum number of traces to keep in memory.
+	// If <= 0, the default capacity is used.
+	TraceCapacity int
 }
 
 // Server is an HTTP server that serves the ADK REST API.

--- a/server/adkrest/handler.go
+++ b/server/adkrest/handler.go
@@ -15,6 +15,7 @@
 package adkrest
 
 import (
+	"fmt"
 	"net/http"
 	"time"
 
@@ -34,9 +35,12 @@ import (
 
 // NewServer creates a new ADK REST API server which implements [http.Handler] interface.
 func NewServer(cfg ServerConfig) (*Server, error) {
-	debugTelemetry := services.NewDebugTelemetry(&services.DebugTelemetryConfig{
+	debugTelemetry, err := services.NewDebugTelemetryWithConfig(&services.DebugTelemetryConfig{
 		TraceCapacity: cfg.DebugConfig.TraceCapacity,
 	})
+	if err != nil {
+		return nil, fmt.Errorf("failed to create debug telemetry service: %w", err)
+	}
 
 	router := mux.NewRouter().StrictSlash(true)
 	// TODO: Allow taking a prefix to allow customizing the path
@@ -69,7 +73,7 @@ type ServerConfig struct {
 // DebugTelemetryConfig contains parameters for the debug telemetry.
 type DebugTelemetryConfig struct {
 	// Maximum number of traces to keep in memory.
-	// If <= 0, the default capacity is used.
+	// If <= 0, the default capacity 10_000 is used.
 	TraceCapacity int
 }
 

--- a/server/adkrest/internal/services/debugtelemetry.go
+++ b/server/adkrest/internal/services/debugtelemetry.go
@@ -17,6 +17,7 @@ package services
 import (
 	"cmp"
 	"context"
+	"fmt"
 	"slices"
 	"sync"
 	"time"
@@ -44,19 +45,23 @@ type DebugTelemetry struct {
 
 type DebugTelemetryConfig struct {
 	// Maximum number of traces to keep in memory.
-	// If 0, default capacity (10k) is used.
+	// If <= 0, default capacity (10_000) is used.
 	TraceCapacity int
 }
 
-// NewDebugTelemetry returns a new DebugTelemetry instance with default capacity (10k).
-func NewDebugTelemetry(cfg *DebugTelemetryConfig) *DebugTelemetry {
+// NewDebugTelemetryWithConfig returns a new DebugTelemetry instance with custom capacity.
+func NewDebugTelemetryWithConfig(cfg *DebugTelemetryConfig) (*DebugTelemetry, error) {
 	capacity := defaultTraceCapacity
 	if cfg != nil && cfg.TraceCapacity > 0 {
 		capacity = cfg.TraceCapacity
 	}
-	return &DebugTelemetry{
-		store: newSpanStore(capacity),
+	store, err := newSpanStore(capacity)
+	if err != nil {
+		return nil, fmt.Errorf("failed to create span store: %w", err)
 	}
+	return &DebugTelemetry{
+		store: store,
+	}, nil
 }
 
 func (d *DebugTelemetry) SpanProcessor() sdktrace.SpanProcessor {
@@ -132,17 +137,18 @@ type spanStore struct {
 	recordsByEventID map[string][]*spanRecord
 }
 
-func newSpanStore(capacity int) *spanStore {
+func newSpanStore(capacity int) (*spanStore, error) {
 	store := &spanStore{
 		recordsBySpanID:     make(map[string]*spanRecord),
 		traceIDsBySessionID: make(map[string]map[string]struct{}),
 		recordsByEventID:    make(map[string][]*spanRecord),
 	}
-	cache, err := lru.NewWithEvict(capacity, store.evict)
-	if err == nil {
-		store.recordsByTraceID = cache
+	var err error
+	store.recordsByTraceID, err = lru.NewWithEvict(capacity, store.evict)
+	if err != nil {
+		return nil, fmt.Errorf("failed to create LRU cache: %w", err)
 	}
-	return store
+	return store, nil
 }
 
 func (s *spanStore) getSpansByEventID(id string) []DebugSpan {

--- a/server/adkrest/internal/services/debugtelemetry.go
+++ b/server/adkrest/internal/services/debugtelemetry.go
@@ -156,15 +156,22 @@ func (s *spanStore) getSpansByEventID(id string) []DebugSpan {
 	defer s.mu.RUnlock()
 	// Create a copy of the slice to avoid race conditions.
 	records := slices.Clone(s.recordsByEventID[id])
-	seenTraces := make(map[string]bool)
+	s.touchTraces(records)
+	return convertRecords(records)
+}
+
+// touchTraces marks traces as recently used. Required because fetching by event ID bypasses the trace LRU cache.
+func (s *spanStore) touchTraces(records []*spanRecord) {
+	// touchedTraces is used to avoid touching the same trace multiple times.
+	touchedTraces := make(map[string]bool)
 	for _, r := range records {
 		traceIDStr := r.Context.TraceID().String()
-		if traceIDStr != "" && !seenTraces[traceIDStr] {
+		if traceIDStr != "" && !touchedTraces[traceIDStr] {
+			touchedTraces[traceIDStr] = true
+			// Get the trace to update its access time in the LRU cache, ignore the result.
 			s.recordsByTraceID.Get(traceIDStr)
-			seenTraces[traceIDStr] = true
 		}
 	}
-	return convertRecords(records)
 }
 
 func (s *spanStore) getSpansBySessionID(sessionID string) []DebugSpan {
@@ -304,7 +311,7 @@ func (s *spanStore) evict(traceID string, spans []*spanRecord) {
 func (s *spanStore) evictRecordsByEventID(eventID string, span *spanRecord) {
 	records := s.recordsByEventID[eventID]
 	records = slices.DeleteFunc(records, func(r *spanRecord) bool {
-		return r == span
+		return r.Context.SpanID() == span.Context.SpanID()
 	})
 	if len(records) == 0 {
 		delete(s.recordsByEventID, eventID)

--- a/server/adkrest/internal/services/debugtelemetry.go
+++ b/server/adkrest/internal/services/debugtelemetry.go
@@ -15,10 +15,13 @@
 package services
 
 import (
+	"cmp"
 	"context"
 	"slices"
 	"sync"
 	"time"
+
+	lru "github.com/hashicorp/golang-lru/v2"
 
 	"go.opentelemetry.io/otel/attribute"
 	sdklog "go.opentelemetry.io/otel/sdk/log"
@@ -29,17 +32,30 @@ import (
 	"google.golang.org/adk/internal/telemetry"
 )
 
-const eventIDKey = "gcp.vertex.agent.event_id"
+const (
+	defaultTraceCapacity = 10_000
+	eventIDKey           = "gcp.vertex.agent.event_id"
+)
 
 // DebugTelemetry stores the in memory spans and logs, grouped by session and event.
 type DebugTelemetry struct {
 	store *spanStore
 }
 
-// NewDebugTelemetry returns a new DebugTelemetry instance.
-func NewDebugTelemetry() *DebugTelemetry {
+type DebugTelemetryConfig struct {
+	// Maximum number of traces to keep in memory.
+	// If 0, default capacity (10k) is used.
+	TraceCapacity int
+}
+
+// NewDebugTelemetry returns a new DebugTelemetry instance with default capacity (10k).
+func NewDebugTelemetry(cfg *DebugTelemetryConfig) *DebugTelemetry {
+	capacity := defaultTraceCapacity
+	if cfg != nil && cfg.TraceCapacity > 0 {
+		capacity = cfg.TraceCapacity
+	}
 	return &DebugTelemetry{
-		store: newSpanStore(),
+		store: newSpanStore(capacity),
 	}
 }
 
@@ -64,7 +80,7 @@ func (d *DebugTelemetry) GetSpansBySessionID(sessionID string) []DebugSpan {
 }
 
 func convertAttrs(in []attribute.KeyValue) map[string]string {
-	out := make(map[string]string)
+	out := make(map[string]string, len(in))
 	for _, attr := range in {
 		out[string(attr.Key)] = attr.Value.Emit()
 	}
@@ -94,40 +110,39 @@ type DebugLog struct {
 
 // spanRecord stores a span and its associated logs.
 type spanRecord struct {
-	Span *inMemorySpan
-	Logs []DebugLog
-}
-
-// inMemorySpan stores spans in memory for debug telemetry.
-type inMemorySpan struct {
 	Name         string
 	StartTime    time.Time
 	EndTime      time.Time
 	Context      trace.SpanContext
 	ParentSpanID trace.SpanID
 	Attributes   map[string]string
+	Logs         []DebugLog
 }
 
 // spanStore stores spans and logs in memory for debug telemetry.
 type spanStore struct {
 	mu sync.RWMutex
+	// recordsByTraceID is the main store for spans, indexed by trace id.
+	recordsByTraceID *lru.Cache[string, []*spanRecord]
 	// recordsBySpanID stores spans indexed by span id.
 	recordsBySpanID map[string]*spanRecord
 	// traceIDsBySessionID stores trace ids indexed by session id for easy lookup.
 	traceIDsBySessionID map[string]map[string]struct{}
 	// recordsByEventID stores spans indexed by event id for easy lookup.
 	recordsByEventID map[string][]*spanRecord
-	// recordsByTraceID stores spans indexed by trace id for easy lookup.
-	recordsByTraceID map[string][]*spanRecord
 }
 
-func newSpanStore() *spanStore {
-	return &spanStore{
+func newSpanStore(capacity int) *spanStore {
+	store := &spanStore{
 		recordsBySpanID:     make(map[string]*spanRecord),
 		traceIDsBySessionID: make(map[string]map[string]struct{}),
 		recordsByEventID:    make(map[string][]*spanRecord),
-		recordsByTraceID:    make(map[string][]*spanRecord),
 	}
+	cache, err := lru.NewWithEvict(capacity, store.evict)
+	if err == nil {
+		store.recordsByTraceID = cache
+	}
+	return store
 }
 
 func (s *spanStore) getSpansByEventID(id string) []DebugSpan {
@@ -135,6 +150,14 @@ func (s *spanStore) getSpansByEventID(id string) []DebugSpan {
 	defer s.mu.RUnlock()
 	// Create a copy of the slice to avoid race conditions.
 	records := slices.Clone(s.recordsByEventID[id])
+	seenTraces := make(map[string]bool)
+	for _, r := range records {
+		traceIDStr := r.Context.TraceID().String()
+		if traceIDStr != "" && !seenTraces[traceIDStr] {
+			s.recordsByTraceID.Get(traceIDStr)
+			seenTraces[traceIDStr] = true
+		}
+	}
 	return convertRecords(records)
 }
 
@@ -144,41 +167,41 @@ func (s *spanStore) getSpansBySessionID(sessionID string) []DebugSpan {
 	traces := s.traceIDsBySessionID[sessionID]
 	var records []*spanRecord
 	for traceID := range traces {
-		if r, ok := s.recordsByTraceID[traceID]; ok {
-			records = append(records, r...)
+		if traceRecords, ok := s.recordsByTraceID.Get(traceID); ok {
+			records = append(records, traceRecords...)
 		}
 	}
 	return convertRecords(records)
 }
 
 func convertRecords(records []*spanRecord) []DebugSpan {
-	records = filterNilsAndSort(records)
+	records = filterUnclosedAndSort(records)
 	debugSpans := make([]DebugSpan, len(records))
 	for i, r := range records {
 		// Clone the logs to avoid race conditions.
 		logs := slices.Clone(r.Logs)
 		debugSpans[i] = DebugSpan{
-			Name:         r.Span.Name,
-			StartTime:    r.Span.StartTime.UnixNano(),
-			EndTime:      r.Span.EndTime.UnixNano(),
-			TraceID:      r.Span.Context.TraceID().String(),
-			SpanID:       r.Span.Context.SpanID().String(),
-			ParentSpanID: r.Span.ParentSpanID.String(),
-			Attributes:   r.Span.Attributes,
+			Name:         r.Name,
+			StartTime:    r.StartTime.UnixNano(),
+			EndTime:      r.EndTime.UnixNano(),
+			SpanID:       r.Context.SpanID().String(),
+			TraceID:      r.Context.TraceID().String(),
+			ParentSpanID: r.ParentSpanID.String(),
+			Attributes:   r.Attributes,
 			Logs:         logs,
 		}
 	}
 	return debugSpans
 }
 
-func filterNilsAndSort(records []*spanRecord) []*spanRecord {
+func filterUnclosedAndSort(records []*spanRecord) []*spanRecord {
 	filtered := slices.DeleteFunc(records, func(s *spanRecord) bool {
 		// Logs are emitted before the span is closed and sent to the processor.
 		// Skip them in the response.
-		return s == nil || s.Span == nil
+		return s == nil || !s.Context.TraceID().IsValid()
 	})
-	slices.SortFunc(filtered, func(a, b *spanRecord) int {
-		return a.Span.StartTime.Compare(b.Span.StartTime)
+	slices.SortStableFunc(filtered, func(a, b *spanRecord) int {
+		return cmp.Compare(a.StartTime.UnixNano(), b.StartTime.UnixNano())
 	})
 	return filtered
 }
@@ -222,21 +245,20 @@ func (s *spanStore) ExportSpans(ctx context.Context, spans []sdktrace.ReadOnlySp
 			s.recordsBySpanID[spanID] = record
 		}
 
-		record.Span = &inMemorySpan{
-			Name:         span.Name(),
-			StartTime:    span.StartTime(),
-			EndTime:      span.EndTime(),
-			Context:      span.SpanContext(),
-			ParentSpanID: span.Parent().SpanID(),
-			Attributes:   attrs,
-		}
+		record.Name = span.Name()
+		record.StartTime = span.StartTime()
+		record.EndTime = span.EndTime()
+		record.Context = span.SpanContext()
+		record.ParentSpanID = span.Parent().SpanID()
+		record.Attributes = attrs
 
-		s.updateSpanIndexes(record.Span, record)
+		s.updateSpanIndexes(record)
 	}
 	return nil
 }
 
-func (s *spanStore) updateSpanIndexes(span *inMemorySpan, record *spanRecord) {
+func (s *spanStore) updateSpanIndexes(span *spanRecord) {
+	traceIDStr := span.Context.TraceID().String()
 	// Update session id -> trace id mapping.
 	sessionIDKey := string(semconv.GenAIConversationIDKey)
 	if sessionID, ok := span.Attributes[sessionIDKey]; ok {
@@ -245,16 +267,54 @@ func (s *spanStore) updateSpanIndexes(span *inMemorySpan, record *spanRecord) {
 			traces = make(map[string]struct{})
 			s.traceIDsBySessionID[sessionID] = traces
 		}
-		traceID := span.Context.TraceID().String()
-		traces[traceID] = struct{}{}
+		traces[traceIDStr] = struct{}{}
 	}
 	// Update event id -> span id mapping.
 	if eventID, ok := span.Attributes[eventIDKey]; ok {
-		s.recordsByEventID[eventID] = append(s.recordsByEventID[eventID], record)
+		s.recordsByEventID[eventID] = append(s.recordsByEventID[eventID], span)
 	}
-	// Update trace id -> span id mapping.
-	traceID := span.Context.TraceID().String()
-	s.recordsByTraceID[traceID] = append(s.recordsByTraceID[traceID], record)
+
+	// Update trace id -> span id mapping (LRU).
+	records, _ := s.recordsByTraceID.Get(traceIDStr)
+	s.recordsByTraceID.Add(traceIDStr, append(records, span))
+}
+
+func (s *spanStore) evict(traceID string, spans []*spanRecord) {
+	for _, span := range spans {
+		if span.Context.TraceID().IsValid() {
+			delete(s.recordsBySpanID, span.Context.SpanID().String())
+
+			if eventID, ok := span.Attributes[eventIDKey]; ok {
+				s.evictRecordsByEventID(eventID, span)
+			}
+
+			if sessionID, ok := span.Attributes[string(semconv.GenAIConversationIDKey)]; ok {
+				s.evictTraceIDsBySessionID(sessionID, traceID)
+			}
+		}
+	}
+}
+
+func (s *spanStore) evictRecordsByEventID(eventID string, span *spanRecord) {
+	records := s.recordsByEventID[eventID]
+	records = slices.DeleteFunc(records, func(r *spanRecord) bool {
+		return r == span
+	})
+	if len(records) == 0 {
+		delete(s.recordsByEventID, eventID)
+	} else {
+		s.recordsByEventID[eventID] = records
+	}
+}
+
+func (s *spanStore) evictTraceIDsBySessionID(sessionID, traceID string) {
+	traces := s.traceIDsBySessionID[sessionID]
+	if traces != nil {
+		delete(traces, traceID)
+		if len(traces) == 0 {
+			delete(s.traceIDsBySessionID, sessionID)
+		}
+	}
 }
 
 // ForceFlush implements sdklog.Exporter and sdktrace.SpanProcessor.

--- a/server/adkrest/internal/services/debugtelemetry_test.go
+++ b/server/adkrest/internal/services/debugtelemetry_test.go
@@ -212,7 +212,7 @@ func TestDebugTelemetryGetSpansBySessionID(t *testing.T) {
 
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			debugTelemetry, tp, lp := setup()
+			debugTelemetry, tp, lp := setup(t)
 
 			if tt.testSetup != nil {
 				tt.testSetup(ctx, tp.Tracer("test-tracer"), lp.Logger("test-logger"))
@@ -349,7 +349,7 @@ func TestDebugTelemetryGetSpansByEventID(t *testing.T) {
 
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			debugTelemetry, tp, lp := setup()
+			debugTelemetry, tp, lp := setup(t)
 
 			if tt.testSetup != nil {
 				tt.testSetup(ctx, tp.Tracer("test-tracer"), lp.Logger("test-logger"))
@@ -380,7 +380,7 @@ func TestDebugTelemetryGetSpansByEventID(t *testing.T) {
 func TestDebugTelemetryLRU(t *testing.T) {
 	ctx := t.Context()
 
-	debugTelemetry, tp, lp := setupWithConfig(&DebugTelemetryConfig{TraceCapacity: 2})
+	debugTelemetry, tp, lp := setupWithConfig(t, &DebugTelemetryConfig{TraceCapacity: 2})
 	tracer := tp.Tracer("test-tracer")
 
 	// 1. Add Trace 1.
@@ -456,8 +456,11 @@ func TestDebugTelemetryLRU(t *testing.T) {
 	}
 }
 
-func setupWithConfig(cfg *DebugTelemetryConfig) (*DebugTelemetry, *sdktrace.TracerProvider, *sdklog.LoggerProvider) {
-	debugTelemetry := NewDebugTelemetry(cfg)
+func setupWithConfig(t *testing.T, cfg *DebugTelemetryConfig) (*DebugTelemetry, *sdktrace.TracerProvider, *sdklog.LoggerProvider) {
+	debugTelemetry, err := NewDebugTelemetryWithConfig(cfg)
+	if err != nil {
+		t.Fatalf("Failed to create debug telemetry: %v", err)
+	}
 	tp := sdktrace.NewTracerProvider(
 		sdktrace.WithSpanProcessor(debugTelemetry.SpanProcessor()),
 	)
@@ -466,12 +469,6 @@ func setupWithConfig(cfg *DebugTelemetryConfig) (*DebugTelemetry, *sdktrace.Trac
 	return debugTelemetry, tp, lp
 }
 
-func setup() (*DebugTelemetry, *sdktrace.TracerProvider, *sdklog.LoggerProvider) {
-	debugTelemetry := NewDebugTelemetry(nil)
-	tp := sdktrace.NewTracerProvider(
-		sdktrace.WithSpanProcessor(debugTelemetry.SpanProcessor()),
-	)
-	lp := sdklog.NewLoggerProvider(sdklog.WithProcessor(debugTelemetry.LogProcessor()))
-
-	return debugTelemetry, tp, lp
+func setup(t *testing.T) (*DebugTelemetry, *sdktrace.TracerProvider, *sdklog.LoggerProvider) {
+	return setupWithConfig(t, nil)
 }

--- a/server/adkrest/internal/services/debugtelemetry_test.go
+++ b/server/adkrest/internal/services/debugtelemetry_test.go
@@ -377,8 +377,97 @@ func TestDebugTelemetryGetSpansByEventID(t *testing.T) {
 	}
 }
 
+func TestDebugTelemetryLRU(t *testing.T) {
+	ctx := t.Context()
+
+	debugTelemetry, tp, lp := setupWithConfig(&DebugTelemetryConfig{TraceCapacity: 2})
+	tracer := tp.Tracer("test-tracer")
+
+	// 1. Add Trace 1.
+	_, span1 := tracer.Start(ctx, "root-1", trace.WithAttributes(
+		semconv.GenAIConversationID("session-1"),
+		attribute.String("gcp.vertex.agent.event_id", "event-1"),
+	))
+	span1.End()
+
+	// 2. Add Trace 2.
+	_, span2 := tracer.Start(ctx, "root-2", trace.WithAttributes(
+		semconv.GenAIConversationID("session-2"),
+		attribute.String("gcp.vertex.agent.event_id", "event-2"),
+	))
+	span2.End()
+
+	_ = tp.ForceFlush(ctx)
+	_ = lp.ForceFlush(ctx)
+
+	// 3. Verify both traces are present.
+	if gotSpans := len(debugTelemetry.GetSpansBySessionID("session-1")); gotSpans != 1 {
+		t.Errorf("expected 1 span for session-1, got %d", gotSpans)
+	}
+	if gotSpans := len(debugTelemetry.GetSpansBySessionID("session-2")); gotSpans != 1 {
+		t.Errorf("expected 1 span for session-2, got %d", gotSpans)
+	}
+
+	// 4. Access session-2 making it the most recently used.
+	_ = debugTelemetry.GetSpansBySessionID("session-2")
+
+	// 5. Add Trace 3 - should evict Trace 1 because it's the least recently used.
+	_, span3 := tracer.Start(ctx, "root-3", trace.WithAttributes(
+		semconv.GenAIConversationID("session-3"),
+		attribute.String("gcp.vertex.agent.event_id", "event-3"),
+	))
+	span3.End()
+
+	// 6. Verify Trace 1 is evicted, Trace 2 and 3 are present.
+	if gotSpans := len(debugTelemetry.GetSpansBySessionID("session-1")); gotSpans != 0 {
+		t.Errorf("expected 0 spans for session-1, got %d", gotSpans)
+	}
+	if gotSpans := len(debugTelemetry.GetSpansBySessionID("session-2")); gotSpans != 1 {
+		t.Errorf("expected 1 span for session-2, got %d", gotSpans)
+	}
+	if gotSpans := len(debugTelemetry.GetSpansBySessionID("session-3")); gotSpans != 1 {
+		t.Errorf("expected 1 span for session-3, got %d", gotSpans)
+	}
+
+	// 7. Verify Trace 1 spans are removed from event index.
+	if gotSpans := len(debugTelemetry.GetSpansByEventID("event-1")); gotSpans != 0 {
+		t.Errorf("expected 0 spans for event-1, got %d", gotSpans)
+	}
+
+	// 8. Access Trace 2 via GetSpansByEventID, making it the most recently used.
+	_ = debugTelemetry.GetSpansByEventID("event-2")
+
+	// 9. Add Trace 4 - should evict Trace 3 because it's the least recently used.
+	_, span4 := tracer.Start(ctx, "root-4", trace.WithAttributes(
+		semconv.GenAIConversationID("session-4"),
+		attribute.String("gcp.vertex.agent.event_id", "event-4"),
+	))
+	span4.End()
+
+	// 10. Verify Trace 3 is evicted, Trace 2 and 4 are present.
+	if gotSpans := len(debugTelemetry.GetSpansBySessionID("session-2")); gotSpans != 1 {
+		t.Errorf("expected 1 span for session-2, got %d", gotSpans)
+	}
+	if gotSpans := len(debugTelemetry.GetSpansBySessionID("session-4")); gotSpans != 1 {
+		t.Errorf("expected 1 span for session-4, got %d", gotSpans)
+	}
+	if gotSpans := len(debugTelemetry.GetSpansBySessionID("session-3")); gotSpans != 0 {
+		t.Errorf("expected 0 spans for session-3, got %d", gotSpans)
+	}
+}
+
+func setupWithConfig(cfg *DebugTelemetryConfig) (*DebugTelemetry, *sdktrace.TracerProvider, *sdklog.LoggerProvider) {
+	debugTelemetry := NewDebugTelemetry(cfg)
+	tp := sdktrace.NewTracerProvider(
+		sdktrace.WithSpanProcessor(debugTelemetry.SpanProcessor()),
+	)
+	lp := sdklog.NewLoggerProvider(sdklog.WithProcessor(debugTelemetry.LogProcessor()))
+
+	return debugTelemetry, tp, lp
+}
+
 func setup() (*DebugTelemetry, *sdktrace.TracerProvider, *sdklog.LoggerProvider) {
-	debugTelemetry := NewDebugTelemetry()
+	debugTelemetry := NewDebugTelemetry(nil)
 	tp := sdktrace.NewTracerProvider(
 		sdktrace.WithSpanProcessor(debugTelemetry.SpanProcessor()),
 	)


### PR DESCRIPTION
This CL adds LRU cache to limit the number of traces kept in memory for debug telemetry.
The cache size is configurable via the newly added config struct. The default is 10k traces.
