### PR TITLE
feat: implement workflow routing support with tagged events and conditional graph traversal

### DIFF
--- a/session/database/storage_session.go
+++ b/session/database/storage_session.go
@@ -79,6 +79,7 @@ type storageEvent struct {
 	// equivalent. Unpickling would require a custom library or service.
 	Actions                []byte
 	LongRunningToolIDsJSON dynamicJSON
+	RouteJSON              dynamicJSON
 	Branch                 *string
 	Timestamp              time.Time `gorm:"precision:6"`
 
@@ -133,6 +134,14 @@ func createStorageEvent(session session.Session, event *session.Event) (*storage
 			return nil, fmt.Errorf("failed to marshal long running tool IDs: %w", err)
 		}
 		storageEv.LongRunningToolIDsJSON = toolIDsJSON
+	}
+
+	if len(event.Route) > 0 {
+		routeJSON, err := json.Marshal(event.Route)
+		if err != nil {
+			return nil, fmt.Errorf("failed to marshal event route: %w", err)
+		}
+		storageEv.RouteJSON = routeJSON
 	}
 
 	// Handle optional fields by taking the address of the value.
@@ -250,6 +259,13 @@ func createEventFromStorageEvent(se *storageEvent) (*session.Event, error) {
 		}
 	}
 
+	var route []string
+	if se.RouteJSON != nil {
+		if err := json.Unmarshal([]byte(se.RouteJSON), &route); err != nil {
+			return nil, fmt.Errorf("failed to unmarshal event route: %w", err)
+		}
+	}
+
 	// --- Handle simple pointer fields (dereference or use zero value) ---
 	// Use the helper to safely get the value or its zero-value default
 	branch := derefOrZero(se.Branch)
