### PR TITLE
fix(llminternal): re-evaluate toolsets on every step in toolProcessor

### DIFF
--- a/internal/llminternal/base_flow_test.go
+++ b/internal/llminternal/base_flow_test.go
@@ -683,3 +683,65 @@ func TestPreprocess_Toolset(t *testing.T) {
 		})
 	}
 }
+
+// dynamicToolset returns different tools on each call to simulate a toolset
+// whose output depends on session state written by an earlier tool in the run.
+type dynamicToolset struct {
+	callCount int
+	toolsByCall map[int][]tool.Tool
+}
+
+func (d *dynamicToolset) Name() string { return "dynamic" }
+func (d *dynamicToolset) Tools(_ agent.ReadonlyContext) ([]tool.Tool, error) {
+	tools := d.toolsByCall[d.callCount]
+	d.callCount++
+	return tools, nil
+}
+
+// TestToolProcessorReEvaluatesToolsetsEachStep verifies that toolProcessor
+// calls Toolset.Tools() on every step, not just the first. This ensures that
+// tools activated by session-state changes in an earlier step are visible to
+// subsequent model calls within the same Runner.Run().
+func TestToolProcessorReEvaluatesToolsetsEachStep(t *testing.T) {
+	extraTool := &mockFunctionTool{name: "extra_tool"}
+
+	// Call 0: no tools yet. Call 1+: return extraTool.
+	ts := &dynamicToolset{
+		toolsByCall: map[int][]tool.Tool{
+			0: nil,
+			1: {extraTool},
+		},
+	}
+
+	agentState := &State{Toolsets: []tool.Toolset{ts}}
+	mockAgent := &mockLLMAgent{s: agentState}
+	ctx := icontext.NewInvocationContext(t.Context(), icontext.InvocationContextParams{Agent: mockAgent})
+
+	f := &Flow{}
+
+	// First call: toolset returns nil — f.Tools should be empty.
+	req1 := &model.LLMRequest{}
+	for _, err := range toolProcessor(ctx, req1, f) {
+		if err != nil {
+			t.Fatalf("toolProcessor call 1 error: %v", err)
+		}
+	}
+	if len(f.Tools) != 0 {
+		t.Errorf("after call 1: got %d tools, want 0", len(f.Tools))
+	}
+
+	// Second call: toolset now returns extraTool — f.Tools must be updated.
+	req2 := &model.LLMRequest{}
+	for _, err := range toolProcessor(ctx, req2, f) {
+		if err != nil {
+			t.Fatalf("toolProcessor call 2 error: %v", err)
+		}
+	}
+	if len(f.Tools) != 1 || f.Tools[0].Name() != extraTool.Name() {
+		t.Errorf("after call 2: got tools %v, want [%s]", f.Tools, extraTool.Name())
+	}
+
+	if ts.callCount != 2 {
+		t.Errorf("toolset.Tools() called %d times, want 2", ts.callCount)
+	}
+}

--- a/internal/llminternal/base_flow_test.go
+++ b/internal/llminternal/base_flow_test.go
@@ -771,3 +771,65 @@ func TestIsThoughtOnlyTurn(t *testing.T) {
 		})
 	}
 }
+
+// dynamicToolset returns different tools on each call to simulate a toolset
+// whose output depends on session state written by an earlier tool in the run.
+type dynamicToolset struct {
+	callCount   int
+	toolsByCall map[int][]tool.Tool
+}
+
+func (d *dynamicToolset) Name() string { return "dynamic" }
+func (d *dynamicToolset) Tools(_ agent.ReadonlyContext) ([]tool.Tool, error) {
+	tools := d.toolsByCall[d.callCount]
+	d.callCount++
+	return tools, nil
+}
+
+// TestToolProcessorReEvaluatesToolsetsEachStep verifies that toolProcessor
+// calls Toolset.Tools() on every step, not just the first. This ensures that
+// tools activated by session-state changes in an earlier step are visible to
+// subsequent model calls within the same Runner.Run().
+func TestToolProcessorReEvaluatesToolsetsEachStep(t *testing.T) {
+	extraTool := &mockFunctionTool{name: "extra_tool"}
+
+	// Call 0: no tools yet. Call 1+: return extraTool.
+	ts := &dynamicToolset{
+		toolsByCall: map[int][]tool.Tool{
+			0: nil,
+			1: {extraTool},
+		},
+	}
+
+	agentState := &State{Toolsets: []tool.Toolset{ts}}
+	mockAgent := &mockLLMAgent{s: agentState}
+	ctx := icontext.NewInvocationContext(t.Context(), icontext.InvocationContextParams{Agent: mockAgent})
+
+	f := &Flow{}
+
+	// First call: toolset returns nil — f.Tools should be empty.
+	req1 := &model.LLMRequest{}
+	for _, err := range toolProcessor(ctx, req1, f) {
+		if err != nil {
+			t.Fatalf("toolProcessor call 1 error: %v", err)
+		}
+	}
+	if len(f.Tools) != 0 {
+		t.Errorf("after call 1: got %d tools, want 0", len(f.Tools))
+	}
+
+	// Second call: toolset now returns extraTool — f.Tools must be updated.
+	req2 := &model.LLMRequest{}
+	for _, err := range toolProcessor(ctx, req2, f) {
+		if err != nil {
+			t.Fatalf("toolProcessor call 2 error: %v", err)
+		}
+	}
+	if len(f.Tools) != 1 || f.Tools[0].Name() != extraTool.Name() {
+		t.Errorf("after call 2: got tools %v, want [%s]", f.Tools, extraTool.Name())
+	}
+
+	if ts.callCount != 2 {
+		t.Errorf("toolset.Tools() called %d times, want 2", ts.callCount)
+	}
+}

