### PR TITLE
feat: Allow toolsets implement toolinternal.RequestProcessor.

### DIFF
--- a/agent/llmagent/state_agent_test.go
+++ b/agent/llmagent/state_agent_test.go
@@ -29,6 +29,7 @@ import (
 
 	"google.golang.org/adk/agent"
 	"google.golang.org/adk/agent/llmagent"
+	"google.golang.org/adk/internal/utils"
 	"google.golang.org/adk/model"
 	"google.golang.org/adk/runner"
 	"google.golang.org/adk/session"
@@ -647,5 +648,72 @@ func TestToolCallbacksAgent(t *testing.T) {
 				}
 			}
 		})
+	}
+}
+
+type mockToolset struct{}
+
+func (m *mockToolset) ProcessRequest(ctx tool.Context, req *model.LLMRequest) error {
+	utils.AppendInstructions(req, "Extra instruction from mockToolset")
+	return nil
+}
+func (m *mockToolset) Name() string                                         { return "test_toolset" }
+func (m *mockToolset) Tools(ctx agent.ReadonlyContext) ([]tool.Tool, error) { return nil, nil }
+
+func TestAgentToolsetPreprocessEffect(t *testing.T) {
+	var capturedReq *model.LLMRequest
+	ctx := t.Context()
+	service := session.InMemoryService()
+	fakeLLM := &FakeLLM{
+		GenerateContentFunc: func(ctx context.Context, req *model.LLMRequest, stream bool) (model.LLMResponse, error) {
+			capturedReq = req
+			return model.LLMResponse{
+				Content: genai.NewContentFromText("fake response", genai.RoleModel),
+			}, nil
+		},
+	}
+	toolset := &mockToolset{}
+	agentConfig := llmagent.Config{
+		Name:        "toolset_effect_agent",
+		Instruction: "Agent instruction.",
+		Model:       fakeLLM,
+		Toolsets:    []tool.Toolset{toolset},
+	}
+	rootAgent, err := llmagent.New(agentConfig)
+	if err != nil {
+		t.Fatalf("Failed to create LLM Agent: %v", err)
+	}
+	runner, err := runner.New(runner.Config{
+		AppName:        "test_app",
+		Agent:          rootAgent,
+		SessionService: service,
+	})
+	if err != nil {
+		t.Fatalf("Failed to create runner: %v", err)
+	}
+	createSessionReq := &session.CreateRequest{AppName: "test_app", UserID: "test_user"}
+	createSessionResp, err := service.Create(ctx, createSessionReq)
+	if err != nil {
+		t.Fatalf("Failed to create session: %v", err)
+	}
+	sessionID := createSessionResp.Session.ID()
+	userContent := genai.NewContentFromText("Hello", genai.RoleUser)
+
+	eventStream := runner.Run(ctx, "test_user", sessionID, userContent, agent.RunConfig{})
+
+	for _, err := range eventStream {
+		if err != nil {
+			t.Fatalf("Error during agent run: %v", err)
+		}
+	}
+	if capturedReq == nil {
+		t.Fatalf("LLMRequest was not captured")
+	}
+	systemInstruction := ""
+	if capturedReq.Config != nil && capturedReq.Config.SystemInstruction != nil {
+		systemInstruction = strings.Join(utils.TextParts(capturedReq.Config.SystemInstruction), " ")
+	}
+	if got, want := systemInstruction, "Extra instruction from mockToolset"; !strings.Contains(got, want) {
+		t.Errorf("got SystemInstruction = %q, want it to contain %q", got, want)
 	}
 }

--- a/internal/llminternal/base_flow.go
+++ b/internal/llminternal/base_flow.go
@@ -262,10 +262,13 @@ func (f *Flow) preprocess(ctx agent.InvocationContext, req *model.LLMRequest) it
 			}
 		}
 
-		if f.Tools != nil {
-			if err := toolPreprocess(ctx, req, f.Tools); err != nil {
-				yield(nil, err)
-			}
+		if err := toolPreprocess(ctx, req, f.Tools); err != nil {
+			yield(nil, err)
+			return
+		}
+		if err := toolsetPreprocess(ctx, req); err != nil {
+			yield(nil, err)
+			return
 		}
 	}
 }
