### PR TITLE
test(artifact): add contract tests for GetArtifactVersion

### DIFF
--- a/internal/artifact/tests/service_suite.go
+++ b/internal/artifact/tests/service_suite.go
@@ -143,6 +143,48 @@ func testArtifactService(ctx context.Context, t *testing.T, srv artifact.Service
 		}
 	})
 
+	t.Run(fmt.Sprintf("GetArtifactVersion_%s", testSuffix), func(t *testing.T) {
+		for _, tc := range []struct {
+			name        string
+			version     int64
+			wantVersion int64
+			wantMIME    string
+		}{
+			{"latest", 0, 3, "text/plain"},
+			{"ver=1", 1, 1, "text/plain"},
+			{"ver=2", 2, 2, "text/plain"},
+			{"ver=3", 3, 3, "text/plain"},
+		} {
+			resp, err := srv.GetArtifactVersion(ctx, &artifact.GetArtifactVersionRequest{
+				AppName: appName, UserID: userID, SessionID: sessionID, FileName: "file1",
+				Version: tc.version,
+			})
+			if err != nil {
+				t.Errorf("GetArtifactVersion(%v) failed: %v", tc.version, err)
+				continue
+			}
+			if resp.ArtifactVersion == nil {
+				t.Errorf("GetArtifactVersion(%v): ArtifactVersion is nil", tc.version)
+				continue
+			}
+			if resp.ArtifactVersion.Version != tc.wantVersion {
+				t.Errorf("GetArtifactVersion(%v).Version = %v, want %v", tc.version, resp.ArtifactVersion.Version, tc.wantVersion)
+			}
+			if resp.ArtifactVersion.MimeType != tc.wantMIME {
+				t.Errorf("GetArtifactVersion(%v).MimeType = %v, want %v", tc.version, resp.ArtifactVersion.MimeType, tc.wantMIME)
+			}
+		}
+	})
+
+	t.Run(fmt.Sprintf("GetArtifactVersion_NotFound_%s", testSuffix), func(t *testing.T) {
+		got, err := srv.GetArtifactVersion(ctx, &artifact.GetArtifactVersionRequest{
+			AppName: appName, UserID: userID, SessionID: sessionID, FileName: "nonexistent",
+		})
+		if !errors.Is(err, fs.ErrNotExist) {
+			t.Fatalf("GetArtifactVersion('nonexistent') = (%v, %v), want error(%v)", got, err, fs.ErrNotExist)
+		}
+	})
+
 	t.Log("Delete file1 version 3")
 	if err := srv.Delete(ctx, &artifact.DeleteRequest{
 		AppName: appName, UserID: userID, SessionID: sessionID, FileName: "file1",
@@ -201,6 +243,15 @@ func testArtifactService(ctx context.Context, t *testing.T, srv artifact.Service
 		})
 		if !errors.Is(err, fs.ErrNotExist) {
 			t.Fatalf("Versions('file1') = (%v, %v), want error(%v)", got, err, fs.ErrNotExist)
+		}
+	})
+
+	t.Run(fmt.Sprintf("GetArtifactVersionAfterDelete_%s", testSuffix), func(t *testing.T) {
+		got, err := srv.GetArtifactVersion(ctx, &artifact.GetArtifactVersionRequest{
+			AppName: appName, UserID: userID, SessionID: sessionID, FileName: "file1",
+		})
+		if !errors.Is(err, fs.ErrNotExist) {
+			t.Fatalf("GetArtifactVersion('file1') = (%v, %v), want error(%v)", got, err, fs.ErrNotExist)
 		}
 	})
 
@@ -406,6 +457,14 @@ func testArtifactService_Empty(ctx context.Context, t *testing.T, srv artifact.S
 		})
 		if !errors.Is(err, fs.ErrNotExist) {
 			t.Fatalf("Versions() = (%v, %v), want error(%v)", got, err, fs.ErrNotExist)
+		}
+	})
+	t.Run(fmt.Sprintf("GetArtifactVersion_%s", testSuffix), func(t *testing.T) {
+		got, err := srv.GetArtifactVersion(ctx, &artifact.GetArtifactVersionRequest{
+			AppName: "app", UserID: "user", SessionID: "session", FileName: "file1",
+		})
+		if !errors.Is(err, fs.ErrNotExist) {
+			t.Fatalf("GetArtifactVersion() = (%v, %v), want error(%v)", got, err, fs.ErrNotExist)
 		}
 	})
 }


### PR DESCRIPTION
### Link to Issue

Fixes #681

### Description

The `GetArtifactVersion` method had no coverage in the shared contract test suite. This PR adds tests to `internal/artifact/tests/service_suite.go` so both the in-memory and GCS backends are covered automatically.

**Tests added:**

- `GetArtifactVersion_<suffix>` — fetches metadata for versions 1, 2, 3 and latest (version=0); asserts `Version` and `MimeType` fields are correct
- `GetArtifactVersion_NotFound_<suffix>` — asserts `fs.ErrNotExist` is returned for a non-existent file
- `GetArtifactVersion_<suffix>` in the empty-service suite — asserts `fs.ErrNotExist` on an empty store
- `GetArtifactVersionAfterDelete_<suffix>` — asserts `fs.ErrNotExist` after the artifact is deleted

### Testing Plan

- [x] Unit tests added
- [x] All existing tests pass: `go test ./artifact/... ./internal/artifact/...`
