### PR TITLE
fix: persist resume inputs across re-entry cycles

### DIFF
--- a/agent/workflowagent/reentry_test.go
+++ b/agent/workflowagent/reentry_test.go
@@ -16,6 +16,7 @@ package workflowagent
 
 import (
 	"iter"
+	"reflect"
 	"sync"
 	"sync/atomic"
 	"testing"
@@ -143,6 +144,54 @@ func TestWorkflowAgent_ReEntry_DefaultModeIsHandoff(t *testing.T) {
 	}
 	if got := handlerInput.Load(); got != "approve" {
 		t.Errorf("handler input = %v, want %q (handoff mode delivers response as next-node input)", got, "approve")
+	}
+}
+
+// TestWorkflowAgent_ReEntry_AccumulatesResumeInputs verifies that
+// a re-entry-mode node which yields RequestInput more than once
+// across resume cycles sees every prior response on every
+// subsequent activation, not only the most recent one.
+//
+// Scenario: asker walks through ask_1, ask_2, ask_3. After each
+// resume it must see every response answered so far. After the
+// third resume it observes all three and emits a final output.
+func TestWorkflowAgent_ReEntry_AccumulatesResumeInputs(t *testing.T) {
+	asker, acts := askerForSequence("asker", []string{"ask_1", "ask_2", "ask_3"}, "all answered")
+
+	var handlerInput atomic.Value
+	handler := newStringHandlerNode("handler", &handlerInput)
+
+	a := makeAgent(t, workflow.Chain(workflow.Start, asker, handler))
+	sess := newFakeSession()
+
+	turn1 := runFreshTurn(t, sess, a, "draft")
+	if got := findRequest(turn1); got != "ask_1" {
+		t.Fatalf("turn 1 RequestedInput = %q, want %q", got, "ask_1")
+	}
+	resumeAndExpect(t, sess, a, "ask_1", "yes", "ask_2")
+	resumeAndExpect(t, sess, a, "ask_2", "ok", "ask_3")
+	resumeAndExpect(t, sess, a, "ask_3", "approve", "")
+
+	if got := handlerInput.Load(); got != "all answered" {
+		t.Errorf("handler input = %v, want %q", got, "all answered")
+	}
+
+	// Per-activation accumulation: each row is what the asker
+	// must have observed on its i-th run.
+	wantResumed := []map[string]any{
+		{},                              // turn 1: fresh, nothing answered yet
+		{"ask_1": "yes"},                // turn 2: after first reply
+		{"ask_1": "yes", "ask_2": "ok"}, // turn 3
+		{"ask_1": "yes", "ask_2": "ok", "ask_3": "approve"}, // turn 4: all three visible
+	}
+	if got := acts.count(); got != len(wantResumed) {
+		t.Fatalf("activations = %d, want %d", got, len(wantResumed))
+	}
+	for i, want := range wantResumed {
+		act, _ := acts.at(i)
+		if !reflect.DeepEqual(act.resumed, want) {
+			t.Errorf("activation %d resumed = %v, want %v", i, act.resumed, want)
+		}
 	}
 }
 

--- a/workflow/resume.go
+++ b/workflow/resume.go
@@ -127,8 +127,17 @@ func (w *Workflow) Resume(
 				// ctx.ResumedInput(InterruptID), not via the
 				// input parameter. Successors fire only when the
 				// re-entry activation produces an output.
-				resumeInputs := map[string]any{interruptID: resp}
-				s.scheduleResumedNode(node, ns.Input, ns.TriggeredBy, resumeInputs)
+				//
+				// Accumulate into ns.ResumedInputs so a node that
+				// yields multiple RequestInputs across resume
+				// cycles sees every prior response, not just the
+				// most recent one. The map is cleared when the
+				// node transitions to NodeCompleted.
+				if ns.ResumedInputs == nil {
+					ns.ResumedInputs = map[string]any{}
+				}
+				ns.ResumedInputs[interruptID] = resp
+				s.scheduleResumedNode(node, ns.Input, ns.TriggeredBy, ns.ResumedInputs)
 			} else {
 				// Handoff mode: schedule each successor with the
 				// response as its input, exactly as if the asker

--- a/workflow/scheduler.go
+++ b/workflow/scheduler.go
@@ -447,6 +447,10 @@ func (s *scheduler) handleCompletion(it completionItem, scheduleSuccessors bool)
 	}
 
 	ns.Status = NodeCompleted
+	// Release the accumulated re-entry response history; the node
+	// has finished and a future activation (if any, e.g. via
+	// loop-back routing) starts a fresh lifecycle.
+	ns.ResumedInputs = nil
 
 	if !scheduleSuccessors {
 		return nil

--- a/workflow/state.go
+++ b/workflow/state.go
@@ -98,6 +98,19 @@ type NodeState struct {
 	// NodeWaiting and the wait was caused by a human-input request
 	// (as opposed to a fan-in barrier).
 	PendingRequest *session.RequestInput `json:"pendingRequest,omitempty"`
+
+	// ResumedInputs accumulates response payloads for re-entry-mode
+	// nodes that yield RequestInput more than once during a single
+	// activation lifecycle. Each Resume call adds the new response
+	// keyed by its InterruptID. The map is exposed to the node via
+	// ctx.ResumedInput on every re-entry activation, so the node
+	// can observe responses to all prior requests, not only the
+	// most recent one.
+	//
+	// Cleared when the node transitions to NodeCompleted; absent
+	// for handoff-mode nodes (where successors receive the response
+	// as input and the asker never re-runs).
+	ResumedInputs map[string]any `json:"resumedInputs,omitempty"`
 }
 
 // RunState is the per-invocation lifecycle state for a workflow


### PR DESCRIPTION
## Summary

Fixes a re-entry-mode regression: a node configured with
`NodeConfig.RerunOnResume = true` that yields `RequestInput` more
than once across resume cycles previously lost prior responses on
each subsequent resume. `ctx.ResumedInput("ask_1")` returned
`(nil, false)` after the user answered `ask_2`, even though
`ask_1` had already been answered in an earlier turn.

The fix accumulates response payloads on `NodeState.ResumedInputs`
across resume cycles. Each `Resume` call merges the new
`{InterruptID: response}` entry into the map; the scheduler hands
the full history to the per-node context on every re-entry
activation. The node sees every prior response on every
subsequent run, not only the most recent one.

Backward-compatible for single-question re-entry workflows: the
accumulated map on the first resume equals the
previously-constructed single-entry map.

## Changes

- `workflow/state.go` — new `NodeState.ResumedInputs map[string]any`
  field with `json:"resumedInputs,omitempty"`. Forward-compatible:
  existing persisted RunState decodes into a nil map.
- `workflow/resume.go` — `Workflow.Resume` writes the new response
  into `ns.ResumedInputs` (allocating the map on first use) and
  passes that map to `scheduleResumedNode`, instead of
  constructing a fresh single-entry map per resume.
- `workflow/scheduler.go` — `handleCompletion` clears
  `ns.ResumedInputs = nil` when the node transitions to
  `NodeCompleted`. Memory hygiene; a future activation (e.g. via
  loop-back routing) starts a fresh history.

## Test plan

- [x] `go build ./...` clean
- [x] `go test ./workflow/... ./agent/workflowagent/...` — all pass
- [x] New test `TestWorkflowAgent_ReEntry_AccumulatesResumeInputs`
  walks an asker through 3 sequential `RequestInput`s and asserts
  the per-activation `ctx.ResumedInput` map contains every prior
  response on each successive run
- [x] Four existing re-entry tests still pass without modification
