### PR TITLE
fix: correct json envelope for datapart

### DIFF
--- a/server/adka2a/parts.go
+++ b/server/adka2a/parts.go
@@ -65,8 +65,8 @@ func validateDataPartJSON(d *genai.Part) ([]byte, bool) {
 	if d.InlineData == nil || d.InlineData.MIMEType != "text/plain" {
 		return nil, false
 	}
-	if noPrefix, ok := bytes.CutPrefix(d.InlineData.Data, []byte("<json>")); ok {
-		if result, ok := bytes.CutSuffix(noPrefix, []byte("</json>")); ok {
+	if noPrefix, ok := bytes.CutPrefix(d.InlineData.Data, []byte("<a2a_datapart_json>")); ok {
+		if result, ok := bytes.CutSuffix(noPrefix, []byte("</a2a_datapart_json>")); ok {
 			return result, true
 		}
 	}
@@ -365,7 +365,7 @@ func toGenAIDataPart(part a2a.DataPart) (*genai.Part, error) {
 
 	default:
 		var jsonData []byte
-		prefix, suffix := []byte("<json>"), []byte("</json>")
+		prefix, suffix := []byte("<a2a_datapart_json>"), []byte("</a2a_datapart_json>")
 		jsonData = make([]byte, 0, len(prefix)+len(bytes)+len(suffix))
 		jsonData = append(jsonData, prefix...)
 		jsonData = append(jsonData, bytes...)

--- a/server/adka2a/parts_test.go
+++ b/server/adka2a/parts_test.go
@@ -171,7 +171,7 @@ func TestPartsTwoWayConversion(t *testing.T) {
 
 func TestPartsDataPartConversionRoundTrip(t *testing.T) {
 	a2aPart := a2a.DataPart{Data: map[string]any{"arbitrary": "data"}}
-	wantGenAI := &genai.Part{InlineData: &genai.Blob{Data: []byte("<json>{\"arbitrary\":\"data\"}</json>"), MIMEType: "text/plain"}}
+	wantGenAI := &genai.Part{InlineData: &genai.Blob{Data: []byte("<a2a_datapart_json>{\"arbitrary\":\"data\"}</a2a_datapart_json>"), MIMEType: "text/plain"}}
 
 	gotGenAI, err := ToGenAIParts([]a2a.Part{a2aPart})
 	if err != nil {


### PR DESCRIPTION
Updated a2a.DataPart conversion to use the correct <a2a_datapart_json> envelope.