### PR TITLE
feat: Implement SkillToolset.

### DIFF
--- a/examples/skills/main.go
+++ b/examples/skills/main.go
@@ -1,0 +1,83 @@
+// Copyright 2026 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+// Package provides an example of using skills via skill toolset.
+package main
+
+import (
+	"context"
+	"log"
+	"os"
+
+	"google.golang.org/genai"
+
+	"google.golang.org/adk/agent"
+	"google.golang.org/adk/agent/llmagent"
+	"google.golang.org/adk/cmd/launcher"
+	"google.golang.org/adk/cmd/launcher/full"
+	"google.golang.org/adk/model/gemini"
+	"google.golang.org/adk/tool"
+	"google.golang.org/adk/tool/skilltoolset"
+	"google.golang.org/adk/tool/skilltoolset/skill"
+)
+
+// IMPORTANT: run from the examples/skills directory.
+// It relies on the relative path ('./skills') from the examples/skills dir.
+//
+// go run main.go
+//
+/*
+  Example user query:
+
+	What countries do you know current prices for? List the countries.
+	Then find the prices for each. Then re-organize these prices into a table:
+	products on one side - countries on another.
+*/
+func main() {
+	ctx := context.Background()
+
+	model, err := gemini.NewModel(ctx, "gemini-2.5-flash", &genai.ClientConfig{
+		APIKey: os.Getenv("GOOGLE_API_KEY"),
+	})
+	if err != nil {
+		log.Fatalf("Failed to create model: %v", err)
+	}
+
+	skillToolset, err := skilltoolset.New(ctx, skilltoolset.Config{
+		Source: skill.NewFileSystemSource(os.DirFS("./skills")),
+	})
+	if err != nil {
+		log.Fatalf("Failed to create skill toolset: %v", err)
+	}
+
+	a, err := llmagent.New(llmagent.Config{
+		Name:        "skills_agent",
+		Model:       model,
+		Description: "Agent to demonstrate using skills.",
+		Instruction: "You are a helpful assistant.",
+		Toolsets:    []tool.Toolset{skillToolset},
+	})
+	if err != nil {
+		log.Fatalf("Failed to create agent: %v", err)
+	}
+
+	config := &launcher.Config{
+		AgentLoader: agent.NewSingleLoader(a),
+	}
+
+	l := full.NewLauncher()
+	if err = l.Execute(ctx, config, os.Args[1:]); err != nil {
+		log.Fatalf("Run failed: %v\n\n%s", err, l.CommandLineSyntax())
+	}
+}

--- a/examples/skills/skills/grocery-prices/SKILL.md
+++ b/examples/skills/skills/grocery-prices/SKILL.md
@@ -1,0 +1,15 @@
+---
+name: grocery-prices
+description: A skill to calculate grocery prices with country-specific taxes.
+---
+# Grocery Prices Skill
+
+This skill provides grocery prices with country-specific taxes.
+
+## Instructions
+1. When asked about grocery prices or totals for a specific country, check if there is a resource file for the country in the `assets/` directory.
+2. The file will be named `prices_<country_code>.json`.
+3. Apply taxes to specific categories based on the country:
+   - For **US** (us): Add a 20% tax to items in the **"electronics"** and **"alcohol"** categories.
+   - For **Poland** (pl): Add a 23% tax to items in the **"electronics"** and **"alcohol"** categories.
+4. Calculate the final price including tax and report it to the user.

--- a/examples/skills/skills/grocery-prices/assets/prices_pl.json
+++ b/examples/skills/skills/grocery-prices/assets/prices_pl.json
@@ -1,0 +1,22 @@
+[
+  {
+    "item": "Milk",
+    "price": 4.00,
+    "category": "Dairy"
+  },
+  {
+    "item": "Bread",
+    "price": 5.00,
+    "category": "Bakery"
+  },
+  {
+    "item": "Beer",
+    "price": 12.00,
+    "category": "Alcohol"
+  },
+  {
+    "item": "Headphones",
+    "price": 200.00,
+    "category": "Electronics"
+  }
+]

--- a/examples/skills/skills/grocery-prices/assets/prices_us.json
+++ b/examples/skills/skills/grocery-prices/assets/prices_us.json
@@ -1,0 +1,22 @@
+[
+  {
+    "item": "Milk",
+    "price": 2.50,
+    "category": "Dairy"
+  },
+  {
+    "item": "Bread",
+    "price": 3.00,
+    "category": "Bakery"
+  },
+  {
+    "item": "Beer",
+    "price": 10.00,
+    "category": "Alcohol"
+  },
+  {
+    "item": "Headphones",
+    "price": 50.00,
+    "category": "Electronics"
+  }
+]

