### PR TITLE
feat: add telemetry attributes for cache read input tokens and reason…

### DIFF
--- a/internal/telemetry/telemetry.go
+++ b/internal/telemetry/telemetry.go
@@ -42,10 +42,10 @@ const (
 )
 
 var (
-	gcpVertexAgentToolCallArgsName = attribute.Key("gcp.vertex.agent.tool_call_args")
-	gcpVertexAgentEventID          = attribute.Key("gcp.vertex.agent.event_id")
-	gcpVertexAgentToolResponseName = attribute.Key("gcp.vertex.agent.tool_response")
-	gcpVertexAgentInvocationID     = attribute.Key("gcp.vertex.agent.invocation_id")
+	gcpVertexAgentToolCallArgsName        = attribute.Key("gcp.vertex.agent.tool_call_args")
+	gcpVertexAgentEventID                 = attribute.Key("gcp.vertex.agent.event_id")
+	gcpVertexAgentToolResponseName        = attribute.Key("gcp.vertex.agent.tool_response")
+	gcpVertexAgentInvocationID            = attribute.Key("gcp.vertex.agent.invocation_id")
 	genAIUsageCacheReadInputTokens        = attribute.Key("gen_ai.usage.cache_read.input_tokens")
 	genAIUsageExperimentalReasoningTokens = attribute.Key("gen_ai.usage.experimental.reasoning_tokens")
 )

--- a/internal/telemetry/telemetry.go
+++ b/internal/telemetry/telemetry.go
@@ -46,6 +46,8 @@ var (
 	gcpVertexAgentEventID          = attribute.Key("gcp.vertex.agent.event_id")
 	gcpVertexAgentToolResponseName = attribute.Key("gcp.vertex.agent.tool_response")
 	gcpVertexAgentInvocationID     = attribute.Key("gcp.vertex.agent.invocation_id")
+	genAIUsageCacheReadInputTokens        = attribute.Key("gen_ai.usage.cache_read.input_tokens")
+	genAIUsageExperimentalReasoningTokens = attribute.Key("gen_ai.usage.experimental.reasoning_tokens")
 )
 
 // tracer is the tracer instance for ADK go.
@@ -125,6 +127,8 @@ func TraceGenerateContentResult(span trace.Span, params TraceGenerateContentResu
 		span.SetAttributes(
 			semconv.GenAIUsageInputTokens(int(params.Response.UsageMetadata.PromptTokenCount)),
 			semconv.GenAIUsageOutputTokens(int(params.Response.UsageMetadata.CandidatesTokenCount)),
+			genAIUsageCacheReadInputTokens.Int(int(params.Response.UsageMetadata.CachedContentTokenCount)),
+			genAIUsageExperimentalReasoningTokens.Int(int(params.Response.UsageMetadata.ThoughtsTokenCount)),
 		)
 	}
 }

