### PR TITLE
fix: add nil check for DebugConfig to prevent startup panic (#727)

### DIFF
--- a/cmd/launcher/web/api/api.go
+++ b/cmd/launcher/web/api/api.go
@@ -81,7 +81,6 @@ func (a *apiLauncher) SetupSubrouters(router *mux.Router, config *launcher.Confi
 		ArtifactService: config.ArtifactService,
 		SSEWriteTimeout: a.config.sseWriteTimeout,
 		PluginConfig:    config.PluginConfig,
-		DebugConfig:     &adkrest.DebugTelemetryConfig{},
 	})
 	if err != nil {
 		return fmt.Errorf("failed to create REST server: %w", err)

--- a/cmd/launcher/web/api/api.go
+++ b/cmd/launcher/web/api/api.go
@@ -81,6 +81,7 @@ func (a *apiLauncher) SetupSubrouters(router *mux.Router, config *launcher.Confi
 		ArtifactService: config.ArtifactService,
 		SSEWriteTimeout: a.config.sseWriteTimeout,
 		PluginConfig:    config.PluginConfig,
+		DebugConfig:     &adkrest.DebugTelemetryConfig{},
 	})
 	if err != nil {
 		return fmt.Errorf("failed to create REST server: %w", err)

--- a/server/adkrest/handler.go
+++ b/server/adkrest/handler.go
@@ -35,8 +35,12 @@ import (
 
 // NewServer creates a new ADK REST API server which implements [http.Handler] interface.
 func NewServer(cfg ServerConfig) (*Server, error) {
+	var traceCapacity int
+	if cfg.DebugConfig != nil {
+		traceCapacity = cfg.DebugConfig.TraceCapacity
+	}
 	debugTelemetry, err := services.NewDebugTelemetryWithConfig(&services.DebugTelemetryConfig{
-		TraceCapacity: cfg.DebugConfig.TraceCapacity,
+		TraceCapacity: traceCapacity,
 	})
 	if err != nil {
 		return nil, fmt.Errorf("failed to create debug telemetry service: %w", err)

--- a/server/adkrest/handler.go
+++ b/server/adkrest/handler.go
@@ -35,13 +35,11 @@ import (
 
 // NewServer creates a new ADK REST API server which implements [http.Handler] interface.
 func NewServer(cfg ServerConfig) (*Server, error) {
-	var traceCapacity int
+	var debugCfg *services.DebugTelemetryConfig
 	if cfg.DebugConfig != nil {
-		traceCapacity = cfg.DebugConfig.TraceCapacity
+		debugCfg = &services.DebugTelemetryConfig{TraceCapacity: cfg.DebugConfig.TraceCapacity}
 	}
-	debugTelemetry, err := services.NewDebugTelemetryWithConfig(&services.DebugTelemetryConfig{
-		TraceCapacity: traceCapacity,
-	})
+	debugTelemetry, err := services.NewDebugTelemetryWithConfig(debugCfg)
 	if err != nil {
 		return nil, fmt.Errorf("failed to create debug telemetry service: %w", err)
 	}


### PR DESCRIPTION
**Please ensure you have read the [contribution guide](./CONTRIBUTING.md) before creating a pull request.**

### Link to Issue or Description of Change

**1. Link to an existing issue (if applicable):**

- Closes: #727 
- Related: #727 

**2. Or, if no issue exists, describe the change:**

_If applicable, please follow the issue templates to provide as much detail as
possible._

**Problem:**
During application startup, calling adkrest.NewServer causes a panic due to a nil pointer dereference. This happens because the code attempts to access cfg.DebugConfig.TraceCapacity without verifying if cfg.DebugConfig actually exists. When using some built-in launchers, DebugConfig is left uninitialized (nil), causing the application to crash immediately upon startup.

**Solution:**
Added a nil check for cfg.DebugConfig inside adkrest.NewServer before attempting to access TraceCapacity or any other debug-related configuration fields. If DebugConfig is nil, the server will now gracefully fall back to default behavior instead of panicking.

### Testing Plan

_Please describe the tests that you ran to verify your changes. This is required
for all PRs that are not small documentation or typo fixes._

**Unit Tests:**

- [ ] I have added or updated unit tests for my change.
- [x] All unit tests pass locally.

_Please include a summary of passed go test results._

**Manual End-to-End (E2E) Tests:**

_Please provide instructions on how to manually test your changes, including any
necessary setup or configuration. Please provide logs or screenshots to help
reviewers better understand the fix._

### Checklist

- [x] I have read the [CONTRIBUTING.md](./CONTRIBUTING.md) document.
- [x] I have performed a self-review of my own code.
- [x] I have commented my code, particularly in hard-to-understand areas.
- [ ] I have added tests that prove my fix is effective or that my feature works.
- [x] New and existing unit tests pass locally with my changes.
- [x] I have manually tested my changes end-to-end.
- [ ] Any dependent changes have been merged and published in downstream modules.

### Additional context

**Before fix:** Server crashes on startup with a nil pointer exception.
<img width="2038" height="874" alt="image" src="https://github.com/user-attachments/assets/f09c19e2-0555-48b3-8f51-e8fcb1128e20" />

**After fix:** Server starts up and runs successfully without panicking.
<img width="2098" height="1200" alt="image" src="https://github.com/user-attachments/assets/80f93000-542f-437c-a19f-1db0e1b070c9" />
