### PR TITLE
feat: add MultiRoute generic type to support matching multiple route values

### DIFF
--- a/workflow/workflow.go
+++ b/workflow/workflow.go
@@ -64,6 +64,18 @@ func (r BoolRoute) Matches(event *session.Event) bool {
 	return matchRoute(fmt.Sprint(r), event)
 }
 
+// MultiRoute matches any value within a specified list of allowed routes.
+type MultiRoute[T comparable] []T
+
+func (r MultiRoute[T]) Matches(event *session.Event) bool {
+	for _, route := range r {
+		if matchRoute(fmt.Sprint(route), event) {
+			return true
+		}
+	}
+	return false
+}
+
 // baseNode provides common fields for all nodes.
 type baseNode struct {
 	name        string
@@ -182,6 +194,15 @@ type nodeInput struct {
 	input any
 }
 
+// findNextNodes determines the set of nodes to execute next based on the outgoing edges of the currentNode.
+// It evaluates routes attached to edges against the provided session.Event.
+// 
+// Behavior:
+// - Edges with no route condition always match.
+// - Edges with a route condition match only if the route matches the event.
+// - Duplicate target nodes are excluded to avoid queuing the same node multiple times.
+// - If there are outgoing edges but none of them match (neither by route nor by being unrouted),
+//   it falls back to the default route (TODO: hanorik - add default route support).
 func (w *Workflow) findNextNodes(currentNode Node, input any, event *session.Event) ([]nodeInput, error) {
 	if len(w.edges[currentNode]) == 0 {
 		return nil, nil

--- a/workflow/workflow_test.go
+++ b/workflow/workflow_test.go
@@ -64,7 +64,7 @@ func TestFunctionNode(t *testing.T) {
 			t.Fatalf("unexpected error: %v", err)
 		}
 		count++
-		
+
 		output, ok := ev.Actions.StateDelta["output"]
 		if !ok {
 			t.Errorf("expected output in state delta")
@@ -168,6 +168,36 @@ func TestBoolRoute(t *testing.T) {
 	}
 	if BoolRoute(false).Matches(event) {
 		t.Errorf("BoolRoute should not match")
+	}
+}
+
+func TestMultiRouteString(t *testing.T) {
+	event := &session.Event{
+		Routes: []string{"hello", "42", "true"},
+	}
+
+	strMulti := MultiRoute[string]{"world", "hello"}
+	if !strMulti.Matches(event) {
+		t.Errorf("MultiRoute[string] should match")
+	}
+	strMultiNoMatch := MultiRoute[string]{"world", "golang"}
+	if strMultiNoMatch.Matches(event) {
+		t.Errorf("MultiRoute[string] should not match")
+	}
+}
+
+func TestMultiRouteInt(t *testing.T) {
+	event := &session.Event{
+		Routes: []string{"hello", "42", "true"},
+	}
+
+	intMulti := MultiRoute[int]{10, 42}
+	if !intMulti.Matches(event) {
+		t.Errorf("MultiRoute[int] should match")
+	}
+	intMultiNoMatch := MultiRoute[int]{10, 20}
+	if intMultiNoMatch.Matches(event) {
+		t.Errorf("MultiRoute[int] should not match")
 	}
 }
 
@@ -284,6 +314,47 @@ func TestWorkflowRouting(t *testing.T) {
 				}
 			},
 			expectErrorMsg: "no outgoing edge matches the event with routes",
+		},
+		{
+			name:        "correct MultiRoute",
+			startRoutes: []string{"branchA"},
+			edges: func(x *CustomRouteNode, a *FunctionNode, b *FunctionNode, c *CustomRouteNode, d *FunctionNode) []Edge {
+				return []Edge{
+					{From: Start, To: x},
+					{From: x, To: a, Route: MultiRoute[string]{"branchX", "branchA"}},
+					{From: x, To: b},
+					{From: x, To: c},
+					{From: c, To: d},
+				}
+			},
+			expectedExec: []string{"A", "B", "C", "D"},
+		},
+		{
+			name:        "no MultiRoute matches event routes",
+			startRoutes: []string{"invalid"},
+			edges: func(x *CustomRouteNode, a *FunctionNode, b *FunctionNode, c *CustomRouteNode, d *FunctionNode) []Edge {
+				return []Edge{
+					{From: Start, To: x},
+					{From: x, To: a, Route: MultiRoute[string]{"branchX", "branchY"}},
+					{From: x, To: b, Route: MultiRoute[string]{"branchZ"}},
+				}
+			},
+			expectErrorMsg: "no outgoing edge matches the event with routes",
+		},
+		{
+			name:        "duplicate edges to same node",
+			startRoutes: []string{"branchA"},
+			edges: func(x *CustomRouteNode, a *FunctionNode, b *FunctionNode, c *CustomRouteNode, d *FunctionNode) []Edge {
+				return []Edge{
+					{From: Start, To: x},
+					{From: x, To: a},
+					{From: x, To: a, Route: StringRoute("branchA")},
+					{From: x, To: b},
+					{From: x, To: c},
+					{From: c, To: d},
+				}
+			},
+			expectedExec: []string{"A", "B", "C", "D"},
 		},
 	}
 


### PR DESCRIPTION
This PR introduces a new `MultiRoute` generic type in the workflow package to support matching multiple route values. This allows an edge in the workflow to be followed if the event matches any of the routes specified in the MultiRoute list.

Key Changes:

- Added `MultiRoute` generic type and implemented the `Matches` method to check if any value in the list matches the event's routes.
- Added unit tests for `MultiRoute` with both string and int types, test cases in `TestWorkflowRouting` to verify routing behavior with `MultiRoute` and a test case to verify behavior when duplicate edges exist between the same nodes.