--- a/internal/telemetry/telemetry_test.go
+++ b/internal/telemetry/telemetry_test.go
@@ -216,8 +216,10 @@ func TestGenerateContent(t *testing.T) {
 			resultParams: TraceGenerateContentResultParams{
 				Response: &model.LLMResponse{
 					UsageMetadata: &genai.GenerateContentResponseUsageMetadata{
-						PromptTokenCount:     10,
-						CandidatesTokenCount: 20,
+						PromptTokenCount:        10,
+						CandidatesTokenCount:   20,
+						CachedContentTokenCount: 5,
+						ThoughtsTokenCount:      15,
 					},
 					FinishReason: genai.FinishReasonStop,
 				},
@@ -229,6 +231,8 @@ func TestGenerateContent(t *testing.T) {
 				semconv.GenAIRequestModelKey:          "test-model",
 				semconv.GenAIUsageInputTokensKey:      "10",
 				semconv.GenAIUsageOutputTokensKey:     "20",
+				genAIUsageCacheReadInputTokens:        "5",
+				genAIUsageExperimentalReasoningTokens: "15",
 				semconv.GenAIResponseFinishReasonsKey: "[\"STOP\"]",
 				gcpVertexAgentInvocationID:            invocationID,
 			},

--- a/internal/telemetry/telemetry_test.go
+++ b/internal/telemetry/telemetry_test.go
@@ -217,7 +217,7 @@ func TestGenerateContent(t *testing.T) {
 				Response: &model.LLMResponse{
 					UsageMetadata: &genai.GenerateContentResponseUsageMetadata{
 						PromptTokenCount:        10,
-						CandidatesTokenCount:   20,
+						CandidatesTokenCount:    20,
 						CachedContentTokenCount: 5,
 						ThoughtsTokenCount:      15,
 					},


### PR DESCRIPTION
…ing tokens

### Description of Change

**Problem:**
The telemetry tracing for content generation was missing details about cached input tokens and reasoning tokens (thoughts). This information is crucial for detailed analysis of token usage and cost, especially when using models that support context caching or chain-of-thought reasoning.

**Solution:**
Added two new attributes to the telemetry span in TraceGenerateContentResult:
- `gen_ai.usage.cache_read.input_tokens`: Populated from CachedContentTokenCount.
- `gen_ai.usage.experimental.reasoning_tokens`: Populated from ThoughtsTokenCount.

These changes allow better visibility into token usage patterns for models that utilize caching or generate reasoning tokens.
I also updated the corresponding tests in telemetry_test.go to verify that these new attributes are correctly recorded.

### Testing Plan

**Unit Tests:**

- [x] I have added or updated unit tests for my change.
- [x] All unit tests pass locally.

```
Running tool: /usr/bin/go test -test.fullpath=true -timeout 30s -run ^(TestWrapYield|TestWrapYield_MultipleCalls|TestInvokeAgent|TestGenerateContent|TestExecuteTool)$ google.golang.org/adk/internal/telemetry

=== RUN   TestWrapYield
=== PAUSE TestWrapYield
=== RUN   TestWrapYield_MultipleCalls
=== PAUSE TestWrapYield_MultipleCalls
=== RUN   TestInvokeAgent
=== RUN   TestInvokeAgent/Success
--- PASS: TestInvokeAgent/Success (0.00s)
=== RUN   TestInvokeAgent/Error
--- PASS: TestInvokeAgent/Error (0.00s)
--- PASS: TestInvokeAgent (0.00s)
=== RUN   TestGenerateContent
=== RUN   TestGenerateContent/Success
--- PASS: TestGenerateContent/Success (0.00s)
=== RUN   TestGenerateContent/Error
--- PASS: TestGenerateContent/Error (0.00s)
--- PASS: TestGenerateContent (0.00s)
=== RUN   TestExecuteTool
=== RUN   TestExecuteTool/Success
--- PASS: TestExecuteTool/Success (0.00s)
=== RUN   TestExecuteTool/Error
--- PASS: TestExecuteTool/Error (0.00s)
--- PASS: TestExecuteTool (0.00s)
=== CONT  TestWrapYield
--- PASS: TestWrapYield (0.00s)
=== CONT  TestWrapYield_MultipleCalls
--- PASS: TestWrapYield_MultipleCalls (0.00s)
PASS
ok      google.golang.org/adk/internal/telemetry        0.019s
```

**Manual End-to-End (E2E) Tests:**

1. Set GOOGLE_CLOUD_PROJECT, GOOGLE_API_KEY environment variables
2. `go run examples/tools/multipletools/main.go web -otel_to_cloud api webui`
3. Go to `http://localhost:8080/ui/`
4.  Interact with the agent
5. Go to GCP Console -> Trace explorer and observe the trace spans sent

### Checklist

- [x] I have read the [CONTRIBUTING.md](./CONTRIBUTING.md) document.
- [x] I have performed a self-review of my own code.
- [x] I have added tests that prove my fix is effective or that my feature works.
- [x] New and existing unit tests pass locally with my changes.
- [x] I have manually tested my changes end-to-end.

### Additional context
The new attributes visible in the trace explorer:
<img width="3222" height="1920" alt="image" src="https://github.com/user-attachments/assets/971d09fc-25e6-4158-8b83-c9d6c46b77d4" />

