### PR TITLE
feat: add retry wrapper with exponential backoff for LLM calls (#710)

### DIFF
--- a/agent/llmagent/llmagent.go
+++ b/agent/llmagent/llmagent.go
@@ -62,8 +62,13 @@ func New(cfg Config) (agent.Agent, error) {
 		onToolErrorCallback = append(onToolErrorCallback, llminternal.OnToolErrorCallback(c))
 	}
 
+	m := cfg.Model
+	if cfg.Retry != nil {
+		m = model.WithRetry(cfg.Model, cfg.Retry)
+	}
+
 	a := &llmAgent{
-		model:                 cfg.Model,
+		model:                 m,
 		beforeModelCallbacks:  beforeModelCallbacks,
 		afterModelCallbacks:   afterModelCallbacks,
 		onModelErrorCallbacks: onModelErrorCallbacks,
@@ -75,7 +80,7 @@ func New(cfg Config) (agent.Agent, error) {
 		outputSchema:          cfg.OutputSchema,
 
 		State: llminternal.State{
-			Model:                    cfg.Model,
+			Model:                    m,
 			GenerateContentConfig:    cfg.GenerateContentConfig,
 			Tools:                    cfg.Tools,
 			Toolsets:                 cfg.Toolsets,
@@ -176,6 +181,10 @@ type Config struct {
 	BeforeModelCallbacks []BeforeModelCallback
 	// Model that is used by the agent.
 	Model model.LLM
+	// Retry configures automatic retry with exponential backoff for LLM calls.
+	// When non-nil, the model is wrapped with model.WithRetry using this config.
+	// Leave nil to disable retry.
+	Retry *model.RetryConfig
 	// AfterModelCallbacks will be called in the order they are provided until
 	// there's a callback that returns a non-nil LLMResponse or error. Then
 	// actual LLM response is replaced with the returned response/error.

--- a/agent/llmagent/llmagent.go
+++ b/agent/llmagent/llmagent.go
@@ -67,8 +67,13 @@ func New(cfg Config) (agent.Agent, error) {
 		onToolErrorCallback = append(onToolErrorCallback, llminternal.OnToolErrorCallback(c))
 	}
 
+	m := cfg.Model
+	if cfg.Retry != nil {
+		m = model.WithRetry(cfg.Model, cfg.Retry)
+	}
+
 	a := &llmAgent{
-		model:                 cfg.Model,
+		model:                 m,
 		beforeModelCallbacks:  beforeModelCallbacks,
 		afterModelCallbacks:   afterModelCallbacks,
 		onModelErrorCallbacks: onModelErrorCallbacks,
@@ -80,7 +85,7 @@ func New(cfg Config) (agent.Agent, error) {
 		outputSchema:          cfg.OutputSchema,
 
 		State: llminternal.State{
-			Model:                    cfg.Model,
+			Model:                    m,
 			Mode:                     cfg.Mode,
 			GenerateContentConfig:    cfg.GenerateContentConfig,
 			Tools:                    cfg.Tools,
@@ -232,6 +237,10 @@ type Config struct {
 	BeforeModelCallbacks []BeforeModelCallback
 	// Model that is used by the agent.
 	Model model.LLM
+	// Retry configures automatic retry with exponential backoff for LLM calls.
+	// When non-nil, the model is wrapped with model.WithRetry using this config.
+	// Leave nil to disable retry.
+	Retry *model.RetryConfig
 	// AfterModelCallbacks will be called in the order they are provided until
 	// there's a callback that returns a non-nil LLMResponse or error. Then
 	// actual LLM response is replaced with the returned response/error.

--- a/agent/llmagent/llmagent_test.go
+++ b/agent/llmagent/llmagent_test.go
@@ -93,6 +93,21 @@ func TestLLMAgent(t *testing.T) {
 	}
 }
 
+func TestLLMAgentRetryWithoutModelReturnsConfigurationError(t *testing.T) {
+	a, err := llmagent.New(llmagent.Config{
+		Name:  "missing_model",
+		Retry: &model.RetryConfig{},
+	})
+	if err != nil {
+		t.Fatalf("NewLLMAgent failed: %v", err)
+	}
+
+	_, runErr := testutil.CollectEvents(testutil.NewTestAgentRunner(t, a).Run(t, "session", "hello"))
+	if runErr == nil || !strings.Contains(runErr.Error(), "model not configured") {
+		t.Fatalf("run error = %v, want model-not-configured error", runErr)
+	}
+}
+
 func TestLLMAgentStreamingModeSSE(t *testing.T) {
 	model := newGeminiModel(t, "gemini-2.5-flash", nil)
 	a, err := llmagent.New(llmagent.Config{

--- a/model/retry.go
+++ b/model/retry.go
@@ -1,0 +1,260 @@
+// Copyright 2025 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package model
+
+import (
+	"context"
+	"iter"
+	"log/slog"
+	"math"
+	"math/rand/v2"
+	"strings"
+	"time"
+)
+
+// RetryConfig controls retry behavior for transient LLM errors.
+type RetryConfig struct {
+	// MaxRetries is the maximum number of retry attempts. Defaults to 5.
+	MaxRetries int
+	// InitialDelay is the delay before the first retry. Defaults to 1s.
+	InitialDelay time.Duration
+	// MaxDelay caps the backoff delay. Defaults to 60s.
+	MaxDelay time.Duration
+	// Multiplier is the exponential backoff multiplier. Defaults to 2.0.
+	Multiplier float64
+	// Jitter is the maximum absolute random delay added on top of the
+	// exponential backoff. Defaults to 1s.
+	Jitter time.Duration
+	// IsRetryable determines whether an error should be retried.
+	// When nil, the default policy retries 408, 429, 500, 502, 503, 504,
+	// UNAVAILABLE, RESOURCE_EXHAUSTED, and network-related errors.
+	IsRetryable func(error) bool
+}
+
+func (c *RetryConfig) maxRetries() int {
+	if c != nil && c.MaxRetries > 0 {
+		return c.MaxRetries
+	}
+	return 5
+}
+
+func (c *RetryConfig) initialDelay() time.Duration {
+	if c != nil && c.InitialDelay > 0 {
+		return c.InitialDelay
+	}
+	return time.Second
+}
+
+func (c *RetryConfig) maxDelay() time.Duration {
+	if c != nil && c.MaxDelay > 0 {
+		return c.MaxDelay
+	}
+	return 60 * time.Second
+}
+
+func (c *RetryConfig) multiplier() float64 {
+	if c != nil && c.Multiplier > 0 {
+		return c.Multiplier
+	}
+	return 2.0
+}
+
+func (c *RetryConfig) jitter() time.Duration {
+	if c != nil && c.Jitter > 0 {
+		return c.Jitter
+	}
+	return time.Second
+}
+
+func (c *RetryConfig) isRetryable(err error) bool {
+	if c != nil && c.IsRetryable != nil {
+		return c.IsRetryable(err)
+	}
+	return defaultIsRetryable(err)
+}
+
+// backoff computes the delay for the given zero-based attempt number.
+// Formula matches tenacity.wait_exponential_jitter:
+//
+//	min(initial * multiplier^attempt, maxDelay) + random(0, jitter)
+func (c *RetryConfig) backoff(attempt int) time.Duration {
+	base := float64(c.initialDelay()) * math.Pow(c.multiplier(), float64(attempt))
+	delay := math.Min(base, float64(c.maxDelay()))
+	j := rand.Float64() * float64(c.jitter())
+	return time.Duration(delay + j)
+}
+
+var retryableSubstrings = []string{
+	// HTTP status codes (aligned with adk-python default_status_codes).
+	"408",
+	"429",
+	"500",
+	"502",
+	"503",
+	"504",
+	// gRPC status names.
+	"UNAVAILABLE",
+	"RESOURCE_EXHAUSTED",
+	"ResourceExhausted",
+	"ServiceUnavailable",
+	// Network errors (aligned with adk-python httpx.NetworkError).
+	"connection refused",
+	"connection reset",
+	"no such host",
+	"i/o timeout",
+	"network is unreachable",
+}
+
+func defaultIsRetryable(err error) bool {
+	if err == nil {
+		return false
+	}
+	msg := err.Error()
+	for _, sub := range retryableSubstrings {
+		if strings.Contains(msg, sub) {
+			return true
+		}
+	}
+	return false
+}
+
+// WithRetry wraps an LLM with automatic retry logic using exponential backoff
+// with jitter. Pass nil for cfg to use sensible defaults.
+func WithRetry(llm LLM, cfg *RetryConfig) LLM {
+	return &retryLLM{inner: llm, cfg: cfg}
+}
+
+type retryLLM struct {
+	inner LLM
+	cfg   *RetryConfig
+}
+
+func (r *retryLLM) Name() string {
+	return r.inner.Name()
+}
+
+func (r *retryLLM) GenerateContent(ctx context.Context, req *LLMRequest, stream bool) iter.Seq2[*LLMResponse, error] {
+	if stream {
+		return r.generateContentStream(ctx, req)
+	}
+	return r.generateContentUnary(ctx, req)
+}
+
+// generateContentUnary retries the full unary call on retryable errors.
+func (r *retryLLM) generateContentUnary(ctx context.Context, req *LLMRequest) iter.Seq2[*LLMResponse, error] {
+	return func(yield func(*LLMResponse, error) bool) {
+		maxRetries := r.cfg.maxRetries()
+		var lastErr error
+
+		for attempt := range maxRetries + 1 {
+			if attempt > 0 {
+				delay := r.cfg.backoff(attempt - 1)
+				slog.WarnContext(ctx, "retrying LLM call",
+					"model", r.inner.Name(),
+					"attempt", attempt,
+					"max_retries", maxRetries,
+					"delay", delay,
+					"error", lastErr,
+				)
+				if err := sleepCtx(ctx, delay); err != nil {
+					yield(nil, lastErr)
+					return
+				}
+			}
+
+			var resp *LLMResponse
+			var callErr error
+			for r, e := range r.inner.GenerateContent(ctx, req, false) {
+				resp, callErr = r, e
+			}
+
+			if callErr == nil {
+				yield(resp, nil)
+				return
+			}
+
+			lastErr = callErr
+			if !r.cfg.isRetryable(callErr) {
+				yield(nil, callErr)
+				return
+			}
+		}
+
+		yield(nil, lastErr)
+	}
+}
+
+// generateContentStream retries only when the stream fails before yielding
+// any successful response, preventing duplicate partial content.
+func (r *retryLLM) generateContentStream(ctx context.Context, req *LLMRequest) iter.Seq2[*LLMResponse, error] {
+	return func(yield func(*LLMResponse, error) bool) {
+		maxRetries := r.cfg.maxRetries()
+		var lastErr error
+
+		for attempt := range maxRetries + 1 {
+			if attempt > 0 {
+				delay := r.cfg.backoff(attempt - 1)
+				slog.WarnContext(ctx, "retrying LLM stream",
+					"model", r.inner.Name(),
+					"attempt", attempt,
+					"max_retries", maxRetries,
+					"delay", delay,
+					"error", lastErr,
+				)
+				if err := sleepCtx(ctx, delay); err != nil {
+					yield(nil, lastErr)
+					return
+				}
+			}
+
+			yieldedData := false
+			shouldRetry := false
+
+			for resp, err := range r.inner.GenerateContent(ctx, req, true) {
+				if err != nil {
+					if !yieldedData && r.cfg.isRetryable(err) {
+						lastErr = err
+						shouldRetry = true
+						break
+					}
+					yield(nil, err)
+					return
+				}
+				yieldedData = true
+				if !yield(resp, nil) {
+					return
+				}
+			}
+
+			if !shouldRetry {
+				return
+			}
+		}
+
+		yield(nil, lastErr)
+	}
+}
+
+// sleepCtx blocks for d or until ctx is cancelled, whichever comes first.
+func sleepCtx(ctx context.Context, d time.Duration) error {
+	t := time.NewTimer(d)
+	defer t.Stop()
+	select {
+	case <-ctx.Done():
+		return ctx.Err()
+	case <-t.C:
+		return nil
+	}
+}

--- a/model/retry.go
+++ b/model/retry.go
@@ -1,0 +1,273 @@
+// Copyright 2025 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package model
+
+import (
+	"context"
+	"iter"
+	"log/slog"
+	"math"
+	"math/rand/v2"
+	"regexp"
+	"strings"
+	"time"
+
+	"google.golang.org/genai"
+)
+
+// RetryConfig controls retry behavior for transient LLM errors.
+type RetryConfig struct {
+	// MaxRetries is the maximum number of retry attempts. Defaults to 5.
+	MaxRetries int
+	// InitialDelay is the delay before the first retry. Defaults to 1s.
+	InitialDelay time.Duration
+	// MaxDelay caps the backoff delay. Defaults to 60s.
+	MaxDelay time.Duration
+	// Multiplier is the exponential backoff multiplier. Defaults to 2.0.
+	Multiplier float64
+	// Jitter is the maximum absolute random delay added on top of the
+	// exponential backoff. Defaults to 1s.
+	Jitter time.Duration
+	// IsRetryable determines whether an error should be retried.
+	// When nil, the default policy retries 408, 429, 500, 502, 503, 504,
+	// UNAVAILABLE, RESOURCE_EXHAUSTED, and network-related errors.
+	IsRetryable func(error) bool
+}
+
+func (c *RetryConfig) maxRetries() int {
+	if c != nil && c.MaxRetries > 0 {
+		return c.MaxRetries
+	}
+	return 5
+}
+
+func (c *RetryConfig) initialDelay() time.Duration {
+	if c != nil && c.InitialDelay > 0 {
+		return c.InitialDelay
+	}
+	return time.Second
+}
+
+func (c *RetryConfig) maxDelay() time.Duration {
+	if c != nil && c.MaxDelay > 0 {
+		return c.MaxDelay
+	}
+	return 60 * time.Second
+}
+
+func (c *RetryConfig) multiplier() float64 {
+	if c != nil && c.Multiplier > 0 {
+		return c.Multiplier
+	}
+	return 2.0
+}
+
+func (c *RetryConfig) jitter() time.Duration {
+	if c != nil && c.Jitter > 0 {
+		return c.Jitter
+	}
+	return time.Second
+}
+
+func (c *RetryConfig) isRetryable(err error) bool {
+	if c != nil && c.IsRetryable != nil {
+		return c.IsRetryable(err)
+	}
+	return defaultIsRetryable(err)
+}
+
+// backoff computes the delay for the given zero-based attempt number.
+// Formula matches tenacity.wait_exponential_jitter:
+//
+//	min(initial * multiplier^attempt, maxDelay) + random(0, jitter)
+func (c *RetryConfig) backoff(attempt int) time.Duration {
+	base := float64(c.initialDelay()) * math.Pow(c.multiplier(), float64(attempt))
+	delay := math.Min(base, float64(c.maxDelay()))
+	j := rand.Float64() * float64(c.jitter())
+	return time.Duration(delay + j)
+}
+
+var retryableHTTPStatus = regexp.MustCompile(`\b(?:408|429|500|502|503|504)\b`)
+
+var retryableErrorSubstrings = []string{
+	// gRPC status names.
+	"UNAVAILABLE",
+	"RESOURCE_EXHAUSTED",
+	"ResourceExhausted",
+	"ServiceUnavailable",
+	// Network errors (aligned with adk-python httpx.NetworkError).
+	"connection refused",
+	"connection reset",
+	"no such host",
+	"i/o timeout",
+	"network is unreachable",
+}
+
+func defaultIsRetryable(err error) bool {
+	if err == nil {
+		return false
+	}
+	msg := err.Error()
+	if retryableHTTPStatus.MatchString(msg) {
+		return true
+	}
+	for _, sub := range retryableErrorSubstrings {
+		if strings.Contains(msg, sub) {
+			return true
+		}
+	}
+	return false
+}
+
+// WithRetry wraps an LLM with automatic retry logic using exponential backoff
+// with jitter. Pass nil for cfg to use sensible defaults.
+func WithRetry(llm LLM, cfg *RetryConfig) LLM {
+	if llm == nil {
+		return nil
+	}
+	return &retryLLM{inner: llm, cfg: cfg}
+}
+
+type retryLLM struct {
+	inner LLM
+	cfg   *RetryConfig
+}
+
+func (r *retryLLM) Name() string {
+	return r.inner.Name()
+}
+
+// GetGoogleLLMVariant preserves the optional backend capability used by ADK's
+// Gemini-specific request processors. Non-Google models return unspecified.
+func (r *retryLLM) GetGoogleLLMVariant() genai.Backend {
+	if llm, ok := r.inner.(interface{ GetGoogleLLMVariant() genai.Backend }); ok {
+		return llm.GetGoogleLLMVariant()
+	}
+	return genai.BackendUnspecified
+}
+
+func (r *retryLLM) GenerateContent(ctx context.Context, req *LLMRequest, stream bool) iter.Seq2[*LLMResponse, error] {
+	if stream {
+		return r.generateContentStream(ctx, req)
+	}
+	return r.generateContentUnary(ctx, req)
+}
+
+// generateContentUnary retries the full unary call on retryable errors.
+func (r *retryLLM) generateContentUnary(ctx context.Context, req *LLMRequest) iter.Seq2[*LLMResponse, error] {
+	return func(yield func(*LLMResponse, error) bool) {
+		maxRetries := r.cfg.maxRetries()
+		var lastErr error
+
+		for attempt := range maxRetries + 1 {
+			if attempt > 0 {
+				delay := r.cfg.backoff(attempt - 1)
+				slog.WarnContext(ctx, "retrying LLM call",
+					"model", r.inner.Name(),
+					"attempt", attempt,
+					"max_retries", maxRetries,
+					"delay", delay,
+					"error", lastErr,
+				)
+				if err := sleepCtx(ctx, delay); err != nil {
+					yield(nil, err)
+					return
+				}
+			}
+
+			var resp *LLMResponse
+			var callErr error
+			for r, e := range r.inner.GenerateContent(ctx, req, false) {
+				resp, callErr = r, e
+			}
+
+			if callErr == nil {
+				yield(resp, nil)
+				return
+			}
+
+			lastErr = callErr
+			if !r.cfg.isRetryable(callErr) {
+				yield(nil, callErr)
+				return
+			}
+		}
+
+		yield(nil, lastErr)
+	}
+}
+
+// generateContentStream retries only when the stream fails before yielding
+// any successful response, preventing duplicate partial content.
+func (r *retryLLM) generateContentStream(ctx context.Context, req *LLMRequest) iter.Seq2[*LLMResponse, error] {
+	return func(yield func(*LLMResponse, error) bool) {
+		maxRetries := r.cfg.maxRetries()
+		var lastErr error
+
+		for attempt := range maxRetries + 1 {
+			if attempt > 0 {
+				delay := r.cfg.backoff(attempt - 1)
+				slog.WarnContext(ctx, "retrying LLM stream",
+					"model", r.inner.Name(),
+					"attempt", attempt,
+					"max_retries", maxRetries,
+					"delay", delay,
+					"error", lastErr,
+				)
+				if err := sleepCtx(ctx, delay); err != nil {
+					yield(nil, err)
+					return
+				}
+			}
+
+			yieldedData := false
+			shouldRetry := false
+
+			for resp, err := range r.inner.GenerateContent(ctx, req, true) {
+				if err != nil {
+					if !yieldedData && r.cfg.isRetryable(err) {
+						lastErr = err
+						shouldRetry = true
+						break
+					}
+					yield(nil, err)
+					return
+				}
+				yieldedData = true
+				if !yield(resp, nil) {
+					return
+				}
+			}
+
+			if !shouldRetry {
+				return
+			}
+		}
+
+		yield(nil, lastErr)
+	}
+}
+
+// sleepCtx blocks for d or until ctx is cancelled, whichever comes first.
+func sleepCtx(ctx context.Context, d time.Duration) error {
+	t := time.NewTimer(d)
+	defer t.Stop()
+	select {
+	case <-ctx.Done():
+		return ctx.Err()
+	case <-t.C:
+		return nil
+	}
+}

--- a/model/retry_test.go
+++ b/model/retry_test.go
@@ -1,0 +1,445 @@
+// Copyright 2025 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package model
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"iter"
+	"sync/atomic"
+	"testing"
+	"time"
+
+	"google.golang.org/genai"
+)
+
+// fakeLLM records calls and returns preconfigured responses/errors per attempt.
+type fakeLLM struct {
+	attempts  atomic.Int32
+	responses []fakeLLMResult
+}
+
+type fakeLLMResult struct {
+	// For non-streaming: single response/error pair.
+	resp *LLMResponse
+	err  error
+	// For streaming: sequence of response/error pairs.
+	stream []struct {
+		resp *LLMResponse
+		err  error
+	}
+}
+
+func (f *fakeLLM) Name() string { return "fake" }
+
+func (f *fakeLLM) GenerateContent(_ context.Context, _ *LLMRequest, stream bool) iter.Seq2[*LLMResponse, error] {
+	idx := int(f.attempts.Add(1)) - 1
+	if idx >= len(f.responses) {
+		idx = len(f.responses) - 1
+	}
+	result := f.responses[idx]
+
+	return func(yield func(*LLMResponse, error) bool) {
+		if stream && len(result.stream) > 0 {
+			for _, s := range result.stream {
+				if !yield(s.resp, s.err) {
+					return
+				}
+				if s.err != nil {
+					return
+				}
+			}
+			return
+		}
+		yield(result.resp, result.err)
+	}
+}
+
+func okResponse(text string) *LLMResponse {
+	return &LLMResponse{
+		Content: &genai.Content{Parts: []*genai.Part{{Text: text}}},
+	}
+}
+
+func TestRetryUnary_SuccessNoRetry(t *testing.T) {
+	fake := &fakeLLM{responses: []fakeLLMResult{
+		{resp: okResponse("hello")},
+	}}
+	llm := WithRetry(fake, nil)
+
+	var got *LLMResponse
+	for r, err := range llm.GenerateContent(context.Background(), &LLMRequest{}, false) {
+		if err != nil {
+			t.Fatalf("unexpected error: %v", err)
+		}
+		got = r
+	}
+
+	if got.Content.Parts[0].Text != "hello" {
+		t.Errorf("want 'hello', got %q", got.Content.Parts[0].Text)
+	}
+	if fake.attempts.Load() != 1 {
+		t.Errorf("want 1 attempt, got %d", fake.attempts.Load())
+	}
+}
+
+func TestRetryUnary_RetriesOnTransientError(t *testing.T) {
+	fake := &fakeLLM{responses: []fakeLLMResult{
+		{err: errors.New("Error 503, UNAVAILABLE")},
+		{err: errors.New("Error 503, UNAVAILABLE")},
+		{resp: okResponse("recovered")},
+	}}
+	cfg := &RetryConfig{
+		MaxRetries:   3,
+		InitialDelay: time.Millisecond,
+		MaxDelay:     10 * time.Millisecond,
+		Jitter:       time.Millisecond,
+	}
+	llm := WithRetry(fake, cfg)
+
+	var got *LLMResponse
+	for r, err := range llm.GenerateContent(context.Background(), &LLMRequest{}, false) {
+		if err != nil {
+			t.Fatalf("unexpected error: %v", err)
+		}
+		got = r
+	}
+
+	if got.Content.Parts[0].Text != "recovered" {
+		t.Errorf("want 'recovered', got %q", got.Content.Parts[0].Text)
+	}
+	if fake.attempts.Load() != 3 {
+		t.Errorf("want 3 attempts, got %d", fake.attempts.Load())
+	}
+}
+
+func TestRetryUnary_NonRetryableError(t *testing.T) {
+	fake := &fakeLLM{responses: []fakeLLMResult{
+		{err: errors.New("invalid API key")},
+	}}
+	cfg := &RetryConfig{InitialDelay: time.Millisecond, Jitter: time.Millisecond}
+	llm := WithRetry(fake, cfg)
+
+	for _, err := range llm.GenerateContent(context.Background(), &LLMRequest{}, false) {
+		if err == nil {
+			t.Fatal("expected error, got nil")
+		}
+		if err.Error() != "invalid API key" {
+			t.Errorf("want 'invalid API key', got %q", err.Error())
+		}
+	}
+
+	if fake.attempts.Load() != 1 {
+		t.Errorf("want 1 attempt (no retry), got %d", fake.attempts.Load())
+	}
+}
+
+func TestRetryUnary_ExhaustsRetries(t *testing.T) {
+	fake := &fakeLLM{responses: []fakeLLMResult{
+		{err: errors.New("503 UNAVAILABLE")},
+		{err: errors.New("503 UNAVAILABLE")},
+		{err: errors.New("503 UNAVAILABLE")},
+		{err: errors.New("503 UNAVAILABLE")},
+	}}
+	cfg := &RetryConfig{
+		MaxRetries:   3,
+		InitialDelay: time.Millisecond,
+		MaxDelay:     10 * time.Millisecond,
+		Jitter:       time.Millisecond,
+	}
+	llm := WithRetry(fake, cfg)
+
+	var lastErr error
+	for _, err := range llm.GenerateContent(context.Background(), &LLMRequest{}, false) {
+		lastErr = err
+	}
+
+	if lastErr == nil {
+		t.Fatal("expected error after exhausting retries")
+	}
+	// 1 initial + 3 retries = 4 total
+	if fake.attempts.Load() != 4 {
+		t.Errorf("want 4 attempts, got %d", fake.attempts.Load())
+	}
+}
+
+func TestRetryUnary_RespectsContextCancellation(t *testing.T) {
+	fake := &fakeLLM{responses: []fakeLLMResult{
+		{err: errors.New("503 UNAVAILABLE")},
+		{err: errors.New("503 UNAVAILABLE")},
+	}}
+	cfg := &RetryConfig{
+		MaxRetries:   5,
+		InitialDelay: time.Second, // long delay so cancellation beats it
+	}
+	llm := WithRetry(fake, cfg)
+
+	ctx, cancel := context.WithCancel(context.Background())
+	// Cancel after a short time to interrupt the backoff sleep.
+	go func() {
+		time.Sleep(50 * time.Millisecond)
+		cancel()
+	}()
+
+	var lastErr error
+	for _, err := range llm.GenerateContent(ctx, &LLMRequest{}, false) {
+		lastErr = err
+	}
+
+	if lastErr == nil {
+		t.Fatal("expected error after context cancellation")
+	}
+	// Should not have exhausted all retries.
+	if fake.attempts.Load() > 3 {
+		t.Errorf("expected fewer attempts due to cancellation, got %d", fake.attempts.Load())
+	}
+}
+
+func TestRetryUnary_CustomIsRetryable(t *testing.T) {
+	fake := &fakeLLM{responses: []fakeLLMResult{
+		{err: errors.New("custom-transient")},
+		{resp: okResponse("ok")},
+	}}
+	cfg := &RetryConfig{
+		InitialDelay: time.Millisecond,
+		Jitter:       time.Millisecond,
+		IsRetryable: func(err error) bool {
+			return err != nil && err.Error() == "custom-transient"
+		},
+	}
+	llm := WithRetry(fake, cfg)
+
+	var got *LLMResponse
+	for r, err := range llm.GenerateContent(context.Background(), &LLMRequest{}, false) {
+		if err != nil {
+			t.Fatalf("unexpected error: %v", err)
+		}
+		got = r
+	}
+
+	if got.Content.Parts[0].Text != "ok" {
+		t.Errorf("want 'ok', got %q", got.Content.Parts[0].Text)
+	}
+	if fake.attempts.Load() != 2 {
+		t.Errorf("want 2 attempts, got %d", fake.attempts.Load())
+	}
+}
+
+func TestRetryStream_SuccessNoRetry(t *testing.T) {
+	fake := &fakeLLM{responses: []fakeLLMResult{
+		{stream: []struct {
+			resp *LLMResponse
+			err  error
+		}{
+			{resp: &LLMResponse{Content: &genai.Content{Parts: []*genai.Part{{Text: "chunk1"}}}, Partial: true}},
+			{resp: &LLMResponse{Content: &genai.Content{Parts: []*genai.Part{{Text: "chunk2"}}}, TurnComplete: true}},
+		}},
+	}}
+	llm := WithRetry(fake, &RetryConfig{InitialDelay: time.Millisecond, Jitter: time.Millisecond})
+
+	var chunks []string
+	for r, err := range llm.GenerateContent(context.Background(), &LLMRequest{}, true) {
+		if err != nil {
+			t.Fatalf("unexpected error: %v", err)
+		}
+		chunks = append(chunks, r.Content.Parts[0].Text)
+	}
+
+	if len(chunks) != 2 || chunks[0] != "chunk1" || chunks[1] != "chunk2" {
+		t.Errorf("unexpected chunks: %v", chunks)
+	}
+	if fake.attempts.Load() != 1 {
+		t.Errorf("want 1 attempt, got %d", fake.attempts.Load())
+	}
+}
+
+func TestRetryStream_RetriesBeforeFirstData(t *testing.T) {
+	fake := &fakeLLM{responses: []fakeLLMResult{
+		{stream: []struct {
+			resp *LLMResponse
+			err  error
+		}{
+			{err: errors.New("503 UNAVAILABLE")},
+		}},
+		{stream: []struct {
+			resp *LLMResponse
+			err  error
+		}{
+			{resp: &LLMResponse{Content: &genai.Content{Parts: []*genai.Part{{Text: "ok"}}}, TurnComplete: true}},
+		}},
+	}}
+	cfg := &RetryConfig{
+		MaxRetries:   2,
+		InitialDelay: time.Millisecond,
+		Jitter:       time.Millisecond,
+	}
+	llm := WithRetry(fake, cfg)
+
+	var chunks []string
+	for r, err := range llm.GenerateContent(context.Background(), &LLMRequest{}, true) {
+		if err != nil {
+			t.Fatalf("unexpected error: %v", err)
+		}
+		chunks = append(chunks, r.Content.Parts[0].Text)
+	}
+
+	if len(chunks) != 1 || chunks[0] != "ok" {
+		t.Errorf("unexpected chunks: %v", chunks)
+	}
+	if fake.attempts.Load() != 2 {
+		t.Errorf("want 2 attempts, got %d", fake.attempts.Load())
+	}
+}
+
+func TestRetryStream_NoRetryAfterPartialData(t *testing.T) {
+	fake := &fakeLLM{responses: []fakeLLMResult{
+		{stream: []struct {
+			resp *LLMResponse
+			err  error
+		}{
+			{resp: &LLMResponse{Content: &genai.Content{Parts: []*genai.Part{{Text: "partial"}}}, Partial: true}},
+			{err: errors.New("503 UNAVAILABLE")},
+		}},
+	}}
+	cfg := &RetryConfig{
+		MaxRetries:   3,
+		InitialDelay: time.Millisecond,
+		Jitter:       time.Millisecond,
+	}
+	llm := WithRetry(fake, cfg)
+
+	var lastErr error
+	var chunks []string
+	for r, err := range llm.GenerateContent(context.Background(), &LLMRequest{}, true) {
+		if err != nil {
+			lastErr = err
+			break
+		}
+		chunks = append(chunks, r.Content.Parts[0].Text)
+	}
+
+	if lastErr == nil {
+		t.Fatal("expected error after partial data")
+	}
+	if len(chunks) != 1 || chunks[0] != "partial" {
+		t.Errorf("unexpected chunks before error: %v", chunks)
+	}
+	// Only 1 attempt — no retry because data was already yielded.
+	if fake.attempts.Load() != 1 {
+		t.Errorf("want 1 attempt (no retry after partial), got %d", fake.attempts.Load())
+	}
+}
+
+func TestRetryName_DelegatesToInner(t *testing.T) {
+	fake := &fakeLLM{}
+	llm := WithRetry(fake, nil)
+	if llm.Name() != "fake" {
+		t.Errorf("want 'fake', got %q", llm.Name())
+	}
+}
+
+func TestRetryConfig_Defaults(t *testing.T) {
+	var cfg *RetryConfig // nil
+	if cfg.maxRetries() != 5 {
+		t.Errorf("default maxRetries: want 5, got %d", cfg.maxRetries())
+	}
+	if cfg.initialDelay() != time.Second {
+		t.Errorf("default initialDelay: want 1s, got %v", cfg.initialDelay())
+	}
+	if cfg.maxDelay() != 60*time.Second {
+		t.Errorf("default maxDelay: want 60s, got %v", cfg.maxDelay())
+	}
+	if cfg.multiplier() != 2.0 {
+		t.Errorf("default multiplier: want 2.0, got %f", cfg.multiplier())
+	}
+	if cfg.jitter() != time.Second {
+		t.Errorf("default jitter: want 1s, got %v", cfg.jitter())
+	}
+}
+
+func TestRetryConfig_BackoffGrowth(t *testing.T) {
+	cfg := &RetryConfig{
+		InitialDelay: 100 * time.Millisecond,
+		MaxDelay:     10 * time.Second,
+		Multiplier:   2.0,
+		Jitter:       10 * time.Millisecond, // small jitter to keep growth observable
+	}
+
+	d0 := cfg.backoff(0)
+	d1 := cfg.backoff(1)
+	d2 := cfg.backoff(2)
+
+	// Jitter is absolute: delay is in [base, base + 10ms).
+	assertInRange(t, "backoff(0)", d0, 100*time.Millisecond, 110*time.Millisecond)
+	assertInRange(t, "backoff(1)", d1, 200*time.Millisecond, 210*time.Millisecond)
+	assertInRange(t, "backoff(2)", d2, 400*time.Millisecond, 410*time.Millisecond)
+
+	if d1 <= d0 || d2 <= d1 {
+		t.Errorf("backoff should increase: d0=%v, d1=%v, d2=%v", d0, d1, d2)
+	}
+}
+
+func TestRetryConfig_BackoffCapsAtMax(t *testing.T) {
+	cfg := &RetryConfig{
+		InitialDelay: time.Second,
+		MaxDelay:     5 * time.Second,
+		Multiplier:   10.0,
+	}
+	// 1s * 10^2 = 100s → capped at 5s, plus absolute jitter up to 1s (default).
+	d := cfg.backoff(2)
+	assertInRange(t, "backoff(2)", d, 5*time.Second, 6*time.Second)
+}
+
+func assertInRange(t *testing.T, name string, got, lo, hi time.Duration) {
+	t.Helper()
+	if got < lo || got > hi {
+		t.Errorf("%s: got %v, want in [%v, %v]", name, got, lo, hi)
+	}
+}
+
+func TestDefaultIsRetryable(t *testing.T) {
+	tests := []struct {
+		err  error
+		want bool
+	}{
+		{nil, false},
+		{errors.New("invalid request"), false},
+		{errors.New("408 Request Timeout"), true},
+		{errors.New("429 Too Many Requests"), true},
+		{errors.New("500 Internal Server Error"), true},
+		{errors.New("502 Bad Gateway"), true},
+		{errors.New("Error 503, Message: high demand, Status: UNAVAILABLE"), true},
+		{errors.New("504 Gateway Timeout"), true},
+		{errors.New("RESOURCE_EXHAUSTED: quota exceeded"), true},
+		{errors.New("ResourceExhausted"), true},
+		{errors.New("ServiceUnavailable"), true},
+		// Network errors (aligned with adk-python httpx.NetworkError).
+		{errors.New("dial tcp 127.0.0.1:443: connection refused"), true},
+		{errors.New("read tcp: connection reset by peer"), true},
+		{errors.New("lookup api.example.com: no such host"), true},
+		{errors.New("dial tcp: i/o timeout"), true},
+		{errors.New("connect: network is unreachable"), true},
+		{fmt.Errorf("wrapped: %w", errors.New("503 service down")), true},
+	}
+	for _, tt := range tests {
+		t.Run(fmt.Sprintf("%v", tt.err), func(t *testing.T) {
+			got := defaultIsRetryable(tt.err)
+			if got != tt.want {
+				t.Errorf("defaultIsRetryable(%v) = %v, want %v", tt.err, got, tt.want)
+			}
+		})
+	}
+}

--- a/model/retry_test.go
+++ b/model/retry_test.go
@@ -1,0 +1,475 @@
+// Copyright 2025 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package model
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"iter"
+	"sync/atomic"
+	"testing"
+	"time"
+
+	"google.golang.org/genai"
+)
+
+// fakeLLM records calls and returns preconfigured responses/errors per attempt.
+type fakeLLM struct {
+	attempts  atomic.Int32
+	responses []fakeLLMResult
+}
+
+type fakeLLMResult struct {
+	// For non-streaming: single response/error pair.
+	resp *LLMResponse
+	err  error
+	// For streaming: sequence of response/error pairs.
+	stream []struct {
+		resp *LLMResponse
+		err  error
+	}
+}
+
+func (f *fakeLLM) Name() string { return "fake" }
+
+func (f *fakeLLM) GenerateContent(_ context.Context, _ *LLMRequest, stream bool) iter.Seq2[*LLMResponse, error] {
+	idx := int(f.attempts.Add(1)) - 1
+	if idx >= len(f.responses) {
+		idx = len(f.responses) - 1
+	}
+	result := f.responses[idx]
+
+	return func(yield func(*LLMResponse, error) bool) {
+		if stream && len(result.stream) > 0 {
+			for _, s := range result.stream {
+				if !yield(s.resp, s.err) {
+					return
+				}
+				if s.err != nil {
+					return
+				}
+			}
+			return
+		}
+		yield(result.resp, result.err)
+	}
+}
+
+func okResponse(text string) *LLMResponse {
+	return &LLMResponse{
+		Content: &genai.Content{Parts: []*genai.Part{{Text: text}}},
+	}
+}
+
+func TestRetryUnary_SuccessNoRetry(t *testing.T) {
+	fake := &fakeLLM{responses: []fakeLLMResult{
+		{resp: okResponse("hello")},
+	}}
+	llm := WithRetry(fake, nil)
+
+	var got *LLMResponse
+	for r, err := range llm.GenerateContent(context.Background(), &LLMRequest{}, false) {
+		if err != nil {
+			t.Fatalf("unexpected error: %v", err)
+		}
+		got = r
+	}
+
+	if got.Content.Parts[0].Text != "hello" {
+		t.Errorf("want 'hello', got %q", got.Content.Parts[0].Text)
+	}
+	if fake.attempts.Load() != 1 {
+		t.Errorf("want 1 attempt, got %d", fake.attempts.Load())
+	}
+}
+
+func TestRetryUnary_RetriesOnTransientError(t *testing.T) {
+	fake := &fakeLLM{responses: []fakeLLMResult{
+		{err: errors.New("Error 503, UNAVAILABLE")},
+		{err: errors.New("Error 503, UNAVAILABLE")},
+		{resp: okResponse("recovered")},
+	}}
+	cfg := &RetryConfig{
+		MaxRetries:   3,
+		InitialDelay: time.Millisecond,
+		MaxDelay:     10 * time.Millisecond,
+		Jitter:       time.Millisecond,
+	}
+	llm := WithRetry(fake, cfg)
+
+	var got *LLMResponse
+	for r, err := range llm.GenerateContent(context.Background(), &LLMRequest{}, false) {
+		if err != nil {
+			t.Fatalf("unexpected error: %v", err)
+		}
+		got = r
+	}
+
+	if got.Content.Parts[0].Text != "recovered" {
+		t.Errorf("want 'recovered', got %q", got.Content.Parts[0].Text)
+	}
+	if fake.attempts.Load() != 3 {
+		t.Errorf("want 3 attempts, got %d", fake.attempts.Load())
+	}
+}
+
+func TestRetryUnary_NonRetryableError(t *testing.T) {
+	fake := &fakeLLM{responses: []fakeLLMResult{
+		{err: errors.New("invalid API key")},
+	}}
+	cfg := &RetryConfig{InitialDelay: time.Millisecond, Jitter: time.Millisecond}
+	llm := WithRetry(fake, cfg)
+
+	for _, err := range llm.GenerateContent(context.Background(), &LLMRequest{}, false) {
+		if err == nil {
+			t.Fatal("expected error, got nil")
+		}
+		if err.Error() != "invalid API key" {
+			t.Errorf("want 'invalid API key', got %q", err.Error())
+		}
+	}
+
+	if fake.attempts.Load() != 1 {
+		t.Errorf("want 1 attempt (no retry), got %d", fake.attempts.Load())
+	}
+}
+
+func TestRetryUnary_ExhaustsRetries(t *testing.T) {
+	fake := &fakeLLM{responses: []fakeLLMResult{
+		{err: errors.New("503 UNAVAILABLE")},
+		{err: errors.New("503 UNAVAILABLE")},
+		{err: errors.New("503 UNAVAILABLE")},
+		{err: errors.New("503 UNAVAILABLE")},
+	}}
+	cfg := &RetryConfig{
+		MaxRetries:   3,
+		InitialDelay: time.Millisecond,
+		MaxDelay:     10 * time.Millisecond,
+		Jitter:       time.Millisecond,
+	}
+	llm := WithRetry(fake, cfg)
+
+	var lastErr error
+	for _, err := range llm.GenerateContent(context.Background(), &LLMRequest{}, false) {
+		lastErr = err
+	}
+
+	if lastErr == nil {
+		t.Fatal("expected error after exhausting retries")
+	}
+	// 1 initial + 3 retries = 4 total
+	if fake.attempts.Load() != 4 {
+		t.Errorf("want 4 attempts, got %d", fake.attempts.Load())
+	}
+}
+
+func TestRetryUnary_RespectsContextCancellation(t *testing.T) {
+	fake := &fakeLLM{responses: []fakeLLMResult{
+		{err: errors.New("503 UNAVAILABLE")},
+		{err: errors.New("503 UNAVAILABLE")},
+	}}
+	cfg := &RetryConfig{
+		MaxRetries:   5,
+		InitialDelay: time.Second, // long delay so cancellation beats it
+	}
+	llm := WithRetry(fake, cfg)
+
+	ctx, cancel := context.WithCancel(context.Background())
+	// Cancel after a short time to interrupt the backoff sleep.
+	go func() {
+		time.Sleep(50 * time.Millisecond)
+		cancel()
+	}()
+
+	var lastErr error
+	for _, err := range llm.GenerateContent(ctx, &LLMRequest{}, false) {
+		lastErr = err
+	}
+
+	if lastErr == nil {
+		t.Fatal("expected error after context cancellation")
+	}
+	if !errors.Is(lastErr, context.Canceled) {
+		t.Fatalf("error = %v, want context.Canceled", lastErr)
+	}
+	// Should not have exhausted all retries.
+	if fake.attempts.Load() > 3 {
+		t.Errorf("expected fewer attempts due to cancellation, got %d", fake.attempts.Load())
+	}
+}
+
+func TestRetryUnary_CustomIsRetryable(t *testing.T) {
+	fake := &fakeLLM{responses: []fakeLLMResult{
+		{err: errors.New("custom-transient")},
+		{resp: okResponse("ok")},
+	}}
+	cfg := &RetryConfig{
+		InitialDelay: time.Millisecond,
+		Jitter:       time.Millisecond,
+		IsRetryable: func(err error) bool {
+			return err != nil && err.Error() == "custom-transient"
+		},
+	}
+	llm := WithRetry(fake, cfg)
+
+	var got *LLMResponse
+	for r, err := range llm.GenerateContent(context.Background(), &LLMRequest{}, false) {
+		if err != nil {
+			t.Fatalf("unexpected error: %v", err)
+		}
+		got = r
+	}
+
+	if got.Content.Parts[0].Text != "ok" {
+		t.Errorf("want 'ok', got %q", got.Content.Parts[0].Text)
+	}
+	if fake.attempts.Load() != 2 {
+		t.Errorf("want 2 attempts, got %d", fake.attempts.Load())
+	}
+}
+
+func TestRetryStream_SuccessNoRetry(t *testing.T) {
+	fake := &fakeLLM{responses: []fakeLLMResult{
+		{stream: []struct {
+			resp *LLMResponse
+			err  error
+		}{
+			{resp: &LLMResponse{Content: &genai.Content{Parts: []*genai.Part{{Text: "chunk1"}}}, Partial: true}},
+			{resp: &LLMResponse{Content: &genai.Content{Parts: []*genai.Part{{Text: "chunk2"}}}, TurnComplete: true}},
+		}},
+	}}
+	llm := WithRetry(fake, &RetryConfig{InitialDelay: time.Millisecond, Jitter: time.Millisecond})
+
+	var chunks []string
+	for r, err := range llm.GenerateContent(context.Background(), &LLMRequest{}, true) {
+		if err != nil {
+			t.Fatalf("unexpected error: %v", err)
+		}
+		chunks = append(chunks, r.Content.Parts[0].Text)
+	}
+
+	if len(chunks) != 2 || chunks[0] != "chunk1" || chunks[1] != "chunk2" {
+		t.Errorf("unexpected chunks: %v", chunks)
+	}
+	if fake.attempts.Load() != 1 {
+		t.Errorf("want 1 attempt, got %d", fake.attempts.Load())
+	}
+}
+
+func TestRetryStream_RetriesBeforeFirstData(t *testing.T) {
+	fake := &fakeLLM{responses: []fakeLLMResult{
+		{stream: []struct {
+			resp *LLMResponse
+			err  error
+		}{
+			{err: errors.New("503 UNAVAILABLE")},
+		}},
+		{stream: []struct {
+			resp *LLMResponse
+			err  error
+		}{
+			{resp: &LLMResponse{Content: &genai.Content{Parts: []*genai.Part{{Text: "ok"}}}, TurnComplete: true}},
+		}},
+	}}
+	cfg := &RetryConfig{
+		MaxRetries:   2,
+		InitialDelay: time.Millisecond,
+		Jitter:       time.Millisecond,
+	}
+	llm := WithRetry(fake, cfg)
+
+	var chunks []string
+	for r, err := range llm.GenerateContent(context.Background(), &LLMRequest{}, true) {
+		if err != nil {
+			t.Fatalf("unexpected error: %v", err)
+		}
+		chunks = append(chunks, r.Content.Parts[0].Text)
+	}
+
+	if len(chunks) != 1 || chunks[0] != "ok" {
+		t.Errorf("unexpected chunks: %v", chunks)
+	}
+	if fake.attempts.Load() != 2 {
+		t.Errorf("want 2 attempts, got %d", fake.attempts.Load())
+	}
+}
+
+func TestRetryStream_NoRetryAfterPartialData(t *testing.T) {
+	fake := &fakeLLM{responses: []fakeLLMResult{
+		{stream: []struct {
+			resp *LLMResponse
+			err  error
+		}{
+			{resp: &LLMResponse{Content: &genai.Content{Parts: []*genai.Part{{Text: "partial"}}}, Partial: true}},
+			{err: errors.New("503 UNAVAILABLE")},
+		}},
+	}}
+	cfg := &RetryConfig{
+		MaxRetries:   3,
+		InitialDelay: time.Millisecond,
+		Jitter:       time.Millisecond,
+	}
+	llm := WithRetry(fake, cfg)
+
+	var lastErr error
+	var chunks []string
+	for r, err := range llm.GenerateContent(context.Background(), &LLMRequest{}, true) {
+		if err != nil {
+			lastErr = err
+			break
+		}
+		chunks = append(chunks, r.Content.Parts[0].Text)
+	}
+
+	if lastErr == nil {
+		t.Fatal("expected error after partial data")
+	}
+	if len(chunks) != 1 || chunks[0] != "partial" {
+		t.Errorf("unexpected chunks before error: %v", chunks)
+	}
+	// Only 1 attempt — no retry because data was already yielded.
+	if fake.attempts.Load() != 1 {
+		t.Errorf("want 1 attempt (no retry after partial), got %d", fake.attempts.Load())
+	}
+}
+
+func TestRetryName_DelegatesToInner(t *testing.T) {
+	fake := &fakeLLM{}
+	llm := WithRetry(fake, nil)
+	if llm.Name() != "fake" {
+		t.Errorf("want 'fake', got %q", llm.Name())
+	}
+}
+
+func TestWithRetry_NilLLM(t *testing.T) {
+	if got := WithRetry(nil, nil); got != nil {
+		t.Fatalf("WithRetry(nil, nil) = %T, want nil", got)
+	}
+}
+
+type backendLLM struct {
+	fakeLLM
+	backend genai.Backend
+}
+
+func (m *backendLLM) GetGoogleLLMVariant() genai.Backend { return m.backend }
+
+func TestRetryGoogleLLMVariant_DelegatesToInner(t *testing.T) {
+	inner := &backendLLM{backend: genai.BackendGeminiAPI}
+	wrapped := WithRetry(inner, nil)
+	googleLLM, ok := wrapped.(interface{ GetGoogleLLMVariant() genai.Backend })
+	if !ok {
+		t.Fatal("retry wrapper does not preserve GoogleLLM capability")
+	}
+	if got := googleLLM.GetGoogleLLMVariant(); got != genai.BackendGeminiAPI {
+		t.Fatalf("backend = %v, want %v", got, genai.BackendGeminiAPI)
+	}
+}
+
+func TestRetryConfig_Defaults(t *testing.T) {
+	var cfg *RetryConfig // nil
+	if cfg.maxRetries() != 5 {
+		t.Errorf("default maxRetries: want 5, got %d", cfg.maxRetries())
+	}
+	if cfg.initialDelay() != time.Second {
+		t.Errorf("default initialDelay: want 1s, got %v", cfg.initialDelay())
+	}
+	if cfg.maxDelay() != 60*time.Second {
+		t.Errorf("default maxDelay: want 60s, got %v", cfg.maxDelay())
+	}
+	if cfg.multiplier() != 2.0 {
+		t.Errorf("default multiplier: want 2.0, got %f", cfg.multiplier())
+	}
+	if cfg.jitter() != time.Second {
+		t.Errorf("default jitter: want 1s, got %v", cfg.jitter())
+	}
+}
+
+func TestRetryConfig_BackoffGrowth(t *testing.T) {
+	cfg := &RetryConfig{
+		InitialDelay: 100 * time.Millisecond,
+		MaxDelay:     10 * time.Second,
+		Multiplier:   2.0,
+		Jitter:       10 * time.Millisecond, // small jitter to keep growth observable
+	}
+
+	d0 := cfg.backoff(0)
+	d1 := cfg.backoff(1)
+	d2 := cfg.backoff(2)
+
+	// Jitter is absolute: delay is in [base, base + 10ms).
+	assertInRange(t, "backoff(0)", d0, 100*time.Millisecond, 110*time.Millisecond)
+	assertInRange(t, "backoff(1)", d1, 200*time.Millisecond, 210*time.Millisecond)
+	assertInRange(t, "backoff(2)", d2, 400*time.Millisecond, 410*time.Millisecond)
+
+	if d1 <= d0 || d2 <= d1 {
+		t.Errorf("backoff should increase: d0=%v, d1=%v, d2=%v", d0, d1, d2)
+	}
+}
+
+func TestRetryConfig_BackoffCapsAtMax(t *testing.T) {
+	cfg := &RetryConfig{
+		InitialDelay: time.Second,
+		MaxDelay:     5 * time.Second,
+		Multiplier:   10.0,
+	}
+	// 1s * 10^2 = 100s → capped at 5s, plus absolute jitter up to 1s (default).
+	d := cfg.backoff(2)
+	assertInRange(t, "backoff(2)", d, 5*time.Second, 6*time.Second)
+}
+
+func assertInRange(t *testing.T, name string, got, lo, hi time.Duration) {
+	t.Helper()
+	if got < lo || got > hi {
+		t.Errorf("%s: got %v, want in [%v, %v]", name, got, lo, hi)
+	}
+}
+
+func TestDefaultIsRetryable(t *testing.T) {
+	tests := []struct {
+		err  error
+		want bool
+	}{
+		{nil, false},
+		{errors.New("invalid request"), false},
+		{errors.New("request took 500ms"), false},
+		{errors.New("project ID 123429"), false},
+		{errors.New("408 Request Timeout"), true},
+		{errors.New("429 Too Many Requests"), true},
+		{errors.New("500 Internal Server Error"), true},
+		{errors.New("502 Bad Gateway"), true},
+		{errors.New("Error 503, Message: high demand, Status: UNAVAILABLE"), true},
+		{errors.New("504 Gateway Timeout"), true},
+		{errors.New("RESOURCE_EXHAUSTED: quota exceeded"), true},
+		{errors.New("ResourceExhausted"), true},
+		{errors.New("ServiceUnavailable"), true},
+		// Network errors (aligned with adk-python httpx.NetworkError).
+		{errors.New("dial tcp 127.0.0.1:443: connection refused"), true},
+		{errors.New("read tcp: connection reset by peer"), true},
+		{errors.New("lookup api.example.com: no such host"), true},
+		{errors.New("dial tcp: i/o timeout"), true},
+		{errors.New("connect: network is unreachable"), true},
+		{fmt.Errorf("wrapped: %w", errors.New("503 service down")), true},
+	}
+	for _, tt := range tests {
+		t.Run(fmt.Sprintf("%v", tt.err), func(t *testing.T) {
+			got := defaultIsRetryable(tt.err)
+			if got != tt.want {
+				t.Errorf("defaultIsRetryable(%v) = %v, want %v", tt.err, got, tt.want)
+			}
+		})
+	}
+}


### PR DESCRIPTION
                                            
  ### Link to Issue or Description of Change                                                                            
                                                                                                                          
  - Closes: #710                                                                                                                                
                                                                                                                        
  **Problem:**                                                                                                          
  LLM API calls can fail with transient errors (429 rate limiting, 503 service unavailable, RESOURCE_EXHAUSTED) causing 
  unnecessary request failures. There is currently no built-in retry mechanism in the model layer to handle these       
  recoverable errors gracefully.                                                                                        
                                                            
  **Solution:**                                                                                                         
  Add a `WithRetry()` LLM decorator that wraps any `model.LLM` implementation with automatic retry logic using 
  configurable exponential backoff and jitter, aligned with adk-python's retry behavior                                 
  (`tenacity.wait_exponential_jitter`).                     

  Key design decisions:                                                                                                 
  - **Decorator pattern**: `WithRetry(llm, cfg)` returns a new `LLM`, composable with any existing implementation 
  without modifying it. Unlike adk-python where retry logic is embedded in each LLM class, the Go version uses this     
  pattern to avoid duplication across `gemini` and `apigee` packages, following idiomatic Go composition.
  - **Aligned with adk-python defaults**: 5 retries, 1s initial delay, 60s max delay, 2x multiplier, 1s absolute jitter.
  - **Retryable errors**: HTTP 408/429/500/502/503/504, gRPC UNAVAILABLE/RESOURCE_EXHAUSTED, and network errors         
  (connection refused/reset, DNS failure, i/o timeout) — matching adk-python's `default_status_codes` and
  `httpx.NetworkError`.                                                                                                 
  - **Stream-safe**: Streaming calls only retry before the first yielded response to prevent duplicate partial content. 
  - **Context-aware**: Backoff sleeps respect context cancellation.                                                     
  - **Customizable**: Users can provide their own `IsRetryable` function for custom error classification.               
                                                                                                                        
  ### Testing Plan                                                                                                      
                                                                                                                        
  **Unit Tests:**                                                                                                       
                                                                                                                        
  - [x] I have added or updated unit tests for my change.                                                               
  - [x] All unit tests pass locally.                        
                                              
  13 test cases with 18 sub-tests covering:                                                                             
  - Unary: success without retry, retry on transient error, non-retryable error passthrough, retry exhaustion, context
  cancellation, custom `IsRetryable`                                                                                    
  - Streaming: success without retry, retry before first data, no retry after partial data
  - Config: default values, backoff growth, backoff max cap                                                             
  - Error classification: table-driven tests for all HTTP status codes, gRPC errors, and network errors                 
  - Name delegation                                                                                                                 
   
<img width="750" height="813" alt="截屏2026-04-15 22 24 00" src="https://github.com/user-attachments/assets/e3e9c53d-4aa0-4546-b3c9-396b12f581c3" />
                                                                                                                        
  **Manual End-to-End (E2E) Tests:**                                                                                    
                                                                                                                        
  ```go                                                                                                                 
  // Default config (aligned with adk-python):
  llm := model.WithRetry(baseLLM, nil)                                                                                  
                                                            
  // Custom config:                       
  llm := model.WithRetry(baseLLM, &model.RetryConfig{                                                                   
      MaxRetries:   3,                                                                                                  
      InitialDelay: 2 * time.Second,                                                                                    
      Jitter:       500 * time.Millisecond,                                                                             
  })                                                        
```
  The wrapped LLM is a drop-in replacement for any existing model.LLM. When a retryable error occurs, the retry log     
  output looks like:                      
                                                                                                                        
  WARN retrying LLM call model=gemini-2.5-flash attempt=1 max_retries=5 delay=1.536s error="Error 503, Message: high    
  demand, Status: UNAVAILABLE"                
                                                                                                                        
  Checklist                                                 
                                                                                                                        
  - I have read the CONTRIBUTING.md document.
  - I have performed a self-review of my own code.                                                                      
  - I have commented my code, particularly in hard-to-understand areas.
  - I have added tests that prove my fix is effective or that my feature works.
  - New and existing unit tests pass locally with my changes.
  - I have manually tested my changes end-to-end.                                                                       
  - Any dependent changes have been merged and published in downstream modules.
                                                                                                                        
   Additional context                                                                                                
                                                                                                                       
  **Design note — standalone `model/retry.go` vs embedding in each LLM:**                                               
                                                                                                                        
  In adk-python, retry logic is embedded in each LLM class (`google_llm.py` delegates to SDK's `HttpRetryOptions`,      
  `apigee_llm.py` uses tenacity). The Go version extracts it into a standalone decorator because:                       
                                                                                                                        
  1. Go's `model.LLM` is a single interface — a decorator wraps any implementation without modifying it.                
  2. Avoids duplicating retry logic across `model/gemini/` and `model/apigee/` packages.                                
  3. Follows idiomatic Go composition (`WithRetry(llm, cfg)` is the same pattern as `io.LimitReader`,                   
  `http.TimeoutHandler`, etc.).                                                         
                                                                                                                        
  New files:                                                                                                            
  - `model/retry.go` — `RetryConfig`, `WithRetry()`, `retryLLM` decorator, `defaultIsRetryable`, `sleepCtx`
  - `model/retry_test.go` — 13 test cases with `fakeLLM` test double 