### PR TITLE
feat: add HITL console launcher support for workflow input prompts

### DIFF
--- a/cmd/launcher/console/console.go
+++ b/cmd/launcher/console/console.go
@@ -99,7 +99,7 @@ func (l *consoleLauncher) Run(ctx context.Context, config *launcher.Config) erro
 
 	rootAgent := config.AgentLoader.RootAgent()
 
-	session := resp.Session
+	sess := resp.Session
 
 	r, err := runner.New(runner.Config{
 		AppName:         appName,
@@ -144,6 +144,14 @@ func (l *consoleLauncher) Run(ctx context.Context, config *launcher.Config) erro
 		}
 	}
 
+	// pendingInterrupts carries human-input prompts the agent
+	// emitted on the previous turn. While non-empty, the next
+	// stdin read is interpreted as the answer to its head; once
+	// every prompt has an answer the assembled FunctionResponse
+	// content is sent as the next "user message" turn.
+	var pendingInterrupts []pendingInterrupt
+	var pendingResponses []*genai.Part
+
 	for {
 		select {
 		case <-ctx.Done():
@@ -156,7 +164,33 @@ func (l *consoleLauncher) Run(ctx context.Context, config *launcher.Config) erro
 			log.Fatal(err)
 		case userInput := <-inputChan:
 
-			userMsg := genai.NewContentFromText(userInput, genai.RoleUser)
+			var userMsg *genai.Content
+			if len(pendingInterrupts) > 0 {
+				// Answer the head of the queue; loop back if more
+				// prompts remain.
+				current := pendingInterrupts[0]
+				pendingInterrupts = pendingInterrupts[1:]
+				pendingResponses = append(pendingResponses, buildInterruptResponse(current, userInput))
+				if len(pendingInterrupts) > 0 {
+					renderInterruptPrompt(pendingInterrupts[0])
+					continue
+				}
+				// All answers collected. Bundle every
+				// FunctionResponse into one user Content; the
+				// workflow runtime routes each to its waiting
+				// node by FunctionResponse.ID.
+				// TODO: legacy non-workflow agents still pick
+				// one agent from the first FunctionResponse.ID
+				// and drop the rest.
+				userMsg = &genai.Content{
+					Role:  string(genai.RoleUser),
+					Parts: pendingResponses,
+				}
+				pendingResponses = nil
+			} else {
+				userMsg = genai.NewContentFromText(userInput, genai.RoleUser)
+			}
+
 			streamingMode := l.config.streamingMode
 			if streamingMode == "" {
 				streamingMode = defaultStreamingMode
@@ -164,12 +198,14 @@ func (l *consoleLauncher) Run(ctx context.Context, config *launcher.Config) erro
 
 			fmt.Print("\nAgent -> ")
 			prevText := ""
-			for event, err := range r.Run(ctx, userID, session.ID(), userMsg, agent.RunConfig{
+			var collectedEvents []*session.Event
+			for event, err := range r.Run(ctx, userID, sess.ID(), userMsg, agent.RunConfig{
 				StreamingMode: streamingMode,
 			}) {
 				if err != nil {
 					fmt.Printf("\nAGENT_ERROR: %v\n", err)
 				} else {
+					collectedEvents = append(collectedEvents, event)
 					if event.LLMResponse.Content == nil {
 						continue
 					}
@@ -198,6 +234,16 @@ func (l *consoleLauncher) Run(ctx context.Context, config *launcher.Config) erro
 
 					prevText = ""
 				}
+			}
+
+			// If the turn paused on any long-running interrupts,
+			// render the first prompt; the next stdin read will
+			// be its answer.
+			pendingInterrupts = collectPendingInterrupts(collectedEvents)
+			if len(pendingInterrupts) > 0 {
+				fmt.Println()
+				renderInterruptPrompt(pendingInterrupts[0])
+				continue
 			}
 			fmt.Print("\nUser -> ")
 		}

--- a/cmd/launcher/console/hitl.go
+++ b/cmd/launcher/console/hitl.go
@@ -1,0 +1,186 @@
+// Copyright 2026 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package console
+
+import (
+	"encoding/json"
+	"fmt"
+	"strings"
+
+	"google.golang.org/genai"
+
+	"google.golang.org/adk/session"
+	"google.golang.org/adk/workflow"
+)
+
+// pendingInterrupt is one HITL prompt the agent emitted on the
+// previous turn that still needs a user reply on the next. The
+// id+name pair come from a FunctionCall part whose ID appears
+// in Event.LongRunningToolIDs.
+type pendingInterrupt struct {
+	id   string
+	name string
+	args map[string]any
+}
+
+// collectPendingInterrupts scans events for FunctionCall parts
+// referenced from LongRunningToolIDs on the same event and
+// returns them in order of appearance.
+func collectPendingInterrupts(events []*session.Event) []pendingInterrupt {
+	var out []pendingInterrupt
+	for _, ev := range events {
+		if ev == nil || len(ev.LongRunningToolIDs) == 0 {
+			continue
+		}
+		lr := map[string]struct{}{}
+		for _, id := range ev.LongRunningToolIDs {
+			lr[id] = struct{}{}
+		}
+		c := ev.Content
+		if c == nil {
+			continue
+		}
+		for _, p := range c.Parts {
+			fc := p.FunctionCall
+			if fc == nil {
+				continue
+			}
+			if _, isInterrupt := lr[fc.ID]; !isInterrupt {
+				continue
+			}
+			out = append(out, pendingInterrupt{
+				id:   fc.ID,
+				name: fc.Name,
+				args: fc.Args,
+			})
+		}
+	}
+	return out
+}
+
+// renderInterruptPrompt prints the pending interrupt and a
+// "User -> " input prompt to stdout. The caller reads the user's
+// reply and passes it to buildInterruptResponse.
+func renderInterruptPrompt(p pendingInterrupt) {
+	switch p.name {
+	case workflow.WorkflowInputFunctionCallName:
+		renderWorkflowInputPrompt(p.args)
+	default:
+		renderGenericInterruptPrompt(p.name, p.args)
+	}
+	fmt.Print("User -> ")
+}
+
+// buildInterruptResponse converts the operator's one-line input
+// into a FunctionResponse part keyed by the interrupt's id and
+// name. Same per-name dispatch as renderInterruptPrompt.
+func buildInterruptResponse(p pendingInterrupt, userInput string) *genai.Part {
+	line := strings.TrimRight(userInput, "\r\n")
+
+	var response map[string]any
+	switch p.name {
+	case workflow.WorkflowInputFunctionCallName:
+		response = workflowInputResponseFromUserInput(line)
+	default:
+		response = genericResponseFromUserInput(line)
+	}
+	return &genai.Part{
+		FunctionResponse: &genai.FunctionResponse{
+			ID:       p.id,
+			Name:     p.name,
+			Response: response,
+		},
+	}
+}
+
+// renderWorkflowInputPrompt prints the workflow request prompt.
+// Args carry the fields populated by workflow.NewRequestInputEvent:
+// interruptId, message, payload, responseSchema.
+func renderWorkflowInputPrompt(args map[string]any) {
+	msg, _ := args["message"].(string)
+	if msg == "" {
+		msg = "Input requested"
+	}
+	fmt.Printf("Agent -> %s\n", msg)
+	if payload, ok := args["payload"]; ok && payload != nil {
+		// Strings (incl. those that survived a JSON persistence
+		// roundtrip) print raw to avoid the noisy "\"escaped\""
+		// form. Other values render as pretty JSON aligned under
+		// the "  Payload: " label: prefix="  " puts continuation
+		// lines (incl. the closing brace) at the label's column,
+		// and indent="  " adds two spaces per nesting level — so
+		// top-level keys sit two columns inside the opening brace.
+		if s, ok := payload.(string); ok {
+			fmt.Printf("  Payload: %s\n", s)
+		} else if pretty, err := json.MarshalIndent(payload, "  ", "  "); err == nil {
+			fmt.Printf("  Payload: %s\n", pretty)
+		} else {
+			fmt.Printf("  Payload: %v\n", payload)
+		}
+	}
+	if schema, ok := args["responseSchema"]; ok && schema != nil {
+		if pretty, err := json.Marshal(schema); err == nil {
+			fmt.Printf("  Expected response schema: %s\n", pretty)
+		}
+	}
+}
+
+// workflowInputResponseFromUserInput shapes a one-line operator
+// reply into a workflow-input FunctionResponse payload. Tries
+// JSON first; a parsed object is returned verbatim so the
+// operator can submit a fully-structured response, scalars and
+// arrays are wrapped under "payload", and unparseable input is
+// passed through under "payload" too.
+func workflowInputResponseFromUserInput(line string) map[string]any {
+	var parsed any
+	if err := json.Unmarshal([]byte(line), &parsed); err == nil {
+		if asMap, ok := parsed.(map[string]any); ok {
+			return asMap
+		}
+		return map[string]any{"payload": parsed}
+	}
+	return map[string]any{"payload": line}
+}
+
+// renderGenericInterruptPrompt is the fallback for HITL kinds the
+// launcher does not specifically recognise. Prints the kind name
+// and the raw args so the operator can compose a sensible
+// response by hand.
+func renderGenericInterruptPrompt(name string, args map[string]any) {
+	fmt.Printf("Agent -> waiting for response (kind: %s)\n", name)
+	if len(args) > 0 {
+		if pretty, err := json.Marshal(args); err == nil {
+			fmt.Printf("  Args: %s\n", pretty)
+		} else {
+			fmt.Printf("  Args: %v\n", args)
+		}
+	}
+}
+
+// genericResponseFromUserInput shapes the operator's reply for
+// HITL kinds without a dedicated parser. A parsed JSON object is
+// returned verbatim so the operator can submit a fully-structured
+// response; scalars and arrays are wrapped under "result"; raw
+// text falls back to "result" too.
+func genericResponseFromUserInput(line string) map[string]any {
+	var parsed any
+	if err := json.Unmarshal([]byte(line), &parsed); err == nil {
+		if asMap, ok := parsed.(map[string]any); ok {
+			return asMap
+		}
+		return map[string]any{"result": parsed}
+	}
+	return map[string]any{"result": line}
+}

--- a/cmd/launcher/console/hitl_test.go
+++ b/cmd/launcher/console/hitl_test.go
@@ -1,0 +1,331 @@
+// Copyright 2026 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package console
+
+import (
+	"io"
+	"os"
+	"reflect"
+	"strings"
+	"testing"
+
+	"google.golang.org/genai"
+
+	"google.golang.org/adk/model"
+	"google.golang.org/adk/session"
+	"google.golang.org/adk/workflow"
+)
+
+// captureStdout runs f with os.Stdout redirected to a pipe and
+// returns everything f wrote.
+func captureStdout(t *testing.T, f func()) string {
+	t.Helper()
+	orig := os.Stdout
+	r, w, err := os.Pipe()
+	if err != nil {
+		t.Fatalf("os.Pipe: %v", err)
+	}
+	os.Stdout = w
+	done := make(chan string, 1)
+	go func() {
+		b, _ := io.ReadAll(r)
+		done <- string(b)
+	}()
+	f()
+	w.Close()
+	os.Stdout = orig
+	return <-done
+}
+
+// TestCollectPendingInterrupts_DetectionByLongRunningToolIDs
+// verifies the detection contract: an event is a HITL prompt
+// iff it has a non-empty LongRunningToolIDs and one of its
+// content parts is a FunctionCall whose ID is in that set. The
+// function name is not the discriminator — workflow input and
+// any future kind all flow through the same detection path.
+func TestCollectPendingInterrupts_DetectionByLongRunningToolIDs(t *testing.T) {
+	tests := []struct {
+		name   string
+		events []*session.Event
+		want   []pendingInterrupt
+	}{
+		{
+			name:   "empty event list",
+			events: nil,
+			want:   nil,
+		},
+		{
+			name: "event with FunctionCall but no LongRunningToolIDs is not an interrupt",
+			events: []*session.Event{
+				{
+					LLMResponse: model.LLMResponse{
+						Content: &genai.Content{
+							Parts: []*genai.Part{{
+								FunctionCall: &genai.FunctionCall{ID: "x", Name: "regular_tool"},
+							}},
+						},
+					},
+				},
+			},
+			want: nil,
+		},
+		{
+			name: "event with LongRunningToolIDs but no matching FunctionCall is not an interrupt",
+			events: []*session.Event{
+				{
+					LongRunningToolIDs: []string{"abc"},
+					LLMResponse: model.LLMResponse{
+						Content: &genai.Content{
+							Parts: []*genai.Part{{
+								FunctionCall: &genai.FunctionCall{ID: "different_id", Name: "unmatched"},
+							}},
+						},
+					},
+				},
+			},
+			want: nil,
+		},
+		{
+			name: "workflow input on Event.LLMResponse.Content is detected",
+			events: []*session.Event{
+				{
+					LongRunningToolIDs: []string{"int-1"},
+					LLMResponse: model.LLMResponse{
+						Content: &genai.Content{
+							Parts: []*genai.Part{{
+								FunctionCall: &genai.FunctionCall{
+									ID:   "int-1",
+									Name: workflow.WorkflowInputFunctionCallName,
+									Args: map[string]any{"message": "ok?"},
+								},
+							}},
+						},
+					},
+				},
+			},
+			want: []pendingInterrupt{
+				{id: "int-1", name: workflow.WorkflowInputFunctionCallName, args: map[string]any{"message": "ok?"}},
+			},
+		},
+		{
+			name: "multiple events, only ones with matching IDs surface",
+			events: []*session.Event{
+				{LLMResponse: model.LLMResponse{Content: &genai.Content{Parts: []*genai.Part{{Text: "intro"}}}}},
+				{
+					LongRunningToolIDs: []string{"int-2"},
+					LLMResponse: model.LLMResponse{
+						Content: &genai.Content{
+							Parts: []*genai.Part{{FunctionCall: &genai.FunctionCall{ID: "int-2", Name: "x"}}},
+						},
+					},
+				},
+				{LLMResponse: model.LLMResponse{Content: &genai.Content{Parts: []*genai.Part{{Text: "outro"}}}}},
+			},
+			want: []pendingInterrupt{
+				{id: "int-2", name: "x", args: nil},
+			},
+		},
+	}
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			got := collectPendingInterrupts(tc.events)
+			if !reflect.DeepEqual(got, tc.want) {
+				t.Errorf("collectPendingInterrupts() = %#v, want %#v", got, tc.want)
+			}
+		})
+	}
+}
+
+// TestBuildInterruptResponse_WorkflowInput verifies the
+// workflow-input dispatch: a JSON object reply is returned
+// verbatim (the operator submitted the final shape); scalars,
+// arrays, and raw text are wrapped under "payload".
+func TestBuildInterruptResponse_WorkflowInput(t *testing.T) {
+	tests := []struct {
+		name         string
+		userInput    string
+		wantResponse map[string]any
+	}{
+		{
+			name:         "raw text is wrapped under payload",
+			userInput:    "approve\n",
+			wantResponse: map[string]any{"payload": "approve"},
+		},
+		{
+			name:         "JSON object is returned verbatim (no wrapper)",
+			userInput:    `{"approved": true, "days": 3}` + "\n",
+			wantResponse: map[string]any{"approved": true, "days": float64(3)},
+		},
+		{
+			name:         "JSON scalar is wrapped under payload",
+			userInput:    "42\n",
+			wantResponse: map[string]any{"payload": float64(42)},
+		},
+		{
+			name:         "JSON array is wrapped under payload",
+			userInput:    `[1, 2, "three"]` + "\n",
+			wantResponse: map[string]any{"payload": []any{float64(1), float64(2), "three"}},
+		},
+		{
+			name:         "trailing CR is stripped",
+			userInput:    "approve\r\n",
+			wantResponse: map[string]any{"payload": "approve"},
+		},
+	}
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			p := pendingInterrupt{id: "x", name: workflow.WorkflowInputFunctionCallName}
+			part := buildInterruptResponse(p, tc.userInput)
+			if part.FunctionResponse == nil {
+				t.Fatalf("expected FunctionResponse part, got %+v", part)
+			}
+			if got, want := part.FunctionResponse.ID, "x"; got != want {
+				t.Errorf("ID = %q, want %q", got, want)
+			}
+			if got, want := part.FunctionResponse.Name, workflow.WorkflowInputFunctionCallName; got != want {
+				t.Errorf("Name = %q, want %q", got, want)
+			}
+			if !reflect.DeepEqual(part.FunctionResponse.Response, tc.wantResponse) {
+				t.Errorf("Response = %#v, want %#v",
+					part.FunctionResponse.Response, tc.wantResponse)
+			}
+		})
+	}
+}
+
+// TestBuildInterruptResponse_GenericFallback verifies the catch-all
+// path used for any long-running call name the launcher does not
+// specifically know about.
+func TestBuildInterruptResponse_GenericFallback(t *testing.T) {
+	tests := []struct {
+		name         string
+		userInput    string
+		wantResponse map[string]any
+	}{
+		{
+			name:         "raw text is wrapped under result",
+			userInput:    "some_value\n",
+			wantResponse: map[string]any{"result": "some_value"},
+		},
+		{
+			name:         "JSON object is returned verbatim (no wrapper)",
+			userInput:    `{"foo": "bar"}` + "\n",
+			wantResponse: map[string]any{"foo": "bar"},
+		},
+		{
+			name:         "JSON scalar is wrapped under result",
+			userInput:    "42\n",
+			wantResponse: map[string]any{"result": float64(42)},
+		},
+		{
+			name:         "JSON array is wrapped under result",
+			userInput:    `[1, 2]` + "\n",
+			wantResponse: map[string]any{"result": []any{float64(1), float64(2)}},
+		},
+	}
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			p := pendingInterrupt{id: "g", name: "some_unknown_kind"}
+			part := buildInterruptResponse(p, tc.userInput)
+			if !reflect.DeepEqual(part.FunctionResponse.Response, tc.wantResponse) {
+				t.Errorf("Response = %#v, want %#v",
+					part.FunctionResponse.Response, tc.wantResponse)
+			}
+		})
+	}
+}
+
+// TestRenderWorkflowInputPrompt_PayloadFormatting locks in the
+// payload-rendering contract:
+//
+//   - a string payload prints raw (no surrounding quotes, no
+//     escapes) so a value that survived a JSON roundtrip stays
+//     human-readable;
+//   - an object payload prints as JSON aligned under the
+//     "  Payload: " label: top-level keys are indented 4 spaces
+//     (2-space label column + 2-space JSON indent) and the closing
+//     brace sits at the 2-space label column. Drop the prefix and
+//     keys/brace collapse left of the label, producing visually
+//     broken output.
+func TestRenderWorkflowInputPrompt_PayloadFormatting(t *testing.T) {
+	tests := []struct {
+		name         string
+		args         map[string]any
+		wantContains []string
+		wantAbsent   []string
+	}{
+		{
+			name: "string payload prints raw, no escaped quotes",
+			args: map[string]any{
+				"message": "approve?",
+				"payload": "hello world",
+			},
+			wantContains: []string{
+				"Agent -> approve?\n",
+				"  Payload: hello world\n",
+			},
+			wantAbsent: []string{`"hello world"`, `\"`},
+		},
+		{
+			name: "object payload is indented under the Payload label",
+			args: map[string]any{
+				"message": "ok?",
+				"payload": map[string]any{"user": "alice", "days": float64(5)},
+			},
+			// Expected exact form. prefix="  " is appended at the
+			// start of every continuation line; indent="  " adds
+			// one more level for object keys. So keys land at
+			// column 4 ("    \"days\"") and the closing brace
+			// at column 2 ("  }"):
+			//   Agent -> ok?
+			//     Payload: {
+			//         "days": 5,
+			//         "user": "alice"
+			//       }
+			// (Go map keys serialise in sorted order, so "days"
+			// precedes "user".)
+			wantContains: []string{
+				"  Payload: {\n",
+				"\n    \"days\": 5",
+				"\n    \"user\": \"alice\"",
+				"\n  }\n",
+			},
+			// Without prefix="  ", keys would land flush at
+			// column 2 (one indent level, no prefix) and the
+			// closing brace at column 0; assert neither happens.
+			wantAbsent: []string{
+				"\n  \"days\"",
+				"\n}\n",
+			},
+		},
+	}
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			out := captureStdout(t, func() {
+				renderWorkflowInputPrompt(tc.args)
+			})
+			for _, s := range tc.wantContains {
+				if !strings.Contains(out, s) {
+					t.Errorf("output missing %q\nfull output:\n%s", s, out)
+				}
+			}
+			for _, s := range tc.wantAbsent {
+				if strings.Contains(out, s) {
+					t.Errorf("output contains forbidden %q\nfull output:\n%s", s, out)
+				}
+			}
+		})
+	}
+}