--- a/examples/skills/skills/weather/SKILL.md
+++ b/examples/skills/skills/weather/SKILL.md
@@ -1,0 +1,12 @@
+---
+name: weather
+description: A skill to check weather in different countries.
+---
+# Weather Skill
+
+This skill provides weather information for different countries.
+
+## Instructions
+1. When asked about weather in a specific country, check if there is a resource file for that country in the `references/` directory.
+2. The resource file will be named `weather_<country_code>.json`. Supports `us` and `pl`.
+3. Report the weather for the country to the user.

--- a/examples/skills/skills/weather/references/weather_pl.json
+++ b/examples/skills/skills/weather/references/weather_pl.json
@@ -1,0 +1,6 @@
+{
+  "country": "Poland",
+  "temperature": "15°C",
+  "condition": "Cloudy",
+  "forecast": "Rain expected in the evening"
+}

--- a/examples/skills/skills/weather/references/weather_us.json
+++ b/examples/skills/skills/weather/references/weather_us.json
@@ -1,0 +1,6 @@
+{
+  "country": "US",
+  "temperature": "77°F",
+  "condition": "Sunny",
+  "forecast": "Sunny all day"
+}

--- a/tool/skilltoolset/internal/skilltool/list_skills.go
+++ b/tool/skilltoolset/internal/skilltool/list_skills.go
@@ -1,0 +1,70 @@
+// Copyright 2026 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package skilltool
+
+import (
+	"html"
+	"strings"
+
+	"google.golang.org/adk/tool"
+	"google.golang.org/adk/tool/functiontool"
+	"google.golang.org/adk/tool/skilltoolset/skill"
+)
+
+// ListSkillsArgs represents the input for ListSkills tool.
+type ListSkillsArgs struct{}
+
+// ListSkillsResult represents the output for ListSkills tool.
+type ListSkillsResult struct {
+	SkillsXML string `json:"skills"`
+}
+
+// ListSkills creates a tool.Tool to list available skills.
+func ListSkills(source skill.Source) (tool.Tool, error) {
+	return functiontool.New(
+		functiontool.Config{
+			Name:        "list_skills",
+			Description: "Lists all available skills with their names and descriptions.",
+		},
+		func(ctx tool.Context, args ListSkillsArgs) (*ListSkillsResult, error) {
+			return listSkills(ctx, args, source)
+		},
+	)
+}
+
+func listSkills(ctx tool.Context, _ ListSkillsArgs, source skill.Source) (*ListSkillsResult, error) {
+	skills, err := source.ListFrontmatters(ctx)
+	if err != nil {
+		return nil, err
+	}
+	return &ListSkillsResult{SkillsXML: skillsToXML(skills)}, nil
+}
+
+func skillsToXML(frontmatters []*skill.Frontmatter) string {
+	var sb strings.Builder
+	sb.WriteString("<available_skills>\n")
+	for _, fm := range frontmatters {
+		sb.WriteString("<skill>\n")
+		sb.WriteString("<name>\n")
+		sb.WriteString(html.EscapeString(fm.Name))
+		sb.WriteString("\n</name>\n")
+		sb.WriteString("<description>\n")
+		sb.WriteString(html.EscapeString(fm.Description))
+		sb.WriteString("\n</description>\n")
+		sb.WriteString("</skill>\n")
+	}
+	sb.WriteString("</available_skills>")
+	return sb.String()
+}

--- a/tool/skilltoolset/internal/skilltool/list_skills.go
+++ b/tool/skilltoolset/internal/skilltool/list_skills.go
@@ -49,10 +49,10 @@ func listSkills(ctx tool.Context, _ ListSkillsArgs, source skill.Source) (*ListS
 	if err != nil {
 		return nil, err
 	}
-	return &ListSkillsResult{SkillsXML: skillsToXML(skills)}, nil
+	return &ListSkillsResult{SkillsXML: SkillsToXML(skills)}, nil
 }
 
