### PR TITLE
feat: add start node validation

### DIFF
--- a/workflow/edgebuilder_test.go
+++ b/workflow/edgebuilder_test.go
@@ -120,6 +120,7 @@ type dummyNode struct {
 
 func (n *dummyNode) Name() string        { return n.name }
 func (n *dummyNode) Description() string { return "" }
+func (n *dummyNode) Config() NodeConfig     { return NodeConfig{} }
 func (n *dummyNode) Run(ctx agent.InvocationContext, input any) iter.Seq2[*session.Event, error] {
 	return func(yield func(*session.Event, error) bool) {}
 }

--- a/workflow/validation.go
+++ b/workflow/validation.go
@@ -23,6 +23,26 @@ import (
 // distinct Node instances that share the same Name.
 var ErrDuplicateNodeName = errors.New("duplicate node name")
 
+// ErrNoStartNode is returned when no start node is found in the edge set.
+var ErrNoStartNode = errors.New("no start node found")
+
+// ErrNodePointsToStart is returned when a node points to the start node.
+var ErrNodePointsToStart = errors.New("node points to start node")
+
+// validateNodes executes a set of edges validation checks.
+func validateNodes(edges []Edge) error {
+	if err := validateUniqueNames(edges); err != nil {
+		return err
+	}
+	if err := validateStartNodePresent(edges); err != nil {
+		return err
+	}
+	if err := validateStartNodeNoIncoming(edges); err != nil {
+		return err
+	}
+	return nil
+}
+
 // validateUniqueNames checks that all nodes in the edge set have unique names.
 // If duplicate node names are found, it returns an error. The equality between
 // nodes is checked by comparing the nodes directly.
@@ -44,6 +64,26 @@ func validateUniqueNames(edges []Edge) error {
 		}
 		if err := checkNode(edge.To); err != nil {
 			return err
+		}
+	}
+	return nil
+}
+
+// validateStartNodePresent checks that there is at least one edge starting from the start node.
+func validateStartNodePresent(edges []Edge) error {
+	for _, edge := range edges {
+		if edge.From == Start {
+			return nil
+		}
+	}
+	return ErrNoStartNode
+}
+
+// validateStartNodeNoIncoming checks that no node points to the start node.
+func validateStartNodeNoIncoming(edges []Edge) error {
+	for _, edge := range edges {
+		if edge.To == Start {
+			return fmt.Errorf("%w: %s", ErrNodePointsToStart, edge.From.Name())
 		}
 	}
 	return nil

--- a/workflow/validation_test.go
+++ b/workflow/validation_test.go
@@ -64,3 +64,92 @@ func TestUniqueNames(t *testing.T) {
 		})
 	}
 }
+
+func TestStartNodePresent(t *testing.T) {
+	tests := []struct {
+		name           string
+		edges          []Edge
+		expectErrorMsg string
+	}{
+		{
+			name: "with start node",
+			edges: func() []Edge {
+				nodeA := &dummyNode{name: "A"}
+				nodeB := &dummyNode{name: "B"}
+				return []Edge{
+					{From: Start, To: nodeA},
+					{From: nodeA, To: nodeB},
+				}
+			}(),
+		},
+		{
+			name: "no start node",
+			edges: func() []Edge {
+				nodeA := &dummyNode{name: "A"}
+				nodeB := &dummyNode{name: "B"}
+				return []Edge{
+					{From: nodeA, To: nodeB},
+				}
+			}(),
+			expectErrorMsg: "no start node found",
+		},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			err := validateStartNodePresent(tc.edges)
+			if tc.expectErrorMsg != "" {
+				if err == nil {
+					t.Errorf("expected error matching %q, got none", tc.expectErrorMsg)
+				} else if !strings.Contains(err.Error(), tc.expectErrorMsg) {
+					t.Errorf("expected error containing %q, got %v", tc.expectErrorMsg, err)
+				}
+			}
+		})
+	}
+}
+
+func TestStartNodeNoIncomingEdges(t *testing.T) {
+	tests := []struct {
+		name           string
+		edges          []Edge
+		expectErrorMsg string
+	}{
+		{
+			name: "start node with no incoming edges",
+			edges: func() []Edge {
+				nodeA := &dummyNode{name: "A"}
+				nodeB := &dummyNode{name: "B"}
+				return []Edge{
+					{From: Start, To: nodeA},
+					{From: nodeA, To: nodeB},
+				}
+			}(),
+		},
+		{
+			name: "start node has incoming edges",
+			edges: func() []Edge {
+				nodeA := &dummyNode{name: "A"}
+				nodeB := &dummyNode{name: "B"}
+				return []Edge{
+					{From: nodeA, To: Start},
+					{From: Start, To: nodeB},
+				}
+			}(),
+			expectErrorMsg: "node points to start node: A",
+		},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			err := validateStartNodeNoIncoming(tc.edges)
+			if tc.expectErrorMsg != "" {
+				if err == nil {
+					t.Errorf("expected error matching %q, got none", tc.expectErrorMsg)
+				} else if !strings.Contains(err.Error(), tc.expectErrorMsg) {
+					t.Errorf("expected error containing %q, got %v", tc.expectErrorMsg, err)
+				}
+			}
+		})
+	}
+}

--- a/workflow/workflow.go
+++ b/workflow/workflow.go
@@ -178,7 +178,7 @@ type Workflow struct {
 
 // New creates a new Workflow engine with the given edges.
 func New(edges []Edge) (*Workflow, error) {
-	if err := validateUniqueNames(edges); err != nil {
+	if err := validateNodes(edges); err != nil {
 		return nil, err
 	}
 	adj := make(map[Node][]Edge)

--- a/workflow/workflow_test.go
+++ b/workflow/workflow_test.go
@@ -101,7 +101,7 @@ func TestSequentialWorkflow(t *testing.T) {
 	nodeB := NewFunctionNode("suffix", suffixFn, defaultNodeConfig)
 
 	edges := Chain(Start, nodeA, nodeB)
-	
+
 	w, err := New(edges)
 	if err != nil {
 		t.Fatalf("unexpected error: %v", err)
@@ -232,10 +232,10 @@ func TestWorkflowRouting(t *testing.T) {
 	}
 
 	type testCase struct {
-		name           string
-		startRoutes    []string
-		edges          func(nodeStart *CustomRouteNode, nodeA, nodeB *FunctionNode, nodeC *CustomRouteNode, nodeD *FunctionNode) []Edge
-		expectedExec   []string
+		name         string
+		startRoutes  []string
+		edges        func(nodeStart *CustomRouteNode, nodeA, nodeB *FunctionNode, nodeC *CustomRouteNode, nodeD *FunctionNode) []Edge
+		expectedExec []string
 	}
 
 	createNodes := func() (*CustomRouteNode, *FunctionNode, *FunctionNode, *CustomRouteNode, *FunctionNode, *testTracker) {


### PR DESCRIPTION
This PR introduces validation rules to ensure the integrity of the workflow graph's entry point.

Key Changes:

- `Start` Node Requirement: Validates that the workflow graph contains a `Start` node as an origin for at least one edge, ensuring the workflow can begin execution and that no edges in the graph point back to the `Start` node.
- New Error Types: Introduced `ErrNoStartNode` and `ErrNodePointsToStart` in to represent these failure cases.

Tests: Added corresponding unit tests to verify these conditions.