### PR TITLE
feat: introduce scheduler-based engine with goroutine-per-node execution

### DIFF
--- a/agent/agent.go
+++ b/agent/agent.go
@@ -504,6 +504,11 @@ func (c *invocationContext) WithContext(ctx context.Context) InvocationContext {
 	return &newCtx
 }
 
+// TriggeredBy returns "" for non-workflow invocation contexts. The
+// workflow engine wraps this context in a private per-node context
+// that overrides the method when running inside a workflow.Node.
+func (c *invocationContext) TriggeredBy() string { return "" }
+
 func pluginManagerFromContext(ctx context.Context) pluginManager {
 	a := ctx.Value(plugincontext.PluginManagerCtxKey)
 	m, ok := a.(pluginManager)

--- a/agent/context.go
+++ b/agent/context.go
@@ -96,6 +96,14 @@ type InvocationContext interface {
 	// Ended returns whether the invocation has ended.
 	Ended() bool
 
+	// TriggeredBy returns the name of the upstream node whose output
+	// scheduled the current node activation, when this context is
+	// running inside a workflow.Node. Returns "" outside a workflow
+	// (e.g. in plain agent runs) and for the initial workflow START
+	// activation. The workflow engine populates this via an internal
+	// per-node context wrapper.
+	TriggeredBy() string
+
 	// WithContext returns a new instance of the context with overridden embedded context.
 	// NOTE: This is a temporary solution and will be removed later. The proper solution
 	// we plan is to stop embedding go context in adk context types and split it.

--- a/agent/workflowagent/workflow_test.go
+++ b/agent/workflowagent/workflow_test.go
@@ -94,6 +94,7 @@ func (m *MockInvocationContext) Branch() string              { return "" }
 func (m *MockInvocationContext) RunConfig() *agent.RunConfig { return nil }
 func (m *MockInvocationContext) Ended() bool                 { return false }
 func (m *MockInvocationContext) EndInvocation()              {}
+func (m *MockInvocationContext) TriggeredBy() string         { return "" }
 
 func TestWorkflowAgent(t *testing.T) {
 	upperFn := func(ctx agent.InvocationContext, input any) (string, error) {

--- a/internal/configurable/conformance/replayplugin/replay_plugin_test.go
+++ b/internal/configurable/conformance/replayplugin/replay_plugin_test.go
@@ -400,6 +400,7 @@ func (m *MockInvocationContext) RunConfig() *agent.RunConfig                    
 func (m *MockInvocationContext) EndInvocation()                                          {}
 func (m *MockInvocationContext) Ended() bool                                             { return false }
 func (m *MockInvocationContext) WithContext(ctx context.Context) agent.InvocationContext { return m }
+func (m *MockInvocationContext) TriggeredBy() string                                     { return "" }
 func (m *MockInvocationContext) Value(key any) any                                       { return nil }
 func (m *MockInvocationContext) Deadline() (deadline time.Time, ok bool)                 { return time.Time{}, false }
 func (m *MockInvocationContext) Done() <-chan struct{}                                   { return nil }

--- a/internal/context/invocation_context.go
+++ b/internal/context/invocation_context.go
@@ -100,4 +100,9 @@ func (c *InvocationContext) WithContext(ctx context.Context) agent.InvocationCon
 	return &newCtx
 }
 
+// TriggeredBy returns "" for non-workflow invocation contexts. The
+// workflow engine wraps this context in a private per-node context
+// that overrides the method when running inside a workflow.Node.
+func (c *InvocationContext) TriggeredBy() string { return "" }
+
 var _ agent.InvocationContext = (*InvocationContext)(nil)

--- a/internal/llminternal/functions_test.go
+++ b/internal/llminternal/functions_test.go
@@ -55,6 +55,8 @@ func (m *mockInvocationContext) Branch() string {
 	return m.branch
 }
 
+func (m *mockInvocationContext) TriggeredBy() string { return "" }
+
 func TestGenerateRequestConfirmationEvent(t *testing.T) {
 	confirmingFunctionCall := &genai.FunctionCall{
 		ID:   "call_1",

--- a/workflow/base_node.go
+++ b/workflow/base_node.go
@@ -1,0 +1,49 @@
+// Copyright 2026 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package workflow
+
+// BaseNode provides identity and a default Config implementation for
+// types that satisfy the Node interface. Custom node types embed
+// BaseNode by value and supply only Run.
+type BaseNode struct {
+	name   string
+	desc   string
+	config NodeConfig
+}
+
+// NewBaseNode returns a BaseNode with the given identity and
+// configuration. Embedders typically call it from their own
+// constructor:
+//
+//	type CustomNode struct {
+//	    BaseNode
+//	    // ...
+//	}
+//
+//	func NewCustomNode(name string, cfg NodeConfig) *CustomNode {
+//	    return &CustomNode{BaseNode: NewBaseNode(name, "", cfg)}
+//	}
+func NewBaseNode(name, description string, cfg NodeConfig) BaseNode {
+	return BaseNode{name: name, desc: description, config: cfg}
+}
+
+// Name returns the node's name.
+func (b BaseNode) Name() string { return b.name }
+
+// Description returns the node's human-readable description.
+func (b BaseNode) Description() string { return b.desc }
+
+// Config returns the node's configuration.
+func (b BaseNode) Config() NodeConfig { return b.config }

--- a/workflow/base_node_test.go
+++ b/workflow/base_node_test.go
@@ -1,0 +1,108 @@
+// Copyright 2026 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package workflow
+
+import (
+	"testing"
+	"time"
+
+	"github.com/google/go-cmp/cmp"
+)
+
+// Compile-time assertions: every built-in workflow node must satisfy
+// the Node interface.
+var (
+	_ Node = (*startNode)(nil)
+	_ Node = (*FunctionNode)(nil)
+)
+
+func TestNewBaseNode_RoundTrip(t *testing.T) {
+	tTrue := true
+	tFalse := false
+	tests := []struct {
+		name       string
+		nameArg    string
+		descArg    string
+		cfg        NodeConfig
+		wantConfig NodeConfig
+	}{
+		{
+			name:    "zero config",
+			nameArg: "n",
+			descArg: "desc",
+		},
+		{
+			name:       "WaitForOutput=true (JoinNode shape)",
+			nameArg:    "join",
+			descArg:    "fan-in",
+			cfg:        NodeConfig{WaitForOutput: &tTrue},
+			wantConfig: NodeConfig{WaitForOutput: &tTrue},
+		},
+		{
+			name:       "ParallelWorker=true",
+			nameArg:    "mapper",
+			descArg:    "data parallel",
+			cfg:        NodeConfig{ParallelWorker: true},
+			wantConfig: NodeConfig{ParallelWorker: true},
+		},
+		{
+			name:       "empty name and description",
+			cfg:        NodeConfig{},
+			wantConfig: NodeConfig{},
+		},
+		{
+			name:    "fully populated configuration",
+			nameArg: "full_node",
+			descArg: "Node with all config fields set",
+			cfg: NodeConfig{
+				ParallelWorker: true,
+				RerunOnResume:  &tFalse,
+				WaitForOutput:  &tTrue,
+				RetryConfig: &RetryConfig{
+					MaxAttempts: 3,
+				},
+				Timeout: 10 * time.Second,
+			},
+			wantConfig: NodeConfig{
+				ParallelWorker: true,
+				RerunOnResume:  &tFalse,
+				WaitForOutput:  &tTrue,
+				RetryConfig: &RetryConfig{
+					MaxAttempts: 3,
+				},
+				Timeout: 10 * time.Second,
+			},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			b := NewBaseNode(tt.nameArg, tt.descArg, tt.cfg)
+			if got := b.Name(); got != tt.nameArg {
+				t.Errorf("Name() = %q, want %q", got, tt.nameArg)
+			}
+			if got := b.Description(); got != tt.descArg {
+				t.Errorf("Description() = %q, want %q", got, tt.descArg)
+			}
+			want := tt.wantConfig
+			if (tt.cfg.WaitForOutput == nil) && (tt.cfg.ParallelWorker == false) {
+				want = NodeConfig{}
+			}
+			if diff := cmp.Diff(want, b.Config()); diff != "" {
+				t.Errorf("Config() mismatch (-want +got):\n%s", diff)
+			}
+		})
+	}
+}

--- a/workflow/config.go
+++ b/workflow/config.go
@@ -28,26 +28,61 @@ var defaultRetryConfig = RetryConfig{
 	},
 }
 
+// DefaultRetryConfig returns a copy of the default retry policy
+// (5 attempts, 1s initial delay, 60s cap, 2x backoff, full jitter,
+// retry every error). Override fields on the returned value to
+// customise:
+//
+//	rc := workflow.DefaultRetryConfig()
+//	rc.MaxAttempts = 10
+//	cfg := workflow.NodeConfig{RetryConfig: rc}
 func DefaultRetryConfig() *RetryConfig {
 	cfg := defaultRetryConfig
 	return &cfg
 }
 
 // NodeConfig defines the configuration for a node.
+//
+// All fields are optional. The pointer-typed fields (RerunOnResume,
+// WaitForOutput) are tri-state: nil means "use the engine default for
+// this node kind", which mirrors Python's per-node-type defaults
+// (e.g. AgentNode in task mode defaults WaitForOutput to true while
+// other nodes default to false). Use the *Or accessor helpers to
+// read these values with an explicit per-call-site default.
 type NodeConfig struct {
-	// Enables data parallelism (runs node concurrently for each item in input collection)
+	// ParallelWorker, when true, runs the node concurrently for each
+	// item of a list-typed input. The engine collects per-item
+	// outputs and emits a single aggregate output event.
 	ParallelWorker bool
-	// Re-runs node on resume. Defaults to true for AgentNode
+
+	// RerunOnResume controls human-in-the-loop resume behaviour. When
+	// true, an interrupted node re-runs from scratch on resume; when
+	// false, the resume payload is treated as the node's output.
+	// nil means "use the engine default", which is true for AgentNode
+	// and false elsewhere.
 	RerunOnResume *bool
-	// Wait for output before triggering edges. Defaults to true for Task agents
+
+	// WaitForOutput, when true, keeps the node in NodeWaiting
+	// (re-triggerable) until it actually yields an event carrying an
+	// "output" key in Actions.StateDelta, instead of moving it to
+	// NodeCompleted on first return. JoinNode and any custom fan-in
+	// node sets this. nil means "use the engine default" — false for
+	// most node kinds.
 	WaitForOutput *bool
-	// Retry configuration on failure
+
+	// RetryConfig, when non-nil, makes the scheduler retry this node
+	// on failure per the policy. nil means "no retries".
 	RetryConfig *RetryConfig
-	// Max duration for node to complete. Optional for global defaults
-	Timeout *time.Duration
+
+	// Timeout, when > 0, bounds a single activation of the node via
+	// context.WithTimeout on the per-node context. Zero (the default)
+	// means the node is bounded only by the parent invocation
+	// context's deadline, if any.
+	Timeout time.Duration
 }
 
 // RetryConfig defines the parameters for retrying a failed node.
+//
 // Recommended construction is via DefaultRetryConfig and override
 // the fields you want to customize:
 //
@@ -59,17 +94,31 @@ type NodeConfig struct {
 // but discouraged: any unset field defaults to its zero value, not
 // to DefaultRetryConfig's value. The zero RetryConfig is a valid
 // "no retry, no backoff, no jitter" policy.
+//
+// The struct shape is deliberately a flat set of plain values: no
+// dependency on cenkalti/backoff/v5. The scheduler's retry handler
+// implements the backoff math in workflow/retry.go.
 type RetryConfig struct {
 	// Maximum number of attempts, including the original request. If 0 or 1, it means no retries. If not specified, default to 5.
 	MaxAttempts int
+
 	// Initial delay before the first retry, in fractions of a second. If not specified, default to 1 second.
 	InitialDelay time.Duration
+
 	// Maximum delay between retries, in fractions of a second. If not specified, default to 60 seconds.
 	MaxDelay time.Duration
-	// Multiplier by which the delay increases after each attempt. If not specified, default to 2.0.
+
+	// BackoffFactor is the per-attempt multiplier applied to the
+	// delay. A factor of 1.0 means a constant InitialDelay between
+	// retries; 2.0 means classic exponential backoff. Values < 1.0
+	// shrink the delay each attempt (rare but permitted).
 	BackoffFactor float64
-	// Randomness factor for the delay. Use 0.0 to remove randomness. If not specified, default to 1.0.
+
+	// Jitter is a randomness factor in [0.0, 1.0]. The actual delay
+	// is sampled from delay * (1 ± Jitter). Zero means deterministic
+	// delays.
 	Jitter float64
+
 	// Predicate that defines when to retry (true means retry). If not specified, default to true.
 	ShouldRetry func(error) bool
 }

--- a/workflow/config.go
+++ b/workflow/config.go
@@ -96,8 +96,7 @@ type NodeConfig struct {
 // "no retry, no backoff, no jitter" policy.
 //
 // The struct shape is deliberately a flat set of plain values: no
-// dependency on cenkalti/backoff/v5. The scheduler's retry handler
-// implements the backoff math in workflow/retry.go.
+// dependency on cenkalti/backoff/v5.
 type RetryConfig struct {
 	// Maximum number of attempts, including the original request. If 0 or 1, it means no retries. If not specified, default to 5.
 	MaxAttempts int

--- a/workflow/config_test.go
+++ b/workflow/config_test.go
@@ -22,6 +22,9 @@ import (
 	"github.com/google/go-cmp/cmp/cmpopts"
 )
 
+// TestDefaultRetryConfig verifies the values returned by
+// DefaultRetryConfig (5 attempts, 1s initial delay, 60s cap, 2x
+// backoff, full jitter, retry-every-error predicate).
 func TestDefaultRetryConfig(t *testing.T) {
 	want := &RetryConfig{
 		MaxAttempts:   5,

--- a/workflow/edgebuilder_test.go
+++ b/workflow/edgebuilder_test.go
@@ -120,7 +120,7 @@ type dummyNode struct {
 
 func (n *dummyNode) Name() string        { return n.name }
 func (n *dummyNode) Description() string { return "" }
-func (n *dummyNode) Config() NodeConfig     { return NodeConfig{} }
+func (n *dummyNode) Config() NodeConfig  { return NodeConfig{} }
 func (n *dummyNode) Run(ctx agent.InvocationContext, input any) iter.Seq2[*session.Event, error] {
 	return func(yield func(*session.Event, error) bool) {}
 }

--- a/workflow/graph.go
+++ b/workflow/graph.go
@@ -1,0 +1,43 @@
+// Copyright 2026 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package workflow
+
+// graph is the precomputed structural view of a workflow's edges.
+// Built once at workflow construction; queried by the engine at
+// dispatch time.
+type graph struct {
+	successors map[Node][]Edge
+}
+
+// newGraph indexes edges by source node so successor lookups are
+// O(1) at dispatch time. The returned graph references the input
+// edges by value; mutating the input edge slice afterwards does not
+// affect the graph.
+func newGraph(edges []Edge) *graph {
+	succ := make(map[Node][]Edge)
+	for _, edge := range edges {
+		succ[edge.From] = append(succ[edge.From], edge)
+	}
+	return &graph{successors: succ}
+}
+
+// successorsOf returns the outgoing edges for a node.
+// Returns nil if n has no outgoing edges
+// (including the case where n is not in the graph at all). The
+// returned slice is owned by the graph and must not be mutated by
+// callers.
+func (g *graph) successorsOf(n Node) []Edge {
+	return g.successors[n]
+}

--- a/workflow/graph_test.go
+++ b/workflow/graph_test.go
@@ -1,0 +1,181 @@
+// Copyright 2026 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package workflow
+
+import (
+	"iter"
+	"testing"
+
+	"github.com/google/go-cmp/cmp"
+	"google.golang.org/adk/agent"
+	"google.golang.org/adk/session"
+)
+
+// edgeIDs renders edges as "From→To" strings using node names.
+func edgeIDs(es []Edge) []string {
+	if len(es) == 0 {
+		return nil
+	}
+	out := make([]string, len(es))
+	for i, e := range es {
+		out[i] = e.From.Name() + "→" + e.To.Name()
+	}
+	return out
+}
+
+func TestNewGraph_SuccessorsOf(t *testing.T) {
+	a := newTestNode("A")
+	b := newTestNode("B")
+	c := newTestNode("C")
+
+	tests := []struct {
+		name  string
+		edges []Edge
+		// want maps a node name to the expected outgoing-edge IDs
+		// ("From→To" strings). Nodes absent from want are expected
+		// to have no successors.
+		want map[string][]string
+	}{
+		{
+			name:  "empty graph",
+			edges: nil,
+			want:  map[string][]string{},
+		},
+		{
+			name:  "single edge",
+			edges: []Edge{{From: Start, To: a}},
+			want: map[string][]string{
+				"START": {"START→A"},
+			},
+		},
+		{
+			name: "linear chain",
+			edges: []Edge{
+				{From: Start, To: a},
+				{From: a, To: b},
+				{From: b, To: c},
+			},
+			want: map[string][]string{
+				"START": {"START→A"},
+				"A":     {"A→B"},
+				"B":     {"B→C"},
+			},
+		},
+		{
+			name: "fan-out from Start to three nodes",
+			edges: []Edge{
+				{From: Start, To: a},
+				{From: Start, To: b},
+				{From: Start, To: c},
+			},
+			want: map[string][]string{
+				"START": {"START→A", "START→B", "START→C"},
+			},
+		},
+		{
+			name: "fan-in: two upstreams converge on c",
+			edges: []Edge{
+				{From: Start, To: a},
+				{From: Start, To: b},
+				{From: a, To: c},
+				{From: b, To: c},
+			},
+			want: map[string][]string{
+				"START": {"START→A", "START→B"},
+				"A":     {"A→C"},
+				"B":     {"B→C"},
+			},
+		},
+		{
+			name: "cycle a → b → a",
+			edges: []Edge{
+				{From: a, To: b},
+				{From: b, To: a},
+			},
+			want: map[string][]string{
+				"A": {"A→B"},
+				"B": {"B→A"},
+			},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			g := newGraph(tt.edges)
+			for _, n := range []Node{Start, a, b, c} {
+				want := tt.want[n.Name()]
+				got := edgeIDs(g.successorsOf(n))
+				if diff := cmp.Diff(want, got); diff != "" {
+					t.Errorf("successorsOf(%q) mismatch (-want +got):\n%s", n.Name(), diff)
+				}
+			}
+		})
+	}
+}
+
+func TestNewGraph_SuccessorsOf_NodeNotInGraph(t *testing.T) {
+	a := newTestNode("A")
+	b := newTestNode("B")
+	stranger := newTestNode("stranger")
+
+	g := newGraph([]Edge{{From: a, To: b}})
+
+	if got := g.successorsOf(stranger); got != nil {
+		t.Errorf("successorsOf(stranger) = %v, want nil", got)
+	}
+	// Terminal-detection callsite pattern: a node with no outgoing
+	// edges (here: b) should also report nil/empty so the engine can
+	// stop dispatching successors.
+	if got := g.successorsOf(b); len(got) != 0 {
+		t.Errorf("successorsOf(b) = %v, want empty (b is terminal)", got)
+	}
+}
+
+func TestNewGraph_PreservesEdgeOrder(t *testing.T) {
+	// Within a single From node, successorsOf returns edges in input
+	// order.
+	a := newTestNode("A")
+	b := newTestNode("B")
+	c := newTestNode("C")
+	d := newTestNode("D")
+
+	edges := []Edge{
+		{From: a, To: c},
+		{From: a, To: d},
+		{From: a, To: b},
+	}
+	g := newGraph(edges)
+
+	got := edgeIDs(g.successorsOf(a))
+	want := []string{"A→C", "A→D", "A→B"}
+	if diff := cmp.Diff(want, got); diff != "" {
+		t.Errorf("successorsOf(a) mismatch (-want +got):\n%s", diff)
+	}
+}
+
+// newTestNode returns a minimal Node implementation suitable for
+// graph-structure tests. Run is a no-op; only Name matters for
+// diagnostic output.
+func newTestNode(name string) Node {
+	return &testNode{BaseNode: NewBaseNode(name, "", NodeConfig{})}
+}
+
+type testNode struct {
+	BaseNode
+}
+
+func (n *testNode) Run(_ agent.InvocationContext, _ any) iter.Seq2[*session.Event, error] {
+	return func(yield func(*session.Event, error) bool) {}
+}

--- a/workflow/node_context.go
+++ b/workflow/node_context.go
@@ -1,0 +1,41 @@
+// Copyright 2026 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package workflow
+
+import "google.golang.org/adk/agent"
+
+// nodeContext is the per-node InvocationContext seen inside Node.Run.
+// It wraps the workflow's incoming agent.InvocationContext and adds
+// engine-supplied metadata — currently only the upstream node name
+// (TriggeredBy).
+//
+// TODO(wolo): replace once context-unification work lands.
+type nodeContext struct {
+	agent.InvocationContext
+	triggeredBy string
+}
+
+// newNodeContext returns a nodeContext wrapping parent with the given
+// upstream-node name. triggeredBy is empty for the initial START
+// activation.
+func newNodeContext(parent agent.InvocationContext, triggeredBy string) *nodeContext {
+	return &nodeContext{InvocationContext: parent, triggeredBy: triggeredBy}
+}
+
+// TriggeredBy returns the name of the upstream node whose output
+// scheduled this node activation. Empty for the initial START
+// trigger and for non-workflow invocations (where the wrapper is not
+// used).
+func (c *nodeContext) TriggeredBy() string { return c.triggeredBy }

--- a/workflow/node_context_test.go
+++ b/workflow/node_context_test.go
@@ -1,0 +1,45 @@
+// Copyright 2026 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package workflow
+
+import (
+	"testing"
+
+	"google.golang.org/adk/agent"
+)
+
+func TestNewNodeContext_TriggeredByRoundTrip(t *testing.T) {
+	tests := []struct {
+		name        string
+		triggeredBy string
+	}{
+		{name: "empty (initial START activation)", triggeredBy: ""},
+		{name: "named upstream node", triggeredBy: "upstream"},
+		{name: "node name with dots (branch path)", triggeredBy: "agent_1.agent_2"},
+	}
+
+	parent := newMockCtx(t)
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			c := newNodeContext(parent, tt.triggeredBy)
+			if got := c.TriggeredBy(); got != tt.triggeredBy {
+				t.Errorf("TriggeredBy() = %q, want %q", got, tt.triggeredBy)
+			}
+		})
+	}
+}
+
+// Compile-time assertion: *nodeContext satisfies agent.InvocationContext.
+var _ agent.InvocationContext = (*nodeContext)(nil)

--- a/workflow/scheduler.go
+++ b/workflow/scheduler.go
@@ -1,0 +1,475 @@
+// Copyright 2026 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package workflow
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"sync"
+
+	"google.golang.org/adk/agent"
+	"google.golang.org/adk/session"
+)
+
+// defaultEventQueueCapacity bounds the buffered channel between
+// node-runner goroutines and the consumer. A small fixed capacity
+// keeps backpressure tight without serialising producers.
+const defaultEventQueueCapacity = 16
+
+var (
+	// ErrMultipleOutputs is returned when a node yields more than
+	// one event whose Actions.StateDelta carries an "output" key.
+	// A node activation may emit at most one output value.
+	ErrMultipleOutputs = errors.New("workflow: node produced multiple events with output values; only one event per execution can carry output")
+
+	// ErrMultipleRoutingEvents is returned when a node yields more
+	// than one event whose Routes field is set. A node activation
+	// may emit at most one routing decision.
+	ErrMultipleRoutingEvents = errors.New("workflow: node produced multiple events with route tags; only one event per execution can specify routes")
+)
+
+// scheduler drives a single Workflow.Run invocation. It owns the
+// per-node task table, the event channel, lifecycle counters, and
+// the parent invocation context — none of which survive across
+// processes. The persistable view of the same run (node statuses,
+// inputs, triggers) lives on the embedded *RunState.
+//
+// Concurrency model: producer-consumer over eventQueue.
+//
+//   - Producers are the per-node goroutines started by scheduleNode.
+//     They only send to eventQueue (events and a final completion);
+//     they never read from it and never touch any other scheduler
+//     field.
+//   - The consumer is the single goroutine running scheduler.run
+//     (the caller of Workflow.Run). It is the only reader of
+//     eventQueue and the only mutator of runsByName, runCancels,
+//     state.Nodes, and per-node accumulators.
+//
+// Because producers and the consumer share only eventQueue (a
+// channel — already safe for concurrent use), the consumer-only
+// fields below need no mutex.
+type scheduler struct {
+	state       *RunState       // persisted lifecycle state
+	graph       *graph          // adjacency, terminal lookup
+	nodesByName map[string]Node // built once at construction; lets handleCompletion resolve a completion's name back to its Node in O(1)
+
+	// Per-node accumulators, created when a node is scheduled and
+	// deleted on its completion. Owned by the consumer goroutine.
+	runsByName map[string]*nodeRun
+
+	// Per-node cancel funcs. Owned by the consumer goroutine.
+	runCancels map[string]context.CancelFunc
+
+	// eventQueue carries events and completions from producer
+	// goroutines to the consumer.
+	eventQueue chan queueItem
+	wg         sync.WaitGroup
+
+	parentCtx agent.InvocationContext
+}
+
+// nodeRun is the per-node consumer-side accumulator. It buffers the
+// node's routing event (if any) and its single output between the
+// time those events arrive and the time the node's completion
+// arrives, at which point successors are scheduled.
+//
+// The single-output and single-routing-event constraints are
+// enforced here: a second event carrying either kind sets err
+// without overwriting the first value, and the consumer surfaces
+// the error at completion.
+type nodeRun struct {
+	routingEvent *session.Event // at most one; multiple is an error
+	output       any            // single StateDelta["output"]; nil if hasOutput is false
+	hasOutput    bool           // distinguishes "no output yet" from "output was nil"
+	err          error          // set on duplicate output or duplicate routing event
+}
+
+// recordErr stores err as the accumulator's first error. Subsequent
+// calls are no-ops, preserving the first failure for handleCompletion
+// to surface.
+func (nr *nodeRun) recordErr(err error) {
+	if nr.err == nil {
+		nr.err = err
+	}
+}
+
+// setRoutingEvent stores ev as the node's single routing event. A
+// second call records ErrMultipleRoutingEvents instead of overwriting.
+func (nr *nodeRun) setRoutingEvent(ev *session.Event, nodeName string) {
+	if nr.routingEvent != nil {
+		nr.recordErr(fmt.Errorf("%w: node %q", ErrMultipleRoutingEvents, nodeName))
+		return
+	}
+	nr.routingEvent = ev
+}
+
+// setOutput stores out as the node's single output value. A second
+// call records ErrMultipleOutputs instead of overwriting.
+func (nr *nodeRun) setOutput(out any, nodeName string) {
+	if nr.hasOutput {
+		nr.recordErr(fmt.Errorf("%w: node %q", ErrMultipleOutputs, nodeName))
+		return
+	}
+	nr.output = out
+	nr.hasOutput = true
+}
+
+// queueItem is sealed: only types in this package can satisfy it.
+// The unexported sentinel method enforces the seal at compile time.
+type queueItem interface{ isQueueItem() }
+
+// eventItem carries one event from a node-runner goroutine to the
+// consumer. nodeName is required so the consumer can correlate the
+// event with the right nodeRun without relying on channel-FIFO-
+// per-task semantics (which Go channels do not provide).
+type eventItem struct {
+	nodeName string
+	ev       *session.Event
+}
+
+func (eventItem) isQueueItem() {}
+
+// completionItem signals that a node-runner goroutine has finished.
+// err is nil on success; non-nil errors are classified by the
+// consumer via errors.Is (currently: context.Canceled,
+// context.DeadlineExceeded, anything else → NodeFailed).
+type completionItem struct {
+	nodeName string
+	err      error
+}
+
+func (completionItem) isQueueItem() {}
+
+// newScheduler returns an initialised scheduler ready for the
+// consumer to drive. The caller is responsible for seeding the
+// initial trigger (typically Start with the user input).
+func newScheduler(parent agent.InvocationContext, g *graph) *scheduler {
+	return &scheduler{
+		state:       NewRunState(),
+		graph:       g,
+		nodesByName: buildNodesByName(g),
+		runsByName:  map[string]*nodeRun{},
+		runCancels:  map[string]context.CancelFunc{},
+		eventQueue:  make(chan queueItem, defaultEventQueueCapacity),
+		parentCtx:   parent,
+	}
+}
+
+// buildNodesByName walks the graph's edges and returns the name→Node
+// lookup. Lets handleCompletion resolve a completion's node name to
+// its instance in O(1) instead of scanning the full table.
+func buildNodesByName(g *graph) map[string]Node {
+	nodesByName := map[string]Node{}
+	add := func(n Node) { nodesByName[n.Name()] = n }
+	for n, edges := range g.successors {
+		add(n)
+		for _, e := range edges {
+			add(e.To)
+		}
+	}
+	return nodesByName
+}
+
+// scheduleNode launches a per-node goroutine for n with the given
+// input. The node's lifecycle status transitions to NodeRunning, and
+// the node is registered in runsByName and runCancels. The goroutine
+// wrapper is responsible for pushing exactly one completionItem when
+// it returns (success, error, panic, or cancellation).
+//
+// scheduleNode runs only on the consumer goroutine.
+func (s *scheduler) scheduleNode(n Node, input any, triggeredBy string) {
+	name := n.Name()
+
+	// Per-node context: WithTimeout when Config().Timeout > 0,
+	// WithCancel otherwise. Either way it inherits from parentCtx,
+	// so an ambient deadline on the workflow invocation still
+	// applies.
+	cfg := n.Config()
+	var (
+		nodeCtx context.Context
+		cancel  context.CancelFunc
+	)
+	if cfg.Timeout > 0 {
+		nodeCtx, cancel = context.WithTimeout(s.parentCtx, cfg.Timeout)
+	} else {
+		nodeCtx, cancel = context.WithCancel(s.parentCtx)
+	}
+	perNodeCtx := newNodeContext(s.parentCtx.WithContext(nodeCtx), triggeredBy)
+
+	ns := s.state.EnsureNode(name)
+	ns.Status = NodeRunning
+	ns.Input = input
+	ns.TriggeredBy = triggeredBy
+	s.runsByName[name] = &nodeRun{}
+
+	s.runCancels[name] = cancel
+	s.wg.Add(1)
+
+	go runNode(s.eventQueue, &s.wg, name, n, perNodeCtx, input)
+}
+
+// runNode is the per-node goroutine wrapper. It drives the node's
+// iter.Seq2, pushes events into the queue, and ends with exactly
+// one completionItem. A panic in the node body is recovered and
+// reported as a completion error so the consumer never deadlocks
+// waiting for a vanished goroutine.
+//
+// Event sends select on ctx.Done(): if the scheduler has cancelled
+// this node, an in-progress send to a full eventQueue does not
+// deadlock — the goroutine drops the pending event and proceeds to
+// completion. The completion send is unconditional because the
+// consumer's runsByName bookkeeping relies on it.
+func runNode(
+	out chan<- queueItem,
+	wg *sync.WaitGroup,
+	name string,
+	n Node,
+	ctx agent.InvocationContext,
+	input any,
+) {
+	defer wg.Done()
+
+	// completion holds the final completionItem. It is sent in the
+	// outer defer so panic recovery, normal exit, and cancellation
+	// all funnel through the same send path.
+	completion := completionItem{nodeName: name}
+	defer func() {
+		if r := recover(); r != nil {
+			completion.err = fmt.Errorf("node %q panicked: %v", name, r)
+		}
+		out <- completion
+	}()
+
+	for ev, err := range n.Run(ctx, input) {
+		if err != nil {
+			completion.err = err
+			return
+		}
+		select {
+		case out <- eventItem{nodeName: name, ev: ev}:
+		case <-ctx.Done():
+			completion.err = ctx.Err()
+			return
+		}
+	}
+	// If the node's iter returned cleanly but the context was
+	// cancelled or its deadline elapsed, surface that as the
+	// completion error: the node likely returned because it observed
+	// ctx.Done(), and the consumer needs to classify it.
+	if ctxErr := ctx.Err(); ctxErr != nil {
+		completion.err = ctxErr
+	}
+}
+
+// cancelAll cancels every running task. Idempotent: cancelled
+// goroutines may still push events that already left the producer
+// before observing ctx.Done(); the consumer continues draining
+// until runsByName is empty.
+//
+// cancelAll runs only on the consumer goroutine.
+func (s *scheduler) cancelAll() {
+	for _, cancel := range s.runCancels {
+		cancel()
+	}
+}
+
+// run is the single-consumer loop. It drains the eventQueue, applies
+// state-side effects, yields events to the caller, and schedules
+// successor nodes when a node completes. Returns when all running
+// tasks have signalled completion.
+//
+// On non-nil yield-return-false (caller broke from the range loop)
+// or on a non-retryable node error, run cancels all in-flight
+// tasks and continues draining until runsByName is empty, then
+// surfaces the original error (if any) via yield.
+//
+// run runs on the caller's goroutine (the goroutine that called
+// Workflow.Run); it is the only mutator of state.Nodes and the
+// node-side accumulators.
+func (s *scheduler) run(yield func(*session.Event, error) bool) {
+	var pendingErr error // first non-nil node error; surfaced after drain
+	draining := false    // true once cancelAll has run; remaining queue items are drained without yielding or scheduling new successors
+
+	for len(s.runsByName) > 0 {
+		item := <-s.eventQueue
+		switch it := item.(type) {
+		case eventItem:
+			s.handleEvent(it)
+			if !draining {
+				if !yield(it.ev, nil) {
+					draining = true
+					s.cancelAll()
+				}
+			}
+		case completionItem:
+			err := s.handleCompletion(it, !draining)
+			if err != nil && pendingErr == nil {
+				pendingErr = err
+				if !draining {
+					draining = true
+					s.cancelAll()
+				}
+			}
+		}
+	}
+
+	// All goroutines have returned and pushed their final events.
+	// Surface the first error to the caller, unless we're already
+	// draining.
+	if pendingErr != nil {
+		yield(nil, pendingErr)
+	}
+}
+
+// handleEvent updates the per-node accumulator and is called once
+// per event. The event itself has already been read from the queue
+// and will be yielded to the caller by the consumer loop.
+func (s *scheduler) handleEvent(it eventItem) {
+	nr := s.runsByName[it.nodeName]
+	if nr == nil {
+		// Defensive: completion already processed for this node;
+		// shouldn't happen if producer goroutines preserve send order.
+		return
+	}
+	if it.ev == nil {
+		return
+	}
+	if it.ev.Routes != nil {
+		nr.setRoutingEvent(it.ev, it.nodeName)
+	}
+	if it.ev.Actions.StateDelta != nil {
+		if out, ok := it.ev.Actions.StateDelta["output"]; ok {
+			nr.setOutput(out, it.nodeName)
+		}
+	}
+}
+
+// handleCompletion finalises a node's run: transitions its lifecycle
+// status, removes the live task, and (if scheduleSuccessors is true)
+// schedules its successors. When the consumer is draining (caller
+// stopped or a node failed), pass scheduleSuccessors=false so the
+// workflow does not keep dispatching new nodes after cancellation.
+//
+// The returned error is the node's own error (NodeFailed); nil on
+// clean success or sibling cancellation.
+func (s *scheduler) handleCompletion(it completionItem, scheduleSuccessors bool) error {
+	ns := s.state.EnsureNode(it.nodeName)
+	nr := s.runsByName[it.nodeName]
+	delete(s.runsByName, it.nodeName)
+	delete(s.runCancels, it.nodeName)
+
+	switch {
+	case it.err == nil:
+		ns.Status = NodeCompleted
+	case errors.Is(it.err, context.Canceled):
+		ns.Status = NodeCancelled
+		return nil // sibling cancellation; not the original error
+	default:
+		ns.Status = NodeFailed
+		return it.err
+	}
+
+	if nr != nil && nr.err != nil {
+		ns.Status = NodeFailed
+		return nr.err
+	}
+
+	if !scheduleSuccessors {
+		return nil
+	}
+
+	// Schedule successors. Find them via the routing-aware helper,
+	// which reads any routing event off this completion's accumulator.
+	currentNode := s.nodesByName[it.nodeName]
+	if currentNode == nil {
+		return nil
+	}
+	var input any
+	var routingEv *session.Event
+	if nr != nil {
+		input = nr.output
+		routingEv = nr.routingEvent
+	}
+	// START's own output is empty by definition; for START we
+	// propagate the workflow's seed input (carried as the START
+	// node's NodeState.Input).
+	if currentNode == Start {
+		input = ns.Input
+	}
+
+	for _, succ := range findSuccessors(s.graph, currentNode, input, routingEv) {
+		s.scheduleNode(succ.node, succ.input, succ.triggeredBy)
+	}
+	return nil
+}
+
+// successor is the per-target dispatch tuple produced by
+// findSuccessors. The triggeredBy field carries the upstream node's
+// name for downstream visibility via ctx.TriggeredBy().
+type successor struct {
+	node        Node
+	input       any
+	triggeredBy string
+}
+
+// findSuccessors evaluates the outgoing edges of currentNode against
+// the optional routing event and returns the dispatch list:
+//
+//   - Edges with no Route always fire (and do not suppress Default).
+//   - Edges with a concrete Route fire only if Route.Matches(event) is true.
+//   - Duplicate To targets are deduplicated (same target node may not
+//     be queued twice for one parent activation).
+//   - The Default edge fires when no concrete Route matched. An
+//     unconditional edge does not count as a "match" for this
+//     purpose, so a graph with one unconditional edge and one
+//     Default edge fans out to both targets.
+//   - If every outgoing edge has a concrete Route and none matched,
+//     and no Default is present, the workflow silently dead-ends at
+//     this node — by design, mirroring adk-python's routing semantics.
+func findSuccessors(g *graph, currentNode Node, input any, event *session.Event) []successor {
+	succs := g.successorsOf(currentNode)
+	if len(succs) == 0 {
+		return nil
+	}
+	from := currentNode.Name()
+	concreteMatched := false // any concrete Route fired (controls Default)
+	out := []successor{}
+	added := map[Node]struct{}{}
+	var defaultRouteNode Node
+	for _, edge := range succs {
+		if _, ok := added[edge.To]; ok {
+			continue
+		}
+		if edge.Route == nil {
+			out = append(out, successor{node: edge.To, input: input, triggeredBy: from})
+			added[edge.To] = struct{}{}
+			continue
+		}
+		if edge.Route == Default {
+			defaultRouteNode = edge.To
+			continue
+		}
+		if event != nil && edge.Route.Matches(event) {
+			out = append(out, successor{node: edge.To, input: input, triggeredBy: from})
+			added[edge.To] = struct{}{}
+			concreteMatched = true
+		}
+	}
+	if !concreteMatched && defaultRouteNode != nil {
+		out = append(out, successor{node: defaultRouteNode, input: input, triggeredBy: from})
+	}
+	return out
+}

--- a/workflow/scheduler.go
+++ b/workflow/scheduler.go
@@ -173,11 +173,10 @@ func newScheduler(parent agent.InvocationContext, g *graph) *scheduler {
 // its instance in O(1) instead of scanning the full table.
 func buildNodesByName(g *graph) map[string]Node {
 	nodesByName := map[string]Node{}
-	add := func(n Node) { nodesByName[n.Name()] = n }
 	for n, edges := range g.successors {
-		add(n)
+		nodesByName[n.Name()] = n
 		for _, e := range edges {
-			add(e.To)
+			nodesByName[e.To.Name()] = e.To
 		}
 	}
 	return nodesByName

--- a/workflow/scheduler_test.go
+++ b/workflow/scheduler_test.go
@@ -1,0 +1,460 @@
+// Copyright 2026 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package workflow
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"iter"
+	"sort"
+	"sync/atomic"
+	"testing"
+	"time"
+
+	"github.com/google/go-cmp/cmp"
+
+	"google.golang.org/adk/agent"
+	"google.golang.org/adk/session"
+)
+
+// TestScheduler_LinearChain verifies that a linear graph
+// Start → A → B → C runs to completion in the expected order and
+// that each node's lifecycle ends at NodeCompleted.
+func TestScheduler_LinearChain(t *testing.T) {
+	mockCtx := newSeededMockCtx(t)
+
+	a := newRecordingNode("A")
+	b := newRecordingNode("B")
+	c := newRecordingNode("C")
+	a.release()
+	b.release()
+	c.release()
+
+	w := mustNew(t, Chain(Start, a, b, c))
+
+	gotEvents := drain(t, w.Run(mockCtx))
+
+	// Each recording node yields exactly one event with output =
+	// "<input>:<name>". The chain accumulates: A sees "seed", B sees
+	// "seed:A", C sees "seed:A:B".
+	wantOutputs := []string{"seed:A", "seed:A:B", "seed:A:B:C"}
+	gotOutputs := outputsOf(gotEvents)
+	if diff := cmp.Diff(wantOutputs, gotOutputs); diff != "" {
+		t.Errorf("outputs mismatch (-want +got):\n%s", diff)
+	}
+}
+
+// TestScheduler_FanOutConcurrency verifies that three nodes
+// downstream of START are mid-Run simultaneously, not serialised by
+// the legacy BFS. Each node blocks on its release channel until the
+// test signals.
+func TestScheduler_FanOutConcurrency(t *testing.T) {
+	const fanOut = 3
+
+	mockCtx := newSeededMockCtx(t)
+
+	var concurrent atomic.Int32
+	var peakConcurrent atomic.Int32
+
+	// Make N nodes that each bump a "currently running" counter on
+	// entry and decrement on exit. Track the peak. They block on a
+	// shared barrier so they can all be observed mid-flight together.
+	barrier := make(chan struct{})
+	nodes := make([]Node, fanOut)
+	for i := range fanOut {
+		name := fmt.Sprintf("N%d", i)
+		nodes[i] = newBlockingNode(name, func() {
+			nowConcurrent := concurrent.Add(1)
+			for {
+				peak := peakConcurrent.Load()
+				if nowConcurrent <= peak || peakConcurrent.CompareAndSwap(peak, nowConcurrent) {
+					break
+				}
+			}
+			<-barrier
+			concurrent.Add(-1)
+		})
+	}
+
+	edges := make([]Edge, 0, fanOut)
+	for _, n := range nodes {
+		edges = append(edges, Edge{From: Start, To: n})
+	}
+	w := mustNew(t, edges)
+
+	// Release the barrier once we observe peak == fanOut, or fail
+	// after a generous timeout.
+	done := make(chan struct{})
+	go func() {
+		defer close(done)
+		drain(t, w.Run(mockCtx))
+	}()
+
+	deadline := time.Now().Add(2 * time.Second)
+	for time.Now().Before(deadline) {
+		if peakConcurrent.Load() == fanOut {
+			break
+		}
+		time.Sleep(time.Millisecond)
+	}
+
+	close(barrier)
+	<-done
+
+	if got := peakConcurrent.Load(); got != fanOut {
+		t.Errorf("peak concurrent nodes = %d, want %d (fan-out children should run in parallel)", got, fanOut)
+	}
+}
+
+// TestScheduler_FailedSiblingsCancelled verifies that when one
+// node returns an error, the consumer cancels every sibling, the
+// final yielded error is the failing node's own error, and the
+// lifecycle map ends up with the right mix of statuses.
+func TestScheduler_FailedSiblingsCancelled(t *testing.T) {
+	mockCtx := newSeededMockCtx(t)
+
+	failErr := errors.New("B failed intentionally")
+
+	// A and C block until their context is cancelled. B errors
+	// immediately. After B's failure, A and C should observe ctx.Done.
+	a := newCancelObservingNode("A")
+	b := newErroringNode("B", failErr)
+	c := newCancelObservingNode("C")
+
+	edges := []Edge{
+		{From: Start, To: a},
+		{From: Start, To: b},
+		{From: Start, To: c},
+	}
+	w := mustNew(t, edges)
+
+	gotErr := drainErr(t, w.Run(mockCtx))
+	if !errors.Is(gotErr, failErr) {
+		t.Errorf("Run error = %v, want it to wrap %v", gotErr, failErr)
+	}
+	if got := a.cancelObserved.Load(); !got {
+		t.Errorf("node A: ctx.Done() not observed (sibling cancellation broken)")
+	}
+	if got := c.cancelObserved.Load(); !got {
+		t.Errorf("node C: ctx.Done() not observed (sibling cancellation broken)")
+	}
+}
+
+// TestScheduler_CallerBreakStopsScheduling verifies that when the
+// caller breaks out of the event range loop, the scheduler stops
+// dispatching new successor nodes — not just stops yielding events.
+// Without this guarantee, an early caller break would leave the rest
+// of the workflow running silently in the background.
+func TestScheduler_CallerBreakStopsScheduling(t *testing.T) {
+	mockCtx := newSeededMockCtx(t)
+
+	var bRan, cRan atomic.Bool
+
+	a := NewFunctionNode("A", func(ctx agent.InvocationContext, input any) (string, error) {
+		return "a-out", nil
+	}, defaultNodeConfig)
+	b := NewFunctionNode("B", func(ctx agent.InvocationContext, input any) (string, error) {
+		bRan.Store(true)
+		return "b-out", nil
+	}, defaultNodeConfig)
+	c := NewFunctionNode("C", func(ctx agent.InvocationContext, input any) (string, error) {
+		cRan.Store(true)
+		return "c-out", nil
+	}, defaultNodeConfig)
+
+	w := mustNew(t, []Edge{
+		{From: Start, To: a},
+		{From: a, To: b},
+		{From: b, To: c},
+	})
+
+	// Caller breaks immediately after the first event.
+	for range w.Run(mockCtx) {
+		break
+	}
+
+	if bRan.Load() {
+		t.Error("node B ran after caller break; draining should stop further scheduling")
+	}
+	if cRan.Load() {
+		t.Error("node C ran after caller break; draining should stop further scheduling")
+	}
+}
+
+// TestScheduler_NodeTimeout verifies that a node with
+// Config().Timeout set is killed after the timeout and the resulting
+// completion is treated as a failure (deadline exceeded). Sibling
+// nodes without a timeout are not affected.
+func TestScheduler_NodeTimeout(t *testing.T) {
+	mockCtx := newSeededMockCtx(t)
+
+	slow := newCancelObservingNode("slow")
+	slow.cfg = NodeConfig{Timeout: 50 * time.Millisecond}
+
+	w := mustNew(t, []Edge{{From: Start, To: slow}})
+
+	gotErr := drainErr(t, w.Run(mockCtx))
+	if !errors.Is(gotErr, context.DeadlineExceeded) {
+		t.Errorf("Run error = %v, want context.DeadlineExceeded", gotErr)
+	}
+	if !slow.cancelObserved.Load() {
+		t.Error("slow node: ctx.Done() not observed (timeout cancellation broken)")
+	}
+}
+
+// TestScheduler_MultipleOutputsFailNode verifies that a node which
+// yields more than one event carrying StateDelta["output"] fails
+// the workflow with ErrMultipleOutputs (matching adk-python's
+// "single output per node" contract). The first output value is
+// preserved; subsequent ones trip the accumulator error.
+func TestScheduler_MultipleOutputsFailNode(t *testing.T) {
+	mockCtx := newSeededMockCtx(t)
+
+	bad := newMultiOutputNode("bad", []string{"first", "second"})
+	w := mustNew(t, []Edge{{From: Start, To: bad}})
+
+	gotErr := drainErr(t, w.Run(mockCtx))
+	if !errors.Is(gotErr, ErrMultipleOutputs) {
+		t.Errorf("Run error = %v, want it to wrap ErrMultipleOutputs", gotErr)
+	}
+}
+
+// TestScheduler_ProgressEventsThenSingleOutputSucceed verifies
+// that events with no StateDelta["output"] (progress / status
+// events) do not consume the single-output budget. A node may
+// yield many such events followed by exactly one output event
+// without violating the contract.
+func TestScheduler_ProgressEventsThenSingleOutputSucceed(t *testing.T) {
+	mockCtx := newSeededMockCtx(t)
+
+	n := newProgressThenOutputNode("n", 3 /*progress events*/, "final")
+	w := mustNew(t, []Edge{{From: Start, To: n}})
+
+	events := drain(t, w.Run(mockCtx))
+
+	// Expect 3 progress events + 1 output event = 4 events total,
+	// and the last one carries the output value.
+	if got, want := len(events), 4; got != want {
+		t.Fatalf("event count = %d, want %d", got, want)
+	}
+	last := events[len(events)-1]
+	if last.Actions.StateDelta == nil {
+		t.Fatal("last event has nil StateDelta")
+	}
+	if got, want := fmt.Sprint(last.Actions.StateDelta["output"]), "final"; got != want {
+		t.Errorf("last event output = %q, want %q", got, want)
+	}
+}
+
+// --- test fixtures: helper nodes and drain helpers below this line ---
+
+// drain consumes all events from an iter.Seq2 and returns the
+// successful events. The first error fails the test.
+func drain(t *testing.T, seq iter.Seq2[*session.Event, error]) []*session.Event {
+	t.Helper()
+	var out []*session.Event
+	for ev, err := range seq {
+		if err != nil {
+			t.Fatalf("unexpected error: %v", err)
+		}
+		out = append(out, ev)
+	}
+	return out
+}
+
+// drainErr consumes all events and returns the first error. Fails
+// the test if no error was produced.
+func drainErr(t *testing.T, seq iter.Seq2[*session.Event, error]) error {
+	t.Helper()
+	var firstErr error
+	for _, err := range seq {
+		if err != nil && firstErr == nil {
+			firstErr = err
+		}
+	}
+	if firstErr == nil {
+		t.Fatal("expected an error from Run, got none")
+	}
+	return firstErr
+}
+
+// outputsOf extracts the StateDelta["output"] string from each event,
+// sorted to make assertions order-independent across concurrent runs.
+func outputsOf(events []*session.Event) []string {
+	out := make([]string, 0, len(events))
+	for _, ev := range events {
+		if ev == nil || ev.Actions.StateDelta == nil {
+			continue
+		}
+		if v, ok := ev.Actions.StateDelta["output"]; ok {
+			out = append(out, fmt.Sprint(v))
+		}
+	}
+	sort.Strings(out)
+	return out
+}
+
+// recordingNode emits one event with output = "<input>:<name>".
+// Used in chains to verify per-step input propagation.
+type recordingNode struct {
+	BaseNode
+	released chan struct{}
+}
+
+func newRecordingNode(name string) *recordingNode {
+	return &recordingNode{
+		BaseNode: NewBaseNode(name, "", NodeConfig{}),
+		released: make(chan struct{}),
+	}
+}
+
+func (n *recordingNode) release() { close(n.released) }
+
+func (n *recordingNode) Run(ctx agent.InvocationContext, input any) iter.Seq2[*session.Event, error] {
+	return func(yield func(*session.Event, error) bool) {
+		<-n.released
+		ev := session.NewEvent(ctx.InvocationID())
+		out := fmt.Sprintf("%v:%s", input, n.Name())
+		ev.Actions.StateDelta["output"] = out
+		yield(ev, nil)
+	}
+}
+
+// blockingNode runs the supplied work function (which typically
+// touches an external counter and waits on a barrier). Yields one
+// empty event after the work returns so the scheduler can record
+// completion.
+type blockingNode struct {
+	BaseNode
+	work func()
+}
+
+func newBlockingNode(name string, work func()) *blockingNode {
+	return &blockingNode{
+		BaseNode: NewBaseNode(name, "", NodeConfig{}),
+		work:     work,
+	}
+}
+
+func (n *blockingNode) Run(ctx agent.InvocationContext, _ any) iter.Seq2[*session.Event, error] {
+	return func(yield func(*session.Event, error) bool) {
+		n.work()
+		ev := session.NewEvent(ctx.InvocationID())
+		ev.Actions.StateDelta["output"] = n.Name()
+		yield(ev, nil)
+	}
+}
+
+// erroringNode returns the supplied error immediately.
+type erroringNode struct {
+	BaseNode
+	err error
+}
+
+func newErroringNode(name string, err error) *erroringNode {
+	return &erroringNode{
+		BaseNode: NewBaseNode(name, "", NodeConfig{}),
+		err:      err,
+	}
+}
+
+func (n *erroringNode) Run(_ agent.InvocationContext, _ any) iter.Seq2[*session.Event, error] {
+	return func(yield func(*session.Event, error) bool) {
+		yield(nil, n.err)
+	}
+}
+
+// cancelObservingNode blocks until its context is cancelled, then
+// records that fact via cancelObserved. Used to verify sibling
+// cancellation and timeout behaviour.
+type cancelObservingNode struct {
+	BaseNode
+	cfg            NodeConfig
+	cancelObserved atomic.Bool
+}
+
+func newCancelObservingNode(name string) *cancelObservingNode {
+	return &cancelObservingNode{BaseNode: NewBaseNode(name, "", NodeConfig{})}
+}
+
+// Config returns n.cfg, which tests may mutate after construction.
+func (n *cancelObservingNode) Config() NodeConfig { return n.cfg }
+
+func (n *cancelObservingNode) Run(ctx agent.InvocationContext, _ any) iter.Seq2[*session.Event, error] {
+	return func(yield func(*session.Event, error) bool) {
+		<-ctx.Done()
+		n.cancelObserved.Store(true)
+	}
+}
+
+// multiOutputNode yields one event per supplied output value, each
+// carrying StateDelta["output"]. Used to exercise the
+// single-output-per-node constraint.
+type multiOutputNode struct {
+	BaseNode
+	outputs []string
+}
+
+func newMultiOutputNode(name string, outputs []string) *multiOutputNode {
+	return &multiOutputNode{
+		BaseNode: NewBaseNode(name, "", NodeConfig{}),
+		outputs:  outputs,
+	}
+}
+
+func (n *multiOutputNode) Run(ctx agent.InvocationContext, _ any) iter.Seq2[*session.Event, error] {
+	return func(yield func(*session.Event, error) bool) {
+		for _, out := range n.outputs {
+			ev := session.NewEvent(ctx.InvocationID())
+			ev.Actions.StateDelta["output"] = out
+			if !yield(ev, nil) {
+				return
+			}
+		}
+	}
+}
+
+// progressThenOutputNode yields N events with no output (progress
+// events) followed by exactly one output event. Used to verify
+// that progress events do not consume the single-output budget.
+type progressThenOutputNode struct {
+	BaseNode
+	progressCount int
+	finalOutput   string
+}
+
+func newProgressThenOutputNode(name string, progressCount int, finalOutput string) *progressThenOutputNode {
+	return &progressThenOutputNode{
+		BaseNode:      NewBaseNode(name, "", NodeConfig{}),
+		progressCount: progressCount,
+		finalOutput:   finalOutput,
+	}
+}
+
+func (n *progressThenOutputNode) Run(ctx agent.InvocationContext, _ any) iter.Seq2[*session.Event, error] {
+	return func(yield func(*session.Event, error) bool) {
+		for range n.progressCount {
+			ev := session.NewEvent(ctx.InvocationID())
+			// progress event: no StateDelta["output"]
+			if !yield(ev, nil) {
+				return
+			}
+		}
+		final := session.NewEvent(ctx.InvocationID())
+		final.Actions.StateDelta["output"] = n.finalOutput
+		yield(final, nil)
+	}
+}

--- a/workflow/state.go
+++ b/workflow/state.go
@@ -1,0 +1,116 @@
+// Copyright 2026 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package workflow
+
+// NodeStatus is the lifecycle status of a node in the workflow graph.
+//
+// The status is the engine's single source of truth for what a node
+// is doing. It mediates between the trigger buffer (what wants to
+// run), the in-process task table (what is currently running), and
+// the persisted node history (what has run).
+type NodeStatus uint8
+
+const (
+	// NodeInactive means the node has not been touched yet. This is
+	// the zero value.
+	NodeInactive NodeStatus = iota
+
+	// NodePending means the node is ready to run. It may be queued
+	// because its input has arrived (consumed from the trigger
+	// buffer) or because it is being retried after a failure. The
+	// scheduler may keep a NodePending node from starting if the
+	// engine's max-concurrency cap is reached.
+	NodePending
+
+	// NodeRunning means the engine has started a task for this node.
+	// The task is in flight in the current process. A NodeRunning
+	// entry that has no live task in the run state (e.g. after a
+	// process restart) must be re-scheduled.
+	NodeRunning
+
+	// NodeCompleted means the node finished and produced its output.
+	// This is a terminal status for normal execution, but a node in
+	// NodeCompleted may still be re-triggered by a fresh entry in
+	// the trigger buffer (this is what enables loops as graph
+	// cycles).
+	NodeCompleted
+
+	// NodeWaiting means the node is paused. Two cases share this
+	// status:
+	//
+	//   1. Human-in-the-loop: the node yielded a RequestInput and
+	//      is blocked until a function-response payload resumes it.
+	//   2. Fan-in (WaitForOutput=true, e.g. JoinNode): the node ran
+	//      but did not yet produce its final output because not all
+	//      predecessors have triggered it.
+	//
+	// While any node is NodeWaiting the workflow does not finalize.
+	NodeWaiting
+
+	// NodeFailed means the node returned an error and the retry
+	// policy (if any) has been exhausted. Terminal.
+	NodeFailed
+
+	// NodeCancelled means the node was cancelled, typically because
+	// a sibling node failed and the engine cancelled all running
+	// tasks. Terminal.
+	NodeCancelled
+)
+
+// NodeState is the per-node lifecycle record. A RunState holds one
+// of these for every node the engine has touched.
+type NodeState struct {
+	// Status is the current lifecycle position. See NodeStatus.
+	Status NodeStatus
+
+	// Input is the value most recently handed to the node's Run
+	// method. It is set when the node is scheduled.
+	Input any
+
+	// TriggeredBy is the name of the upstream node that produced
+	// the current Input. Empty for the initial START activation.
+	TriggeredBy string
+}
+
+// RunState is the per-invocation lifecycle state for a workflow
+// run. It is intended to be embedded in (or referenced from) the
+// agent's session-persisted state so HITL pauses and crash
+// recovery can pick up where a previous invocation left off.
+type RunState struct {
+	// Nodes is the per-node lifecycle map. Absent entries are
+	// inactive.
+	Nodes map[string]*NodeState
+}
+
+// NewRunState returns an empty state with the Nodes map
+// initialised so callers can write to it without a nil check.
+func NewRunState() *RunState {
+	return &RunState{Nodes: map[string]*NodeState{}}
+}
+
+// EnsureNode returns the NodeState for the given node name,
+// creating an inactive entry if none exists. The returned pointer
+// is owned by the state and may be mutated in place.
+func (s *RunState) EnsureNode(name string) *NodeState {
+	if s.Nodes == nil {
+		s.Nodes = map[string]*NodeState{}
+	}
+	ns, ok := s.Nodes[name]
+	if !ok {
+		ns = &NodeState{Status: NodeInactive}
+		s.Nodes[name] = ns
+	}
+	return ns
+}

--- a/workflow/state_test.go
+++ b/workflow/state_test.go
@@ -1,0 +1,56 @@
+// Copyright 2026 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package workflow
+
+import (
+	"testing"
+)
+
+func TestRunState_EnsureNode(t *testing.T) {
+	t.Run("creates inactive node when absent", func(t *testing.T) {
+		s := NewRunState()
+		ns := s.EnsureNode("A")
+		if ns.Status != NodeInactive {
+			t.Errorf("new node Status = %v, want NodeInactive", ns.Status)
+		}
+		if s.Nodes["A"] != ns {
+			t.Error("EnsureNode should return the same pointer stored in Nodes map")
+		}
+	})
+
+	t.Run("returns existing node without resetting it", func(t *testing.T) {
+		s := NewRunState()
+		first := s.EnsureNode("A")
+		first.Status = NodeRunning
+		first.Input = "in"
+		first.TriggeredBy = "X"
+
+		second := s.EnsureNode("A")
+		if first != second {
+			t.Error("EnsureNode should return the same pointer on repeat call")
+		}
+		if second.Status != NodeRunning || second.Input != "in" || second.TriggeredBy != "X" {
+			t.Errorf("EnsureNode should not reset existing node, got %+v", *second)
+		}
+	})
+
+	t.Run("allocates Nodes map on demand", func(t *testing.T) {
+		s := &RunState{} // Nodes nil
+		s.EnsureNode("A")
+		if s.Nodes == nil {
+			t.Error("EnsureNode should allocate Nodes map")
+		}
+	})
+}

--- a/workflow/tool_node.go
+++ b/workflow/tool_node.go
@@ -31,7 +31,7 @@ import (
 
 // toolNode wraps a tool from the tool package.
 type toolNode struct {
-	baseNode
+	BaseNode
 	tool         tool.Tool
 	inputSchema  *jsonschema.Resolved
 	outputSchema *jsonschema.Resolved
@@ -67,7 +67,7 @@ func newToolNodeWithSchemasTyped[Input, Output any](t tool.Tool, inputSchema, ou
 	}
 
 	return &toolNode{
-		baseNode:     baseNode{name: t.Name(), description: t.Description(), config: cfg},
+		BaseNode:     NewBaseNode(t.Name(), t.Description(), cfg),
 		tool:         t,
 		inputSchema:  ischema,
 		outputSchema: oschema,

--- a/workflow/tool_node_test.go
+++ b/workflow/tool_node_test.go
@@ -219,7 +219,7 @@ func TestToolNode_Run(t *testing.T) {
 				t.Fatalf("node creation failed: %v", err)
 			}
 
-			mockCtx := &MockInvocationContext{sess: nil}
+			mockCtx := newMockCtx(t)
 			events := node.Run(mockCtx, tc.nodeInput)
 
 			var got string
@@ -309,7 +309,7 @@ func TestToolNode_WorkflowIntegration(t *testing.T) {
 				return in.Result + 1, nil
 			}, defaultNodeConfig)
 
-			mockCtx := &MockInvocationContext{sess: nil}
+			mockCtx := newMockCtx(t)
 
 			t.Run("WorkflowExecution", func(t *testing.T) {
 				// Use a seed node to pass the struct input to toolNode,
@@ -319,10 +319,7 @@ func TestToolNode_WorkflowIntegration(t *testing.T) {
 				}, defaultNodeConfig)
 
 				edges := Chain(Start, seedNode, toolNode, functionNode)
-				w, err := New(edges)
-				if err != nil {
-					t.Fatalf("unexpexted error: %v", err)
-				}
+				w := mustNew(t, edges)
 				events := w.Run(mockCtx)
 
 				var outB any

--- a/workflow/workflow.go
+++ b/workflow/workflow.go
@@ -27,11 +27,15 @@ import (
 )
 
 // Node is the interface for all nodes in a workflow.
+//
+// Custom nodes typically embed BaseNode (constructed via NewBaseNode)
+// to inherit Name, Description, and Config implementations, and
+// supply only Run.
 type Node interface {
 	Name() string
 	Description() string
-	Run(ctx agent.InvocationContext, input any) iter.Seq2[*session.Event, error]
 	Config() NodeConfig
+	Run(ctx agent.InvocationContext, input any) iter.Seq2[*session.Event, error]
 }
 
 // Route defines the interface for matching execution results to edges.
@@ -90,25 +94,21 @@ func (r *defaultRoute) Matches(event *session.Event) bool {
 	return false
 }
 
-// baseNode provides common fields for all nodes.
-type baseNode struct {
-	name        string
-	description string
-	config      NodeConfig
-}
-
-func (b *baseNode) Name() string        { return b.name }
-func (b *baseNode) Description() string { return b.description }
-func (b *baseNode) Config() NodeConfig  { return b.config }
-
 // FunctionNode wraps a custom function.
 type FunctionNode struct {
-	baseNode
+	BaseNode
 	fn func(ctx agent.InvocationContext, input any) (any, error)
 }
 
-// NewFunctionNode creates a new node wrapping a custom function using generics to automatically infer input and output types.
-func NewFunctionNode[IN, OUT any](name string, fn func(ctx agent.InvocationContext, input IN) (OUT, error), cfg NodeConfig) *FunctionNode {
+// NewFunctionNode creates a new node wrapping a custom function. The
+// IN and OUT type parameters are inferred from the function signature
+// by the compiler. The cfg argument carries per-node knobs (retry,
+// timeout, fan-in barrier); pass NodeConfig{} for defaults.
+func NewFunctionNode[IN any, OUT any](
+	name string,
+	fn func(ctx agent.InvocationContext, input IN) (OUT, error),
+	cfg NodeConfig,
+) *FunctionNode {
 	wrappedFn := func(ctx agent.InvocationContext, input any) (any, error) {
 		if input == nil {
 			var zero IN
@@ -128,7 +128,7 @@ func NewFunctionNode[IN, OUT any](name string, fn func(ctx agent.InvocationConte
 	}
 
 	return &FunctionNode{
-		baseNode: baseNode{name: name, config: cfg},
+		BaseNode: NewBaseNode(name, "", cfg),
 		fn:       wrappedFn,
 	}
 }
@@ -166,14 +166,14 @@ type startNode struct{}
 
 func (s *startNode) Name() string        { return "START" }
 func (s *startNode) Description() string { return "Start node" }
+func (s *startNode) Config() NodeConfig  { return NodeConfig{} }
 func (s *startNode) Run(ctx agent.InvocationContext, input any) iter.Seq2[*session.Event, error] {
 	return func(yield func(*session.Event, error) bool) {}
 }
-func (s *startNode) Config() NodeConfig { return NodeConfig{} }
 
 // Workflow manages the workflow graph execution.
 type Workflow struct {
-	edges map[Node][]Edge
+	graph *graph
 }
 
 // New creates a new Workflow engine with the given edges.
@@ -181,119 +181,51 @@ func New(edges []Edge) (*Workflow, error) {
 	if err := validateNodes(edges); err != nil {
 		return nil, err
 	}
-	adj := make(map[Node][]Edge)
-	for _, edge := range edges {
-		adj[edge.From] = append(adj[edge.From], edge)
-	}
-	return &Workflow{edges: adj}, nil
+	return &Workflow{graph: newGraph(edges)}, nil
 }
 
-type nodeInput struct {
-	node  Node
-	input any
-}
-
-// findNextNodes determines the set of nodes to execute next based on the outgoing edges of the currentNode.
-// It evaluates routes attached to edges against the provided session.Event.
+// Run drives the workflow to completion (or to a graceful pause in
+// later milestones). It returns an iter.Seq2 that yields events
+// from per-node goroutines in arrival order; the caller may break
+// from the range loop at any point and the engine will cancel all
+// in-flight nodes before returning.
 //
-// Behavior:
-//   - Edges with no route condition always match.
-//   - Edges with a route condition match only if the route matches the event.
-//   - Duplicate target nodes are excluded to avoid queuing the same node multiple times.
-//   - If there are outgoing edges but none of them match (neither by route nor by being unrouted),
-//     it falls back to the default route (TODO: hanorik - add default route support).
-func (w *Workflow) findNextNodes(currentNode Node, input any, event *session.Event) []nodeInput {
-	if len(w.edges[currentNode]) == 0 {
-		return nil
-	}
-	matched := false
-	queue := []nodeInput{}
-	added := make(map[Node]struct{})
-	var defaultRouteNode Node
-	for _, edge := range w.edges[currentNode] {
-		if _, ok := added[edge.To]; ok {
-			continue
-		}
-		if edge.Route == nil {
-			queue = append(queue, nodeInput{node: edge.To, input: input})
-			added[edge.To] = struct{}{}
-			continue
-		}
-		if edge.Route == Default {
-			defaultRouteNode = edge.To
-			continue
-		}
-		if edge.Route.Matches(event) {
-			queue = append(queue, nodeInput{node: edge.To, input: input})
-			added[edge.To] = struct{}{}
-			matched = true
-		}
-	}
-	if !matched && defaultRouteNode != nil {
-		queue = append(queue, nodeInput{node: defaultRouteNode, input: input})
-	}
-
-	return queue
-}
-
-// Run executes the workflow.
+// The engine model: each scheduled node runs in its own goroutine
+// pushing events into a buffered channel. A single consumer
+// goroutine (this one) drains the channel, applies state-side
+// effects, yields events to the caller, and schedules successors
+// when nodes complete. The consumer is the only mutator of the
+// per-node lifecycle map and of session state.
 func (w *Workflow) Run(ctx agent.InvocationContext) iter.Seq2[*session.Event, error] {
 	return func(yield func(*session.Event, error) bool) {
-		var input any
-		userContent := ctx.UserContent()
-		if userContent != nil {
-			var sb strings.Builder
-			for _, part := range userContent.Parts {
-				if part.Text != "" {
-					sb.WriteString(part.Text)
-				}
-			}
-			input = sb.String()
-		}
+		input := userInput(ctx)
 
-		queue := []nodeInput{{Start, input}}
+		s := newScheduler(ctx, w.graph)
+		// Seed: schedule START with the user-supplied input.
+		startState := s.state.EnsureNode(Start.Name())
+		startState.Input = input
+		s.scheduleNode(Start, input, "")
 
-		for len(queue) > 0 {
-			currentNode := queue[0].node
-			input = queue[0].input
-			queue = queue[1:]
+		s.run(yield)
 
-			var eventsWithRoutes []*session.Event
-			var outputData any
-			for ev, err := range currentNode.Run(ctx, input) {
-				if err != nil {
-					yield(nil, err)
-					return
-				}
-				if !yield(ev, nil) {
-					return
-				}
+		// All goroutines have returned; ensure no leak.
+		s.wg.Wait()
+	}
+}
 
-				if ev.Routes != nil {
-					eventsWithRoutes = append(eventsWithRoutes, ev)
-				}
-
-				// Extract output for next node
-				if ev.Actions.StateDelta != nil {
-					if out, ok := ev.Actions.StateDelta["output"]; ok {
-						outputData = out
-					}
-				}
-			}
-
-			if len(eventsWithRoutes) > 1 {
-				yield(nil, fmt.Errorf("node %s produced multiple events with route tags. Only one event per execution can specify routes", currentNode.Name()))
-				return
-			}
-			var event *session.Event
-			if len(eventsWithRoutes) == 1 {
-				event = eventsWithRoutes[0]
-			}
-			if currentNode != Start {
-				input = outputData
-			}
-			nextNodes := w.findNextNodes(currentNode, input, event)
-			queue = append(queue, nextNodes...)
+// userInput extracts the workflow's seed input from the
+// InvocationContext's UserContent. Concatenates all text parts;
+// returns nil for an empty UserContent.
+func userInput(ctx agent.InvocationContext) any {
+	uc := ctx.UserContent()
+	if uc == nil {
+		return nil
+	}
+	var sb strings.Builder
+	for _, part := range uc.Parts {
+		if part.Text != "" {
+			sb.WriteString(part.Text)
 		}
 	}
+	return sb.String()
 }

--- a/workflow/workflow_test.go
+++ b/workflow/workflow_test.go
@@ -19,6 +19,7 @@ import (
 	"fmt"
 	"iter"
 	"strings"
+	"sync"
 	"testing"
 
 	"google.golang.org/genai"
@@ -27,27 +28,64 @@ import (
 	"google.golang.org/adk/session"
 )
 
+// defaultNodeConfig is the explicit "use defaults" NodeConfig used
+// across this package's tests where no per-node knobs are exercised.
 var defaultNodeConfig = NodeConfig{}
 
-// MockInvocationContext is a minimal implementation of agent.InvocationContext for testing.
+// MockInvocationContext is a minimal implementation of
+// agent.InvocationContext for testing. It embeds a real
+// context.Context so child cancellation works.
 type MockInvocationContext struct {
-	agent.InvocationContext
+	context.Context
 	sess        session.Session
 	userContent *genai.Content
+}
+
+// newMockCtx returns a fresh MockInvocationContext backed by
+// t.Context(), which is automatically cancelled when the test ends
+// — preventing leaked scheduler goroutines from outliving the test.
+func newMockCtx(t *testing.T) *MockInvocationContext {
+	t.Helper()
+	return &MockInvocationContext{Context: t.Context()}
+}
+
+// newSeededMockCtx returns a mockCtx pre-loaded with a "seed" user
+// content part — the standard fixture for scheduler tests that need
+// an initial input flowing into Start.
+func newSeededMockCtx(t *testing.T) *MockInvocationContext {
+	t.Helper()
+	ctx := newMockCtx(t)
+	ctx.userContent = &genai.Content{Parts: []*genai.Part{{Text: "seed"}}}
+	return ctx
+}
+
+// mustNew builds a workflow from edges and fails the test if
+// construction errors. The returned workflow is ready to Run.
+func mustNew(t *testing.T, edges []Edge) *Workflow {
+	t.Helper()
+	w, err := New(edges)
+	if err != nil {
+		t.Fatalf("New: %v", err)
+	}
+	return w
 }
 
 func (m *MockInvocationContext) Session() session.Session    { return m.sess }
 func (m *MockInvocationContext) InvocationID() string        { return "test-invocation-id" }
 func (m *MockInvocationContext) UserContent() *genai.Content { return m.userContent }
+func (m *MockInvocationContext) TriggeredBy() string         { return "" }
+func (m *MockInvocationContext) Agent() agent.Agent          { return nil }
 func (m *MockInvocationContext) Artifacts() agent.Artifacts  { return nil }
 func (m *MockInvocationContext) Memory() agent.Memory        { return nil }
-func (m *MockInvocationContext) Agent() agent.Agent          { return nil }
 func (m *MockInvocationContext) Branch() string              { return "" }
 func (m *MockInvocationContext) RunConfig() *agent.RunConfig { return nil }
-func (m *MockInvocationContext) EndInvocation()              {}
 func (m *MockInvocationContext) Ended() bool                 { return false }
+func (m *MockInvocationContext) EndInvocation()              {}
+
 func (m *MockInvocationContext) WithContext(ctx context.Context) agent.InvocationContext {
-	return m
+	cp := *m
+	cp.Context = ctx
+	return &cp
 }
 
 func TestFunctionNode(t *testing.T) {
@@ -58,7 +96,7 @@ func TestFunctionNode(t *testing.T) {
 	node := NewFunctionNode("upper", upperFn, defaultNodeConfig)
 
 	// Create a mock context
-	mockCtx := &MockInvocationContext{sess: nil}
+	mockCtx := newMockCtx(t)
 
 	// Run the node
 	events := node.Run(mockCtx, "hello")
@@ -102,16 +140,11 @@ func TestSequentialWorkflow(t *testing.T) {
 
 	edges := Chain(Start, nodeA, nodeB)
 
-	w, err := New(edges)
-	if err != nil {
-		t.Fatalf("unexpected error: %v", err)
-	}
+	w := mustNew(t, edges)
 
-	mockCtx := &MockInvocationContext{
-		sess: nil,
-		userContent: &genai.Content{
-			Parts: []*genai.Part{{Text: "hello"}},
-		},
+	mockCtx := newMockCtx(t)
+	mockCtx.userContent = &genai.Content{
+		Parts: []*genai.Part{{Text: "hello"}},
 	}
 
 	events := w.Run(mockCtx)
@@ -210,7 +243,7 @@ func TestMultiRouteInt(t *testing.T) {
 }
 
 type CustomRouteNode struct {
-	baseNode
+	BaseNode
 	route []string
 	onRun func()
 }
@@ -227,8 +260,17 @@ func (n *CustomRouteNode) Run(ctx agent.InvocationContext, input any) iter.Seq2[
 }
 
 func TestWorkflowRouting(t *testing.T) {
+	// testTracker collects the names of nodes that ran. The
+	// scheduler runs sibling nodes concurrently, so appends must be
+	// serialised.
 	type testTracker struct {
+		mu       sync.Mutex
 		executed []string
+	}
+	record := func(tracker *testTracker, name string) {
+		tracker.mu.Lock()
+		tracker.executed = append(tracker.executed, name)
+		tracker.mu.Unlock()
 	}
 
 	type testCase struct {
@@ -241,25 +283,25 @@ func TestWorkflowRouting(t *testing.T) {
 	createNodes := func() (*CustomRouteNode, *FunctionNode, *FunctionNode, *CustomRouteNode, *FunctionNode, *testTracker) {
 		tracker := &testTracker{}
 		nodeX := &CustomRouteNode{
-			baseNode: baseNode{name: "X"},
+			BaseNode: NewBaseNode("X", "", defaultNodeConfig),
 		}
 		nodeA := NewFunctionNode("A", func(ctx agent.InvocationContext, input any) (string, error) {
-			tracker.executed = append(tracker.executed, "A")
+			record(tracker, "A")
 			return "pathA", nil
 		}, defaultNodeConfig)
 		nodeB := NewFunctionNode("B", func(ctx agent.InvocationContext, input any) (string, error) {
-			tracker.executed = append(tracker.executed, "B")
+			record(tracker, "B")
 			return "pathB", nil
 		}, defaultNodeConfig)
 		nodeC := &CustomRouteNode{
-			baseNode: baseNode{name: "C"},
+			BaseNode: NewBaseNode("C", "", defaultNodeConfig),
 			route:    []string{"branchD"},
 			onRun: func() {
-				tracker.executed = append(tracker.executed, "C")
+				record(tracker, "C")
 			},
 		}
 		nodeD := NewFunctionNode("D", func(ctx agent.InvocationContext, input any) (string, error) {
-			tracker.executed = append(tracker.executed, "D")
+			record(tracker, "D")
 			return "pathD", nil
 		}, defaultNodeConfig)
 		return nodeX, nodeA, nodeB, nodeC, nodeD, tracker
@@ -406,13 +448,10 @@ func TestWorkflowRouting(t *testing.T) {
 			start.route = tc.startRoutes
 			edges := tc.edges(start, a, b, c, d)
 
-			w, err := New(edges)
-			if err != nil {
-				t.Fatalf("unexpected error: %v", err)
-			}
+			w := mustNew(t, edges)
+			mockCtx := newMockCtx(t)
 
-			mockCtx := &MockInvocationContext{sess: nil}
-
+			var err error
 			for _, testErr := range w.Run(mockCtx) {
 				if testErr != nil {
 					err = testErr


### PR DESCRIPTION
## Link to Issue or Description of Change

**1. Link to an existing issue (if applicable):**

- ADK 2.O Workflow Agents: https://adk.dev/2.0/

**2. Or, if no issue exists, describe the change:**

**Problem:**
The legacy in-process BFS dispatcher in `Workflow.Run` cannot run sibling nodes
concurrently, lacks per-node timeouts and cancellation, and provides no place
to hang HITL pauses, retries, or dynamic children — all of which are upcoming
workflow milestones.

**Solution:**
Replace the BFS with a goroutine-per-node scheduler. Each scheduled node runs
in its own goroutine, pushes events into a buffered channel, and a single
consumer goroutine drains the channel, applies state-side effects, yields
events to the caller, and schedules successors when nodes complete.

Sibling cancellation on first error, per-node `Config().Timeout`, and
caller-break draining (`break` outside the range loop stops further
scheduling, not just yielding) are included. Producer-consumer model means no
mutexes are needed for scheduler state; race detector is clean.

### Testing Plan

**Unit Tests:**

- [X] I have added or updated unit tests for my change.
- [X] All unit tests pass locally.

`workflow/scheduler_test.go` covers linear chains, fan-out concurrency
(barrier-based, verifies parallelism), sibling cancellation on first error,
caller-break stops scheduling (regression), per-node timeout, and the
single-output / single-routing-event accumulator contract.

```
go test -race ./workflow/...               # ok 1.24s
go test ./...                              # all packages pass
go vet ./...                               # clean
go build ./...                             # clean
```

**Manual End-to-End (E2E) Tests:**

- [X] `examples/workflow/basic` runs end-to-end on the new engine.

### Checklist

- [X] I have read the [CONTRIBUTING.md](./CONTRIBUTING.md) document.
- [X] I have performed a self-review of my own code.
- [X] I have commented my code, particularly in hard-to-understand areas.
- [X] I have added tests that prove my feature works.
- [X] New and existing unit tests pass locally with my changes.
- [X] I have manually tested my changes end-to-end.
- [X] Any dependent changes have been merged and published in downstream modules.

