### PR TITLE
Add support for simple text instead of full genai.Content for stream_query

### DIFF
--- a/server/agentengine/controllers/method/stream_query.go
+++ b/server/agentengine/controllers/method/stream_query.go
@@ -68,7 +68,7 @@ func (s *streamQueryHandler) streamJSONL(ctx context.Context, rw http.ResponseWr
 		errText := json.Unmarshal(payload, &reqText)
 		if errText != nil {
 			// cannot unmarshall to models.StreamQueryRequest and models.StreamQueryTextRequest
-			err = fmt.Errorf("json.Unmarshal() failed both for models.StreamQueryRequest (%v) and models.StreamQueryTextRequest (%v) ", err, errText)
+			err = fmt.Errorf("json.Unmarshal() failed both for models.StreamQueryRequest (%v) and models.StreamQueryTextRequest (%v)", err, errText)
 			log.Print(err.Error())
 			return err
 		}

--- a/server/agentengine/controllers/method/stream_query.go
+++ b/server/agentengine/controllers/method/stream_query.go
@@ -79,7 +79,8 @@ func (s *streamQueryHandler) streamJSONL(ctx context.Context, rw http.ResponseWr
 				UserID:    reqText.Input.UserID,
 				SessionID: reqText.Input.SessionID,
 				Message:   *genai.NewContentFromText(reqText.Input.Message, genai.RoleUser),
-			}}
+			},
+		}
 	}
 
 	events, err := s.run(ctx, &req, &req.Input.Message, s.config)