@@ -283,6 +286,24 @@ func toolPreprocess(ctx agent.InvocationContext, req *model.LLMRequest, tools []
 		toolCtx := toolinternal.NewToolContext(ctx, "", &session.EventActions{}, nil)
 		if err := requestProcessor.ProcessRequest(toolCtx, req); err != nil {
 			return err
+		}
+	}
+	return nil
+}
+
+func toolsetPreprocess(ctx agent.InvocationContext, req *model.LLMRequest) error {
+	llmAgent, ok := ctx.Agent().(Agent)
+	if !ok {
+		return nil
+	}
+	for _, toolset := range Reveal(llmAgent).Toolsets {
+		processor, ok := toolset.(toolinternal.RequestProcessor)
+		if !ok {
+			continue // Not all toolsets implement RequestProcessor.
+		}
+		toolCtx := toolinternal.NewToolContext(ctx, "", nil, nil)
+		if err := processor.ProcessRequest(toolCtx, req); err != nil {
+			return fmt.Errorf("process request by toolset %q: %w", toolset.Name(), err)
 		}
 	}
 	return nil

--- a/internal/llminternal/base_flow_test.go
+++ b/internal/llminternal/base_flow_test.go
@@ -21,6 +21,7 @@ import (
 	"github.com/google/go-cmp/cmp"
 	"google.golang.org/genai"
 
+	"google.golang.org/adk/agent"
 	icontext "google.golang.org/adk/internal/context"
 	"google.golang.org/adk/internal/toolinternal"
 	"google.golang.org/adk/model"
@@ -66,6 +67,31 @@ func (m *mockFunctionTool) Run(ctx tool.Context, args any) (map[string]any, erro
 
 func (m *mockFunctionTool) Declaration() *genai.FunctionDeclaration {
 	return nil
+}
+
+type mockToolset struct {
+	name string
+}
+
+func (m *mockToolset) Name() string { return m.name }
+func (m *mockToolset) Tools(ctx agent.ReadonlyContext) ([]tool.Tool, error) {
+	return nil, nil
+}
+
+type mockRequestProcessorToolset struct {
+	name    string
+	process func(ctx tool.Context, req *model.LLMRequest) error
+}
+
+func (m *mockRequestProcessorToolset) ProcessRequest(ctx tool.Context, req *model.LLMRequest) error {
+	if m.process != nil {
+		return m.process(ctx, req)
+	}
+	return nil
+}
+func (m *mockRequestProcessorToolset) Name() string { return m.name }
+func (m *mockRequestProcessorToolset) Tools(ctx agent.ReadonlyContext) ([]tool.Tool, error) {
+	return nil, nil
 }
 
 type testCase struct {
@@ -571,6 +597,88 @@ func TestMergeEventActions(t *testing.T) {
 			got := mergeEventActions(tc.base, tc.other)
 			if diff := cmp.Diff(tc.want, got); diff != "" {
 				t.Errorf("mergeEventActions() mismatch (-want +got):\n%s", diff)
+			}
+		})
+	}
+}
+
+func TestPreprocess_Toolset(t *testing.T) {
+	noOpAgent, err := agent.New(agent.Config{Name: "no-op"})
+	if err != nil {
+		t.Fatalf("Failed to create agent: %v", err)
+	}
+
+	tests := []struct {
+		name      string
+		agent     agent.Agent
+		wantModel string
+		wantError bool
+	}{
+		{
+			name:      "agent not llminternal.Agent",
+			agent:     noOpAgent,
+			wantError: false,
+		},
+		{
+			name:      "agent has no toolsets",
+			agent:     &mockLLMAgent{s: &State{}},
+			wantError: false,
+		},
+		{
+			name: "toolset implements RequestProcessor, error",
+			agent: &mockLLMAgent{
+				s: &State{
+					Toolsets: []tool.Toolset{&mockRequestProcessorToolset{
+						name: "toolset",
+						process: func(_ tool.Context, _ *model.LLMRequest) error {
+							return errors.New("process error")
+						},
+					}},
+				},
+			},
+			wantError: true,
+		},
+		{
+			name: "toolsets, success",
+			agent: &mockLLMAgent{
+				s: &State{
+					Toolsets: []tool.Toolset{
+						&mockToolset{name: "toolset_without_processor"},
+						&mockRequestProcessorToolset{
+							name: "toolset_with_processor",
+							process: func(_ tool.Context, req *model.LLMRequest) error {
+								req.Model = "modified-model"
+								return nil
+							},
+						},
+					},
+				},
+			},
+			wantError: false,
+			wantModel: "modified-model",
+		},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			f := &Flow{}
+			ctx := icontext.NewInvocationContext(t.Context(), icontext.InvocationContextParams{Agent: tc.agent})
+			req := &model.LLMRequest{}
+
+			events := f.preprocess(ctx, req)
+
+			var gotErr error
+			for _, err := range events {
+				if err != nil {
+					gotErr = err
+					break
+				}
+			}
+			if (gotErr != nil) != tc.wantError {
+				t.Errorf("preprocess() error = %v, wantError %v", gotErr, tc.wantError)
+			}
+			if req.Model != tc.wantModel {
+				t.Errorf("preprocess() model = %s, wantModel %s", req.Model, tc.wantModel)
 			}
 		})
 	}


### PR DESCRIPTION
While for tools implementing RequestProcessor is a requirement, for toolsets it is optional.
The ability of toolsets to implement RequestProcessor is required to implement the Agent Skills feature as a toolset.