### PR TITLE
fix: spelling inconsistencies per Go style guidelines

### DIFF
--- a/agent/llmagent/llmagent.go
+++ b/agent/llmagent/llmagent.go
@@ -412,9 +412,9 @@ func (a *llmAgent) maybeSaveOutputToState(event *session.Event) {
 		}
 		result := sb.String()
 
-		// TODO: add output schema validation and unmarshalling
+		// TODO: add output schema validation and unmarshaling
 		if a.OutputSchema != nil {
-			// If the result from the final chunk is just whitespace or empty,
+			// If the result from the final chunk is just white space or empty,
 			// it means this is an empty final chunk of a stream.
 			// Do not attempt to parse it as JSON.
 			if strings.TrimSpace(result) == "" {

--- a/agent/remoteagent/a2a_e2e_test.go
+++ b/agent/remoteagent/a2a_e2e_test.go
@@ -374,7 +374,7 @@ func TestA2AMultiHopInputRequired(t *testing.T) {
 
 func TestA2ACleanupPropagation(t *testing.T) {
 	// Remote A2A server publishes a submitted task and start generating artifact updates
-	// until it detects a context cancelation
+	// until it detects a context cancellation
 	remoteTaskIDChan, remoteCleanupCalledChan := make(chan a2a.TaskID, 1), make(chan struct{}, 2)
 	serverB := startA2AServer(&mockA2AExecutor{
 		executeFn: func(ctx context.Context, reqCtx *a2asrv.RequestContext, queue eventqueue.Queue) error {
@@ -437,7 +437,7 @@ func TestA2ACleanupPropagation(t *testing.T) {
 		cancelResultChan <- task
 	}()
 
-	// Check the streaming message sender got a cancelled state task in their response
+	// Check the streaming message sender got a canceled state task in their response
 	var lastStreamingUpdate a2a.Event
 	for event := range statusUpdateEventChan {
 		lastStreamingUpdate = event
@@ -450,8 +450,8 @@ func TestA2ACleanupPropagation(t *testing.T) {
 		t.Fatalf("type(lastStreamingUpdate) = %T, want *a2a.TaskStatusUpdateEvent", lastStreamingUpdate)
 	}
 
-	// Check subagent task got cancelled when the parent task was cancelled.
-	// Reads from channel twice because cleanup gets called both for cancelation and execution.
+	// Check subagent task got canceled when the parent task was canceled.
+	// Reads from channel twice because cleanup gets called both for cancellation and execution.
 	<-remoteCleanupCalledChan
 	<-remoteCleanupCalledChan
 	remoteTaskID := <-remoteTaskIDChan
@@ -875,11 +875,11 @@ func newToolConfirmation(t *testing.T) tool.Tool {
 		}
 		jsonBytes, err := json.Marshal(confirmation.Payload)
 		if err != nil {
-			return approval{}, fmt.Errorf("error marshalling payload %s: %w", confirmation.Payload, err)
+			return approval{}, fmt.Errorf("error marshaling payload %s: %w", confirmation.Payload, err)
 		}
 		var payload approval
 		if err := json.Unmarshal(jsonBytes, &payload); err != nil {
-			return approval{}, fmt.Errorf("error unmarshalling payload %s: %w", confirmation.Payload, err)
+			return approval{}, fmt.Errorf("error unmarshaling payload %s: %w", confirmation.Payload, err)
 		}
 		return approval{Status: approvalStatusVerified, TicketID: payload.TicketID}, nil
 	})
@@ -1167,7 +1167,7 @@ func TestA2AMultiHopInputRequiredCancellation(t *testing.T) {
 		t.Fatalf("client.CancelTask() error = %v", err)
 	}
 
-	// Verify that Server B's task was cancelled
+	// Verify that Server B's task was canceled
 	remoteTaskID := <-remoteTaskIDChan
 	clientB := newA2AClient(t, serverB)
 	remoteTask, err := clientB.GetTask(t.Context(), &a2a.TaskQueryParams{ID: remoteTaskID})

--- a/examples/toolconfirmation/main.go
+++ b/examples/toolconfirmation/main.go
@@ -172,11 +172,11 @@ func requestVacationDays(ctx tool.Context, args RequestVacationArgs) (*RequestVa
 	if confirmation.Confirmed {
 		jsonBytes, err := json.Marshal(confirmation.Payload)
 		if err != nil {
-			return nil, fmt.Errorf("error marshalling payload %s: %w", confirmation.Payload, err)
+			return nil, fmt.Errorf("error marshaling payload %s: %w", confirmation.Payload, err)
 		}
 		var payload ConfirmationPayload
 		if err := json.Unmarshal(jsonBytes, &payload); err != nil {
-			return nil, fmt.Errorf("error unmarshalling payload %s: %w", confirmation.Payload, err)
+			return nil, fmt.Errorf("error unmarshaling payload %s: %w", confirmation.Payload, err)
 		}
 		approvedDays := min(payload.DaysApproved, args.Days)
 		req.Status = "APPROVED"
@@ -342,7 +342,7 @@ func processApproval(ctx context.Context, r *runner.Runner, sessionID, requestID
 		daysInput, _ := reader.ReadString('\n')
 		days, err := strconv.Atoi(strings.TrimSpace(daysInput))
 		if err != nil || days < 0 || days > req.Days {
-			fmt.Println("Invalid number of days. Approval cancelled.")
+			fmt.Println("Invalid number of days. Approval canceled.")
 			return
 		}
 		daysApproved = days

--- a/internal/configurable/configurable.go
+++ b/internal/configurable/configurable.go
@@ -61,7 +61,7 @@ type ToolConfig struct {
 
 // baseAgentConfig matches the Python baseAgentConfig Pydantic model.
 //
-// Usage: Do not use this struct directly for unmarshalling specific agents.
+// Usage: Do not use this struct directly for unmarshaling specific agents.
 // Embed it into concrete agent configs (see Example below).
 type baseAgentConfig struct {
 	// Required. The class of the agent.

--- a/internal/llminternal/instruction_processor_test.go
+++ b/internal/llminternal/instruction_processor_test.go
@@ -216,7 +216,7 @@ And another optional artifact:
 					t.Fatalf("did not expect an error but got: %v", err)
 				}
 				if got != tc.want {
-					// Use %q to clearly show differences in strings, especially with whitespace.
+					// Use %q to clearly show differences in strings, especially with white space.
 					t.Errorf("got %q, want %q", got, tc.want)
 				}
 			}

--- a/internal/llminternal/request_confirmation_processor.go
+++ b/internal/llminternal/request_confirmation_processor.go
@@ -76,7 +76,7 @@ func RequestConfirmationRequestProcessor(ctx agent.InvocationContext, req *model
 						if jsonString, ok := resp.(string); ok {
 							err := json.Unmarshal([]byte(jsonString), &tc)
 							if err != nil {
-								yield(nil, fmt.Errorf("error 'response' key found but failed unmarshalling confirmation function response for event id %q: %w", event.ID, err))
+								yield(nil, fmt.Errorf("error 'response' key found but failed unmarshaling confirmation function response for event id %q: %w", event.ID, err))
 								return
 							}
 						} else {
@@ -86,12 +86,12 @@ func RequestConfirmationRequestProcessor(ctx agent.InvocationContext, req *model
 					} else {
 						tempJSON, err := json.Marshal(funcResp.Response)
 						if err != nil {
-							yield(nil, fmt.Errorf("error failed marshalling confirmation function response for event id %q: %w", event.ID, err))
+							yield(nil, fmt.Errorf("error failed marshaling confirmation function response for event id %q: %w", event.ID, err))
 							return
 						}
 						err = json.Unmarshal(tempJSON, &tc)
 						if err != nil {
-							yield(nil, fmt.Errorf("error failed unmarshalling confirmation function response for event id %q: %w", event.ID, err))
+							yield(nil, fmt.Errorf("error failed unmarshaling confirmation function response for event id %q: %w", event.ID, err))
 							return
 						}
 					}

--- a/internal/telemetry/logger.go
+++ b/internal/telemetry/logger.go
@@ -176,7 +176,7 @@ func contentToJSONLikeValue(c *genai.Content) any {
 		return nil
 	}
 
-	// Marshall to JSON first to preserve the json key names, omit null fields, etc.
+	// Marshal to JSON first to preserve the json key names, omit null fields, etc.
 	b, err := json.Marshal(c)
 	if err != nil {
 		return "<not_serializable>"

--- a/internal/typeutil/convert.go
+++ b/internal/typeutil/convert.go
@@ -33,7 +33,7 @@ func ConvertToWithJSONSchema[From, To any](v From, resolvedSchema *jsonschema.Re
 	if resolvedSchema != nil {
 		// See https://github.com/google/jsonschema-go/issues/23: in order to
 		// validate, we must validate against a map[string]any. Struct validation
-		// does not work as it cannot account for `omitempty` or custom marshalling.
+		// does not work as it cannot account for `omitempty` or custom marshaling.
 		var m map[string]any
 		if err := json.Unmarshal(rawArgs, &m); err != nil {
 			return zero, err

--- a/server/adka2a/executor.go
+++ b/server/adka2a/executor.go
@@ -243,7 +243,7 @@ func (e *Executor) Cleanup(ctx context.Context, reqCtx *a2asrv.RequestContext, r
 
 	remoteSubagents := findRemoteSubagents(cfg.Agent)
 
-	// If task was in input-required and got successfully cancelled - run the cleanup logic
+	// If task was in input-required and got successfully canceled - run the cleanup logic
 	if reqCtx.StoredTask != nil && reqCtx.StoredTask.Status.State == a2a.TaskStateInputRequired {
 		if task, ok := result.(*a2a.Task); ok && task.Status.State == a2a.TaskStateCanceled && reqCtx.Message == nil {
 			if err := e.cancelChildInputRequiredTasks(ctx, reqCtx, reqCtx.StoredTask.Status, remoteSubagents); err != nil {

--- a/server/adkrest/controllers/runtime.go
+++ b/server/adkrest/controllers/runtime.go
@@ -147,12 +147,12 @@ func (c *RuntimeAPIController) RunSSEHandler(rw http.ResponseWriter, req *http.R
 			continue
 		}
 		// Skip reporting error if it fails to marshal to the client (to avoid recursive error reporting).
-		marshalledData, err := json.Marshal(models.FromSessionEvent(*event))
+		marshaledData, err := json.Marshal(models.FromSessionEvent(*event))
 		if err != nil {
 			log.Printf("failed to marshal event: %v", err)
 			return
 		}
-		err = flashEvent(rc, rw, string(marshalledData))
+		err = flashEvent(rc, rw, string(marshaledData))
 		if err != nil {
 			log.Printf("failed to flash event: %v", err)
 			return

--- a/telemetry/telemetry_test.go
+++ b/telemetry/telemetry_test.go
@@ -287,7 +287,7 @@ func TestResolveResourceProject(t *testing.T) {
 			wantErr: true,
 		},
 		{
-			name: "env var whitespace",
+			name: "env var white space",
 			opts: []Option{
 				WithOtelToCloud(true),
 				WithGoogleCredentials(&google.Credentials{}),
@@ -296,7 +296,7 @@ func TestResolveResourceProject(t *testing.T) {
 			wantErr: true,
 		},
 		{
-			name: "option project whitespace",
+			name: "option project white space",
 			opts: []Option{
 				WithOtelToCloud(true),
 				WithGcpResourceProject(" "),
@@ -389,7 +389,7 @@ func TestResolveQuotaProject(t *testing.T) {
 			wantProject: "",
 		},
 		{
-			name: "env var whitespace",
+			name: "env var white space",
 			opts: []Option{
 				WithOtelToCloud(true),
 				WithGoogleCredentials(&google.Credentials{}),
@@ -398,7 +398,7 @@ func TestResolveQuotaProject(t *testing.T) {
 			wantErr: true,
 		},
 		{
-			name: "option project whitespace",
+			name: "option project white space",
 			opts: []Option{
 				WithOtelToCloud(true),
 				WithGcpQuotaProject(" "),

--- a/tool/skilltoolset/skill/frontmatter.go
+++ b/tool/skilltoolset/skill/frontmatter.go
@@ -143,9 +143,9 @@ func Build(fm *Frontmatter, markdown string) ([]byte, error) {
 	if err := Validate(fm); err != nil {
 		return nil, fmt.Errorf("invalid frontmatter: %v", err)
 	}
-	marshalled, err := yaml.Marshal(fm)
+	marshaled, err := yaml.Marshal(fm)
 	if err != nil {
 		return nil, fmt.Errorf("marshal frontmatter: %v", err)
 	}
-	return slices.Concat(frontmatterSeparator, marshalled, frontmatterSeparator, []byte(markdown)), nil
+	return slices.Concat(frontmatterSeparator, marshaled, frontmatterSeparator, []byte(markdown)), nil
 }


### PR DESCRIPTION
This PR fixes minor spelling inconsistencies across the codebase to align with the Go project's recommended conventions from the Go Wiki (Spelling).
https://go.dev/wiki/Spelling

**Problem:**
The codebase contains inconsistent spelling (e.g., “unmarshalling”, “cancelled”, “whitespace”) that does not align with Go’s recommended spelling conventions.

**Solution:**
Standardized spelling across the codebase according to the Go Wiki (Spelling). This includes updating terms like “unmarshalling” → “unmarshaling” and “cancelled” → “canceled”, along with similar fixes in comments and tests.

### Testing Plan

_Please describe the tests that you ran to verify your changes. This is required
for all PRs that are not small documentation or typo fixes._

**Unit Tests:**

- [ ] I have added or updated unit tests for my change.
- [ ] All unit tests pass locally.

_Please include a summary of passed go test results._

**Manual End-to-End (E2E) Tests:**

_Please provide instructions on how to manually test your changes, including any
necessary setup or configuration. Please provide logs or screenshots to help
reviewers better understand the fix._

### Checklist

- [x] I have read the [CONTRIBUTING.md](./CONTRIBUTING.md) document.
- [x] I have performed a self-review of my own code.
- [x] I have commented my code, particularly in hard-to-understand areas.
- [ ] I have added tests that prove my fix is effective or that my feature works.
- [ ] New and existing unit tests pass locally with my changes.
- [x] I have manually tested my changes end-to-end.
- [x] Any dependent changes have been merged and published in downstream modules.

### Additional context

https://go.dev/wiki/Spelling

