### PR TITLE
feat: add HITL re-entry resume mode for workflow agents

### DIFF
--- a/agent/agent.go
+++ b/agent/agent.go
@@ -509,6 +509,11 @@ func (c *invocationContext) WithContext(ctx context.Context) InvocationContext {
 // that overrides the method when running inside a workflow.Node.
 func (c *invocationContext) TriggeredBy() string { return "" }
 
+// ResumedInput always returns (nil, false) for the base
+// invocation context. Implementations that carry a resume payload
+// override this method.
+func (c *invocationContext) ResumedInput(string) (any, bool) { return nil, false }
+
 func pluginManagerFromContext(ctx context.Context) pluginManager {
 	a := ctx.Value(plugincontext.PluginManagerCtxKey)
 	m, ok := a.(pluginManager)

--- a/agent/context.go
+++ b/agent/context.go
@@ -104,6 +104,12 @@ type InvocationContext interface {
 	// per-node context wrapper.
 	TriggeredBy() string
 
+	// ResumedInput returns the user-supplied response payload
+	// associated with the given InterruptID for the current
+	// activation, or (nil, false) if none. Implementations that
+	// do not carry resume payloads always return (nil, false).
+	ResumedInput(interruptID string) (any, bool)
+
 	// WithContext returns a new instance of the context with overridden embedded context.
 	// NOTE: This is a temporary solution and will be removed later. The proper solution
 	// we plan is to stop embedding go context in adk context types and split it.

--- a/agent/workflowagent/reentry_test.go
+++ b/agent/workflowagent/reentry_test.go
@@ -25,62 +25,12 @@ import (
 	"google.golang.org/adk/workflow"
 )
 
-// reentryNode is a custom Node with NodeConfig.RerunOnResume = true
-// whose Run body is supplied by the test via runFn. The test
-// decides what to do on the first activation (typically yield a
-// RequestInput) and on re-entry (read ctx.ResumedInput, emit an
-// output). Single helper covers both the "ask + handle reply"
-// shape of TestWorkflowAgent_ReEntry_ResumesAtSameNode and the
-// raw input-observing shape of
-// TestWorkflowAgent_ReEntry_PreservesOriginalInput.
-type reentryNode struct {
-	workflow.BaseNode
-	runFn func(ctx agent.InvocationContext, input any) iter.Seq2[*session.Event, error]
-}
-
-func newReentryNode(name string, runFn func(agent.InvocationContext, any) iter.Seq2[*session.Event, error]) *reentryNode {
-	return &reentryNode{
-		BaseNode: workflow.NewBaseNode(name, "", workflow.NodeConfig{RerunOnResume: ptrTrue()}),
-		runFn:    runFn,
-	}
-}
-
-func (n *reentryNode) Run(ctx agent.InvocationContext, input any) iter.Seq2[*session.Event, error] {
-	return n.runFn(ctx, input)
-}
-
 // TestWorkflowAgent_ReEntry_ResumesAtSameNode verifies the canonical
 // re-entry round-trip: the asker is re-activated on resume, sees
 // the response via ResumedInput, and produces an output that flows
 // to its successor.
 func TestWorkflowAgent_ReEntry_ResumesAtSameNode(t *testing.T) {
-	var resumeActivations atomic.Int32
-	var capturedResponse atomic.Value
-	var capturedUnknownOK atomic.Bool
-
-	asker := newReentryNode("asker", func(ctx agent.InvocationContext, _ any) iter.Seq2[*session.Event, error] {
-		return func(yield func(*session.Event, error) bool) {
-			response, ok := ctx.ResumedInput("decide")
-			if !ok {
-				yield(workflow.NewRequestInputEvent(ctx, session.RequestInput{
-					InterruptID: "decide",
-					Message:     "decide",
-				}), nil)
-				return
-			}
-			resumeActivations.Add(1)
-			capturedResponse.Store(response)
-			// Scheduler must populate resumeInputs with exactly the
-			// matching InterruptID — unrelated lookups return
-			// (nil, false). Pins the contract from the asker's side
-			// (complements the unit test in workflow/node_context_test.go).
-			_, okOther := ctx.ResumedInput("other_id")
-			capturedUnknownOK.Store(okOther)
-			ev := session.NewEvent(ctx.InvocationID())
-			ev.Actions.StateDelta["output"] = "decision: " + response.(string)
-			yield(ev, nil)
-		}
-	})
+	asker, acts := askerForSequence("asker", []string{"decide"}, "decision")
 
 	var handlerInput atomic.Value
 	handler := newStringHandlerNode("handler", &handlerInput)
@@ -88,28 +38,22 @@ func TestWorkflowAgent_ReEntry_ResumesAtSameNode(t *testing.T) {
 	a := makeAgent(t, workflow.Chain(workflow.Start, asker, handler))
 	sess := newFakeSession()
 
-	// Turn 1: fresh; pauses with RequestedInput.
+	// Turn 1: fresh; asker pauses with RequestedInput "decide".
 	turn1 := runFreshTurn(t, sess, a, "draft")
 	if got := findRequest(turn1); got != "decide" {
 		t.Fatalf("turn 1 RequestedInput = %q, want %q", got, "decide")
 	}
-	if resumeActivations.Load() != 0 {
-		t.Errorf("re-entry happened on turn 1; resumeActivations = %d", resumeActivations.Load())
-	}
 
-	// Turn 2: resume; asker re-runs with response visible via
-	// ResumedInput, then handler runs.
-	drainAgent(t, sess, a.Run(newMockCtx(sess, a, resumeMessage("decide", "approve"))), nil)
-	if got := resumeActivations.Load(); got != 1 {
-		t.Errorf("resume activations = %d, want 1", got)
+	// Turn 2: resume; asker re-runs, emits output, handler runs.
+	resumeAndExpect(t, sess, a, "decide", "approve", "")
+
+	if got, want := acts.count(), 2; got != want {
+		t.Fatalf("activations = %d, want %d (one initial + one re-entry)", got, want)
 	}
-	if got := capturedResponse.Load(); got != "approve" {
-		t.Errorf("ResumedInput response = %v, want %q", got, "approve")
+	if act, _ := acts.at(1); act.resumed["decide"] != "approve" {
+		t.Errorf("re-entry resumed[\"decide\"] = %v, want %q", act.resumed["decide"], "approve")
 	}
-	if capturedUnknownOK.Load() {
-		t.Errorf("ResumedInput(\"other_id\") returned ok=true on re-entry; want false")
-	}
-	if got, want := handlerInput.Load(), "decision: approve"; got != want {
+	if got, want := handlerInput.Load(), "decision"; got != want {
 		t.Errorf("handler input = %v, want %q", got, want)
 	}
 }
@@ -119,29 +63,7 @@ func TestWorkflowAgent_ReEntry_ResumesAtSameNode(t *testing.T) {
 // first activation, not the user's response. The response is
 // delivered separately via ResumedInput.
 func TestWorkflowAgent_ReEntry_PreservesOriginalInput(t *testing.T) {
-	var seenInputs sync.Map // attempt index (int32) -> input
-	var attempts atomic.Int32
-
-	asker := newReentryNode("asker", func(ctx agent.InvocationContext, input any) iter.Seq2[*session.Event, error] {
-		return func(yield func(*session.Event, error) bool) {
-			// get-and-increment: avoids a Load+Add window where two
-			// concurrent activations could record under the same key.
-			// (The workflow scheduler is single-consumer in practice,
-			// but the idiom is the safe default for atomic counters.)
-			attempt := attempts.Add(1) - 1
-			seenInputs.Store(attempt, input)
-			if _, ok := ctx.ResumedInput("decide"); ok {
-				ev := session.NewEvent(ctx.InvocationID())
-				ev.Actions.StateDelta["output"] = "ack"
-				yield(ev, nil)
-				return
-			}
-			yield(workflow.NewRequestInputEvent(ctx, session.RequestInput{
-				InterruptID: "decide",
-				Message:     "?",
-			}), nil)
-		}
-	})
+	asker, acts := askerForSequence("asker", []string{"decide"}, "ack")
 
 	a := makeAgent(t, workflow.Chain(workflow.Start, asker))
 	sess := newFakeSession()
@@ -151,21 +73,18 @@ func TestWorkflowAgent_ReEntry_PreservesOriginalInput(t *testing.T) {
 
 	// Turn 2: resume with response "approve". Asker re-runs and
 	// must see "draft" again as input (not "approve").
-	drainAgent(t, sess, a.Run(newMockCtx(sess, a, resumeMessage("decide", "approve"))), nil)
+	resumeAndExpect(t, sess, a, "decide", "approve", "")
 
-	first, ok1 := seenInputs.Load(int32(0))
-	if !ok1 {
-		t.Fatal("first activation never observed (no entry stored under index 0)")
+	if got, want := acts.count(), 2; got != want {
+		t.Fatalf("activations = %d, want %d", got, want)
 	}
-	second, ok2 := seenInputs.Load(int32(1))
-	if !ok2 {
-		t.Fatal("re-entry activation never observed (no entry stored under index 1)")
+	first, _ := acts.at(0)
+	second, _ := acts.at(1)
+	if first.input != "draft" {
+		t.Errorf("initial activation input = %v, want %q", first.input, "draft")
 	}
-	if first != "draft" {
-		t.Errorf("first activation input = %v, want %q", first, "draft")
-	}
-	if second != "draft" {
-		t.Errorf("re-entry activation input = %v, want %q (must preserve original input, not the response)", second, "draft")
+	if second.input != "draft" {
+		t.Errorf("re-entry activation input = %v, want %q (must preserve original input, not the response)", second.input, "draft")
 	}
 }
 
@@ -177,34 +96,20 @@ func TestWorkflowAgent_ReEntry_PreservesOriginalInput(t *testing.T) {
 func TestWorkflowAgent_ReEntry_NoSuccessorBeforeOutput(t *testing.T) {
 	var handlerCount atomic.Int32
 
-	asker := newReentryNode("asker", func(ctx agent.InvocationContext, _ any) iter.Seq2[*session.Event, error] {
-		return func(yield func(*session.Event, error) bool) {
-			if _, ok := ctx.ResumedInput("decide"); !ok {
-				yield(workflow.NewRequestInputEvent(ctx, session.RequestInput{
-					InterruptID: "decide",
-					Message:     "decide",
-				}), nil)
-				return
-			}
-			ev := session.NewEvent(ctx.InvocationID())
-			ev.Actions.StateDelta["output"] = "ack"
-			yield(ev, nil)
-		}
-	})
+	asker, _ := askerForSequence("asker", []string{"decide"}, "ack")
 	handler := newCountingHandlerNode("handler", &handlerCount)
 
 	a := makeAgent(t, workflow.Chain(workflow.Start, asker, handler))
 	sess := newFakeSession()
 
-	// Pause turn.
+	// Pause turn: handler must not have fired.
 	runFreshTurn(t, sess, a, "x")
-	if handlerCount.Load() != 0 {
-		t.Errorf("handler ran during pause turn; count = %d", handlerCount.Load())
+	if got := handlerCount.Load(); got != 0 {
+		t.Errorf("handler ran during pause turn; count = %d", got)
 	}
 
-	// Resume turn — asker re-runs and emits "ack"; handler runs
-	// once with that input.
-	drainAgent(t, sess, a.Run(newMockCtx(sess, a, resumeMessage("decide", "yes"))), nil)
+	// Resume turn: asker re-runs and emits output; handler runs once.
+	resumeAndExpect(t, sess, a, "decide", "yes", "")
 	if got := handlerCount.Load(); got != 1 {
 		t.Errorf("handler runs after re-entry = %d, want 1", got)
 	}
@@ -239,6 +144,129 @@ func TestWorkflowAgent_ReEntry_DefaultModeIsHandoff(t *testing.T) {
 	if got := handlerInput.Load(); got != "approve" {
 		t.Errorf("handler input = %v, want %q (handoff mode delivers response as next-node input)", got, "approve")
 	}
+}
+
+// --- test helpers below ---------------------------------------------------
+
+// reentryNode is a custom Node with NodeConfig.RerunOnResume = true
+// whose Run body is supplied by the test via runFn. Each test
+// decides what to do on the first activation (typically yield a
+// RequestInput) and on re-entry (read ctx.ResumedInput, emit an
+// output).
+type reentryNode struct {
+	workflow.BaseNode
+	runFn func(ctx agent.InvocationContext, input any) iter.Seq2[*session.Event, error]
+}
+
+func newReentryNode(name string, runFn func(agent.InvocationContext, any) iter.Seq2[*session.Event, error]) *reentryNode {
+	return &reentryNode{
+		BaseNode: workflow.NewBaseNode(name, "", workflow.NodeConfig{RerunOnResume: ptrTrue()}),
+		runFn:    runFn,
+	}
+}
+
+func (n *reentryNode) Run(ctx agent.InvocationContext, input any) iter.Seq2[*session.Event, error] {
+	return n.runFn(ctx, input)
+}
+
+// reentryActivation records what a re-entry asker observed during
+// a single Run call: the input it received and the snapshot of
+// resume-input payloads visible to it via ctx.ResumedInput.
+type reentryActivation struct {
+	input   any
+	resumed map[string]any
+}
+
+// activations is a concurrent-safe ordered log of reentryActivation
+// entries, used by tests to assert what an asker observed on each
+// of its successive activations (initial run + N re-entries).
+type activations struct {
+	mu   sync.Mutex
+	list []reentryActivation
+}
+
+func (a *activations) record(input any, resumed map[string]any) {
+	a.mu.Lock()
+	defer a.mu.Unlock()
+	a.list = append(a.list, reentryActivation{input: input, resumed: resumed})
+}
+
+func (a *activations) at(i int) (reentryActivation, bool) {
+	a.mu.Lock()
+	defer a.mu.Unlock()
+	if i < 0 || i >= len(a.list) {
+		return reentryActivation{}, false
+	}
+	return a.list[i], true
+}
+
+func (a *activations) count() int {
+	a.mu.Lock()
+	defer a.mu.Unlock()
+	return len(a.list)
+}
+
+// snapshotResumed reads ctx.ResumedInput for each of ids and
+// returns the subset that the scheduler currently exposes. Missing
+// IDs are omitted from the map so test assertions can compare
+// against literal map[string]any{"id": value} expectations.
+func snapshotResumed(ctx agent.InvocationContext, ids ...string) map[string]any {
+	out := map[string]any{}
+	for _, id := range ids {
+		if v, ok := ctx.ResumedInput(id); ok {
+			out[id] = v
+		}
+	}
+	return out
+}
+
+// askerForSequence builds a reentryNode that walks through ids,
+// pausing on each with a RequestInput. On every activation it
+// records what input and resumed map it saw; once every id has a
+// response it emits a final output event carrying finalOutput.
+//
+// Use it for tests that exercise multi-step ask-then-observe
+// patterns without the per-test ceremony of branching on which
+// question is next or maintaining a per-test activation counter.
+func askerForSequence(name string, ids []string, finalOutput any) (*reentryNode, *activations) {
+	acts := &activations{}
+	node := newReentryNode(name, func(ctx agent.InvocationContext, input any) iter.Seq2[*session.Event, error] {
+		return func(yield func(*session.Event, error) bool) {
+			resumed := snapshotResumed(ctx, ids...)
+			acts.record(input, resumed)
+
+			// Pause on the first id we haven't seen a response for.
+			for _, id := range ids {
+				if _, answered := resumed[id]; !answered {
+					yield(workflow.NewRequestInputEvent(ctx, session.RequestInput{
+						InterruptID: id,
+						Message:     id,
+					}), nil)
+					return
+				}
+			}
+
+			// All answered: emit the terminal output.
+			ev := session.NewEvent(ctx.InvocationID())
+			ev.Actions.StateDelta["output"] = finalOutput
+			yield(ev, nil)
+		}
+	})
+	return node, acts
+}
+
+// resumeAndExpect performs one resume turn replying to replyID
+// with replyValue, then asserts the next pause (if any) carries
+// the expected InterruptID. Pass wantNextRequest = "" to assert
+// that the workflow did not pause again (i.e. the resume turn
+// completed without yielding another RequestInput).
+func resumeAndExpect(t *testing.T, sess *fakeSession, a agent.Agent, replyID string, replyValue any, wantNextRequest string) []*session.Event {
+	t.Helper()
+	events := drainAgent(t, sess, a.Run(newMockCtx(sess, a, resumeMessage(replyID, replyValue))), nil)
+	if got := findRequest(events); got != wantNextRequest {
+		t.Fatalf("after resume %q=%v: RequestedInput = %q, want %q", replyID, replyValue, got, wantNextRequest)
+	}
+	return events
 }
 
 func ptrTrue() *bool {

--- a/agent/workflowagent/reentry_test.go
+++ b/agent/workflowagent/reentry_test.go
@@ -1,0 +1,237 @@
+// Copyright 2026 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package workflowagent
+
+import (
+	"iter"
+	"sync"
+	"sync/atomic"
+	"testing"
+
+	"google.golang.org/adk/agent"
+	"google.golang.org/adk/session"
+	"google.golang.org/adk/workflow"
+)
+
+// reentryNode is a custom Node with NodeConfig.RerunOnResume = true.
+// On the first activation it issues a RequestInput and exits; on the
+// re-entry activation it observes the user's response via
+// ctx.ResumedInput and emits an output, optionally calling a hook
+// supplied by the test.
+type reentryNode struct {
+	workflow.BaseNode
+	interruptID string
+	onResume    func(response any, originalInput any) (output any)
+}
+
+func newReentryNode(name, interruptID string, onResume func(response, originalInput any) any) *reentryNode {
+	t := true
+	return &reentryNode{
+		BaseNode:    workflow.NewBaseNode(name, "", workflow.NodeConfig{RerunOnResume: &t}),
+		interruptID: interruptID,
+		onResume:    onResume,
+	}
+}
+
+func (n *reentryNode) Run(ctx agent.InvocationContext, input any) iter.Seq2[*session.Event, error] {
+	return func(yield func(*session.Event, error) bool) {
+		if response, ok := ctx.ResumedInput(n.interruptID); ok {
+			out := n.onResume(response, input)
+			ev := session.NewEvent(ctx.InvocationID())
+			ev.Actions.StateDelta["output"] = out
+			yield(ev, nil)
+			return
+		}
+		// First activation: ask.
+		yield(workflow.NewRequestInputEvent(ctx, session.RequestInput{
+			InterruptID: n.interruptID,
+			Message:     "decide",
+		}), nil)
+	}
+}
+
+// TestWorkflowAgent_ReEntry_ResumesAtSameNode verifies the canonical
+// re-entry round-trip: the asker is re-activated on resume, sees
+// the response via ResumedInput, and produces an output that flows
+// to its successor.
+func TestWorkflowAgent_ReEntry_ResumesAtSameNode(t *testing.T) {
+	var resumeActivations atomic.Int32
+	var capturedResponse atomic.Value
+
+	asker := newReentryNode("asker", "decide", func(response, _ any) any {
+		resumeActivations.Add(1)
+		capturedResponse.Store(response)
+		return "decision: " + response.(string)
+	})
+
+	var handlerInput atomic.Value
+	handler := newStringHandlerNode("handler", &handlerInput)
+
+	a := makeAgent(t, workflow.Chain(workflow.Start, asker, handler))
+	sess := newFakeSession()
+
+	// Turn 1: fresh; pauses with RequestedInput.
+	turn1 := runFreshTurn(t, sess, a, "draft")
+	if got := findRequest(turn1); got != "decide" {
+		t.Fatalf("turn 1 RequestedInput = %q, want %q", got, "decide")
+	}
+	if resumeActivations.Load() != 0 {
+		t.Errorf("re-entry happened on turn 1; resumeActivations = %d", resumeActivations.Load())
+	}
+
+	// Turn 2: resume; asker re-runs with response visible via
+	// ResumedInput, then handler runs.
+	drainAgent(t, sess, a.Run(newMockCtx(sess, a, resumeMessage("decide", "approve"))), nil)
+	if got := resumeActivations.Load(); got != 1 {
+		t.Errorf("resume activations = %d, want 1", got)
+	}
+	if got := capturedResponse.Load(); got != "approve" {
+		t.Errorf("ResumedInput response = %v, want %q", got, "approve")
+	}
+	if got, want := handlerInput.Load(), "decision: approve"; got != want {
+		t.Errorf("handler input = %v, want %q", got, want)
+	}
+}
+
+// TestWorkflowAgent_ReEntry_PreservesOriginalInput verifies that on
+// re-entry the asker receives the SAME input value it saw on its
+// first activation, not the user's response. The response is
+// delivered separately via ResumedInput.
+func TestWorkflowAgent_ReEntry_PreservesOriginalInput(t *testing.T) {
+	var seenInputs sync.Map // attempt index -> input
+	var attempts atomic.Int32
+
+	// observeInput captures input on every activation (first or
+	// re-entry); the body uses ResumedInput to decide whether to
+	// emit the request or the final output.
+	observeInput := func(ctx agent.InvocationContext, input any) iter.Seq2[*session.Event, error] {
+		return func(yield func(*session.Event, error) bool) {
+			seenInputs.Store(attempts.Load(), input)
+			attempts.Add(1)
+			if _, ok := ctx.ResumedInput("decide"); ok {
+				ev := session.NewEvent(ctx.InvocationID())
+				ev.Actions.StateDelta["output"] = "ack"
+				yield(ev, nil)
+				return
+			}
+			yield(workflow.NewRequestInputEvent(ctx, session.RequestInput{
+				InterruptID: "decide",
+				Message:     "?",
+			}), nil)
+		}
+	}
+
+	asker := &observingReentryNode{
+		BaseNode: workflow.NewBaseNode("asker", "", workflow.NodeConfig{RerunOnResume: ptrTrue()}),
+		runFn:    observeInput,
+	}
+
+	a := makeAgent(t, workflow.Chain(workflow.Start, asker))
+	sess := newFakeSession()
+
+	// Turn 1: fresh, asker sees "draft" as input.
+	runFreshTurn(t, sess, a, "draft")
+
+	// Turn 2: resume with response "approve". Asker re-runs and
+	// must see "draft" again as input (not "approve").
+	drainAgent(t, sess, a.Run(newMockCtx(sess, a, resumeMessage("decide", "approve"))), nil)
+
+	first, _ := seenInputs.Load(int32(0))
+	second, _ := seenInputs.Load(int32(1))
+	if first != "draft" {
+		t.Errorf("first activation input = %v, want %q", first, "draft")
+	}
+	if second != "draft" {
+		t.Errorf("re-entry activation input = %v, want %q (must preserve original input, not the response)", second, "draft")
+	}
+}
+
+// observingReentryNode is a Node whose Run delegates to a function-
+// typed field, so individual tests can supply their own Run body
+// without subclassing.
+type observingReentryNode struct {
+	workflow.BaseNode
+	runFn func(ctx agent.InvocationContext, input any) iter.Seq2[*session.Event, error]
+}
+
+func (n *observingReentryNode) Run(ctx agent.InvocationContext, input any) iter.Seq2[*session.Event, error] {
+	return n.runFn(ctx, input)
+}
+
+// TestWorkflowAgent_ReEntry_NoSuccessorBeforeOutput verifies that a
+// re-entry asker's downstream successor only fires once the
+// re-entry activation actually emits an output event. (Compare to
+// handoff mode, where the successor would fire immediately on
+// resume even without a re-entry activation.)
+func TestWorkflowAgent_ReEntry_NoSuccessorBeforeOutput(t *testing.T) {
+	var handlerCount atomic.Int32
+
+	asker := newReentryNode("asker", "decide", func(response, _ any) any {
+		return "ack"
+	})
+	handler := newCountingHandlerNode("handler", &handlerCount)
+
+	a := makeAgent(t, workflow.Chain(workflow.Start, asker, handler))
+	sess := newFakeSession()
+
+	// Pause turn.
+	runFreshTurn(t, sess, a, "x")
+	if handlerCount.Load() != 0 {
+		t.Errorf("handler ran during pause turn; count = %d", handlerCount.Load())
+	}
+
+	// Resume turn — asker re-runs and emits "ack"; handler runs
+	// once with that input.
+	drainAgent(t, sess, a.Run(newMockCtx(sess, a, resumeMessage("decide", "yes"))), nil)
+	if got := handlerCount.Load(); got != 1 {
+		t.Errorf("handler runs after re-entry = %d, want 1", got)
+	}
+}
+
+// TestWorkflowAgent_ReEntry_DefaultModeIsHandoff confirms that a
+// node without RerunOnResume = true uses handoff mode on resume:
+// the response flows to the successor as its input and the asker
+// does not re-run.
+func TestWorkflowAgent_ReEntry_DefaultModeIsHandoff(t *testing.T) {
+	var askerActivations atomic.Int32
+
+	asker := newHitlNode("asker", func(ctx agent.InvocationContext, _ any, yield func(*session.Event, error) bool) {
+		askerActivations.Add(1)
+		yield(workflow.NewRequestInputEvent(ctx, session.RequestInput{
+			InterruptID: "decide",
+			Message:     "?",
+		}), nil)
+	})
+	var handlerInput atomic.Value
+	handler := newStringHandlerNode("handler", &handlerInput)
+
+	a := makeAgent(t, workflow.Chain(workflow.Start, asker, handler))
+	sess := newFakeSession()
+
+	runFreshTurn(t, sess, a, "x")
+	drainAgent(t, sess, a.Run(newMockCtx(sess, a, resumeMessage("decide", "approve"))), nil)
+
+	if got := askerActivations.Load(); got != 1 {
+		t.Errorf("asker activations = %d, want 1 (handoff mode must NOT re-activate the asker)", got)
+	}
+	if got := handlerInput.Load(); got != "approve" {
+		t.Errorf("handler input = %v, want %q (handoff mode delivers response as next-node input)", got, "approve")
+	}
+}
+
+func ptrTrue() *bool {
+	t := true
+	return &t
+}

--- a/agent/workflowagent/reentry_test.go
+++ b/agent/workflowagent/reentry_test.go
@@ -1,0 +1,238 @@
+// Copyright 2026 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package workflowagent
+
+import (
+	"iter"
+	"sync"
+	"sync/atomic"
+	"testing"
+
+	"google.golang.org/adk/agent"
+	"google.golang.org/adk/session"
+	"google.golang.org/adk/workflow"
+)
+
+// reentryNode is a custom Node with NodeConfig.RerunOnResume = true.
+// On the first activation it issues a RequestInput and exits; on the
+// re-entry activation it observes the user's response via
+// ctx.ResumedInput and emits an output, optionally calling a hook
+// supplied by the test.
+type reentryNode struct {
+	workflow.BaseNode
+	interruptID string
+	onResume    func(response any, originalInput any) (output any)
+}
+
+func newReentryNode(name, interruptID string, onResume func(response, originalInput any) any) *reentryNode {
+	t := true
+	return &reentryNode{
+		BaseNode:    workflow.NewBaseNode(name, "", workflow.NodeConfig{RerunOnResume: &t}),
+		interruptID: interruptID,
+		onResume:    onResume,
+	}
+}
+
+func (n *reentryNode) Run(ctx agent.InvocationContext, input any) iter.Seq2[*session.Event, error] {
+	return func(yield func(*session.Event, error) bool) {
+		if response, ok := ctx.ResumedInput(n.interruptID); ok {
+			out := n.onResume(response, input)
+			ev := session.NewEvent(ctx.InvocationID())
+			ev.Actions.StateDelta["output"] = out
+			yield(ev, nil)
+			return
+		}
+		// First activation: ask.
+		yield(workflow.NewRequestInputEvent(ctx, session.RequestInput{
+			InterruptID: n.interruptID,
+			Message:     "decide",
+		}), nil)
+	}
+}
+
+// TestWorkflowAgent_ReEntry_ResumesAtSameNode verifies the canonical
+// re-entry round-trip: the asker is re-activated on resume, sees
+// the response via ResumedInput, and produces an output that flows
+// to its successor.
+func TestWorkflowAgent_ReEntry_ResumesAtSameNode(t *testing.T) {
+	var resumeActivations atomic.Int32
+	var capturedResponse atomic.Value
+
+	asker := newReentryNode("asker", "decide", func(response, _ any) any {
+		resumeActivations.Add(1)
+		capturedResponse.Store(response)
+		return "decision: " + response.(string)
+	})
+
+	var handlerInput atomic.Value
+	handler := newStringHandlerNode("handler", &handlerInput)
+
+	a := makeAgent(t, workflow.Chain(workflow.Start, asker, handler))
+	sess := newFakeSession()
+
+	// Turn 1: fresh; pauses with RequestedInput.
+	turn1 := runFreshTurn(t, sess, a, "draft")
+	if got := findRequest(turn1); got != "decide" {
+		t.Fatalf("turn 1 RequestedInput = %q, want %q", got, "decide")
+	}
+	if resumeActivations.Load() != 0 {
+		t.Errorf("re-entry happened on turn 1; resumeActivations = %d", resumeActivations.Load())
+	}
+
+	// Turn 2: resume; asker re-runs with response visible via
+	// ResumedInput, then handler runs.
+	drainAgent(t, sess, a.Run(newMockCtx(sess, a, resumeMessage("decide", "approve"))), nil)
+	if got := resumeActivations.Load(); got != 1 {
+		t.Errorf("resume activations = %d, want 1", got)
+	}
+	if got := capturedResponse.Load(); got != "approve" {
+		t.Errorf("ResumedInput response = %v, want %q", got, "approve")
+	}
+	if got, want := handlerInput.Load(), "decision: approve"; got != want {
+		t.Errorf("handler input = %v, want %q", got, want)
+	}
+}
+
+// TestWorkflowAgent_ReEntry_PreservesOriginalInput verifies that on
+// re-entry the asker receives the SAME input value it saw on its
+// first activation, not the user's response. The response is
+// delivered separately via ResumedInput.
+func TestWorkflowAgent_ReEntry_PreservesOriginalInput(t *testing.T) {
+	var seenInputs sync.Map // attempt index -> input
+	var attempts atomic.Int32
+
+	// observeInput captures input on every activation (first or
+	// re-entry); the body uses ResumedInput to decide whether to
+	// emit the request or the final output.
+	observeInput := func(ctx agent.InvocationContext, input any) iter.Seq2[*session.Event, error] {
+		return func(yield func(*session.Event, error) bool) {
+			seenInputs.Store(attempts.Load(), input)
+			attempts.Add(1)
+			if _, ok := ctx.ResumedInput("decide"); ok {
+				ev := session.NewEvent(ctx.InvocationID())
+				ev.Actions.StateDelta["output"] = "ack"
+				yield(ev, nil)
+				return
+			}
+			yield(workflow.NewRequestInputEvent(ctx, session.RequestInput{
+				InterruptID: "decide",
+				Message:     "?",
+			}), nil)
+		}
+	}
+
+	asker := &observingReentryNode{
+		BaseNode: workflow.NewBaseNode("asker", "", workflow.NodeConfig{RerunOnResume: ptrTrue()}),
+		runFn:    observeInput,
+	}
+
+	a := makeAgent(t, workflow.Chain(workflow.Start, asker))
+	sess := newFakeSession()
+
+	// Turn 1: fresh, asker sees "draft" as input.
+	runFreshTurn(t, sess, a, "draft")
+
+	// Turn 2: resume with response "approve". Asker re-runs and
+	// must see "draft" again as input (not "approve").
+	drainAgent(t, sess, a.Run(newMockCtx(sess, a, resumeMessage("decide", "approve"))), nil)
+
+	first, _ := seenInputs.Load(int32(0))
+	second, _ := seenInputs.Load(int32(1))
+	if first != "draft" {
+		t.Errorf("first activation input = %v, want %q", first, "draft")
+	}
+	if second != "draft" {
+		t.Errorf("re-entry activation input = %v, want %q (must preserve original input, not the response)", second, "draft")
+	}
+}
+
+// observingReentryNode is a Node whose Run delegates to a function-
+// typed field, so individual tests can supply their own Run body
+// without subclassing.
+type observingReentryNode struct {
+	workflow.BaseNode
+	runFn func(ctx agent.InvocationContext, input any) iter.Seq2[*session.Event, error]
+}
+
+func (n *observingReentryNode) Run(ctx agent.InvocationContext, input any) iter.Seq2[*session.Event, error] {
+	return n.runFn(ctx, input)
+}
+
+// TestWorkflowAgent_ReEntry_NoSuccessorBeforeOutput verifies that a
+// re-entry asker's downstream successor only fires once the
+// re-entry activation actually emits an output event. (Compare to
+// handoff mode, where the successor would fire immediately on
+// resume even without a re-entry activation.)
+func TestWorkflowAgent_ReEntry_NoSuccessorBeforeOutput(t *testing.T) {
+	var handlerCount atomic.Int32
+
+	asker := newReentryNode("asker", "decide", func(response, _ any) any {
+		return "ack"
+	})
+	handler := newCountingHandlerNode("handler", &handlerCount)
+
+	a := makeAgent(t, workflow.Chain(workflow.Start, asker, handler))
+	sess := newFakeSession()
+
+	// Pause turn.
+	runFreshTurn(t, sess, a, "x")
+	if handlerCount.Load() != 0 {
+		t.Errorf("handler ran during pause turn; count = %d", handlerCount.Load())
+	}
+
+	// Resume turn — asker re-runs and emits "ack"; handler runs
+	// once with that input.
+	drainAgent(t, sess, a.Run(newMockCtx(sess, a, resumeMessage("decide", "yes"))), nil)
+	if got := handlerCount.Load(); got != 1 {
+		t.Errorf("handler runs after re-entry = %d, want 1", got)
+	}
+}
+
+// TestWorkflowAgent_ReEntry_DefaultModeIsHandoff confirms that
+// without RerunOnResume = true the engine still uses handoff mode
+// (the response flows to the successor as input; the asker does
+// not re-run). Pins the default-mode contract from PR #2 against
+// regression in this PR.
+func TestWorkflowAgent_ReEntry_DefaultModeIsHandoff(t *testing.T) {
+	var askerActivations atomic.Int32
+
+	asker := newHitlNode("asker", func(ctx agent.InvocationContext, _ any, yield func(*session.Event, error) bool) {
+		askerActivations.Add(1)
+		yield(workflow.NewRequestInputEvent(ctx, session.RequestInput{
+			InterruptID: "decide",
+			Message:     "?",
+		}), nil)
+	})
+	var handlerInput atomic.Value
+	handler := newStringHandlerNode("handler", &handlerInput)
+
+	a := makeAgent(t, workflow.Chain(workflow.Start, asker, handler))
+	sess := newFakeSession()
+
+	runFreshTurn(t, sess, a, "x")
+	drainAgent(t, sess, a.Run(newMockCtx(sess, a, resumeMessage("decide", "approve"))), nil)
+
+	if got := askerActivations.Load(); got != 1 {
+		t.Errorf("asker activations = %d, want 1 (handoff mode must NOT re-activate the asker)", got)
+	}
+	if got := handlerInput.Load(); got != "approve" {
+		t.Errorf("handler input = %v, want %q (handoff mode delivers response as next-node input)", got, "approve")
+	}
+}
+
+func ptrTrue() *bool {
+	t := true
+	return &t
+}

--- a/agent/workflowagent/reentry_test.go
+++ b/agent/workflowagent/reentry_test.go
@@ -25,41 +25,28 @@ import (
 	"google.golang.org/adk/workflow"
 )
 
-// reentryNode is a custom Node with NodeConfig.RerunOnResume = true.
-// On the first activation it issues a RequestInput and exits; on the
-// re-entry activation it observes the user's response via
-// ctx.ResumedInput and emits an output, optionally calling a hook
-// supplied by the test.
+// reentryNode is a custom Node with NodeConfig.RerunOnResume = true
+// whose Run body is supplied by the test via runFn. The test
+// decides what to do on the first activation (typically yield a
+// RequestInput) and on re-entry (read ctx.ResumedInput, emit an
+// output). Single helper covers both the "ask + handle reply"
+// shape of TestWorkflowAgent_ReEntry_ResumesAtSameNode and the
+// raw input-observing shape of
+// TestWorkflowAgent_ReEntry_PreservesOriginalInput.
 type reentryNode struct {
 	workflow.BaseNode
-	interruptID string
-	onResume    func(response any, originalInput any) (output any)
+	runFn func(ctx agent.InvocationContext, input any) iter.Seq2[*session.Event, error]
 }
 
-func newReentryNode(name, interruptID string, onResume func(response, originalInput any) any) *reentryNode {
-	t := true
+func newReentryNode(name string, runFn func(agent.InvocationContext, any) iter.Seq2[*session.Event, error]) *reentryNode {
 	return &reentryNode{
-		BaseNode:    workflow.NewBaseNode(name, "", workflow.NodeConfig{RerunOnResume: &t}),
-		interruptID: interruptID,
-		onResume:    onResume,
+		BaseNode: workflow.NewBaseNode(name, "", workflow.NodeConfig{RerunOnResume: ptrTrue()}),
+		runFn:    runFn,
 	}
 }
 
 func (n *reentryNode) Run(ctx agent.InvocationContext, input any) iter.Seq2[*session.Event, error] {
-	return func(yield func(*session.Event, error) bool) {
-		if response, ok := ctx.ResumedInput(n.interruptID); ok {
-			out := n.onResume(response, input)
-			ev := session.NewEvent(ctx.InvocationID())
-			ev.Actions.StateDelta["output"] = out
-			yield(ev, nil)
-			return
-		}
-		// First activation: ask.
-		yield(workflow.NewRequestInputEvent(ctx, session.RequestInput{
-			InterruptID: n.interruptID,
-			Message:     "decide",
-		}), nil)
-	}
+	return n.runFn(ctx, input)
 }
 
 // TestWorkflowAgent_ReEntry_ResumesAtSameNode verifies the canonical
@@ -69,11 +56,30 @@ func (n *reentryNode) Run(ctx agent.InvocationContext, input any) iter.Seq2[*ses
 func TestWorkflowAgent_ReEntry_ResumesAtSameNode(t *testing.T) {
 	var resumeActivations atomic.Int32
 	var capturedResponse atomic.Value
+	var capturedUnknownOK atomic.Bool
 
-	asker := newReentryNode("asker", "decide", func(response, _ any) any {
-		resumeActivations.Add(1)
-		capturedResponse.Store(response)
-		return "decision: " + response.(string)
+	asker := newReentryNode("asker", func(ctx agent.InvocationContext, _ any) iter.Seq2[*session.Event, error] {
+		return func(yield func(*session.Event, error) bool) {
+			response, ok := ctx.ResumedInput("decide")
+			if !ok {
+				yield(workflow.NewRequestInputEvent(ctx, session.RequestInput{
+					InterruptID: "decide",
+					Message:     "decide",
+				}), nil)
+				return
+			}
+			resumeActivations.Add(1)
+			capturedResponse.Store(response)
+			// Scheduler must populate resumeInputs with exactly the
+			// matching InterruptID — unrelated lookups return
+			// (nil, false). Pins the contract from the asker's side
+			// (complements the unit test in workflow/node_context_test.go).
+			_, okOther := ctx.ResumedInput("other_id")
+			capturedUnknownOK.Store(okOther)
+			ev := session.NewEvent(ctx.InvocationID())
+			ev.Actions.StateDelta["output"] = "decision: " + response.(string)
+			yield(ev, nil)
+		}
 	})
 
 	var handlerInput atomic.Value
@@ -100,6 +106,9 @@ func TestWorkflowAgent_ReEntry_ResumesAtSameNode(t *testing.T) {
 	if got := capturedResponse.Load(); got != "approve" {
 		t.Errorf("ResumedInput response = %v, want %q", got, "approve")
 	}
+	if capturedUnknownOK.Load() {
+		t.Errorf("ResumedInput(\"other_id\") returned ok=true on re-entry; want false")
+	}
 	if got, want := handlerInput.Load(), "decision: approve"; got != want {
 		t.Errorf("handler input = %v, want %q", got, want)
 	}
@@ -110,16 +119,17 @@ func TestWorkflowAgent_ReEntry_ResumesAtSameNode(t *testing.T) {
 // first activation, not the user's response. The response is
 // delivered separately via ResumedInput.
 func TestWorkflowAgent_ReEntry_PreservesOriginalInput(t *testing.T) {
-	var seenInputs sync.Map // attempt index -> input
+	var seenInputs sync.Map // attempt index (int32) -> input
 	var attempts atomic.Int32
 
-	// observeInput captures input on every activation (first or
-	// re-entry); the body uses ResumedInput to decide whether to
-	// emit the request or the final output.
-	observeInput := func(ctx agent.InvocationContext, input any) iter.Seq2[*session.Event, error] {
+	asker := newReentryNode("asker", func(ctx agent.InvocationContext, input any) iter.Seq2[*session.Event, error] {
 		return func(yield func(*session.Event, error) bool) {
-			seenInputs.Store(attempts.Load(), input)
-			attempts.Add(1)
+			// get-and-increment: avoids a Load+Add window where two
+			// concurrent activations could record under the same key.
+			// (The workflow scheduler is single-consumer in practice,
+			// but the idiom is the safe default for atomic counters.)
+			attempt := attempts.Add(1) - 1
+			seenInputs.Store(attempt, input)
 			if _, ok := ctx.ResumedInput("decide"); ok {
 				ev := session.NewEvent(ctx.InvocationID())
 				ev.Actions.StateDelta["output"] = "ack"
@@ -131,12 +141,7 @@ func TestWorkflowAgent_ReEntry_PreservesOriginalInput(t *testing.T) {
 				Message:     "?",
 			}), nil)
 		}
-	}
-
-	asker := &observingReentryNode{
-		BaseNode: workflow.NewBaseNode("asker", "", workflow.NodeConfig{RerunOnResume: ptrTrue()}),
-		runFn:    observeInput,
-	}
+	})
 
 	a := makeAgent(t, workflow.Chain(workflow.Start, asker))
 	sess := newFakeSession()
@@ -148,26 +153,20 @@ func TestWorkflowAgent_ReEntry_PreservesOriginalInput(t *testing.T) {
 	// must see "draft" again as input (not "approve").
 	drainAgent(t, sess, a.Run(newMockCtx(sess, a, resumeMessage("decide", "approve"))), nil)
 
-	first, _ := seenInputs.Load(int32(0))
-	second, _ := seenInputs.Load(int32(1))
+	first, ok1 := seenInputs.Load(int32(0))
+	if !ok1 {
+		t.Fatal("first activation never observed (no entry stored under index 0)")
+	}
+	second, ok2 := seenInputs.Load(int32(1))
+	if !ok2 {
+		t.Fatal("re-entry activation never observed (no entry stored under index 1)")
+	}
 	if first != "draft" {
 		t.Errorf("first activation input = %v, want %q", first, "draft")
 	}
 	if second != "draft" {
 		t.Errorf("re-entry activation input = %v, want %q (must preserve original input, not the response)", second, "draft")
 	}
-}
-
-// observingReentryNode is a Node whose Run delegates to a function-
-// typed field, so individual tests can supply their own Run body
-// without subclassing.
-type observingReentryNode struct {
-	workflow.BaseNode
-	runFn func(ctx agent.InvocationContext, input any) iter.Seq2[*session.Event, error]
-}
-
-func (n *observingReentryNode) Run(ctx agent.InvocationContext, input any) iter.Seq2[*session.Event, error] {
-	return n.runFn(ctx, input)
 }
 
 // TestWorkflowAgent_ReEntry_NoSuccessorBeforeOutput verifies that a
@@ -178,8 +177,19 @@ func (n *observingReentryNode) Run(ctx agent.InvocationContext, input any) iter.
 func TestWorkflowAgent_ReEntry_NoSuccessorBeforeOutput(t *testing.T) {
 	var handlerCount atomic.Int32
 
-	asker := newReentryNode("asker", "decide", func(response, _ any) any {
-		return "ack"
+	asker := newReentryNode("asker", func(ctx agent.InvocationContext, _ any) iter.Seq2[*session.Event, error] {
+		return func(yield func(*session.Event, error) bool) {
+			if _, ok := ctx.ResumedInput("decide"); !ok {
+				yield(workflow.NewRequestInputEvent(ctx, session.RequestInput{
+					InterruptID: "decide",
+					Message:     "decide",
+				}), nil)
+				return
+			}
+			ev := session.NewEvent(ctx.InvocationID())
+			ev.Actions.StateDelta["output"] = "ack"
+			yield(ev, nil)
+		}
 	})
 	handler := newCountingHandlerNode("handler", &handlerCount)
 

--- a/agent/workflowagent/workflow_test.go
+++ b/agent/workflowagent/workflow_test.go
@@ -95,13 +95,14 @@ func (m *MockInvocationContext) Value(key any) any {
 	return m.Context.Value(key)
 }
 
-func (m *MockInvocationContext) Artifacts() agent.Artifacts  { return nil }
-func (m *MockInvocationContext) Memory() agent.Memory        { return nil }
-func (m *MockInvocationContext) Branch() string              { return "" }
-func (m *MockInvocationContext) RunConfig() *agent.RunConfig { return nil }
-func (m *MockInvocationContext) Ended() bool                 { return false }
-func (m *MockInvocationContext) EndInvocation()              {}
-func (m *MockInvocationContext) TriggeredBy() string         { return "" }
+func (m *MockInvocationContext) Artifacts() agent.Artifacts      { return nil }
+func (m *MockInvocationContext) Memory() agent.Memory            { return nil }
+func (m *MockInvocationContext) Branch() string                  { return "" }
+func (m *MockInvocationContext) RunConfig() *agent.RunConfig     { return nil }
+func (m *MockInvocationContext) Ended() bool                     { return false }
+func (m *MockInvocationContext) EndInvocation()                  {}
+func (m *MockInvocationContext) TriggeredBy() string             { return "" }
+func (m *MockInvocationContext) ResumedInput(string) (any, bool) { return nil, false }
 
 func TestWorkflowAgent(t *testing.T) {
 	upperFn := func(ctx agent.InvocationContext, input any) (string, error) {

--- a/internal/configurable/conformance/replayplugin/replay_plugin_test.go
+++ b/internal/configurable/conformance/replayplugin/replay_plugin_test.go
@@ -401,6 +401,7 @@ func (m *MockInvocationContext) EndInvocation()                                 
 func (m *MockInvocationContext) Ended() bool                                             { return false }
 func (m *MockInvocationContext) WithContext(ctx context.Context) agent.InvocationContext { return m }
 func (m *MockInvocationContext) TriggeredBy() string                                     { return "" }
+func (m *MockInvocationContext) ResumedInput(string) (any, bool)                         { return nil, false }
 func (m *MockInvocationContext) Value(key any) any                                       { return nil }
 func (m *MockInvocationContext) Deadline() (deadline time.Time, ok bool)                 { return time.Time{}, false }
 func (m *MockInvocationContext) Done() <-chan struct{}                                   { return nil }

--- a/internal/context/invocation_context.go
+++ b/internal/context/invocation_context.go
@@ -105,4 +105,9 @@ func (c *InvocationContext) WithContext(ctx context.Context) agent.InvocationCon
 // that overrides the method when running inside a workflow.Node.
 func (c *InvocationContext) TriggeredBy() string { return "" }
 
+// ResumedInput always returns (nil, false) for the base
+// invocation context. Implementations that carry a resume payload
+// override this method.
+func (c *InvocationContext) ResumedInput(string) (any, bool) { return nil, false }
+
 var _ agent.InvocationContext = (*InvocationContext)(nil)

--- a/internal/llminternal/functions_test.go
+++ b/internal/llminternal/functions_test.go
@@ -55,7 +55,8 @@ func (m *mockInvocationContext) Branch() string {
 	return m.branch
 }
 
-func (m *mockInvocationContext) TriggeredBy() string { return "" }
+func (m *mockInvocationContext) TriggeredBy() string             { return "" }
+func (m *mockInvocationContext) ResumedInput(string) (any, bool) { return nil, false }
 
 func TestGenerateRequestConfirmationEvent(t *testing.T) {
 	confirmingFunctionCall := &genai.FunctionCall{

--- a/workflow/config.go
+++ b/workflow/config.go
@@ -61,11 +61,11 @@ type NodeConfig struct {
 	RerunOnResume *bool
 
 	// WaitForOutput, when true, keeps the node in NodeWaiting
-	// (re-triggerable) until it actually yields an event carrying
-	// an "output" key in Actions.StateDelta, instead of moving it
-	// to NodeCompleted on first return. JoinNode and any custom
-	// fan-in node sets this. nil defers to the engine; the
-	// engine currently treats nil as false.
+	// (re-triggerable) until it actually yields an event carrying an
+	// "output" key in Actions.StateDelta, instead of moving it to
+	// NodeCompleted on first return. JoinNode and any custom fan-in
+	// node sets this. nil means "use the engine default" — false for
+	// most node kinds.
 	WaitForOutput *bool
 
 	// RetryConfig, when non-nil, makes the scheduler retry this node

--- a/workflow/config.go
+++ b/workflow/config.go
@@ -44,30 +44,28 @@ func DefaultRetryConfig() *RetryConfig {
 // NodeConfig defines the configuration for a node.
 //
 // All fields are optional. The pointer-typed fields (RerunOnResume,
-// WaitForOutput) are tri-state: nil means "use the engine default for
-// this node kind", which mirrors Python's per-node-type defaults
-// (e.g. AgentNode in task mode defaults WaitForOutput to true while
-// other nodes default to false). Use the *Or accessor helpers to
-// read these values with an explicit per-call-site default.
+// WaitForOutput) are tri-state so node implementations can
+// distinguish "user explicitly opted out" (&false) from "user did
+// not configure" (nil).
 type NodeConfig struct {
 	// ParallelWorker, when true, runs the node concurrently for each
 	// item of a list-typed input. The engine collects per-item
 	// outputs and emits a single aggregate output event.
 	ParallelWorker bool
 
-	// RerunOnResume controls human-in-the-loop resume behaviour. When
-	// true, an interrupted node re-runs from scratch on resume; when
-	// false, the resume payload is treated as the node's output.
-	// nil means "use the engine default", which is true for AgentNode
-	// and false elsewhere.
+	// RerunOnResume controls human-in-the-loop resume behaviour:
+	// &true re-runs the interrupted node from scratch on resume
+	// (re-entry mode), &false routes the resume payload to the
+	// node's successor as input (handoff mode), and nil defers to
+	// the engine. The engine currently treats nil as handoff.
 	RerunOnResume *bool
 
 	// WaitForOutput, when true, keeps the node in NodeWaiting
-	// (re-triggerable) until it actually yields an event carrying an
-	// "output" key in Actions.StateDelta, instead of moving it to
-	// NodeCompleted on first return. JoinNode and any custom fan-in
-	// node sets this. nil means "use the engine default" — false for
-	// most node kinds.
+	// (re-triggerable) until it actually yields an event carrying
+	// an "output" key in Actions.StateDelta, instead of moving it
+	// to NodeCompleted on first return. JoinNode and any custom
+	// fan-in node sets this. nil defers to the engine; the
+	// engine currently treats nil as false.
 	WaitForOutput *bool
 
 	// RetryConfig, when non-nil, makes the scheduler retry this node

--- a/workflow/graph_test.go
+++ b/workflow/graph_test.go
@@ -19,6 +19,7 @@ import (
 	"testing"
 
 	"github.com/google/go-cmp/cmp"
+
 	"google.golang.org/adk/agent"
 	"google.golang.org/adk/session"
 )

--- a/workflow/node_context.go
+++ b/workflow/node_context.go
@@ -18,20 +18,34 @@ import "google.golang.org/adk/agent"
 
 // nodeContext is the per-node InvocationContext seen inside Node.Run.
 // It wraps the workflow's incoming agent.InvocationContext and adds
-// engine-supplied metadata — currently only the upstream node name
-// (TriggeredBy).
+// engine-supplied metadata: the upstream node name (TriggeredBy)
+// and any human-input responses the scheduler injected for a
+// re-entry resume activation (ResumedInput).
 //
-// TODO(wolo): replace once context-unification work lands.
+// TODO(wolo): replace once context-unification work lands. The
+// wrapper exists today only to surface workflow-specific accessors
+// that the base interface does not have.
 type nodeContext struct {
 	agent.InvocationContext
 	triggeredBy string
+
+	// resumeInputs carries the user-supplied response payloads for
+	// a re-entry resume activation, keyed by InterruptID. Nil on
+	// fresh activations and on handoff resume (where the response
+	// flows to the successor as its input rather than back to the
+	// asker via this map).
+	resumeInputs map[string]any
 }
 
 // newNodeContext returns a nodeContext wrapping parent with the given
 // upstream-node name. triggeredBy is empty for the initial START
-// activation.
-func newNodeContext(parent agent.InvocationContext, triggeredBy string) *nodeContext {
-	return &nodeContext{InvocationContext: parent, triggeredBy: triggeredBy}
+// activation. resumeInputs is nil for non-resume activations.
+func newNodeContext(parent agent.InvocationContext, triggeredBy string, resumeInputs map[string]any) *nodeContext {
+	return &nodeContext{
+		InvocationContext: parent,
+		triggeredBy:       triggeredBy,
+		resumeInputs:      resumeInputs,
+	}
 }
 
 // TriggeredBy returns the name of the upstream node whose output
@@ -39,3 +53,16 @@ func newNodeContext(parent agent.InvocationContext, triggeredBy string) *nodeCon
 // trigger and for non-workflow invocations (where the wrapper is not
 // used).
 func (c *nodeContext) TriggeredBy() string { return c.triggeredBy }
+
+// ResumedInput returns the response payload associated with the
+// given InterruptID for a re-entry resume activation. Returns
+// (nil, false) on fresh activations, on handoff resume, and when
+// the InterruptID does not match any payload supplied by the
+// resuming caller.
+func (c *nodeContext) ResumedInput(interruptID string) (any, bool) {
+	if c.resumeInputs == nil {
+		return nil, false
+	}
+	v, ok := c.resumeInputs[interruptID]
+	return v, ok
+}

--- a/workflow/node_context_test.go
+++ b/workflow/node_context_test.go
@@ -20,7 +20,7 @@ import (
 	"google.golang.org/adk/agent"
 )
 
-func TestNewNodeContext_TriggeredByRoundTrip(t *testing.T) {
+func TestNodeContext_TriggeredByPreservesValue(t *testing.T) {
 	tests := []struct {
 		name        string
 		triggeredBy string
@@ -59,9 +59,6 @@ func TestNodeContext_ResumedInput(t *testing.T) {
 		})
 		if v, ok := c.ResumedInput("approval"); !ok || v != "yes" {
 			t.Errorf("ResumedInput(\"approval\") = (%v, %v), want (\"yes\", true)", v, ok)
-		}
-		if v, ok := c.ResumedInput("missing"); ok || v != nil {
-			t.Errorf("ResumedInput(\"missing\") = (%v, %v), want (nil, false)", v, ok)
 		}
 	})
 }

--- a/workflow/node_context_test.go
+++ b/workflow/node_context_test.go
@@ -33,12 +33,37 @@ func TestNewNodeContext_TriggeredByRoundTrip(t *testing.T) {
 	parent := newMockCtx(t)
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			c := newNodeContext(parent, tt.triggeredBy)
+			c := newNodeContext(parent, tt.triggeredBy, nil)
 			if got := c.TriggeredBy(); got != tt.triggeredBy {
 				t.Errorf("TriggeredBy() = %q, want %q", got, tt.triggeredBy)
 			}
 		})
 	}
+}
+
+func TestNodeContext_ResumedInput(t *testing.T) {
+	parent := newMockCtx(t)
+
+	t.Run("nil resumeInputs returns (nil, false)", func(t *testing.T) {
+		c := newNodeContext(parent, "", nil)
+		v, ok := c.ResumedInput("any_id")
+		if v != nil || ok {
+			t.Errorf("ResumedInput() = (%v, %v), want (nil, false)", v, ok)
+		}
+	})
+
+	t.Run("populated resumeInputs returns matched payload", func(t *testing.T) {
+		c := newNodeContext(parent, "", map[string]any{
+			"approval": "yes",
+			"comment":  "looks good",
+		})
+		if v, ok := c.ResumedInput("approval"); !ok || v != "yes" {
+			t.Errorf("ResumedInput(\"approval\") = (%v, %v), want (\"yes\", true)", v, ok)
+		}
+		if v, ok := c.ResumedInput("missing"); ok || v != nil {
+			t.Errorf("ResumedInput(\"missing\") = (%v, %v), want (nil, false)", v, ok)
+		}
+	})
 }
 
 // Compile-time assertion: *nodeContext satisfies agent.InvocationContext.

--- a/workflow/resume.go
+++ b/workflow/resume.go
@@ -111,21 +111,38 @@ func (w *Workflow) Resume(
 				continue
 			}
 
+			// Snapshot InterruptID before consuming PendingRequest;
+			// re-entry mode passes it through resumeInputs.
+			interruptID := ns.PendingRequest.InterruptID
+
 			// Consume PendingRequest before scheduling. A duplicate
 			// Resume with the same InterruptID will skip this node
 			// because PendingRequest is now nil.
 			ns.PendingRequest = nil
 			ns.Status = NodePending
 
-			// Handoff mode: schedule each successor with the
-			// response as its input, exactly as if the asker had
-			// emitted it as output. Reuses findSuccessors so
-			// routing, fan-out and fan-in invariants apply
-			// uniformly. (No routing event is supplied, so a
-			// router-style handoff target falls back to its
-			// Default route or dead-ends.)
-			for _, succ := range findSuccessors(s.graph, node, resp, nil) {
-				s.scheduleNode(succ.node, succ.input, succ.triggeredBy)
+			if r := node.Config().RerunOnResume; r != nil && *r {
+				// Re-entry mode: re-activate the asker with its
+				// original input; the response is delivered via
+				// ctx.ResumedInput(InterruptID), not via the
+				// input parameter. Successors fire only when the
+				// re-entry activation produces an output.
+				resumeInputs := map[string]any{interruptID: resp}
+				s.scheduleResumedNode(node, ns.Input, ns.TriggeredBy, resumeInputs)
+			} else {
+				// Handoff mode: schedule each successor with the
+				// response as its input, exactly as if the asker
+				// had emitted it as output. Reuses findSuccessors
+				// so routing, fan-out and fan-in invariants apply
+				// uniformly. findSuccessors is called with
+				// event=nil, so successors reached only via a
+				// concrete Route (StringRoute etc.) do not fire —
+				// the response is opaque to the routing layer.
+				// Successors reached via an unconditional edge or
+				// via the Default route fire as usual.
+				for _, succ := range findSuccessors(s.graph, node, resp, nil) {
+					s.scheduleNode(succ.node, succ.input, succ.triggeredBy)
+				}
 			}
 			scheduled++
 		}

--- a/workflow/scheduler.go
+++ b/workflow/scheduler.go
@@ -210,6 +210,18 @@ func buildNodesByName(g *graph) map[string]Node {
 //
 // scheduleNode runs only on the consumer goroutine.
 func (s *scheduler) scheduleNode(n Node, input any, triggeredBy string) {
+	s.scheduleResumedNode(n, input, triggeredBy, nil)
+}
+
+// scheduleResumedNode is like scheduleNode but additionally
+// injects resumeInputs into the per-node context, so re-entry
+// nodes can read the user-supplied response payload via
+// ctx.ResumedInput(interruptID). resumeInputs is keyed by
+// InterruptID; nil disables re-entry semantics and yields the same
+// behaviour as scheduleNode.
+//
+// scheduleResumedNode runs only on the consumer goroutine.
+func (s *scheduler) scheduleResumedNode(n Node, input any, triggeredBy string, resumeInputs map[string]any) {
 	name := n.Name()
 
 	// Per-node context: WithTimeout when Config().Timeout > 0,
@@ -226,7 +238,7 @@ func (s *scheduler) scheduleNode(n Node, input any, triggeredBy string) {
 	} else {
 		nodeCtx, cancel = context.WithCancel(s.parentCtx)
 	}
-	perNodeCtx := newNodeContext(s.parentCtx.WithContext(nodeCtx), triggeredBy)
+	perNodeCtx := newNodeContext(s.parentCtx.WithContext(nodeCtx), triggeredBy, resumeInputs)
 
 	ns := s.state.EnsureNode(name)
 	ns.Status = NodeRunning

--- a/workflow/validation_test.go
+++ b/workflow/validation_test.go
@@ -239,14 +239,16 @@ func TestConnectivity(t *testing.T) {
 	}{
 		{
 			name: "all nodes connected",
-			edges: []Edge{{From: Start, To: nodeA},
+			edges: []Edge{
+				{From: Start, To: nodeA},
 				{From: nodeA, To: nodeB},
 				{From: nodeB, To: nodeC},
 			},
 		},
 		{
 			name: "disconnected nodes",
-			edges: []Edge{{From: Start, To: nodeA},
+			edges: []Edge{
+				{From: Start, To: nodeA},
 				{From: nodeB, To: nodeC},
 			},
 			expectErrorMsg: "nodes not reachable from start node: \"B, C\"",

--- a/workflow/workflow_test.go
+++ b/workflow/workflow_test.go
@@ -71,17 +71,18 @@ func mustNew(t *testing.T, edges []Edge) *Workflow {
 	return w
 }
 
-func (m *MockInvocationContext) Session() session.Session    { return m.sess }
-func (m *MockInvocationContext) InvocationID() string        { return "test-invocation-id" }
-func (m *MockInvocationContext) UserContent() *genai.Content { return m.userContent }
-func (m *MockInvocationContext) TriggeredBy() string         { return "" }
-func (m *MockInvocationContext) Agent() agent.Agent          { return nil }
-func (m *MockInvocationContext) Artifacts() agent.Artifacts  { return nil }
-func (m *MockInvocationContext) Memory() agent.Memory        { return nil }
-func (m *MockInvocationContext) Branch() string              { return "" }
-func (m *MockInvocationContext) RunConfig() *agent.RunConfig { return nil }
-func (m *MockInvocationContext) Ended() bool                 { return false }
-func (m *MockInvocationContext) EndInvocation()              {}
+func (m *MockInvocationContext) Session() session.Session        { return m.sess }
+func (m *MockInvocationContext) InvocationID() string            { return "test-invocation-id" }
+func (m *MockInvocationContext) UserContent() *genai.Content     { return m.userContent }
+func (m *MockInvocationContext) TriggeredBy() string             { return "" }
+func (m *MockInvocationContext) ResumedInput(string) (any, bool) { return nil, false }
+func (m *MockInvocationContext) Agent() agent.Agent              { return nil }
+func (m *MockInvocationContext) Artifacts() agent.Artifacts      { return nil }
+func (m *MockInvocationContext) Memory() agent.Memory            { return nil }
+func (m *MockInvocationContext) Branch() string                  { return "" }
+func (m *MockInvocationContext) RunConfig() *agent.RunConfig     { return nil }
+func (m *MockInvocationContext) Ended() bool                     { return false }
+func (m *MockInvocationContext) EndInvocation()                  {}
 
 func (m *MockInvocationContext) WithContext(ctx context.Context) agent.InvocationContext {
 	cp := *m


### PR DESCRIPTION
## Summary

Builds on #831 (HITL handoff resume) by adding re-entry mode:
when a paused node is configured with `NodeConfig.RerunOnResume =
true`, `Workflow.Resume` re-activates the asker itself instead of
forwarding the response to its successors. The asker observes the
response via `ctx.ResumedInput(interruptID)` and decides what to
emit. Direct analogue of adk-python's `@node(rerun_on_resume=True)`.

Re-entry preserves the asker's original input, so the node can
recompute its decision with the same context it had on the first
turn — only the user's response arrives separately. Successors
fire only when the re-entry activation produces an output, not on
the bare resume call.

Support of multiple asks while executing one node will be added in a follow-up PR.

## Test plan

- [x] `go build ./...` clean
- [x] `go test ./workflow/... ./agent/workflowagent/...` — all pass
- [x] `go test -race` clean
- [x] 4 new tests covering the canonical re-entry round-trip,
  original-input preservation across re-entry, the
  no-successor-before-output invariant, and a regression guard
  pinning that handoff is still the default mode
- [x] 1 new test (`TestNodeContext_ResumedInput`) pinning the
  per-node context-level contract