### PR TITLE
fix: branch filtering in ParallelAgent subagents

### DIFF
--- a/internal/llminternal/contents_processor.go
+++ b/internal/llminternal/contents_processor.go
@@ -442,9 +442,15 @@ func mergeFunctionResponseEvents(functionResponseEvents []*session.Event) (*sess
 //	In multi-agent scenarios, the "current turn" for an agent starts from an
 //	actual user or from another agent.
 func buildContentsCurrentTurnContextOnly(agentName, branch string, events []*session.Event) ([]*genai.Content, error) {
-	// Find the latest event that starts the current turn and process from there
+	// Find the latest event that starts the current turn and process from there.
+	// Guard with eventBelongsToBranch to avoid anchoring on events from sibling
+	// branches in a ParallelAgent.
+	// This matches the Python SDK's _should_include_event_in_context guard.
 	for i := len(events) - 1; i >= 0; i-- {
 		event := events[i]
+		if !eventBelongsToBranch(branch, event) {
+			continue
+		}
 		if event.Author == "user" || isOtherAgentReply(agentName, event) {
 			return buildContentsDefault(agentName, branch, events[i:])
 		}

--- a/internal/llminternal/contents_processor_test.go
+++ b/internal/llminternal/contents_processor_test.go
@@ -909,6 +909,155 @@ func TestContentsRequestProcessor_Rearrange(t *testing.T) {
 	}
 }
 
+// Scenario: ParallelAgent with sub-agents "run-alpha" and "run-beta",
+// branches "parallel.run-alpha" and "parallel.run-beta". The user message
+// has empty branch (visible to all). After alpha yields its FunctionCall
+// event, beta's model call reads the session.
+func TestContentsRequestProcessor_IncludeContentsNone_ParallelBranch(t *testing.T) {
+	t.Parallel()
+
+	const (
+		betaAgent   = "run-beta"
+		alphaBranch = "parallel.run-alpha"
+		betaBranch  = "parallel.run-beta"
+	)
+	testModel := &testModel{}
+
+	betaFC := &genai.FunctionCall{
+		ID:   "beta_call_1",
+		Name: "run_command",
+		Args: map[string]any{"command": "ls"},
+	}
+	betaFR := &genai.FunctionResponse{
+		ID:       "beta_call_1",
+		Name:     "run_command",
+		Response: map[string]any{"output": "file1 file2"},
+	}
+
+	testCases := []struct {
+		name   string
+		events []*session.Event
+		want   []*genai.Content
+	}{
+		{
+			// Beta's first model call. Session has:
+			// [user(branch=""), alpha:FC(branch=alpha)]
+			// Expected: beta should see [user message] only.
+			// Bug: buildContentsCurrentTurnContextOnly finds alpha:FC
+			//   as "other agent reply", skips user message, then
+			//   buildContentsDefault filters alpha:FC by branch → empty.
+			name: "FirstModelCall_AlphaFCPresent",
+			events: []*session.Event{
+				{
+					Author: "user",
+					Branch: "", // User message — empty branch, visible to all.
+					LLMResponse: model.LLMResponse{
+						Content: genai.NewContentFromText("Run the parallel test", "user"),
+					},
+				},
+				{
+					Author: "run-alpha",
+					Branch: alphaBranch, // Alpha's FunctionCall on alpha's branch.
+					LLMResponse: model.LLMResponse{
+						Content: NewContentFromFunctionCall(
+							&genai.FunctionCall{
+								ID:   "alpha_call_1",
+								Name: "run_command",
+								Args: map[string]any{"command": "pwd"},
+							}, "model"),
+					},
+				},
+			},
+			want: []*genai.Content{
+				// Must include the user message.
+				genai.NewContentFromText("Run the parallel test", "user"),
+			},
+		},
+		{
+			// Beta's second model call (after beta's tool confirmation).
+			// Session has:
+			// [user(branch=""), alpha:FC(branch=alpha), beta:FC(branch=beta), beta:FR(branch=beta)]
+			// Expected: beta should see [user, beta:FC, beta:FR].
+			// Bug: backward scan finds alpha:FC as "other agent reply",
+			//   starts from there, skips user. After branch filter:
+			//   [beta:FC, beta:FR] — no user message → Gemini 400.
+			name: "SecondModelCall_BetaFCFRPresent",
+			events: []*session.Event{
+				{
+					Author: "user",
+					Branch: "",
+					LLMResponse: model.LLMResponse{
+						Content: genai.NewContentFromText("Run the parallel test", "user"),
+					},
+				},
+				{
+					Author: "run-alpha",
+					Branch: alphaBranch,
+					LLMResponse: model.LLMResponse{
+						Content: NewContentFromFunctionCall(
+							&genai.FunctionCall{
+								ID:   "alpha_call_1",
+								Name: "run_command",
+								Args: map[string]any{"command": "pwd"},
+							}, "model"),
+					},
+				},
+				{
+					Author: betaAgent,
+					Branch: betaBranch,
+					LLMResponse: model.LLMResponse{
+						Content: NewContentFromFunctionCall(betaFC, "model"),
+					},
+				},
+				{
+					Author: betaAgent,
+					Branch: betaBranch,
+					LLMResponse: model.LLMResponse{
+						Content: NewContentFromFunctionResponse(betaFR, "user"),
+					},
+				},
+			},
+			want: []*genai.Content{
+				genai.NewContentFromText("Run the parallel test", "user"),
+				NewContentFromFunctionCall(betaFC, "model"),
+				NewContentFromFunctionResponse(betaFR, "user"),
+			},
+		},
+	}
+
+	for _, tc := range testCases {
+		t.Run(tc.name, func(t *testing.T) {
+			testAgent := utils.Must(llmagent.New(llmagent.Config{
+				Name:            betaAgent,
+				Model:           testModel,
+				IncludeContents: llmagent.IncludeContentsNone,
+			}))
+
+			ctx := icontext.NewInvocationContext(t.Context(), icontext.InvocationContextParams{
+				Agent:  testAgent,
+				Branch: betaBranch,
+				Session: &fakeSession{
+					events: tc.events,
+				},
+			})
+
+			req := &model.LLMRequest{}
+			for ev, err := range llminternal.ContentsRequestProcessor(ctx, req, &llminternal.Flow{}) {
+				if ev != nil {
+					t.Fatal("ContentsRequestProcessor generated an unexpected event")
+				}
+				if err != nil {
+					t.Fatalf("ContentsRequestProcessor failed: %v", err)
+				}
+			}
+			got := req.Contents
+			if diff := cmp.Diff(tc.want, got); diff != "" {
+				t.Errorf("LLMRequest.Contents mismatch (-want +got):\n%s", diff)
+			}
+		})
+	}
+}
+
 // NewContentFromFunctionCall creates a new Content struct with a single FunctionCall part.
 // It assigns the provided role to the Content.
 func NewContentFromFunctionCall(fc *genai.FunctionCall, role string) *genai.Content {


### PR DESCRIPTION
### Link to Issue or Description of Change

**1. Link to an existing issue (if applicable):**

- Closes: #719 

**2. Or, if no issue exists, describe the change:**

N/A

### Testing Plan

_Please describe the tests that you ran to verify your changes. This is required
for all PRs that are not small documentation or typo fixes._

**Unit Tests:**

- [x] I have added or updated unit tests for my change.
- [x] All unit tests pass locally. (NOTE: Unit tests that were already failing prior to my changes are still failing - not affected by these. changes)

_Please include a summary of passed go test results._

A new test suite (`TestContentsRequestProcessor_IncludeContentsNone_ParallelBranch`) was added to `contents_processor_test.go` and passes locally. Specifically, this verifies two complex edge cases for parallel interactions:
1. `FirstModelCall_AlphaFCPresent`: Verifies that if sibling agent A yields a `FunctionCall` on its branch, agent B still correctly anchors onto the root user message without being interrupted.
2. `SecondModelCall_BetaFCFRPresent`: Verifies that agent B successfully scans backward past sibling agent A's events to retrieve its own context (`FunctionCall` and `FunctionResponse`) as well as the root user message to prevent the empty-context crash.

**Manual End-to-End (E2E) Tests:**

_Please provide instructions on how to manually test your changes, including any
necessary setup or configuration. Please provide logs or screenshots to help
reviewers better understand the fix._

N/A

### Checklist

- [x] I have read the [CONTRIBUTING.md](./CONTRIBUTING.md) document.
- [x] I have performed a self-review of my own code.
- [x] I have commented my code, particularly in hard-to-understand areas.
- [x] I have added tests that prove my fix is effective or that my feature works.
- [x] New and existing unit tests pass locally with my changes.
- [x] I have manually tested my changes end-to-end.
- [x] Any dependent changes have been merged and published in downstream modules.

### Additional context

N/A