--- a/examples/workflow/hitl_simple/main.go
+++ b/examples/workflow/hitl_simple/main.go
@@ -1,0 +1,124 @@
+// Copyright 2026 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+// hitl_simple is the minimal end-to-end HITL workflow for
+// verifying the console launcher's pause/resume support.
+// No LLM, no API key, no streaming — just two workflow nodes:
+//
+//	Start → ask_name → greet
+//
+// The ask_name node yields a RequestInput that pauses the
+// workflow. The console launcher renders the prompt; the user's
+// reply is delivered to greet as its input.
+//
+//	go run ./examples/workflow/hitl_simple/ console
+//
+//	User -> hello
+//	Agent -> What's your name?
+//	User -> Alice
+//	Agent -> Hello, Alice!
+//	User ->
+package main
+
+import (
+	"context"
+	"fmt"
+	"iter"
+	"log"
+	"os"
+
+	"google.golang.org/genai"
+
+	"google.golang.org/adk/agent"
+	"google.golang.org/adk/agent/workflowagent"
+	"google.golang.org/adk/cmd/launcher"
+	"google.golang.org/adk/cmd/launcher/full"
+	"google.golang.org/adk/session"
+	"google.golang.org/adk/workflow"
+)
+
+// inlineNode wraps a closure as a workflow.Node so we can yield
+// RequestInput (FunctionNode's "input → output" shape does not
+// cover that).
+type inlineNode struct {
+	workflow.BaseNode
+	run func(agent.InvocationContext, any) iter.Seq2[*session.Event, error]
+}
+
+func (n *inlineNode) Run(ctx agent.InvocationContext, input any) iter.Seq2[*session.Event, error] {
+	return n.run(ctx, input)
+}
+
+func mkNode(name, desc string, run func(agent.InvocationContext, any) iter.Seq2[*session.Event, error]) *inlineNode {
+	return &inlineNode{BaseNode: workflow.NewBaseNode(name, desc, workflow.NodeConfig{}), run: run}
+}
+
+// askName pauses the workflow with a RequestInput asking for the
+// user's name. The handoff resume delivers the reply as the next
+// node's input.
+func askName(ctx agent.InvocationContext, _ any) iter.Seq2[*session.Event, error] {
+	return func(yield func(*session.Event, error) bool) {
+		yield(workflow.NewRequestInputEvent(ctx, session.RequestInput{
+			InterruptID: "ask_name",
+			Message:     "What's your name?",
+		}), nil)
+	}
+}
+
+// greet receives the user's reply (as plain text) and yields one
+// event with the greeting as both the workflow output (StateDelta)
+// and Content (so the console launcher prints it).
+func greet(ctx agent.InvocationContext, input any) iter.Seq2[*session.Event, error] {
+	return func(yield func(*session.Event, error) bool) {
+		name, _ := input.(string)
+		if name == "" {
+			name = "stranger"
+		}
+		msg := fmt.Sprintf("Hello, %s!", name)
+		ev := session.NewEvent(ctx.InvocationID())
+		ev.Output = msg
+		ev.Content = &genai.Content{
+			Parts: []*genai.Part{{Text: msg}},
+		}
+		yield(ev, nil)
+	}
+}
+
+func main() {
+	ctx := context.Background()
+
+	ask := mkNode("ask_name", "asks the user for their name", askName)
+	hello := mkNode("greet", "greets the user by name", greet)
+
+	edges := workflow.Chain(workflow.Start, ask, hello)
+
+	rootAgent, err := workflowagent.New(workflowagent.Config{
+		Name:        "hitl_simple",
+		Description: "minimal HITL workflow for console launcher verification",
+		Edges:       edges,
+	})
+	if err != nil {
+		log.Fatalf("failed to create workflow agent: %v", err)
+	}
+
+	log.Printf("hitl_simple sample ready — type anything to start, then answer the prompt")
+
+	launcherCfg := &launcher.Config{
+		AgentLoader: agent.NewSingleLoader(rootAgent),
+	}
+	l := full.NewLauncher()
+	if err := l.Execute(ctx, launcherCfg, os.Args[1:]); err != nil {
+		log.Fatalf("Run failed: %v\n\n%s", err, l.CommandLineSyntax())
+	}
+}


