### PR TITLE
fix: add streaming_run_with_events handler for Gemini Enterprise integration

### DIFF
--- a/server/agentengine/handler.go
+++ b/server/agentengine/handler.go
@@ -93,6 +93,7 @@ func listNonStreamHandlers(config *launcher.Config, agentEngineID string) []meth
 func listStreamHandlers(config *launcher.Config, agentEngineID string) []method.MethodHandler {
 	return []method.MethodHandler{
 		method.NewStreamQueryHandler(config, agentEngineID, "async_stream_query", "async_stream"),
+		method.NewStreamQueryHandler(config, agentEngineID, "streaming_agent_run_with_events", "stream"),
 	}
 }
 


### PR DESCRIPTION
### Link to Issue or Description of Change

Closes: #770

**Problem:** Agents deployed to Vertex AI Agent Engine work in the Playground (which calls `/api/stream_reasoning_engine` with `class_method: async_stream_query`), but fail when integrated into Gemini Enterprise. Gemini Enterprise sends requests with `class_method: streaming_agent_run_with_events`, which was not registered in `listStreamHandlers` in `server/agentengine/handler.go`. This caused `handleQuery` in the controller to return `"unrecognized class method: streaming_agent_run_with_events"`.

**Solution:** Registered a second `streamQueryHandler` instance for the `streaming_agent_run_with_events` method name with `api_mode: "stream"` in `listStreamHandlers`. The existing `streamQueryHandler` is fully parameterized by method name and already handles the streaming logic correctly — it just needed to be registered under the additional method name that Gemini Enterprise uses. This mirrors the pattern in the adk-python CLI deploy logic (see `cli_deploy.py` line 390).

### Testing Plan

#### Unit Tests
- [ ] Added or updated unit tests
- [ ] All unit tests pass locally

#### Manual E2E Tests

1. Deploy an adk-go agent to Vertex AI Agent Engine.
2. Integrate the agent into Gemini Enterprise.
3. Submit a query and confirm no `"unrecognized class method"` error in the logs.
4. Verify the agent responds correctly in Gemini Enterprise.

Local build verification: `go build ./server/agentengine/...` passes without errors.

### Checklist

- [ ] Read CONTRIBUTING.md
- [ ] Self-review completed
- [ ] Code commented (especially complex areas)
- [ ] Tests added and passing
- [ ] Manual E2E testing completed
- [ ] Dependent changes merged/published

Fixes #770
