### PR TITLE
fix: preserve unrelated function events

### DIFF
--- a/internal/llminternal/contents_processor.go
+++ b/internal/llminternal/contents_processor.go
@@ -225,10 +225,18 @@ SearchLoop: // A label to allow breaking out of the nested loop
 		)
 	}
 
-	// Collect all function response events *between* the call and the last response.
+	// Collect function response events related to the matching call while
+	// preserving unrelated tool events that happened in between.
 	var responseEventsToMerge []*session.Event
+	resultEvents := events[:functionCallEventIdx+1]
 	for i := functionCallEventIdx + 1; i < len(events)-1; i++ {
 		event := events[i]
+		calls := utils.FunctionCalls(event.Content)
+		if len(calls) > 0 {
+			resultEvents = append(resultEvents, event)
+			continue
+		}
+
 		responses := utils.FunctionResponses(event.Content)
 		if len(responses) == 0 {
 			continue
@@ -245,13 +253,14 @@ SearchLoop: // A label to allow breaking out of the nested loop
 
 		if isRelated {
 			responseEventsToMerge = append(responseEventsToMerge, event)
+		} else {
+			resultEvents = append(resultEvents, event)
 		}
 	}
 
 	// Add the final response event itself to the list to be merged.
 	responseEventsToMerge = append(responseEventsToMerge, events[len(events)-1])
 
-	resultEvents := events[:functionCallEventIdx+1]
 	mergedEvent, err := mergeFunctionResponseEvents(responseEventsToMerge)
 	if err != nil {
 		return nil, err

--- a/internal/llminternal/contents_processor.go
+++ b/internal/llminternal/contents_processor.go
@@ -272,10 +272,18 @@ SearchLoop: // A label to allow breaking out of the nested loop
 		)
 	}
 
-	// Collect all function response events *between* the call and the last response.
+	// Collect function response events related to the matching call while
+	// preserving unrelated tool events that happened in between.
 	var responseEventsToMerge []*session.Event