--- a/server/agentengine/controllers/method/stream_query.go
+++ b/server/agentengine/controllers/method/stream_query.go
@@ -60,11 +60,26 @@ func (s *streamQueryHandler) Handle(ctx context.Context, rw http.ResponseWriter,
 func (s *streamQueryHandler) streamJSONL(ctx context.Context, rw http.ResponseWriter, payload []byte) error {
 	var req models.StreamQueryRequest
 
+	// try to unmarshal models.StreamQueryRequest first
 	err := json.Unmarshal(payload, &req)
 	if err != nil {
-		err = fmt.Errorf("json.Unmarshal() failed: %v", err)
-		log.Print(err.Error())
-		return err
+		// try to unmarshal models.StreamQueryTextRequest
+		var reqText models.StreamQueryTextRequest
+		errText := json.Unmarshal(payload, &reqText)
+		if errText != nil {
+			// cannot unmarshall to models.StreamQueryRequest and models.StreamQueryTextRequest
+			err = fmt.Errorf("json.Unmarshal() failed both for models.StreamQueryRequest (%v) and models.StreamQueryTextRequest (%v) ", err, errText)
+			log.Print(err.Error())
+			return err
+		}
+		// got text, create a full content based on that text
+		req = models.StreamQueryRequest{
+			ClassMethod: reqText.ClassMethod,
+			Input: models.StreamQueryInput{
+				UserID:    reqText.Input.UserID,
+				SessionID: reqText.Input.SessionID,
+				Message:   *genai.NewContentFromText(reqText.Input.Message, genai.RoleUser),
+			}}
 	}
 
 	events, err := s.run(ctx, &req, &req.Input.Message, s.config)
@@ -135,8 +150,15 @@ func (s *streamQueryHandler) Metadata() (*structpb.Struct, error) {
 					"type":     "string",
 				},
 				"message": map[string]any{
-					"additionalProperties": true,
-					"type":                 "object",
+					"anyOf": []any{
+						map[string]any{
+							"type": "string",
+						},
+						map[string]any{
+							"additionalProperties": true,
+							"type":                 "object",
+						},
+					},
 				},
 			},
 			"required": []any{

--- a/server/agentengine/controllers/method/stream_query_test.go
+++ b/server/agentengine/controllers/method/stream_query_test.go
@@ -21,11 +21,12 @@ import (
 	"strings"
 	"testing"
 
+	"google.golang.org/genai"
+
 	"google.golang.org/adk/agent"
 	"google.golang.org/adk/agent/llmagent"
 	"google.golang.org/adk/cmd/launcher"
 	"google.golang.org/adk/session"
-	"google.golang.org/genai"
 )
 
 type simpleEvent struct {
@@ -44,7 +45,8 @@ func TestSimpleText(t *testing.T) {
 		BeforeAgentCallbacks: []agent.BeforeAgentCallback{
 			func(cc agent.CallbackContext) (*genai.Content, error) {
 				return cc.UserContent(), nil
-			}},
+			},
+		},
 	})
 	if err != nil {
 		t.Fatalf("failed to create agent: %v", err)
@@ -110,7 +112,6 @@ func TestSimpleText(t *testing.T) {
 		p := w.sb.String()
 
 		err = json.Unmarshal([]byte(p), &ev)
-
 		if err != nil {
 			t.Fatalf("json.Unmarshal() failed: %v", err)
 		}
@@ -151,8 +152,10 @@ func (s *stringWriter) Flush() {
 	// do nothing
 }
 
-var _ http.ResponseWriter = (*stringWriter)(nil)
-var _ http.Flusher = (*stringWriter)(nil)
+var (
+	_ http.ResponseWriter = (*stringWriter)(nil)
+	_ http.Flusher        = (*stringWriter)(nil)
+)
 
 func newStringWriter() *stringWriter {
 	return &stringWriter{

--- a/server/agentengine/controllers/method/stream_query_test.go
+++ b/server/agentengine/controllers/method/stream_query_test.go
@@ -1,0 +1,162 @@
+// Copyright 2026 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package method
+
+import (
+	"encoding/json"
+	"net/http"
+	"strconv"
+	"strings"
+	"testing"
+
+	"google.golang.org/adk/agent"
+	"google.golang.org/adk/agent/llmagent"
+	"google.golang.org/adk/cmd/launcher"
+	"google.golang.org/adk/session"
+	"google.golang.org/genai"
+)
+
+type simpleEvent struct {
+	Content *genai.Content `json:"content"`
+}
+
+// TestSimpleText checks whether a simple message as string gives the same result as genai.Content.
+func TestSimpleText(t *testing.T) {
+	agentEngineId := 123
+	appName := strconv.Itoa(agentEngineId)
+	userID := "u"
+
+	// agent invokes BeforeAgent callback which returns the content as provided as an answer
+	a, err := llmagent.New(llmagent.Config{
+		Name: "Echo",
+		BeforeAgentCallbacks: []agent.BeforeAgentCallback{
+			func(cc agent.CallbackContext) (*genai.Content, error) {
+				return cc.UserContent(), nil
+			}},
+	})
+	if err != nil {
+		t.Fatalf("failed to create agent: %v", err)
+	}
+
+	config := &launcher.Config{
+		AgentLoader:    agent.NewSingleLoader(a),
+		SessionService: session.InMemoryService(),
+	}
+	h := NewStreamQueryHandler(config, appName, "async_stream_query", "")
+
+	ctx := t.Context()
+	sess, err := config.SessionService.Create(ctx, &session.CreateRequest{AppName: appName, UserID: userID})
+	if err != nil {
+		t.Fatalf("failed to create session: %v", err)
+	}
+
+	wantContent := genai.NewContentFromText("Say hello", genai.RoleUser)
+	wantBytes, err := json.Marshal(wantContent)
+	if err != nil {
+		t.Fatalf("json.Marshal() failed: %v", err)
+	}
+	want := string(wantBytes)
+
+	tests := []struct {
+		name    string
+		payload string
+	}{
+		{
+			name: "full content",
+			payload: `{
+"class_method":"async_stream_query",
+"input":{
+   "message":{
+     "parts":[
+        {"text":"Say hello"}
+      ],
+      "role":"user"
+   },
+   "session_id":"` + sess.Session.ID() + `",
+   "user_id":"` + userID + `"}}`,
+		},
+		{
+			name: "simplified content",
+			payload: `{
+"class_method":"async_stream_query",
+"input":{
+   "message":"Say hello",
+   "session_id":"` + sess.Session.ID() + `",
+   "user_id":"` + userID + `"}}`,
+		},
+	}
+
+	for _, tt := range tests {
+		w := newStringWriter()
+		b := []byte(tt.payload)
+		err := h.streamJSONL(t.Context(), w, b)
+		if err != nil {
+			t.Fatalf("streamJSONL() failed: %v", err)
+		}
+
+		var ev simpleEvent
+		p := w.sb.String()
+
+		err = json.Unmarshal([]byte(p), &ev)
+
+		if err != nil {
+			t.Fatalf("json.Unmarshal() failed: %v", err)
+		}
+		gotBytes, err := json.Marshal(ev.Content)
+		if err != nil {
+			t.Fatalf("json.Marshal() failed: %v", err)
+		}
+		got := string(gotBytes)
+		if got != want {
+			t.Errorf("streamJSONL() = %v, want %v", got, want)
+		}
+	}
+}
+
+// mock writer for http
+type stringWriter struct {
+	sb strings.Builder
+	h  http.Header
+}
+
+// Header implements [http.ResponseWriter].
+func (s *stringWriter) Header() http.Header {
+	return s.h
+}
+
+// WriteHeader implements [http.ResponseWriter].
+func (s *stringWriter) WriteHeader(statusCode int) {
+	s.h = http.Header{"Status": []string{http.StatusText(statusCode)}}
+}
+
+// Write implements [http.ResponseWriter].
+func (s *stringWriter) Write(p []byte) (n int, err error) {
+	return s.sb.Write(p)
+}
+
+// Flush implements [http.Flusher]
+func (s *stringWriter) Flush() {
+	// do nothing
+}
+
+var _ http.ResponseWriter = (*stringWriter)(nil)
+var _ http.Flusher = (*stringWriter)(nil)
+
+func newStringWriter() *stringWriter {
+	return &stringWriter{
+		sb: strings.Builder{},
+		h:  http.Header{},
+	}
+}

--- a/server/agentengine/internal/models/stream_query.go
+++ b/server/agentengine/internal/models/stream_query.go
@@ -20,7 +20,7 @@ import (
 	"google.golang.org/adk/session"
 )
 
-// StreamQueryRequest is a struct representing JSON-encoded payload to async_stream_query method with dedicated Input.
+// StreamQueryRequest is a struct representing JSON-encoded payload to async_stream_query method with dedicated Input with full genai.Content.
 type StreamQueryRequest struct {
 	ClassMethod string           `json:"class_method"`
 	Input       StreamQueryInput `json:"input"`
@@ -31,6 +31,19 @@ type StreamQueryInput struct {
 	UserID    string        `json:"user_id"`
 	SessionID string        `json:"session_id"`
 	Message   genai.Content `json:"message"`
+}
+
+// StreamQueryTextRequest is a struct representing JSON-encoded payload to async_stream_query method with dedicated Input with simple text as the content.
+type StreamQueryTextRequest struct {
+	ClassMethod string               `json:"class_method"`
+	Input       StreamQueryTextInput `json:"input"`
+}
+
+// StreamQueryInput is the actual Input for async_stream_query method.
+type StreamQueryTextInput struct {
+	UserID    string `json:"user_id"`
+	SessionID string `json:"session_id"`
+	Message   string `json:"message"`
 }
 
 // StreamQueryResponse defines the content of event data for async_stream_query method.

--- a/server/agentengine/internal/models/stream_query.go
+++ b/server/agentengine/internal/models/stream_query.go
@@ -39,7 +39,7 @@ type StreamQueryTextRequest struct {
 	Input       StreamQueryTextInput `json:"input"`
 }
 
-// StreamQueryInput is the actual Input for async_stream_query method.
+// StreamQueryTextInput is the actual Input for async_stream_query method.
 type StreamQueryTextInput struct {
 	UserID    string `json:"user_id"`
 	SessionID string `json:"session_id"`


### PR DESCRIPTION
**Please ensure you have read the [contribution guide](./CONTRIBUTING.md) before creating a pull request.**

### Link to Issue or Description of Change

**1. Link to an existing issue (if applicable):**
N/A
**2. Or, if no issue exists, describe the change:**
Instead of providing genai.Content to (async_)stream_query, user can provide simple text which will be upgraded to genai.Content. 

### Testing Plan

**Unit Tests:**

- [X ] I have added or updated unit tests for my change.
- [X ] All unit tests pass locally.

_Please include a summary of passed go test results._

**Manual End-to-End (E2E) Tests:**

for a deployed AgentEngine instance run 

```bash
export LOCATION_ID=us-central1
export PROJECT_ID=YOUR_PROJECT
export RESOURCE_ID=YOUR_AGENT_ENGINE_ID

export BASE_URL=https://${LOCATION_ID}-aiplatform.googleapis.com/v1/projects/${PROJECT_ID}/locations/${LOCATION_ID}/reasoningEngines/${RESOURCE_ID}
export STREAMING_QUERY_URL=${BASE_URL}:streamQuery?alt=sse

curl -v \
-H "Authorization: Bearer $(gcloud auth print-access-token)" \
-H "Content-Type: application/json" \
${STREAMING_QUERY_URL} \
-d '{
"class_method":"async_stream_query",
"input": {
            "user_id": "u_123",
            "message":"Hey whats the weather in new york today?"
}}'
```


### Checklist

- [X ] I have read the [CONTRIBUTING.md](./CONTRIBUTING.md) document.
- [X] I have performed a self-review of my own code.
- [X] I have commented my code, particularly in hard-to-understand areas.
- [X] I have added tests that prove my fix is effective or that my feature works.
- [X] New and existing unit tests pass locally with my changes.
- [X] I have manually tested my changes end-to-end.
- [X] Any dependent changes have been merged and published in downstream modules.

### Additional context



