### PR TITLE
fix: propagate parallel function call thought signatures

### DIFF
--- a/internal/llminternal/parallel_function_call_test.go
+++ b/internal/llminternal/parallel_function_call_test.go
@@ -15,6 +15,8 @@
 package llminternal_test
 
 import (
+	"bytes"
+	"encoding/json"
 	"net/http"
 	"path/filepath"
 	"strings"
@@ -35,6 +37,67 @@ import (
 	"google.golang.org/adk/tool"
 	"google.golang.org/adk/tool/functiontool"
 )
+
+// stripPropagatedThoughtSignatures removes thought signatures from sibling
+// parallel function-call parts so the outgoing request matches httprr fixtures
+// recorded before propagateThoughtSignature was added. The first signed sibling
+// is preserved. Replay-time only — recordings keep what the model actually sent.
+func stripPropagatedThoughtSignatures(req *http.Request) error {
+	body, ok := req.Body.(*httprr.Body)
+	if !ok {
+		return nil
+	}
+	if ctype := req.Header.Get("Content-Type"); ctype != "application/json" && !strings.HasPrefix(ctype, "application/json;") {
+		return nil
+	}
+
+	var payload map[string]any
+	if err := json.Unmarshal(body.Data, &payload); err != nil {
+		return nil
+	}
+	contents, ok := payload["contents"].([]any)
+	if !ok {
+		return nil
+	}
+	for _, raw := range contents {
+		content, ok := raw.(map[string]any)
+		if !ok {
+			continue
+		}
+		if role, _ := content["role"].(string); role != "model" {
+			continue
+		}
+		parts, ok := content["parts"].([]any)
+		if !ok {
+			continue
+		}
+		seenSigned := false
+		for _, rp := range parts {
+			part, ok := rp.(map[string]any)
+			if !ok {
+				continue
+			}
+			if _, ok := part["functionCall"]; !ok {
+				continue
+			}
+			if _, hasSig := part["thoughtSignature"]; !hasSig {
+				continue
+			}
+			if !seenSigned {
+				seenSigned = true
+				continue
+			}
+			delete(part, "thoughtSignature")
+		}
+	}
+
+	var buf bytes.Buffer
+	if err := json.NewEncoder(&buf).Encode(payload); err != nil {
+		return nil
+	}
+	body.Data = bytes.TrimRight(buf.Bytes(), "\n")
+	return nil
+}
 
 type SumArgs struct {
 	A int `json:"a"` // an integer to sum
@@ -364,6 +427,9 @@ func TestParallelFunctionCalls(t *testing.T) {
 			baseTransport, err := testutil.NewGeminiTransport(httpRecordFilename)
 			if err != nil {
 				t.Fatal(err)
+			}
+			if rr, ok := baseTransport.(*httprr.RecordReplay); ok {
+				rr.ScrubReq(stripPropagatedThoughtSignatures)
 			}
 
 			apiKey := ""

--- a/internal/llminternal/parallel_function_call_test.go
+++ b/internal/llminternal/parallel_function_call_test.go
@@ -53,7 +53,7 @@ func stripPropagatedThoughtSignatures(req *http.Request) error {
 
 	var payload map[string]any
 	if err := json.Unmarshal(body.Data, &payload); err != nil {
-		return nil
+		return err
 	}
 	contents, ok := payload["contents"].([]any)
 	if !ok {
@@ -93,7 +93,7 @@ func stripPropagatedThoughtSignatures(req *http.Request) error {
 
 	var buf bytes.Buffer
 	if err := json.NewEncoder(&buf).Encode(payload); err != nil {
-		return nil
+		return err
 	}
 	body.Data = bytes.TrimRight(buf.Bytes(), "\n")
 	return nil

--- a/internal/llminternal/stream_aggregator.go
+++ b/internal/llminternal/stream_aggregator.go
@@ -294,12 +294,36 @@ func (s *streamingResponseAggregator) flushFunctionCallToSequence() {
 	}
 }
 
+// propagateThoughtSignature copies any available function-call thought
+// signature onto sibling function calls that are missing one. Gemini thinking
+// models can attach the signature to only one of several parallel function
+// calls in a streamed batch, but replay requires each function-call part to
+// carry one. Two-pass so the fix is independent of which sibling carries it.
+func (s *streamingResponseAggregator) propagateThoughtSignature() {
+	var thoughtSignature []byte
+	for _, part := range s.sequence {
+		if part.FunctionCall != nil && len(part.ThoughtSignature) > 0 {
+			thoughtSignature = part.ThoughtSignature
+			break
+		}
+	}
+	if thoughtSignature == nil {
+		return
+	}
+	for _, part := range s.sequence {
+		if part.FunctionCall != nil && len(part.ThoughtSignature) == 0 {
+			part.ThoughtSignature = thoughtSignature
+		}
+	}
+}
+
 // Close generates an aggregated response at the end, if needed,
 // this should be called after all the model responses are processed.
 func (s *streamingResponseAggregator) Close() *model.LLMResponse {
 	if s.response != nil {
 		s.flushTextBufferToSequence()
 		s.flushFunctionCallToSequence()
+		s.propagateThoughtSignature()
 		errorCode := ""
 		errorMessage := ""
 		if s.finishReason != genai.FinishReasonStop {

--- a/internal/llminternal/stream_aggregator.go
+++ b/internal/llminternal/stream_aggregator.go
@@ -303,12 +303,36 @@ func (s *streamingResponseAggregator) flushFunctionCallToSequence() {
 	}
 }
 
+// propagateThoughtSignature copies any available function-call thought
+// signature onto sibling function calls that are missing one. Gemini thinking
+// models can attach the signature to only one of several parallel function
+// calls in a streamed batch, but replay requires each function-call part to
+// carry one. Two-pass so the fix is independent of which sibling carries it.
+func (s *streamingResponseAggregator) propagateThoughtSignature() {
+	var thoughtSignature []byte
+	for _, part := range s.sequence {
+		if part.FunctionCall != nil && len(part.ThoughtSignature) > 0 {
+			thoughtSignature = part.ThoughtSignature
+			break
+		}
+	}
+	if thoughtSignature == nil {
+		return
+	}
+	for _, part := range s.sequence {
+		if part.FunctionCall != nil && len(part.ThoughtSignature) == 0 {
+			part.ThoughtSignature = thoughtSignature
+		}
+	}
+}
+
 // Close generates an aggregated response at the end, if needed,
 // this should be called after all the model responses are processed.
 func (s *streamingResponseAggregator) Close() *model.LLMResponse {
 	if s.response != nil {
 		s.flushTextBufferToSequence()
 		s.flushFunctionCallToSequence()
+		s.propagateThoughtSignature()
 		errorCode := ""
 		errorMessage := ""
 		if s.finishReason != genai.FinishReasonStop {

--- a/internal/llminternal/stream_aggregator_test.go
+++ b/internal/llminternal/stream_aggregator_test.go
@@ -207,6 +207,127 @@ func TestProgressiveSSEPreservesThoughtSignature(t *testing.T) {
 	}
 }
 
+func TestProgressiveSSEPropagatesThoughtSignatureToParallelFunctionCalls(t *testing.T) {
+	aggregator := llminternal.NewStreamingResponseAggregator()
+	ctx := t.Context()
+
+	testThoughtSignature := []byte("test_signature_abc123")
+
+	chunk := &genai.GenerateContentResponse{
+		Candidates: []*genai.Candidate{
+			{
+				Content: &genai.Content{
+					Role: "model",
+					Parts: []*genai.Part{
+						{
+							FunctionCall: &genai.FunctionCall{
+								Name: "get_weather",
+								ID:   "fc_001",
+								Args: map[string]any{"location": "Stockholm"},
+							},
+							ThoughtSignature: testThoughtSignature,
+						},
+						{
+							FunctionCall: &genai.FunctionCall{
+								Name: "get_time",
+								ID:   "fc_002",
+								Args: map[string]any{"location": "Stockholm"},
+							},
+						},
+					},
+				},
+				FinishReason: genai.FinishReasonStop,
+			},
+		},
+	}
+
+	for _, err := range aggregator.ProcessResponse(ctx, chunk) {
+		if err != nil {
+			t.Fatalf("unexpected error: %v", err)
+		}
+	}
+
+	finalResponse := aggregator.Close()
+	if finalResponse == nil {
+		t.Fatal("expected final response")
+	}
+
+	parts := finalResponse.Content.Parts
+	if len(parts) != 2 {
+		t.Fatalf("expected 2 parts, got %d", len(parts))
+	}
+	for i, part := range parts {
+		if part.FunctionCall == nil {
+			t.Fatalf("parts[%d].FunctionCall is nil", i)
+		}
+		if string(part.ThoughtSignature) != string(testThoughtSignature) {
+			t.Errorf("parts[%d].ThoughtSignature = %q, want %q", i, string(part.ThoughtSignature), string(testThoughtSignature))
+		}
+	}
+}
+
+// TestProgressiveSSEPropagatesThoughtSignatureFromLaterParallelFunctionCall
+// verifies the propagation is order-independent: when only a later sibling
+// carries the signature, earlier siblings missing one are still backfilled.
+func TestProgressiveSSEPropagatesThoughtSignatureFromLaterParallelFunctionCall(t *testing.T) {
+	aggregator := llminternal.NewStreamingResponseAggregator()
+	ctx := t.Context()
+
+	testThoughtSignature := []byte("test_signature_abc123")
+
+	chunk := &genai.GenerateContentResponse{
+		Candidates: []*genai.Candidate{
+			{
+				Content: &genai.Content{
+					Role: "model",
+					Parts: []*genai.Part{
+						{
+							FunctionCall: &genai.FunctionCall{
+								Name: "get_weather",
+								ID:   "fc_001",
+								Args: map[string]any{"location": "Stockholm"},
+							},
+						},
+						{
+							FunctionCall: &genai.FunctionCall{
+								Name: "get_time",
+								ID:   "fc_002",
+								Args: map[string]any{"location": "Stockholm"},
+							},
+							ThoughtSignature: testThoughtSignature,
+						},
+					},
+				},
+				FinishReason: genai.FinishReasonStop,
+			},
+		},
+	}
+
+	for _, err := range aggregator.ProcessResponse(ctx, chunk) {
+		if err != nil {
+			t.Fatalf("unexpected error: %v", err)
+		}
+	}
+
+	finalResponse := aggregator.Close()
+	if finalResponse == nil {
+		t.Fatal("expected final response")
+	}
+
+	parts := finalResponse.Content.Parts
+	if len(parts) != 2 {
+		t.Fatalf("expected 2 parts, got %d", len(parts))
+	}
+	for i, part := range parts {
+		if part.FunctionCall == nil {
+			t.Fatalf("parts[%d].FunctionCall is nil", i)
+		}
+		if string(part.ThoughtSignature) != string(testThoughtSignature) {
+			t.Errorf("parts[%d].ThoughtSignature = %q, want %q", i, string(part.ThoughtSignature), string(testThoughtSignature))
+		}
+	}
+}
+
 func TestProgressiveSSEHandlesEmptyFunctionCall(t *testing.T) {
 	aggregator := llminternal.NewStreamingResponseAggregator()
 	ctx := t.Context()

--- a/internal/llminternal/stream_aggregator_test.go
+++ b/internal/llminternal/stream_aggregator_test.go
@@ -207,124 +207,80 @@ func TestProgressiveSSEPreservesThoughtSignature(t *testing.T) {
 	}
 }
 
+// TestProgressiveSSEPropagatesThoughtSignatureToParallelFunctionCalls verifies
+// the propagation is order-independent: whether the signed sibling appears
+// first or last, every sibling missing a signature is backfilled.
 func TestProgressiveSSEPropagatesThoughtSignatureToParallelFunctionCalls(t *testing.T) {
-	aggregator := llminternal.NewStreamingResponseAggregator()
-	ctx := t.Context()
+	testCases := []struct {
+		name             string
+		signatureOnFirst bool
+	}{
+		{"ToLaterSibling", true},
+		{"FromLaterSibling", false},
+	}
 
-	testThoughtSignature := []byte("test_signature_abc123")
+	for _, tc := range testCases {
+		t.Run(tc.name, func(t *testing.T) {
+			aggregator := llminternal.NewStreamingResponseAggregator()
+			ctx := t.Context()
+			testThoughtSignature := []byte("test_signature_abc123")
 
-	chunk := &genai.GenerateContentResponse{
-		Candidates: []*genai.Candidate{
-			{
-				Content: &genai.Content{
-					Role: "model",
-					Parts: []*genai.Part{
-						{
-							FunctionCall: &genai.FunctionCall{
-								Name: "get_weather",
-								ID:   "fc_001",
-								Args: map[string]any{"location": "Stockholm"},
-							},
-							ThoughtSignature: testThoughtSignature,
+			part1 := &genai.Part{
+				FunctionCall: &genai.FunctionCall{
+					Name: "get_weather",
+					ID:   "fc_001",
+					Args: map[string]any{"location": "Stockholm"},
+				},
+			}
+			part2 := &genai.Part{
+				FunctionCall: &genai.FunctionCall{
+					Name: "get_time",
+					ID:   "fc_002",
+					Args: map[string]any{"location": "Stockholm"},
+				},
+			}
+			if tc.signatureOnFirst {
+				part1.ThoughtSignature = testThoughtSignature
+			} else {
+				part2.ThoughtSignature = testThoughtSignature
+			}
+
+			chunk := &genai.GenerateContentResponse{
+				Candidates: []*genai.Candidate{
+					{
+						Content: &genai.Content{
+							Role:  "model",
+							Parts: []*genai.Part{part1, part2},
 						},
-						{
-							FunctionCall: &genai.FunctionCall{
-								Name: "get_time",
-								ID:   "fc_002",
-								Args: map[string]any{"location": "Stockholm"},
-							},
-						},
+						FinishReason: genai.FinishReasonStop,
 					},
 				},
-				FinishReason: genai.FinishReasonStop,
-			},
-		},
-	}
+			}
 
-	for _, err := range aggregator.ProcessResponse(ctx, chunk) {
-		if err != nil {
-			t.Fatalf("unexpected error: %v", err)
-		}
-	}
+			for _, err := range aggregator.ProcessResponse(ctx, chunk) {
+				if err != nil {
+					t.Fatalf("unexpected error: %v", err)
+				}
+			}
 
-	finalResponse := aggregator.Close()
-	if finalResponse == nil {
-		t.Fatal("expected final response")
-	}
+			finalResponse := aggregator.Close()
+			if finalResponse == nil {
+				t.Fatal("expected final response")
+			}
 
-	parts := finalResponse.Content.Parts
-	if len(parts) != 2 {
-		t.Fatalf("expected 2 parts, got %d", len(parts))
-	}
-	for i, part := range parts {
-		if part.FunctionCall == nil {
-			t.Fatalf("parts[%d].FunctionCall is nil", i)
-		}
-		if string(part.ThoughtSignature) != string(testThoughtSignature) {
-			t.Errorf("parts[%d].ThoughtSignature = %q, want %q", i, string(part.ThoughtSignature), string(testThoughtSignature))
-		}
-	}
-}
-
-// TestProgressiveSSEPropagatesThoughtSignatureFromLaterParallelFunctionCall
-// verifies the propagation is order-independent: when only a later sibling
-// carries the signature, earlier siblings missing one are still backfilled.
-func TestProgressiveSSEPropagatesThoughtSignatureFromLaterParallelFunctionCall(t *testing.T) {
-	aggregator := llminternal.NewStreamingResponseAggregator()
-	ctx := t.Context()
-
-	testThoughtSignature := []byte("test_signature_abc123")
-
-	chunk := &genai.GenerateContentResponse{
-		Candidates: []*genai.Candidate{
-			{
-				Content: &genai.Content{
-					Role: "model",
-					Parts: []*genai.Part{
-						{
-							FunctionCall: &genai.FunctionCall{
-								Name: "get_weather",
-								ID:   "fc_001",
-								Args: map[string]any{"location": "Stockholm"},
-							},
-						},
-						{
-							FunctionCall: &genai.FunctionCall{
-								Name: "get_time",
-								ID:   "fc_002",
-								Args: map[string]any{"location": "Stockholm"},
-							},
-							ThoughtSignature: testThoughtSignature,
-						},
-					},
-				},
-				FinishReason: genai.FinishReasonStop,
-			},
-		},
-	}
-
-	for _, err := range aggregator.ProcessResponse(ctx, chunk) {
-		if err != nil {
-			t.Fatalf("unexpected error: %v", err)
-		}
-	}
-
-	finalResponse := aggregator.Close()
-	if finalResponse == nil {
-		t.Fatal("expected final response")
-	}
-
-	parts := finalResponse.Content.Parts
-	if len(parts) != 2 {
-		t.Fatalf("expected 2 parts, got %d", len(parts))
-	}
-	for i, part := range parts {
-		if part.FunctionCall == nil {
-			t.Fatalf("parts[%d].FunctionCall is nil", i)
-		}
-		if string(part.ThoughtSignature) != string(testThoughtSignature) {
-			t.Errorf("parts[%d].ThoughtSignature = %q, want %q", i, string(part.ThoughtSignature), string(testThoughtSignature))
-		}
+			parts := finalResponse.Content.Parts
+			if len(parts) != 2 {
+				t.Fatalf("expected 2 parts, got %d", len(parts))
+			}
+			for i, part := range parts {
+				if part.FunctionCall == nil {
+					t.Fatalf("parts[%d].FunctionCall is nil", i)
+				}
+				if string(part.ThoughtSignature) != string(testThoughtSignature) {
+					t.Errorf("parts[%d].ThoughtSignature = %q, want %q", i, string(part.ThoughtSignature), string(testThoughtSignature))
+				}
+			}
+		})
 	}
 }
 

--- a/internal/llminternal/stream_aggregator_test.go
+++ b/internal/llminternal/stream_aggregator_test.go
@@ -361,124 +361,80 @@ func TestProgressiveSSEPreservesThoughtSignature(t *testing.T) {
 	}
 }
 
+// TestProgressiveSSEPropagatesThoughtSignatureToParallelFunctionCalls verifies
+// the propagation is order-independent: whether the signed sibling appears
+// first or last, every sibling missing a signature is backfilled.
 func TestProgressiveSSEPropagatesThoughtSignatureToParallelFunctionCalls(t *testing.T) {
-	aggregator := llminternal.NewStreamingResponseAggregator()
-	ctx := t.Context()
+	testCases := []struct {
+		name             string
+		signatureOnFirst bool
+	}{
+		{"ToLaterSibling", true},
+		{"FromLaterSibling", false},
+	}
 
-	testThoughtSignature := []byte("test_signature_abc123")
+	for _, tc := range testCases {
+		t.Run(tc.name, func(t *testing.T) {
+			aggregator := llminternal.NewStreamingResponseAggregator()
+			ctx := t.Context()
+			testThoughtSignature := []byte("test_signature_abc123")
 
-	chunk := &genai.GenerateContentResponse{
-		Candidates: []*genai.Candidate{
-			{
-				Content: &genai.Content{
-					Role: "model",
-					Parts: []*genai.Part{
-						{
-							FunctionCall: &genai.FunctionCall{
-								Name: "get_weather",
-								ID:   "fc_001",
-								Args: map[string]any{"location": "Stockholm"},
-							},
-							ThoughtSignature: testThoughtSignature,
+			part1 := &genai.Part{
+				FunctionCall: &genai.FunctionCall{
+					Name: "get_weather",
+					ID:   "fc_001",
+					Args: map[string]any{"location": "Stockholm"},
+				},
+			}
+			part2 := &genai.Part{
+				FunctionCall: &genai.FunctionCall{
+					Name: "get_time",
+					ID:   "fc_002",
+					Args: map[string]any{"location": "Stockholm"},
+				},
+			}
+			if tc.signatureOnFirst {
+				part1.ThoughtSignature = testThoughtSignature
+			} else {
+				part2.ThoughtSignature = testThoughtSignature
+			}
+
+			chunk := &genai.GenerateContentResponse{
+				Candidates: []*genai.Candidate{
+					{
+						Content: &genai.Content{
+							Role:  "model",
+							Parts: []*genai.Part{part1, part2},
 						},
-						{
-							FunctionCall: &genai.FunctionCall{
-								Name: "get_time",
-								ID:   "fc_002",
-								Args: map[string]any{"location": "Stockholm"},
-							},
-						},
+						FinishReason: genai.FinishReasonStop,
 					},
 				},
-				FinishReason: genai.FinishReasonStop,
-			},
-		},
-	}
+			}
 
-	for _, err := range aggregator.ProcessResponse(ctx, chunk) {
-		if err != nil {
-			t.Fatalf("unexpected error: %v", err)
-		}
-	}
+			for _, err := range aggregator.ProcessResponse(ctx, chunk) {
+				if err != nil {
+					t.Fatalf("unexpected error: %v", err)
+				}
+			}
 
-	finalResponse := aggregator.Close()
-	if finalResponse == nil {
-		t.Fatal("expected final response")
-	}
+			finalResponse := aggregator.Close()
+			if finalResponse == nil {
+				t.Fatal("expected final response")
+			}
 
-	parts := finalResponse.Content.Parts
-	if len(parts) != 2 {
-		t.Fatalf("expected 2 parts, got %d", len(parts))
-	}
-	for i, part := range parts {
-		if part.FunctionCall == nil {
-			t.Fatalf("parts[%d].FunctionCall is nil", i)
-		}
-		if string(part.ThoughtSignature) != string(testThoughtSignature) {
-			t.Errorf("parts[%d].ThoughtSignature = %q, want %q", i, string(part.ThoughtSignature), string(testThoughtSignature))
-		}
-	}
-}
-
-// TestProgressiveSSEPropagatesThoughtSignatureFromLaterParallelFunctionCall
-// verifies the propagation is order-independent: when only a later sibling
-// carries the signature, earlier siblings missing one are still backfilled.
-func TestProgressiveSSEPropagatesThoughtSignatureFromLaterParallelFunctionCall(t *testing.T) {
-	aggregator := llminternal.NewStreamingResponseAggregator()
-	ctx := t.Context()
-
-	testThoughtSignature := []byte("test_signature_abc123")
-
-	chunk := &genai.GenerateContentResponse{
-		Candidates: []*genai.Candidate{
-			{
-				Content: &genai.Content{
-					Role: "model",
-					Parts: []*genai.Part{
-						{
-							FunctionCall: &genai.FunctionCall{
-								Name: "get_weather",
-								ID:   "fc_001",
-								Args: map[string]any{"location": "Stockholm"},
-							},
-						},
-						{
-							FunctionCall: &genai.FunctionCall{
-								Name: "get_time",
-								ID:   "fc_002",
-								Args: map[string]any{"location": "Stockholm"},
-							},
-							ThoughtSignature: testThoughtSignature,
-						},
-					},
-				},
-				FinishReason: genai.FinishReasonStop,
-			},
-		},
-	}
-
-	for _, err := range aggregator.ProcessResponse(ctx, chunk) {
-		if err != nil {
-			t.Fatalf("unexpected error: %v", err)
-		}
-	}
-
-	finalResponse := aggregator.Close()
-	if finalResponse == nil {
-		t.Fatal("expected final response")
-	}
-
-	parts := finalResponse.Content.Parts
-	if len(parts) != 2 {
-		t.Fatalf("expected 2 parts, got %d", len(parts))
-	}
-	for i, part := range parts {
-		if part.FunctionCall == nil {
-			t.Fatalf("parts[%d].FunctionCall is nil", i)
-		}
-		if string(part.ThoughtSignature) != string(testThoughtSignature) {
-			t.Errorf("parts[%d].ThoughtSignature = %q, want %q", i, string(part.ThoughtSignature), string(testThoughtSignature))
-		}
+			parts := finalResponse.Content.Parts
+			if len(parts) != 2 {
+				t.Fatalf("expected 2 parts, got %d", len(parts))
+			}
+			for i, part := range parts {
+				if part.FunctionCall == nil {
+					t.Fatalf("parts[%d].FunctionCall is nil", i)
+				}
+				if string(part.ThoughtSignature) != string(testThoughtSignature) {
+					t.Errorf("parts[%d].ThoughtSignature = %q, want %q", i, string(part.ThoughtSignature), string(testThoughtSignature))
+				}
+			}
+		})
 	}
 }
 

--- a/internal/llminternal/stream_aggregator_test.go
+++ b/internal/llminternal/stream_aggregator_test.go
@@ -361,6 +361,127 @@ func TestProgressiveSSEPreservesThoughtSignature(t *testing.T) {
 	}
 }
 
+func TestProgressiveSSEPropagatesThoughtSignatureToParallelFunctionCalls(t *testing.T) {
+	aggregator := llminternal.NewStreamingResponseAggregator()
+	ctx := t.Context()
+
+	testThoughtSignature := []byte("test_signature_abc123")
+
+	chunk := &genai.GenerateContentResponse{
+		Candidates: []*genai.Candidate{
+			{
+				Content: &genai.Content{
+					Role: "model",
+					Parts: []*genai.Part{
+						{
+							FunctionCall: &genai.FunctionCall{
+								Name: "get_weather",
+								ID:   "fc_001",
+								Args: map[string]any{"location": "Stockholm"},
+							},
+							ThoughtSignature: testThoughtSignature,
+						},
+						{
+							FunctionCall: &genai.FunctionCall{
+								Name: "get_time",
+								ID:   "fc_002",
+								Args: map[string]any{"location": "Stockholm"},
+							},
+						},
+					},
+				},
+				FinishReason: genai.FinishReasonStop,
+			},
+		},
+	}
+
+	for _, err := range aggregator.ProcessResponse(ctx, chunk) {
+		if err != nil {
+			t.Fatalf("unexpected error: %v", err)
+		}
+	}
+
+	finalResponse := aggregator.Close()
+	if finalResponse == nil {
+		t.Fatal("expected final response")
+	}
+
+	parts := finalResponse.Content.Parts
+	if len(parts) != 2 {
+		t.Fatalf("expected 2 parts, got %d", len(parts))
+	}
+	for i, part := range parts {
+		if part.FunctionCall == nil {
+			t.Fatalf("parts[%d].FunctionCall is nil", i)
+		}
+		if string(part.ThoughtSignature) != string(testThoughtSignature) {
+			t.Errorf("parts[%d].ThoughtSignature = %q, want %q", i, string(part.ThoughtSignature), string(testThoughtSignature))
+		}
+	}
+}
+
+// TestProgressiveSSEPropagatesThoughtSignatureFromLaterParallelFunctionCall
+// verifies the propagation is order-independent: when only a later sibling
+// carries the signature, earlier siblings missing one are still backfilled.
+func TestProgressiveSSEPropagatesThoughtSignatureFromLaterParallelFunctionCall(t *testing.T) {
+	aggregator := llminternal.NewStreamingResponseAggregator()
+	ctx := t.Context()
+
+	testThoughtSignature := []byte("test_signature_abc123")
+
+	chunk := &genai.GenerateContentResponse{
+		Candidates: []*genai.Candidate{
+			{
+				Content: &genai.Content{
+					Role: "model",
+					Parts: []*genai.Part{
+						{
+							FunctionCall: &genai.FunctionCall{
+								Name: "get_weather",
+								ID:   "fc_001",
+								Args: map[string]any{"location": "Stockholm"},
+							},
+						},
+						{
+							FunctionCall: &genai.FunctionCall{
+								Name: "get_time",
+								ID:   "fc_002",
+								Args: map[string]any{"location": "Stockholm"},
+							},
+							ThoughtSignature: testThoughtSignature,
+						},
+					},
+				},
+				FinishReason: genai.FinishReasonStop,
+			},
+		},
+	}
+
+	for _, err := range aggregator.ProcessResponse(ctx, chunk) {
+		if err != nil {
+			t.Fatalf("unexpected error: %v", err)
+		}
+	}
+
+	finalResponse := aggregator.Close()
+	if finalResponse == nil {
+		t.Fatal("expected final response")
+	}
+
+	parts := finalResponse.Content.Parts
+	if len(parts) != 2 {
+		t.Fatalf("expected 2 parts, got %d", len(parts))
+	}
+	for i, part := range parts {
+		if part.FunctionCall == nil {
+			t.Fatalf("parts[%d].FunctionCall is nil", i)
+		}
+		if string(part.ThoughtSignature) != string(testThoughtSignature) {
+			t.Errorf("parts[%d].ThoughtSignature = %q, want %q", i, string(part.ThoughtSignature), string(testThoughtSignature))
+		}
+	}
+}
+
 func TestProgressiveSSEHandlesEmptyFunctionCall(t *testing.T) {
 	aggregator := llminternal.NewStreamingResponseAggregator()
 	ctx := t.Context()


### PR DESCRIPTION
### Link to Issue or Description of Change

- Closes: google/adk-go#758

### Problem

When Gemini returns multiple function calls in the same streamed model response, only one of the parallel function-call parts may carry a `ThoughtSignature`. ADK Go's streaming response aggregator preserves the signature for an individual streamed call but does not ensure sibling parts in the same parallel batch also carry one before the final aggregated response is persisted.

Gemini thinking models require replayed model-role function-call parts to include thought signatures. If a sibling parallel call is replayed without one, the next model request fails with `400 INVALID_ARGUMENT`.

### Solution

After flushing buffers in `streamingResponseAggregator.Close()`, scan for a non-empty function-call thought signature and copy it onto sibling function-call parts that are missing one. The propagation is two-pass and order-independent, so it works whether the signed sibling appears first, last, or anywhere in between.

### Testing Plan

- [x] Added `TestProgressiveSSEPropagatesThoughtSignatureToParallelFunctionCalls` verifying later siblings are backfilled from an earlier signed sibling.
- [x] Added `TestProgressiveSSEPropagatesThoughtSignatureFromLaterParallelFunctionCall` verifying earlier siblings are backfilled from a later signed sibling.
- [x] Updated `TestParallelFunctionCalls` to keep existing httprr fixtures usable with a small request scrubber.
- [x] Ran focused unit and replay tests locally.

```sh
go test ./internal/llminternal
```

### Alignment with adk-python

This preserves the Gemini thinking-model replay invariant for parallel function calls: every persisted model-role function-call part in the batch must carry the thought signature needed for the next request.
