### PR TITLE
refactor: remove manual session ID input and enable auto-creation in runner

### DIFF
--- a/server/agentengine/controllers/method/create_session.go
+++ b/server/agentengine/controllers/method/create_session.go
@@ -45,10 +45,6 @@ func (c *createSessionHandler) Metadata() (*structpb.Struct, error) {
 		"name":     c.methodName,
 		"parameters": map[string]any{
 			"properties": map[string]any{
-				"session_id": map[string]any{
-					"nullable": true,
-					"type":     "string",
-				},
 				"user_id": map[string]any{
 					"type": "string",
 				},
@@ -67,8 +63,6 @@ func (c *createSessionHandler) Metadata() (*structpb.Struct, error) {
 Args:
     user_id (str):
 	        Required. The ID of the user.
-    session_id (str):
-        Optional. The ID of the session. If not provided, an ID will be generated for the session.
     state (dict[str, Any]):
         Optional. The initial state of the session.
 
@@ -92,10 +86,9 @@ func (c *createSessionHandler) Handle(ctx context.Context, rw http.ResponseWrite
 	}
 
 	ssReq := &session.CreateRequest{
-		AppName:   c.agentEngineID,
-		UserID:    req.Input.UserID,
-		SessionID: req.Input.SessionID,
-		State:     req.Input.State,
+		AppName: c.agentEngineID,
+		UserID:  req.Input.UserID,
+		State:   req.Input.State,
 	}
 	resp, err := c.sessionService.Create(ctx, ssReq)
 	if err != nil {

--- a/server/agentengine/controllers/method/delete_session.go
+++ b/server/agentengine/controllers/method/delete_session.go
@@ -94,7 +94,7 @@ func (g *deleteSessionHandler) Handle(ctx context.Context, rw http.ResponseWrite
 	err = g.sessionservice.Delete(ctx, ssReq)
 	output := ""
 	if err != nil {
-		output = err.Error()
+		return fmt.Errorf("g.sessionservice.Delete() failed: %v", err)
 	}
 
 	result := models.DeleteSessionResponse{

--- a/server/agentengine/controllers/method/delete_session.go
+++ b/server/agentengine/controllers/method/delete_session.go
@@ -92,14 +92,11 @@ func (g *deleteSessionHandler) Handle(ctx context.Context, rw http.ResponseWrite
 		SessionID: req.Input.SessionID,
 	}
 	err = g.sessionservice.Delete(ctx, ssReq)
-	output := ""
 	if err != nil {
 		return fmt.Errorf("g.sessionservice.Delete() failed: %v", err)
 	}
 
-	result := models.DeleteSessionResponse{
-		Output: output,
-	}
+	result := models.DeleteSessionResponse{}
 	err = json.NewEncoder(rw).Encode(result)
 	if err != nil {
 		return fmt.Errorf("json.NewEncoder failed: %v", err)

--- a/server/agentengine/controllers/method/stream_query.go
+++ b/server/agentengine/controllers/method/stream_query.go
@@ -169,11 +169,12 @@ func (s *streamQueryHandler) run(ctx context.Context, req *models.StreamQueryReq
 	rootAgent := config.AgentLoader.RootAgent()
 
 	r, err := runner.New(runner.Config{
-		AppName:         s.agentEngineID,
-		Agent:           rootAgent,
-		SessionService:  config.SessionService,
-		ArtifactService: config.ArtifactService,
-		PluginConfig:    config.PluginConfig,
+		AppName:           s.agentEngineID,
+		Agent:             rootAgent,
+		SessionService:    config.SessionService,
+		ArtifactService:   config.ArtifactService,
+		PluginConfig:      config.PluginConfig,
+		AutoCreateSession: true,
 	})
 	if err != nil {
 		return nil, fmt.Errorf("failed to create runner: %v", err)

--- a/server/agentengine/internal/models/session.go
+++ b/server/agentengine/internal/models/session.go
@@ -26,9 +26,8 @@ type CreateSessionRequest struct {
 
 // CreateSessionInput contains input parameters
 type CreateSessionInput struct {
-	UserID    string         `json:"user_id"`
-	SessionID string         `json:"session_id,omitempty"`
-	State     map[string]any `json:"state,omitempty"`
+	UserID string         `json:"user_id"`
+	State  map[string]any `json:"state,omitempty"`
 }
 
 // CreateSessionResponse contains response


### PR DESCRIPTION
This PR streamlines the Agent Engine session management flow by shifting the responsibility of session ID generation from the client to the server completely. It also updates the stream query runner to automatically handle session creation.