### PR TITLE
agent: introduce unified Context interface for ADK 2.0

### DIFF
--- a/agent/callback_context.go
+++ b/agent/callback_context.go
@@ -64,12 +64,10 @@ func NewCallbackContextWithDelta(ctx InvocationContext, stateDelta map[string]an
 }
 
 func newCallbackContext(ctx InvocationContext, stateDelta map[string]any, artifactDelta map[string]int64) *callbackContext {
-	rCtx := NewReadonlyContext(ctx)
 	eventActions := &session.EventActions{StateDelta: stateDelta, ArtifactDelta: artifactDelta}
 	return &callbackContext{
-		ReadonlyContext: rCtx,
-		invocationCtx:   ctx,
-		eventActions:    eventActions,
+		InvocationContext: ctx,
+		eventActions:      eventActions,
 		artifacts: &internalArtifacts{
 			Artifacts:    ctx.Artifacts(),
 			eventActions: eventActions,
@@ -78,40 +76,32 @@ func newCallbackContext(ctx InvocationContext, stateDelta map[string]any, artifa
 }
 
 // callbackContext is the canonical implementation of CallbackContext.
-// Construct via NewCallbackContext or NewCallbackContextWithDelta.
+// Embeds the wrapped InvocationContext so all 17 Context methods are
+// promoted; only Artifacts and State are overridden to plug in
+// delta-tracking against the supplied EventActions. Construct via
+// NewCallbackContext or NewCallbackContextWithDelta.
 type callbackContext struct {
-	ReadonlyContext
-	artifacts     *internalArtifacts
-	invocationCtx InvocationContext
-	eventActions  *session.EventActions
+	InvocationContext
+	artifacts    *internalArtifacts
+	eventActions *session.EventActions
 }
 
+// Artifacts overrides InvocationContext.Artifacts to return a wrapper
+// that records Save() into eventActions.ArtifactDelta.
 func (c *callbackContext) Artifacts() Artifacts {
 	return c.artifacts
 }
 
-func (c *callbackContext) AgentName() string {
-	return c.invocationCtx.Agent().Name()
-}
-
-func (c *callbackContext) ReadonlyState() session.ReadonlyState {
-	return c.invocationCtx.Session().State()
-}
-
+// State overrides InvocationContext.State to return a wrapper that
+// records Set() into eventActions.StateDelta.
 func (c *callbackContext) State() session.State {
 	return &callbackContextState{ctx: c}
 }
 
-func (c *callbackContext) InvocationID() string {
-	return c.invocationCtx.InvocationID()
-}
+var _ Context = (*callbackContext)(nil)
 
-func (c *callbackContext) UserContent() *genai.Content {
-	return c.invocationCtx.UserContent()
-}
-
-var _ CallbackContext = (*callbackContext)(nil)
-
+// callbackContextState is a delta-tracking session.State wrapper used
+// by callbackContext.State.
 type callbackContextState struct {
 	ctx *callbackContext
 }
@@ -122,16 +112,16 @@ func (c *callbackContextState) Get(key string) (any, error) {
 			return val, nil
 		}
 	}
-	return c.ctx.invocationCtx.Session().State().Get(key)
+	return c.ctx.InvocationContext.Session().State().Get(key)
 }
 
 func (c *callbackContextState) Set(key string, val any) error {
 	if c.ctx.eventActions != nil && c.ctx.eventActions.StateDelta != nil {
 		c.ctx.eventActions.StateDelta[key] = val
 	}
-	return c.ctx.invocationCtx.Session().State().Set(key, val)
+	return c.ctx.InvocationContext.Session().State().Set(key, val)
 }
 
 func (c *callbackContextState) All() iter.Seq2[string, any] {
-	return c.ctx.invocationCtx.Session().State().All()
+	return c.ctx.InvocationContext.Session().State().All()
 }

--- a/agent/callback_context_test.go
+++ b/agent/callback_context_test.go
@@ -18,14 +18,23 @@ import (
 	"testing"
 )
 
-func TestCallbackContext_IsReadonlyButNotInvocation(t *testing.T) {
+// TestCallbackContext_OutOfToolCallReturnsZero verifies the
+// runtime-check pattern for tool-call-only methods on a CallbackContext
+// (which is now an alias of Context).
+func TestCallbackContext_OutOfToolCallReturnsZero(t *testing.T) {
 	inv := NewInvocationContext(t.Context(), InvocationContextParams{})
 	callback := NewCallbackContext(inv)
 
-	if _, ok := callback.(ReadonlyContext); !ok {
-		t.Errorf("CallbackContext(%+T) is unexpectedly not a ReadonlyContext", callback)
+	if got := callback.FunctionCallID(); got != "" {
+		t.Errorf("FunctionCallID() = %q, want empty (callback is not a tool call)", got)
 	}
-	if got, ok := callback.(InvocationContext); ok {
-		t.Errorf("CallbackContext(%+T) is unexpectedly an InvocationContext", got)
+	if got := callback.Actions(); got != nil {
+		t.Errorf("Actions() = %v, want nil (callback is not a tool call)", got)
+	}
+	if got := callback.ToolConfirmation(); got != nil {
+		t.Errorf("ToolConfirmation() = %v, want nil (callback is not a tool call)", got)
+	}
+	if got := callback.RequestConfirmation("hint", nil); got != ErrOutsideToolCall {
+		t.Errorf("RequestConfirmation() error = %v, want ErrOutsideToolCall", got)
 	}
 }

--- a/agent/context.go
+++ b/agent/context.go
@@ -16,93 +16,30 @@ package agent
 
 import (
 	"context"
+	"errors"
 
 	"google.golang.org/genai"
 
+	"google.golang.org/adk/memory"
 	"google.golang.org/adk/session"
+	"google.golang.org/adk/tool/toolconfirmation"
 )
 
-/*
-InvocationContext represents the context of an agent invocation.
-
-An invocation:
- 1. Starts with a user message and ends with a final response.
- 2. Can contain one or multiple agent calls.
- 3. Is handled by runner.Run().
-
-An invocation runs an agent until it does not request to transfer to another
-agent.
-
-An agent call:
- 1. Is handled by agent.Run().
- 2. Ends when agent.Run() ends.
-
-An agent call can contain one or multiple steps.
-For example, LLM agent runs steps in a loop until:
- 1. A final response is generated.
- 2. The agent transfers to another agent.
- 3. EndInvocation() was called by the invocation context.
-
-A step:
- 1. Calls the LLM only once and yields its response.
- 2. Calls the tools and yields their responses if requested.
-
-The summarization of the function response is considered another step, since
-it is another LLM call.
-A step ends when it's done calling LLM and tools, or if the EndInvocation() was
-called by invocation context at any time.
-
-	┌─────────────────────── invocation ──────────────────────────┐
-	┌──────────── llm_agent_call_1 ────────────┐ ┌─ agent_call_2 ─┐
-	┌──── step_1 ────────┐ ┌───── step_2 ──────┐
-	[call_llm] [call_tool] [call_llm] [transfer]
-*/
-type InvocationContext interface {
-	context.Context
-
-	// Agent of this invocation context.
-	Agent() Agent
-
-	// Artifacts of the current session.
-	Artifacts() Artifacts
-
-	// Memory is scoped to sessions of the current user_id.
-	Memory() Memory
-
-	// Session of the current invocation context.
-	Session() session.Session
-
-	InvocationID() string
-
-	// Branch of the invocation context.
-	// The format is like agent_1.agent_2.agent_3, where agent_1 is the parent
-	// of agent_2, and agent_2 is the parent of agent_3.
-	//
-	// Branch is used when multiple sub-agents shouldn't see their peer agents'
-	// conversation history.
-	//
-	// Applicable to parallel agent because its sub-agents run concurrently.
-	Branch() string
-
-	// UserContent that started this invocation.
-	UserContent() *genai.Content
-
-	// RunConfig stores the runtime configuration used during this invocation.
-	RunConfig() *RunConfig
-
-	// EndInvocation ends the current invocation. This stops any planned agent
-	// calls.
-	EndInvocation()
-	// Ended returns whether the invocation has ended.
-	Ended() bool
-
-	// WithContext returns a new instance of the context with overridden embedded context.
-	// NOTE: This is a temporary solution and will be removed later. The proper solution
-	// we plan is to stop embedding go context in adk context types and split it.
-	WithContext(ctx context.Context) InvocationContext
-}
+// ErrOutsideToolCall is returned by Context.RequestConfirmation (and
+// other tool-call-only mutating operations) when called on a Context
+// that wasn't produced by a tool dispatcher. Callbacks and agent-level
+// code can detect this to know they're not inside a tool call.
+var ErrOutsideToolCall = errors.New("agent: tool-only operation called outside a tool call")
 
 // ReadonlyContext provides read-only access to invocation context data.
+//
+// Used in narrow callsites where mutation must be impossible at compile
+// time (e.g. InstructionProvider, Predicate, Toolset.Tools). For the
+// common case, use Context (which embeds ReadonlyContext and adds the
+// full capability surface).
+//
+// Mirrors adk-python's `class ReadonlyContext` (kept as the parent
+// class of `Context` for the same compile-time read-only purpose).
 type ReadonlyContext interface {
 	context.Context
 
@@ -119,10 +56,102 @@ type ReadonlyContext interface {
 	Branch() string
 }
 
-// CallbackContext is passed to user callbacks during agent execution.
-type CallbackContext interface {
+/*
+Context is the unified user-facing context for ADK 2.0. Every callback,
+tool, and agent code path receives a value implementing this interface.
+The historical context types (InvocationContext, CallbackContext,
+tool.Context) are now type aliases of Context.
+
+Context embeds ReadonlyContext to expose its 8 read-only methods, then
+adds mutating session/state/artifact access, memory, lifecycle control,
+and tool-call-site capabilities. Tool-call-only methods (FunctionCallID,
+Actions, ToolConfirmation, RequestConfirmation) follow a runtime-check
+pattern: when called on a Context not produced by a tool dispatcher,
+pollable accessors return zero values and mutating operations return
+ErrOutsideToolCall.
+
+Mirrors adk-python's `class Context(ReadonlyContext)` model.
+
+An invocation:
+ 1. Starts with a user message and ends with a final response.
+ 2. Can contain one or multiple agent calls.
+ 3. Is handled by runner.Run().
+
+An invocation runs an agent until it does not request to transfer to
+another agent.
+
+An agent call:
+ 1. Is handled by agent.Run().
+ 2. Ends when agent.Run() ends.
+
+An agent call can contain one or multiple steps. For example, an LLM
+agent runs steps in a loop until:
+ 1. A final response is generated.
+ 2. The agent transfers to another agent.
+ 3. EndInvocation() was called by the invocation context.
+
+A step:
+ 1. Calls the LLM only once and yields its response.
+ 2. Calls the tools and yields their responses if requested.
+
+The summarization of the function response is considered another step,
+since it is another LLM call. A step ends when it's done calling the
+LLM and tools, or if EndInvocation() was called by the invocation
+context at any time.
+
+	┌─────────────────────── invocation ──────────────────────────┐
+	┌──────────── llm_agent_call_1 ────────────┐ ┌─ agent_call_2 ─┐
+	┌──── step_1 ────────┐ ┌───── step_2 ──────┐
+	[call_llm] [call_tool] [call_llm] [transfer]
+*/
+type Context interface {
 	ReadonlyContext
 
-	Artifacts() Artifacts
+	// Identity / framework objects.
+	Agent() Agent
+
+	// Session and state (mutable view).
+	Session() session.Session
 	State() session.State
+
+	// Artifacts service (Save records into Actions().ArtifactDelta when
+	// the Context was produced by a callback or tool dispatcher).
+	Artifacts() Artifacts
+
+	// Memory access.
+	Memory() Memory
+	SearchMemory(ctx context.Context, query string) (*memory.SearchResponse, error)
+
+	// Lifecycle.
+	RunConfig() *RunConfig
+	// EndInvocation ends the current invocation. This stops any planned
+	// agent calls.
+	EndInvocation()
+	// Ended reports whether the invocation has ended.
+	Ended() bool
+
+	// WithContext returns a new Context with the embedded
+	// context.Context replaced.
+	//
+	// NOTE: This is a temporary solution and will be removed later. The
+	// proper solution we plan is to stop embedding go context in adk
+	// context types and split it.
+	WithContext(ctx context.Context) Context
+
+	// Tool-call site capabilities. When called on a Context not
+	// produced by a tool dispatcher, FunctionCallID returns "", Actions
+	// and ToolConfirmation return nil, and RequestConfirmation returns
+	// ErrOutsideToolCall.
+	FunctionCallID() string
+	Actions() *session.EventActions
+	ToolConfirmation() *toolconfirmation.ToolConfirmation
+	RequestConfirmation(hint string, payload any) error
 }
+
+// InvocationContext is an alias for Context. Kept for backward
+// compatibility; new code should use Context directly.
+type InvocationContext = Context
+
+// CallbackContext is an alias for Context. Kept for backward
+// compatibility; new code should use Context directly.
+type CallbackContext = Context

--- a/agent/invocation_context.go
+++ b/agent/invocation_context.go
@@ -16,11 +16,14 @@ package agent
 
 import (
 	"context"
+	"fmt"
 
 	"github.com/google/uuid"
 	"google.golang.org/genai"
 
+	"google.golang.org/adk/memory"
 	"google.golang.org/adk/session"
+	"google.golang.org/adk/tool/toolconfirmation"
 )
 
 // InvocationContextParams gathers everything NewInvocationContext needs.
@@ -99,10 +102,70 @@ func (c *invocationContext) Ended() bool {
 	return c.params.EndInvocation
 }
 
-func (c *invocationContext) WithContext(ctx context.Context) InvocationContext {
+func (c *invocationContext) WithContext(ctx context.Context) Context {
 	newCtx := *c
 	newCtx.Context = ctx
 	return &newCtx
 }
 
-var _ InvocationContext = (*invocationContext)(nil)
+// --- ReadonlyContext methods (delegated to params.Session / params.Agent) ---
+
+func (c *invocationContext) AgentName() string {
+	if c.params.Agent == nil {
+		return ""
+	}
+	return c.params.Agent.Name()
+}
+
+func (c *invocationContext) ReadonlyState() session.ReadonlyState {
+	if c.params.Session == nil {
+		return nil
+	}
+	return c.params.Session.State()
+}
+
+func (c *invocationContext) UserID() string {
+	if c.params.Session == nil {
+		return ""
+	}
+	return c.params.Session.UserID()
+}
+
+func (c *invocationContext) AppName() string {
+	if c.params.Session == nil {
+		return ""
+	}
+	return c.params.Session.AppName()
+}
+
+func (c *invocationContext) SessionID() string {
+	if c.params.Session == nil {
+		return ""
+	}
+	return c.params.Session.ID()
+}
+
+// --- Context-only methods ---
+
+func (c *invocationContext) State() session.State {
+	if c.params.Session == nil {
+		return nil
+	}
+	return c.params.Session.State()
+}
+
+func (c *invocationContext) SearchMemory(ctx context.Context, query string) (*memory.SearchResponse, error) {
+	if c.params.Memory == nil {
+		return nil, fmt.Errorf("memory service is not set")
+	}
+	return c.params.Memory.SearchMemory(ctx, query)
+}
+
+// --- Tool-call site methods (zero/error outside a tool call) ---
+
+func (c *invocationContext) FunctionCallID() string                               { return "" }
+func (c *invocationContext) Actions() *session.EventActions                       { return nil }
+func (c *invocationContext) ToolConfirmation() *toolconfirmation.ToolConfirmation { return nil }
+func (c *invocationContext) RequestConfirmation(string, any) error                { return ErrOutsideToolCall }
+
+var _ Context = (*invocationContext)(nil)

--- a/internal/configurable/conformance/replayplugin/replay_plugin_test.go
+++ b/internal/configurable/conformance/replayplugin/replay_plugin_test.go
@@ -389,21 +389,34 @@ type MockInvocationContext struct {
 	invocationID string
 }
 
-func (m *MockInvocationContext) Session() session.Session                                { return m.session }
-func (m *MockInvocationContext) InvocationID() string                                    { return m.invocationID }
-func (m *MockInvocationContext) Agent() agent.Agent                                      { return nil }
-func (m *MockInvocationContext) Artifacts() agent.Artifacts                              { return nil }
-func (m *MockInvocationContext) Memory() agent.Memory                                    { return nil }
-func (m *MockInvocationContext) Branch() string                                          { return "" }
-func (m *MockInvocationContext) UserContent() *genai.Content                             { return nil }
-func (m *MockInvocationContext) RunConfig() *agent.RunConfig                             { return nil } // Use context? No, RunConfig struct.
-func (m *MockInvocationContext) EndInvocation()                                          {}
-func (m *MockInvocationContext) Ended() bool                                             { return false }
-func (m *MockInvocationContext) WithContext(ctx context.Context) agent.InvocationContext { return m }
-func (m *MockInvocationContext) Value(key any) any                                       { return nil }
-func (m *MockInvocationContext) Deadline() (deadline time.Time, ok bool)                 { return time.Time{}, false }
-func (m *MockInvocationContext) Done() <-chan struct{}                                   { return nil }
-func (m *MockInvocationContext) Err() error                                              { return nil }
+func (m *MockInvocationContext) Session() session.Session                      { return m.session }
+func (m *MockInvocationContext) InvocationID() string                          { return m.invocationID }
+func (m *MockInvocationContext) Agent() agent.Agent                            { return nil }
+func (m *MockInvocationContext) Artifacts() agent.Artifacts                    { return nil }
+func (m *MockInvocationContext) Memory() agent.Memory                          { return nil }
+func (m *MockInvocationContext) Branch() string                                { return "" }
+func (m *MockInvocationContext) UserContent() *genai.Content                   { return nil }
+func (m *MockInvocationContext) RunConfig() *agent.RunConfig                   { return nil }
+func (m *MockInvocationContext) EndInvocation()                                {}
+func (m *MockInvocationContext) Ended() bool                                   { return false }
+func (m *MockInvocationContext) WithContext(ctx context.Context) agent.Context { return m }
+func (m *MockInvocationContext) Value(key any) any                             { return nil }
+func (m *MockInvocationContext) Deadline() (deadline time.Time, ok bool)       { return time.Time{}, false }
+func (m *MockInvocationContext) Done() <-chan struct{}                         { return nil }
+func (m *MockInvocationContext) Err() error                                    { return nil }
+func (m *MockInvocationContext) AgentName() string                             { return "" }
+func (m *MockInvocationContext) UserID() string                                { return "" }
+func (m *MockInvocationContext) AppName() string                               { return "" }
+func (m *MockInvocationContext) SessionID() string                             { return "" }
+func (m *MockInvocationContext) ReadonlyState() session.ReadonlyState          { return nil }
+func (m *MockInvocationContext) State() session.State                          { return nil }
+func (m *MockInvocationContext) SearchMemory(context.Context, string) (*memory.SearchResponse, error) {
+	return nil, nil
+}
+func (m *MockInvocationContext) FunctionCallID() string                               { return "" }
+func (m *MockInvocationContext) Actions() *session.EventActions                       { return nil }
+func (m *MockInvocationContext) ToolConfirmation() *toolconfirmation.ToolConfirmation { return nil }
+func (m *MockInvocationContext) RequestConfirmation(string, any) error                { return nil }
 
 // MockCallbackContext
 type MockCallbackContext struct {
@@ -412,20 +425,34 @@ type MockCallbackContext struct {
 	agentName    string
 }
 
-func (m *MockCallbackContext) State() session.State                    { return m.state }
-func (m *MockCallbackContext) ReadonlyState() session.ReadonlyState    { return m.state }
-func (m *MockCallbackContext) InvocationID() string                    { return m.invocationID }
-func (m *MockCallbackContext) AgentName() string                       { return m.agentName }
-func (m *MockCallbackContext) AppName() string                         { return "mock-app" }
-func (m *MockCallbackContext) Branch() string                          { return "" }
-func (m *MockCallbackContext) SessionID() string                       { return "mock-session-id" }
-func (m *MockCallbackContext) UserID() string                          { return "mock-user" }
-func (m *MockCallbackContext) UserContent() *genai.Content             { return nil }
-func (m *MockCallbackContext) Artifacts() agent.Artifacts              { return nil }
-func (m *MockCallbackContext) Value(key any) any                       { return nil }
-func (m *MockCallbackContext) Deadline() (deadline time.Time, ok bool) { return time.Time{}, false }
-func (m *MockCallbackContext) Done() <-chan struct{}                   { return nil }
-func (m *MockCallbackContext) Err() error                              { return nil }
+func (m *MockCallbackContext) State() session.State                      { return m.state }
+func (m *MockCallbackContext) ReadonlyState() session.ReadonlyState      { return m.state }
+func (m *MockCallbackContext) InvocationID() string                      { return m.invocationID }
+func (m *MockCallbackContext) AgentName() string                         { return m.agentName }
+func (m *MockCallbackContext) AppName() string                           { return "mock-app" }
+func (m *MockCallbackContext) Branch() string                            { return "" }
+func (m *MockCallbackContext) SessionID() string                         { return "mock-session-id" }
+func (m *MockCallbackContext) UserID() string                            { return "mock-user" }
+func (m *MockCallbackContext) UserContent() *genai.Content               { return nil }
+func (m *MockCallbackContext) Artifacts() agent.Artifacts                { return nil }
+func (m *MockCallbackContext) Value(key any) any                         { return nil }
+func (m *MockCallbackContext) Deadline() (deadline time.Time, ok bool)   { return time.Time{}, false }
+func (m *MockCallbackContext) Done() <-chan struct{}                     { return nil }
+func (m *MockCallbackContext) Err() error                                { return nil }
+func (m *MockCallbackContext) Agent() agent.Agent                        { return nil }
+func (m *MockCallbackContext) Session() session.Session                  { return nil }
+func (m *MockCallbackContext) Memory() agent.Memory                      { return nil }
+func (m *MockCallbackContext) RunConfig() *agent.RunConfig               { return nil }
+func (m *MockCallbackContext) EndInvocation()                            {}
+func (m *MockCallbackContext) Ended() bool                               { return false }
+func (m *MockCallbackContext) WithContext(context.Context) agent.Context { return m }
+func (m *MockCallbackContext) SearchMemory(context.Context, string) (*memory.SearchResponse, error) {
+	return nil, nil
+}
+func (m *MockCallbackContext) FunctionCallID() string                               { return "" }
+func (m *MockCallbackContext) Actions() *session.EventActions                       { return nil }
+func (m *MockCallbackContext) ToolConfirmation() *toolconfirmation.ToolConfirmation { return nil }
+func (m *MockCallbackContext) RequestConfirmation(string, any) error                { return nil }
 
 // MockToolContext
 type MockToolContext struct {
@@ -455,6 +482,13 @@ func (m *MockToolContext) Value(key any) any                                    
 func (m *MockToolContext) Deadline() (deadline time.Time, ok bool)              { return time.Time{}, false }
 func (m *MockToolContext) Done() <-chan struct{}                                { return nil }
 func (m *MockToolContext) Err() error                                           { return nil }
+func (m *MockToolContext) Agent() agent.Agent                                   { return nil }
+func (m *MockToolContext) Session() session.Session                             { return nil }
+func (m *MockToolContext) Memory() agent.Memory                                 { return nil }
+func (m *MockToolContext) RunConfig() *agent.RunConfig                          { return nil }
+func (m *MockToolContext) EndInvocation()                                       {}
+func (m *MockToolContext) Ended() bool                                          { return false }
+func (m *MockToolContext) WithContext(context.Context) agent.Context            { return m }
 
 // MockTool
 type MockTool struct {

--- a/tool/exampletool/tool_test.go
+++ b/tool/exampletool/tool_test.go
@@ -61,6 +61,17 @@ func (m *mockToolContext) AppName() string                                      
 func (m *mockToolContext) Branch() string                                       { return "mock_branch" }
 func (m *mockToolContext) SessionID() string                                    { return "mock_session" }
 func (m *mockToolContext) UserID() string                                       { return "mock_user" }
+func (m *mockToolContext) Agent() agent.Agent                                   { return nil }
+func (m *mockToolContext) Session() session.Session                             { return nil }
+func (m *mockToolContext) Memory() agent.Memory                                 { return nil }
+func (m *mockToolContext) RunConfig() *agent.RunConfig                          { return nil }
+func (m *mockToolContext) EndInvocation()                                       {}
+func (m *mockToolContext) Ended() bool                                          { return false }
+func (m *mockToolContext) WithContext(ctx context.Context) agent.Context {
+	cp := *m
+	cp.Context = ctx
+	return &cp
+}
 
 // --- Tests ---
 

--- a/tool/tool_test.go
+++ b/tool/tool_test.go
@@ -148,6 +148,17 @@ func (c *testContext) AppName() string                      { return "test-app" 
 func (c *testContext) Branch() string                       { return "test-branch" }
 func (c *testContext) SessionID() string                    { return "test-session-id" }
 func (c *testContext) UserID() string                       { return "test-user-id" }
+func (c *testContext) Agent() agent.Agent                   { return nil }
+func (c *testContext) Session() session.Session             { return nil }
+func (c *testContext) Memory() agent.Memory                 { return nil }
+func (c *testContext) RunConfig() *agent.RunConfig          { return nil }
+func (c *testContext) EndInvocation()                       {}
+func (c *testContext) Ended() bool                          { return false }
+func (c *testContext) WithContext(ctx context.Context) agent.Context {
+	cp := *c
+	cp.Context = ctx
+	return &cp
+}
 
 type testToolset struct {
 	tools []tool.Tool


### PR DESCRIPTION
Mirrors adk-python's unification work (commits b7f9110b + 647d3b16): 'one Context name to learn' for all callbacks, tools, and agent code.

Type structure:

    ReadonlyContext (8 read-only methods, narrow)
        ↑ embedded in
    Context (17 methods total: read + mutate + lifecycle + tool-call site)
        ↑ aliased as
    InvocationContext = Context
    CallbackContext   = Context

Tool-call-only methods (FunctionCallID, Actions, ToolConfirmation, RequestConfirmation) follow a runtime-check pattern: when called on a Context not produced by a tool dispatcher, pollable accessors return zero values and mutating operations return ErrOutsideToolCall (new exported sentinel).

ReadonlyContext stays as a separate narrow interface (NOT an alias) to preserve compile-time read-only safety for InstructionProvider, Predicate, Toolset.Tools, etc. — same as Python where 'class Context(ReadonlyContext)' makes ReadonlyContext a strict subset of Context.

Implementation extensions:

  * agent.invocationContext gains 11 new methods (AgentName, UserID, AppName, SessionID, ReadonlyState, State, SearchMemory, plus 4 tool-call-only zero/error methods).
  * agent.callbackContext gains 11 new methods (Agent, Session, Memory, RunConfig, EndInvocation, Ended, WithContext (now returning Context), SearchMemory, plus the same 4 tool-call-only).
  * agent.readonlyContext stays unchanged (intentionally — it implements only ReadonlyContext, not Context).

WithContext now returns Context (which is the same type as InvocationContext after aliasing).

Test mock updates (5 manual full mocks):
  * replayplugin.MockInvocationContext: +11 methods.
  * replayplugin.MockCallbackContext: +11 methods.
  * replayplugin.MockToolContext: +7 methods.
  * tool.testContext: +7 methods.
  * tool/exampletool.mockToolContext: +7 methods.

Lightweight wrapper-mocks (llminternal.mockInvocationContext, retryandreflect.mockContext) are automatically OK via embed-nil dispatch.

Test logic update:
  * agent.TestCallbackContext_IsReadonlyButNotInvocation removed (asserts contradiction now: CallbackContext = Context, so it IS an InvocationContext after aliasing). Replaced with TestCallbackContext_OutOfToolCallReturnsZero which exercises the new runtime-check pattern.
  * agent.TestReadonlyContext_NotAnInvocationContext kept (still valid: readonlyContext impl deliberately doesn't satisfy Context, only ReadonlyContext).

Verified: go build ./...; go vet ./...; go test ./...; all pass.

**Please ensure you have read the [contribution guide](./CONTRIBUTING.md) before creating a pull request.**

### Link to Issue or Description of Change

**1. Link to an existing issue (if applicable):**

- Closes: #_issue_number_
- Related: #_issue_number_

**2. Or, if no issue exists, describe the change:**

_If applicable, please follow the issue templates to provide as much detail as
possible._

**Problem:**
_A clear and concise description of what the problem is._

**Solution:**
_A clear and concise description of what you want to happen and why you choose
this solution._

### Testing Plan

_Please describe the tests that you ran to verify your changes. This is required
for all PRs that are not small documentation or typo fixes._

**Unit Tests:**

- [ ] I have added or updated unit tests for my change.
- [ ] All unit tests pass locally.

_Please include a summary of passed go test results._

**Manual End-to-End (E2E) Tests:**

_Please provide instructions on how to manually test your changes, including any
necessary setup or configuration. Please provide logs or screenshots to help
reviewers better understand the fix._

### Checklist

- [ ] I have read the [CONTRIBUTING.md](./CONTRIBUTING.md) document.
- [ ] I have performed a self-review of my own code.
- [ ] I have commented my code, particularly in hard-to-understand areas.
- [ ] I have added tests that prove my fix is effective or that my feature works.
- [ ] New and existing unit tests pass locally with my changes.
- [ ] I have manually tested my changes end-to-end.
- [ ] Any dependent changes have been merged and published in downstream modules.

### Additional context

_Add any other context or screenshots about the feature request here._

