### PR TITLE
feat: init trigger routes set up for event processing

### DIFF
--- a/cmd/launcher/launcher.go
+++ b/cmd/launcher/launcher.go
@@ -17,6 +17,7 @@ package launcher
 
 import (
 	"context"
+	"time"
 
 	"github.com/a2aproject/a2a-go/a2asrv"
 
@@ -54,6 +55,18 @@ type SubLauncher interface {
 	Run(ctx context.Context, config *Config) error
 }
 
+// TriggerConfig contains configuration options for triggers.
+type TriggerConfig struct {
+	// MaxRetries is the maximum number of times to retry a failed agent execution.
+	MaxRetries int
+	// BaseDelay is the base delay between retries.
+	BaseDelay time.Duration
+	// MaxDelay is the maximum delay between retries.
+	MaxDelay time.Duration
+	// MaxConcurrentRuns is the maximum number of concurrent runs.
+	MaxConcurrentRuns int
+}
+
 // Config contains parameters for web & console execution: sessions, artifacts, agents etc
 type Config struct {
 	SessionService   session.Service
@@ -63,4 +76,6 @@ type Config struct {
 	A2AOptions       []a2asrv.RequestHandlerOption
 	PluginConfig     runner.PluginConfig
 	TelemetryOptions []telemetry.Option
+	TriggerSources   []string
+	TriggerConfig    TriggerConfig
 }

--- a/cmd/launcher/web/api/api.go
+++ b/cmd/launcher/web/api/api.go
@@ -19,6 +19,7 @@ import (
 	"flag"
 	"fmt"
 	"net/http"
+	"slices"
 	"strings"
 	"time"
 
@@ -31,11 +32,19 @@ import (
 	"google.golang.org/adk/telemetry"
 )
 
+// SupportedTriggers defines the allowed trigger sources for the ADK REST API.
+var SupportedTriggers = []string{"pubsub"}
+
 // apiConfig contains parametres for lauching ADK REST API
 type apiConfig struct {
-	frontendAddress string
-	pathPrefix      string
-	sseWriteTimeout time.Duration
+	frontendAddress   string
+	pathPrefix        string
+	sseWriteTimeout   time.Duration
+	triggerSources    string
+	triggerMaxRetries int
+	triggerBaseDelay  time.Duration
+	triggerMaxDelay   time.Duration
+	triggerMaxRuns    int
 }
 
 // apiLauncher can launch ADK REST API
@@ -73,6 +82,25 @@ func (a *apiLauncher) UserMessage(webURL string, printer func(v ...any)) {
 
 // SetupSubrouters adds the API router to the parent router.
 func (a *apiLauncher) SetupSubrouters(router *mux.Router, config *launcher.Config) error {
+	if a.config.triggerSources != "" {
+		sources := strings.Split(a.config.triggerSources, ",")
+		for _, source := range sources {
+			if !slices.Contains(SupportedTriggers, source) {
+				return fmt.Errorf("invalid trigger source: %q. Any subset of %s is allowed. Values should be comma-separated", source, strings.Join(SupportedTriggers, ", "))
+			}
+		}
+		// De-duplicate the input sources.
+		slices.Sort(sources)
+		config.TriggerSources = slices.Compact(sources)
+	}
+
+	config.TriggerConfig = launcher.TriggerConfig{
+		MaxRetries:        a.config.triggerMaxRetries,
+		BaseDelay:         a.config.triggerBaseDelay,
+		MaxDelay:          a.config.triggerMaxDelay,
+		MaxConcurrentRuns: a.config.triggerMaxRuns,
+	}
+
 	// Create the ADK REST API handler
 	restServer, err := adkrest.NewServer(adkrest.ServerConfig{
 		SessionService:  config.SessionService,
@@ -81,6 +109,7 @@ func (a *apiLauncher) SetupSubrouters(router *mux.Router, config *launcher.Confi
 		ArtifactService: config.ArtifactService,
 		SSEWriteTimeout: a.config.sseWriteTimeout,
 		PluginConfig:    config.PluginConfig,
+		TriggerSources:  config.TriggerSources,
 	})
 	if err != nil {
 		return fmt.Errorf("failed to create REST server: %w", err)
@@ -115,6 +144,19 @@ func (a *apiLauncher) Parse(args []string) ([]string, error) {
 	if err != nil || !a.flags.Parsed() {
 		return nil, fmt.Errorf("failed to parse api flags: %v", err)
 	}
+	if a.config.triggerMaxRetries < 0 {
+		return nil, fmt.Errorf("trigger_max_retries must be >= 0")
+	}
+	if a.config.triggerBaseDelay < 0 {
+		return nil, fmt.Errorf("trigger_base_delay must be >= 0")
+	}
+	if a.config.triggerMaxDelay < 0 {
+		return nil, fmt.Errorf("trigger_max_delay must be >= 0")
+	}
+	if a.config.triggerMaxRuns < 0 {
+		return nil, fmt.Errorf("trigger_max_concurrent_runs must be >= 0")
+	}
+
 	p := a.config.pathPrefix
 	if !strings.HasPrefix(p, "/") {
 		p = "/" + p
@@ -138,6 +180,11 @@ func NewLauncher() weblauncher.Sublauncher {
 	fs.StringVar(&config.frontendAddress, "webui_address", "localhost:8080", "ADK WebUI address as seen from the user browser. It's used to allow CORS requests. Please specify only hostname and (optionally) port.")
 	fs.StringVar(&config.pathPrefix, "path_prefix", "/api", "ADK REST API path prefix. Default is '/api'.")
 	fs.DurationVar(&config.sseWriteTimeout, "sse-write-timeout", 120*time.Second, "SSE server write timeout (i.e. '10s', '2m' - see time.ParseDuration for details) - for writing the SSE response after reading the headers & body")
+	fs.IntVar(&config.triggerMaxRetries, "trigger_max_retries", 3, "Maximum retries for HTTP 429 errors from triggers")
+	fs.DurationVar(&config.triggerBaseDelay, "trigger_base_delay", 1*time.Second, "Base delay for trigger retry exponential backoff")
+	fs.DurationVar(&config.triggerMaxDelay, "trigger_max_delay", 10*time.Second, "Maximum delay for trigger retry exponential backoff")
+	fs.IntVar(&config.triggerMaxRuns, "trigger_max_concurrent_runs", 100, "Maximum concurrent trigger runs")
+	fs.StringVar(&config.triggerSources, "trigger_sources", "", fmt.Sprintf("Comma-separated list of trigger sources to enable (any subset of %s)", strings.Join(SupportedTriggers, ", ")))
 
 	return &apiLauncher{
 		config: config,

--- a/cmd/launcher/web/api/api_test.go
+++ b/cmd/launcher/web/api/api_test.go
@@ -1,0 +1,94 @@
+// Copyright 2026 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package api
+
+import (
+	"testing"
+
+	"github.com/google/go-cmp/cmp"
+	"github.com/google/go-cmp/cmp/cmpopts"
+	"github.com/gorilla/mux"
+
+	"google.golang.org/adk/cmd/launcher"
+)
+
+func TestSetupSubrouters_TriggerSourcesValidation(t *testing.T) {
+	tests := []struct {
+		name           string
+		triggerSources string
+		wantErr        bool
+		wantSources    []string
+	}{
+		{
+			name:           "empty trigger sources",
+			triggerSources: "",
+			wantErr:        false,
+			wantSources:    nil,
+		},
+		{
+			name:           "valid trigger sources single",
+			triggerSources: "pubsub",
+			wantErr:        false,
+			wantSources:    []string{"pubsub"},
+		},
+		{
+			name:           "deduplicatedd trigger sources",
+			triggerSources: "pubsub,pubsub,pubsub",
+			wantErr:        false,
+			wantSources:    []string{"pubsub"},
+		},
+		{
+			name:           "invalid trigger source",
+			triggerSources: "invalid",
+			wantErr:        true,
+			wantSources:    nil,
+		},
+		{
+			name:           "mixed valid and invalid",
+			triggerSources: "pubsub,invalid,bq",
+			wantErr:        true,
+			wantSources:    nil,
+		},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			a := &apiLauncher{
+				config: &apiConfig{
+					triggerSources: tc.triggerSources,
+				},
+			}
+			router := mux.NewRouter()
+			config := &launcher.Config{}
+
+			err := a.SetupSubrouters(router, config)
+			if tc.wantErr {
+				if err == nil {
+					t.Errorf("SetupSubrouters() error = nil, wantErr %v", tc.wantErr)
+				}
+			} else {
+				if err != nil {
+					t.Errorf("SetupSubrouters() error = %v, wantErr %v", err, tc.wantErr)
+				}
+				diff := cmp.Diff(tc.wantSources, config.TriggerSources, cmpopts.SortSlices(func(a, b string) bool {
+					return a < b
+				}))
+				if diff != "" {
+					t.Errorf("SetupSubrouters() config.TriggerSources mismatch (-want +got):\n%s", diff)
+				}
+			}
+		})
+	}
+}

--- a/server/adkrest/controllers/triggers.go
+++ b/server/adkrest/controllers/triggers.go
@@ -1,0 +1,217 @@
+// Copyright 2026 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package controllers
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+	"math"
+	"math/rand"
+	"net/http"
+	"strings"
+	"time"
+
+	"github.com/gorilla/mux"
+	"google.golang.org/genai"
+
+	"google.golang.org/adk/agent"
+	"google.golang.org/adk/artifact"
+	"google.golang.org/adk/cmd/launcher"
+	"google.golang.org/adk/memory"
+	"google.golang.org/adk/runner"
+	"google.golang.org/adk/server/adkrest/internal/models"
+	"google.golang.org/adk/session"
+)
+
+const defaultUserID = "pubsub-caller"
+
+// TriggersAPIController handles the ADK triggered endpoints.
+type TriggersAPIController struct {
+	sessionService  session.Service
+	agentLoader     agent.Loader
+	memoryService   memory.Service
+	artifactService artifact.Service
+	pluginConfig    runner.PluginConfig
+	triggerConfig   launcher.TriggerConfig
+	semaphore       chan struct{}
+}
+
+// NewTriggersAPIController creates a new TriggersAPIController.
+func NewTriggersAPIController(sessionService session.Service, agentLoader agent.Loader, memoryService memory.Service, artifactService artifact.Service, pluginConfig runner.PluginConfig, triggerConfig launcher.TriggerConfig) *TriggersAPIController {
+	return &TriggersAPIController{
+		sessionService:  sessionService,
+		agentLoader:     agentLoader,
+		memoryService:   memoryService,
+		artifactService: artifactService,
+		pluginConfig:    pluginConfig,
+		triggerConfig:   triggerConfig,
+		semaphore:       make(chan struct{}, triggerConfig.MaxConcurrentRuns),
+	}
+}
+
+// PubSubTriggerHandler handles the PubSub trigger endpoint.
+func (c *TriggersAPIController) PubSubTriggerHandler(w http.ResponseWriter, r *http.Request) {
+	if c.semaphore != nil {
+		c.semaphore <- struct{}{}
+		defer func() { <-c.semaphore }()
+	}
+
+	// Parse the request to the request model.
+	var req models.PubSubTriggerRequest
+	if err := json.NewDecoder(r.Body).Decode(&req); err != nil {
+		c.respondError(w, http.StatusBadRequest, fmt.Sprintf("failed to decode request: %v", err))
+		return
+	}
+
+	// Decode base64 message data.
+	var messageContent string
+	if len(req.Message.Data) > 0 {
+		messageContent = string(req.Message.Data)
+		// Use Attributes if Data is empty.
+	} else if len(req.Message.Attributes) > 0 {
+		attrBytes, err := json.Marshal(req.Message.Attributes)
+		if err != nil {
+			c.respondError(w, http.StatusInternalServerError, fmt.Sprintf("failed to marshal attributes: %v", err))
+			return
+		}
+		messageContent = string(attrBytes)
+	} else {
+		c.respondError(w, http.StatusBadRequest, "pubsub message contains no data or attributes")
+		return
+	}
+
+	appName, err := c.appName(r)
+	if err != nil {
+		c.respondError(w, http.StatusInternalServerError, err.Error())
+		return
+	}
+
+	if _, err := c.runAgent(r.Context(), appName, req.Subscription, messageContent); err != nil {
+		c.respondError(w, http.StatusInternalServerError, fmt.Sprintf("failed to run agent: %v", err))
+		return
+	}
+
+	c.respondSuccess(w)
+}
+
+func (c *TriggersAPIController) runAgent(ctx context.Context, appName, userID, messageContent string) ([]*session.Event, error) {
+	if userID == "" {
+		userID = defaultUserID
+	}
+
+	// Each retry = new session
+	sessReq := &session.CreateRequest{
+		AppName: appName,
+		UserID:  userID,
+	}
+	sessResp, err := c.sessionService.Create(ctx, sessReq)
+	if err != nil {
+		return nil, fmt.Errorf("failed to create session: %v", err)
+	}
+
+	userMessage := genai.Content{
+		Role: "user",
+		Parts: []*genai.Part{
+			{Text: messageContent},
+		},
+	}
+
+	curAgent, err := c.agentLoader.LoadAgent(appName)
+	if err != nil {
+		return nil, fmt.Errorf("failed to load agent: %v", err)
+	}
+
+	runR, err := runner.New(runner.Config{
+		AppName:         appName,
+		Agent:           curAgent,
+		SessionService:  c.sessionService,
+		MemoryService:   c.memoryService,
+		ArtifactService: c.artifactService,
+		PluginConfig:    c.pluginConfig,
+	})
+	if err != nil {
+		return nil, fmt.Errorf("failed to create runner: %v", err)
+	}
+
+	return c.runAgentWithRetry(ctx, runR, sessResp.Session.UserID(), sessResp.Session.ID(), &userMessage)
+}
+
+// runAgentWithRetry uses exponential backoff with jitter to handle 429 rate-limit errors.
+// After MaxRetries is exhausted, raises an error to signal the upstream service (Pub/Sub, Eventarc) to retry at a higher level.
+func (c *TriggersAPIController) runAgentWithRetry(ctx context.Context, runR *runner.Runner, userID, sessionID string, userMessage *genai.Content) ([]*session.Event, error) {
+	var runErr error
+	events := []*session.Event{}
+	for i := 0; i <= c.triggerConfig.MaxRetries; i++ {
+		resp := runR.Run(ctx, userID, sessionID, userMessage, agent.RunConfig{StreamingMode: agent.StreamingModeNone})
+
+		isThrottled := false
+		for event, err := range resp {
+			if err != nil {
+				runErr = err
+				if isResourceExhausted(err) {
+					isThrottled = true
+				}
+				break
+			}
+			events = append(events, event)
+		}
+
+		if !isThrottled && runErr == nil {
+			return events, nil // Success
+		}
+
+		if i < c.triggerConfig.MaxRetries && isThrottled {
+			delay := calculateBackoff(i, c.triggerConfig.BaseDelay, c.triggerConfig.MaxDelay)
+			time.Sleep(delay)
+			runErr = nil // Clear error for next attempt
+			continue
+		}
+		break // Not throttled (but error raised) or max retries reached
+	}
+	return nil, runErr
+}
+
+func (c *TriggersAPIController) respondError(w http.ResponseWriter, code int, msg string) {
+	resp := models.TriggerResponse{Status: msg}
+	EncodeJSONResponse(resp, code, w)
+}
+
+func (c *TriggersAPIController) respondSuccess(w http.ResponseWriter) {
+	resp := models.TriggerResponse{Status: "success"}
+	EncodeJSONResponse(resp, http.StatusOK, w)
+}
+
+// Check if an exception represents a transient rate-limit error.
+func isResourceExhausted(err error) bool {
+	return err != nil && (strings.Contains(err.Error(), "429") || strings.Contains(err.Error(), "ResourceExhausted"))
+}
+
+func calculateBackoff(attempt int, base, maxDelay time.Duration) time.Duration {
+	backoff := float64(base) * math.Pow(2, float64(attempt))
+	delay := min(time.Duration(backoff), maxDelay)
+	jitter := time.Duration(rand.Float64() * float64(delay) * 0.5)
+	return delay + jitter
+}
+
+// Resolve the target app name from the request.
+func (c *TriggersAPIController) appName(r *http.Request) (string, error) {
+	vars := mux.Vars(r)
+	appName := vars["app_name"]
+	if appName == "" {
+		return "", fmt.Errorf("no application name provided")
+	}
+	return appName, nil
+}

--- a/server/adkrest/controllers/triggers_test.go
+++ b/server/adkrest/controllers/triggers_test.go
@@ -1,0 +1,146 @@
+// Copyright 2026 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package controllers_test
+
+import (
+	"bytes"
+	"encoding/json"
+	"fmt"
+	"iter"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+	"time"
+
+	"github.com/gorilla/mux"
+
+	"google.golang.org/adk/agent"
+	"google.golang.org/adk/cmd/launcher"
+	"google.golang.org/adk/runner"
+	"google.golang.org/adk/server/adkrest/controllers"
+	"google.golang.org/adk/server/adkrest/internal/fakes"
+	"google.golang.org/adk/server/adkrest/internal/models"
+	"google.golang.org/adk/session"
+)
+
+var defaultTriggerConfig = launcher.TriggerConfig{
+	MaxConcurrentRuns: 10,
+	MaxRetries:        3,
+	BaseDelay:         1 * time.Millisecond,
+	MaxDelay:          5 * time.Millisecond,
+}
+
+func TestPubSubTriggerHandler(t *testing.T) {
+	tests := []struct {
+		name             string
+		mockAgentResults []error
+		expectedCode     int
+		expectedRunCount int
+		requestBody      string
+	}{
+		{
+			name:             "Success_Immediate",
+			mockAgentResults: nil,
+			expectedCode:     http.StatusOK,
+			expectedRunCount: 1,
+		},
+		{
+			name:             "ResourceExhaustedRetry",
+			mockAgentResults: []error{fmt.Errorf("429 ResourceExhausted"), fmt.Errorf("429 ResourceExhausted")},
+			expectedCode:     http.StatusOK,
+			expectedRunCount: 3,
+		},
+		{
+			name:             "Success_AdditionalJSONFields",
+			requestBody:      `{"message": {"data": "SGVsbG8gYWdlbnQ="}, "subscription": "test-sub", "extra_field": "ignore me"}`,
+			expectedCode:     http.StatusOK,
+			expectedRunCount: 1,
+		},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			mockAgentRunCount := 0
+			testAgent := createMockAgent(t, tc.mockAgentResults, &mockAgentRunCount)
+
+			apiController := setupTest(t, testAgent)
+
+			var reqBytes []byte
+			if tc.requestBody != "" {
+				reqBytes = []byte(tc.requestBody)
+			} else {
+				reqObj := models.PubSubTriggerRequest{
+					Message: models.PubSubMessage{
+						Data: []byte("Hello agent"),
+					},
+					Subscription: "test-sub",
+				}
+				var err error
+				reqBytes, err = json.Marshal(reqObj)
+				if err != nil {
+					t.Fatalf("marshal request: %v", err)
+				}
+			}
+
+			req, err := http.NewRequest(http.MethodPost, "/apps/test-agent/triggers/pubsub", bytes.NewBuffer(reqBytes))
+			if err != nil {
+				t.Fatalf("new request: %v", err)
+			}
+			req = mux.SetURLVars(req, map[string]string{"app_name": "test-agent"})
+			rr := httptest.NewRecorder()
+
+			apiController.PubSubTriggerHandler(rr, req)
+
+			if rr.Code != tc.expectedCode {
+				t.Errorf("expected status %d, got %d. Body: %s", tc.expectedCode, rr.Code, rr.Body.String())
+			}
+
+			if mockAgentRunCount != tc.expectedRunCount {
+				t.Errorf("expected %d run attempts, got %d", tc.expectedRunCount, mockAgentRunCount)
+			}
+		})
+	}
+}
+
+func setupTest(t *testing.T, a agent.Agent) *controllers.TriggersAPIController {
+	t.Helper()
+	sessionService := &fakes.FakeSessionService{Sessions: make(map[fakes.SessionKey]fakes.TestSession)}
+	agentLoader := agent.NewSingleLoader(a)
+	return controllers.NewTriggersAPIController(sessionService, agentLoader, nil, nil, runner.PluginConfig{}, defaultTriggerConfig)
+}
+
+func createMockAgent(t *testing.T, results []error, runCount *int) agent.Agent {
+	t.Helper()
+	testAgent, err := agent.New(agent.Config{
+		Name: "test-agent",
+		Run: func(ctx agent.InvocationContext) iter.Seq2[*session.Event, error] {
+			return func(yield func(*session.Event, error) bool) {
+				*runCount++
+				if *runCount <= len(results) {
+					err := results[*runCount-1]
+					if err != nil {
+						yield(nil, err)
+						return
+					}
+				}
+				yield(&session.Event{ID: "success-event"}, nil)
+			}
+		},
+	})
+	if err != nil {
+		t.Fatalf("agent.New failed: %v", err)
+	}
+	return testAgent
+}

--- a/server/adkrest/handler.go
+++ b/server/adkrest/handler.go
@@ -24,6 +24,7 @@ import (
 
 	"google.golang.org/adk/agent"
 	"google.golang.org/adk/artifact"
+	"google.golang.org/adk/cmd/launcher"
 	"google.golang.org/adk/memory"
 	"google.golang.org/adk/runner"
 	"google.golang.org/adk/server/adkrest/controllers"
@@ -45,6 +46,7 @@ func NewServer(cfg ServerConfig) (*Server, error) {
 		routers.NewAppsAPIRouter(controllers.NewAppsAPIController(cfg.AgentLoader)),
 		routers.NewDebugAPIRouter(controllers.NewDebugAPIController(cfg.SessionService, cfg.AgentLoader, debugTelemetry)),
 		routers.NewArtifactsAPIRouter(controllers.NewArtifactsAPIController(cfg.ArtifactService)),
+		routers.NewTriggersAPIRouter(controllers.NewTriggersAPIController(cfg.SessionService, cfg.AgentLoader, cfg.MemoryService, cfg.ArtifactService, cfg.PluginConfig, cfg.TriggerConfig), cfg.TriggerSources),
 		&routers.EvalAPIRouter{},
 	)
 	return &Server{
@@ -61,6 +63,8 @@ type ServerConfig struct {
 	ArtifactService artifact.Service
 	SSEWriteTimeout time.Duration
 	PluginConfig    runner.PluginConfig
+	TriggerSources  []string
+	TriggerConfig   launcher.TriggerConfig
 }
 
 // Server is an HTTP server that serves the ADK REST API.

--- a/server/adkrest/internal/models/triggers.go
+++ b/server/adkrest/internal/models/triggers.go
@@ -1,0 +1,44 @@
+// Copyright 2026 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package models
+
+// PubSubTriggerRequest represents the request for the PubSub trigger.
+// See: https://cloud.google.com/pubsub/docs/push#receive_push
+type PubSubTriggerRequest struct {
+	// The Pub/Sub message.
+	Message PubSubMessage `json:"message"`
+	// The subscription this message was published to.
+	Subscription string `json:"subscription"`
+}
+
+// PubSubMessage represents the message for the PubSub trigger.
+type PubSubMessage struct {
+	// The message payload. This will always be a base64-encoded string.
+	Data []byte `json:"data"`
+	// ID of this message, assigned by the Pub/Sub server.
+	MessageID string `json:"messageId"`
+	// The time at which the message was published, populated by the server.
+	PublishTime string `json:"publishTime"`
+	// Optional attributes for this message. An object containing a list of 'key': 'value' string pairs.
+	Attributes map[string]string `json:"attributes,omitempty"`
+	// If message ordering is enabled, this identifies related messages for which publish order should be respected.
+	OrderingKey string `json:"orderingKey,omitempty"`
+}
+
+// TriggerResponse represents the standard response for Pub/Sub and Eventarc triggers.
+type TriggerResponse struct {
+	// Processing status: 'success' or error message.
+	Status string `json:"status"`
+}

--- a/server/adkrest/internal/routers/triggers.go
+++ b/server/adkrest/internal/routers/triggers.go
@@ -1,0 +1,54 @@
+// Copyright 2026 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package routers
+
+import (
+	"net/http"
+
+	"google.golang.org/adk/server/adkrest/controllers"
+)
+
+// TriggersAPIRouter defines the routes for the triggers APIs.
+type TriggersAPIRouter struct {
+	controller     *controllers.TriggersAPIController
+	triggerSources []string
+}
+
+// NewTriggersAPIRouter creates a new TriggersAPIRouter.
+func NewTriggersAPIRouter(controller *controllers.TriggersAPIController, triggerSources []string) *TriggersAPIRouter {
+	return &TriggersAPIRouter{
+		controller:     controller,
+		triggerSources: triggerSources,
+	}
+}
+
+// Routes returns the routes for the triggers API depending on configured triggerSources.
+func (r *TriggersAPIRouter) Routes() Routes {
+	var routes Routes
+
+	for _, source := range r.triggerSources {
+		switch source {
+		case "pubsub":
+			routes = append(routes, Route{
+				Name:        "PubSubTrigger",
+				Methods:     []string{http.MethodPost},
+				Pattern:     "/apps/{app_name}/trigger/pubsub",
+				HandlerFunc: r.controller.PubSubTriggerHandler,
+			})
+		}
+	}
+
+	return routes
+}


### PR DESCRIPTION
Extends the ADK Web with Event processing endpoints based on the provided flags, this will be used to allow users specify ADK Web endpoints as the processing endpoints for Pubsub, Eventarc and BigQuery GCP services. (see the details in [go/orcas-rfc-522](http://go/orcas-rfc-522))