### PR TITLE
Update telemetry to use standard gen_ai.usage.reasoning.output_tokens

### DIFF
--- a/internal/telemetry/telemetry.go
+++ b/internal/telemetry/telemetry.go
@@ -47,7 +47,7 @@ var (
 	gcpVertexAgentToolResponseName        = attribute.Key("gcp.vertex.agent.tool_response")
 	gcpVertexAgentInvocationID            = attribute.Key("gcp.vertex.agent.invocation_id")
 	genAIUsageCacheReadInputTokens        = attribute.Key("gen_ai.usage.cache_read.input_tokens")
-	genAIUsageExperimentalReasoningTokens = attribute.Key("gen_ai.usage.experimental.reasoning_tokens")
+	genAIUsageReasoningOutputTokens       = attribute.Key("gen_ai.usage.reasoning.output_tokens")
 )
 
 // tracer is the tracer instance for ADK go.
@@ -128,7 +128,7 @@ func TraceGenerateContentResult(span trace.Span, params TraceGenerateContentResu
 			semconv.GenAIUsageInputTokens(int(params.Response.UsageMetadata.PromptTokenCount)),
 			semconv.GenAIUsageOutputTokens(int(params.Response.UsageMetadata.CandidatesTokenCount)),
 			genAIUsageCacheReadInputTokens.Int(int(params.Response.UsageMetadata.CachedContentTokenCount)),
-			genAIUsageExperimentalReasoningTokens.Int(int(params.Response.UsageMetadata.ThoughtsTokenCount)),
+			genAIUsageReasoningOutputTokens.Int(int(params.Response.UsageMetadata.ThoughtsTokenCount)),
 		)
 	}
 }

--- a/internal/telemetry/telemetry.go
+++ b/internal/telemetry/telemetry.go
@@ -42,10 +42,10 @@ const (
 )
 
 var (
-	gcpVertexAgentToolCallArgsName = attribute.Key("gcp.vertex.agent.tool_call_args")
-	gcpVertexAgentEventID          = attribute.Key("gcp.vertex.agent.event_id")
-	gcpVertexAgentToolResponseName = attribute.Key("gcp.vertex.agent.tool_response")
-	gcpVertexAgentInvocationID     = attribute.Key("gcp.vertex.agent.invocation_id")
+	gcpVertexAgentToolCallArgsName        = attribute.Key("gcp.vertex.agent.tool_call_args")
+	gcpVertexAgentEventID                 = attribute.Key("gcp.vertex.agent.event_id")
+	gcpVertexAgentToolResponseName        = attribute.Key("gcp.vertex.agent.tool_response")
+	gcpVertexAgentInvocationID            = attribute.Key("gcp.vertex.agent.invocation_id")
 	genAIUsageCacheReadInputTokens        = attribute.Key("gen_ai.usage.cache_read.input_tokens")
 	genAIUsageExperimentalReasoningTokens = attribute.Key("gen_ai.usage.experimental.reasoning_tokens")
 )

--- a/internal/telemetry/telemetry.go
+++ b/internal/telemetry/telemetry.go
@@ -46,6 +46,8 @@ var (
 	gcpVertexAgentEventID          = attribute.Key("gcp.vertex.agent.event_id")
 	gcpVertexAgentToolResponseName = attribute.Key("gcp.vertex.agent.tool_response")
 	gcpVertexAgentInvocationID     = attribute.Key("gcp.vertex.agent.invocation_id")
+	genAIUsageCacheReadInputTokens        = attribute.Key("gen_ai.usage.cache_read.input_tokens")
+	genAIUsageExperimentalReasoningTokens = attribute.Key("gen_ai.usage.experimental.reasoning_tokens")
 )
 
 // tracer is the tracer instance for ADK go.
@@ -125,6 +127,8 @@ func TraceGenerateContentResult(span trace.Span, params TraceGenerateContentResu
 		span.SetAttributes(
 			semconv.GenAIUsageInputTokens(int(params.Response.UsageMetadata.PromptTokenCount)),
 			semconv.GenAIUsageOutputTokens(int(params.Response.UsageMetadata.CandidatesTokenCount)),
+			genAIUsageCacheReadInputTokens.Int(int(params.Response.UsageMetadata.CachedContentTokenCount)),
+			genAIUsageExperimentalReasoningTokens.Int(int(params.Response.UsageMetadata.ThoughtsTokenCount)),
 		)
 	}
 }