### PR DESCRIPTION
## Summary

Wires human-in-the-loop pauses into `cmd/launcher/console`, so a
user running `adk launcher console` sees a HITL prompt when a
workflow node pauses for input, can type a reply, and that reply
routes back to the paused node on the next turn — closing the
loop end-to-end through the console UI.

Detection is name-agnostic: any event with a non-empty
`LongRunningToolIDs` containing a `FunctionCall.ID` is treated as
a pending interrupt, regardless of which kind of pause produced
it (workflow `RequestInput`, future `RequestConfirmation` / other
kinds — same path). Rendering and response shaping then dispatch
on the `FunctionCall.Name`, with `workflow.WorkflowInputFunctionCallName`
having a dedicated renderer and unknown kinds falling back to a
generic banner that still gets the operator's reply through.

Tool confirmation (`toolconfirmation.FunctionCallName`) currently
hits the generic fallback. The transport works (the reply routes
back to the tool by FunctionCall.ID) but the `{"result": <text>}`
envelope does not match what `ctx.ToolConfirmation()` expects.
A dedicated renderer + yes/no parser will land in a follow-up PR.

## Output format

Aligned with the existing console launcher convention
(`Agent -> ` / `User -> `, no brackets, no jargon). Example
session:

    User -> Approve my vacation request for 5 days

    Agent -> Approve $500 vacation request?
      Payload: {
        "user": "alice",
        "days": 5,
        "cost": 500
      }
      Expected response schema: {"type":"object","properties":{"approved":{"type":"boolean"}}}
    User -> {"approved": true}

    Agent -> Request approved. Booked vacation Mon-Fri.

    User ->


## Test plan

- [x] `go build ./...` clean
- [x] `go test ./cmd/launcher/console/...` — all pass
- [x] `go test -race ./cmd/launcher/console/...` — clean
- [x] 3 new tests in `cmd/launcher/console/hitl_test.go`
  (no test infrastructure existed for this package previously):
  - `TestCollectPendingInterrupts_DetectionByLongRunningToolIDs`
    — empty input, FunctionCall without long-running marker,
    long-running marker without matching call, workflow input
    on LLMResponse.Content, and multi-event filtering
  - `TestBuildInterruptResponse_WorkflowInput` — raw-text,
    JSON-object, JSON-scalar, JSON-array, and CRLF-stripping
    cases
  - `TestBuildInterruptResponse_GenericFallback` — catch-all
    path for an unknown long-running call name