### PR TITLE
refactor: remove unused TriggeredBy() interface method

### DIFF
--- a/agent/agent.go
+++ b/agent/agent.go
@@ -504,11 +504,6 @@ func (c *invocationContext) WithContext(ctx context.Context) InvocationContext {
 	return &newCtx
 }
 
-// TriggeredBy returns "" for non-workflow invocation contexts. The
-// workflow engine wraps this context in a private per-node context
-// that overrides the method when running inside a workflow.Node.
-func (c *invocationContext) TriggeredBy() string { return "" }
-
 // ResumedInput always returns (nil, false) for the base
 // invocation context. Implementations that carry a resume payload
 // override this method.

--- a/agent/context.go
+++ b/agent/context.go
@@ -96,14 +96,6 @@ type InvocationContext interface {
 	// Ended returns whether the invocation has ended.
 	Ended() bool
 
-	// TriggeredBy returns the name of the upstream node whose output
-	// scheduled the current node activation, when this context is
-	// running inside a workflow.Node. Returns "" outside a workflow
-	// (e.g. in plain agent runs) and for the initial workflow START
-	// activation. The workflow engine populates this via an internal
-	// per-node context wrapper.
-	TriggeredBy() string
-
 	// ResumedInput returns the user-supplied response payload
 	// associated with the given InterruptID for the current
 	// activation, or (nil, false) if none. Implementations that

--- a/agent/workflowagent/workflow_test.go
+++ b/agent/workflowagent/workflow_test.go
@@ -101,7 +101,6 @@ func (m *MockInvocationContext) Branch() string                  { return "" }
 func (m *MockInvocationContext) RunConfig() *agent.RunConfig     { return nil }
 func (m *MockInvocationContext) Ended() bool                     { return false }
 func (m *MockInvocationContext) EndInvocation()                  {}
-func (m *MockInvocationContext) TriggeredBy() string             { return "" }
 func (m *MockInvocationContext) ResumedInput(string) (any, bool) { return nil, false }
 
 func TestWorkflowAgent(t *testing.T) {

--- a/internal/configurable/conformance/replayplugin/replay_plugin_test.go
+++ b/internal/configurable/conformance/replayplugin/replay_plugin_test.go
@@ -400,7 +400,6 @@ func (m *MockInvocationContext) RunConfig() *agent.RunConfig                    
 func (m *MockInvocationContext) EndInvocation()                                          {}
 func (m *MockInvocationContext) Ended() bool                                             { return false }
 func (m *MockInvocationContext) WithContext(ctx context.Context) agent.InvocationContext { return m }
-func (m *MockInvocationContext) TriggeredBy() string                                     { return "" }
 func (m *MockInvocationContext) ResumedInput(string) (any, bool)                         { return nil, false }
 func (m *MockInvocationContext) Value(key any) any                                       { return nil }
 func (m *MockInvocationContext) Deadline() (deadline time.Time, ok bool)                 { return time.Time{}, false }

--- a/internal/context/invocation_context.go
+++ b/internal/context/invocation_context.go
@@ -100,11 +100,6 @@ func (c *InvocationContext) WithContext(ctx context.Context) agent.InvocationCon
 	return &newCtx
 }
 
-// TriggeredBy returns "" for non-workflow invocation contexts. The
-// workflow engine wraps this context in a private per-node context
-// that overrides the method when running inside a workflow.Node.
-func (c *InvocationContext) TriggeredBy() string { return "" }
-
 // ResumedInput always returns (nil, false) for the base
 // invocation context. Implementations that carry a resume payload
 // override this method.

--- a/internal/llminternal/functions_test.go
+++ b/internal/llminternal/functions_test.go
@@ -55,7 +55,6 @@ func (m *mockInvocationContext) Branch() string {
 	return m.branch
 }
 
-func (m *mockInvocationContext) TriggeredBy() string             { return "" }
 func (m *mockInvocationContext) ResumedInput(string) (any, bool) { return nil, false }
 
 func TestGenerateRequestConfirmationEvent(t *testing.T) {

--- a/workflow/node_context.go
+++ b/workflow/node_context.go
@@ -17,9 +17,8 @@ package workflow
 import "google.golang.org/adk/agent"
 
 // nodeContext is the per-node InvocationContext seen inside Node.Run.
-// It wraps the workflow's incoming agent.InvocationContext and adds
-// engine-supplied metadata: the upstream node name (TriggeredBy)
-// and any human-input responses the scheduler injected for a
+// It wraps the workflow's incoming agent.InvocationContext and
+// surfaces the human-input responses the scheduler injected for a
 // re-entry resume activation (ResumedInput).
 //
 // TODO(wolo): replace once context-unification work lands. The
@@ -27,7 +26,6 @@ import "google.golang.org/adk/agent"
 // that the base interface does not have.
 type nodeContext struct {
 	agent.InvocationContext
-	triggeredBy string
 
 	// resumeInputs carries the user-supplied response payloads for
 	// a re-entry resume activation, keyed by InterruptID. Nil on
@@ -37,22 +35,14 @@ type nodeContext struct {
 	resumeInputs map[string]any
 }
 
-// newNodeContext returns a nodeContext wrapping parent with the given
-// upstream-node name. triggeredBy is empty for the initial START
-// activation. resumeInputs is nil for non-resume activations.
-func newNodeContext(parent agent.InvocationContext, triggeredBy string, resumeInputs map[string]any) *nodeContext {
+// newNodeContext returns a nodeContext wrapping parent. resumeInputs
+// is nil for non-resume activations.
+func newNodeContext(parent agent.InvocationContext, resumeInputs map[string]any) *nodeContext {
 	return &nodeContext{
 		InvocationContext: parent,
-		triggeredBy:       triggeredBy,
 		resumeInputs:      resumeInputs,
 	}
 }
-
-// TriggeredBy returns the name of the upstream node whose output
-// scheduled this node activation. Empty for the initial START
-// trigger and for non-workflow invocations (where the wrapper is not
-// used).
-func (c *nodeContext) TriggeredBy() string { return c.triggeredBy }
 
 // ResumedInput returns the response payload associated with the
 // given InterruptID for a re-entry resume activation. Returns

--- a/workflow/node_context_test.go
+++ b/workflow/node_context_test.go
@@ -20,32 +20,11 @@ import (
 	"google.golang.org/adk/agent"
 )
 
-func TestNodeContext_TriggeredByPreservesValue(t *testing.T) {
-	tests := []struct {
-		name        string
-		triggeredBy string
-	}{
-		{name: "empty (initial START activation)", triggeredBy: ""},
-		{name: "named upstream node", triggeredBy: "upstream"},
-		{name: "node name with dots (branch path)", triggeredBy: "agent_1.agent_2"},
-	}
-
-	parent := newMockCtx(t)
-	for _, tt := range tests {
-		t.Run(tt.name, func(t *testing.T) {
-			c := newNodeContext(parent, tt.triggeredBy, nil)
-			if got := c.TriggeredBy(); got != tt.triggeredBy {
-				t.Errorf("TriggeredBy() = %q, want %q", got, tt.triggeredBy)
-			}
-		})
-	}
-}
-
 func TestNodeContext_ResumedInput(t *testing.T) {
 	parent := newMockCtx(t)
 
 	t.Run("nil resumeInputs returns (nil, false)", func(t *testing.T) {
-		c := newNodeContext(parent, "", nil)
+		c := newNodeContext(parent, nil)
 		v, ok := c.ResumedInput("any_id")
 		if v != nil || ok {
 			t.Errorf("ResumedInput() = (%v, %v), want (nil, false)", v, ok)
@@ -53,7 +32,7 @@ func TestNodeContext_ResumedInput(t *testing.T) {
 	})
 
 	t.Run("populated resumeInputs returns matched payload", func(t *testing.T) {
-		c := newNodeContext(parent, "", map[string]any{
+		c := newNodeContext(parent, map[string]any{
 			"approval": "yes",
 			"comment":  "looks good",
 		})

--- a/workflow/scheduler.go
+++ b/workflow/scheduler.go
@@ -238,7 +238,7 @@ func (s *scheduler) scheduleResumedNode(n Node, input any, triggeredBy string, r
 	} else {
 		nodeCtx, cancel = context.WithCancel(s.parentCtx)
 	}
-	perNodeCtx := newNodeContext(s.parentCtx.WithContext(nodeCtx), triggeredBy, resumeInputs)
+	perNodeCtx := newNodeContext(s.parentCtx.WithContext(nodeCtx), resumeInputs)
 
 	ns := s.state.EnsureNode(name)
 	ns.Status = NodeRunning
@@ -478,8 +478,9 @@ func (s *scheduler) handleCompletion(it completionItem, scheduleSuccessors bool)
 }
 
 // successor is the per-target dispatch tuple produced by
-// findSuccessors. The triggeredBy field carries the upstream node's
-// name for downstream visibility via ctx.TriggeredBy().
+// findSuccessors. The triggeredBy field carries the upstream
+// node's name for persistence on NodeState (used by Resume to
+// reconstruct the activation chain across pause/resume turns).
 type successor struct {
 	node        Node
 	input       any

--- a/workflow/workflow_test.go
+++ b/workflow/workflow_test.go
@@ -74,7 +74,6 @@ func mustNew(t *testing.T, edges []Edge) *Workflow {
 func (m *MockInvocationContext) Session() session.Session        { return m.sess }
 func (m *MockInvocationContext) InvocationID() string            { return "test-invocation-id" }
 func (m *MockInvocationContext) UserContent() *genai.Content     { return m.userContent }
-func (m *MockInvocationContext) TriggeredBy() string             { return "" }
 func (m *MockInvocationContext) ResumedInput(string) (any, bool) { return nil, false }
 func (m *MockInvocationContext) Agent() agent.Agent              { return nil }
 func (m *MockInvocationContext) Artifacts() agent.Artifacts      { return nil }


### PR DESCRIPTION
## Summary

Drops `agent.InvocationContext.TriggeredBy()` from the public
interface. 

The unrelated `NodeState.TriggeredBy` field stays. The scheduler
populates it for resume bookkeeping (`Workflow.Resume` reads it
back when re-scheduling a paused node) and it is part of the
JSON-serialised `RunState`, so dropping it would break forward
compatibility for anyone already running the engine.


## Test plan

- [x] `go build ./...` clean
- [x] `go test ./...` — all pass
- [x] Net change: 10 files, +11 / −63 lines
```