+	resultEvents := events[:functionCallEventIdx+1]
 	for i := functionCallEventIdx + 1; i < len(events)-1; i++ {
 		event := events[i]
+		calls := utils.FunctionCalls(event.Content)
+		if len(calls) > 0 {
+			resultEvents = append(resultEvents, event)
+			continue
+		}
+
 		responses := utils.FunctionResponses(event.Content)
 		if len(responses) == 0 {
 			continue
@@ -292,13 +300,14 @@ SearchLoop: // A label to allow breaking out of the nested loop
 
 		if isRelated {
 			responseEventsToMerge = append(responseEventsToMerge, event)
+		} else {
+			resultEvents = append(resultEvents, event)
 		}
 	}
 
 	// Add the final response event itself to the list to be merged.
 	responseEventsToMerge = append(responseEventsToMerge, events[len(events)-1])
 
-	resultEvents := events[:functionCallEventIdx+1]
 	mergedEvent, err := mergeFunctionResponseEvents(responseEventsToMerge)
 	if err != nil {
 		return nil, err

--- a/internal/llminternal/contents_processor_test.go
+++ b/internal/llminternal/contents_processor_test.go
@@ -765,6 +765,24 @@ func TestContentsRequestProcessor_Rearrange(t *testing.T) {
 			},
 		},
 		{
+			name: "Rearrangement preserves unrelated function events",
+			events: []*session.Event{
+				{Author: "user", LLMResponse: model.LLMResponse{Content: genai.NewContentFromText("Run long process and search", "user")}},
+				{Author: agentName, LLMResponse: model.LLMResponse{Content: NewContentFromFunctionCall(fcLRO, "model")}},
+				{Author: "user", LLMResponse: model.LLMResponse{Content: NewContentFromFunctionResponse(frLROInter, "user")}},
+				{Author: agentName, LLMResponse: model.LLMResponse{Content: NewContentFromFunctionCall(fcBasic, "model")}},
+				{Author: "user", LLMResponse: model.LLMResponse{Content: NewContentFromFunctionResponse(frBasic, "user")}},
+				{Author: "user", LLMResponse: model.LLMResponse{Content: NewContentFromFunctionResponse(frLROFinal, "user")}},
+			},
+			want: []*genai.Content{
+				genai.NewContentFromText("Run long process and search", "user"),
+				NewContentFromFunctionCall(fcLRO, "model"),
+				NewContentFromFunctionResponse(frLROFinal, "user"),
+				NewContentFromFunctionCall(fcBasic, "model"),
+				NewContentFromFunctionResponse(frBasic, "user"),
+			},
+		},
+		{
 			name: "Rearrangement with mixed LRO and normal calls",
 			events: []*session.Event{
 				{Author: "user", LLMResponse: model.LLMResponse{Content: genai.NewContentFromText("Analyze data and search for info", "user")}},

--- a/internal/llminternal/contents_processor_test.go
+++ b/internal/llminternal/contents_processor_test.go
@@ -31,6 +31,7 @@ import (
 	"google.golang.org/adk/internal/utils"
 	"google.golang.org/adk/model"
 	"google.golang.org/adk/session"
+	"google.golang.org/adk/tool/toolconfirmation"
 )
 
 type testModel struct {
@@ -705,6 +706,70 @@ func TestContentsRequestProcessor_Rearrange(t *testing.T) {
 		Response: map[string]any{"output": "preserved"},
 	}
 
+	// Human-in-the-loop confirmation call/responses
+	fcHITLApproved := &genai.FunctionCall{
+		ID:   "hitl_approved_call",
+		Name: "request_vacation_days",
+		Args: map[string]any{"days": 5, "user_id": "user-123"},
+	}
+	frHITLApprovedPending := &genai.FunctionResponse{
+		ID:       "hitl_approved_call",
+		Name:     "request_vacation_days",
+		Response: map[string]any{"status": "Manager approval is required.", "request_id": "req-1"},
+	}
+	frHITLApprovedFinal := &genai.FunctionResponse{
+		ID:       "hitl_approved_call",
+		Name:     "request_vacation_days",
+		Response: map[string]any{"status": "The time off request is accepted.", "days_approved": 5, "request_id": "req-1"},
+	}
+	fcHITLApprovalRequest := &genai.FunctionCall{
+		ID:   "hitl_approved_confirmation",
+		Name: toolconfirmation.FunctionCallName,
+		Args: map[string]any{
+			"originalFunctionCall": fcHITLApproved,
+			"toolConfirmation": toolconfirmation.ToolConfirmation{
+				Confirmed: false,
+				Hint:      "Please approve or reject the tool call request_vacation_days().",
+			},
+		},
+	}
+	frHITLApprovalConfirmed := &genai.FunctionResponse{
+		ID:       "hitl_approved_confirmation",
+		Name:     toolconfirmation.FunctionCallName,
+		Response: map[string]any{"confirmed": true},
+	}
+	fcHITLDenied := &genai.FunctionCall{
+		ID:   "hitl_denied_call",
+		Name: "request_vacation_days",
+		Args: map[string]any{"days": 10, "user_id": "user-123"},
+	}
+	frHITLDeniedPending := &genai.FunctionResponse{
+		ID:       "hitl_denied_call",
+		Name:     "request_vacation_days",
+		Response: map[string]any{"status": "Manager approval is required.", "request_id": "req-2"},
+	}
+	frHITLDeniedFinal := &genai.FunctionResponse{
+		ID:       "hitl_denied_call",
+		Name:     "request_vacation_days",
+		Response: map[string]any{"status": "The time off request is rejected.", "days_approved": 0, "request_id": "req-2"},
+	}
+	fcHITLDenialRequest := &genai.FunctionCall{
+		ID:   "hitl_denied_confirmation",
+		Name: toolconfirmation.FunctionCallName,
+		Args: map[string]any{
+			"originalFunctionCall": fcHITLDenied,
+			"toolConfirmation": toolconfirmation.ToolConfirmation{
+				Confirmed: false,
+				Hint:      "Please approve or reject the tool call request_vacation_days().",
+			},
+		},
+	}
+	frHITLDenialRejected := &genai.FunctionResponse{
+		ID:       "hitl_denied_confirmation",
+		Name:     toolconfirmation.FunctionCallName,
+		Response: map[string]any{"confirmed": false},
+	}
+
 	// Error Call/Response
 	frOrphaned := &genai.FunctionResponse{
 		ID:       "no_matching_call",
@@ -780,6 +845,38 @@ func TestContentsRequestProcessor_Rearrange(t *testing.T) {
 				NewContentFromFunctionResponse(frLROFinal, "user"),
 				NewContentFromFunctionCall(fcBasic, "model"),
 				NewContentFromFunctionResponse(frBasic, "user"),
+			},
+		},
+		{
+			name: "HITL confirmation approved preserves resumed tool response",
+			events: []*session.Event{
+				{Author: "user", LLMResponse: model.LLMResponse{Content: genai.NewContentFromText("Request five vacation days", "user")}},
+				{Author: agentName, LLMResponse: model.LLMResponse{Content: NewContentFromFunctionCall(fcHITLApproved, "model")}},
+				{Author: agentName, LLMResponse: model.LLMResponse{Content: NewContentFromFunctionResponse(frHITLApprovedPending, "user")}},
+				{Author: agentName, LLMResponse: model.LLMResponse{Content: NewContentFromFunctionCall(fcHITLApprovalRequest, "model")}},
+				{Author: "user", LLMResponse: model.LLMResponse{Content: NewContentFromFunctionResponse(frHITLApprovalConfirmed, "user")}},
+				{Author: agentName, LLMResponse: model.LLMResponse{Content: NewContentFromFunctionResponse(frHITLApprovedFinal, "user")}},
+			},
+			want: []*genai.Content{
+				genai.NewContentFromText("Request five vacation days", "user"),
+				NewContentFromFunctionCall(fcHITLApproved, "model"),
+				NewContentFromFunctionResponse(frHITLApprovedFinal, "user"),
+			},
+		},
+		{
+			name: "HITL confirmation denied preserves rejected tool response",
+			events: []*session.Event{
+				{Author: "user", LLMResponse: model.LLMResponse{Content: genai.NewContentFromText("Request ten vacation days", "user")}},
+				{Author: agentName, LLMResponse: model.LLMResponse{Content: NewContentFromFunctionCall(fcHITLDenied, "model")}},
+				{Author: agentName, LLMResponse: model.LLMResponse{Content: NewContentFromFunctionResponse(frHITLDeniedPending, "user")}},
+				{Author: agentName, LLMResponse: model.LLMResponse{Content: NewContentFromFunctionCall(fcHITLDenialRequest, "model")}},
+				{Author: "user", LLMResponse: model.LLMResponse{Content: NewContentFromFunctionResponse(frHITLDenialRejected, "user")}},
+				{Author: agentName, LLMResponse: model.LLMResponse{Content: NewContentFromFunctionResponse(frHITLDeniedFinal, "user")}},
+			},
+			want: []*genai.Content{
+				genai.NewContentFromText("Request ten vacation days", "user"),
+				NewContentFromFunctionCall(fcHITLDenied, "model"),
+				NewContentFromFunctionResponse(frHITLDeniedFinal, "user"),
 			},
 		},
 		{

--- a/internal/llminternal/contents_processor_test.go
+++ b/internal/llminternal/contents_processor_test.go
@@ -805,6 +805,24 @@ func TestContentsRequestProcessor_Rearrange(t *testing.T) {
 			},
 		},
 		{
+			name: "Rearrangement preserves unrelated function events",
+			events: []*session.Event{
+				{Author: "user", LLMResponse: model.LLMResponse{Content: genai.NewContentFromText("Run long process and search", "user")}},
+				{Author: agentName, LLMResponse: model.LLMResponse{Content: NewContentFromFunctionCall(fcLRO, "model")}},
+				{Author: "user", LLMResponse: model.LLMResponse{Content: NewContentFromFunctionResponse(frLROInter, "user")}},
+				{Author: agentName, LLMResponse: model.LLMResponse{Content: NewContentFromFunctionCall(fcBasic, "model")}},
+				{Author: "user", LLMResponse: model.LLMResponse{Content: NewContentFromFunctionResponse(frBasic, "user")}},
+				{Author: "user", LLMResponse: model.LLMResponse{Content: NewContentFromFunctionResponse(frLROFinal, "user")}},
+			},
+			want: []*genai.Content{
+				genai.NewContentFromText("Run long process and search", "user"),
+				NewContentFromFunctionCall(fcLRO, "model"),
+				NewContentFromFunctionResponse(frLROFinal, "user"),
+				NewContentFromFunctionCall(fcBasic, "model"),
+				NewContentFromFunctionResponse(frBasic, "user"),
+			},
+		},
+		{
 			name: "Rearrangement with mixed LRO and normal calls",
 			events: []*session.Event{
 				{Author: "user", LLMResponse: model.LLMResponse{Content: genai.NewContentFromText("Analyze data and search for info", "user")}},

--- a/internal/llminternal/contents_processor_test.go
+++ b/internal/llminternal/contents_processor_test.go
@@ -31,6 +31,7 @@ import (
 	"google.golang.org/adk/internal/utils"
 	"google.golang.org/adk/model"
 	"google.golang.org/adk/session"
+	"google.golang.org/adk/tool/toolconfirmation"
 )
 
 type testModel struct {
@@ -745,6 +746,70 @@ func TestContentsRequestProcessor_Rearrange(t *testing.T) {
 		Response: map[string]any{"output": "preserved"},
 	}
 
+	// Human-in-the-loop confirmation call/responses
+	fcHITLApproved := &genai.FunctionCall{
+		ID:   "hitl_approved_call",
+		Name: "request_vacation_days",
+		Args: map[string]any{"days": 5, "user_id": "user-123"},
+	}
+	frHITLApprovedPending := &genai.FunctionResponse{
+		ID:       "hitl_approved_call",
+		Name:     "request_vacation_days",
+		Response: map[string]any{"status": "Manager approval is required.", "request_id": "req-1"},
+	}
+	frHITLApprovedFinal := &genai.FunctionResponse{
+		ID:       "hitl_approved_call",
+		Name:     "request_vacation_days",
+		Response: map[string]any{"status": "The time off request is accepted.", "days_approved": 5, "request_id": "req-1"},
+	}
+	fcHITLApprovalRequest := &genai.FunctionCall{
+		ID:   "hitl_approved_confirmation",
+		Name: toolconfirmation.FunctionCallName,
+		Args: map[string]any{
+			"originalFunctionCall": fcHITLApproved,
+			"toolConfirmation": toolconfirmation.ToolConfirmation{
+				Confirmed: false,
+				Hint:      "Please approve or reject the tool call request_vacation_days().",
+			},
+		},
+	}
+	frHITLApprovalConfirmed := &genai.FunctionResponse{
+		ID:       "hitl_approved_confirmation",
+		Name:     toolconfirmation.FunctionCallName,
+		Response: map[string]any{"confirmed": true},
+	}
+	fcHITLDenied := &genai.FunctionCall{
+		ID:   "hitl_denied_call",
+		Name: "request_vacation_days",
+		Args: map[string]any{"days": 10, "user_id": "user-123"},
+	}
+	frHITLDeniedPending := &genai.FunctionResponse{
+		ID:       "hitl_denied_call",
+		Name:     "request_vacation_days",
+		Response: map[string]any{"status": "Manager approval is required.", "request_id": "req-2"},
+	}
+	frHITLDeniedFinal := &genai.FunctionResponse{
+		ID:       "hitl_denied_call",
+		Name:     "request_vacation_days",
+		Response: map[string]any{"status": "The time off request is rejected.", "days_approved": 0, "request_id": "req-2"},
+	}
+	fcHITLDenialRequest := &genai.FunctionCall{
+		ID:   "hitl_denied_confirmation",
+		Name: toolconfirmation.FunctionCallName,
+		Args: map[string]any{
+			"originalFunctionCall": fcHITLDenied,
+			"toolConfirmation": toolconfirmation.ToolConfirmation{
+				Confirmed: false,
+				Hint:      "Please approve or reject the tool call request_vacation_days().",
+			},
+		},
+	}
+	frHITLDenialRejected := &genai.FunctionResponse{
+		ID:       "hitl_denied_confirmation",
+		Name:     toolconfirmation.FunctionCallName,
+		Response: map[string]any{"confirmed": false},
+	}
+
 	// Error Call/Response
 	frOrphaned := &genai.FunctionResponse{
 		ID:       "no_matching_call",
@@ -820,6 +885,38 @@ func TestContentsRequestProcessor_Rearrange(t *testing.T) {
 				NewContentFromFunctionResponse(frLROFinal, "user"),
 				NewContentFromFunctionCall(fcBasic, "model"),
 				NewContentFromFunctionResponse(frBasic, "user"),
+			},
+		},
+		{
+			name: "HITL confirmation approved preserves resumed tool response",
+			events: []*session.Event{
+				{Author: "user", LLMResponse: model.LLMResponse{Content: genai.NewContentFromText("Request five vacation days", "user")}},
+				{Author: agentName, LLMResponse: model.LLMResponse{Content: NewContentFromFunctionCall(fcHITLApproved, "model")}},
+				{Author: agentName, LLMResponse: model.LLMResponse{Content: NewContentFromFunctionResponse(frHITLApprovedPending, "user")}},
+				{Author: agentName, LLMResponse: model.LLMResponse{Content: NewContentFromFunctionCall(fcHITLApprovalRequest, "model")}},
+				{Author: "user", LLMResponse: model.LLMResponse{Content: NewContentFromFunctionResponse(frHITLApprovalConfirmed, "user")}},
+				{Author: agentName, LLMResponse: model.LLMResponse{Content: NewContentFromFunctionResponse(frHITLApprovedFinal, "user")}},
+			},
+			want: []*genai.Content{
+				genai.NewContentFromText("Request five vacation days", "user"),
+				NewContentFromFunctionCall(fcHITLApproved, "model"),
+				NewContentFromFunctionResponse(frHITLApprovedFinal, "user"),
+			},
+		},
+		{
+			name: "HITL confirmation denied preserves rejected tool response",
+			events: []*session.Event{
+				{Author: "user", LLMResponse: model.LLMResponse{Content: genai.NewContentFromText("Request ten vacation days", "user")}},
+				{Author: agentName, LLMResponse: model.LLMResponse{Content: NewContentFromFunctionCall(fcHITLDenied, "model")}},
+				{Author: agentName, LLMResponse: model.LLMResponse{Content: NewContentFromFunctionResponse(frHITLDeniedPending, "user")}},
+				{Author: agentName, LLMResponse: model.LLMResponse{Content: NewContentFromFunctionCall(fcHITLDenialRequest, "model")}},
+				{Author: "user", LLMResponse: model.LLMResponse{Content: NewContentFromFunctionResponse(frHITLDenialRejected, "user")}},
+				{Author: agentName, LLMResponse: model.LLMResponse{Content: NewContentFromFunctionResponse(frHITLDeniedFinal, "user")}},
+			},
+			want: []*genai.Content{
+				genai.NewContentFromText("Request ten vacation days", "user"),
+				NewContentFromFunctionCall(fcHITLDenied, "model"),
+				NewContentFromFunctionResponse(frHITLDeniedFinal, "user"),
 			},
 		},
 		{


### PR DESCRIPTION
### Link to Issue or Description of Change

- Closes: google/adk-go#761

### Problem

`rearrangeEventsForLatestFunctionResponse` rebuilds history when the latest event is a function response. After finding the matching function-call event, it collects related response events to merge, then returns only the history up to that matching call plus the merged response.

That can drop unrelated function-call or function-response events that happened between the matching call and the latest response. For long-running tool flows, this loses valid tool history that should still be replayed.

### Solution

When scanning intermediate events between the matching function-call event and the latest response:

- preserve intermediate function-call events in the result history
- preserve unrelated intermediate function-response events in the result history
- merge only response events related to the matching call event

This keeps unrelated tool history intact while still consolidating the response sequence that triggered rearrangement.

### Testing Plan

- [x] Added `Rearrangement preserves unrelated function events` covering an interleaved long-running response sequence with an unrelated tool call/response before the final response.
- [x] Ran focused unit tests locally.

```sh
go test ./internal/llminternal
```

### Alignment with adk-python

This preserves the shared history invariant that function-response rearrangement should repair pairing for the target long-running response without dropping unrelated valid events from the conversation history.