-func skillsToXML(frontmatters []*skill.Frontmatter) string {
+func SkillsToXML(frontmatters []*skill.Frontmatter) string {
 	var sb strings.Builder
 	sb.WriteString("<available_skills>\n")
 	for _, fm := range frontmatters {

--- a/tool/skilltoolset/internal/skilltool/load_skill.go
+++ b/tool/skilltoolset/internal/skilltool/load_skill.go
@@ -1,0 +1,84 @@
+// Copyright 2026 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+// Package skilltool provides the standard tools for the skill toolset.
+package skilltool
+
+import (
+	"fmt"
+
+	"google.golang.org/adk/tool"
+	"google.golang.org/adk/tool/functiontool"
+	"google.golang.org/adk/tool/skilltoolset/skill"
+)
+
+// LoadSkillArgs represents the input to load a skill.
+type LoadSkillArgs struct {
+	Name string `json:"name" jsonschema:"The name of the skill to load."`
+}
+
+type FrontmatterJSON struct {
+	Name          string            `json:"name"`
+	Description   string            `json:"description"`
+	License       string            `json:"license,omitempty"`
+	Compatibility string            `json:"compatibility,omitempty"`
+	Metadata      map[string]string `json:"metadata,omitempty"`
+	AllowedTools  []string          `json:"allowed-tools,omitempty"`
+}
+
+// LoadSkillResult represents the output of a loaded skill.
+type LoadSkillResult struct {
+	SkillName    string           `json:"skill_name,omitempty"`
+	Instructions string           `json:"instructions,omitempty"`
+	Frontmatter  *FrontmatterJSON `json:"frontmatter,omitempty"`
+}
+
+// LoadSkill creates a tool.Tool to load a skill's instructions.
+func LoadSkill(source skill.Source) (tool.Tool, error) {
+	return functiontool.New(
+		functiontool.Config{
+			Name:        "load_skill",
+			Description: "Loads the SKILL.md instructions for a given skill.",
+		},
+		func(ctx tool.Context, args LoadSkillArgs) (*LoadSkillResult, error) {
+			return loadSkill(ctx, args, source)
+		},
+	)
+}
+
+func loadSkill(ctx tool.Context, args LoadSkillArgs, source skill.Source) (*LoadSkillResult, error) {
+	if args.Name == "" {
+		return nil, fmt.Errorf("skill name is required to load a skill")
+	}
+	frontmatter, err := source.LoadFrontmatter(ctx, args.Name)
+	if err != nil {
+		return nil, fmt.Errorf("load frontmatter for skill %q: %w", args.Name, err)
+	}
+	instructions, err := source.LoadInstructions(ctx, args.Name)
+	if err != nil {
+		return nil, fmt.Errorf("load instructions for skill %q: %w", args.Name, err)
+	}
+	return &LoadSkillResult{
+		SkillName:    args.Name,
+		Instructions: instructions,
+		Frontmatter: &FrontmatterJSON{
+			Name:          frontmatter.Name,
+			Description:   frontmatter.Description,
+			License:       frontmatter.License,
+			Compatibility: frontmatter.Compatibility,
+			Metadata:      frontmatter.Metadata,
+			AllowedTools:  frontmatter.AllowedTools,
+		},
+	}, nil
+}

--- a/tool/skilltoolset/internal/skilltool/load_skill_resource.go
+++ b/tool/skilltoolset/internal/skilltool/load_skill_resource.go
@@ -1,0 +1,75 @@
+// Copyright 2026 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package skilltool
+
+import (
+	"fmt"
+	"io"
+
+	"google.golang.org/adk/tool"
+	"google.golang.org/adk/tool/functiontool"
+	"google.golang.org/adk/tool/skilltoolset/skill"
+)
+
+// LoadSkillResourceArgs represents the input for retrieving a resource out of a skill's resources.
+type LoadSkillResourceArgs struct {
+	SkillName    string `json:"skill_name" jsonschema:"The name of the skill."`
+	ResourcePath string `json:"resource_path" jsonschema:"The relative path to the resource (e.g., 'references/my_doc.md', 'assets/template.txt', or 'scripts/setup.sh')."`
+}
+
+// LoadSkillResourceResult encapsulates the resource content.
+type LoadSkillResourceResult struct {
+	SkillName string `json:"skill_name,omitempty"`
+	Path      string `json:"path,omitempty"`
+	Content   string `json:"content,omitempty"`
+}
+
+// LoadSkillResource creates a tool.Tool to load a resource file for a skill.
+func LoadSkillResource(source skill.Source) (tool.Tool, error) {
+	return functiontool.New(
+		functiontool.Config{
+			Name:        "load_skill_resource",
+			Description: "Loads a resource file (e.g., from references/ or assets/) associated with the specified skill.",
+		},
+		func(ctx tool.Context, args LoadSkillResourceArgs) (*LoadSkillResourceResult, error) {
+			return loadSkillResource(ctx, args, source)
+		},
+	)
+}
+
+func loadSkillResource(ctx tool.Context, args LoadSkillResourceArgs, source skill.Source) (*LoadSkillResourceResult, error) {
+	if args.SkillName == "" {
+		return nil, fmt.Errorf("skill name is required to load a resource")
+	}
+	if args.ResourcePath == "" {
+		return nil, fmt.Errorf("resource path is required to load a resource for skill %q", args.SkillName)
+	}
+	reader, err := source.LoadResource(ctx, args.SkillName, args.ResourcePath)
+	if err != nil {
+		return nil, fmt.Errorf("load resource '%s' from skill '%s': %w", args.ResourcePath, args.SkillName, err)
+	}
+	defer func() {
+		_ = reader.Close()
+	}()
+	content, err := io.ReadAll(reader)
+	if err != nil {
+		return nil, fmt.Errorf("read resource '%s' from skill '%s': %w", args.ResourcePath, args.SkillName, err)
+	}
+	return &LoadSkillResourceResult{
+		SkillName: args.SkillName,
+		Path:      args.ResourcePath,
+		Content:   string(content),
+	}, nil
+}

--- a/tool/skilltoolset/internal/skilltool/load_skill_resource.go
+++ b/tool/skilltoolset/internal/skilltool/load_skill_resource.go
@@ -23,6 +23,8 @@ import (
 	"google.golang.org/adk/tool/skilltoolset/skill"
 )
 
+const maxResourceSize = 10 * 1024 * 1024 // 10 MiB
+
 // LoadSkillResourceArgs represents the input for retrieving a resource out of a skill's resources.
 type LoadSkillResourceArgs struct {
 	SkillName    string `json:"skill_name" jsonschema:"The name of the skill."`
@@ -63,9 +65,12 @@ func loadSkillResource(ctx tool.Context, args LoadSkillResourceArgs, source skil
 	defer func() {
 		_ = reader.Close()
 	}()
-	content, err := io.ReadAll(reader)
+	content, err := io.ReadAll(io.LimitReader(reader, maxResourceSize+1))
 	if err != nil {
 		return nil, fmt.Errorf("read resource '%s' from skill '%s': %w", args.ResourcePath, args.SkillName, err)
+	}
+	if int64(len(content)) > maxResourceSize {
+		return nil, fmt.Errorf("resource '%s' from skill '%s' is too large (limit: %d bytes)", args.ResourcePath, args.SkillName, maxResourceSize)
 	}
 	return &LoadSkillResourceResult{
 		SkillName: args.SkillName,

--- a/tool/skilltoolset/internal/skilltool/tools_test.go
+++ b/tool/skilltoolset/internal/skilltool/tools_test.go
@@ -1,0 +1,187 @@
+// Copyright 2026 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package skilltool_test
+
+import (
+	"context"
+	"io"
+	"strings"
+	"testing"
+
+	"github.com/google/go-cmp/cmp"
+
+	icontext "google.golang.org/adk/internal/context"
+	"google.golang.org/adk/internal/toolinternal"
+	"google.golang.org/adk/tool"
+	"google.golang.org/adk/tool/skilltoolset/internal/skilltool"
+	"google.golang.org/adk/tool/skilltoolset/skill"
+)
+
+type mockSource struct {
+	frontmatters []*skill.Frontmatter
+	resources    map[string]map[string]string
+	instructions map[string]string
+}
+
+func (m *mockSource) ListFrontmatters(ctx context.Context) ([]*skill.Frontmatter, error) {
+	return m.frontmatters, nil
+}
+
+func (m *mockSource) ListResources(ctx context.Context, name, subpath string) ([]string, error) {
+	var res []string
+	for p := range m.resources[name] {
+		if strings.HasPrefix(p, subpath) {
+			res = append(res, p)
+		}
+	}
+	return res, nil
+}
+
+func (m *mockSource) LoadFrontmatter(ctx context.Context, name string) (*skill.Frontmatter, error) {
+	for _, fm := range m.frontmatters {
+		if fm.Name == name {
+			return fm, nil
+		}
+	}
+	return nil, skill.ErrSkillNotFound
+}
+
+func (m *mockSource) LoadInstructions(ctx context.Context, name string) (string, error) {
+	inst, ok := m.instructions[name]
+	if !ok {
+		return "", skill.ErrSkillNotFound
+	}
+	return inst, nil
+}
+
+func (m *mockSource) LoadResource(ctx context.Context, name, resourcePath string) (io.ReadCloser, error) {
+	res, ok := m.resources[name][resourcePath]
+	if !ok {
+		return nil, skill.ErrResourceNotFound
+	}
+	return io.NopCloser(strings.NewReader(res)), nil
+}
+
+func createToolContext(t *testing.T) tool.Context {
+	invCtx := icontext.NewInvocationContext(t.Context(), icontext.InvocationContextParams{})
+	return toolinternal.NewToolContext(invCtx, "", nil, nil)
+}
+
+func TestListSkills(t *testing.T) {
+	source := &mockSource{
+		frontmatters: []*skill.Frontmatter{
+			{Name: "skill1", Description: "description1"},
+			{Name: "skill2", Description: "description2"},
+		},
+	}
+
+	tTool, err := skilltool.ListSkills(source)
+	if err != nil {
+		t.Fatalf("ListSkills failed: %v", err)
+	}
+
+	funcTool, ok := tTool.(toolinternal.FunctionTool)
+	if !ok {
+		t.Fatal("tool does not implement toolinternal.FunctionTool")
+	}
+
+	result, err := funcTool.Run(createToolContext(t), map[string]any{})
+	if err != nil {
+		t.Fatalf("tool.Run failed: %v", err)
+	}
+
+	want := map[string]any{
+		"skills": "<available_skills>\n<skill>\n<name>\nskill1\n</name>\n<description>\ndescription1\n</description>\n</skill>\n<skill>\n<name>\nskill2\n</name>\n<description>\ndescription2\n</description>\n</skill>\n</available_skills>",
+	}
+
+	if diff := cmp.Diff(want, result); diff != "" {
+		t.Errorf("result mismatch (-want +got):\n%s", diff)
+	}
+}
+
+func TestLoadSkill(t *testing.T) {
+	source := &mockSource{
+		frontmatters: []*skill.Frontmatter{
+			{
+				Name:        "skill1",
+				Description: "description1",
+				Metadata: map[string]string{
+					"key1": "value1",
+				},
+			},
+		},
+		instructions: map[string]string{
+			"skill1": "instructions1",
+		},
+	}
+	tool, err := skilltool.LoadSkill(source)
+	if err != nil {
+		t.Fatalf("LoadSkill failed: %v", err)
+	}
+	functionTool, ok := tool.(toolinternal.FunctionTool)
+	if !ok {
+		t.Fatal("LoadSkill tool does not implement toolinternal.FunctionTool")
+	}
+
+	got, err := functionTool.Run(createToolContext(t), map[string]any{"name": "skill1"})
+	if err != nil {
+		t.Fatalf("LoadSkill tool.Run failed: %v", err)
+	}
+	want := map[string]any{
+		"skill_name":   "skill1",
+		"instructions": "instructions1",
+		"frontmatter": map[string]any{
+			"name":        "skill1",
+			"description": "description1",
+			"metadata": map[string]any{
+				"key1": "value1",
+			},
+		},
+	}
+	if diff := cmp.Diff(want, got); diff != "" {
+		t.Errorf("LoadSkill result mismatch (-want +got):\n%s", diff)
+	}
+}
+
+func TestLoadSkillResource(t *testing.T) {
+	source := &mockSource{
+		resources: map[string]map[string]string{
+			"skill1": {"assets/data.txt": "content1"},
+		},
+	}
+	tool, err := skilltool.LoadSkillResource(source)
+	if err != nil {
+		t.Fatalf("LoadSkillResource: %v", err)
+	}
+	functionTool, ok := tool.(toolinternal.FunctionTool)
+	if !ok {
+		t.Fatalf("LoadSkillResource: tool does not implement toolinternal.FunctionTool")
+	}
+	result, err := functionTool.Run(createToolContext(t), map[string]any{
+		"skill_name":    "skill1",
+		"resource_path": "assets/data.txt",
+	})
+	if err != nil {
+		t.Fatalf("tool.Run failed: %v", err)
+	}
+	want := map[string]any{
+		"skill_name": "skill1",
+		"path":       "assets/data.txt",
+		"content":    "content1",
+	}
+	if diff := cmp.Diff(want, result); diff != "" {
+		t.Errorf("result mismatch (-want +got):\n%s", diff)
+	}
+}

--- a/tool/skilltoolset/toolset.go
+++ b/tool/skilltoolset/toolset.go
@@ -1,0 +1,152 @@
+// Copyright 2026 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package skilltoolset
+
+import (
+	"context"
+	"fmt"
+	"html"
+	"strings"
+
+	"google.golang.org/genai"
+
+	"google.golang.org/adk/agent"
+	"google.golang.org/adk/model"
+	"google.golang.org/adk/tool"
+	"google.golang.org/adk/tool/skilltoolset/internal/skilltool"
+	"google.golang.org/adk/tool/skilltoolset/skill"
+)
+
+const (
+	defaultName                   string = "SkillToolset"
+	defaultSkillSystemInstruction string = `You can use specialized 'skills' to help you with complex tasks. You MUST use the skill tools to interact with these skills.
+
+Skills are folders of instructions and resources that extend your capabilities for specialized tasks. Each skill folder contains:
+- **SKILL.md** (required): The main instruction file with skill metadata and detailed markdown instructions.
+- **references/** (Optional): Additional documentation or examples for skill usage.
+- **assets/** (Optional): Templates, scripts or other resources used by the skill.
+- **scripts/** (Optional): Executable scripts that can be run via bash.
+
+This is very important:
+
+` +
+		"1. If a skill seems relevant to the current user query, you MUST use the `load_skill` tool with `skill_name=\"<SKILL_NAME>\"` to read its full instructions before proceeding.\n" +
+		"2. Once you have read the instructions, follow them exactly as documented before replying to the user. For example, If the instruction lists multiple steps, please make sure you complete all of them in order.\n" +
+		"3. The `load_skill_resource` tool is for viewing files within a skill's directory (e.g., `references/*`, `assets/*`, `scripts/*`). Do NOT use other tools to access these files.\n"
+)
+
+// Config holds the configuration for creating a Skill Toolset.
+type Config struct {
+	Source skill.Source
+	// Optional name of the toolset. If empty, default name will be used.
+	Name string
+	// Optional system instruction. If not provided, default instruction will be used.
+	SystemInstruction *string
+}
+
+// SkillToolset provides a toolset for skills.
+type SkillToolset struct {
+	name              string
+	tools             []tool.Tool
+	source            skill.Source
+	systemInstruction string
+}
+
+// New creates a new Skill Toolset based on the provided configuration.
+func New(ctx context.Context, cfg Config) (*SkillToolset, error) {
+	if cfg.Source == nil {
+		return nil, fmt.Errorf("skill source must be provided")
+	}
+	name := defaultName
+	if cfg.Name != "" {
+		name = cfg.Name
+	}
+	instruction := defaultSkillSystemInstruction
+	if cfg.SystemInstruction != nil {
+		instruction = *cfg.SystemInstruction
+	}
+	listTool, err := skilltool.ListSkills(cfg.Source)
+	if err != nil {
+		return nil, fmt.Errorf("create list skills tool: %w", err)
+	}
+	loadTool, err := skilltool.LoadSkill(cfg.Source)
+	if err != nil {
+		return nil, fmt.Errorf("create load skill tool: %w", err)
+	}
+	loadResourceTool, err := skilltool.LoadSkillResource(cfg.Source)
+	if err != nil {
+		return nil, fmt.Errorf("create load skill resource tool: %w", err)
+	}
+	return &SkillToolset{
+		name:              name,
+		tools:             []tool.Tool{listTool, loadTool, loadResourceTool},
+		source:            cfg.Source,
+		systemInstruction: instruction,
+	}, nil
+}
+
+// Name implements tool.Toolset. Returns the name of the toolset.
+func (ts *SkillToolset) Name() string { return ts.name }
+
+// Tools implements tool.Toolset. It returns a list of tools agent can use to
+// interact with skills.
+func (ts *SkillToolset) Tools(ctx agent.ReadonlyContext) ([]tool.Tool, error) { return ts.tools, nil }
+
+// ProcessRequest implements toolinternal.RequestProcessor. It attaches
+// the list of available skills and the system instruction explaining to the
+// agent what it can do with these skills.
+func (ts *SkillToolset) ProcessRequest(ctx tool.Context, req *model.LLMRequest) error {
+	skills, err := ts.source.ListFrontmatters(ctx)
+	if err != nil {
+		return err
+	}
+	if len(skills) == 0 {
+		return nil
+	}
+	appendInstruction(req, ts.systemInstruction+"\n"+skillsToXML(skills))
+	return nil
+}
+
+func skillsToXML(frontmatters []*skill.Frontmatter) string {
+	var sb strings.Builder
+	sb.WriteString("<available_skills>\n")
+	for _, fm := range frontmatters {
+		sb.WriteString("<skill>\n")
+		sb.WriteString("<name>\n")
+		sb.WriteString(html.EscapeString(fm.Name))
+		sb.WriteString("\n</name>\n")
+		sb.WriteString("<description>\n")
+		sb.WriteString(html.EscapeString(fm.Description))
+		sb.WriteString("\n</description>\n")
+		sb.WriteString("</skill>\n")
+	}
+	sb.WriteString("</available_skills>")
+	return sb.String()
+}
+
+func appendInstruction(req *model.LLMRequest, instruction string) {
+	if req.Config == nil {
+		req.Config = &genai.GenerateContentConfig{}
+	}
+	if req.Config.SystemInstruction == nil {
+		req.Config.SystemInstruction = &genai.Content{
+			Role: genai.RoleUser,
+		}
+	}
+	req.Config.SystemInstruction.Parts = append(
+		req.Config.SystemInstruction.Parts,
+		genai.NewPartFromText(instruction),
+	)
+}

--- a/tool/skilltoolset/toolset.go
+++ b/tool/skilltoolset/toolset.go
@@ -17,12 +17,9 @@ package skilltoolset
 import (
 	"context"
 	"fmt"
-	"html"
-	"strings"
-
-	"google.golang.org/genai"
 
 	"google.golang.org/adk/agent"
+	"google.golang.org/adk/internal/utils"
 	"google.golang.org/adk/model"
 	"google.golang.org/adk/tool"
 	"google.golang.org/adk/tool/skilltoolset/internal/skilltool"
@@ -115,38 +112,6 @@ func (ts *SkillToolset) ProcessRequest(ctx tool.Context, req *model.LLMRequest) 
 	if len(skills) == 0 {
 		return nil
 	}
-	appendInstruction(req, ts.systemInstruction+"\n"+skillsToXML(skills))
+	utils.AppendInstructions(req, ts.systemInstruction, skilltool.SkillsToXML(skills))
 	return nil
-}
-
-func skillsToXML(frontmatters []*skill.Frontmatter) string {
-	var sb strings.Builder
-	sb.WriteString("<available_skills>\n")
-	for _, fm := range frontmatters {
-		sb.WriteString("<skill>\n")
-		sb.WriteString("<name>\n")
-		sb.WriteString(html.EscapeString(fm.Name))
-		sb.WriteString("\n</name>\n")
-		sb.WriteString("<description>\n")
-		sb.WriteString(html.EscapeString(fm.Description))
-		sb.WriteString("\n</description>\n")
-		sb.WriteString("</skill>\n")
-	}
-	sb.WriteString("</available_skills>")
-	return sb.String()
-}
-
-func appendInstruction(req *model.LLMRequest, instruction string) {
-	if req.Config == nil {
-		req.Config = &genai.GenerateContentConfig{}
-	}
-	if req.Config.SystemInstruction == nil {
-		req.Config.SystemInstruction = &genai.Content{
-			Role: genai.RoleUser,
-		}
-	}
-	req.Config.SystemInstruction.Parts = append(
-		req.Config.SystemInstruction.Parts,
-		genai.NewPartFromText(instruction),
-	)
 }

--- a/tool/skilltoolset/toolset.go
+++ b/tool/skilltoolset/toolset.go
@@ -49,8 +49,8 @@ type Config struct {
 	Source skill.Source
 	// Optional name of the toolset. If empty, default name will be used.
 	Name string
-	// Optional system instruction. If not provided, default instruction will be used.
-	SystemInstruction *string
+	// Optional system instruction. If empty, default instruction will be used.
+	SystemInstruction string
 }
 
 // SkillToolset provides a toolset for skills.
@@ -71,8 +71,8 @@ func New(ctx context.Context, cfg Config) (*SkillToolset, error) {
 		name = cfg.Name
 	}
 	instruction := defaultSkillSystemInstruction
-	if cfg.SystemInstruction != nil {
-		instruction = *cfg.SystemInstruction
+	if cfg.SystemInstruction != "" {
+		instruction = cfg.SystemInstruction
 	}
 	listTool, err := skilltool.ListSkills(cfg.Source)
 	if err != nil {

--- a/tool/skilltoolset/toolset_test.go
+++ b/tool/skilltoolset/toolset_test.go
@@ -1,0 +1,125 @@
+// Copyright 2026 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package skilltoolset_test
+
+import (
+	"context"
+	"strings"
+	"testing"
+
+	"github.com/google/go-cmp/cmp"
+	"github.com/google/go-cmp/cmp/cmpopts"
+
+	"google.golang.org/adk/model"
+	"google.golang.org/adk/tool/skilltoolset"
+	"google.golang.org/adk/tool/skilltoolset/skill"
+)
+
+type mockSource struct {
+	skill.Source
+	frontmatters []*skill.Frontmatter
+}
+
+func (m *mockSource) ListFrontmatters(ctx context.Context) ([]*skill.Frontmatter, error) {
+	return m.frontmatters, nil
+}
+
+func TestProcessRequest(t *testing.T) {
+	source := &mockSource{
+		frontmatters: []*skill.Frontmatter{
+			{
+				Name:        "skill0",
+				Description: "description0",
+			},
+			{
+				Name:          "skill1",
+				Description:   "description1",
+				Compatibility: "...",
+				Metadata: map[string]string{
+					"flag1": "key1",
+					"flag2": "key2",
+				},
+			},
+		},
+	}
+	ts, err := skilltoolset.New(t.Context(), skilltoolset.Config{Source: source})
+	if err != nil {
+		t.Fatalf("skilltoolset.New failed: %v", err)
+	}
+	req := &model.LLMRequest{}
+
+	err = ts.ProcessRequest(nil, req)
+	if err != nil {
+		t.Fatalf("ProcessRequest failed: %v", err)
+	}
+	if req.Config == nil {
+		t.Fatalf("ProcessRequest: req.Config is nil")
+	}
+	if req.Config.SystemInstruction == nil {
+		t.Fatalf("ProcessRequest: req.Config.SystemInstruction is nil")
+	}
+	if len(req.Config.SystemInstruction.Parts) != 1 {
+		t.Fatalf("ProcessRequest: got %d parts, expected 1", len(req.Config.SystemInstruction.Parts))
+	}
+	gotText := req.Config.SystemInstruction.Parts[0].Text
+	for _, want := range []string{"SKILL.md", "skills", "<available_skills>", "skill0", "description1"} {
+		if !strings.Contains(gotText, want) {
+			t.Errorf("ProcessRequest: got %q, want to contain %q", gotText, want)
+		}
+	}
+}
+
+func TestProcessRequest_NoSkills(t *testing.T) {
+	ts, err := skilltoolset.New(t.Context(), skilltoolset.Config{Source: &mockSource{}})
+	if err != nil {
+		t.Fatalf("skilltoolset.New failed: %v", err)
+	}
+	req := &model.LLMRequest{}
+
+	err = ts.ProcessRequest(nil, req)
+	if err != nil {
+		t.Fatalf("ProcessRequest failed: %v", err)
+	}
+	if req.Config != nil && req.Config.SystemInstruction != nil && len(req.Config.SystemInstruction.Parts) > 0 {
+		t.Errorf("ProcessRequest: got %d parts, expected 0", len(req.Config.SystemInstruction.Parts))
+	}
+}
+
+func TestNew_MissingSource(t *testing.T) {
+	_, err := skilltoolset.New(t.Context(), skilltoolset.Config{})
+	if err == nil {
+		t.Errorf("skilltoolset.New: expected error when source is missing")
+	}
+}
+
+func TestTools(t *testing.T) {
+	toolset, err := skilltoolset.New(t.Context(), skilltoolset.Config{Source: &mockSource{}})
+	if err != nil {
+		t.Fatalf("skilltoolset.New failed: %v", err)
+	}
+
+	tools, err := toolset.Tools(nil)
+	if err != nil {
+		t.Fatalf("Tools failed: %v", err)
+	}
+	var got []string
+	for _, t := range tools {
+		got = append(got, t.Name())
+	}
+	want := []string{"list_skills", "load_skill", "load_skill_resource"}
+	if diff := cmp.Diff(want, got, cmpopts.SortSlices(func(a, b string) bool { return a < b })); diff != "" {
+		t.Errorf("Tools result mismatch (-want +got):\n%s", diff)
+	}
+}


### PR DESCRIPTION
SkillToolset encapsulates the Agent Skills feature. This toolset ensures agent is equipped with all the tools needed to use skills and is provided with proper instructions.

What skill toolset enable agent to do:
- List available skills.
- Read instructions of the skills (by skill name).
- Read specific resources of the skills (by resource path).

Current implementation is very basic, e.g.:
- There is no script execution support yet.
- Skill activation is history-based: skill instructions and resources are provided to the llm as function call results in conversation history.
- Every resource should be specifically mentioned in the SKILL.md file: the agent is unable to list resources available for the skills.