### PR TITLE
feat: add the implementation of Eventarc subrouter

### DIFF
--- a/cmd/launcher/full/full.go
+++ b/cmd/launcher/full/full.go
@@ -22,11 +22,12 @@ import (
 	"google.golang.org/adk/cmd/launcher/web"
 	"google.golang.org/adk/cmd/launcher/web/a2a"
 	"google.golang.org/adk/cmd/launcher/web/api"
+	"google.golang.org/adk/cmd/launcher/web/triggers/eventarc"
 	"google.golang.org/adk/cmd/launcher/web/triggers/pubsub"
 	"google.golang.org/adk/cmd/launcher/web/webui"
 )
 
 // NewLauncher returnes the most versatile universal launcher with all options built-in.
 func NewLauncher() launcher.Launcher {
-	return universal.NewLauncher(console.NewLauncher(), web.NewLauncher(webui.NewLauncher(), a2a.NewLauncher(), pubsub.NewLauncher(), api.NewLauncher()))
+	return universal.NewLauncher(console.NewLauncher(), web.NewLauncher(webui.NewLauncher(), a2a.NewLauncher(), pubsub.NewLauncher(), eventarc.NewLauncher(), api.NewLauncher()))
 }

--- a/cmd/launcher/web/triggers/eventarc/eventarc.go
+++ b/cmd/launcher/web/triggers/eventarc/eventarc.go
@@ -68,19 +68,19 @@ func (e *eventarcLauncher) Keyword() string {
 // Parse parses the command-line arguments for the eventarc launcher.
 func (e *eventarcLauncher) Parse(args []string) ([]string, error) {
 	err := e.flags.Parse(args)
-	if err != nil || !p.flags.Parsed() {
-		return nil, fmt.Errorf("failed to parse pubsub flags: %v", err)
+	if err != nil || !e.flags.Parsed() {
+		return nil, fmt.Errorf("failed to parse eventarc flags: %v", err)
 	}
-	if p.config.triggerMaxRetries <= 0 {
+	if e.config.triggerMaxRetries <= 0 {
 		return nil, fmt.Errorf("trigger_max_retries must be > 0")
 	}
-	if p.config.triggerBaseDelay < 0 {
+	if e.config.triggerBaseDelay < 0 {
 		return nil, fmt.Errorf("trigger_base_delay must be >= 0")
 	}
-	if p.config.triggerMaxDelay <= 0 {
+	if e.config.triggerMaxDelay <= 0 {
 		return nil, fmt.Errorf("trigger_max_delay must be > 0")
 	}
-	if p.config.triggerMaxRuns <= 0 {
+	if e.config.triggerMaxRuns <= 0 {
 		return nil, fmt.Errorf("trigger_max_concurrent_runs must be > 0")
 	}
 

--- a/cmd/launcher/web/triggers/eventarc/eventarc.go
+++ b/cmd/launcher/web/triggers/eventarc/eventarc.go
@@ -1,0 +1,136 @@
+// Copyright 2026 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+// Package eventarc provides a sublauncher that adds Eventarc trigger capabilities to ADK web server.
+package eventarc
+
+import (
+	"flag"
+	"fmt"
+	"net/http"
+	"strings"
+	"time"
+
+	"github.com/gorilla/mux"
+
+	"google.golang.org/adk/cmd/launcher"
+	"google.golang.org/adk/cmd/launcher/web"
+	"google.golang.org/adk/internal/cli/util"
+	"google.golang.org/adk/server/adkrest/controllers/triggers"
+)
+
+type eventarcConfig struct {
+	pathPrefix        string
+	triggerMaxRetries int
+	triggerBaseDelay  time.Duration
+	triggerMaxDelay   time.Duration
+	triggerMaxRuns    int
+}
+
+type eventarcLauncher struct {
+	flags  *flag.FlagSet
+	config *eventarcConfig
+}
+
+// NewLauncher creates a new eventarc launcher. It extends Web launcher.
+func NewLauncher() web.Sublauncher {
+	config := &eventarcConfig{}
+
+	fs := flag.NewFlagSet("eventarc", flag.ContinueOnError)
+	fs.StringVar(&config.pathPrefix, "path_prefix", "/api", "Path prefix for the Eventarc trigger endpoint. Default is '/api'.")
+	fs.IntVar(&config.triggerMaxRetries, "trigger_max_retries", 3, "Maximum retries for HTTP 429 errors from triggers")
+	fs.DurationVar(&config.triggerBaseDelay, "trigger_base_delay", 1*time.Second, "Base delay for trigger retry exponential backoff")
+	fs.DurationVar(&config.triggerMaxDelay, "trigger_max_delay", 10*time.Second, "Maximum delay for trigger retry exponential backoff")
+	fs.IntVar(&config.triggerMaxRuns, "trigger_max_concurrent_runs", 100, "Maximum concurrent trigger runs")
+
+	return &eventarcLauncher{
+		config: config,
+		flags:  fs,
+	}
+}
+
+// Keyword implements web.Sublauncher. Returns the command-line keyword for eventarc launcher.
+func (e *eventarcLauncher) Keyword() string {
+	return "eventarc"
+}
+
+// Parse parses the command-line arguments for the eventarc launcher.
+func (e *eventarcLauncher) Parse(args []string) ([]string, error) {
+	err := e.flags.Parse(args)
+	if err != nil || !p.flags.Parsed() {
+		return nil, fmt.Errorf("failed to parse pubsub flags: %v", err)
+	}
+	if p.config.triggerMaxRetries <= 0 {
+		return nil, fmt.Errorf("trigger_max_retries must be > 0")
+	}
+	if p.config.triggerBaseDelay < 0 {
+		return nil, fmt.Errorf("trigger_base_delay must be >= 0")
+	}
+	if p.config.triggerMaxDelay <= 0 {
+		return nil, fmt.Errorf("trigger_max_delay must be > 0")
+	}
+	if p.config.triggerMaxRuns <= 0 {
+		return nil, fmt.Errorf("trigger_max_concurrent_runs must be > 0")
+	}
+
+	prefix := e.config.pathPrefix
+	if !strings.HasPrefix(prefix, "/") {
+		prefix = "/" + prefix
+	}
+	e.config.pathPrefix = strings.TrimSuffix(prefix, "/")
+
+	return e.flags.Args(), nil
+}
+
+// CommandLineSyntax returns the command-line syntax for the eventarc launcher.
+func (e *eventarcLauncher) CommandLineSyntax() string {
+	return util.FormatFlagUsage(e.flags)
+}
+
+// SimpleDescription implements web.Sublauncher.
+func (e *eventarcLauncher) SimpleDescription() string {
+	return "starts ADK Eventarc trigger endpoint server"
+}
+
+// SetupSubrouters adds the Eventarc trigger endpoint to the parent router.
+func (e *eventarcLauncher) SetupSubrouters(router *mux.Router, config *launcher.Config) error {
+	triggerConfig := triggers.TriggerConfig{
+		MaxRetries:        e.config.triggerMaxRetries,
+		BaseDelay:         e.config.triggerBaseDelay,
+		MaxDelay:          e.config.triggerMaxDelay,
+		MaxConcurrentRuns: e.config.triggerMaxRuns,
+	}
+
+	controller := triggers.NewEventarcController(
+		config.SessionService,
+		config.AgentLoader,
+		config.MemoryService,
+		config.ArtifactService,
+		config.PluginConfig,
+		triggerConfig,
+	)
+
+	subrouter := router
+	if e.config.pathPrefix != "" && e.config.pathPrefix != "/" {
+		subrouter = router.PathPrefix(e.config.pathPrefix).Subrouter()
+	}
+
+	subrouter.HandleFunc("/apps/{app_name}/trigger/eventarc", controller.EventarcTriggerHandler).Methods(http.MethodPost)
+	return nil
+}
+
+// UserMessage implements web.Sublauncher.
+func (e *eventarcLauncher) UserMessage(webURL string, printer func(v ...any)) {
+	printer(fmt.Sprintf("       eventarc: Eventarc trigger endpoint is available at %s%s/apps/{app_name}/trigger/eventarc", webURL, e.config.pathPrefix))
+}

--- a/server/adkrest/controllers/triggers/eventarc.go
+++ b/server/adkrest/controllers/triggers/eventarc.go
@@ -97,7 +97,7 @@ func (c *EventarcController) EventarcTriggerHandler(w http.ResponseWriter, r *ht
 		}
 		messageContent, err = messageContentFromPubSub(pubsub)
 		if err != nil {
-			respondError(w, http.StatusBadRequest, err.Error())
+			respondError(w, http.StatusBadRequest, fmt.Sprintf("failed to retrieve message content: %v", err))
 			return
 		}
 	} else {
@@ -113,7 +113,7 @@ func (c *EventarcController) EventarcTriggerHandler(w http.ResponseWriter, r *ht
 
 	appName, err := appName(r)
 	if err != nil {
-		respondError(w, http.StatusInternalServerError, err.Error())
+		respondError(w, http.StatusInternalServerError, fmt.Sprintf("failed to retrieve app name: %v", err))
 		return
 	}
 

--- a/server/adkrest/controllers/triggers/eventarc.go
+++ b/server/adkrest/controllers/triggers/eventarc.go
@@ -62,7 +62,7 @@ func (c *EventarcController) EventarcTriggerHandler(w http.ResponseWriter, r *ht
 		// The entire event is in the body. Decode it.
 		// The payload (Storage or Pub/Sub) gets safely trapped in event.Data as bytes.
 		if err := json.NewDecoder(r.Body).Decode(&event); err != nil {
-			http.Error(w, "Bad Request", http.StatusBadRequest)
+			respondError(w, http.StatusBadRequest, fmt.Sprintf("failed to unmarshal eventarc request: %v", err))
 			return
 		}
 	} else {
@@ -78,7 +78,7 @@ func (c *EventarcController) EventarcTriggerHandler(w http.ResponseWriter, r *ht
 		// We just read it as raw bytes into event.Data.
 		bodyBytes, err := io.ReadAll(r.Body)
 		if err != nil {
-			http.Error(w, "Failed to read body", http.StatusInternalServerError)
+			respondError(w, http.StatusInternalServerError, fmt.Sprintf("failed to read body: %v", err))
 			return
 		}
 		event.Data = bodyBytes

--- a/server/adkrest/controllers/triggers/eventarc.go
+++ b/server/adkrest/controllers/triggers/eventarc.go
@@ -100,9 +100,9 @@ func (c *EventarcController) EventarcTriggerHandler(w http.ResponseWriter, r *ht
 			respondError(w, http.StatusBadRequest, err.Error())
 			return
 		}
+	} else {
 		// Otherwise just marshal the whole event as an input data.
 		// E.g. as https://googleapis.github.io/google-cloudevents/examples/binary/storage/StorageObjectData-simple.json
-	} else {
 		messageBytes, err := json.Marshal(event)
 		if err != nil {
 			respondError(w, http.StatusInternalServerError, fmt.Sprintf("failed to marshal agent message: %v", err))

--- a/server/adkrest/controllers/triggers/eventarc.go
+++ b/server/adkrest/controllers/triggers/eventarc.go
@@ -1,0 +1,137 @@
+// Copyright 2026 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package triggers
+
+import (
+	"encoding/json"
+	"fmt"
+	"io"
+	"net/http"
+
+	"google.golang.org/adk/agent"
+	"google.golang.org/adk/artifact"
+	"google.golang.org/adk/memory"
+	"google.golang.org/adk/runner"
+	"google.golang.org/adk/server/adkrest/internal/models"
+	"google.golang.org/adk/session"
+)
+
+const eventArcDefaultUserID = "eventarc-caller"
+
+// EventarcController handles the Eventarc trigger endpoints.
+type EventarcController struct {
+	runner    *RetriableRunner
+	semaphore chan struct{}
+}
+
+// NewEventarcController creates a new EventarcController.
+func NewEventarcController(sessionService session.Service, agentLoader agent.Loader, memoryService memory.Service, artifactService artifact.Service, pluginConfig runner.PluginConfig, triggerConfig TriggerConfig) *EventarcController {
+	return &EventarcController{
+		runner: &RetriableRunner{
+			sessionService:  sessionService,
+			agentLoader:     agentLoader,
+			memoryService:   memoryService,
+			artifactService: artifactService,
+			pluginConfig:    pluginConfig,
+			triggerConfig:   triggerConfig,
+		},
+		semaphore: make(chan struct{}, triggerConfig.MaxConcurrentRuns),
+	}
+}
+
+// EventarcTriggerHandler handles the Eventarc trigger endpoint.
+func (c *EventarcController) EventarcTriggerHandler(w http.ResponseWriter, r *http.Request) {
+	var event models.EventarcTriggerRequest
+	contentType := r.Header.Get("Content-Type")
+	// The HTTP Content-Type header MUST be set to the media type of an event format for structured mode.
+	// https://github.com/cloudevents/spec/blob/main/cloudevents/bindings/http-protocol-binding.md#321-http-content-type
+	if contentType == "application/cloudevents+json" {
+		// --- STRUCTURED MODE ---
+		// The entire event is in the body. Decode it.
+		// The payload (Storage or Pub/Sub) gets safely trapped in event.Data as bytes.
+		if err := json.NewDecoder(r.Body).Decode(&event); err != nil {
+			http.Error(w, "Bad Request", http.StatusBadRequest)
+			return
+		}
+	} else {
+		// --- BINARY MODE ---
+		// Metadata is in the headers.
+		event.ID = r.Header.Get("ce-id")
+		event.Type = r.Header.Get("ce-type")
+		event.Source = r.Header.Get("ce-source")
+		event.SpecVersion = r.Header.Get("ce-specversion")
+		event.Time = r.Header.Get("ce-time")
+
+		// The entire body is the payload.
+		// We just read it as raw bytes into event.Data.
+		bodyBytes, err := io.ReadAll(r.Body)
+		if err != nil {
+			http.Error(w, "Failed to read body", http.StatusInternalServerError)
+			return
+		}
+		event.Data = bodyBytes
+	}
+
+	var messageContent string
+
+	// Handle Pub/Sub Specifically ---
+	if event.Type == "google.cloud.pubsub.topic.v1.messagePublished" {
+		var pubsub models.PubSubTriggerRequest
+		var err error
+		// Unmarshal the raw bytes into our specific Pub/Sub struct
+		if err := json.Unmarshal(event.Data, &pubsub); err != nil {
+			respondError(w, http.StatusInternalServerError, fmt.Sprintf("failed to unmarshal pubsub data: %v", err))
+			return
+		}
+		messageContent, err = messageContentFromPubSub(pubsub)
+		if err != nil {
+			respondError(w, http.StatusBadRequest, err.Error())
+			return
+		}
+		// Otherwise just marshal the whole event as an input data.
+		// E.g. as https://googleapis.github.io/google-cloudevents/examples/binary/storage/StorageObjectData-simple.json
+	} else {
+		messageBytes, err := json.Marshal(event)
+		if err != nil {
+			respondError(w, http.StatusInternalServerError, fmt.Sprintf("failed to marshal agent message: %v", err))
+			return
+		}
+		messageContent = string(messageBytes)
+	}
+
+	appName, err := appName(r)
+	if err != nil {
+		respondError(w, http.StatusInternalServerError, err.Error())
+		return
+	}
+
+	userID := event.Source
+	if userID == "" {
+		userID = eventArcDefaultUserID
+	}
+
+	// Semaphore limits concurrent agent calls based on the TriggerConfig.
+	if c.semaphore != nil {
+		c.semaphore <- struct{}{}
+		defer func() { <-c.semaphore }()
+	}
+
+	if _, err := c.runner.RunAgent(r.Context(), appName, userID, messageContent); err != nil {
+		respondError(w, http.StatusInternalServerError, fmt.Sprintf("failed to run agent: %v", err))
+		return
+	}
+
+	respondSuccess(w)
+}

--- a/server/adkrest/controllers/triggers/eventarc_test.go
+++ b/server/adkrest/controllers/triggers/eventarc_test.go
@@ -1,0 +1,203 @@
+// Copyright 2026 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package triggers_test
+
+import (
+	"bytes"
+	"encoding/json"
+	"iter"
+	"net/http"
+	"net/http/httptest"
+	"github.com/google/go-cmp/cmp"
+	"testing"
+
+	"github.com/gorilla/mux"
+
+	"google.golang.org/adk/agent"
+	"google.golang.org/adk/runner"
+	"google.golang.org/adk/server/adkrest/controllers/triggers"
+	"google.golang.org/adk/server/adkrest/internal/fakes"
+	"google.golang.org/adk/session"
+)
+
+func TestEventarcTriggerHandler(t *testing.T) {
+	storagePayload := `{
+  "bucket": "sample-bucket",
+  "contentType": "text/plain",
+  "generation": "1587627537231057",
+  "id": "sample-bucket/folder/Test.cs/1587627537231057",
+  "kind": "storage#object",
+  "size": "352",
+  "storageClass": "MULTI_REGIONAL",
+  "timeCreated": "2020-04-23T07:38:57.230Z",
+  "timeStorageClassUpdated": "2020-04-23T07:38:57.230Z",
+  "updated": "2020-04-23T07:38:57.230Z"
+}`
+
+	pubsubPayload := `{
+  "subscription": "projects/test-project/subscriptions/my-subscription",
+  "message": {
+    "attributes": {
+      "attr1":"attr1-value"
+    },
+    "data": "dGVzdCBtZXNzYWdlIDM=",
+    "messageId": "message-id",
+    "publishTime":"2021-02-05T04:06:14.109Z",
+    "orderingKey": "ordering-key"
+  }
+}`
+
+	jsonRawToMap := func(t *testing.T, data []byte) map[string]any {
+		var m map[string]any
+		if err := json.Unmarshal(data, &m); err != nil {
+			t.Fatalf("failed to unmarshal JSON to map: %v", err)
+		}
+		return m
+	}
+
+	tests := []struct {
+		name            string
+		contentType     string
+		headers         map[string]string
+		body            []byte
+		expectedPayload map[string]any
+	}{
+		{
+			name:        "Storage_Structured_Mode",
+			contentType: "application/cloudevents+json",
+			body:        []byte(storagePayload),
+			expectedPayload: map[string]any{
+				"id":          "sample-bucket/folder/Test.cs/1587627537231057",
+				"source":      "",
+				"type":        "",
+				"specversion": "",
+			},
+		},
+		{
+			name:        "Storage_Binary_Mode",
+			contentType: "application/json",
+			headers: map[string]string{
+				"ce-id":          "1234-5678",
+				"ce-type":        "google.storage.object.v1.finalized",
+				"ce-source":      "//storage.googleapis.com/projects/_/buckets/sample-bucket",
+				"ce-specversion": "1.0",
+			},
+			body: []byte(storagePayload),
+			expectedPayload: map[string]any{
+				"id":          "1234-5678",
+				"type":        "google.storage.object.v1.finalized",
+				"source":      "//storage.googleapis.com/projects/_/buckets/sample-bucket",
+				"specversion": "1.0",
+				"data":        jsonRawToMap(t, []byte(storagePayload)),
+			},
+		},
+		{
+			name:        "PubSub_Structured_Mode",
+			contentType: "application/cloudevents+json",
+			body: func() []byte {
+				ce := map[string]any{
+					"specversion": "1.0",
+					"type":        "google.cloud.pubsub.topic.v1.messagePublished",
+					"source":      "//pubsub.googleapis.com/projects/test-project/topics/test-topic",
+					"id":          "1234-5678",
+					"data":        json.RawMessage(pubsubPayload),
+				}
+				b, _ := json.Marshal(ce)
+				return b
+			}(),
+			expectedPayload: map[string]any{
+				"data": "test message 3",
+				"attributes": map[string]any{
+					"attr1": "attr1-value",
+				},
+			},
+		},
+		{
+			name:        "PubSub_Binary_Mode",
+			contentType: "application/json",
+			headers: map[string]string{
+				"ce-id":          "1234-5678",
+				"ce-type":        "google.cloud.pubsub.topic.v1.messagePublished",
+				"ce-source":      "//pubsub.googleapis.com/projects/test-project/topics/test-topic",
+				"ce-specversion": "1.0",
+			},
+			body: []byte(pubsubPayload),
+			expectedPayload: map[string]any{
+				"data": "test message 3",
+				"attributes": map[string]any{
+					"attr1": "attr1-value",
+				},
+			},
+		},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			mockAgentRunCount := 0
+			var receivedContent string
+			testAgent, err := agent.New(agent.Config{
+				Name: "test-agent",
+				Run: func(ctx agent.InvocationContext) iter.Seq2[*session.Event, error] {
+					return func(yield func(*session.Event, error) bool) {
+						mockAgentRunCount++
+						userContent := ctx.UserContent()
+						if userContent != nil && len(userContent.Parts) > 0 {
+							receivedContent = userContent.Parts[0].Text
+						}
+						yield(&session.Event{ID: "success-event"}, nil)
+					}
+				},
+			})
+			if err != nil {
+				t.Fatalf("agent.New failed: %v", err)
+			}
+
+			sessionService := &fakes.FakeSessionService{Sessions: make(map[fakes.SessionKey]fakes.TestSession)}
+			agentLoader := agent.NewSingleLoader(testAgent)
+			controller := triggers.NewEventarcController(sessionService, agentLoader, nil, nil, runner.PluginConfig{}, defaultTriggerConfig)
+
+			req, err := http.NewRequest(http.MethodPost, "/apps/test-agent/triggers/eventarc", bytes.NewBuffer(tc.body))
+			if err != nil {
+				t.Fatalf("new request: %v", err)
+			}
+			req.Header.Set("Content-Type", tc.contentType)
+			for k, v := range tc.headers {
+				req.Header.Set(k, v)
+			}
+			req = mux.SetURLVars(req, map[string]string{"app_name": "test-agent"})
+			rr := httptest.NewRecorder()
+
+			controller.EventarcTriggerHandler(rr, req)
+
+			if rr.Code != http.StatusOK {
+				t.Errorf("expected status 200, got %d. Body: %s", rr.Code, rr.Body.String())
+			}
+
+			if mockAgentRunCount != 1 {
+				t.Errorf("expected 1 run attempt, got %d", mockAgentRunCount)
+			}
+
+			if tc.expectedPayload != nil {
+				var gotPayload map[string]any
+				if err := json.Unmarshal([]byte(receivedContent), &gotPayload); err != nil {
+					t.Fatalf("failed to unmarshal received content: %v", err)
+				}
+				if diff := cmp.Diff(tc.expectedPayload, gotPayload); diff != "" {
+					t.Errorf("payload mismatch (-want +got):\n%s", diff)
+				}
+			}
+		})
+	}
+}

--- a/server/adkrest/controllers/triggers/eventarc_test.go
+++ b/server/adkrest/controllers/triggers/eventarc_test.go
@@ -20,8 +20,9 @@ import (
 	"iter"
 	"net/http"
 	"net/http/httptest"
-	"github.com/google/go-cmp/cmp"
 	"testing"
+
+	"github.com/google/go-cmp/cmp"
 
 	"github.com/gorilla/mux"
 

--- a/server/adkrest/controllers/triggers/pubsub.go
+++ b/server/adkrest/controllers/triggers/pubsub.go
@@ -61,13 +61,13 @@ func (c *PubSubController) PubSubTriggerHandler(w http.ResponseWriter, r *http.R
 
 	agentMessage, err := messageContentFromPubSub(req)
 	if err != nil {
-		respondError(w, http.StatusBadRequest, err.Error())
+		respondError(w, http.StatusBadRequest, fmt.Sprintf("failed to retrieve message content: %v", err))
 		return
 	}
 
 	appName, err := appName(r)
 	if err != nil {
-		respondError(w, http.StatusInternalServerError, err.Error())
+		respondError(w, http.StatusInternalServerError, fmt.Sprintf("failed to retrieve app name: %v", err))
 		return
 	}
 

--- a/server/adkrest/controllers/triggers/pubsub.go
+++ b/server/adkrest/controllers/triggers/pubsub.go
@@ -27,7 +27,7 @@ import (
 	"google.golang.org/adk/session"
 )
 
-const defaultUserID = "pubsub-caller"
+const pubSubDefaultUserID = "pubsub-caller"
 
 // PubSubController handles the PubSub trigger endpoints.
 type PubSubController struct {
@@ -52,11 +52,6 @@ func NewPubSubController(sessionService session.Service, agentLoader agent.Loade
 
 // PubSubTriggerHandler handles the PubSub trigger endpoint.
 func (c *PubSubController) PubSubTriggerHandler(w http.ResponseWriter, r *http.Request) {
-	if c.semaphore != nil {
-		c.semaphore <- struct{}{}
-		defer func() { <-c.semaphore }()
-	}
-
 	// Parse the request to the request model.
 	var req models.PubSubTriggerRequest
 	if err := json.NewDecoder(r.Body).Decode(&req); err != nil {
@@ -64,25 +59,9 @@ func (c *PubSubController) PubSubTriggerHandler(w http.ResponseWriter, r *http.R
 		return
 	}
 
-	// Decode base64 message data.
-	messageContent := make(map[string]any)
-	if len(req.Message.Data) > 0 {
-		// Avoids encoding the data twice later with json.Marshal.
-		messageContent["data"] = string(req.Message.Data)
-	}
-	// Add attributes to the messageContent if present
-	if len(req.Message.Attributes) > 0 {
-		messageContent["attributes"] = req.Message.Attributes
-	}
-
-	if len(messageContent) == 0 {
-		respondError(w, http.StatusBadRequest, "empty message data and attributes")
-		return
-	}
-
-	agentMessage, err := json.Marshal(messageContent)
+	agentMessage, err := messageContentFromPubSub(req)
 	if err != nil {
-		respondError(w, http.StatusInternalServerError, fmt.Sprintf("failed to marshal agent message: %v", err))
+		respondError(w, http.StatusBadRequest, err.Error())
 		return
 	}
 
@@ -92,10 +71,42 @@ func (c *PubSubController) PubSubTriggerHandler(w http.ResponseWriter, r *http.R
 		return
 	}
 
-	if _, err := c.runner.RunAgent(r.Context(), appName, req.Subscription, string(agentMessage)); err != nil {
+	userID := req.Subscription
+	if userID == "" {
+		userID = pubSubDefaultUserID
+	}
+
+	// Semaphore limits concurrent agent calls based on the TriggerConfig.
+	if c.semaphore != nil {
+		c.semaphore <- struct{}{}
+		defer func() { <-c.semaphore }()
+	}
+
+	if _, err := c.runner.RunAgent(r.Context(), appName, userID, agentMessage); err != nil {
 		respondError(w, http.StatusInternalServerError, fmt.Sprintf("failed to run agent: %v", err))
 		return
 	}
 
 	respondSuccess(w)
+}
+
+func messageContentFromPubSub(req models.PubSubTriggerRequest) (string, error) {
+	messageContent := make(map[string]any)
+	if len(req.Message.Data) > 0 {
+		messageContent["data"] = string(req.Message.Data)
+	}
+	// Add attributes to the messageContent if present
+	if len(req.Message.Attributes) > 0 {
+		messageContent["attributes"] = req.Message.Attributes
+	}
+
+	if len(messageContent) == 0 {
+		return "", fmt.Errorf("empty message data and attributes")
+	}
+
+	agentMessage, err := json.Marshal(messageContent)
+	if err != nil {
+		return "", fmt.Errorf("failed to marshal agent message: %v", err)
+	}
+	return string(agentMessage), nil
 }

--- a/server/adkrest/controllers/triggers/triggers.go
+++ b/server/adkrest/controllers/triggers/triggers.go
@@ -45,10 +45,6 @@ type RetriableRunner struct {
 }
 
 func (r *RetriableRunner) RunAgent(ctx context.Context, appName, userID, messageContent string) ([]*session.Event, error) {
-	if userID == "" {
-		userID = defaultUserID
-	}
-
 	// Each retry = new session
 	sessReq := &session.CreateRequest{
 		AppName: appName,

--- a/server/adkrest/internal/models/triggers.go
+++ b/server/adkrest/internal/models/triggers.go
@@ -65,8 +65,8 @@ type EventarcTriggerRequest struct {
 	Time string `json:"time,omitempty"`
 	// In structured mode, ``data`` is always present.
 	// In binary mode, the entire body is the data (often a Pub/Sub wrapper).
-	// json.RawMessage captures the raw JSON payload (Storage, PubSub, whatever)
-	// without needing to know its internal structure!
+	// But sometimes it can be just a JSON object.
+	// E.g. https://googleapis.github.io/google-cloudevents/examples/binary/firestore/DocumentEventData-simple.json
 	Data json.RawMessage `json:"data,omitempty"`
 }
 

--- a/server/adkrest/internal/models/triggers.go
+++ b/server/adkrest/internal/models/triggers.go
@@ -14,6 +14,8 @@
 
 package models
 
+import "encoding/json"
+
 // PubSubTriggerRequest represents the request for the PubSub trigger.
 // See: https://cloud.google.com/pubsub/docs/push#receive_push
 type PubSubTriggerRequest struct {
@@ -35,6 +37,37 @@ type PubSubMessage struct {
 	Attributes map[string]string `json:"attributes,omitempty"`
 	// If message ordering is enabled, this identifies related messages for which publish order should be respected.
 	OrderingKey string `json:"orderingKey,omitempty"`
+}
+
+// EventarcTriggerRequest represents the request for the Eventarc trigger.
+// Eventarc / CloudEvents request format.
+//
+// Eventarc delivers events as CloudEvents over HTTP in two modes:
+//
+//  1. **Structured content mode** (JSON body): All CloudEvents attributes
+//     and the event data are in the JSON body.  Used by direct HTTP callers.
+//  2. **Binary content mode** (Eventarc default): CloudEvents attributes are
+//     sent as “ce-*“ HTTP headers, and the body contains only the event
+//     data — typically a Pub/Sub message wrapper for Pub/Sub-sourced events:
+//     “{"message": {"data": "<base64>", ...}, "subscription": "..."}“.
+//
+// See: https://cloud.google.com/eventarc/docs/cloudevents
+type EventarcTriggerRequest struct {
+	// Unique identifier for the event
+	ID string `json:"id"`
+	// Identifies the source of the event
+	Source string `json:"source"`
+	// The type of event data
+	Type string `json:"type"`
+	// The CloudEvents specification version used for this event
+	SpecVersion string `json:"specversion"`
+	// Event generation time, in RFC 3339 format (optional)
+	Time string `json:"time,omitempty"`
+	// In structured mode, ``data`` is always present.
+	// In binary mode, the entire body is the data (often a Pub/Sub wrapper).
+	// json.RawMessage captures the raw JSON payload (Storage, PubSub, whatever)
+	// without needing to know its internal structure!
+	Data json.RawMessage `json:"data,omitempty"`
 }
 
 // TriggerResponse represents the standard response for Pub/Sub and Eventarc triggers.


### PR DESCRIPTION
Implementation of Cloud Events trigger processing.

This implementation should handle the resource exhausted exceptions with jitter to prevent thundering herd (configured per subrouter).

Similar to https://github.com/google/adk-go/pull/704

(see the details in [go/orcas-rfc-522](http://go/orcas-rfc-522))