### PR TITLE
feat: Add CSAT survey workflow for ADK Go

### DIFF
--- a/.github/scripts/constant.js
+++ b/.github/scripts/constant.js
@@ -1,0 +1,44 @@
+/*
+Copyright 2026 Google LLC. All Rights Reserved.
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+     http://www.apache.org/licenses/LICENSE-2.0
+
+ Unless required by applicable law or agreed to in writing, software
+ distributed under the License is distributed on an "AS IS" BASIS,
+ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ See the License for the specific language governing permissions and
+ limitations under the License.
+*/
+let CONSTANT_VALUES = {
+  GLOBALS: {
+    LABELS: {
+      BUG: 'bug',
+      DOCUMENTATION: 'documentation',
+      GOOD_FIRST_ISSUE: 'good first issue',
+      ENHANCEMENT: 'enhancement',
+      QUESTION: 'question',
+      GO: 'go',
+      API: 'api',
+      BREAKING_CHANGE: 'breaking change',
+      DEPENDENCIES: 'dependencies',
+      DUPLICATE: 'duplicate',
+      V1_0_TRIAGE: 'v1.0 - triage'
+    },
+    STATE: { CLOSED: 'closed' },
+  },
+  MODULE: {
+    CSAT: {
+      YES: 'Yes',
+      NO: 'No',
+      BASE_URL: 'https://docs.google.com/forms/d/e/1FAIpQLSfxqjtTIt1zOslbLI1OCtMMRElYe69e2oBdLjy6N47NpKiIZA/viewform?usp=pp_url&',
+      SATISFACTION_PARAM: 'entry.1036457101=',
+      ISSUEID_PARAM: '&entry.375200511=',
+      MSG: 'Are you satisfied with the resolution of your issue?',
+    }
+  }
+
+};
+module.exports = CONSTANT_VALUES;

--- a/.github/scripts/csat.js
+++ b/.github/scripts/csat.js
@@ -1,0 +1,57 @@
+/*
+Copyright 2026 Google LLC. All Rights Reserved.
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+     http://www.apache.org/licenses/LICENSE-2.0
+
+ Unless required by applicable law or agreed to in writing, software
+ distributed under the License is distributed on an "AS IS" BASIS,
+ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ See the License for the specific language governing permissions and
+ limitations under the License.
+*/
+const CONSTANT_VALUES = require('./constant');
+
+/**
+ * Invoked from csat_adkgo.yml file to post survey link
+ * in closed issue.
+ * @param {!Object.<string,!Object>} github contains pre defined functions.
+ *  context Information about the workflow run.
+ * @return {null}
+ */
+module.exports = async ({ github, context }) => {
+  const issue = context.payload.issue.html_url;
+  
+  // Check if any label matches (case-insensitive) the supported CSAT labels.
+  const supportedLabels = Object.values(CONSTANT_VALUES.GLOBALS.LABELS);
+  const hasMatchingLabel = context.payload.issue.labels.some(label => {
+    const name = label.name.toLowerCase();
+    return supportedLabels.some(supportedLabel => name.includes(supportedLabel));
+  });
+
+  if (hasMatchingLabel) {
+    console.log(`Posting CSAT survey for issue =${issue}`);
+    const baseUrl = CONSTANT_VALUES.MODULE.CSAT.BASE_URL;
+
+    const yesCsat = `<a href="${baseUrl + CONSTANT_VALUES.MODULE.CSAT.SATISFACTION_PARAM +
+      CONSTANT_VALUES.MODULE.CSAT.YES +
+      CONSTANT_VALUES.MODULE.CSAT.ISSUEID_PARAM + encodeURIComponent(issue)}"> ${CONSTANT_VALUES.MODULE.CSAT.YES}</a>`;
+
+    const noCsat = `<a href="${baseUrl + CONSTANT_VALUES.MODULE.CSAT.SATISFACTION_PARAM +
+      CONSTANT_VALUES.MODULE.CSAT.NO +
+      CONSTANT_VALUES.MODULE.CSAT.ISSUEID_PARAM + encodeURIComponent(issue)}"> ${CONSTANT_VALUES.MODULE.CSAT.NO}</a>`;
+
+    const comment = CONSTANT_VALUES.MODULE.CSAT.MSG + '\n' + yesCsat + '\n' +
+      noCsat + '\n';
+    const issueNumber = context.issue.number ?? context.payload.issue.number;
+
+    await github.rest.issues.createComment({
+      issue_number: issueNumber,
+      owner: context.repo.owner,
+      repo: context.repo.repo,
+      body: comment
+    });
+  }
+};

