### PR TITLE
Fix/issue 719 anchoring

### DIFF
--- a/internal/llminternal/contents_processor.go
+++ b/internal/llminternal/contents_processor.go
@@ -443,18 +443,23 @@ func mergeFunctionResponseEvents(functionResponseEvents []*session.Event) (*sess
 //	In multi-agent scenarios, the "current turn" for an agent starts from an
 //	actual user or from another agent.
 func buildContentsCurrentTurnContextOnly(agentName, branch string, events []*session.Event) ([]*genai.Content, error) {
-	// Find the latest event that starts the current turn and process from there
-	for i := len(events) - 1; i >= 0; i-- {
-		event := events[i]
-		if event.Author == "user" || isOtherAgentReply(agentName, event) {
-			return buildContentsDefault(agentName, branch, events[i:])
-		}
-	}
-	// NOTE: in Python, it returns [] if there is no event authored by a user or another agent,
-	// but that may be a bug.
-	return buildContentsDefault(agentName, branch, events)
+    var filteredEvents []*session.Event
+    for _, e := range events {
+        if branch == "" || e.Branch == "" || e.Branch == branch {
+            filteredEvents = append(filteredEvents, e)
+        }
+    }
+    
+    for i := len(filteredEvents) - 1; i >= 0; i-- {
+        event := filteredEvents[i]
+        if event.Author == "user" || isOtherAgentReply(agentName, event) {
+            return buildContentsDefault(agentName, branch, filteredEvents[i:])
+        }        
+    }
+    
+    res, err := buildContentsDefault(agentName, branch, filteredEvents)
+    return res, err
 }
-
 func isOtherAgentReply(currentAgentName string, ev *session.Event) bool {
 	return ev.Author != currentAgentName && ev.Author != "user"
 }

--- a/internal/llminternal/contents_processor.go
+++ b/internal/llminternal/contents_processor.go
@@ -442,23 +442,19 @@ func mergeFunctionResponseEvents(functionResponseEvents []*session.Event) (*sess
 //
 //	In multi-agent scenarios, the "current turn" for an agent starts from an
 //	actual user or from another agent.
+
 func buildContentsCurrentTurnContextOnly(agentName, branch string, events []*session.Event) ([]*genai.Content, error) {
-    var filteredEvents []*session.Event
-    for _, e := range events {
-        if branch == "" || e.Branch == "" || e.Branch == branch {
-            filteredEvents = append(filteredEvents, e)
-        }
-    }
-    
-    for i := len(filteredEvents) - 1; i >= 0; i-- {
-        event := filteredEvents[i]
-        if event.Author == "user" || isOtherAgentReply(agentName, event) {
-            return buildContentsDefault(agentName, branch, filteredEvents[i:])
-        }        
-    }
-    
-    res, err := buildContentsDefault(agentName, branch, filteredEvents)
-    return res, err
+	for i := len(events) - 1; i >= 0; i-- {
+		event := events[i]
+		if !eventBelongsToBranch(branch, event) {
+			continue
+		}
+		if event.Author == "user" || isOtherAgentReply(agentName, event) {
+			return buildContentsDefault(agentName, branch, events[i:])
+		}
+	}
+	return buildContentsDefault(agentName, branch, events)
+
 }
 func isOtherAgentReply(currentAgentName string, ev *session.Event) bool {
 	return ev.Author != currentAgentName && ev.Author != "user"

--- a/internal/llminternal/contents_processor_test.go
+++ b/internal/llminternal/contents_processor_test.go
@@ -15,22 +15,22 @@
 package llminternal_test
 
 import (
+	"fmt"
+	"github.com/google/go-cmp/cmp"
+	"google.golang.org/genai"
 	"iter"
 	"slices"
 	"strings"
 	"testing"
 	"time"
-    "fmt"
-	"github.com/google/go-cmp/cmp"
-	"google.golang.org/genai"
 
 	"google.golang.org/adk/agent"
 	"google.golang.org/adk/agent/llmagent"
 	icontext "google.golang.org/adk/internal/context"
+	"google.golang.org/adk/internal/llminternal"
 	"google.golang.org/adk/internal/utils"
 	"google.golang.org/adk/model"
 	"google.golang.org/adk/session"
-    "google.golang.org/adk/internal/llminternal"
 )
 
 type testModel struct {
@@ -1034,24 +1034,72 @@ func TestBuildContentsCurrentTurnContextOnly_BranchFiltering(t *testing.T) {
 			LLMResponse: model.LLMResponse{
 				Content: genai.NewContentFromText("world !!!", "user"),
 			},
-		}, 
-	} 
+		},
+	}
 
 	got, err := llminternal.BuildContentsCurrentTurnContextOnlyForTest("agent", "branch-A", events)
-    
-    if err != nil {
-        t.Fatalf("Eroare la apel: %v", err)
-    }
 
-    if len(got) != 1 {
-        t.Errorf("Filtrarea a eșuat la număr, am primit %d evenimente", len(got))
-        return 
-    }
+	if err != nil {
+		t.Fatalf("Call erorr: %v", err)
+	}
 
-    gotText := fmt.Sprintf("%v", got[0].Parts[0])
+	if len(got) != 1 {
+		t.Errorf("Filter failed !!!")
+		return
+	}
 
-    expectedText := "world !!!"
-    if !strings.Contains(gotText, expectedText) {
-        t.Errorf("Filtrarea a eșuat la conținut! Așteptam [%s], dar am primit [%s]", expectedText, gotText)
-    }
+	gotText := fmt.Sprintf("%v", got[0].Parts[0])
+
+	expectedText := "world !!!"
+	if !strings.Contains(gotText, expectedText) {
+		t.Errorf("Filter failed! Expected [%s], and received [%s]", expectedText, gotText)
+	}
+}
+
+func TestIssue719_BranchAnchoringBug(t *testing.T) {
+	const (
+		alphaBranch = "parallel.run-alpha"
+		betaBranch  = "parallel.run-beta"
+	)
+
+	events := []*session.Event{
+		{
+			Author: "user",
+			Branch: "",
+			LLMResponse: model.LLMResponse{
+				Content: genai.NewContentFromText("Mesajul original de la User", "user"),
+			},
+		},
+		{
+			Author: "run-alpha",
+			Branch: alphaBranch,
+			LLMResponse: model.LLMResponse{
+				Content: NewContentFromFunctionCall(&genai.FunctionCall{
+					Name: "alpha_tool",
+				}, "model"),
+			},
+		},
+	}
+
+	got, err := llminternal.BuildContentsCurrentTurnContextOnlyForTest("run-beta", betaBranch, events)
+	if err != nil {
+		t.Fatalf("Unexpected error: %v", err)
+	}
+
+	if len(got) == 0 {
+		t.Errorf("Context is empty! Scan branch %s", alphaBranch)
+	} else {
+		foundUserMessage := false
+		for _, c := range got {
+			if c.Role == "user" {
+				foundUserMessage = true
+				break
+			}
+		}
+		if !foundUserMessage {
+			t.Errorf("FAIL: Received roles: %v", got[0].Role)
+		} else {
+			t.Log("SUCCESS")
+		}
+	}
 }

