### PR TITLE
fix: sanitize user_id derived from PubSub subscription and Eventarc source

### DIFF
--- a/server/adkrest/controllers/triggers/triggers.go
+++ b/server/adkrest/controllers/triggers/triggers.go
@@ -47,6 +47,10 @@ type RetriableRunner struct {
 func (r *RetriableRunner) RunAgent(ctx context.Context, appName, userID, messageContent string) ([]*session.Event, error) {
 	userID = strings.ReplaceAll(strings.Trim(userID, "/"), "/", "--")
 
+	if userID == "" {
+		return nil, fmt.Errorf("user id cannot be empty")
+	}
+
 	// Each retry = new session
 	sessReq := &session.CreateRequest{
 		AppName: appName,

--- a/server/adkrest/controllers/triggers/triggers.go
+++ b/server/adkrest/controllers/triggers/triggers.go
@@ -45,6 +45,8 @@ type RetriableRunner struct {
 }
 
 func (r *RetriableRunner) RunAgent(ctx context.Context, appName, userID, messageContent string) ([]*session.Event, error) {
+	userID = strings.ReplaceAll(strings.Trim(userID, "/"), "/", "--")
+
 	// Each retry = new session
 	sessReq := &session.CreateRequest{
 		AppName: appName,

--- a/server/adkrest/controllers/triggers/triggers_test.go
+++ b/server/adkrest/controllers/triggers/triggers_test.go
@@ -1,0 +1,98 @@
+// Copyright 2026 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package triggers
+
+import (
+	"context"
+	"iter"
+	"testing"
+
+	"google.golang.org/adk/agent"
+	"google.golang.org/adk/server/adkrest/internal/fakes"
+	"google.golang.org/adk/session"
+)
+
+func TestRunAgent_UserIDTrimming(t *testing.T) {
+	tests := []struct {
+		name           string
+		inputUserID    string
+		expectedUserID string
+	}{
+		{
+			name:           "NoSlashes",
+			inputUserID:    "user123",
+			expectedUserID: "user123",
+		},
+		{
+			name:           "LeadingTrailingSlashes",
+			inputUserID:    "/user123/",
+			expectedUserID: "user123",
+		},
+		{
+			name:           "InternalSlashes",
+			inputUserID:    "users/123",
+			expectedUserID: "users--123",
+		},
+		{
+			name:           "ComplexSlashes",
+			inputUserID:    "//users/123/profile/",
+			expectedUserID: "users--123--profile",
+		},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			sessionService := &fakes.FakeSessionService{Sessions: make(map[fakes.SessionKey]fakes.TestSession)}
+			
+			mockAgent, err := agent.New(agent.Config{
+				Name: "test-agent",
+				Run: func(ctx agent.InvocationContext) iter.Seq2[*session.Event, error] {
+					return func(yield func(*session.Event, error) bool) {
+						yield(&session.Event{ID: "success"}, nil)
+					}
+				},
+			})
+			if err != nil {
+				t.Fatalf("agent.New failed: %v", err)
+			}
+
+			agentLoader := agent.NewSingleLoader(mockAgent)
+
+			r := &RetriableRunner{
+				sessionService:  sessionService,
+				agentLoader:     agentLoader,
+				triggerConfig:   TriggerConfig{MaxRetries: 0},
+			}
+
+			_, err = r.RunAgent(context.Background(), "test-agent", tc.inputUserID, "hello")
+			if err != nil {
+				t.Fatalf("RunAgent failed: %v", err)
+			}
+
+			// Verify that the session was created with the expected UserID
+			found := false
+			for key := range sessionService.Sessions {
+				if key.UserID == tc.expectedUserID {
+					found = true
+					break
+				}
+			}
+
+			if !found {
+				t.Errorf("Expected session with UserID %q not found in %v", tc.expectedUserID, sessionService.Sessions)
+			}
+		})
+	}
+}

--- a/server/adkrest/controllers/triggers/triggers_test.go
+++ b/server/adkrest/controllers/triggers/triggers_test.go
@@ -55,7 +55,7 @@ func TestRunAgent_UserIDTrimming(t *testing.T) {
 	for _, tc := range tests {
 		t.Run(tc.name, func(t *testing.T) {
 			sessionService := &fakes.FakeSessionService{Sessions: make(map[fakes.SessionKey]fakes.TestSession)}
-			
+
 			mockAgent, err := agent.New(agent.Config{
 				Name: "test-agent",
 				Run: func(ctx agent.InvocationContext) iter.Seq2[*session.Event, error] {
@@ -71,9 +71,9 @@ func TestRunAgent_UserIDTrimming(t *testing.T) {
 			agentLoader := agent.NewSingleLoader(mockAgent)
 
 			r := &RetriableRunner{
-				sessionService:  sessionService,
-				agentLoader:     agentLoader,
-				triggerConfig:   TriggerConfig{MaxRetries: 0},
+				sessionService: sessionService,
+				agentLoader:    agentLoader,
+				triggerConfig:  TriggerConfig{MaxRetries: 0},
 			}
 
 			_, err = r.RunAgent(context.Background(), "test-agent", tc.inputUserID, "hello")


### PR DESCRIPTION
This ensures that the user_id is a valid identifier without path separators.