### PR TITLE
chore: add compile-time interface assertions for tool implementations

### DIFF
--- a/internal/llminternal/agent_transfer.go
+++ b/internal/llminternal/agent_transfer.go
@@ -180,7 +180,10 @@ func (t *TransferToAgentTool) Run(ctx agent.ToolContext, args any) (map[string]a
 	return map[string]any{}, nil
 }
 
-var _ tool.Tool = (*TransferToAgentTool)(nil)
+var (
+	_ toolinternal.FunctionTool     = (*TransferToAgentTool)(nil)
+	_ toolinternal.RequestProcessor = (*TransferToAgentTool)(nil)
+)
 
 func transferTargets(agent, parent agent.Agent) []agent.Agent {
 	targets := slices.Clone(agent.SubAgents())

--- a/internal/llminternal/outputschema_processor.go
+++ b/internal/llminternal/outputschema_processor.go
@@ -23,6 +23,7 @@ import (
 
 	"google.golang.org/adk/agent"
 	"google.golang.org/adk/internal/llminternal/googlellm"
+	"google.golang.org/adk/internal/toolinternal"
 	"google.golang.org/adk/internal/toolinternal/toolutils"
 	"google.golang.org/adk/internal/utils"
 	"google.golang.org/adk/model"
@@ -138,3 +139,5 @@ func (t *setModelResponseTool) Run(ctx agent.ToolContext, args any) (map[string]
 	}
 	return m, nil
 }
+
+var _ toolinternal.FunctionTool = (*setModelResponseTool)(nil)

--- a/tool/agenttool/agent_tool.go
+++ b/tool/agenttool/agent_tool.go
@@ -27,6 +27,7 @@ import (
 	"google.golang.org/adk/agent"
 	"google.golang.org/adk/artifact"
 	"google.golang.org/adk/internal/llminternal"
+	"google.golang.org/adk/internal/toolinternal"
 	"google.golang.org/adk/internal/toolinternal/toolutils"
 	"google.golang.org/adk/internal/utils"
 	"google.golang.org/adk/memory"
@@ -254,3 +255,8 @@ func (t *agentTool) Run(toolCtx tool.Context, args any) (map[string]any, error) 
 func (t *agentTool) ProcessRequest(ctx tool.Context, req *model.LLMRequest) error {
 	return toolutils.PackTool(req, t)
 }
+
+var (
+	_ toolinternal.FunctionTool     = (*agentTool)(nil)
+	_ toolinternal.RequestProcessor = (*agentTool)(nil)
+)

--- a/tool/agenttool/agent_tool.go
+++ b/tool/agenttool/agent_tool.go
@@ -27,6 +27,7 @@ import (
 	"google.golang.org/adk/agent"
 	"google.golang.org/adk/artifact"
 	"google.golang.org/adk/internal/llminternal"
+	"google.golang.org/adk/internal/toolinternal"
 	"google.golang.org/adk/internal/toolinternal/toolutils"
 	"google.golang.org/adk/internal/utils"
 	"google.golang.org/adk/memory"
@@ -254,3 +255,8 @@ func (t *agentTool) Run(toolCtx agent.ToolContext, args any) (map[string]any, er
 func (t *agentTool) ProcessRequest(ctx agent.ToolContext, req *model.LLMRequest) error {
 	return toolutils.PackTool(req, t)
 }
+
+var (
+	_ toolinternal.FunctionTool     = (*agentTool)(nil)
+	_ toolinternal.RequestProcessor = (*agentTool)(nil)
+)

--- a/tool/exampletool/tool.go
+++ b/tool/exampletool/tool.go
@@ -21,6 +21,7 @@ import (
 
 	"google.golang.org/genai"
 
+	"google.golang.org/adk/internal/toolinternal"
 	"google.golang.org/adk/internal/utils"
 	"google.golang.org/adk/model"
 	"google.golang.org/adk/tool"
@@ -148,3 +149,5 @@ func buildExamplesSystemInstruction(examples []*Example, model string) string {
 	sb.WriteString(examplesEnd)
 	return sb.String()
 }
+
+var _ toolinternal.RequestProcessor = (*exampleTool)(nil)

--- a/tool/exampletool/tool.go
+++ b/tool/exampletool/tool.go
@@ -22,6 +22,7 @@ import (
 	"google.golang.org/genai"
 
 	"google.golang.org/adk/agent"
+	"google.golang.org/adk/internal/toolinternal"
 	"google.golang.org/adk/internal/utils"
 	"google.golang.org/adk/model"
 )
@@ -148,3 +149,5 @@ func buildExamplesSystemInstruction(examples []*Example, model string) string {
 	sb.WriteString(examplesEnd)
 	return sb.String()
 }
+
+var _ toolinternal.RequestProcessor = (*exampleTool)(nil)

--- a/tool/functiontool/function.go
+++ b/tool/functiontool/function.go
@@ -24,6 +24,7 @@ import (
 	"github.com/google/jsonschema-go/jsonschema"
 	"google.golang.org/genai"
 
+	"google.golang.org/adk/internal/toolinternal"
 	"google.golang.org/adk/internal/toolinternal/toolutils"
 	"google.golang.org/adk/internal/typeutil"
 	"google.golang.org/adk/model"
@@ -274,3 +275,8 @@ func resolvedSchema[T any](override *jsonschema.Schema) (*jsonschema.Resolved, e
 	}
 	return schema.Resolve(nil)
 }
+
+var (
+	_ toolinternal.FunctionTool     = (*functionTool[struct{}, struct{}])(nil)
+	_ toolinternal.RequestProcessor = (*functionTool[struct{}, struct{}])(nil)
+)

--- a/tool/functiontool/function.go
+++ b/tool/functiontool/function.go
@@ -25,6 +25,7 @@ import (
 	"google.golang.org/genai"
 
 	"google.golang.org/adk/agent"
+	"google.golang.org/adk/internal/toolinternal"
 	"google.golang.org/adk/internal/toolinternal/toolutils"
 	"google.golang.org/adk/internal/typeutil"
 	"google.golang.org/adk/model"
@@ -275,3 +276,8 @@ func resolvedSchema[T any](override *jsonschema.Schema) (*jsonschema.Resolved, e
 	}
 	return schema.Resolve(nil)
 }
+
+var (
+	_ toolinternal.FunctionTool     = (*functionTool[struct{}, struct{}])(nil)
+	_ toolinternal.RequestProcessor = (*functionTool[struct{}, struct{}])(nil)
+)

--- a/tool/functiontool/streaming_function.go
+++ b/tool/functiontool/streaming_function.go
@@ -25,6 +25,7 @@ import (
 	"google.golang.org/genai"
 
 	"google.golang.org/adk/agent"
+	"google.golang.org/adk/internal/toolinternal"
 	"google.golang.org/adk/internal/toolinternal/toolutils"
 	"google.golang.org/adk/internal/typeutil"
 	"google.golang.org/adk/model"
@@ -179,3 +180,8 @@ func (f *streamingFunctionTool[TArgs]) RunStream(ctx agent.ToolContext, args any
 		}
 	}
 }
+
+var (
+	_ toolinternal.StreamingFunctionTool = (*streamingFunctionTool[struct{}])(nil)
+	_ toolinternal.RequestProcessor      = (*streamingFunctionTool[struct{}])(nil)
+)

--- a/tool/geminitool/google_search.go
+++ b/tool/geminitool/google_search.go
@@ -18,6 +18,7 @@ import (
 	"google.golang.org/genai"
 
 	"google.golang.org/adk/agent"
+	"google.golang.org/adk/internal/toolinternal"
 	"google.golang.org/adk/model"
 )
 
@@ -48,3 +49,5 @@ func (s GoogleSearch) ProcessRequest(ctx agent.ToolContext, req *model.LLMReques
 func (s GoogleSearch) IsLongRunning() bool {
 	return false
 }
+
+var _ toolinternal.RequestProcessor = GoogleSearch{}

--- a/tool/geminitool/tool.go
+++ b/tool/geminitool/tool.go
@@ -34,6 +34,7 @@ import (
 
 	"google.golang.org/genai"
 
+	"google.golang.org/adk/internal/toolinternal"
 	"google.golang.org/adk/model"
 	"google.golang.org/adk/tool"
 )
@@ -86,3 +87,5 @@ func setTool(req *model.LLMRequest, t *genai.Tool) error {
 	req.Config.Tools = append(req.Config.Tools, t)
 	return nil
 }
+
+var _ toolinternal.RequestProcessor = (*geminiTool)(nil)

--- a/tool/geminitool/tool.go
+++ b/tool/geminitool/tool.go
@@ -35,6 +35,7 @@ import (
 	"google.golang.org/genai"
 
 	"google.golang.org/adk/agent"
+	"google.golang.org/adk/internal/toolinternal"
 	"google.golang.org/adk/model"
 	"google.golang.org/adk/tool"
 )
@@ -87,3 +88,5 @@ func setTool(req *model.LLMRequest, t *genai.Tool) error {
 	req.Config.Tools = append(req.Config.Tools, t)
 	return nil
 }
+
+var _ toolinternal.RequestProcessor = (*geminiTool)(nil)

--- a/tool/loadartifactstool/load_artifacts_tool.go
+++ b/tool/loadartifactstool/load_artifacts_tool.go
@@ -26,6 +26,7 @@ import (
 	"google.golang.org/genai"
 
 	"google.golang.org/adk/agent"
+	"google.golang.org/adk/internal/toolinternal"
 	"google.golang.org/adk/internal/toolinternal/toolutils"
 	"google.golang.org/adk/internal/utils"
 	"google.golang.org/adk/model"
@@ -218,3 +219,8 @@ func (t *artifactsTool) loadIndividualArtifact(ctx context.Context, artifactsSer
 		Role: genai.RoleUser,
 	}, nil
 }
+
+var (
+	_ toolinternal.FunctionTool     = (*artifactsTool)(nil)
+	_ toolinternal.RequestProcessor = (*artifactsTool)(nil)
+)

--- a/tool/loadmemorytool/tool.go
+++ b/tool/loadmemorytool/tool.go
@@ -116,3 +116,8 @@ func (t *loadMemoryTool) ProcessRequest(ctx tool.Context, req *model.LLMRequest)
 	utils.AppendInstructions(req, memoryInstructions)
 	return nil
 }
+
+var (
+	_ toolinternal.FunctionTool     = (*loadMemoryTool)(nil)
+	_ toolinternal.RequestProcessor = (*loadMemoryTool)(nil)
+)

--- a/tool/loadmemorytool/tool.go
+++ b/tool/loadmemorytool/tool.go
@@ -116,3 +116,8 @@ func (t *loadMemoryTool) ProcessRequest(ctx agent.ToolContext, req *model.LLMReq
 	utils.AppendInstructions(req, memoryInstructions)
 	return nil
 }
+
+var (
+	_ toolinternal.FunctionTool     = (*loadMemoryTool)(nil)
+	_ toolinternal.RequestProcessor = (*loadMemoryTool)(nil)
+)

--- a/tool/preloadmemorytool/tool.go
+++ b/tool/preloadmemorytool/tool.go
@@ -26,6 +26,7 @@ import (
 	"strings"
 	"time"
 
+	"google.golang.org/adk/internal/toolinternal"
 	"google.golang.org/adk/internal/utils"
 	"google.golang.org/adk/memory"
 	"google.golang.org/adk/model"
@@ -133,3 +134,5 @@ func extractText(mem memory.Entry) string {
 	}
 	return b.String()
 }
+
+var _ toolinternal.RequestProcessor = (*preloadMemoryTool)(nil)

--- a/tool/preloadmemorytool/tool.go
+++ b/tool/preloadmemorytool/tool.go
@@ -27,6 +27,7 @@ import (
 	"time"
 
 	"google.golang.org/adk/agent"
+	"google.golang.org/adk/internal/toolinternal"
 	"google.golang.org/adk/internal/utils"
 	"google.golang.org/adk/memory"
 	"google.golang.org/adk/model"
@@ -133,3 +134,5 @@ func extractText(mem memory.Entry) string {
 	}
 	return b.String()
 }
+
+var _ toolinternal.RequestProcessor = (*preloadMemoryTool)(nil)

--- a/tool/skilltoolset/toolset.go
+++ b/tool/skilltoolset/toolset.go
@@ -19,6 +19,7 @@ import (
 	"fmt"
 
 	"google.golang.org/adk/agent"
+	"google.golang.org/adk/internal/toolinternal"
 	"google.golang.org/adk/internal/utils"
 	"google.golang.org/adk/model"
 	"google.golang.org/adk/tool"
@@ -115,3 +116,5 @@ func (ts *SkillToolset) ProcessRequest(ctx agent.ToolContext, req *model.LLMRequ
 	utils.AppendInstructions(req, ts.systemInstruction, skilltool.SkillsToXML(skills))
 	return nil
 }
+
+var _ toolinternal.RequestProcessor = (*SkillToolset)(nil)


### PR DESCRIPTION
### Description of Change

  **Problem:**
  Currently, explicit compile-time checks exist only for the MCP tool via `RequestProcessor` and `FunctionTool`. Other tool
  types rely on runtime validation in `base_flow`, which makes interface conformance checks less explicit.

  **Solution:**
  Add compile-time `var _` interface assertions to all tool implementations that implement `toolinternal.RequestProcessor`
  and/or `toolinternal.FunctionTool`, consistent with the existing pattern in `mcpTool`.

  ### Testing Plan

  No tests needed.
  This PR only adds explicit compile-time interface checks and does not change runtime behavior.

  ### Checklist

  - [x] I have read the [CONTRIBUTING.md](CONTRIBUTING.md) document.
  - [x] I have performed a self-review of my own code.
  - [x] I have commented my code, particularly in hard-to-understand areas.
  - [ ] I have added tests that prove my fix is effective or that my feature works.
  - [x] New and existing unit tests pass locally with my changes.
  - [x] I have manually tested my changes end-to-end.
  - [x] Any dependent changes have been merged and published in downstream modules.