### PR TITLE
feat: add WithInvocationID run option

### DIFF
--- a/runner/runner.go
+++ b/runner/runner.go
@@ -65,7 +65,8 @@ type PluginConfig struct {
 type RunOption func(*runOptions)
 
 type runOptions struct {
-	stateDelta map[string]any
+	stateDelta          map[string]any
+	invocationID  string
 }
 
 // WithStateDelta sets a state delta for the run invocation.
@@ -73,6 +74,12 @@ func WithStateDelta(delta map[string]any) RunOption {
 	return func(o *runOptions) {
 		o.stateDelta = delta
 	}
+}
+
+// WithInvocationID sets the invocation ID for the run.
+// When omitted, a new ID is generated automatically.
+func WithInvocationID(id string) RunOption {
+	return func(o *runOptions) { o.invocationID = id }
 }
 
 // New creates a new [Runner].
@@ -196,12 +203,13 @@ func (r *Runner) Run(ctx context.Context, userID, sessionID string, msg *genai.C
 		}
 
 		ctx := icontext.NewInvocationContext(ctx, icontext.InvocationContextParams{
-			Artifacts:   artifacts,
-			Memory:      memoryImpl,
-			Session:     storedSession,
-			Agent:       agentToRun,
-			UserContent: msg,
-			RunConfig:   &cfg,
+			Artifacts:    artifacts,
+			Memory:       memoryImpl,
+			Session:      storedSession,
+			Agent:        agentToRun,
+			UserContent:  msg,
+			RunConfig:    &cfg,
+			InvocationID: options.invocationID,
 		})
 		ctx, err = r.appendMessageToSession(ctx, storedSession, msg, cfg.SaveInputBlobsAsArtifacts, r.pluginManager, options.stateDelta)
 		if err != nil {

--- a/runner/runner_test.go
+++ b/runner/runner_test.go
@@ -447,3 +447,61 @@ func TestRunner_AutoCreateSession(t *testing.T) {
 		})
 	}
 }
+
+func TestWithInvocationID(t *testing.T) {
+	t.Parallel()
+
+	const wantInvocationID = "e-test-invocation-id"
+
+	var gotInvocationID string
+	testAgent := must(agent.New(agent.Config{
+		Name: "test_agent",
+		Run: func(ctx agent.InvocationContext) iter.Seq2[*session.Event, error] {
+			return func(yield func(*session.Event, error) bool) {
+				ev := session.NewEvent(ctx.InvocationID())
+				ev.Author = "test_agent"
+				ev.LLMResponse = model.LLMResponse{
+					Content: &genai.Content{Role: "model", Parts: []*genai.Part{{Text: "hello"}}},
+				}
+				yield(ev, nil)
+			}
+		},
+	}))
+
+	ctx := context.Background()
+	sessionService := session.InMemoryService()
+
+	_, err := sessionService.Create(ctx, &session.CreateRequest{
+		AppName:   "app",
+		UserID:    "user",
+		SessionID: "sess",
+	})
+	if err != nil {
+		t.Fatalf("create session: %v", err)
+	}
+
+	r, err := New(Config{
+		AppName:           "app",
+		Agent:             testAgent,
+		SessionService:    sessionService,
+		AutoCreateSession: false,
+	})
+	if err != nil {
+		t.Fatalf("new runner: %v", err)
+	}
+
+	for ev, err := range r.Run(ctx, "user", "sess", nil, agent.RunConfig{},
+		WithInvocationID(wantInvocationID),
+	) {
+		if err != nil {
+			t.Fatalf("run error: %v", err)
+		}
+		if ev != nil && gotInvocationID == "" {
+			gotInvocationID = ev.InvocationID
+		}
+	}
+
+	if gotInvocationID != wantInvocationID {
+		t.Errorf("invocation ID = %q, want %q", gotInvocationID, wantInvocationID)
+	}
+}


### PR DESCRIPTION
**Problem:**
`InvocationID` was not able to be set from the callers of the ADK. This did not match the adk-python implementation. This has made us not being able to follow the resume functionality within the adk-python guide [here](https://adk.dev/runtime/resume/).

**Solution:**
This adds a RunOption that lets a caller pass an existing invocation ID into
runner.Run. When set, the invocation context uses the supplied ID
instead of generating a fresh one.

### Testing Plan

**Unit Tests:**

- [x] I have added or updated unit tests for my change.
- [x] All unit tests pass locally.

_Please include a summary of passed go test results._

**Manual End-to-End (E2E) Tests:**

I have started and run our adk-go Agent with these fixes, and ensured that there are no regressions in other behaviors.

### Checklist

- [x] I have read the [CONTRIBUTING.md](./CONTRIBUTING.md) document.
- [x] I have performed a self-review of my own code.
- [x] I have commented my code, particularly in hard-to-understand areas.
- [x] I have added tests that prove my fix is effective or that my feature works.
- [x] New and existing unit tests pass locally with my changes.
- [x] I have manually tested my changes end-to-end.
- [x] Any dependent changes have been merged and published in downstream modules.