### PR TITLE
feat: implement workflow validation to reject duplicate edges and remove redundant edge filtering logic

### DIFF
--- a/workflow/edgebuilder_test.go
+++ b/workflow/edgebuilder_test.go
@@ -120,6 +120,7 @@ type dummyNode struct {
 
 func (n *dummyNode) Name() string        { return n.name }
 func (n *dummyNode) Description() string { return "" }
+func (n *dummyNode) Config() NodeConfig  { return NodeConfig{} }
 func (n *dummyNode) Run(ctx agent.InvocationContext, input any) iter.Seq2[*session.Event, error] {
 	return func(yield func(*session.Event, error) bool) {}
 }

--- a/workflow/validation.go
+++ b/workflow/validation.go
@@ -23,6 +23,11 @@ import (
 // distinct Node instances that share the same Name.
 var ErrDuplicateNodeName = errors.New("duplicate node name")
 
+// ErrDuplicateEdge is returned when an edge set contains two identical edges.
+// Two edges with the same (From, To) are rejected regardless of Route; use
+// MultiRoute to express alternatives to the same target.
+var ErrDuplicateEdge = errors.New("duplicate edge")
+
 // validateUniqueNames checks that all nodes in the edge set have unique names.
 // If duplicate node names are found, it returns an error. The equality between
 // nodes is checked by comparing the nodes directly.
@@ -44,6 +49,30 @@ func validateUniqueNames(edges []Edge) error {
 		}
 		if err := checkNode(edge.To); err != nil {
 			return err
+		}
+	}
+	return nil
+}
+
+// validateWorkflow executes a set of workflow validation checks.
+func validateWorkflow(workflow *Workflow) error {
+	if err := validateUniqueEdges(workflow); err != nil {
+		return err
+	}
+	return nil
+}
+
+// validateUniqueEdges checks that there are no duplicate edges in the workflow.
+// Two edges with the same (From, To) are rejected regardless of Route; use
+// MultiRoute to express alternatives to the same target.
+func validateUniqueEdges(workflow *Workflow) error {
+	for node, edges := range workflow.edges {
+		uniqueEdges := make(map[Node]struct{})
+		for _, edge := range edges {
+			if _, ok := uniqueEdges[edge.To]; ok {
+				return fmt.Errorf("%w: from %q to %q", ErrDuplicateEdge, node.Name(), edge.To.Name())
+			}
+			uniqueEdges[edge.To] = struct{}{}
 		}
 	}
 	return nil

--- a/workflow/validation_test.go
+++ b/workflow/validation_test.go
@@ -64,3 +64,47 @@ func TestUniqueNames(t *testing.T) {
 		})
 	}
 }
+
+func TestDuplicateEdges(t *testing.T) {
+	nodeA := &dummyNode{name: "A"}
+	nodeB := &dummyNode{name: "B"}
+	tests := []struct {
+		name      string
+		edges     []Edge
+		expectErr bool
+	}{
+		{
+			name:  "no duplicate edges",
+			edges: []Edge{{From: nodeA, To: nodeB}},
+		},
+		{
+			name:      "duplicate edges",
+			edges:     []Edge{{From: nodeA, To: nodeB}, {From: nodeA, To: nodeB}},
+			expectErr: true,
+		},
+		{
+			name:      "duplicate edges with different routes",
+			edges:     []Edge{{From: nodeA, To: nodeB, Route: StringRoute("test1")}, {From: nodeA, To: nodeB, Route: StringRoute("test2")}},
+			expectErr: true,
+		},
+		{
+			name:      "duplicate edges one without route",
+			edges:     []Edge{{From: nodeA, To: nodeB, Route: StringRoute("test1")}, {From: nodeA, To: nodeB}},
+			expectErr: true,
+		},
+		{
+			name:  "empty edges",
+			edges: []Edge{},
+		},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			if err := validateUniqueEdges(&Workflow{edges: map[Node][]Edge{nodeA: tc.edges}}); err != nil && !tc.expectErr {
+				t.Errorf("got an error %v, expected none", err)
+			} else if err == nil && tc.expectErr {
+				t.Errorf("expected an error, got none")
+			}
+		})
+	}
+}

