### PR TITLE
feat: add tool node to workflow agents

### DIFF
--- a/agent/workflowagent/workflow_test.go
+++ b/agent/workflowagent/workflow_test.go
@@ -86,12 +86,12 @@ func (m *MockInvocationContext) Value(key any) any {
 	return m.Context.Value(key)
 }
 
-func (m *MockInvocationContext) Artifacts() agent.Artifacts { return nil }
-func (m *MockInvocationContext) Memory() agent.Memory       { return nil }
-func (m *MockInvocationContext) Branch() string             { return "" }
+func (m *MockInvocationContext) Artifacts() agent.Artifacts  { return nil }
+func (m *MockInvocationContext) Memory() agent.Memory        { return nil }
+func (m *MockInvocationContext) Branch() string              { return "" }
 func (m *MockInvocationContext) RunConfig() *agent.RunConfig { return nil }
-func (m *MockInvocationContext) Ended() bool                { return false }
-func (m *MockInvocationContext) EndInvocation()             {}
+func (m *MockInvocationContext) Ended() bool                 { return false }
+func (m *MockInvocationContext) EndInvocation()              {}
 
 func TestWorkflowAgent(t *testing.T) {
 	upperFn := func(ctx agent.InvocationContext, input any) (string, error) {

--- a/workflow/tool_node.go
+++ b/workflow/tool_node.go
@@ -1,0 +1,153 @@
+// Copyright 2026 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package workflow
+
+import (
+	"fmt"
+	"iter"
+
+	"github.com/google/jsonschema-go/jsonschema"
+	"github.com/google/uuid"
+	"google.golang.org/genai"
+
+	"google.golang.org/adk/agent"
+	"google.golang.org/adk/internal/toolinternal"
+	"google.golang.org/adk/internal/typeutil"
+	"google.golang.org/adk/session"
+	"google.golang.org/adk/tool"
+)
+
+// toolNode wraps a tool from the tool package.
+type toolNode[Input, Output any] struct {
+	baseNode
+	tool         tool.Tool
+	inputSchema  *jsonschema.Resolved
+	outputSchema *jsonschema.Resolved
+}
+
+// NewToolNodeWithSchemasTyped creates a new node wrapping a tool with explicitly provided schemas.
+// If a schema is nil, it will be inferred from the corresponding generic type Input or Output.
+func NewToolNodeWithSchemasTyped[Input, Output any](t tool.Tool, inputSchema, outputSchema *jsonschema.Schema) (Node, error) {
+	if t == nil {
+		return nil, fmt.Errorf("tool cannot be nil")
+	}
+	ischema, err := resolvedSchema[Input](inputSchema)
+	if err != nil {
+		return nil, fmt.Errorf("resolving input schema for tool %q: %w", t.Name(), err)
+	}
+	oschema, err := resolvedSchema[Output](outputSchema)
+	if err != nil {
+		return nil, fmt.Errorf("resolving output schema for tool %q: %w", t.Name(), err)
+	}
+
+	return &toolNode[Input, Output]{
+		baseNode:     baseNode{name: t.Name(), description: t.Description()},
+		tool:         t,
+		inputSchema:  ischema,
+		outputSchema: oschema,
+	}, nil
+}
+
+// NewToolNodeWithSchemas is a convenience wrapper for NewToolNodeWithSchemasTyped[any, any].
+// It uses explicitly provided schemas for both input and output.
+func NewToolNodeWithSchemas(t tool.Tool, inputSchema, outputSchema *jsonschema.Schema) (Node, error) {
+	return NewToolNodeWithSchemasTyped[any, any](t, inputSchema, outputSchema)
+}
+
+// NewToolNodeTyped creates a new node wrapping a tool using generics to
+// automatically infer input and output schemas from the provided types.
+func NewToolNodeTyped[Input, Output any](t tool.Tool) (Node, error) {
+	return NewToolNodeWithSchemasTyped[Input, Output](t, nil, nil)
+}
+
+// NewToolNode creates a new node wrapping a tool. Input and output schemas
+// are inferred as 'any'.
+func NewToolNode(t tool.Tool) (Node, error) {
+	return NewToolNodeTyped[any, any](t)
+}
+
+func (n *toolNode[Input, Output]) Run(ctx agent.InvocationContext, input any) iter.Seq2[*session.Event, error] {
+	return func(yield func(*session.Event, error) bool) {
+		runnable, ok := n.tool.(interface {
+			Run(ctx tool.Context, args any) (map[string]any, error)
+		})
+		if !ok {
+			yield(nil, fmt.Errorf("tool %q (type %T) is not directly runnable in workflow node", n.tool.Name(), n.tool))
+			return
+		}
+
+		toolInput, err := typeutil.ConvertToWithJSONSchema[any, any](input, n.inputSchema)
+		if err != nil {
+			yield(nil, fmt.Errorf("converting input for tool %q: %w", n.tool.Name(), err))
+			return
+		}
+
+		eventActions := &session.EventActions{StateDelta: make(map[string]any), ArtifactDelta: make(map[string]int64)}
+		toolCtx := toolinternal.NewToolContext(ctx, uuid.NewString(), eventActions, nil)
+
+		output, err := runnable.Run(toolCtx, toolInput)
+		if err != nil {
+			yield(nil, fmt.Errorf("tool %q execution failed: %w", n.tool.Name(), err))
+			return
+		}
+
+		typedOutput, err := typeutil.ConvertToWithJSONSchema[any, Output](output, n.outputSchema)
+		if err != nil {
+			// If outputSchema is not set or direct conversion failed, functiontool might have wrapped
+			// the result in a "result" key (common for basic types).
+			if val, ok := output["result"]; ok {
+				// If we have a "result" key but it can't be converted
+				typedOutput, err = typeutil.ConvertToWithJSONSchema[any, Output](val, n.outputSchema)
+				if err != nil {
+					// Try to convert to the type directly if that's some basic type.
+					if v, ok := val.(Output); ok {
+						typedOutput = v
+					} else {
+						yield(nil, fmt.Errorf("converting tool %q output to %T (from \"result\" key): %w", n.tool.Name(), *new(Output), err))
+						return
+					}
+				}
+			} else {
+				yield(nil, fmt.Errorf("converting tool %q output to %T: %w", n.tool.Name(), *new(Output), err))
+				return
+			}
+		}
+
+		event := session.NewEvent(ctx.InvocationID())
+		event.Actions = *eventActions
+		event.Actions.StateDelta["output"] = typedOutput
+
+		// If output is a string, set it as content for convenience (similar to FunctionNode).
+		if s, ok := any(typedOutput).(string); ok {
+			event.Content = &genai.Content{
+				Parts: []*genai.Part{{Text: s}},
+			}
+		}
+
+		yield(event, nil)
+	}
+}
+
+// resolvedSchema is a helper to infer schema from type T.
+func resolvedSchema[T any](override *jsonschema.Schema) (*jsonschema.Resolved, error) {
+	if override != nil {
+		return override.Resolve(nil)
+	}
+	schema, err := jsonschema.For[T](nil)
+	if err != nil {
+		return nil, err
+	}
+	return schema.Resolve(nil)
+}

--- a/workflow/tool_node.go
+++ b/workflow/tool_node.go
@@ -30,16 +30,16 @@ import (
 )
 
 // toolNode wraps a tool from the tool package.
-type toolNode[Input, Output any] struct {
+type toolNode struct {
 	baseNode
 	tool         tool.Tool
 	inputSchema  *jsonschema.Resolved
 	outputSchema *jsonschema.Resolved
 }
 
-// NewToolNodeWithSchemasTyped creates a new node wrapping a tool with explicitly provided schemas.
+// newToolNodeWithSchemasTyped creates a new node wrapping a tool with explicitly provided schemas.
 // If a schema is nil, it will be inferred from the corresponding generic type Input or Output.
-func NewToolNodeWithSchemasTyped[Input, Output any](t tool.Tool, inputSchema, outputSchema *jsonschema.Schema) (Node, error) {
+func newToolNodeWithSchemasTyped[Input, Output any](t tool.Tool, inputSchema, outputSchema *jsonschema.Schema) (Node, error) {
 	if t == nil {
 		return nil, fmt.Errorf("tool cannot be nil")
 	}
@@ -47,12 +47,18 @@ func NewToolNodeWithSchemasTyped[Input, Output any](t tool.Tool, inputSchema, ou
 	if err != nil {
 		return nil, fmt.Errorf("resolving input schema for tool %q: %w", t.Name(), err)
 	}
+	if ischema == nil {
+		return nil, fmt.Errorf("resolved input schema for tool %q is nil", t.Name())
+	}
 	oschema, err := resolvedSchema[Output](outputSchema)
 	if err != nil {
 		return nil, fmt.Errorf("resolving output schema for tool %q: %w", t.Name(), err)
 	}
+	if oschema == nil {
+		return nil, fmt.Errorf("resolved output schema for tool %q is nil", t.Name())
+	}
 
-	return &toolNode[Input, Output]{
+	return &toolNode{
 		baseNode:     baseNode{name: t.Name(), description: t.Description()},
 		tool:         t,
 		inputSchema:  ischema,
@@ -63,13 +69,13 @@ func NewToolNodeWithSchemasTyped[Input, Output any](t tool.Tool, inputSchema, ou
 // NewToolNodeWithSchemas is a convenience wrapper for NewToolNodeWithSchemasTyped[any, any].
 // It uses explicitly provided schemas for both input and output.
 func NewToolNodeWithSchemas(t tool.Tool, inputSchema, outputSchema *jsonschema.Schema) (Node, error) {
-	return NewToolNodeWithSchemasTyped[any, any](t, inputSchema, outputSchema)
+	return newToolNodeWithSchemasTyped[any, any](t, inputSchema, outputSchema)
 }
 
 // NewToolNodeTyped creates a new node wrapping a tool using generics to
 // automatically infer input and output schemas from the provided types.
 func NewToolNodeTyped[Input, Output any](t tool.Tool) (Node, error) {
-	return NewToolNodeWithSchemasTyped[Input, Output](t, nil, nil)
+	return newToolNodeWithSchemasTyped[Input, Output](t, nil, nil)
 }
 
 // NewToolNode creates a new node wrapping a tool. Input and output schemas
@@ -78,59 +84,59 @@ func NewToolNode(t tool.Tool) (Node, error) {
 	return NewToolNodeTyped[any, any](t)
 }
 
-func (n *toolNode[Input, Output]) Run(ctx agent.InvocationContext, input any) iter.Seq2[*session.Event, error] {
+func (n *toolNode) runTool(toolCtx tool.Context, input any) (any, error) {
+	runnable, ok := n.tool.(interface {
+		Run(ctx tool.Context, args any) (map[string]any, error)
+	})
+	if !ok {
+		return nil, fmt.Errorf("tool %q (type %T) is not directly runnable in workflow node", n.tool.Name(), n.tool)
+	}
+
+	toolInput, err := typeutil.ConvertToWithJSONSchema[any, any](input, n.inputSchema)
+	if err != nil {
+		return nil, fmt.Errorf("converting input for tool %q: %w", n.tool.Name(), err)
+	}
+
+	output, err := runnable.Run(toolCtx, toolInput)
+	if err != nil {
+		return nil, fmt.Errorf("tool %q execution failed: %w", n.tool.Name(), err)
+	}
+
+	var toolOutput any = output
+
+	// Validate
+	if err := n.outputSchema.Validate(output); err != nil {
+		if val, ok := output["result"]; ok {
+			if err := n.outputSchema.Validate(val); err != nil {
+				return nil, fmt.Errorf("converting tool %q output: validation failed for result key: %w", n.tool.Name(), err)
+			}
+			toolOutput = val
+		} else {
+			return nil, fmt.Errorf("converting tool %q output: validation failed: %w", n.tool.Name(), err)
+		}
+	}
+
+	return toolOutput, nil
+}
+
+// Run implements the Node interface and executes the tool.
+func (n *toolNode) Run(ctx agent.InvocationContext, input any) iter.Seq2[*session.Event, error] {
 	return func(yield func(*session.Event, error) bool) {
-		runnable, ok := n.tool.(interface {
-			Run(ctx tool.Context, args any) (map[string]any, error)
-		})
-		if !ok {
-			yield(nil, fmt.Errorf("tool %q (type %T) is not directly runnable in workflow node", n.tool.Name(), n.tool))
-			return
-		}
-
-		toolInput, err := typeutil.ConvertToWithJSONSchema[any, any](input, n.inputSchema)
-		if err != nil {
-			yield(nil, fmt.Errorf("converting input for tool %q: %w", n.tool.Name(), err))
-			return
-		}
-
 		eventActions := &session.EventActions{StateDelta: make(map[string]any), ArtifactDelta: make(map[string]int64)}
 		toolCtx := toolinternal.NewToolContext(ctx, uuid.NewString(), eventActions, nil)
 
-		output, err := runnable.Run(toolCtx, toolInput)
+		toolOutput, err := n.runTool(toolCtx, input)
 		if err != nil {
-			yield(nil, fmt.Errorf("tool %q execution failed: %w", n.tool.Name(), err))
+			yield(nil, err)
 			return
-		}
-
-		typedOutput, err := typeutil.ConvertToWithJSONSchema[any, Output](output, n.outputSchema)
-		if err != nil {
-			// If outputSchema is not set or direct conversion failed, functiontool might have wrapped
-			// the result in a "result" key (common for basic types).
-			if val, ok := output["result"]; ok {
-				// If we have a "result" key but it can't be converted
-				typedOutput, err = typeutil.ConvertToWithJSONSchema[any, Output](val, n.outputSchema)
-				if err != nil {
-					// Try to convert to the type directly if that's some basic type.
-					if v, ok := val.(Output); ok {
-						typedOutput = v
-					} else {
-						yield(nil, fmt.Errorf("converting tool %q output to %T (from \"result\" key): %w", n.tool.Name(), *new(Output), err))
-						return
-					}
-				}
-			} else {
-				yield(nil, fmt.Errorf("converting tool %q output to %T: %w", n.tool.Name(), *new(Output), err))
-				return
-			}
 		}
 
 		event := session.NewEvent(ctx.InvocationID())
 		event.Actions = *eventActions
-		event.Actions.StateDelta["output"] = typedOutput
+		event.Actions.StateDelta["output"] = toolOutput
 
 		// If output is a string, set it as content for convenience (similar to FunctionNode).
-		if s, ok := any(typedOutput).(string); ok {
+		if s, ok := toolOutput.(string); ok {
 			event.Content = &genai.Content{
 				Parts: []*genai.Part{{Text: s}},
 			}

--- a/workflow/tool_node.go
+++ b/workflow/tool_node.go
@@ -37,6 +37,10 @@ type toolNode struct {
 	outputSchema *jsonschema.Resolved
 }
 
+type runnableTool interface {
+	Run(ctx tool.Context, args any) (map[string]any, error)
+}
+
 // newToolNodeWithSchemasTyped creates a new node wrapping a tool with explicitly provided schemas.
 // If a schema is nil, it will be inferred from the corresponding generic type Input or Output.
 func newToolNodeWithSchemasTyped[Input, Output any](t tool.Tool, inputSchema, outputSchema *jsonschema.Schema) (Node, error) {
@@ -56,6 +60,10 @@ func newToolNodeWithSchemasTyped[Input, Output any](t tool.Tool, inputSchema, ou
 	}
 	if oschema == nil {
 		return nil, fmt.Errorf("resolved output schema for tool %q is nil", t.Name())
+	}
+
+	if _, ok := t.(runnableTool); !ok {
+		return nil, fmt.Errorf("tool %q (type %T) is not directly runnable in workflow node", t.Name(), t)
 	}
 
 	return &toolNode{
@@ -85,13 +93,7 @@ func NewToolNode(t tool.Tool) (Node, error) {
 }
 
 func (n *toolNode) runTool(toolCtx tool.Context, input any) (any, error) {
-	runnable, ok := n.tool.(interface {
-		Run(ctx tool.Context, args any) (map[string]any, error)
-	})
-	if !ok {
-		return nil, fmt.Errorf("tool %q (type %T) is not directly runnable in workflow node", n.tool.Name(), n.tool)
-	}
-
+	runnable := n.tool.(runnableTool)
 	toolInput, err := typeutil.ConvertToWithJSONSchema[any, any](input, n.inputSchema)
 	if err != nil {
 		return nil, fmt.Errorf("converting input for tool %q: %w", n.tool.Name(), err)

--- a/workflow/tool_node_test.go
+++ b/workflow/tool_node_test.go
@@ -1,0 +1,321 @@
+// Copyright 2026 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package workflow
+
+import (
+	"strings"
+	"testing"
+
+	"github.com/google/go-cmp/cmp"
+	"github.com/google/jsonschema-go/jsonschema"
+
+	"google.golang.org/adk/agent"
+	"google.golang.org/adk/tool"
+	"google.golang.org/adk/tool/functiontool"
+)
+
+func TestToolNode_New(t *testing.T) {
+	type Input struct {
+		Value string `json:"value"`
+	}
+	type Output struct {
+		Result string `json:"result"`
+	}
+
+	myTool, err := functiontool.New(functiontool.Config{
+		Name:        "test_tool",
+		Description: "a test tool",
+	}, func(ctx tool.Context, in Input) (Output, error) {
+		return Output{Result: strings.ToUpper(in.Value)}, nil
+	})
+	if err != nil {
+		t.Fatalf("failed to create tool: %v", err)
+	}
+
+	ischema, _ := jsonschema.For[Input](nil)
+	oschema, _ := jsonschema.For[Output](nil)
+
+	tests := []struct {
+		name    string
+		creator func() (Node, error)
+		want    string
+	}{
+		{
+			name: "NewToolNodeTyped",
+			creator: func() (Node, error) {
+				return NewToolNodeTyped[Input, Output](myTool)
+			},
+		},
+		{
+			name: "NewToolNodeWithSchemas",
+			creator: func() (Node, error) {
+				return NewToolNodeWithSchemas(myTool, ischema, oschema)
+			},
+		},
+		{
+			name: "NewToolNodeWithSchemasTyped",
+			creator: func() (Node, error) {
+				return NewToolNodeWithSchemasTyped[Input, Output](myTool, nil, nil)
+			},
+		},
+		{
+			name: "NewToolNode",
+			creator: func() (Node, error) {
+				return NewToolNode(myTool)
+			},
+		},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			node, err := tc.creator()
+			if err != nil {
+				t.Fatalf("creation failed: %v", err)
+			}
+
+			if got, want := node.Name(), "test_tool"; got != want {
+				t.Errorf("node.Name() = %q, want %q", got, want)
+			}
+			if got, want := node.Description(), "a test tool"; got != want {
+				t.Errorf("node.Description() = %q, want %q", got, want)
+			}
+
+			// Basic internal check via reflection-like cast.
+			// We use any, any for constructors that don't preserve types in the struct.
+			var inputResolved, outputResolved *jsonschema.Resolved
+			switch tn := node.(type) {
+			case *toolNode[Input, Output]:
+				inputResolved, outputResolved = tn.inputSchema, tn.outputSchema
+			case *toolNode[any, any]:
+				inputResolved, outputResolved = tn.inputSchema, tn.outputSchema
+			}
+
+			if inputResolved == nil || outputResolved == nil {
+				t.Error("expected schemas to be resolved")
+			}
+		})
+	}
+}
+
+func TestToolNode_Run(t *testing.T) {
+	type Input struct {
+		Name string `json:"name"`
+	}
+	type Output struct {
+		Greeting string `json:"greeting"`
+	}
+
+	tests := []struct {
+		name      string
+		tool      func() (tool.Tool, error)
+		nodeInput any
+		node      func(tool.Tool) (Node, error)
+		extract   func(any) string
+		want      string
+		wantErr   string
+	}{
+		{
+			name: "struct_input_output",
+			tool: func() (tool.Tool, error) {
+				return functiontool.New(functiontool.Config{
+					Name: "greet",
+				}, func(ctx tool.Context, in Input) (Output, error) {
+					return Output{Greeting: "Hello " + in.Name}, nil
+				})
+			},
+			nodeInput: Input{Name: "World"},
+			node: func(t tool.Tool) (Node, error) {
+				return NewToolNodeTyped[Input, Output](t)
+			},
+			extract: func(out any) string {
+				return out.(Output).Greeting
+			},
+			want: "Hello World",
+		},
+		{
+			name: "string_output",
+			tool: func() (tool.Tool, error) {
+				return functiontool.New(functiontool.Config{
+					Name: "greet",
+				}, func(ctx tool.Context, in Input) (string, error) {
+					return "HELLO " + strings.ToUpper(in.Name), nil
+				})
+			},
+			nodeInput: Input{Name: "world"},
+			node: func(t tool.Tool) (Node, error) {
+				return NewToolNodeTyped[Input, string](t)
+			},
+			extract: func(out any) string {
+				return out.(string)
+			},
+			want: "HELLO WORLD",
+		},
+		{
+			name: "schema_validation_error",
+			tool: func() (tool.Tool, error) {
+				return functiontool.New(functiontool.Config{
+					Name: "test_tool",
+				}, func(ctx tool.Context, in map[string]any) (map[string]any, error) {
+					return map[string]any{"result": "not-an-int"}, nil
+				})
+			},
+			nodeInput: map[string]any{},
+			node: func(t tool.Tool) (Node, error) {
+				type ErrorOutput struct {
+					Result int `json:"result"`
+				}
+				return NewToolNodeTyped[map[string]any, ErrorOutput](t)
+			},
+			wantErr: "converting tool \"test_tool\" output",
+		},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			myTool, err := tc.tool()
+			if err != nil {
+				t.Fatalf("failed to create tool: %v", err)
+			}
+
+			node, err := tc.node(myTool)
+			if err != nil {
+				t.Fatalf("node creation failed: %v", err)
+			}
+
+			mockCtx := &MockInvocationContext{sess: nil}
+			events := node.Run(mockCtx, tc.nodeInput)
+
+			var got string
+			count := 0
+			for ev, err := range events {
+				if tc.wantErr != "" {
+					if err == nil {
+						t.Fatal("expected error, got nil")
+					}
+					if !strings.Contains(err.Error(), tc.wantErr) {
+						t.Errorf("expected error containing %q, got: %v", tc.wantErr, err)
+					}
+					return
+				}
+
+				if err != nil {
+					t.Fatalf("unexpected error: %v", err)
+				}
+				count++
+
+				output, ok := ev.Actions.StateDelta["output"]
+				if !ok {
+					t.Fatal("expected output in state delta")
+				}
+
+				got = tc.extract(output)
+			}
+
+			if tc.wantErr != "" {
+				t.Error("expected at least one event/error from Run")
+				return
+			}
+
+			if count != 1 {
+				t.Errorf("expected 1 event, got %d", count)
+			}
+			if diff := cmp.Diff(tc.want, got); diff != "" {
+				t.Errorf("output mismatch (-want +got):\n%s", diff)
+			}
+		})
+	}
+}
+
+func TestToolNode_WorkflowIntegration(t *testing.T) {
+	type Input struct {
+		Val int `json:"val"`
+	}
+	type Output struct {
+		Result int `json:"result"`
+	}
+
+	tests := []struct {
+		name  string
+		input int
+		want  int
+	}{
+		{
+			name:  "chain_tool_and_function",
+			input: 5,
+			want:  11,
+		},
+		{
+			name:  "chain_tool_and_function_zero",
+			input: 0,
+			want:  1,
+		},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			doubleTool, err := functiontool.New(functiontool.Config{
+				Name: "double",
+			}, func(ctx tool.Context, in *Input) (Output, error) {
+				return Output{Result: in.Val * 2}, nil
+			})
+			if err != nil {
+				t.Fatalf("failed to create tool: %v", err)
+			}
+
+			nodeA, err := NewToolNodeTyped[*Input, Output](doubleTool)
+			if err != nil {
+				t.Fatalf("NewToolNodeTyped failed: %v", err)
+			}
+
+			// Connect to a function node.
+			nodeB := NewFunctionNode("plus_one", func(ctx agent.InvocationContext, in *Output) (int, error) {
+				return in.Result + 1, nil
+			})
+
+			mockCtx := &MockInvocationContext{sess: nil}
+
+			t.Run("DirectChainExecution", func(t *testing.T) {
+				// Test direct chain execution.
+				eventsA := nodeA.Run(mockCtx, &Input{Val: tc.input})
+				var outA any
+				for ev, err := range eventsA {
+					if err != nil {
+						t.Fatalf("nodeA.Run failed: %v", err)
+					}
+					outA = ev.Actions.StateDelta["output"]
+				}
+
+				// outA should be Output struct.
+				typedOutA, ok := outA.(Output)
+				if !ok {
+					t.Fatalf("unexpected output type from nodeA: %T, want Output", outA)
+				}
+
+				eventsB := nodeB.Run(mockCtx, &typedOutA)
+				var outB any
+				for ev, err := range eventsB {
+					if err != nil {
+						t.Fatalf("nodeB.Run failed: %v", err)
+					}
+					outB = ev.Actions.StateDelta["output"]
+				}
+
+				if diff := cmp.Diff(tc.want, outB); diff != "" {
+					t.Errorf("output mismatch (-want +got):\n%s", diff)
+				}
+			})
+		})
+	}
+}

--- a/workflow/tool_node_test.go
+++ b/workflow/tool_node_test.go
@@ -15,6 +15,8 @@
 package workflow
 
 import (
+	"encoding/json"
+	"errors"
 	"strings"
 	"testing"
 
@@ -44,8 +46,14 @@ func TestToolNode_New(t *testing.T) {
 		t.Fatalf("failed to create tool: %v", err)
 	}
 
-	ischema, _ := jsonschema.For[Input](nil)
-	oschema, _ := jsonschema.For[Output](nil)
+	ischema, err := jsonschema.For[Input](nil)
+	if err != nil {
+		t.Fatalf("jsonschema.For[Input] failed: %v", err)
+	}
+	oschema, err := jsonschema.For[Output](nil)
+	if err != nil {
+		t.Fatalf("jsonschema.For[Output] failed: %v", err)
+	}
 
 	tests := []struct {
 		name    string
@@ -62,12 +70,6 @@ func TestToolNode_New(t *testing.T) {
 			name: "NewToolNodeWithSchemas",
 			creator: func() (Node, error) {
 				return NewToolNodeWithSchemas(myTool, ischema, oschema)
-			},
-		},
-		{
-			name: "NewToolNodeWithSchemasTyped",
-			creator: func() (Node, error) {
-				return NewToolNodeWithSchemasTyped[Input, Output](myTool, nil, nil)
 			},
 		},
 		{
@@ -96,10 +98,10 @@ func TestToolNode_New(t *testing.T) {
 			// We use any, any for constructors that don't preserve types in the struct.
 			var inputResolved, outputResolved *jsonschema.Resolved
 			switch tn := node.(type) {
-			case *toolNode[Input, Output]:
+			case *toolNode:
 				inputResolved, outputResolved = tn.inputSchema, tn.outputSchema
-			case *toolNode[any, any]:
-				inputResolved, outputResolved = tn.inputSchema, tn.outputSchema
+			default:
+				t.Errorf("unknown node type: %T", tn)
 			}
 
 			if inputResolved == nil || outputResolved == nil {
@@ -116,13 +118,16 @@ func TestToolNode_Run(t *testing.T) {
 	type Output struct {
 		Greeting string `json:"greeting"`
 	}
+	type ErrorOutput struct {
+		Result int `json:"result"`
+	}
 
 	tests := []struct {
 		name      string
 		tool      func() (tool.Tool, error)
 		nodeInput any
 		node      func(tool.Tool) (Node, error)
-		extract   func(any) string
+		extract   func(t *testing.T, out any) string
 		want      string
 		wantErr   string
 	}{
@@ -139,8 +144,16 @@ func TestToolNode_Run(t *testing.T) {
 			node: func(t tool.Tool) (Node, error) {
 				return NewToolNodeTyped[Input, Output](t)
 			},
-			extract: func(out any) string {
-				return out.(Output).Greeting
+			extract: func(t *testing.T, out any) string {
+				bytes, err := json.Marshal(out)
+				if err != nil {
+					t.Fatalf("json marshal output: %v", err)
+				}
+				var output Output
+				if err := json.Unmarshal(bytes, &output); err != nil {
+					t.Fatalf("json unmarsal output: %v", err)
+				}
+				return output.Greeting
 			},
 			want: "Hello World",
 		},
@@ -157,7 +170,7 @@ func TestToolNode_Run(t *testing.T) {
 			node: func(t tool.Tool) (Node, error) {
 				return NewToolNodeTyped[Input, string](t)
 			},
-			extract: func(out any) string {
+			extract: func(t *testing.T, out any) string {
 				return out.(string)
 			},
 			want: "HELLO WORLD",
@@ -173,12 +186,24 @@ func TestToolNode_Run(t *testing.T) {
 			},
 			nodeInput: map[string]any{},
 			node: func(t tool.Tool) (Node, error) {
-				type ErrorOutput struct {
-					Result int `json:"result"`
-				}
 				return NewToolNodeTyped[map[string]any, ErrorOutput](t)
 			},
 			wantErr: "converting tool \"test_tool\" output",
+		},
+		{
+			name: "tool_execution_error",
+			tool: func() (tool.Tool, error) {
+				return functiontool.New(functiontool.Config{
+					Name: "fail_tool",
+				}, func(ctx tool.Context, in Input) (*Output, error) {
+					return nil, errors.New("something went wrong")
+				})
+			},
+			nodeInput: Input{Name: "World"},
+			node: func(t tool.Tool) (Node, error) {
+				return NewToolNodeTyped[Input, Output](t)
+			},
+			wantErr: "tool \"fail_tool\" execution failed: something went wrong",
 		},
 	}
 
@@ -220,7 +245,7 @@ func TestToolNode_Run(t *testing.T) {
 					t.Fatal("expected output in state delta")
 				}
 
-				got = tc.extract(output)
+				got = tc.extract(t, output)
 			}
 
 			if tc.wantErr != "" {
@@ -274,42 +299,40 @@ func TestToolNode_WorkflowIntegration(t *testing.T) {
 				t.Fatalf("failed to create tool: %v", err)
 			}
 
-			nodeA, err := NewToolNodeTyped[*Input, Output](doubleTool)
+			nodeA, err := NewToolNodeTyped[*Input, *Output](doubleTool)
 			if err != nil {
 				t.Fatalf("NewToolNodeTyped failed: %v", err)
 			}
 
 			// Connect to a function node.
-			nodeB := NewFunctionNode("plus_one", func(ctx agent.InvocationContext, in *Output) (int, error) {
+			nodeB := NewFunctionNode[Output, int]("plus_one", func(ctx agent.InvocationContext, in Output) (int, error) {
 				return in.Result + 1, nil
 			})
 
 			mockCtx := &MockInvocationContext{sess: nil}
 
-			t.Run("DirectChainExecution", func(t *testing.T) {
-				// Test direct chain execution.
-				eventsA := nodeA.Run(mockCtx, &Input{Val: tc.input})
-				var outA any
-				for ev, err := range eventsA {
-					if err != nil {
-						t.Fatalf("nodeA.Run failed: %v", err)
-					}
-					outA = ev.Actions.StateDelta["output"]
-				}
+			t.Run("WorkflowExecution", func(t *testing.T) {
+				// Use a seed node to pass the struct input to nodeA,
+				// since Workflow.Run currently only passes strings from UserContent.
+				seedNode := NewFunctionNode("seed", func(ctx agent.InvocationContext, input any) (*Input, error) {
+					return &Input{Val: tc.input}, nil
+				})
 
-				// outA should be Output struct.
-				typedOutA, ok := outA.(Output)
-				if !ok {
-					t.Fatalf("unexpected output type from nodeA: %T, want Output", outA)
-				}
+				edges := Chain(Start, seedNode, nodeA, nodeB)
+				w := New(edges)
 
-				eventsB := nodeB.Run(mockCtx, &typedOutA)
+				events := w.Run(mockCtx)
+
 				var outB any
-				for ev, err := range eventsB {
+				for ev, err := range events {
 					if err != nil {
-						t.Fatalf("nodeB.Run failed: %v", err)
+						t.Fatalf("workflow failed: %v", err)
 					}
-					outB = ev.Actions.StateDelta["output"]
+					if ev.Actions.StateDelta != nil {
+						if out, ok := ev.Actions.StateDelta["output"]; ok {
+							outB = out
+						}
+					}
 				}
 
 				if diff := cmp.Diff(tc.want, outB); diff != "" {

--- a/workflow/tool_node_test.go
+++ b/workflow/tool_node_test.go
@@ -299,26 +299,26 @@ func TestToolNode_WorkflowIntegration(t *testing.T) {
 				t.Fatalf("failed to create tool: %v", err)
 			}
 
-			nodeA, err := NewToolNodeTyped[*Input, *Output](doubleTool)
+			toolNode, err := NewToolNodeTyped[*Input, *Output](doubleTool)
 			if err != nil {
 				t.Fatalf("NewToolNodeTyped failed: %v", err)
 			}
 
 			// Connect to a function node.
-			nodeB := NewFunctionNode[Output, int]("plus_one", func(ctx agent.InvocationContext, in Output) (int, error) {
+			functionNode := NewFunctionNode[Output, int]("plus_one", func(ctx agent.InvocationContext, in Output) (int, error) {
 				return in.Result + 1, nil
 			})
 
 			mockCtx := &MockInvocationContext{sess: nil}
 
 			t.Run("WorkflowExecution", func(t *testing.T) {
-				// Use a seed node to pass the struct input to nodeA,
+				// Use a seed node to pass the struct input to toolNode,
 				// since Workflow.Run currently only passes strings from UserContent.
 				seedNode := NewFunctionNode("seed", func(ctx agent.InvocationContext, input any) (*Input, error) {
 					return &Input{Val: tc.input}, nil
 				})
 
-				edges := Chain(Start, seedNode, nodeA, nodeB)
+				edges := Chain(Start, seedNode, toolNode, functionNode)
 				w := New(edges)
 
 				events := w.Run(mockCtx)

--- a/workflow/workflow.go
+++ b/workflow/workflow.go
@@ -63,7 +63,7 @@ type FunctionNode struct {
 }
 
 // NewFunctionNode creates a new node wrapping a custom function using generics to automatically infer input and output types.
-func NewFunctionNode[IN any, OUT any](name string, fn func(ctx agent.InvocationContext, input IN) (OUT, error)) *FunctionNode {
+func NewFunctionNode[IN, OUT any](name string, fn func(ctx agent.InvocationContext, input IN) (OUT, error)) *FunctionNode {
 	wrappedFn := func(ctx agent.InvocationContext, input any) (any, error) {
 		if input == nil {
 			var zero IN
@@ -77,7 +77,7 @@ func NewFunctionNode[IN any, OUT any](name string, fn func(ctx agent.InvocationC
 	}
 	return &FunctionNode{
 		baseNode: baseNode{name: name},
-		fn:        wrappedFn,
+		fn:       wrappedFn,
 	}
 }
 
@@ -88,7 +88,7 @@ func (n *FunctionNode) Run(ctx agent.InvocationContext, input any) iter.Seq2[*se
 			yield(nil, err)
 			return
 		}
-		
+
 		event := session.NewEvent(ctx.InvocationID())
 		event.Actions.StateDelta["output"] = output
 		if s, ok := output.(string); ok {

--- a/workflow/workflow.go
+++ b/workflow/workflow.go
@@ -22,6 +22,7 @@ import (
 	"google.golang.org/genai"
 
 	"google.golang.org/adk/agent"
+	"google.golang.org/adk/internal/typeutil"
 	"google.golang.org/adk/session"
 )
 
@@ -71,7 +72,13 @@ func NewFunctionNode[IN, OUT any](name string, fn func(ctx agent.InvocationConte
 		}
 		typedInput, ok := input.(IN)
 		if !ok {
-			return nil, fmt.Errorf("invalid input type, expected %T", new(IN))
+			// Fallback to the json-like input types that cannot be converted by the standard type assertion.
+			// E.g. tool nodes return map[string]any as input and user may define a struct as the target type.
+			var err error
+			typedInput, err = typeutil.ConvertToWithJSONSchema[any, IN](input, nil)
+			if err != nil {
+				return nil, fmt.Errorf("new function node: invalid input type, expected %T: %v", new(IN), err)
+			}
 		}
 		return fn(ctx, typedInput)
 	}

--- a/workflow/workflow_test.go
+++ b/workflow/workflow_test.go
@@ -15,6 +15,7 @@
 package workflow
 
 import (
+	"context"
 	"fmt"
 	"strings"
 	"testing"
@@ -32,16 +33,18 @@ type MockInvocationContext struct {
 	userContent *genai.Content
 }
 
-func (m *MockInvocationContext) Session() session.Session {
-	return m.sess
-}
-
-func (m *MockInvocationContext) InvocationID() string {
-	return "test-invocation-id"
-}
-
-func (m *MockInvocationContext) UserContent() *genai.Content {
-	return m.userContent
+func (m *MockInvocationContext) Session() session.Session    { return m.sess }
+func (m *MockInvocationContext) InvocationID() string        { return "test-invocation-id" }
+func (m *MockInvocationContext) UserContent() *genai.Content { return m.userContent }
+func (m *MockInvocationContext) Artifacts() agent.Artifacts  { return nil }
+func (m *MockInvocationContext) Memory() agent.Memory        { return nil }
+func (m *MockInvocationContext) Agent() agent.Agent          { return nil }
+func (m *MockInvocationContext) Branch() string              { return "" }
+func (m *MockInvocationContext) RunConfig() *agent.RunConfig { return nil }
+func (m *MockInvocationContext) EndInvocation()              {}
+func (m *MockInvocationContext) Ended() bool                 { return false }
+func (m *MockInvocationContext) WithContext(ctx context.Context) agent.InvocationContext {
+	return m
 }
 
 func TestFunctionNode(t *testing.T) {
@@ -63,7 +66,7 @@ func TestFunctionNode(t *testing.T) {
 			t.Fatalf("unexpected error: %v", err)
 		}
 		count++
-		
+
 		output, ok := ev.Actions.StateDelta["output"]
 		if !ok {
 			t.Errorf("expected output in state delta")


### PR DESCRIPTION
Added a new ToolNode to be used with workflow agents
1. It could be created with 4 constructors - combinations with strongly typed tool node and overwritten validation schemas 
2. The tool node calls the tool if it's runnable and returns the output of the tool casted to the defined Output type.