### PR TITLE
feat: implement explicit Default route support in workflow graph traversal

### DIFF
--- a/workflow/workflow.go
+++ b/workflow/workflow.go
@@ -64,6 +64,15 @@ func (r BoolRoute) Matches(event *session.Event) bool {
 	return matchRoute(fmt.Sprint(r), event)
 }
 
+// DefaultRoute is a special route that matches when no other concrete routes match.
+var Default = &defaultRoute{}
+
+type defaultRoute struct{}
+
+func (r *defaultRoute) Matches(event *session.Event) bool {
+	return false
+}
+
 // baseNode provides common fields for all nodes.
 type baseNode struct {
 	name        string
@@ -161,8 +170,6 @@ func (s *startNode) Run(ctx agent.InvocationContext, input any) iter.Seq2[*sessi
 	return func(yield func(*session.Event, error) bool) {}
 }
 
-const DEFAULT_ROUTE = "__DEFAULT__"
-
 // Workflow manages the workflow graph execution.
 type Workflow struct {
 	edges map[Node][]Edge
@@ -182,13 +189,14 @@ type nodeInput struct {
 	input any
 }
 
-func (w *Workflow) findNextNodes(currentNode Node, input any, event *session.Event) ([]nodeInput, error) {
+func (w *Workflow) findNextNodes(currentNode Node, input any, event *session.Event) []nodeInput {
 	if len(w.edges[currentNode]) == 0 {
-		return nil, nil
+		return nil
 	}
 	matched := false
 	queue := []nodeInput{}
 	added := make(map[Node]struct{})
+	var defaultRouteNode Node
 	for _, edge := range w.edges[currentNode] {
 		if _, ok := added[edge.To]; ok {
 			continue
@@ -196,20 +204,23 @@ func (w *Workflow) findNextNodes(currentNode Node, input any, event *session.Eve
 		if edge.Route == nil {
 			queue = append(queue, nodeInput{node: edge.To, input: input})
 			added[edge.To] = struct{}{}
-			matched = true
 			continue
 		}
-
+		if edge.Route == Default {
+			defaultRouteNode = edge.To
+			continue
+		}
 		if edge.Route.Matches(event) {
 			queue = append(queue, nodeInput{node: edge.To, input: input})
 			added[edge.To] = struct{}{}
 			matched = true
 		}
 	}
-	if !matched {
-		return nil, fmt.Errorf("no outgoing edge matches the event with routes %v emitted by node %s", event.Routes, currentNode.Name())
+	if !matched && defaultRouteNode != nil {
+		queue = append(queue, nodeInput{node: defaultRouteNode, input: input})
 	}
-	return queue, nil
+
+	return queue
 }
 
 func (w *Workflow) Run(ctx agent.InvocationContext) iter.Seq2[*session.Event, error] {
@@ -267,11 +278,7 @@ func (w *Workflow) Run(ctx agent.InvocationContext) iter.Seq2[*session.Event, er
 			if currentNode != Start {
 				input = outputData
 			}
-			nextNodes, err := w.findNextNodes(currentNode, input, event)
-			if err != nil {
-				yield(nil, err)
-				return
-			}
+			nextNodes := w.findNextNodes(currentNode, input, event)
 			queue = append(queue, nextNodes...)
 		}
 	}

--- a/workflow/workflow_test.go
+++ b/workflow/workflow_test.go
@@ -283,7 +283,42 @@ func TestWorkflowRouting(t *testing.T) {
 					{From: c, To: d},
 				}
 			},
-			expectErrorMsg: "no outgoing edge matches the event with routes",
+		},
+		{
+			name:        "fallback to default route when no concrete route matches",
+			startRoutes: []string{"unmatched"},
+			edges: func(x *CustomRouteNode, a *FunctionNode, b *FunctionNode, c *CustomRouteNode, d *FunctionNode) []Edge {
+				return []Edge{
+					{From: Start, To: x},
+					{From: x, To: a, Route: StringRoute("branchA")},
+					{From: x, To: b, Route: (Default)},
+				}
+			},
+			expectedExec: []string{"B"},
+		},
+		{
+			name:        "default route is suppressed by concrete route match",
+			startRoutes: []string{"branchA"},
+			edges: func(x *CustomRouteNode, a *FunctionNode, b *FunctionNode, c *CustomRouteNode, d *FunctionNode) []Edge {
+				return []Edge{
+					{From: Start, To: x},
+					{From: x, To: a, Route: StringRoute("branchA")},
+					{From: x, To: b, Route: Default},
+				}
+			},
+			expectedExec: []string{"A"},
+		},
+		{
+			name:        "unconditional edge does not suppress default route",
+			startRoutes: []string{"unmatched"},
+			edges: func(x *CustomRouteNode, a *FunctionNode, b *FunctionNode, c *CustomRouteNode, d *FunctionNode) []Edge {
+				return []Edge{
+					{From: Start, To: x},
+					{From: x, To: a},
+					{From: x, To: b, Route: (Default)},
+				}
+			},
+			expectedExec: []string{"A", "B"},
 		},
 	}
 


### PR DESCRIPTION
This PR introduces support for an explicit `Default` route in the `workflow` package, serving as a fallback when no other concrete routes match.

**Changes:**
- Added `defaultRoute` type and a global `Default` instance.
- Refactored `findNextNodes` to track and fallback to a `Default` route if no conditional edges match.
- Removed the `DEFAULT_ROUTE` constant.
- Removed error propagation from `findNextNodes` when no routes match; the workflow now proceeds with unconditional edges or the default route, or simply stops.