### PR TITLE
feat: add HITL pause primitives to workflow engine

### DIFF
--- a/session/session.go
+++ b/session/session.go
@@ -19,6 +19,7 @@ import (
 	"iter"
 	"time"
 
+	"github.com/google/jsonschema-go/jsonschema"
 	"github.com/google/uuid"
 
 	"google.golang.org/adk/model"
@@ -117,6 +118,41 @@ type Event struct {
 	LongRunningToolIDs []string
 	// Routing information for workflow execution
 	Routes []string
+	// RequestedInput, when non-nil, signals that the workflow node
+	// emitting this event is asking for human input and is about to
+	// pause. The workflow scheduler observes this field at event
+	// dispatch time and transitions the corresponding node to
+	// NodeWaiting on the activation's completion. UI surfaces read
+	// the same field to render the prompt.
+	//
+	// At most one event per node activation may carry this field.
+	RequestedInput *RequestInput
+}
+
+// RequestInput describes a single human-in-the-loop prompt emitted
+// by a workflow node. It travels on Event.RequestedInput from the
+// node, through the scheduler, out to the UI surface; the matching
+// response is routed back by InterruptID.
+type RequestInput struct {
+	// InterruptID is the stable correlation key for this request.
+	// It identifies the intent of the prompt (e.g. "manager_approval",
+	// "human_review"). If empty when the node yields the event, the
+	// engine fills in a UUID so the downstream contract is always a
+	// non-empty string.
+	InterruptID string
+
+	// Message is the human-readable description of what is being
+	// asked. Surfaced in UI as the prompt text. Optional.
+	Message string
+
+	// ResponseSchema, when non-nil, is the JSON schema the user's
+	// response payload must conform to.
+	ResponseSchema *jsonschema.Schema
+
+	// Payload is optional context the UI may render alongside the
+	// prompt (e.g. the document to approve, the proposed parameters).
+	// Carried through opaquely; the engine does not interpret it.
+	Payload any
 }
 
 // IsFinalResponse returns whether the event is the final response of an agent.

--- a/workflow/hitl_test.go
+++ b/workflow/hitl_test.go
@@ -1,0 +1,247 @@
+// Copyright 2026 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package workflow
+
+import (
+	"errors"
+	"iter"
+	"sync/atomic"
+	"testing"
+
+	"google.golang.org/adk/agent"
+	"google.golang.org/adk/session"
+)
+
+// hitlNode is a small custom Node used by the HITL pause tests. The
+// Run callback is supplied per test so each scenario can shape its
+// own emission pattern (single request, multiple requests, request
+// then error, etc.).
+type hitlNode struct {
+	BaseNode
+	run func(ctx agent.InvocationContext, input any, yield func(*session.Event, error) bool)
+}
+
+func newHitlNode(name string, run func(ctx agent.InvocationContext, input any, yield func(*session.Event, error) bool)) *hitlNode {
+	return &hitlNode{
+		BaseNode: NewBaseNode(name, "", defaultNodeConfig),
+		run:      run,
+	}
+}
+
+func (n *hitlNode) Run(ctx agent.InvocationContext, input any) iter.Seq2[*session.Event, error] {
+	return func(yield func(*session.Event, error) bool) {
+		n.run(ctx, input, yield)
+	}
+}
+
+// findRequestedInputEvent returns the first yielded event whose
+// RequestedInput field is non-nil, plus how many such events were
+// observed in total. Useful for asserting that the engine forwarded
+// the HITL prompt to the caller.
+func findRequestedInputEvent(events []*session.Event) (req *session.Event, count int) {
+	for _, ev := range events {
+		if ev != nil && ev.RequestedInput != nil {
+			if req == nil {
+				req = ev
+			}
+			count++
+		}
+	}
+	return req, count
+}
+
+// TestScheduler_HitlNode_PausesAndForwardsRequest verifies the
+// happy-path single-waiting-node scenario: a node yields one
+// RequestInput event and exits; the engine forwards the event
+// downstream, does not schedule the successor, and the workflow
+// terminates cleanly with the asker parked.
+func TestScheduler_HitlNode_PausesAndForwardsRequest(t *testing.T) {
+	mockCtx := newSeededMockCtx(t)
+
+	var downstreamRan atomic.Bool
+	asker := newHitlNode("asker", func(ctx agent.InvocationContext, _ any, yield func(*session.Event, error) bool) {
+		yield(NewRequestInputEvent(ctx, session.RequestInput{
+			InterruptID: "human_review",
+			Message:     "Please approve",
+			Payload:     "the draft",
+		}), nil)
+	})
+	downstream := newHitlNode("downstream", func(ctx agent.InvocationContext, _ any, yield func(*session.Event, error) bool) {
+		downstreamRan.Store(true)
+	})
+
+	w := mustNew(t, []Edge{
+		{From: Start, To: asker},
+		{From: asker, To: downstream},
+	})
+
+	events := drain(t, w.Run(mockCtx))
+
+	if downstreamRan.Load() {
+		t.Error("downstream node ran; HITL pause must suppress successor scheduling")
+	}
+
+	req, count := findRequestedInputEvent(events)
+	if count != 1 {
+		t.Fatalf("expected exactly 1 event with RequestedInput, got %d (events=%d total)", count, len(events))
+	}
+	if got, want := req.RequestedInput.InterruptID, "human_review"; got != want {
+		t.Errorf("InterruptID = %q, want %q", got, want)
+	}
+	if got, want := req.RequestedInput.Message, "Please approve"; got != want {
+		t.Errorf("Message = %q, want %q", got, want)
+	}
+	if got, want := req.RequestedInput.Payload, "the draft"; got != want {
+		t.Errorf("Payload = %v, want %q", got, want)
+	}
+}
+
+// TestScheduler_HitlNode_AutoGeneratesInterruptID verifies the
+// scheduler-side contract that an empty InterruptID supplied by the
+// node author becomes a non-empty UUID by the time the request
+// reaches the consumer.
+func TestScheduler_HitlNode_AutoGeneratesInterruptID(t *testing.T) {
+	mockCtx := newSeededMockCtx(t)
+
+	asker := newHitlNode("asker", func(ctx agent.InvocationContext, _ any, yield func(*session.Event, error) bool) {
+		// InterruptID intentionally left empty.
+		yield(NewRequestInputEvent(ctx, session.RequestInput{
+			Message: "approve?",
+		}), nil)
+	})
+	w := mustNew(t, []Edge{{From: Start, To: asker}})
+
+	events := drain(t, w.Run(mockCtx))
+	req, count := findRequestedInputEvent(events)
+	if count != 1 {
+		t.Fatalf("expected exactly 1 RequestedInput event, got %d", count)
+	}
+	if req.RequestedInput.InterruptID == "" {
+		t.Error("InterruptID is empty; engine must auto-generate when caller omits it")
+	}
+}
+
+// TestScheduler_HitlNode_PreservesExplicitInterruptID verifies
+// that an explicit InterruptID supplied by the node author flows
+// through to the consumer unchanged.
+func TestScheduler_HitlNode_PreservesExplicitInterruptID(t *testing.T) {
+	mockCtx := newSeededMockCtx(t)
+
+	asker := newHitlNode("asker", func(ctx agent.InvocationContext, _ any, yield func(*session.Event, error) bool) {
+		yield(NewRequestInputEvent(ctx, session.RequestInput{
+			InterruptID: "stable-id-42",
+			Message:     "approve?",
+		}), nil)
+	})
+	w := mustNew(t, []Edge{{From: Start, To: asker}})
+
+	events := drain(t, w.Run(mockCtx))
+	req, _ := findRequestedInputEvent(events)
+	if req == nil {
+		t.Fatal("no RequestedInput event found")
+	}
+	if got, want := req.RequestedInput.InterruptID, "stable-id-42"; got != want {
+		t.Errorf("InterruptID = %q, want %q (engine must preserve caller-supplied IDs)", got, want)
+	}
+}
+
+// TestScheduler_HitlNode_MultipleRequestsFails verifies the
+// single-request-per-activation invariant: a node yielding two
+// RequestedInput events surfaces ErrMultipleInputRequests at
+// completion and is treated as failed, so it does not silently
+// park in NodeWaiting.
+func TestScheduler_HitlNode_MultipleRequestsFails(t *testing.T) {
+	mockCtx := newSeededMockCtx(t)
+
+	asker := newHitlNode("asker", func(ctx agent.InvocationContext, _ any, yield func(*session.Event, error) bool) {
+		yield(NewRequestInputEvent(ctx, session.RequestInput{InterruptID: "first"}), nil)
+		yield(NewRequestInputEvent(ctx, session.RequestInput{InterruptID: "second"}), nil)
+	})
+
+	w := mustNew(t, []Edge{{From: Start, To: asker}})
+
+	gotErr := drainErr(t, w.Run(mockCtx))
+	if !errors.Is(gotErr, ErrMultipleInputRequests) {
+		t.Errorf("Run error = %v, want ErrMultipleInputRequests (node must fail, not park)", gotErr)
+	}
+}
+
+// TestScheduler_HitlNode_ErrorAfterRequestFails verifies the
+// precedence ordering inside handleCompletion: a node that
+// recorded a request and then returned an error surfaces as
+// failed, not as waiting. The waiting branch runs only on a
+// clean activation.
+func TestScheduler_HitlNode_ErrorAfterRequestFails(t *testing.T) {
+	mockCtx := newSeededMockCtx(t)
+
+	wantErr := errors.New("downstream of request")
+	asker := newHitlNode("asker", func(ctx agent.InvocationContext, _ any, yield func(*session.Event, error) bool) {
+		yield(NewRequestInputEvent(ctx, session.RequestInput{InterruptID: "ignored"}), nil)
+		yield(nil, wantErr)
+	})
+	w := mustNew(t, []Edge{{From: Start, To: asker}})
+
+	gotErr := drainErr(t, w.Run(mockCtx))
+	if !errors.Is(gotErr, wantErr) {
+		t.Errorf("Run error = %v, want %v (failure must take precedence over the recorded request)", gotErr, wantErr)
+	}
+}
+
+// TestScheduler_HitlNode_ConcurrentBranches_PausesOnlyWhenAllNonRunning
+// verifies that a workflow with two parallel branches — one that
+// requests input, one that completes normally — pauses cleanly:
+// the non-HITL branch's downstream still runs, the HITL branch's
+// downstream does not. Termination happens once the last live node
+// has either completed or moved into NodeWaiting.
+func TestScheduler_HitlNode_ConcurrentBranches_PausesOnlyWhenAllNonRunning(t *testing.T) {
+	mockCtx := newSeededMockCtx(t)
+
+	var hitlDownstreamRan atomic.Bool
+	var plainDownstreamRan atomic.Bool
+
+	hitlAsker := newHitlNode("hitl_asker", func(ctx agent.InvocationContext, _ any, yield func(*session.Event, error) bool) {
+		yield(NewRequestInputEvent(ctx, session.RequestInput{InterruptID: "ask"}), nil)
+	})
+	hitlDownstream := newHitlNode("hitl_downstream", func(ctx agent.InvocationContext, _ any, yield func(*session.Event, error) bool) {
+		hitlDownstreamRan.Store(true)
+	})
+	plainNode := newHitlNode("plain", func(ctx agent.InvocationContext, _ any, yield func(*session.Event, error) bool) {
+		ev := session.NewEvent(ctx.InvocationID())
+		ev.Actions.StateDelta["output"] = "done"
+		yield(ev, nil)
+	})
+	plainDownstream := newHitlNode("plain_downstream", func(ctx agent.InvocationContext, _ any, yield func(*session.Event, error) bool) {
+		plainDownstreamRan.Store(true)
+	})
+
+	w := mustNew(t, []Edge{
+		{From: Start, To: hitlAsker},
+		{From: Start, To: plainNode},
+		{From: hitlAsker, To: hitlDownstream},
+		{From: plainNode, To: plainDownstream},
+	})
+
+	events := drain(t, w.Run(mockCtx))
+
+	if hitlDownstreamRan.Load() {
+		t.Error("hitl_downstream ran; HITL branch must not schedule successors before resume")
+	}
+	if !plainDownstreamRan.Load() {
+		t.Error("plain_downstream did not run; non-HITL branch must complete normally even while a sibling pauses")
+	}
+	if _, count := findRequestedInputEvent(events); count != 1 {
+		t.Errorf("expected exactly 1 RequestedInput event in the stream, got %d", count)
+	}
+}

--- a/workflow/request_input.go
+++ b/workflow/request_input.go
@@ -1,0 +1,54 @@
+// Copyright 2026 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package workflow
+
+import (
+	"github.com/google/uuid"
+
+	"google.golang.org/adk/agent"
+	"google.golang.org/adk/session"
+)
+
+// NewRequestInputEvent constructs a session.Event that asks the
+// surrounding workflow to pause and surface a human-input prompt.
+// A node yields the returned event and then exits its iter.Seq2;
+// the scheduler observes Event.RequestedInput and transitions the
+// node to NodeWaiting.
+//
+// If req.InterruptID is empty, a UUID is generated so the
+// downstream contract (a non-empty correlation key on
+// NodeState.PendingRequest) is always satisfied. Pass an explicit
+// InterruptID when the prompt has a stable, author-defined intent
+// that the UI or a multi-prompt node needs to recognise.
+//
+// Example:
+//
+//	func (n *MyNode) Run(ctx agent.InvocationContext, in any) iter.Seq2[*session.Event, error] {
+//	    return func(yield func(*session.Event, error) bool) {
+//	        yield(workflow.NewRequestInputEvent(ctx, session.RequestInput{
+//	            InterruptID: "human_review",
+//	            Message:     "Please review this draft.",
+//	            Payload:     draft,
+//	        }), nil)
+//	    }
+//	}
+func NewRequestInputEvent(ctx agent.InvocationContext, req session.RequestInput) *session.Event {
+	if req.InterruptID == "" {
+		req.InterruptID = uuid.NewString()
+	}
+	ev := session.NewEvent(ctx.InvocationID())
+	ev.RequestedInput = &req
+	return ev
+}

--- a/workflow/scheduler.go
+++ b/workflow/scheduler.go
@@ -39,6 +39,11 @@ var (
 	// than one event whose Routes field is set. A node activation
 	// may emit at most one routing decision.
 	ErrMultipleRoutingEvents = errors.New("workflow: node produced multiple events with route tags; only one event per execution can specify routes")
+
+	// ErrMultipleInputRequests is returned when a node yields more
+	// than one event whose RequestedInput field is set. A node
+	// activation may issue at most one human-input request.
+	ErrMultipleInputRequests = errors.New("workflow: node produced multiple events with RequestedInput; only one human-input request per execution is allowed")
 )
 
 // scheduler drives a single Workflow.Run invocation. It owns the
@@ -91,10 +96,11 @@ type scheduler struct {
 // without overwriting the first value, and the consumer surfaces
 // the error at completion.
 type nodeRun struct {
-	routingEvent *session.Event // at most one; multiple is an error
-	output       any            // single StateDelta["output"]; nil if hasOutput is false
-	hasOutput    bool           // distinguishes "no output yet" from "output was nil"
-	err          error          // set on duplicate output or duplicate routing event
+	routingEvent *session.Event        // at most one; multiple is an error
+	output       any                   // single StateDelta["output"]; nil if hasOutput is false
+	hasOutput    bool                  // distinguishes "no output yet" from "output was nil"
+	inputRequest *session.RequestInput // at most one human-input request; multiple is an error
+	err          error                 // set on duplicate output, duplicate routing event, or duplicate input request
 }
 
 // recordErr stores err as the accumulator's first error. Subsequent
@@ -114,6 +120,20 @@ func (nr *nodeRun) setRoutingEvent(ev *session.Event, nodeName string) {
 		return
 	}
 	nr.routingEvent = ev
+}
+
+// setInputRequest stores req as the node's single in-flight
+// human-input request. A second call records
+// ErrMultipleInputRequests instead of overwriting; the consumer
+// surfaces the error at completion and the node ends up
+// NodeFailed (the waiting branch is gated on nr.err == nil so a
+// node that requested twice does not silently park).
+func (nr *nodeRun) setInputRequest(req *session.RequestInput, nodeName string) {
+	if nr.inputRequest != nil {
+		nr.recordErr(fmt.Errorf("%w: node %q", ErrMultipleInputRequests, nodeName))
+		return
+	}
+	nr.inputRequest = req
 }
 
 // setOutput stores out as the node's single output value. A second
@@ -349,6 +369,9 @@ func (s *scheduler) handleEvent(it eventItem) {
 	if it.ev.Routes != nil {
 		nr.setRoutingEvent(it.ev, it.nodeName)
 	}
+	if it.ev.RequestedInput != nil {
+		nr.setInputRequest(it.ev.RequestedInput, it.nodeName)
+	}
 	if it.ev.Actions.StateDelta != nil {
 		if out, ok := it.ev.Actions.StateDelta["output"]; ok {
 			nr.setOutput(out, it.nodeName)
@@ -364,27 +387,54 @@ func (s *scheduler) handleEvent(it eventItem) {
 //
 // The returned error is the node's own error (NodeFailed); nil on
 // clean success or sibling cancellation.
+//
+// # Human-input waiting branch
+//
+// When an activation completes cleanly and recorded a non-nil
+// inputRequest (via setInputRequest from handleEvent), the node
+// transitions to NodeWaiting instead of NodeCompleted, the request
+// is persisted on NodeState.PendingRequest, and successors are not
+// scheduled. The scheduler's main loop terminates naturally when
+// every live node has either completed or moved into NodeWaiting,
+// at which point Workflow.Run's iterator exhausts and the caller
+// observes the pause by inspecting RunState.
+//
+// The waiting branch is checked after the error/cancel branches,
+// so a node that fails for any reason (returned error, panic,
+// context cancel, multiple-output, multiple-routing-event,
+// multiple-input-request) does not silently park in NodeWaiting:
+// failures take precedence and surface as NodeFailed.
 func (s *scheduler) handleCompletion(it completionItem, scheduleSuccessors bool) error {
 	ns := s.state.EnsureNode(it.nodeName)
 	nr := s.runsByName[it.nodeName]
 	delete(s.runsByName, it.nodeName)
 	delete(s.runCancels, it.nodeName)
 
-	switch {
-	case it.err == nil:
-		ns.Status = NodeCompleted
-	case errors.Is(it.err, context.Canceled):
+	if errors.Is(it.err, context.Canceled) {
 		ns.Status = NodeCancelled
 		return nil // sibling cancellation; not the original error
-	default:
+	}
+	if it.err != nil {
 		ns.Status = NodeFailed
 		return it.err
 	}
-
 	if nr != nil && nr.err != nil {
 		ns.Status = NodeFailed
 		return nr.err
 	}
+
+	// Happy path: decide between NodeWaiting (a recorded human-
+	// input request) or NodeCompleted. The waiting branch fires
+	// regardless of the scheduleSuccessors flag — a request that
+	// survived the run must be observable in RunState even when
+	// the consumer is draining, so the caller can persist it.
+	if nr != nil && nr.inputRequest != nil {
+		ns.Status = NodeWaiting
+		ns.PendingRequest = nr.inputRequest
+		return nil
+	}
+
+	ns.Status = NodeCompleted
 
 	if !scheduleSuccessors {
 		return nil

--- a/workflow/state.go
+++ b/workflow/state.go
@@ -14,6 +14,8 @@
 
 package workflow
 
+import "google.golang.org/adk/session"
+
 // NodeStatus is the lifecycle status of a node in the workflow graph.
 //
 // The status is the engine's single source of truth for what a node
@@ -82,6 +84,12 @@ type NodeState struct {
 	// TriggeredBy is the name of the upstream node that produced
 	// the current Input. Empty for the initial START activation.
 	TriggeredBy string
+
+	// PendingRequest, when non-nil, carries the human-input request
+	// the node emitted before pausing. Non-nil iff Status ==
+	// NodeWaiting and the wait was caused by a human-input request
+	// (as opposed to a fan-in barrier).
+	PendingRequest *session.RequestInput
 }
 
 // RunState is the per-invocation lifecycle state for a workflow


### PR DESCRIPTION
Adds the engine-side scaffolding for human-in-the-loop pauses. A node can now
emit a `session.RequestInput` event; the scheduler parks the node in
`NodeWaiting`, persists the request on `NodeState.PendingRequest`, and stops
scheduling its successors instead of finalising the run. Pause-only; resume
(`Workflow.Resume`, schema validation, handoff/re-entry modes) lands in
follow-up PRs.

API additions: `session.RequestInput`, `session.Event.RequestedInput`,
`workflow.NewRequestInputEvent`, `workflow.NodeState.PendingRequest`,
`workflow.ErrMultipleInputRequests` (one request per activation).

Mirrors the existing `Routes`/`setRoutingEvent` dispatch pattern in the
scheduler. The waiting branch in `handleCompletion` runs after error/cancel,
so a node that requested input and then errored lands in `NodeFailed`, not
`NodeWaiting`.