--- a/internal/llminternal/contents_processor_test.go
+++ b/internal/llminternal/contents_processor_test.go
@@ -20,17 +20,17 @@ import (
 	"strings"
 	"testing"
 	"time"
-
+    "fmt"
 	"github.com/google/go-cmp/cmp"
 	"google.golang.org/genai"
 
 	"google.golang.org/adk/agent"
 	"google.golang.org/adk/agent/llmagent"
 	icontext "google.golang.org/adk/internal/context"
-	"google.golang.org/adk/internal/llminternal"
 	"google.golang.org/adk/internal/utils"
 	"google.golang.org/adk/model"
 	"google.golang.org/adk/session"
+    "google.golang.org/adk/internal/llminternal"
 )
 
 type testModel struct {
@@ -1011,3 +1011,47 @@ var (
 	_ session.Session = (*fakeSession)(nil)
 	_ session.Events  = (*fakeSession)(nil)
 )
+
+func TestBuildContentsCurrentTurnContextOnly_BranchFiltering(t *testing.T) {
+	events := []*session.Event{
+		{
+			Author: "user",
+			Branch: "branch-A",
+			LLMResponse: model.LLMResponse{
+				Content: genai.NewContentFromText("Hello ", "user"),
+			},
+		},
+		{
+			Author: "user",
+			Branch: "branch-B",
+			LLMResponse: model.LLMResponse{
+				Content: genai.NewContentFromText("Hy to all!!!", "user"),
+			},
+		},
+		{
+			Author: "user",
+			Branch: "branch-A",
+			LLMResponse: model.LLMResponse{
+				Content: genai.NewContentFromText("world !!!", "user"),
+			},
+		}, 
+	} 
+
+	got, err := llminternal.BuildContentsCurrentTurnContextOnlyForTest("agent", "branch-A", events)
+    
+    if err != nil {
+        t.Fatalf("Eroare la apel: %v", err)
+    }
+
+    if len(got) != 1 {
+        t.Errorf("Filtrarea a eșuat la număr, am primit %d evenimente", len(got))
+        return 
+    }
+
+    gotText := fmt.Sprintf("%v", got[0].Parts[0])
+
+    expectedText := "world !!!"
+    if !strings.Contains(gotText, expectedText) {
+        t.Errorf("Filtrarea a eșuat la conținut! Așteptam [%s], dar am primit [%s]", expectedText, gotText)
+    }
+}

--- a/internal/llminternal/export_test.go
+++ b/internal/llminternal/export_test.go
@@ -1,0 +1,10 @@
+package llminternal
+
+import "google.golang.org/adk/session"
+import "google.golang.org/genai"
+
+// Exportăm funcția privată către pachetul de test extern (llminternal_test)
+// Folosim un alias cu literă mare.
+func BuildContentsCurrentTurnContextOnlyForTest(agentName, branch string, events []*session.Event) ([]*genai.Content, error) {
+	return buildContentsCurrentTurnContextOnly(agentName, branch, events)
+}

--- a/internal/llminternal/export_test.go
+++ b/internal/llminternal/export_test.go
@@ -1,10 +1,18 @@
 package llminternal
 
-import "google.golang.org/adk/session"
-import "google.golang.org/genai"
+import (
+	"google.golang.org/adk/session" 
+	"google.golang.org/genai"
+)
 
-// Exportăm funcția privată către pachetul de test extern (llminternal_test)
-// Folosim un alias cu literă mare.
-func BuildContentsCurrentTurnContextOnlyForTest(agentName, branch string, events []*session.Event) ([]*genai.Content, error) {
-	return buildContentsCurrentTurnContextOnly(agentName, branch, events)
+func BuildContentsCurrentTurnContextOnlyForTest(
+	agentName string,
+	branch string,
+	events []*session.Event,
+) ([]*genai.Content, error) {
+	return buildContentsCurrentTurnContextOnly(
+		agentName,
+		branch,
+		events,
+	)
 }


### PR DESCRIPTION
I filtered in the buildContentsCurrentTurnContextOnly function all the events on the current branch using the function  eventBelongsToBranch to exclude the events from other branches

To use this private function in a testing function, I used  export_test.go to make a bridge for buildContentsCurrentTurnContextOnly  using export_test.go and defining in this file a public function BuildContentsCurrentTurnContextOnlyForTest that calls buildContentsCurrentTurnContextOnly  

Tests

go test -v ./internal/llminternal/ -run TestIssue719
=== RUN   TestIssue719_BranchAnchoringBug
    contents_processor_test.go:1102: SUCCESS
--- PASS: TestIssue719_BranchAnchoringBug (0.00s)
PASS
ok      google.golang.org/adk/internal/llminternal      (cached)

go test -v ./internal/llminternal/ -run TestBuildContentsCurrentTurnContextOnly
=== RUN   TestBuildContentsCurrentTurnContextOnly_BranchFiltering
--- PASS: TestBuildContentsCurrentTurnContextOnly_BranchFiltering (0.00s)
PASS
ok      google.golang.org/adk/internal/llminternal      (cached)
 
The test suite verifies that when a mix of events from 'Branch A' and 'Branch B' is provided, the output contains exclusively events where eventBelongsToBranch returns true for the targeted branch.