--- a/workflow/workflow.go
+++ b/workflow/workflow.go
@@ -185,7 +185,11 @@ func New(edges []Edge) (*Workflow, error) {
 	for _, edge := range edges {
 		adj[edge.From] = append(adj[edge.From], edge)
 	}
-	return &Workflow{edges: adj}, nil
+	wf := &Workflow{edges: adj}
+	if err := validateWorkflow(wf); err != nil {
+		return nil, err
+	}
+	return wf, nil
 }
 
 type nodeInput struct {
@@ -199,7 +203,6 @@ type nodeInput struct {
 // Behavior:
 //   - Edges with no route condition always match.
 //   - Edges with a route condition match only if the route matches the event.
-//   - Duplicate target nodes are excluded to avoid queuing the same node multiple times.
 //   - If there are outgoing edges but none of them match (neither by route nor by being unrouted),
 //     it falls back to the default route (TODO: hanorik - add default route support).
 func (w *Workflow) findNextNodes(currentNode Node, input any, event *session.Event) []nodeInput {
@@ -208,15 +211,10 @@ func (w *Workflow) findNextNodes(currentNode Node, input any, event *session.Eve
 	}
 	matched := false
 	queue := []nodeInput{}
-	added := make(map[Node]struct{})
 	var defaultRouteNode Node
 	for _, edge := range w.edges[currentNode] {
-		if _, ok := added[edge.To]; ok {
-			continue
-		}
 		if edge.Route == nil {
 			queue = append(queue, nodeInput{node: edge.To, input: input})
-			added[edge.To] = struct{}{}
 			continue
 		}
 		if edge.Route == Default {
@@ -225,7 +223,6 @@ func (w *Workflow) findNextNodes(currentNode Node, input any, event *session.Eve
 		}
 		if edge.Route.Matches(event) {
 			queue = append(queue, nodeInput{node: edge.To, input: input})
-			added[edge.To] = struct{}{}
 			matched = true
 		}
 	}

--- a/workflow/workflow_test.go
+++ b/workflow/workflow_test.go
@@ -232,10 +232,10 @@ func TestWorkflowRouting(t *testing.T) {
 	}
 
 	type testCase struct {
-		name           string
-		startRoutes    []string
-		edges          func(nodeStart *CustomRouteNode, nodeA, nodeB *FunctionNode, nodeC *CustomRouteNode, nodeD *FunctionNode) []Edge
-		expectedExec   []string
+		name         string
+		startRoutes  []string
+		edges        func(nodeStart *CustomRouteNode, nodeA, nodeB *FunctionNode, nodeC *CustomRouteNode, nodeD *FunctionNode) []Edge
+		expectedExec []string
 	}
 
 	createNodes := func() (*CustomRouteNode, *FunctionNode, *FunctionNode, *CustomRouteNode, *FunctionNode, *testTracker) {
@@ -384,19 +384,15 @@ func TestWorkflowRouting(t *testing.T) {
 			expectedExec: nil,
 		},
 		{
-			name:        "duplicate edges to same node",
-			startRoutes: []string{"branchA"},
+			name:        "MultiRoute with multiple matching routes",
+			startRoutes: []string{"branchA", "branchB"},
 			edges: func(x *CustomRouteNode, a, b *FunctionNode, c *CustomRouteNode, d *FunctionNode) []Edge {
 				return []Edge{
 					{From: Start, To: x},
-					{From: x, To: a},
-					{From: x, To: a, Route: StringRoute("branchA")},
-					{From: x, To: b},
-					{From: x, To: c},
-					{From: c, To: d},
+					{From: x, To: a, Route: MultiRoute[string]{"branchA", "branchB"}},
 				}
 			},
-			expectedExec: []string{"A", "B", "C", "D"},
+			expectedExec: []string{"A"},
 		},
 	}
 


### PR DESCRIPTION
This PR introduces validation to ensure that a workflow graph does not contain duplicate edges (multiple edges from the same source to the exact same destination). Enforcing this constraint at workflow creation time allows us to simplify the traversal logic during execution.

Key Changes:
- `validation.go`:
  - Added `validateUniqueEdges` to check for duplicate edges.
  - Added `validateWorkflow` as a centralized entry point for workflow validation.
  - Introduced `ErrDuplicateEdge`.
- `workflow.go`:
  - Updated `New` to run the validation checks and fail if they do not pass.
  - Removed the added map from `findNextNodes` which was previously used to filter out duplicate target nodes during traversal.
- `validation_test.go`: Added unit tests to verify that duplicate edges are correctly detected.
- `workflow_test.go`: Removed a test case in `TestWorkflowRouting` that relied on duplicate edges, as this configuration is now invalid.