### PR TITLE
chore: add Dependabot config for automated dependency updates

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,18 @@
+version: 2
+updates:
+  - package-ecosystem: "gomod"
+    directory: "/"
+    schedule:
+      interval: "weekly"
+      day: "monday"
+      time: "02:00"
+    commit-message:
+      prefix: "chore"
+      include: "scope"
+    labels:
+      - "dependencies"
+    reviewers:
+      - "wolo-lab"
+    allow:
+      - dependency-name: "google.golang.org/genai"
+    open-pull-requests-limit: 10


### PR DESCRIPTION
## Summary

Adds a file-based `.github/dependabot.yml` configuration to enable scheduled dependency updates for the adk-go repository.

## What this does

- Enables **weekly** Dependabot checks (Mondays at 02:00 UTC) for Go module updates
- Currently scoped to **`google.golang.org/genai`** only via an allow-list
- Auto-assigns `@wolo-lab` as reviewer on dependency PRs
- Applies the `dependencies` label for easy filtering
- Uses `chore(deps):` commit message prefix (consistent with adk-python and adk-java patterns)

## Why

The adk-go repo currently has no file-based Dependabot configuration. While org-level Dependabot security updates are enabled, there are no **scheduled version updates** for non-security releases. This means we miss routine updates to key dependencies like the genai SDK unless someone manually checks.

## Extending

To add more dependencies later, add entries to the `allow` list:

```yaml
allow:
  - dependency-name: "google.golang.org/genai"
  - dependency-name: "google.golang.org/grpc"
  - dependency-name: "github.com/modelcontextprotocol/go-sdk"
```

Or remove the `allow` block entirely to update all direct dependencies.

## Context

- `adk-samples` already uses a file-based `dependabot.yml`
- `adk-python` and `adk-java` use repo-level settings (no config file)
- This follows the file-based approach for transparency and version control