### PR TITLE
feat: implement default route validation to prevent multiple default routes per node

### DIFF
--- a/workflow/edgebuilder_test.go
+++ b/workflow/edgebuilder_test.go
@@ -120,6 +120,7 @@ type dummyNode struct {
 
 func (n *dummyNode) Name() string        { return n.name }
 func (n *dummyNode) Description() string { return "" }
+func (n *dummyNode) Config() NodeConfig  { return NodeConfig{} }
 func (n *dummyNode) Run(ctx agent.InvocationContext, input any) iter.Seq2[*session.Event, error] {
 	return func(yield func(*session.Event, error) bool) {}
 }

--- a/workflow/validation.go
+++ b/workflow/validation.go
@@ -23,6 +23,9 @@ import (
 // distinct Node instances that share the same Name.
 var ErrDuplicateNodeName = errors.New("duplicate node name")
 
+// ErrMultipleDefaultRoutes is returned when a node has more than one default route.
+var ErrMultipleDefaultRoutes = errors.New("node has more than one default route")
+
 // validateUniqueNames checks that all nodes in the edge set have unique names.
 // If duplicate node names are found, it returns an error. The equality between
 // nodes is checked by comparing the nodes directly.
@@ -44,6 +47,29 @@ func validateUniqueNames(edges []Edge) error {
 		}
 		if err := checkNode(edge.To); err != nil {
 			return err
+		}
+	}
+	return nil
+}
+
+// validateWorkflow executes a set of workflow validation checks.
+func validateWorkflow(workflow *Workflow) error {
+	if err := validateDefaultRoute(workflow); err != nil {
+		return err
+	}
+	return nil
+}
+
+// validateDefaultRoute checks that there are no multiple default routes for one node.
+func validateDefaultRoute(workflow *Workflow) error {
+	for node, edges := range workflow.edges {
+		hasDefault := false
+		for _, edge := range edges {
+			if edge.Route == Default && !hasDefault {
+				hasDefault = true
+			} else if edge.Route == Default && hasDefault {
+				return fmt.Errorf("%w: %q", ErrMultipleDefaultRoutes, node.Name())
+			}
 		}
 	}
 	return nil

--- a/workflow/validation_test.go
+++ b/workflow/validation_test.go
@@ -15,6 +15,7 @@
 package workflow
 
 import (
+	"errors"
 	"strings"
 	"testing"
 )
@@ -60,6 +61,35 @@ func TestUniqueNames(t *testing.T) {
 				}
 			} else if err != nil {
 				t.Errorf("expected no error, got %v", err)
+			}
+		})
+	}
+}
+
+func TestDefaultRoute(t *testing.T) {
+	nodeA := &dummyNode{name: "A"}
+	nodeB := &dummyNode{name: "B"}
+	nodeC := &dummyNode{name: "C"}
+	tests := []struct {
+		name      string
+		edges     []Edge
+		expectErr error
+	}{
+		{
+			name:  "single default route",
+			edges: []Edge{{From: nodeA, To: nodeB, Route: Default}},
+		},
+		{
+			name:      "multiple default routes",
+			edges:     []Edge{{From: nodeA, To: nodeB, Route: Default}, {From: nodeA, To: nodeC, Route: Default}},
+			expectErr: ErrMultipleDefaultRoutes,
+		},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			if err := validateDefaultRoute(&Workflow{edges: map[Node][]Edge{nodeA: tc.edges}}); !errors.Is(err, tc.expectErr) {
+				t.Errorf("got %v, expected %v", err, tc.expectErr)
 			}
 		})
 	}


### PR DESCRIPTION
This PR introduces validation to ensure that a node in a workflow graph does not have more than one default route.

Key Changes:

- Default Route Validation: Added `validateDefaultRoute` in `validation.go` to ensure each node has at most one outgoing edge with `Default` route. It returns a new error `ErrMultipleDefaultRoutes` if a violation is found.
- Unit Tests: Added `TestDefaultRoute` in `validation_test.go` to verify the behavior with both valid and invalid configurations.