--- a/.github/scripts/csat.js
+++ b/.github/scripts/csat.js
@@ -23,42 +23,35 @@ const CONSTANT_VALUES = require('./constant');
  */
 module.exports = async ({ github, context }) => {
   const issue = context.payload.issue.html_url;
-  const baseUrl = CONSTANT_VALUES.MODULE.CSAT.BASE_URL;
+  
+  // Check if any label matches (case-insensitive) the supported CSAT labels.
+  const supportedLabels = Object.values(CONSTANT_VALUES.GLOBALS.LABELS);
+  const hasMatchingLabel = context.payload.issue.labels.some(label => {
+    const name = label.name.toLowerCase();
+    return supportedLabels.some(supportedLabel => name.includes(supportedLabel));
+  });
 
-  // Loop over all ths label present in issue and check if specific label is
-  // present for survey link.
-  for (const label of context.payload.issue.labels) {
-    if (label.name.includes(CONSTANT_VALUES.GLOBALS.LABELS.BUG) ||
-      label.name.includes(CONSTANT_VALUES.GLOBALS.LABELS.DOCUMENTATION) ||
-      label.name.includes(CONSTANT_VALUES.GLOBALS.LABELS.GOOD_FIRST_ISSUE) ||
-      label.name.includes(CONSTANT_VALUES.GLOBALS.LABELS.ENHANCEMENT) ||
-      label.name.includes(CONSTANT_VALUES.GLOBALS.LABELS.QUESTION) ||
-      label.name.includes(CONSTANT_VALUES.GLOBALS.LABELS.GO) ||
-      label.name.includes(CONSTANT_VALUES.GLOBALS.LABELS.API) ||
-      label.name.includes(CONSTANT_VALUES.GLOBALS.LABELS.BREAKING_CHANGE) ||
-      label.name.includes(CONSTANT_VALUES.GLOBALS.LABELS.DEPENDENCIES) ||
-      label.name.includes(CONSTANT_VALUES.GLOBALS.LABELS.DUPLICATE) ||
-      label.name.includes(CONSTANT_VALUES.GLOBALS.LABELS.V1_0_TRIAGE)) {
+  if (hasMatchingLabel) {
+    console.log(`Posting CSAT survey for issue =${issue}`);
+    const baseUrl = CONSTANT_VALUES.MODULE.CSAT.BASE_URL;
 
-      console.log(`label-${label.name}, posting CSAT survey for issue =${issue}`);
+    const yesCsat = `<a href="${baseUrl + CONSTANT_VALUES.MODULE.CSAT.SATISFACTION_PARAM +
+      CONSTANT_VALUES.MODULE.CSAT.YES +
+      CONSTANT_VALUES.MODULE.CSAT.ISSUEID_PARAM + encodeURIComponent(issue)}"> ${CONSTANT_VALUES.MODULE.CSAT.YES}</a>`;
 
-      const yesCsat = `<a href="${baseUrl + CONSTANT_VALUES.MODULE.CSAT.SATISFACTION_PARAM +
-        CONSTANT_VALUES.MODULE.CSAT.YES +
-        CONSTANT_VALUES.MODULE.CSAT.ISSUEID_PARAM + encodeURIComponent(issue)}"> ${CONSTANT_VALUES.MODULE.CSAT.YES}</a>`;
+    const noCsat = `<a href="${baseUrl + CONSTANT_VALUES.MODULE.CSAT.SATISFACTION_PARAM +
+      CONSTANT_VALUES.MODULE.CSAT.NO +
+      CONSTANT_VALUES.MODULE.CSAT.ISSUEID_PARAM + encodeURIComponent(issue)}"> ${CONSTANT_VALUES.MODULE.CSAT.NO}</a>`;
 
-      const noCsat = `<a href="${baseUrl + CONSTANT_VALUES.MODULE.CSAT.SATISFACTION_PARAM +
-        CONSTANT_VALUES.MODULE.CSAT.NO +
-        CONSTANT_VALUES.MODULE.CSAT.ISSUEID_PARAM + encodeURIComponent(issue)}"> ${CONSTANT_VALUES.MODULE.CSAT.NO}</a>`;
+    const comment = CONSTANT_VALUES.MODULE.CSAT.MSG + '\n' + yesCsat + '\n' +
+      noCsat + '\n';
+    const issueNumber = context.issue.number ?? context.payload.issue.number;
 
-      const comment = CONSTANT_VALUES.MODULE.CSAT.MSG + '\n' + yesCsat + '\n' + noCsat + '\n';
-      let issueNumber = context.issue.number ?? context.payload.issue.number;
-
-      await github.rest.issues.createComment({
-        issue_number: issueNumber,
-        owner: context.repo.owner,
-        repo: context.repo.repo,
-        body: comment
-      });
-    }
+    await github.rest.issues.createComment({
+      issue_number: issueNumber,
+      owner: context.repo.owner,
+      repo: context.repo.repo,
+      body: comment
+    });
   }
 };

--- a/.github/scripts/csat.js
+++ b/.github/scripts/csat.js
@@ -1,0 +1,64 @@
+/*
+Copyright 2026 Google LLC. All Rights Reserved.
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+     http://www.apache.org/licenses/LICENSE-2.0
+
+ Unless required by applicable law or agreed to in writing, software
+ distributed under the License is distributed on an "AS IS" BASIS,
+ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ See the License for the specific language governing permissions and
+ limitations under the License.
+*/
+const CONSTANT_VALUES = require('./constant');
+
+/**
+ * Invoked from csat_adkgo.yml file to post survey link
+ * in closed issue.
+ * @param {!Object.<string,!Object>} github contains pre defined functions.
+ *  context Information about the workflow run.
+ * @return {null}
+ */
+module.exports = async ({ github, context }) => {
+  const issue = context.payload.issue.html_url;
+  const baseUrl = CONSTANT_VALUES.MODULE.CSAT.BASE_URL;
+
+  // Loop over all ths label present in issue and check if specific label is
+  // present for survey link.
+  for (const label of context.payload.issue.labels) {
+    if (label.name.includes(CONSTANT_VALUES.GLOBALS.LABELS.BUG) ||
+      label.name.includes(CONSTANT_VALUES.GLOBALS.LABELS.DOCUMENTATION) ||
+      label.name.includes(CONSTANT_VALUES.GLOBALS.LABELS.GOOD_FIRST_ISSUE) ||
+      label.name.includes(CONSTANT_VALUES.GLOBALS.LABELS.ENHANCEMENT) ||
+      label.name.includes(CONSTANT_VALUES.GLOBALS.LABELS.QUESTION) ||
+      label.name.includes(CONSTANT_VALUES.GLOBALS.LABELS.GO) ||
+      label.name.includes(CONSTANT_VALUES.GLOBALS.LABELS.API) ||
+      label.name.includes(CONSTANT_VALUES.GLOBALS.LABELS.BREAKING_CHANGE) ||
+      label.name.includes(CONSTANT_VALUES.GLOBALS.LABELS.DEPENDENCIES) ||
+      label.name.includes(CONSTANT_VALUES.GLOBALS.LABELS.DUPLICATE) ||
+      label.name.includes(CONSTANT_VALUES.GLOBALS.LABELS.V1_0_TRIAGE)) {
+
+      console.log(`label-${label.name}, posting CSAT survey for issue =${issue}`);
+
+      const yesCsat = `<a href="${baseUrl + CONSTANT_VALUES.MODULE.CSAT.SATISFACTION_PARAM +
+        CONSTANT_VALUES.MODULE.CSAT.YES +
+        CONSTANT_VALUES.MODULE.CSAT.ISSUEID_PARAM + encodeURIComponent(issue)}"> ${CONSTANT_VALUES.MODULE.CSAT.YES}</a>`;
+
+      const noCsat = `<a href="${baseUrl + CONSTANT_VALUES.MODULE.CSAT.SATISFACTION_PARAM +
+        CONSTANT_VALUES.MODULE.CSAT.NO +
+        CONSTANT_VALUES.MODULE.CSAT.ISSUEID_PARAM + encodeURIComponent(issue)}"> ${CONSTANT_VALUES.MODULE.CSAT.NO}</a>`;
+
+      const comment = CONSTANT_VALUES.MODULE.CSAT.MSG + '\n' + yesCsat + '\n' + noCsat + '\n';
+      let issueNumber = context.issue.number ?? context.payload.issue.number;
+
+      await github.rest.issues.createComment({
+        issue_number: issueNumber,
+        owner: context.repo.owner,
+        repo: context.repo.repo,
+        body: comment
+      });
+    }
+  }
+};

--- a/.github/workflows/csat.yml
+++ b/.github/workflows/csat.yml
@@ -7,7 +7,6 @@ on:
 permissions:
   contents: read
   issues: write
-  pull-requests: write
 
 jobs:
   welcome:

--- a/.github/workflows/csat.yml
+++ b/.github/workflows/csat.yml
@@ -1,0 +1,21 @@
+name: 'CSAT survey ADK Go'
+on:
+  issues:
+    types:
+      - closed
+
+permissions:
+  contents: read
+  issues: write
+  pull-requests: write
+
+jobs:
+  welcome:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v3
+      - uses: actions/github-script@v6
+        with:
+          script: |
+            const script = require('./.github/scripts/csat.js')
+            script({github, context})

--- a/.github/workflows/csat.yml
+++ b/.github/workflows/csat.yml
@@ -1,0 +1,22 @@
+name: 'CSAT survey ADK Go'
+on:
+  issues:
+    types:
+      - closed
+
+permissions:
+  contents: read
+  issues: write
+
+jobs:
+  welcome:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@f43a0e5ff2bd294095638e18286ca9a3d1956744 # v3.6.0
+        with:
+          persist-credentials: false
+      - uses: actions/github-script@98814c53be79b1d30f795b907e553d8679345975 # v6.4.0
+        with:
+          script: |
+            const script = require('./.github/scripts/csat.js')
+            script({github, context})


### PR DESCRIPTION
Problem:
The repository currently lacks an automated mechanism to collect user feedback (Customer Satisfaction survey) when issues are resolved and closed.

Solution:
This PR implements a Customer Satisfaction (CSAT) survey workflow for the ADK Go repository. When an issue is closed, a GitHub Actions workflow is triggered to post a comment with a survey link if the issue has specific relevant labels.

Changes:
*   .github/workflows/csat.yml: Workflow definition file that triggers on issues: closed and runs the script.
*   .github/scripts/csat.js: JavaScript script that checks issue labels and posts the CSAT comment with generated links.
*   .github/scripts/constant.js: Constants file containing labels, base URL, and message strings for the survey.

Labels Checked:
The script will post the survey if the closed issue contains any of the following labels:
*   bug
*   documentation
*   good first issue
*   enhancement
*   question
*   go
*   api
*   breaking change
*   dependencies
*   duplicate
*   v1.0 - triage

Testing Plan

Manual End-to-End (E2E) Tests:
1.  Label an issue in the ADK Go repository with one of the supported labels listed above.
2.  Close the issue.
3.  Verify that the GitHub Action triggers and posts the CSAT survey comment with the correct links.

Checklist
- [x] I have read the CONTRIBUTING.md document.
- [x] I have performed a self-review of my own code.
- [x] I have commented my code, particularly in hard-to-understand areas.
- [x] I have manually tested my changes end-to-end.

Additional context
The survey links to a Google Form with pre-filled parameters for the issue URL and satisfaction level (Yes/No).