--- a/internal/telemetry/telemetry_test.go
+++ b/internal/telemetry/telemetry_test.go
@@ -216,8 +216,10 @@ func TestGenerateContent(t *testing.T) {
 			resultParams: TraceGenerateContentResultParams{
 				Response: &model.LLMResponse{
 					UsageMetadata: &genai.GenerateContentResponseUsageMetadata{
-						PromptTokenCount:     10,
-						CandidatesTokenCount: 20,
+						PromptTokenCount:        10,
+						CandidatesTokenCount:   20,
+						CachedContentTokenCount: 5,
+						ThoughtsTokenCount:      15,
 					},
 					FinishReason: genai.FinishReasonStop,
 				},
@@ -229,6 +231,8 @@ func TestGenerateContent(t *testing.T) {
 				semconv.GenAIRequestModelKey:          "test-model",
 				semconv.GenAIUsageInputTokensKey:      "10",
 				semconv.GenAIUsageOutputTokensKey:     "20",
+				genAIUsageCacheReadInputTokens:        "5",
+				genAIUsageExperimentalReasoningTokens: "15",
 				semconv.GenAIResponseFinishReasonsKey: "[\"STOP\"]",
 				gcpVertexAgentInvocationID:            invocationID,
 			},

--- a/internal/telemetry/telemetry_test.go
+++ b/internal/telemetry/telemetry_test.go
@@ -232,7 +232,7 @@ func TestGenerateContent(t *testing.T) {
 				semconv.GenAIUsageInputTokensKey:      "10",
 				semconv.GenAIUsageOutputTokensKey:     "20",
 				genAIUsageCacheReadInputTokens:        "5",
-				genAIUsageExperimentalReasoningTokens: "15",
+				genAIUsageReasoningOutputTokens:       "15",
 				semconv.GenAIResponseFinishReasonsKey: "[\"STOP\"]",
 				gcpVertexAgentInvocationID:            invocationID,
 			},

--- a/internal/telemetry/telemetry_test.go
+++ b/internal/telemetry/telemetry_test.go
@@ -217,7 +217,7 @@ func TestGenerateContent(t *testing.T) {
 				Response: &model.LLMResponse{
 					UsageMetadata: &genai.GenerateContentResponseUsageMetadata{
 						PromptTokenCount:        10,
-						CandidatesTokenCount:   20,
+						CandidatesTokenCount:    20,
 						CachedContentTokenCount: 5,
 						ThoughtsTokenCount:      15,
 					},


### PR DESCRIPTION
**Please ensure you have read the [contribution guide](./CONTRIBUTING.md) before creating a pull request.**

### Description of Change

This PR aligns the experimental telemetry attribute used for tracking reasoning tokens with the standard gen_ai.usage.reasoning.output_tokens in OpenTelemetry semantic conventions.

Previously, we were using a custom experimental key: "gen_ai.usage.experimental.reasoning_tokens".


### Testing Plan

**Unit Tests:**

- [x] I have added or updated unit tests for my change.
- [x] All unit tests pass locally.

```
Running tool: /usr/bin/go test -test.fullpath=true -timeout 30s -run ^TestWrapYield$ google.golang.org/adk/internal/telemetry

=== RUN   TestWrapYield
=== PAUSE TestWrapYield
=== CONT  TestWrapYield
--- PASS: TestWrapYield (0.00s)
PASS
ok      google.golang.org/adk/internal/telemetry        0.018s
```

**Manual End-to-End (E2E) Tests:**

_Please provide instructions on how to manually test your changes, including any
necessary setup or configuration. Please provide logs or screenshots to help
reviewers better understand the fix._

### Checklist

- [x] I have read the [CONTRIBUTING.md](./CONTRIBUTING.md) document.
- [x] I have performed a self-review of my own code.
- [x] I have added tests that prove my fix is effective or that my feature works.
- [x] New and existing unit tests pass locally with my changes.
- [x] I have manually tested my changes end-to-end.

### Additional context

The new attribute visible in the trace explorer:
<img width="3216" height="1838" alt="image" src="https://github.com/user-attachments/assets/f4d696fd-dd21-4021-b53f-d9cf742c1d0c" />