--- a/internal/llminternal/tools_processor.go
+++ b/internal/llminternal/tools_processor.go
@@ -24,13 +24,12 @@ import (
 	"google.golang.org/adk/session"
 )
 
-// ContentRequestProcessor populates the LLMRequest's Contents based on
-// the InvocationContext that includes the previous events.
+// toolProcessor populates f.Tools on every step by re-evaluating each
+// Toolset. Toolsets may return different tools based on session state that
+// was modified by an earlier step in the same Run(), so the tool list must
+// be rebuilt before each model call rather than being cached across steps.
 func toolProcessor(ctx agent.InvocationContext, req *model.LLMRequest, f *Flow) iter.Seq2[*session.Event, error] {
 	return func(yield func(*session.Event, error) bool) {
-		if f.Tools != nil {
-			return
-		}
 		llmAgent, ok := ctx.Agent().(Agent)
 		if !ok {
 			yield(nil, fmt.Errorf("agent %v is not an LLMAgent", ctx.Agent().Name()))

--- a/internal/llminternal/tools_processor.go
+++ b/internal/llminternal/tools_processor.go
@@ -24,13 +24,12 @@ import (
 	"google.golang.org/adk/v2/session"
 )
 
-// ContentRequestProcessor populates the LLMRequest's Contents based on
-// the InvocationContext that includes the previous events.
+// toolProcessor populates f.Tools on every step by re-evaluating each
+// Toolset. Toolsets may return different tools based on session state that
+// was modified by an earlier step in the same Run(), so the tool list must
+// be rebuilt before each model call rather than being cached across steps.
 func toolProcessor(ctx agent.InvocationContext, req *model.LLMRequest, f *Flow) iter.Seq2[*session.Event, error] {
 	return func(yield func(*session.Event, error) bool) {
-		if f.Tools != nil {
-			return
-		}
 		llmAgent, ok := ctx.Agent().(Agent)
 		if !ok {
 			yield(nil, fmt.Errorf("agent %v is not an LLMAgent", ctx.Agent().Name()))


### PR DESCRIPTION
### Link to Issue or Description of Change

- Closes: #757

### Description

**Problem:**
`toolProcessor` in `internal/llminternal/tools_processor.go` cached `f.Tools` after the first call and short-circuited with `if f.Tools != nil { return }` on every subsequent step. Since a `Flow` is created once per `Runner.Run()` and reused across all `runOneStep()` iterations, `Toolset.Tools(ctx)` was only ever called on the first step of a run.

Any toolset whose `Tools(ctx)` output depends on session state modified by an earlier tool call could not surface new tools within the same `Runner.Run()`. The `ctx` parameter on `Tools(ctx)` implies dynamic per-step evaluation, but the caching made it effectively static for the duration of the run.

**Root cause:**
```go
// tools_processor.go — before
func toolProcessor(...) iter.Seq2[*session.Event, error] {
    return func(yield func(*session.Event, error) bool) {
        if f.Tools != nil {   // ← cached after first call; never re-evaluated
            return
        }
        ...
        f.Tools = tools
    }
}
```

**Solution:**
Remove the `if f.Tools != nil { return }` guard so `Toolset.Tools()` is called before every model step. Static `Tools` from the agent config and dynamic toolset tools are rebuilt into `f.Tools` on each call, which is correct because `runOneStep` creates a fresh `*model.LLMRequest` each iteration anyway.

```go
// tools_processor.go — after
func toolProcessor(...) iter.Seq2[*session.Event, error] {
    return func(yield func(*session.Event, error) bool) {
        // No cache guard — toolsets re-evaluated every step.
        ...
        f.Tools = tools
    }
}
```

### Testing Plan

**Unit Tests:**

- [x] Added `TestToolProcessorReEvaluatesToolsetsEachStep` in `internal/llminternal/base_flow_test.go` with a `dynamicToolset` that returns no tools on the first call and one tool on the second call — verifying that `toolProcessor` picks up the change on the next step.
- [x] All existing unit tests pass locally.

```
$ go test ./internal/llminternal/... -run TestToolProcessorReEvaluatesToolsetsEachStep -v
=== RUN   TestToolProcessorReEvaluatesToolsetsEachStep
--- PASS: TestToolProcessorReEvaluatesToolsetsEachStep (0.00s)
PASS
ok  	google.golang.org/adk/internal/llminternal	0.392s

$ go test ./internal/llminternal/...
ok  	google.golang.org/adk/internal/llminternal	0.909s
ok  	google.golang.org/adk/internal/llminternal/googlellm	0.196s
```

**Manual End-to-End (E2E) Tests:**

The bug is deterministic: any agent with a `Toolset` that uses session state to control which tools are returned will reproduce it. The `activate_vehicle_tools` example from issue #757 exercises the exact path — `activate_vehicle_tools` sets state, and `conditionalToolset.Tools(ctx)` checks that state to surface a vehicle tool. After this fix, the activated tools appear on the next `runOneStep()` within the same `Runner.Run()`.

### Checklist

- [x] I have read the [CONTRIBUTING.md](./CONTRIBUTING.md) document.
- [x] I have performed a self-review of my own code.
- [x] I have commented my code, particularly in hard-to-understand areas.
- [x] I have added tests that prove my fix is effective or that my feature works.
- [x] New and existing unit tests pass locally with my changes.
- [x] I have manually tested my changes end-to-end.
- [x] Any dependent changes have been merged and published in downstream modules.