### PR TITLE
refactor: remove duplicate agent.invocationContext implementation

### DIFF
--- a/agent/agent.go
+++ b/agent/agent.go
@@ -170,19 +170,7 @@ func (a *agent) Run(ctx InvocationContext) iter.Seq2[*session.Event, error] {
 		})
 		defer endSpan()
 		// TODO: verify&update the setup here. Should we branch etc.
-		ctx := &invocationContext{
-			Context:   ctx.WithContext(spanCtx),
-			agent:     a,
-			artifacts: ctx.Artifacts(),
-			memory:    ctx.Memory(),
-			session:   ctx.Session(),
-
-			invocationID:  ctx.InvocationID(),
-			branch:        ctx.Branch(),
-			userContent:   ctx.UserContent(),
-			runConfig:     ctx.RunConfig(),
-			endInvocation: ctx.Ended(),
-		}
+		ctx := ctx.WithContext(spanCtx).WithAgent(a)
 		event, err := runBeforeAgentCallbacks(ctx)
 		if event != nil || err != nil {
 			if !yield(event, err) {
@@ -443,80 +431,6 @@ func (c *callbackContextState) All() iter.Seq2[string, any] {
 	return c.ctx.invocationContext.Session().State().All()
 }
 
-type invocationContext struct {
-	context.Context
-
-	agent     Agent
-	artifacts Artifacts
-	memory    Memory
-	session   session.Session
-
-	invocationID  string
-	branch        string
-	userContent   *genai.Content
-	runConfig     *RunConfig
-	endInvocation bool
-}
-
-func (c *invocationContext) Agent() Agent {
-	return c.agent
-}
-
-func (c *invocationContext) Artifacts() Artifacts {
-	return c.artifacts
-}
-
-func (c *invocationContext) Memory() Memory {
-	return c.memory
-}
-
-func (c *invocationContext) Session() session.Session {
-	return c.session
-}
-
-func (c *invocationContext) InvocationID() string {
-	return c.invocationID
-}
-
-func (c *invocationContext) Branch() string {
-	return c.branch
-}
-
-func (c *invocationContext) UserContent() *genai.Content {
-	return c.userContent
-}
-
-func (c *invocationContext) RunConfig() *RunConfig {
-	return c.runConfig
-}
-
-func (c *invocationContext) EndInvocation() {
-	c.endInvocation = true
-}
-
-func (c *invocationContext) Ended() bool {
-	return c.endInvocation
-}
-
-func (c *invocationContext) WithContext(ctx context.Context) InvocationContext {
-	newCtx := *c
-	newCtx.Context = ctx
-	return &newCtx
-}
-
-// WithAgent returns a copy of c with the Agent overridden. See
-// InvocationContext.WithAgent for the contract.
-//
-// TODO: this duplicate impl will be removed once (*agent).Run is
-// rewritten to use ctx.WithContext(...).WithAgent(a) on its received
-// InvocationContext instead of constructing a new invocationContext
-// literal. See docs-internal/proposals/context_unification.md.
-func (c *invocationContext) WithAgent(a Agent) InvocationContext {
-	newCtx := *c
-	newCtx.agent = a
-	return &newCtx
-}
-
 func pluginManagerFromContext(ctx context.Context) pluginManager {
 	a := ctx.Value(plugincontext.PluginManagerCtxKey)
 	m, ok := a.(pluginManager)
@@ -530,5 +444,3 @@ type pluginManager interface {
 	RunBeforeAgentCallback(cctx CallbackContext) (*genai.Content, error)
 	RunAfterAgentCallback(cctx CallbackContext) (*genai.Content, error)
 }
-
-var _ InvocationContext = (*invocationContext)(nil)

--- a/agent/agent.go
+++ b/agent/agent.go
@@ -504,6 +504,19 @@ func (c *invocationContext) WithContext(ctx context.Context) InvocationContext {
 	return &newCtx
 }
 
+// WithAgent returns a copy of c with the Agent overridden. See
+// InvocationContext.WithAgent for the contract.
+//
+// TODO: this duplicate impl will be removed once (*agent).Run is
+// rewritten to use ctx.WithContext(...).WithAgent(a) on its received
+// InvocationContext instead of constructing a new invocationContext
+// literal. See docs-internal/proposals/context_unification.md.
+func (c *invocationContext) WithAgent(a Agent) InvocationContext {
+	newCtx := *c
+	newCtx.agent = a
+	return &newCtx
+}
+
 func pluginManagerFromContext(ctx context.Context) pluginManager {
 	a := ctx.Value(plugincontext.PluginManagerCtxKey)
 	m, ok := a.(pluginManager)

--- a/agent/agent_test.go
+++ b/agent/agent_test.go
@@ -121,11 +121,7 @@ func TestAgentCallbacks(t *testing.T) {
 				t.Fatalf("failed to create agent: %v", err)
 			}
 
-			ctx := &invocationContext{
-				Context: t.Context(),
-				agent:   testAgent,
-				session: &mockSession{sessionID: "test-session"},
-			}
+			ctx := newMockInvocationContext(t)
 			var gotEvents []*session.Event
 			for event, err := range testAgent.Run(ctx) {
 				if err != nil {
@@ -168,12 +164,8 @@ func TestEndInvocation_EndsBeforeMainCall(t *testing.T) {
 		t.Fatalf("failed to create agent: %v", err)
 	}
 
-	ctx := &invocationContext{
-		Context:       t.Context(),
-		agent:         testAgent,
-		endInvocation: true,
-		session:       &mockSession{sessionID: "test-session"},
-	}
+	ctx := newMockInvocationContext(t)
+	ctx.EndInvocation()
 	for _, err := range testAgent.Run(ctx) {
 		if err != nil {
 			t.Fatalf("unexpected error from the agent: %v", err)
@@ -203,11 +195,7 @@ func TestEndInvocation_EndsAfterMainCall(t *testing.T) {
 		t.Fatalf("failed to create agent: %v", err)
 	}
 
-	ctx := &invocationContext{
-		Context: t.Context(),
-		agent:   testAgent,
-		session: &mockSession{sessionID: "test-session"},
-	}
+	ctx := newMockInvocationContext(t)
 	var gotEvents []*session.Event
 	for event, err := range testAgent.Run(ctx) {
 		if err != nil {
@@ -254,28 +242,6 @@ func (a *customAgent) Run(ctx InvocationContext) iter.Seq2[*session.Event, error
 				Content: genai.NewContentFromText("hello", genai.RoleModel),
 			},
 		}, nil)
-	}
-}
-
-type testKey struct{}
-
-func TestWithContext(t *testing.T) {
-	baseCtx := t.Context()
-	inv := &invocationContext{
-		Context:      baseCtx,
-		invocationID: "test",
-		branch:       "branch",
-	}
-
-	key := testKey{}
-	val := "val"
-	got := inv.WithContext(context.WithValue(baseCtx, key, val))
-
-	if got.Value(key) != val {
-		t.Errorf("WithContext() did not update context")
-	}
-	if diff := cmp.Diff(inv, got, cmp.AllowUnexported(invocationContext{}), cmpopts.IgnoreFields(invocationContext{}, "Context")); diff != "" {
-		t.Errorf("WithContext() params mismatch (-want +got):\n%s", diff)
 	}
 }
 
@@ -351,3 +317,48 @@ func TestFindAgent(t *testing.T) {
 		})
 	}
 }
+
+// mockInvocationContext is a minimal InvocationContext for driving
+// (*agent).Run in tests. Most methods return zero values; only the
+// fields the agent actually inspects (agent, session, lifecycle)
+// carry real state. (*agent).Run injects itself via WithAgent before
+// any callback fires, so the agent field is populated then.
+type mockInvocationContext struct {
+	context.Context
+	agent         Agent
+	session       session.Session
+	endInvocation bool
+}
+
+func newMockInvocationContext(t *testing.T) *mockInvocationContext {
+	t.Helper()
+	return &mockInvocationContext{
+		Context: t.Context(),
+		session: &mockSession{sessionID: "test-session"},
+	}
+}
+
+func (m *mockInvocationContext) Agent() Agent                { return m.agent }
+func (m *mockInvocationContext) Artifacts() Artifacts        { return nil }
+func (m *mockInvocationContext) Memory() Memory              { return nil }
+func (m *mockInvocationContext) Session() session.Session    { return m.session }
+func (m *mockInvocationContext) InvocationID() string        { return "test-invocation" }
+func (m *mockInvocationContext) Branch() string              { return "" }
+func (m *mockInvocationContext) UserContent() *genai.Content { return nil }
+func (m *mockInvocationContext) RunConfig() *RunConfig       { return nil }
+func (m *mockInvocationContext) EndInvocation()              { m.endInvocation = true }
+func (m *mockInvocationContext) Ended() bool                 { return m.endInvocation }
+
+func (m *mockInvocationContext) WithContext(ctx context.Context) InvocationContext {
+	c := *m
+	c.Context = ctx
+	return &c
+}
+
+func (m *mockInvocationContext) WithAgent(a Agent) InvocationContext {
+	c := *m
+	c.agent = a
+	return &c
+}
+
+var _ InvocationContext = (*mockInvocationContext)(nil)

--- a/agent/context.go
+++ b/agent/context.go
@@ -100,6 +100,13 @@ type InvocationContext interface {
 	// NOTE: This is a temporary solution and will be removed later. The proper solution
 	// we plan is to stop embedding go context in adk context types and split it.
 	WithContext(ctx context.Context) InvocationContext
+
+	// WithAgent returns a new instance of the context with the Agent overridden.
+	// Used by Agent.Run wrappers (e.g. telemetry-wrapped runs, sub-agent
+	// dispatch) that need to swap the active agent without otherwise changing
+	// the invocation. Like WithContext, this returns a copy and does not
+	// mutate the receiver.
+	WithAgent(a Agent) InvocationContext
 }
 
 // ReadonlyContext provides read-only access to invocation context data.

--- a/internal/configurable/conformance/replayplugin/replay_plugin_test.go
+++ b/internal/configurable/conformance/replayplugin/replay_plugin_test.go
@@ -400,6 +400,7 @@ func (m *MockInvocationContext) RunConfig() *agent.RunConfig                    
 func (m *MockInvocationContext) EndInvocation()                                          {}
 func (m *MockInvocationContext) Ended() bool                                             { return false }
 func (m *MockInvocationContext) WithContext(ctx context.Context) agent.InvocationContext { return m }
+func (m *MockInvocationContext) WithAgent(a agent.Agent) agent.InvocationContext         { return m }
 func (m *MockInvocationContext) Value(key any) any                                       { return nil }
 func (m *MockInvocationContext) Deadline() (deadline time.Time, ok bool)                 { return time.Time{}, false }
 func (m *MockInvocationContext) Done() <-chan struct{}                                   { return nil }

--- a/internal/context/context_test.go
+++ b/internal/context/context_test.go
@@ -64,3 +64,38 @@ func TestWithContext(t *testing.T) {
 		t.Errorf("WithContext() mismatch (-want +got):\n%s", diff)
 	}
 }
+
+func TestWithAgent(t *testing.T) {
+	parent, err := agent.New(agent.Config{Name: "parent"})
+	if err != nil {
+		t.Fatalf("agent.New(parent): %v", err)
+	}
+	child, err := agent.New(agent.Config{Name: "child"})
+	if err != nil {
+		t.Fatalf("agent.New(child): %v", err)
+	}
+
+	inv := NewInvocationContext(t.Context(), InvocationContextParams{
+		Agent:  parent,
+		Branch: "test-branch",
+	})
+
+	got := inv.WithAgent(child)
+
+	if got.Agent() != child {
+		t.Errorf("WithAgent() Agent = %v, want %v", got.Agent(), child)
+	}
+	if got.Branch() != "test-branch" {
+		t.Errorf("WithAgent() lost Branch param: got %q, want %q", got.Branch(), "test-branch")
+	}
+	// Receiver must not be mutated.
+	if inv.Agent() != parent {
+		t.Errorf("WithAgent() mutated receiver: Agent = %v, want %v (parent)", inv.Agent(), parent)
+	}
+	// EndInvocation on the derived context must not bleed into the
+	// receiver — sub-agent dispatch relies on this isolation.
+	got.EndInvocation()
+	if inv.Ended() {
+		t.Error("WithAgent() did not isolate lifecycle: parent.Ended() = true after child.EndInvocation()")
+	}
+}

--- a/internal/context/invocation_context.go
+++ b/internal/context/invocation_context.go
@@ -102,7 +102,7 @@ func (c *InvocationContext) WithContext(ctx context.Context) agent.InvocationCon
 
 // WithAgent returns a copy of c with the Agent param overridden. The
 // embedded context.Context and all other params are shared with the
-// receiver. See agent.InvocationContext.WithAgent for the contract.
+// receiver.
 func (c *InvocationContext) WithAgent(a agent.Agent) agent.InvocationContext {
 	newCtx := *c
 	newCtx.params.Agent = a

--- a/internal/context/invocation_context.go
+++ b/internal/context/invocation_context.go
@@ -100,4 +100,13 @@ func (c *InvocationContext) WithContext(ctx context.Context) agent.InvocationCon
 	return &newCtx
 }
 
+// WithAgent returns a copy of c with the Agent param overridden. The
+// embedded context.Context and all other params are shared with the
+// receiver. See agent.InvocationContext.WithAgent for the contract.
+func (c *InvocationContext) WithAgent(a agent.Agent) agent.InvocationContext {
+	newCtx := *c
+	newCtx.params.Agent = a
+	return &newCtx
+}
+
 var _ agent.InvocationContext = (*InvocationContext)(nil)


### PR DESCRIPTION
refactor: remove duplicate agent.invocationContext implementation

### Link to Issue or Description of Change

**1. Link to an existing issue (if applicable):**

N/A

**2. Or, if no issue exists, describe the change:**

**Problem:**
Until now, the `agent` package has had its own private `invocationContext`
implementation, parallel to the canonical one in `internal/context/`. The
duplication existed because `(*agent).Run` had to inject the running agent
into the context, but `WithContext()` could only swap the embedded
`context.Context`. The TODO at `agent/agent.go:368` flagged this for
unification.

**Solution:**
Add `WithAgent(Agent) InvocationContext` to the public interface (commit 1),
then route `(*agent).Run` through the canonical implementation and remove
the duplicate (commit 2). `(*agent).Run` shrinks from a 23-line struct
literal to a one-line `ctx.WithContext(spanCtx).WithAgent(a)` call.

This is the first cleanup step toward the unified `Context` proposed in the
RFC.

### Testing Plan

**Unit Tests:**

- [X] I have added or updated unit tests for my change.
- [X] All unit tests pass locally.

`TestWithAgent` in `internal/context/context_test.go` covers the contract:
override Agent, preserve other params, no receiver mutation, and lifecycle
isolation (`EndInvocation` on a derived context does not bleed into the
receiver — required for sub-agent dispatch).

```
go build ./...                              # clean
go vet ./...                                # clean
go test ./...                               # all packages pass
go test -race ./agent/... ./internal/...    # pass
```

The duplicate `TestWithContext` in `agent/agent_test.go` is removed — the
same test exists in `internal/context/context_test.go` for the canonical
implementation.

**Manual End-to-End (E2E) Tests:**

- [X] N/A — pure refactor, no behavioural change at runtime.

### Checklist

- [X] I have read the [CONTRIBUTING.md](./CONTRIBUTING.md) document.
- [X] I have performed a self-review of my own code.
- [X] I have commented my code, particularly in hard-to-understand areas.
- [X] I have added tests that prove my fix is effective or that my feature works.
- [X] New and existing unit tests pass locally with my changes.
- [X] I have manually tested my changes end-to-end.
- [X] Any dependent changes have been merged and published in downstream modules.


**Planned follow-ups:**

1. Eliminate the remaining `agent.callbackContext` duplicate.
2. Introduce a unified `agent.Context` interface aliased to
   `InvocationContext` / `CallbackContext` / `ReadonlyContext`, so user
   code converges on one name while existing references keep compiling.