### PR TITLE
fix: copy ThoughtSignature onto adk_request_confirmation parts

### DIFF
--- a/internal/llminternal/functions.go
+++ b/internal/llminternal/functions.go
@@ -43,20 +43,22 @@ func generateRequestConfirmationEvent(
 
 	parts := []*genai.Part{}
 	longRunningToolIDs := []string{}
-	functionCalls := make(map[string]*genai.FunctionCall, len(functionCallEvent.Content.Parts))
-	for _, call := range utils.FunctionCalls(functionCallEvent.Content) {
-		functionCalls[call.ID] = call
+	functionCallParts := make(map[string]*genai.Part, len(functionCallEvent.Content.Parts))
+	for _, part := range functionCallEvent.Content.Parts {
+		if part.FunctionCall != nil {
+			functionCallParts[part.FunctionCall.ID] = part
+		}
 	}
 
 	for funcID, confirmation := range functionResponseEvent.Actions.RequestedToolConfirmations {
-		originalFunctionCall, ok := functionCalls[funcID]
-		if !ok || originalFunctionCall == nil {
+		originalPart, ok := functionCallParts[funcID]
+		if !ok || originalPart.FunctionCall == nil {
 			continue
 		}
 
 		// Prepare arguments for the adk_request_confirmation call
 		args := map[string]any{
-			"originalFunctionCall": originalFunctionCall,
+			"originalFunctionCall": originalPart.FunctionCall,
 			"toolConfirmation":     confirmation,
 		}
 
@@ -66,9 +68,14 @@ func generateRequestConfirmationEvent(
 			Args: args,
 		}
 
-		parts = append(parts, &genai.Part{
+		part := &genai.Part{
 			FunctionCall: requestConfirmationFC,
-		})
+		}
+		if len(originalPart.ThoughtSignature) > 0 {
+			part.ThoughtSignature = originalPart.ThoughtSignature
+		}
+
+		parts = append(parts, part)
 		longRunningToolIDs = append(longRunningToolIDs, requestConfirmationFC.ID)
 	}
 

--- a/internal/llminternal/functions.go
+++ b/internal/llminternal/functions.go
@@ -68,14 +68,10 @@ func generateRequestConfirmationEvent(
 			Args: args,
 		}
 
-		part := &genai.Part{
-			FunctionCall: requestConfirmationFC,
-		}
-		if len(originalPart.ThoughtSignature) > 0 {
-			part.ThoughtSignature = originalPart.ThoughtSignature
-		}
-
-		parts = append(parts, part)
+		parts = append(parts, &genai.Part{
+			FunctionCall:     requestConfirmationFC,
+			ThoughtSignature: originalPart.ThoughtSignature,
+		})
 		longRunningToolIDs = append(longRunningToolIDs, requestConfirmationFC.ID)
 	}
 

--- a/internal/llminternal/functions_test.go
+++ b/internal/llminternal/functions_test.go
@@ -157,12 +157,12 @@ func TestGenerateRequestConfirmationEvent(t *testing.T) {
 							{
 								FunctionCall: &genai.FunctionCall{
 									Name: toolconfirmation.FunctionCallName,
-									Args: map[string]any{
-										"originalFunctionCall": confirmingFunctionCall,
-										"toolConfirmation": toolconfirmation.ToolConfirmation{
-											Hint: "Are you sure?",
-										},
+								Args: map[string]any{
+									"originalFunctionCall": confirmingFunctionCall,
+									"toolConfirmation": toolconfirmation.ToolConfirmation{
+										Hint: "Are you sure?",
 									},
+								},
 								},
 							},
 						},
@@ -250,5 +250,81 @@ func TestGenerateRequestConfirmationEventHasID(t *testing.T) {
 
 	if got.InvocationID != "inv_1" {
 		t.Errorf("expected InvocationID=\"inv_1\", got %q", got.InvocationID)
+	}
+}
+
+func TestGenerateRequestConfirmationEventPreservesThoughtSignature(t *testing.T) {
+	thoughtSignature := []byte("test-thought-signature")
+	ctx := &mockInvocationContext{
+		invocationID: "inv_1",
+		agentName:    "agent_1",
+	}
+	functionCallEvent := &session.Event{
+		LLMResponse: model.LLMResponse{
+			Content: &genai.Content{
+				Parts: []*genai.Part{
+					{
+						ThoughtSignature: thoughtSignature,
+						FunctionCall: &genai.FunctionCall{
+							ID:   "call_1",
+							Name: "test_tool",
+							Args: map[string]any{"arg": "val"},
+						},
+					},
+				},
+			},
+		},
+	}
+	functionResponseEvent := &session.Event{
+		Actions: session.EventActions{
+			RequestedToolConfirmations: map[string]toolconfirmation.ToolConfirmation{
+				"call_1": {Hint: "Are you sure?"},
+			},
+		},
+	}
+
+	got := generateRequestConfirmationEvent(ctx, functionCallEvent, functionResponseEvent)
+	if got == nil || got.Content == nil || len(got.Content.Parts) != 1 {
+		t.Fatalf("expected one confirmation part, got %#v", got)
+	}
+	if diff := cmp.Diff(thoughtSignature, got.Content.Parts[0].ThoughtSignature); diff != "" {
+		t.Errorf("ThoughtSignature mismatch (-want +got):\n%s", diff)
+	}
+}
+
+func TestGenerateRequestConfirmationEventNoThoughtSignature(t *testing.T) {
+	ctx := &mockInvocationContext{
+		invocationID: "inv_1",
+		agentName:    "agent_1",
+	}
+	functionCallEvent := &session.Event{
+		LLMResponse: model.LLMResponse{
+			Content: &genai.Content{
+				Parts: []*genai.Part{
+					{
+						FunctionCall: &genai.FunctionCall{
+							ID:   "call_1",
+							Name: "test_tool",
+							Args: map[string]any{"arg": "val"},
+						},
+					},
+				},
+			},
+		},
+	}
+	functionResponseEvent := &session.Event{
+		Actions: session.EventActions{
+			RequestedToolConfirmations: map[string]toolconfirmation.ToolConfirmation{
+				"call_1": {Hint: "Are you sure?"},
+			},
+		},
+	}
+
+	got := generateRequestConfirmationEvent(ctx, functionCallEvent, functionResponseEvent)
+	if got == nil || got.Content == nil || len(got.Content.Parts) != 1 {
+		t.Fatalf("expected one confirmation part, got %#v", got)
+	}
+	if len(got.Content.Parts[0].ThoughtSignature) != 0 {
+		t.Errorf("ThoughtSignature = %q, want empty", got.Content.Parts[0].ThoughtSignature)
 	}
 }

--- a/internal/llminternal/functions_test.go
+++ b/internal/llminternal/functions_test.go
@@ -157,12 +157,12 @@ func TestGenerateRequestConfirmationEvent(t *testing.T) {
 							{
 								FunctionCall: &genai.FunctionCall{
 									Name: toolconfirmation.FunctionCallName,
-								Args: map[string]any{
-									"originalFunctionCall": confirmingFunctionCall,
-									"toolConfirmation": toolconfirmation.ToolConfirmation{
-										Hint: "Are you sure?",
+									Args: map[string]any{
+										"originalFunctionCall": confirmingFunctionCall,
+										"toolConfirmation": toolconfirmation.ToolConfirmation{
+											Hint: "Are you sure?",
+										},
 									},
-								},
 								},
 							},
 						},


### PR DESCRIPTION
### Link to Issue or Description of Change

- Closes: google/adk-go#656

### Problem

`generateRequestConfirmationEvent` in `internal/llminternal/functions.go` creates synthetic `adk_request_confirmation` `FunctionCall` parts but does not copy the `ThoughtSignature` from the original model-generated `FunctionCall` part onto them.

Gemini thinking models require replayed model-role function-call parts to carry their thought signature, so the next model request rejects the synthetic part with `400 INVALID_ARGUMENT`: "function call `adk_request_confirmation` ... is missing a `thought_signature`".

The stream aggregator already handles this for normal streamed function calls. The confirmation flow simply missed it.

### Solution

When building the synthetic confirmation part, look up the original part by function-call ID and copy its `ThoughtSignature` onto the new part when present.

### Testing Plan

- [x] Added `TestGenerateRequestConfirmationEventPreservesThoughtSignature` verifying the original signature is copied onto the synthetic confirmation part.
- [x] Added `TestGenerateRequestConfirmationEventNoThoughtSignature` verifying normal behavior when the original part has no signature.
- [x] Ran focused unit tests locally.

```sh
go test ./internal/llminternal
```

### Alignment with adk-python

This follows the cross-ADK requirement for Gemini thinking models: any replayed model-role function-call part, including ADK-generated confirmation calls, must preserve the thought signature associated with the model output.