@@ -267,6 +283,7 @@ func createEventFromStorageEvent(se *storageEvent) (*session.Event, error) {
 		Timestamp:          se.Timestamp,
 		Actions:            actions,
 		LongRunningToolIDs: toolIDs,
+		Route:              route,
 		Branch:             branch,
 		LLMResponse: model.LLMResponse{
 			Content:           content,

--- a/session/database/storage_session.go
+++ b/session/database/storage_session.go
@@ -79,7 +79,7 @@ type storageEvent struct {
 	// equivalent. Unpickling would require a custom library or service.
 	Actions                []byte
 	LongRunningToolIDsJSON dynamicJSON
-	RouteJSON              dynamicJSON
+	RoutesJSON              dynamicJSON
 	Branch                 *string
 	Timestamp              time.Time `gorm:"precision:6"`
 
@@ -136,12 +136,12 @@ func createStorageEvent(session session.Session, event *session.Event) (*storage
 		storageEv.LongRunningToolIDsJSON = toolIDsJSON
 	}
 
-	if len(event.Route) > 0 {
-		routeJSON, err := json.Marshal(event.Route)
+	if len(event.Routes) > 0 {
+		routesJSON, err := json.Marshal(event.Routes)
 		if err != nil {
 			return nil, fmt.Errorf("failed to marshal event route: %w", err)
 		}
-		storageEv.RouteJSON = routeJSON
+		storageEv.RoutesJSON = routesJSON
 	}
 
 	// Handle optional fields by taking the address of the value.
@@ -259,9 +259,9 @@ func createEventFromStorageEvent(se *storageEvent) (*session.Event, error) {
 		}
 	}
 
-	var route []string
-	if se.RouteJSON != nil {
-		if err := json.Unmarshal([]byte(se.RouteJSON), &route); err != nil {
+	var routes []string
+	if se.RoutesJSON != nil {
+		if err := json.Unmarshal([]byte(se.RoutesJSON), &routes); err != nil {
 			return nil, fmt.Errorf("failed to unmarshal event route: %w", err)
 		}
 	}
@@ -283,7 +283,7 @@ func createEventFromStorageEvent(se *storageEvent) (*session.Event, error) {
 		Timestamp:          se.Timestamp,
 		Actions:            actions,
 		LongRunningToolIDs: toolIDs,
-		Route:              route,
+		Routes:             routes,
 		Branch:             branch,
 		LLMResponse: model.LLMResponse{
 			Content:           content,

--- a/session/session.go
+++ b/session/session.go
@@ -115,6 +115,8 @@ type Event struct {
 	// Agent client will know from this field about which function call is long running.
 	// Only valid for function call event.
 	LongRunningToolIDs []string
+	// Routing information for workflow execution
+	Route []string
 }
 
 // IsFinalResponse returns whether the event is the final response of an agent.

--- a/session/session.go
+++ b/session/session.go
@@ -116,7 +116,7 @@ type Event struct {
 	// Only valid for function call event.
 	LongRunningToolIDs []string
 	// Routing information for workflow execution
-	Route []string
+	Routes []string
 }
 
 // IsFinalResponse returns whether the event is the final response of an agent.

--- a/workflow/workflow.go
+++ b/workflow/workflow.go
@@ -37,39 +37,31 @@ type Route interface {
 	Matches(event *session.Event) bool
 }
 
-type StringRoute string
-
-func (r StringRoute) Matches(event *session.Event) bool {
-	for _, v := range event.Route {
-		if v == string(r) {
+func matchRoute(routeValue string, event *session.Event) bool {
+	for _, v := range event.Routes {
+		if v == routeValue {
 			return true
 		}
 	}
 	return false
+}
+
+type StringRoute string
+
+func (r StringRoute) Matches(event *session.Event) bool {
+	return matchRoute(string(r), event)
 }
 
 type IntRoute int
 
 func (r IntRoute) Matches(event *session.Event) bool {
-	str := fmt.Sprint(r)
-	for _, v := range event.Route {
-		if v == str {
-			return true
-		}
-	}
-	return false
+	return matchRoute(fmt.Sprint(r), event)
 }
 
 type BoolRoute bool
 
 func (r BoolRoute) Matches(event *session.Event) bool {
-	str := fmt.Sprint(r)
-	for _, v := range event.Route {
-		if v == str {
-			return true
-		}
-	}
-	return false
+	return matchRoute(fmt.Sprint(r), event)
 }
 
 // BaseNode provides common fields for all nodes.
@@ -185,34 +177,35 @@ func New(edges []Edge) *Workflow {
 	return &Workflow{edges: adj}
 }
 
-type queueItem struct {
+type nodeInput struct {
 	node  Node
 	input any
 }
 
-func (w *Workflow) findNextNodes(currentNode Node, input any, eventList []*session.Event) ([]queueItem, error) {
+func (w *Workflow) findNextNodes(currentNode Node, input any, event *session.Event) ([]nodeInput, error) {
 	if len(w.edges[currentNode]) == 0 {
 		return nil, nil
 	}
 	matched := false
-	queue := []queueItem{}
+	queue := []nodeInput{}
+	added := make(map[Node]struct{})
 	for _, edge := range w.edges[currentNode] {
+		if _, ok := added[edge.To]; ok {
+			continue
+		}
 		if edge.Route == nil {
-			queue = append(queue, queueItem{node: edge.To, input: input})
+			queue = append(queue, nodeInput{node: edge.To, input: input})
 			matched = true
 			continue
 		}
 
-		for _, event := range eventList {
-			if edge.Route.Matches(event) {
-				queue = append(queue, queueItem{node: edge.To, input: input})
-				matched = true
-				break
-			}
+		if edge.Route.Matches(event) {
+			queue = append(queue, nodeInput{node: edge.To, input: input})
+			matched = true
 		}
 	}
 	if !matched {
-		return nil, fmt.Errorf("node %s produces route tags that do not match any valid outgoing edge", currentNode.Name())
+		return nil, fmt.Errorf("no outgoing edge matches the event with routes %v emitted by node %s", event.Routes, currentNode.Name())
 	}
 	return queue, nil
 }
@@ -231,10 +224,10 @@ func (w *Workflow) Run(ctx agent.InvocationContext) iter.Seq2[*session.Event, er
 			input = sb.String()
 		}
 
-		var queue []queueItem
+		var queue []nodeInput
 		if startEdges, ok := w.edges[START]; ok {
 			for _, edge := range startEdges {
-				queue = append(queue, queueItem{node: edge.To, input: input})
+				queue = append(queue, nodeInput{node: edge.To, input: input})
 			}
 		}
 
@@ -248,9 +241,9 @@ func (w *Workflow) Run(ctx agent.InvocationContext) iter.Seq2[*session.Event, er
 			input = queue[0].input
 			queue = queue[1:]
 
-			var eventList []*session.Event
-			events := currentNode.Run(ctx, input)
-			for ev, err := range events {
+			var eventsWithRoutes []*session.Event
+			var outputData any
+			for ev, err := range currentNode.Run(ctx, input) {
 				if err != nil {
 					yield(nil, err)
 					return
@@ -259,16 +252,28 @@ func (w *Workflow) Run(ctx agent.InvocationContext) iter.Seq2[*session.Event, er
 					return
 				}
 
-				eventList = append(eventList, ev)
+				if ev.Routes != nil {
+					eventsWithRoutes = append(eventsWithRoutes, ev)
+				}
 
 				// Extract output for next node
 				if ev.Actions.StateDelta != nil {
 					if out, ok := ev.Actions.StateDelta["output"]; ok {
-						input = out
+						outputData = out
 					}
 				}
 			}
-			nextNodes, err := w.findNextNodes(currentNode, input, eventList)
+
+			if len(eventsWithRoutes) > 1 {
+				yield(nil, fmt.Errorf("node %s produced multiple events with route tags. Only one event per execution can specify routes.", currentNode.Name()))
+				return
+			}
+			var event *session.Event
+			if len(eventsWithRoutes) == 1 {
+				event = eventsWithRoutes[0]
+			}
+			input = outputData
+			nextNodes, err := w.findNextNodes(currentNode, input, event)
 			if err != nil {
 				yield(nil, err)
 				return

--- a/workflow/workflow.go
+++ b/workflow/workflow.go
@@ -37,39 +37,31 @@ type Route interface {
 	Matches(event *session.Event) bool
 }
 
-type StringRoute string
-
-func (r StringRoute) Matches(event *session.Event) bool {
-	for _, v := range event.Route {
-		if v == string(r) {
+func matchRoute(routeValue string, event *session.Event) bool {
+	for _, v := range event.Routes {
+		if v == routeValue {
 			return true
 		}
 	}
 	return false
+}
+
+type StringRoute string
+
+func (r StringRoute) Matches(event *session.Event) bool {
+	return matchRoute(string(r), event)
 }
 
 type IntRoute int
 
 func (r IntRoute) Matches(event *session.Event) bool {
-	str := fmt.Sprint(r)
-	for _, v := range event.Route {
-		if v == str {
-			return true
-		}
-	}
-	return false
+	return matchRoute(fmt.Sprint(r), event)
 }
 
 type BoolRoute bool
 
 func (r BoolRoute) Matches(event *session.Event) bool {
-	str := fmt.Sprint(r)
-	for _, v := range event.Route {
-		if v == str {
-			return true
-		}
-	}
-	return false
+	return matchRoute(fmt.Sprint(r), event)
 }
 
 // BaseNode provides common fields for all nodes.
@@ -185,34 +177,35 @@ func New(edges []Edge) *Workflow {
 	return &Workflow{edges: adj}
 }
 
-type queueItem struct {
+type nodeInput struct {
 	node  Node
 	input any
 }
 
-func (w *Workflow) findNextNodes(currentNode Node, input any, eventList []*session.Event) ([]queueItem, error) {
+func (w *Workflow) findNextNodes(currentNode Node, input any, event *session.Event) ([]nodeInput, error) {
 	if len(w.edges[currentNode]) == 0 {
 		return nil, nil
 	}
 	matched := false
-	queue := []queueItem{}
+	queue := []nodeInput{}
+	added := make(map[Node]struct{})
 	for _, edge := range w.edges[currentNode] {
+		if _, ok := added[edge.To]; ok {
+			continue
+		}
 		if edge.Route == nil {
-			queue = append(queue, queueItem{node: edge.To, input: input})
+			queue = append(queue, nodeInput{node: edge.To, input: input})
 			matched = true
 			continue
 		}
 
-		for _, event := range eventList {
-			if edge.Route.Matches(event) {
-				queue = append(queue, queueItem{node: edge.To, input: input})
-				matched = true
-				break
-			}
+		if edge.Route.Matches(event) {
+			queue = append(queue, nodeInput{node: edge.To, input: input})
+			matched = true
 		}
 	}
 	if !matched {
-		return nil, fmt.Errorf("node %s produces route tags that do not match any valid outgoing edge", currentNode.Name())
+		return nil, fmt.Errorf("no outgoing edge matches the event with routes %v emitted by node %s", event.Routes, currentNode.Name())
 	}
 	return queue, nil
 }
@@ -231,26 +224,16 @@ func (w *Workflow) Run(ctx agent.InvocationContext) iter.Seq2[*session.Event, er
 			input = sb.String()
 		}
 
-		var queue []queueItem
-		if startEdges, ok := w.edges[START]; ok {
-			for _, edge := range startEdges {
-				queue = append(queue, queueItem{node: edge.To, input: input})
-			}
-		}
-
-		if len(queue) == 0 {
-			yield(nil, fmt.Errorf("no start node found"))
-			return
-		}
+		queue := []nodeInput{{START, input}}
 
 		for len(queue) > 0 {
 			currentNode := queue[0].node
 			input = queue[0].input
 			queue = queue[1:]
 
-			var eventList []*session.Event
-			events := currentNode.Run(ctx, input)
-			for ev, err := range events {
+			var eventsWithRoutes []*session.Event
+			var outputData any
+			for ev, err := range currentNode.Run(ctx, input) {
 				if err != nil {
 					yield(nil, err)
 					return
@@ -259,16 +242,30 @@ func (w *Workflow) Run(ctx agent.InvocationContext) iter.Seq2[*session.Event, er
 					return
 				}
 
-				eventList = append(eventList, ev)
+				if ev.Routes != nil {
+					eventsWithRoutes = append(eventsWithRoutes, ev)
+				}
 
 				// Extract output for next node
 				if ev.Actions.StateDelta != nil {
 					if out, ok := ev.Actions.StateDelta["output"]; ok {
-						input = out
+						outputData = out
 					}
 				}
 			}
-			nextNodes, err := w.findNextNodes(currentNode, input, eventList)
+
+			if len(eventsWithRoutes) > 1 {
+				yield(nil, fmt.Errorf("node %s produced multiple events with route tags. Only one event per execution can specify routes.", currentNode.Name()))
+				return
+			}
+			var event *session.Event
+			if len(eventsWithRoutes) == 1 {
+				event = eventsWithRoutes[0]
+			}
+			if currentNode != START {
+				input = outputData
+			}
+			nextNodes, err := w.findNextNodes(currentNode, input, event)
 			if err != nil {
 				yield(nil, err)
 				return

--- a/workflow/workflow.go
+++ b/workflow/workflow.go
@@ -34,17 +34,42 @@ type Node interface {
 
 // Route defines the interface for matching execution results to edges.
 type Route interface {
-	Matches(output any) bool
+	Matches(event *session.Event) bool
 }
 
-// StringRoute matches an exact string value.
-type StringRoute struct {
-	Value string
+type StringRoute string
+
+func (r StringRoute) Matches(event *session.Event) bool {
+	for _, v := range event.Route {
+		if v == string(r) {
+			return true
+		}
+	}
+	return false
 }
 
-func (r StringRoute) Matches(output any) bool {
-	s, ok := output.(string)
-	return ok && s == r.Value
+type IntRoute int
+
+func (r IntRoute) Matches(event *session.Event) bool {
+	str := fmt.Sprint(r)
+	for _, v := range event.Route {
+		if v == str {
+			return true
+		}
+	}
+	return false
+}
+
+type BoolRoute bool
+
+func (r BoolRoute) Matches(event *session.Event) bool {
+	str := fmt.Sprint(r)
+	for _, v := range event.Route {
+		if v == str {
+			return true
+		}
+	}
+	return false
 }
 
 // BaseNode provides common fields for all nodes.
@@ -77,7 +102,7 @@ func NewFunctionNode[IN any, OUT any](name string, fn func(ctx agent.InvocationC
 	}
 	return &FunctionNode{
 		BaseNode: BaseNode{name: name},
-		fn:        wrappedFn,
+		fn:       wrappedFn,
 	}
 }
 
@@ -88,7 +113,7 @@ func (n *FunctionNode) Run(ctx agent.InvocationContext, input any) iter.Seq2[*se
 			yield(nil, err)
 			return
 		}
-		
+
 		event := session.NewEvent(ctx.InvocationID())
 		event.Actions.StateDelta["output"] = output
 		if s, ok := output.(string); ok {
@@ -148,29 +173,52 @@ const DEFAULT_ROUTE = "__DEFAULT__"
 
 // Workflow manages the workflow graph execution.
 type Workflow struct {
-	edges []Edge
+	edges map[Node][]Edge
 }
 
 // New creates a new Workflow engine with the given edges.
 func New(edges []Edge) *Workflow {
-	return &Workflow{edges: edges}
+	adj := make(map[Node][]Edge)
+	for _, edge := range edges {
+		adj[edge.From] = append(adj[edge.From], edge)
+	}
+	return &Workflow{edges: adj}
+}
+
+type queueItem struct {
+	node  Node
+	input any
+}
+
+func (w *Workflow) findNextNodes(currentNode Node, input any, eventList []*session.Event) ([]queueItem, error) {
+	if len(w.edges[currentNode]) == 0 {
+		return nil, nil
+	}
+	matched := false
+	queue := []queueItem{}
+	for _, edge := range w.edges[currentNode] {
+		if edge.Route == nil {
+			queue = append(queue, queueItem{node: edge.To, input: input})
+			matched = true
+			continue
+		}
+
+		for _, event := range eventList {
+			if edge.Route.Matches(event) {
+				queue = append(queue, queueItem{node: edge.To, input: input})
+				matched = true
+				break
+			}
+		}
+	}
+	if !matched {
+		return nil, fmt.Errorf("node %s produces route tags that do not match any valid outgoing edge", currentNode.Name())
+	}
+	return queue, nil
 }
 
 func (w *Workflow) Run(ctx agent.InvocationContext) iter.Seq2[*session.Event, error] {
 	return func(yield func(*session.Event, error) bool) {
-		var currentNode Node
-		for _, edge := range w.edges {
-			if edge.From == START {
-				currentNode = edge.To
-				break
-			}
-		}
-
-		if currentNode == nil {
-			yield(nil, fmt.Errorf("no start node found"))
-			return
-		}
-
 		var input any
 		userContent := ctx.UserContent()
 		if userContent != nil {
@@ -183,8 +231,26 @@ func (w *Workflow) Run(ctx agent.InvocationContext) iter.Seq2[*session.Event, er
 			input = sb.String()
 		}
 
-		for currentNode != nil {
-			for ev, err := range currentNode.Run(ctx, input) {
+		var queue []queueItem
+		if startEdges, ok := w.edges[START]; ok {
+			for _, edge := range startEdges {
+				queue = append(queue, queueItem{node: edge.To, input: input})
+			}
+		}
+
+		if len(queue) == 0 {
+			yield(nil, fmt.Errorf("no start node found"))
+			return
+		}
+
+		for len(queue) > 0 {
+			currentNode := queue[0].node
+			input = queue[0].input
+			queue = queue[1:]
+
+			var eventList []*session.Event
+			events := currentNode.Run(ctx, input)
+			for ev, err := range events {
 				if err != nil {
 					yield(nil, err)
 					return
@@ -193,6 +259,8 @@ func (w *Workflow) Run(ctx agent.InvocationContext) iter.Seq2[*session.Event, er
 					return
 				}
 
+				eventList = append(eventList, ev)
+
 				// Extract output for next node
 				if ev.Actions.StateDelta != nil {
 					if out, ok := ev.Actions.StateDelta["output"]; ok {
@@ -200,16 +268,12 @@ func (w *Workflow) Run(ctx agent.InvocationContext) iter.Seq2[*session.Event, er
 					}
 				}
 			}
-
-			// Find next node (assuming linear chain for now)
-			var nextNode Node
-			for _, edge := range w.edges {
-				if edge.From == currentNode {
-					nextNode = edge.To
-					break
-				}
+			nextNodes, err := w.findNextNodes(currentNode, input, eventList)
+			if err != nil {
+				yield(nil, err)
+				return
 			}
-			currentNode = nextNode
+			queue = append(queue, nextNodes...)
 		}
 	}
 }

--- a/workflow/workflow_test.go
+++ b/workflow/workflow_test.go
@@ -132,9 +132,9 @@ func TestSequentialWorkflow(t *testing.T) {
 	}
 }
 
-func TestRoutes(t *testing.T) {
+func TestStringRoute(t *testing.T) {
 	event := &session.Event{
-		Route: []string{"hello", "42", "true"},
+		Routes: []string{"hello", "42", "true"},
 	}
 
 	if !StringRoute("hello").Matches(event) {
@@ -143,12 +143,24 @@ func TestRoutes(t *testing.T) {
 	if StringRoute("world").Matches(event) {
 		t.Errorf("StringRoute should not match")
 	}
+}
+
+func TestIntRoute(t *testing.T) {
+	event := &session.Event{
+		Routes: []string{"hello", "42", "true"},
+	}
 
 	if !IntRoute(42).Matches(event) {
 		t.Errorf("IntRoute should match")
 	}
 	if IntRoute(10).Matches(event) {
 		t.Errorf("IntRoute should not match")
+	}
+}
+
+func TestBoolRoute(t *testing.T) {
+	event := &session.Event{
+		Routes: []string{"hello", "42", "true"},
 	}
 
 	if !BoolRoute(true).Matches(event) {
@@ -171,7 +183,7 @@ func (n *CustomRouteNode) Run(ctx agent.InvocationContext, input any) iter.Seq2[
 	}
 	return func(yield func(*session.Event, error) bool) {
 		ev := session.NewEvent(ctx.InvocationID())
-		ev.Route = n.route
+		ev.Routes = n.route
 		yield(ev, nil)
 	}
 }
@@ -184,7 +196,7 @@ func TestWorkflowRouting(t *testing.T) {
 	type testCase struct {
 		name           string
 		startRoutes    []string
-		edges          func(START Node, nodeStart *CustomRouteNode, nodeA, nodeB *FunctionNode, nodeC *CustomRouteNode, nodeD *FunctionNode) []Edge
+		edges          func(nodeStart *CustomRouteNode, nodeA, nodeB *FunctionNode, nodeC *CustomRouteNode, nodeD *FunctionNode) []Edge
 		expectedExec   []string
 		expectErrorMsg string
 	}
@@ -220,7 +232,7 @@ func TestWorkflowRouting(t *testing.T) {
 		{
 			name:        "all edges don't have routing",
 			startRoutes: []string{"branchA", "branchB"},
-			edges: func(START Node, start *CustomRouteNode, a *FunctionNode, b *FunctionNode, c *CustomRouteNode, d *FunctionNode) []Edge {
+			edges: func(start *CustomRouteNode, a *FunctionNode, b *FunctionNode, c *CustomRouteNode, d *FunctionNode) []Edge {
 				return []Edge{
 					{From: START, To: start},
 					{From: start, To: a},
@@ -234,7 +246,7 @@ func TestWorkflowRouting(t *testing.T) {
 		{
 			name:        "only one edge has correct routing and the rest have no routing",
 			startRoutes: []string{"branchA"},
-			edges: func(START Node, start *CustomRouteNode, a *FunctionNode, b *FunctionNode, c *CustomRouteNode, d *FunctionNode) []Edge {
+			edges: func(start *CustomRouteNode, a *FunctionNode, b *FunctionNode, c *CustomRouteNode, d *FunctionNode) []Edge {
 				return []Edge{
 					{From: START, To: start},
 					{From: start, To: a, Route: StringRoute("branchA")},
@@ -248,7 +260,7 @@ func TestWorkflowRouting(t *testing.T) {
 		{
 			name:        "one edge has no routing and the rest have a correct routing",
 			startRoutes: []string{"branchA", "branchB"},
-			edges: func(START Node, start *CustomRouteNode, a *FunctionNode, b *FunctionNode, c *CustomRouteNode, d *FunctionNode) []Edge {
+			edges: func(start *CustomRouteNode, a *FunctionNode, b *FunctionNode, c *CustomRouteNode, d *FunctionNode) []Edge {
 				return []Edge{
 					{From: START, To: start},
 					{From: start, To: a, Route: StringRoute("branchA")},
@@ -262,7 +274,7 @@ func TestWorkflowRouting(t *testing.T) {
 		{
 			name:        "any edge has incorrect routing",
 			startRoutes: []string{"invalid"},
-			edges: func(START Node, start *CustomRouteNode, a *FunctionNode, b *FunctionNode, c *CustomRouteNode, d *FunctionNode) []Edge {
+			edges: func(start *CustomRouteNode, a *FunctionNode, b *FunctionNode, c *CustomRouteNode, d *FunctionNode) []Edge {
 				return []Edge{
 					{From: START, To: start},
 					{From: start, To: a, Route: StringRoute("branchA")},
@@ -271,7 +283,7 @@ func TestWorkflowRouting(t *testing.T) {
 					{From: c, To: d},
 				}
 			},
-			expectErrorMsg: "produces route tags that do not match any valid outgoing edge",
+			expectErrorMsg: "no outgoing edge matches the event with routes",
 		},
 	}
 
@@ -279,7 +291,7 @@ func TestWorkflowRouting(t *testing.T) {
 		t.Run(tc.name, func(t *testing.T) {
 			start, a, b, c, d, tracker := createNodes()
 			start.route = tc.startRoutes
-			edges := tc.edges(START, start, a, b, c, d)
+			edges := tc.edges(start, a, b, c, d)
 
 			w := New(edges)
 			mockCtx := &MockInvocationContext{sess: nil}

--- a/workflow/workflow_test.go
+++ b/workflow/workflow_test.go
@@ -16,6 +16,7 @@ package workflow
 
 import (
 	"fmt"
+	"iter"
 	"strings"
 	"testing"
 
@@ -128,5 +129,185 @@ func TestSequentialWorkflow(t *testing.T) {
 
 	if lastOutput != "HELLO done" {
 		t.Errorf("expected last output 'HELLO done', got %v", lastOutput)
+	}
+}
+
+func TestRoutes(t *testing.T) {
+	event := &session.Event{
+		Route: []string{"hello", "42", "true"},
+	}
+
+	if !StringRoute("hello").Matches(event) {
+		t.Errorf("StringRoute should match")
+	}
+	if StringRoute("world").Matches(event) {
+		t.Errorf("StringRoute should not match")
+	}
+
+	if !IntRoute(42).Matches(event) {
+		t.Errorf("IntRoute should match")
+	}
+	if IntRoute(10).Matches(event) {
+		t.Errorf("IntRoute should not match")
+	}
+
+	if !BoolRoute(true).Matches(event) {
+		t.Errorf("BoolRoute should match")
+	}
+	if BoolRoute(false).Matches(event) {
+		t.Errorf("BoolRoute should not match")
+	}
+}
+
+type CustomRouteNode struct {
+	BaseNode
+	route []string
+	onRun func()
+}
+
+func (n *CustomRouteNode) Run(ctx agent.InvocationContext, input any) iter.Seq2[*session.Event, error] {
+	if n.onRun != nil {
+		n.onRun()
+	}
+	return func(yield func(*session.Event, error) bool) {
+		ev := session.NewEvent(ctx.InvocationID())
+		ev.Route = n.route
+		yield(ev, nil)
+	}
+}
+
+func TestWorkflowRouting(t *testing.T) {
+	type testTracker struct {
+		executed []string
+	}
+
+	type testCase struct {
+		name           string
+		startRoutes    []string
+		edges          func(START Node, nodeStart *CustomRouteNode, nodeA, nodeB *FunctionNode, nodeC *CustomRouteNode, nodeD *FunctionNode) []Edge
+		expectedExec   []string
+		expectErrorMsg string
+	}
+
+	createNodes := func() (*CustomRouteNode, *FunctionNode, *FunctionNode, *CustomRouteNode, *FunctionNode, *testTracker) {
+		tracker := &testTracker{}
+		nodeStart := &CustomRouteNode{
+			BaseNode: BaseNode{name: "START_NODE"},
+		}
+		nodeA := NewFunctionNode("A", func(ctx agent.InvocationContext, input any) (string, error) {
+			tracker.executed = append(tracker.executed, "A")
+			return "pathA", nil
+		})
+		nodeB := NewFunctionNode("B", func(ctx agent.InvocationContext, input any) (string, error) {
+			tracker.executed = append(tracker.executed, "B")
+			return "pathB", nil
+		})
+		nodeC := &CustomRouteNode{
+			BaseNode: BaseNode{name: "C"},
+			route:    []string{"branchD"},
+			onRun: func() {
+				tracker.executed = append(tracker.executed, "C")
+			},
+		}
+		nodeD := NewFunctionNode("D", func(ctx agent.InvocationContext, input any) (string, error) {
+			tracker.executed = append(tracker.executed, "D")
+			return "pathD", nil
+		})
+		return nodeStart, nodeA, nodeB, nodeC, nodeD, tracker
+	}
+
+	tests := []testCase{
+		{
+			name:        "all edges don't have routing",
+			startRoutes: []string{"branchA", "branchB"},
+			edges: func(START Node, start *CustomRouteNode, a *FunctionNode, b *FunctionNode, c *CustomRouteNode, d *FunctionNode) []Edge {
+				return []Edge{
+					{From: START, To: start},
+					{From: start, To: a},
+					{From: start, To: b},
+					{From: start, To: c},
+					{From: c, To: d},
+				}
+			},
+			expectedExec: []string{"A", "B", "C", "D"},
+		},
+		{
+			name:        "only one edge has correct routing and the rest have no routing",
+			startRoutes: []string{"branchA"},
+			edges: func(START Node, start *CustomRouteNode, a *FunctionNode, b *FunctionNode, c *CustomRouteNode, d *FunctionNode) []Edge {
+				return []Edge{
+					{From: START, To: start},
+					{From: start, To: a, Route: StringRoute("branchA")},
+					{From: start, To: b},
+					{From: start, To: c},
+					{From: c, To: d},
+				}
+			},
+			expectedExec: []string{"A", "B", "C", "D"},
+		},
+		{
+			name:        "one edge has no routing and the rest have a correct routing",
+			startRoutes: []string{"branchA", "branchB"},
+			edges: func(START Node, start *CustomRouteNode, a *FunctionNode, b *FunctionNode, c *CustomRouteNode, d *FunctionNode) []Edge {
+				return []Edge{
+					{From: START, To: start},
+					{From: start, To: a, Route: StringRoute("branchA")},
+					{From: start, To: b, Route: StringRoute("branchB")},
+					{From: start, To: c},
+					{From: c, To: d, Route: StringRoute("branchD")},
+				}
+			},
+			expectedExec: []string{"A", "B", "C", "D"},
+		},
+		{
+			name:        "any edge has incorrect routing",
+			startRoutes: []string{"invalid"},
+			edges: func(START Node, start *CustomRouteNode, a *FunctionNode, b *FunctionNode, c *CustomRouteNode, d *FunctionNode) []Edge {
+				return []Edge{
+					{From: START, To: start},
+					{From: start, To: a, Route: StringRoute("branchA")},
+					{From: start, To: b, Route: StringRoute("branchB")},
+					{From: start, To: c, Route: StringRoute("branchC")},
+					{From: c, To: d},
+				}
+			},
+			expectErrorMsg: "produces route tags that do not match any valid outgoing edge",
+		},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			start, a, b, c, d, tracker := createNodes()
+			start.route = tc.startRoutes
+			edges := tc.edges(START, start, a, b, c, d)
+
+			w := New(edges)
+			mockCtx := &MockInvocationContext{sess: nil}
+
+			var err error
+			for _, testErr := range w.Run(mockCtx) {
+				if testErr != nil {
+					err = testErr
+					break
+				}
+			}
+
+			if tc.expectErrorMsg != "" {
+				if err == nil {
+					t.Errorf("expected error matching %q, got none", tc.expectErrorMsg)
+				} else if !strings.Contains(err.Error(), tc.expectErrorMsg) {
+					t.Errorf("expected error containing %q, got %v", tc.expectErrorMsg, err)
+				}
+				return
+			}
+
+			if err != nil {
+				t.Fatalf("unexpected error: %v", err)
+			}
+
+			if len(tracker.executed) != len(tc.expectedExec) {
+				t.Errorf("expected %v executed, got %v", tc.expectedExec, tracker.executed)
+			}
+		})
 	}
 }


### PR DESCRIPTION
Implements conditional routing and event-driven graph traversal, key changes:
- Added Route Interface: Introduced `string`, `int`, and `boolean` route matchers to conditionally traverse workflow edges based on execution events.
- Enhanced Graph Edge: Extended the `Workflow` structure with an adjacency map to evaluate outgoing paths.
- Traversal Queue: Refactored `Workflow.Run` to process node outputs iteratively, using matched routes to determine the next nodes to execute.
- Event Persistence: Added a `Route` field to `session.Event`.