### PR TITLE
feat: add HITL resume API for workflow agents

### DIFF
--- a/agent/workflowagent/hitl_test.go
+++ b/agent/workflowagent/hitl_test.go
@@ -1,0 +1,555 @@
+// Copyright 2026 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package workflowagent
+
+import (
+	"context"
+	"errors"
+	"iter"
+	"sync"
+	"sync/atomic"
+	"testing"
+
+	"github.com/google/jsonschema-go/jsonschema"
+	"google.golang.org/genai"
+
+	"google.golang.org/adk/agent"
+	"google.golang.org/adk/session"
+	"google.golang.org/adk/workflow"
+)
+
+// =============================================================================
+// Tests
+// =============================================================================
+
+// TestWorkflowAgent_RunThenResume_Handoff exercises the canonical
+// round-trip: a fresh Run pauses on a node that requested input,
+// and a follow-up Resume turn delivers the response which flows
+// to the asker's successor as its input.
+func TestWorkflowAgent_RunThenResume_Handoff(t *testing.T) {
+	var handlerInput atomic.Value
+	asker := newAskerNode("approve_or_reject", "Please decide", nil)
+	handler := newStringHandlerNode("handler", &handlerInput)
+
+	a := makeAgent(t, workflow.Chain(workflow.Start, asker, handler))
+	sess := newFakeSession()
+
+	// Turn 1: fresh Run; should pause with a RequestedInput.
+	turn1 := runFreshTurn(t, sess, a, "draft")
+	if got := findRequest(turn1); got != "approve_or_reject" {
+		t.Fatalf("turn 1 RequestedInput = %q, want %q", got, "approve_or_reject")
+	}
+	if v := handlerInput.Load(); v != nil {
+		t.Errorf("handler ran during turn 1; got input %v, want it not to run", v)
+	}
+
+	// Turn 2: resume with a payload; handler should run and
+	// receive the payload as its input.
+	turn2 := drainAgent(t, sess, a.Run(newMockCtx(sess, a, resumeMessage("approve_or_reject", "approve"))), nil)
+	if findRequest(turn2) != "" {
+		t.Errorf("turn 2 unexpectedly emitted a RequestedInput")
+	}
+	if got, want := handlerInput.Load(), "approve"; got != want {
+		t.Errorf("handler input = %v, want %q", got, want)
+	}
+}
+
+// TestWorkflowAgent_Resume_RestoresStateFromSession verifies that
+// the run state survives between agent instances backed by the
+// same session: after Run, a fresh agent built from the same
+// edges (simulating a process restart) can still Resume.
+func TestWorkflowAgent_Resume_RestoresStateFromSession(t *testing.T) {
+	var handlerCalled atomic.Bool
+
+	// makeNodes returns fresh node instances per agent so the test
+	// proves resume goes through session.State, not through any
+	// shared in-memory references between a1 and a2.
+	makeNodes := func() (workflow.Node, workflow.Node) {
+		return newAskerNode("human_approval", "approve?", nil),
+			newFlagHandlerNode("handler", &handlerCalled)
+	}
+
+	sess := newFakeSession()
+
+	// First agent instance: Run → pause.
+	asker1, handler1 := makeNodes()
+	a1 := makeAgent(t, workflow.Chain(workflow.Start, asker1, handler1))
+	turn1 := runFreshTurn(t, sess, a1, "draft")
+	if findRequest(turn1) != "human_approval" {
+		t.Fatalf("first agent did not pause as expected")
+	}
+
+	// Second agent instance, same session: Resume.
+	asker2, handler2 := makeNodes()
+	a2 := makeAgent(t, workflow.Chain(workflow.Start, asker2, handler2))
+	drainAgent(t, sess, a2.Run(newMockCtx(sess, a2, resumeMessage("human_approval", "yes"))), nil)
+	if !handlerCalled.Load() {
+		t.Error("handler did not run after resume on a fresh agent instance")
+	}
+}
+
+// TestWorkflowAgent_Resume_Idempotent verifies that two Resume
+// calls with the same payload run the handler only once.
+func TestWorkflowAgent_Resume_Idempotent(t *testing.T) {
+	var handlerRuns atomic.Int32
+	asker := newAskerNode("approve", "?", nil)
+	handler := newCountingHandlerNode("handler", &handlerRuns)
+
+	a := makeAgent(t, workflow.Chain(workflow.Start, asker, handler))
+	sess := newFakeSession()
+
+	runFreshTurn(t, sess, a, "x")
+	// First resume: matches the waiting node, runs the handler.
+	drainAgent(t, sess, a.Run(newMockCtx(sess, a, resumeMessage("approve", "yes"))), nil)
+	// Second resume with the same payload: PendingRequest was
+	// consumed by the first call, so no waiting node matches and
+	// Resume yields ErrNothingToResume rather than re-running.
+	drainAgent(t, sess, a.Run(newMockCtx(sess, a, resumeMessage("approve", "yes"))), workflow.ErrNothingToResume)
+
+	if got := handlerRuns.Load(); got != 1 {
+		t.Errorf("handler runs = %d, want 1 (duplicate Resume must not re-run the handler)", got)
+	}
+}
+
+// TestWorkflowAgent_Resume_NoMatchingResponse verifies the
+// stale-response signal: a Resume turn that carries a
+// FunctionResponse for an InterruptID that does not match any
+// waiting node yields ErrNothingToResume so the caller can
+// distinguish a no-op resume from a real one (e.g. show "your
+// reply targets a stale request" in the UI).
+func TestWorkflowAgent_Resume_NoMatchingResponse(t *testing.T) {
+	asker := newAskerNode("real_id", "?", nil)
+
+	a := makeAgent(t, workflow.Chain(workflow.Start, asker))
+	sess := newFakeSession()
+
+	// Pause once.
+	runFreshTurn(t, sess, a, "x")
+
+	// Submit a FunctionResponse for an unknown ID. detectResume
+	// will see the magic name, load state, build a responses map,
+	// but no waiting node will match — Resume yields
+	// ErrNothingToResume so the caller can distinguish the
+	// successful-but-no-effect case from a real resume.
+	turn := drainAgent(t, sess, a.Run(newMockCtx(sess, a, resumeMessage("unknown_id", "x"))), workflow.ErrNothingToResume)
+	if findRequest(turn) != "" {
+		t.Errorf("unmatched resume produced a new RequestedInput; got %v", turn)
+	}
+}
+
+// TestWorkflowAgent_Resume_SchemaValidation_Pass verifies that a
+// response payload conforming to ResponseSchema is delivered to
+// the handler unchanged (the validator coerces but here the
+// shape already matches).
+func TestWorkflowAgent_Resume_SchemaValidation_Pass(t *testing.T) {
+	var handlerInput atomic.Value
+	asker := newAskerNode("approval", "decide", approvalSchema())
+	handler := newMapHandlerNode("handler", &handlerInput)
+
+	a := makeAgent(t, workflow.Chain(workflow.Start, asker, handler))
+	sess := newFakeSession()
+
+	runFreshTurn(t, sess, a, "x")
+	drainAgent(t, sess, a.Run(newMockCtx(sess, a, resumeMessage("approval", map[string]any{"approved": true}))), nil)
+
+	got, ok := handlerInput.Load().(map[string]any)
+	if !ok || got["approved"] != true {
+		t.Errorf("handler input = %v, want map with approved=true", handlerInput.Load())
+	}
+}
+
+// TestWorkflowAgent_Resume_SchemaValidation_Fail verifies that a
+// response payload that violates ResponseSchema surfaces
+// ErrInvalidResumeResponse and leaves the node parked, so a
+// follow-up turn with a corrected payload still works.
+func TestWorkflowAgent_Resume_SchemaValidation_Fail(t *testing.T) {
+	var handlerRuns atomic.Int32
+	asker := newAskerNode("approval", "decide", approvalSchema())
+	handler := newCountingHandlerNode("handler", &handlerRuns)
+
+	a := makeAgent(t, workflow.Chain(workflow.Start, asker, handler))
+	sess := newFakeSession()
+
+	// Pause.
+	runFreshTurn(t, sess, a, "x")
+
+	// Submit invalid payload (string instead of {approved: bool}).
+	drainAgent(t, sess, a.Run(newMockCtx(sess, a, resumeMessage("approval", "not an object"))), workflow.ErrInvalidResumeResponse)
+	if handlerRuns.Load() != 0 {
+		t.Fatal("handler ran despite schema validation failure")
+	}
+
+	// Retry with valid payload — should succeed.
+	drainAgent(t, sess, a.Run(newMockCtx(sess, a, resumeMessage("approval", map[string]any{"approved": true}))), nil)
+	if handlerRuns.Load() != 1 {
+		t.Errorf("handler runs after retry = %d, want 1", handlerRuns.Load())
+	}
+}
+
+// TestWorkflowAgent_Resume_FanOut verifies that a handoff resume
+// from an asker with multiple successors fans out the response
+// to every successor, exactly as a normal output would.
+func TestWorkflowAgent_Resume_FanOut(t *testing.T) {
+	var hits atomic.Int32
+	asker := newAskerNode("fan", "?", nil)
+	h1 := newCountingHandlerNode("h1", &hits)
+	h2 := newCountingHandlerNode("h2", &hits)
+	h3 := newCountingHandlerNode("h3", &hits)
+
+	a := makeAgent(t, []workflow.Edge{
+		{From: workflow.Start, To: asker},
+		{From: asker, To: h1},
+		{From: asker, To: h2},
+		{From: asker, To: h3},
+	})
+	sess := newFakeSession()
+
+	runFreshTurn(t, sess, a, "x")
+	drainAgent(t, sess, a.Run(newMockCtx(sess, a, resumeMessage("fan", "go"))), nil)
+
+	if got := hits.Load(); got != 3 {
+		t.Errorf("successor hits = %d, want 3", got)
+	}
+}
+
+// TestWorkflowAgent_FreshTurn_NotMistakenForResume verifies the
+// detectResume guard: a fresh user message that happens to have
+// no FunctionResponse part does NOT trip the resume path even if
+// a RunState is persisted (e.g. from a paused or completed prior
+// workflow). Important because session.State may carry leftover
+// state from previous runs.
+func TestWorkflowAgent_FreshTurn_NotMistakenForResume(t *testing.T) {
+	var firstRun atomic.Bool
+	var secondRun atomic.Bool
+
+	// Custom asker (not newAskerNode) because each instance must
+	// flip its own flag before the request is yielded, so the
+	// test can detect that the asker truly re-ran on turn 2.
+	makeAsker := func(flag *atomic.Bool) workflow.Node {
+		return newHitlNode("asker", func(ctx agent.InvocationContext, _ any, yield func(*session.Event, error) bool) {
+			flag.Store(true)
+			yield(workflow.NewRequestInputEvent(ctx, session.RequestInput{
+				InterruptID: "ask",
+				Message:     "?",
+			}), nil)
+		})
+	}
+
+	a := makeAgent(t, workflow.Chain(workflow.Start, makeAsker(&firstRun)))
+	sess := newFakeSession()
+
+	// Turn 1: fresh; pauses.
+	runFreshTurn(t, sess, a, "x")
+	if !firstRun.Load() {
+		t.Fatal("asker did not run on turn 1")
+	}
+
+	// Turn 2: another fresh user message (no FunctionResponse).
+	// detectResume should return false; Workflow.Run is invoked.
+	a2 := makeAgent(t, workflow.Chain(workflow.Start, makeAsker(&secondRun)))
+	runFreshTurn(t, sess, a2, "fresh")
+	if !secondRun.Load() {
+		t.Error("a fresh user message was misinterpreted as a resume; asker did not run on turn 2")
+	}
+}
+
+// =============================================================================
+// Test fixtures and helpers
+// =============================================================================
+
+// fakeSession is a minimal session.Session implementation that
+// faithfully models the AppendEvent-gated state contract used by
+// session.InMemoryService and persistent backends: state mutations
+// are applied only when applyStateDelta is called for an event
+// (the unit-test analogue of session.Service.AppendEvent), never
+// via direct State.Set from inside the agent.
+//
+// drainAgent (this file) calls applyStateDelta for every event the
+// agent yields, simulating what the runner does in production.
+type fakeSession struct {
+	session.Session
+	state *fakeSessionState
+}
+
+func newFakeSession() *fakeSession {
+	return &fakeSession{state: &fakeSessionState{m: map[string]any{}}}
+}
+
+func (s *fakeSession) ID() string           { return "test-session-id" }
+func (s *fakeSession) State() session.State { return s.state }
+
+// applyStateDelta merges any Actions.StateDelta on the supplied
+// event into the underlying state map. Mirrors what
+// inMemoryService.AppendEvent does for session-scoped (no
+// app:/user:/temp: prefix) keys; HITL persistence uses such keys.
+func (s *fakeSession) applyStateDelta(ev *session.Event) {
+	if ev == nil || len(ev.Actions.StateDelta) == 0 {
+		return
+	}
+	s.state.mu.Lock()
+	defer s.state.mu.Unlock()
+	for k, v := range ev.Actions.StateDelta {
+		s.state.m[k] = v
+	}
+}
+
+// fakeSessionState exposes session.State semantics with one subtle
+// constraint compared to the real services: callers that bypass
+// the runner cannot mutate state via Set; they must construct an
+// event with Actions.StateDelta and route it through
+// fakeSession.applyStateDelta instead. Get reflects the
+// AppendEvent-applied view.
+type fakeSessionState struct {
+	mu sync.Mutex
+	m  map[string]any
+}
+
+func (s *fakeSessionState) Get(key string) (any, error) {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	v, ok := s.m[key]
+	if !ok {
+		return nil, session.ErrStateKeyNotExist
+	}
+	return v, nil
+}
+
+// Set is a no-op writer in this mock to surface accidental direct
+// modification. Production code must route state changes through
+// Event.Actions.StateDelta. Tests that need to pre-seed state can
+// write directly to the underlying map via the fakeSession
+// constructor.
+func (s *fakeSessionState) Set(key string, value any) error {
+	// Intentionally not persisted: real session services do not
+	// propagate direct Set from inside an invocation either.
+	// Returning nil keeps the call non-fatal so production code
+	// that defensively writes through State.Set still compiles
+	// and runs.
+	return nil
+}
+
+func (s *fakeSessionState) All() iter.Seq2[string, any] {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	snapshot := make(map[string]any, len(s.m))
+	for k, v := range s.m {
+		snapshot[k] = v
+	}
+	return func(yield func(string, any) bool) {
+		for k, v := range snapshot {
+			if !yield(k, v) {
+				return
+			}
+		}
+	}
+}
+
+// hitlNode is a custom Node used by the HITL resume tests. The
+// Run callback is supplied per test so each scenario can shape
+// its own emission pattern.
+type hitlNode struct {
+	workflow.BaseNode
+	run func(ctx agent.InvocationContext, input any, yield func(*session.Event, error) bool)
+}
+
+func newHitlNode(name string, run func(ctx agent.InvocationContext, input any, yield func(*session.Event, error) bool)) *hitlNode {
+	return &hitlNode{
+		BaseNode: workflow.NewBaseNode(name, "", workflow.NodeConfig{}),
+		run:      run,
+	}
+}
+
+func (n *hitlNode) Run(ctx agent.InvocationContext, input any) iter.Seq2[*session.Event, error] {
+	return func(yield func(*session.Event, error) bool) {
+		n.run(ctx, input, yield)
+	}
+}
+
+// makeAgent builds a workflowagent with the given edges and the
+// canonical "test_workflow" name (the name is what
+// session.State persistence is keyed by).
+func makeAgent(t *testing.T, edges []workflow.Edge) agent.Agent {
+	t.Helper()
+	a, err := New(Config{Name: "test_workflow", Edges: edges})
+	if err != nil {
+		t.Fatalf("workflowagent.New: %v", err)
+	}
+	return a
+}
+
+// newMockCtx returns an InvocationContext suitable for driving the
+// workflow agent. The same session is reused across calls so
+// pause/resume round-trips through fakeSessionState as they would
+// in production.
+func newMockCtx(sess session.Session, agt agent.Agent, msg *genai.Content) *MockInvocationContext {
+	return &MockInvocationContext{
+		Context:     context.TODO(),
+		sess:        sess,
+		userContent: msg,
+		myAgent:     agt,
+	}
+}
+
+// drainAgent consumes the agent's iter.Seq2, collecting events,
+// and applies each event's StateDelta to sess. The applyStateDelta
+// step replaces the AppendEvent-side state propagation that the
+// real runner performs; without it state writes from the agent
+// would never become visible to subsequent calls. Fails the test
+// if the iterator yields a non-nil error that the test did not
+// opt into via wantErr.
+func drainAgent(t *testing.T, sess *fakeSession, seq iter.Seq2[*session.Event, error], wantErr error) []*session.Event {
+	t.Helper()
+	var got []*session.Event
+	var sawErr error
+	for ev, err := range seq {
+		if err != nil {
+			if sawErr == nil {
+				sawErr = err
+			}
+			continue
+		}
+		got = append(got, ev)
+		sess.applyStateDelta(ev)
+	}
+	switch {
+	case wantErr == nil && sawErr != nil:
+		t.Fatalf("unexpected error from agent: %v", sawErr)
+	case wantErr != nil && sawErr == nil:
+		t.Fatalf("expected error %v, got none", wantErr)
+	case wantErr != nil && !errors.Is(sawErr, wantErr):
+		t.Fatalf("expected error %v, got %v", wantErr, sawErr)
+	}
+	return got
+}
+
+// findRequest scans events for the first one carrying a
+// RequestedInput and returns the InterruptID it carried, or "" if
+// none was found.
+func findRequest(events []*session.Event) string {
+	for _, ev := range events {
+		if ev != nil && ev.RequestedInput != nil {
+			return ev.RequestedInput.InterruptID
+		}
+	}
+	return ""
+}
+
+// resumeMessage builds a user message carrying a FunctionResponse
+// that targets a previously-emitted RequestInput.
+func resumeMessage(interruptID string, payload any) *genai.Content {
+	return &genai.Content{
+		Parts: []*genai.Part{{
+			FunctionResponse: &genai.FunctionResponse{
+				ID:   interruptID,
+				Name: workflow.WorkflowInputFunctionCallName,
+				Response: map[string]any{
+					"payload": payload,
+				},
+			},
+		}},
+	}
+}
+
+// newAskerNode returns a hitlNode whose Run yields a single
+// RequestInput event carrying the given InterruptID, message, and
+// optional schema, then exits. This is the canonical "asker"
+// pattern: a node that pauses the workflow waiting for human input.
+func newAskerNode(interruptID, message string, schema *jsonschema.Schema) *hitlNode {
+	return newHitlNode("asker", func(ctx agent.InvocationContext, _ any, yield func(*session.Event, error) bool) {
+		yield(workflow.NewRequestInputEvent(ctx, session.RequestInput{
+			InterruptID:    interruptID,
+			Message:        message,
+			ResponseSchema: schema,
+		}), nil)
+	})
+}
+
+// runFreshTurn drives the agent through a single turn whose
+// inbound user content is plain text (no FunctionResponse). Used
+// to seed the canonical "first turn" of pause/resume tests where
+// the actual text payload does not matter.
+func runFreshTurn(t *testing.T, sess *fakeSession, a agent.Agent, text string) []*session.Event {
+	t.Helper()
+	return drainAgent(t, sess, a.Run(newMockCtx(sess, a, &genai.Content{
+		Parts: []*genai.Part{{Text: text}},
+	})), nil)
+}
+
+// newStringHandlerNode returns a FunctionNode that stores its
+// string input into dst and returns "handled:<input>".
+func newStringHandlerNode(name string, dst *atomic.Value) workflow.Node {
+	return workflow.NewFunctionNode(
+		name,
+		func(_ agent.InvocationContext, input string) (string, error) {
+			dst.Store(input)
+			return "handled:" + input, nil
+		},
+		workflow.NodeConfig{},
+	)
+}
+
+// newMapHandlerNode returns a FunctionNode that stores its
+// map[string]any input into dst and returns nil.
+func newMapHandlerNode(name string, dst *atomic.Value) workflow.Node {
+	return workflow.NewFunctionNode(
+		name,
+		func(_ agent.InvocationContext, input map[string]any) (any, error) {
+			dst.Store(input)
+			return nil, nil
+		},
+		workflow.NodeConfig{},
+	)
+}
+
+// newCountingHandlerNode returns a FunctionNode that increments counter
+// each time it runs. Input is typed any so the helper accepts
+// payloads of any shape without coercion.
+func newCountingHandlerNode(name string, counter *atomic.Int32) workflow.Node {
+	return workflow.NewFunctionNode(
+		name,
+		func(_ agent.InvocationContext, _ any) (any, error) {
+			counter.Add(1)
+			return nil, nil
+		},
+		workflow.NodeConfig{},
+	)
+}
+
+// newFlagHandlerNode returns a FunctionNode that sets flag to true
+// each time it runs. Input is typed any so the helper accepts
+// payloads of any shape without coercion.
+func newFlagHandlerNode(name string, flag *atomic.Bool) workflow.Node {
+	return workflow.NewFunctionNode(
+		name,
+		func(_ agent.InvocationContext, _ any) (any, error) {
+			flag.Store(true)
+			return nil, nil
+		},
+		workflow.NodeConfig{},
+	)
+}
+
+// approvalSchema returns the canonical schema for an "approval"
+// payload: an object with a single required boolean field named
+// "approved". Shared across the SchemaValidation tests.
+func approvalSchema() *jsonschema.Schema {
+	return &jsonschema.Schema{
+		Type: "object",
+		Properties: map[string]*jsonschema.Schema{
+			"approved": {Type: "boolean"},
+		},
+		Required: []string{"approved"},
+	}
+}

--- a/agent/workflowagent/workflow.go
+++ b/agent/workflowagent/workflow.go
@@ -15,7 +15,14 @@
 package workflowagent
 
 import (
+	"encoding/json"
+	"iter"
+
+	"google.golang.org/genai"
+
 	"google.golang.org/adk/agent"
+	"google.golang.org/adk/internal/utils"
+	"google.golang.org/adk/session"
 	"google.golang.org/adk/workflow"
 )
 
@@ -29,12 +36,19 @@ type Config struct {
 	Edges                []workflow.Edge
 }
 
-// New creates a new Workflow agent.
+// New creates a new Workflow agent. A single returned agent
+// instance can serve many concurrent sessions: the per-invocation
+// run state lives in session.State, not on the agent. A paused
+// workflow resumes on a follow-up turn when the user submits a
+// FunctionResponse targeting the InterruptID emitted by the
+// paused node.
 func New(cfg Config) (agent.Agent, error) {
-	w, err := workflow.New(cfg.Edges)
+	w, err := workflow.New(cfg.Name, cfg.Edges)
 	if err != nil {
 		return nil, err
 	}
+
+	wa := &workflowAgent{workflow: w}
 
 	return agent.New(agent.Config{
 		Name:                 cfg.Name,
@@ -42,6 +56,99 @@ func New(cfg Config) (agent.Agent, error) {
 		SubAgents:            cfg.SubAgents,
 		BeforeAgentCallbacks: cfg.BeforeAgentCallbacks,
 		AfterAgentCallbacks:  cfg.AfterAgentCallbacks,
-		Run:                  w.Run,
+		Run:                  wa.run,
 	})
+}
+
+// workflowAgent is the wrapper that dispatches between
+// Workflow.Run (fresh turn) and Workflow.Resume (resume turn).
+// The dispatch decision is made by inspecting ctx.UserContent for
+// a FunctionResponse targeting a previously-emitted RequestInput.
+// The workflow's RunState lives in session.State, not on this
+// struct, so a single *workflowAgent safely services many
+// concurrent sessions.
+type workflowAgent struct {
+	workflow *workflow.Workflow
+}
+
+// run is the agent.Config.Run callback. It dispatches between
+// Workflow.Resume (when the inbound user content carries a
+// FunctionResponse to a previously-emitted RequestInput) and
+// Workflow.Run (every other turn).
+func (a *workflowAgent) run(ctx agent.InvocationContext) iter.Seq2[*session.Event, error] {
+	return func(yield func(*session.Event, error) bool) {
+		if responses, state, ok := a.detectResume(ctx); ok {
+			for ev, err := range a.workflow.Resume(ctx, state, responses) {
+				if !yield(ev, err) {
+					return
+				}
+			}
+			return
+		}
+		for ev, err := range a.workflow.Run(ctx) {
+			if !yield(ev, err) {
+				return
+			}
+		}
+	}
+}
+
+// detectResume inspects the inbound user message for FunctionResponses
+// targeting a previously-emitted RequestInput. Returns the
+// responses map keyed by InterruptID (suitable for
+// Workflow.Resume), the RunState loaded from session, and true if
+// this turn is a resume; (nil, nil, false) for a fresh turn.
+func (a *workflowAgent) detectResume(ctx agent.InvocationContext) (map[string]any, *workflow.RunState, bool) {
+	frs := utils.FunctionResponses(ctx.UserContent())
+	if len(frs) == 0 {
+		return nil, nil, false
+	}
+
+	responses := map[string]any{}
+	for _, fr := range frs {
+		if fr.Name != workflow.WorkflowInputFunctionCallName {
+			continue
+		}
+		responses[fr.ID] = decodeWorkflowInputResponse(fr)
+	}
+	if len(responses) == 0 {
+		return nil, nil, false
+	}
+
+	state, err := workflow.LoadRunState(ctx.Session(), a.workflow.Name())
+	if err != nil || state == nil {
+		// No persisted state means there is nothing to resume;
+		// fall through to a fresh Workflow.Run.
+		return nil, nil, false
+	}
+
+	return responses, state, true
+}
+
+// decodeWorkflowInputResponse extracts the user-supplied payload
+// from a FunctionResponse targeting a workflow input request.
+//
+// Three accepted shapes, in priority order:
+//
+//  1. {"response": <value>}  — when value is a string, it is
+//     parsed as JSON and the result returned; if the string is
+//     not valid JSON it is returned verbatim. When value is any
+//     other type, it is returned as-is.
+//  2. {"payload": <any>}     — value returned verbatim.
+//  3. anything else           — the whole Response map is returned.
+func decodeWorkflowInputResponse(fr *genai.FunctionResponse) any {
+	if raw, ok := fr.Response["response"]; ok {
+		if s, isStr := raw.(string); isStr {
+			var decoded any
+			if err := json.Unmarshal([]byte(s), &decoded); err == nil {
+				return decoded
+			}
+			return s
+		}
+		return raw
+	}
+	if payload, ok := fr.Response["payload"]; ok {
+		return payload
+	}
+	return fr.Response
 }

--- a/agent/workflowagent/workflow_test.go
+++ b/agent/workflowagent/workflow_test.go
@@ -21,6 +21,7 @@ import (
 	"testing"
 	"time"
 
+	"github.com/google/go-cmp/cmp"
 	"google.golang.org/genai"
 
 	"google.golang.org/adk/agent"
@@ -37,6 +38,12 @@ type MockSession struct {
 
 func (m MockSession) ID() string {
 	return "test-session-id"
+}
+
+// State returns nil; the workflow persistence helpers handle a nil
+// session.State by treating the session as non-persisting.
+func (m MockSession) State() session.State {
+	return nil
 }
 
 // MockInvocationContext is a minimal implementation of agent.InvocationContext for testing.
@@ -134,25 +141,109 @@ func TestWorkflowAgent(t *testing.T) {
 	events := myWorkflow.Run(mockCtx)
 
 	var lastOutput any
-	count := 0
+	nodeEvents := 0
 	for ev, err := range events {
 		if err != nil {
 			t.Fatalf("unexpected error: %v", err)
 		}
-		count++
 
 		if ev.Actions.StateDelta != nil {
 			if out, ok := ev.Actions.StateDelta["output"]; ok {
 				lastOutput = out
+				nodeEvents++
 			}
 		}
 	}
 
-	if count != 2 {
-		t.Errorf("expected 2 events, got %d", count)
+	// One output event per FunctionNode (upper, suffix); Start is
+	// a no-op sentinel and emits nothing.
+	if nodeEvents != 2 {
+		t.Errorf("expected 2 node-output events, got %d", nodeEvents)
 	}
 
 	if lastOutput != "HELLO done" {
 		t.Errorf("expected last output 'HELLO done', got %v", lastOutput)
+	}
+}
+
+func TestDecodeWorkflowInputResponse(t *testing.T) {
+	tests := []struct {
+		name string
+		fr   *genai.FunctionResponse
+		want any
+	}{
+		{
+			name: "ResponseShape_JSONObject",
+			fr: &genai.FunctionResponse{
+				Response: map[string]any{"response": `{"approved":true}`},
+			},
+			want: map[string]any{"approved": true},
+		},
+		{
+			name: "ResponseShape_JSONScalar",
+			fr: &genai.FunctionResponse{
+				Response: map[string]any{"response": `42`},
+			},
+			want: float64(42), // json.Unmarshal decodes JSON numbers to float64
+		},
+		{
+			name: "ResponseShape_InvalidJSONFallsBackToRawString",
+			fr: &genai.FunctionResponse{
+				Response: map[string]any{"response": "not valid json"},
+			},
+			want: "not valid json",
+		},
+		{
+			name: "ResponseShape_NonStringValueReturnedVerbatim",
+			fr: &genai.FunctionResponse{
+				Response: map[string]any{"response": map[string]any{"already": "decoded"}},
+			},
+			want: map[string]any{"already": "decoded"},
+		},
+		{
+			name: "PayloadShape_StringPayload",
+			fr: &genai.FunctionResponse{
+				Response: map[string]any{"payload": "yes"},
+			},
+			want: "yes",
+		},
+		{
+			name: "PayloadShape_StructuredPayload",
+			fr: &genai.FunctionResponse{
+				Response: map[string]any{"payload": map[string]any{"k": "v"}},
+			},
+			want: map[string]any{"k": "v"},
+		},
+		{
+			name: "PriorityOrder_ResponseWinsOverPayload",
+			fr: &genai.FunctionResponse{
+				Response: map[string]any{
+					"response": `"from-response"`,
+					"payload":  "from-payload",
+				},
+			},
+			want: "from-response",
+		},
+		{
+			name: "Fallback_NeitherKey_ReturnsRawMap",
+			fr: &genai.FunctionResponse{
+				Response: map[string]any{"custom": "shape"},
+			},
+			want: map[string]any{"custom": "shape"},
+		},
+		{
+			name: "Fallback_EmptyResponseMap",
+			fr:   &genai.FunctionResponse{Response: map[string]any{}},
+			want: map[string]any{},
+		},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			got := decodeWorkflowInputResponse(tc.fr)
+			if diff := cmp.Diff(tc.want, got); diff != "" {
+				t.Errorf("decodeWorkflowInputResponse(%+v) mismatch (-want +got):\n%s", tc.fr.Response, diff)
+			}
+		})
 	}
 }

--- a/session/session.go
+++ b/session/session.go
@@ -133,26 +133,31 @@ type Event struct {
 // by a workflow node. It travels on Event.RequestedInput from the
 // node, through the scheduler, out to the UI surface; the matching
 // response is routed back by InterruptID.
+//
+// JSON-marshallable: persisted in session.State across pause/resume
+// turns. Payload is typed any and must be JSON-encodable; for
+// binary data, stash the bytes via agent.Artifacts and put a URI
+// string in Payload.
 type RequestInput struct {
 	// InterruptID is the stable correlation key for this request.
 	// It identifies the intent of the prompt (e.g. "manager_approval",
 	// "human_review"). If empty when the node yields the event, the
 	// engine fills in a UUID so the downstream contract is always a
 	// non-empty string.
-	InterruptID string
+	InterruptID string `json:"interruptId"`
 
 	// Message is the human-readable description of what is being
 	// asked. Surfaced in UI as the prompt text. Optional.
-	Message string
+	Message string `json:"message,omitempty"`
 
 	// ResponseSchema, when non-nil, is the JSON schema the user's
 	// response payload must conform to.
-	ResponseSchema *jsonschema.Schema
+	ResponseSchema *jsonschema.Schema `json:"responseSchema,omitempty"`
 
 	// Payload is optional context the UI may render alongside the
 	// prompt (e.g. the document to approve, the proposed parameters).
 	// Carried through opaquely; the engine does not interpret it.
-	Payload any
+	Payload any `json:"payload,omitempty"`
 }
 
 // IsFinalResponse returns whether the event is the final response of an agent.

--- a/workflow/persistence.go
+++ b/workflow/persistence.go
@@ -1,0 +1,101 @@
+// Copyright 2026 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package workflow
+
+import (
+	"encoding/json"
+	"errors"
+	"fmt"
+
+	"google.golang.org/adk/session"
+)
+
+// runStateSessionKeyPrefix is the prefix used by RunStateSessionKey
+// for namespacing workflow RunStates inside session.State.
+const runStateSessionKeyPrefix = "adk.workflow.runstate."
+
+// RunStateSessionKey returns the session.State key under which a
+// workflow's RunState is persisted between invocations. Namespaced
+// by workflow name so multiple workflows in the same session do
+// not collide.
+func RunStateSessionKey(workflowName string) string {
+	return runStateSessionKeyPrefix + workflowName
+}
+
+// LoadRunState reads and decodes the workflow's persisted RunState
+// from the given session. Returns (nil, nil) when no state has
+// been stored yet, so callers can distinguish "nothing to resume"
+// from "load failed". An empty workflowName disables persistence
+// and always returns (nil, nil).
+func LoadRunState(sess session.Session, workflowName string) (*RunState, error) {
+	if sess == nil || workflowName == "" {
+		return nil, nil
+	}
+	state := sess.State()
+	if state == nil {
+		return nil, nil
+	}
+	raw, err := state.Get(RunStateSessionKey(workflowName))
+	if err != nil {
+		if errors.Is(err, session.ErrStateKeyNotExist) {
+			return nil, nil
+		}
+		return nil, err
+	}
+
+	// raw is JSON-encoded []byte (or its base64-string form when
+	// the session backend round-trips StateDelta through JSON).
+	decode := func(b []byte) (*RunState, error) {
+		var state RunState
+		if err := json.Unmarshal(b, &state); err != nil {
+			return nil, fmt.Errorf("workflow: decode run state: %w", err)
+		}
+		return &state, nil
+	}
+	switch v := raw.(type) {
+	case []byte:
+		return decode(v)
+	case string:
+		return decode([]byte(v))
+	default:
+		return nil, fmt.Errorf("workflow: run state has unexpected type %T (want []byte or string)", raw)
+	}
+}
+
+// NewRunStateEvent builds a session.Event whose Actions.StateDelta
+// carries the workflow's serialised RunState. Workflow.Run and
+// Workflow.Resume yield this event before returning so the
+// surrounding event-append pipeline can persist the state
+// alongside every other delta-based update.
+//
+// Persistence backends apply state mutations only when they
+// observe them on Event.Actions.StateDelta during the append
+// path; a direct session.State().Set updates the per-invocation
+// copy but is not propagated to storage. Returning nil for an
+// empty workflowName lets callers use NewRunStateEvent
+// unconditionally and skip the yield when persistence is not
+// desired.
+func NewRunStateEvent(invocationID, workflowName string, state *RunState) (*session.Event, error) {
+	if workflowName == "" || state == nil {
+		return nil, nil
+	}
+	bytes, err := json.Marshal(state)
+	if err != nil {
+		return nil, fmt.Errorf("workflow: encode run state: %w", err)
+	}
+	ev := session.NewEvent(invocationID)
+	ev.Actions.StateDelta[RunStateSessionKey(workflowName)] = bytes
+	return ev, nil
+}

--- a/workflow/request_input.go
+++ b/workflow/request_input.go
@@ -16,16 +16,33 @@ package workflow
 
 import (
 	"github.com/google/uuid"
+	"google.golang.org/genai"
 
 	"google.golang.org/adk/agent"
+	"google.golang.org/adk/model"
 	"google.golang.org/adk/session"
 )
+
+// WorkflowInputFunctionCallName is the FunctionCall name carried on
+// a request event so the agent runtime's generic FunctionResponse-
+// by-ID dispatch can route the user's follow-up reply back to the
+// workflow agent that issued the request. Mirrors
+// toolconfirmation.FunctionCallName.
+const WorkflowInputFunctionCallName = "adk_request_workflow_input"
 
 // NewRequestInputEvent constructs a session.Event that asks the
 // surrounding workflow to pause and surface a human-input prompt.
 // A node yields the returned event and then exits its iter.Seq2;
 // the scheduler observes Event.RequestedInput and transitions the
 // node to NodeWaiting.
+//
+// The event also carries a synthesised FunctionCall part with name
+// WorkflowInputFunctionCallName and ID equal to req.InterruptID,
+// plus req.InterruptID in LongRunningToolIDs. This shape makes
+// Event.IsFinalResponse() return true so the surrounding agent
+// loop terminates after the request is yielded, and lets the
+// generic FunctionResponse-by-ID dispatch route the human's reply
+// back to the workflow agent that issued the request.
 //
 // If req.InterruptID is empty, a UUID is generated so the
 // downstream contract (a non-empty correlation key on
@@ -48,7 +65,42 @@ func NewRequestInputEvent(ctx agent.InvocationContext, req session.RequestInput)
 	if req.InterruptID == "" {
 		req.InterruptID = uuid.NewString()
 	}
+
 	ev := session.NewEvent(ctx.InvocationID())
 	ev.RequestedInput = &req
+
+	// Synthesise the FunctionCall part so generic
+	// FunctionResponse-by-ID dispatch can route the human's reply
+	// back to this agent on the follow-up turn. Args mirror the
+	// RequestInput fields so a client that does not parse the
+	// dedicated RequestedInput field can still display the prompt
+	// from the args alone.
+	args := map[string]any{
+		"interruptId": req.InterruptID,
+		"message":     req.Message,
+		"payload":     req.Payload,
+	}
+	if req.ResponseSchema != nil {
+		args["responseSchema"] = req.ResponseSchema
+	}
+	ev.LLMResponse = model.LLMResponse{
+		Content: &genai.Content{
+			Role: genai.RoleModel,
+			Parts: []*genai.Part{{
+				FunctionCall: &genai.FunctionCall{
+					ID:   req.InterruptID,
+					Name: WorkflowInputFunctionCallName,
+					Args: args,
+				},
+			}},
+		},
+	}
+	ev.LongRunningToolIDs = []string{req.InterruptID}
+
+	if a := ctx.Agent(); a != nil {
+		ev.Author = a.Name()
+	}
+	ev.Branch = ctx.Branch()
+
 	return ev
 }

--- a/workflow/resume.go
+++ b/workflow/resume.go
@@ -1,0 +1,165 @@
+// Copyright 2026 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package workflow
+
+import (
+	"errors"
+	"fmt"
+	"iter"
+
+	"github.com/google/jsonschema-go/jsonschema"
+
+	"google.golang.org/adk/agent"
+	"google.golang.org/adk/internal/typeutil"
+	"google.golang.org/adk/session"
+)
+
+// ErrInvalidResumeResponse is returned by Workflow.Resume when a
+// response payload does not match its corresponding
+// RequestInput.ResponseSchema. The waiting node is left in
+// NodeWaiting with PendingRequest intact so the caller can retry
+// with a corrected payload.
+var ErrInvalidResumeResponse = errors.New("workflow: resume response does not match request schema")
+
+// ErrNothingToResume is returned by Workflow.Resume when the
+// caller supplied a non-empty responses map but no waiting node
+// matched any of the InterruptIDs in it. Lets the caller
+// distinguish "successful resume" from "submitted response had no
+// effect" — typically a sign that the response targets a stale or
+// already-consumed request, or that the workflow graph has
+// evolved out of the node that was waiting.
+var ErrNothingToResume = errors.New("workflow: no waiting node matched the supplied responses")
+
+// Resume continues a previously paused workflow run. state is the
+// RunState loaded from session storage; responses maps
+// RequestInput.InterruptID to the user-supplied response payload.
+//
+// For each waiting node whose InterruptID has a matching entry in
+// responses, Resume:
+//
+//  1. Validates the payload against PendingRequest.ResponseSchema,
+//     if non-nil. A mismatch surfaces as ErrInvalidResumeResponse
+//     via the iterator and leaves the node in NodeWaiting with
+//     PendingRequest intact.
+//
+//  2. Consumes the pending request (clears PendingRequest, sets
+//     Status = NodePending) before re-scheduling, so a duplicate
+//     Resume call with the same InterruptID becomes a no-op.
+//
+//  3. Routes the response to the asker's successors as if the
+//     asker had emitted it as its output (handoff mode). The
+//     asker itself does NOT re-execute.
+//
+// Waiting nodes whose InterruptID is absent from responses remain
+// in NodeWaiting unchanged.
+//
+// If responses is non-empty but no waiting node matches any
+// InterruptID in it, Resume yields ErrNothingToResume so the
+// caller can distinguish a successful resume from a stale or
+// mistargeted submission. An empty responses map (or nil state)
+// is treated as a clean no-op with no error.
+func (w *Workflow) Resume(
+	ctx agent.InvocationContext,
+	state *RunState,
+	responses map[string]any,
+) iter.Seq2[*session.Event, error] {
+	return func(yield func(*session.Event, error) bool) {
+		if state == nil || len(responses) == 0 {
+			return
+		}
+
+		s := newScheduler(ctx, w.graph)
+		s.state = state
+
+		scheduled := 0
+		for name, ns := range state.Nodes {
+			if ns.Status != NodeWaiting || ns.PendingRequest == nil {
+				continue
+			}
+			resp, ok := responses[ns.PendingRequest.InterruptID]
+			if !ok {
+				continue
+			}
+
+			// Schema validation: surface a typed error and leave
+			// the node parked so the caller can retry.
+			if ns.PendingRequest.ResponseSchema != nil {
+				validated, err := validateResumeResponse(resp, ns.PendingRequest.ResponseSchema)
+				if err != nil {
+					if !yield(nil, fmt.Errorf("%w: node %q: %w", ErrInvalidResumeResponse, name, err)) {
+						return
+					}
+					continue
+				}
+				resp = validated
+			}
+
+			node := s.nodesByName[name]
+			if node == nil {
+				continue
+			}
+
+			// Consume PendingRequest before scheduling. A duplicate
+			// Resume with the same InterruptID will skip this node
+			// because PendingRequest is now nil.
+			ns.PendingRequest = nil
+			ns.Status = NodePending
+
+			// Handoff mode: schedule each successor with the
+			// response as its input, exactly as if the asker had
+			// emitted it as output. Reuses findSuccessors so
+			// routing, fan-out and fan-in invariants apply
+			// uniformly. (No routing event is supplied, so a
+			// router-style handoff target falls back to its
+			// Default route or dead-ends.)
+			for _, succ := range findSuccessors(s.graph, node, resp, nil) {
+				s.scheduleNode(succ.node, succ.input, succ.triggeredBy)
+			}
+			scheduled++
+		}
+
+		if scheduled == 0 {
+			yield(nil, ErrNothingToResume)
+			return
+		}
+
+		s.run(yield)
+		s.wg.Wait()
+
+		// Persist the post-resume state via a session.Event with
+		// StateDelta. If new nodes paused during this Resume the
+		// next turn will see them; if the run completed the state
+		// reflects that too.
+		yieldRunStateEvent(ctx, w.name, s.state, yield)
+	}
+}
+
+// validateResumeResponse coerces resp into the type described by
+// schema, returning the validated value or an error. When schema
+// is nil, resp passes through unchanged.
+//
+// The schema is resolved on each call rather than cached: persisted
+// RunState round-trips schemas through JSON, which does not
+// preserve any pre-resolved form.
+func validateResumeResponse(resp any, schema *jsonschema.Schema) (any, error) {
+	if schema == nil {
+		return resp, nil
+	}
+	resolved, err := schema.Resolve(nil)
+	if err != nil {
+		return nil, fmt.Errorf("resolve schema: %w", err)
+	}
+	return typeutil.ConvertToWithJSONSchema[any, any](resp, resolved)
+}

--- a/workflow/state.go
+++ b/workflow/state.go
@@ -73,33 +73,40 @@ const (
 
 // NodeState is the per-node lifecycle record. A RunState holds one
 // of these for every node the engine has touched.
+//
+// JSON-marshallable: NodeState is persisted across pause/resume
+// turns via session.State (see persistence.go). The Input and
+// PendingRequest.Payload fields are typed any and must therefore
+// be JSON-encodable for the persisted state to round-trip. Nodes
+// that need to carry binary data across a pause should store the
+// bytes via agent.Artifacts and stash a URI string in place of
+// the bytes, mirroring how the Live API surfaces audio.
 type NodeState struct {
 	// Status is the current lifecycle position. See NodeStatus.
-	Status NodeStatus
+	Status NodeStatus `json:"status"`
 
 	// Input is the value most recently handed to the node's Run
 	// method. It is set when the node is scheduled.
-	Input any
+	Input any `json:"input,omitempty"`
 
 	// TriggeredBy is the name of the upstream node that produced
 	// the current Input. Empty for the initial START activation.
-	TriggeredBy string
+	TriggeredBy string `json:"triggeredBy,omitempty"`
 
 	// PendingRequest, when non-nil, carries the human-input request
 	// the node emitted before pausing. Non-nil iff Status ==
 	// NodeWaiting and the wait was caused by a human-input request
 	// (as opposed to a fan-in barrier).
-	PendingRequest *session.RequestInput
+	PendingRequest *session.RequestInput `json:"pendingRequest,omitempty"`
 }
 
 // RunState is the per-invocation lifecycle state for a workflow
-// run. It is intended to be embedded in (or referenced from) the
-// agent's session-persisted state so HITL pauses and crash
-// recovery can pick up where a previous invocation left off.
+// run. It rides in session.State across pause and resume turns so
+// the workflow can pick up where a previous invocation left off.
 type RunState struct {
 	// Nodes is the per-node lifecycle map. Absent entries are
 	// inactive.
-	Nodes map[string]*NodeState
+	Nodes map[string]*NodeState `json:"nodes,omitempty"`
 }
 
 // NewRunState returns an empty state with the Nodes map

--- a/workflow/workflow.go
+++ b/workflow/workflow.go
@@ -113,25 +113,56 @@ func (s *startNode) Run(ctx agent.InvocationContext, input any) iter.Seq2[*sessi
 // Workflow manages the workflow graph execution.
 type Workflow struct {
 	graph *graph
+
+	// name is the per-session-unique identifier under which this
+	// workflow's RunState is persisted in session.State. Empty
+	// disables persistence. Set at construction by New.
+	name string
 }
 
-// New creates a new Workflow engine with the given edges.
-func New(edges []Edge) (*Workflow, error) {
+// New creates a new Workflow engine with the given name and edges.
+//
+// The name forms part of the session.State key under which this
+// workflow's RunState is persisted (see RunStateSessionKey for
+// the exact key shape). It must be unique within any session that
+// runs more than one workflow: two workflows sharing a name and a
+// session will silently overwrite each other's RunState, leading
+// to corrupted resume behaviour. The same workflow may safely
+// share a name across different sessions.
+//
+// An empty name disables persistence: the workflow runs normally
+// but its RunState is neither saved nor loaded, so Resume on a
+// follow-up turn will find nothing to resume from.
+func New(name string, edges []Edge) (*Workflow, error) {
 	if err := validateNodes(edges); err != nil {
 		return nil, err
 	}
+	// TODO(wolo): sanity-check name (reject whitespace-only,
+	// reject characters that break the session.State key shape).
+	// TODO(wolo): record a graph fingerprint (e.g. sorted node
+	// names hash) on the Workflow and verify it against any
+	// loaded RunState in Resume; today a name collision or a
+	// graph evolution between deploys silently corrupts the
+	// resume path.
 	graph := newGraph(edges)
 	if err := validateWorkflow(graph); err != nil {
 		return nil, err
 	}
-	return &Workflow{graph: graph}, nil
+	return &Workflow{graph: graph, name: name}, nil
 }
 
-// Run drives the workflow to completion (or to a graceful pause in
-// later milestones). It returns an iter.Seq2 that yields events
-// from per-node goroutines in arrival order; the caller may break
-// from the range loop at any point and the engine will cancel all
-// in-flight nodes before returning.
+// Name returns the workflow's persistence-namespacing name as set
+// by New. Empty when the workflow is anonymous (does not persist
+// its RunState).
+func (w *Workflow) Name() string {
+	return w.name
+}
+
+// Run drives the workflow to completion or to a graceful pause
+// when any node enters NodeWaiting. It returns an iter.Seq2 that
+// yields events from per-node goroutines in arrival order; the
+// caller may break from the range loop at any point and the
+// engine will cancel all in-flight nodes before returning.
 //
 // The engine model: each scheduled node runs in its own goroutine
 // pushing events into a buffered channel. A single consumer
@@ -153,7 +184,38 @@ func (w *Workflow) Run(ctx agent.InvocationContext) iter.Seq2[*session.Event, er
 
 		// All goroutines have returned; ensure no leak.
 		s.wg.Wait()
+
+		// Persist the run state so a follow-up turn can call
+		// Workflow.Resume with the recovered NodeWaiting set.
+		// Emitted as a session.Event with StateDelta so the
+		// surrounding event-append pipeline can propagate it to
+		// storage; see NewRunStateEvent for why a direct
+		// State.Set is not sufficient.
+		yieldRunStateEvent(ctx, w.name, s.state, yield)
 	}
+}
+
+// yieldRunStateEvent emits a session.Event carrying the workflow's
+// serialised RunState in Actions.StateDelta. No-op when the
+// workflow is anonymous (no name → no persistence) or when the
+// caller has stopped consuming the iterator. See NewRunStateEvent
+// for why the state must be delivered as an event rather than via
+// a direct State.Set call.
+func yieldRunStateEvent(
+	ctx agent.InvocationContext,
+	workflowName string,
+	state *RunState,
+	yield func(*session.Event, error) bool,
+) {
+	ev, err := NewRunStateEvent(ctx.InvocationID(), workflowName, state)
+	if err != nil {
+		yield(nil, err)
+		return
+	}
+	if ev == nil {
+		return
+	}
+	yield(ev, nil)
 }
 
 // userInput extracts the workflow's seed input from the

--- a/workflow/workflow_test.go
+++ b/workflow/workflow_test.go
@@ -59,11 +59,12 @@ func newSeededMockCtx(t *testing.T) *MockInvocationContext {
 	return ctx
 }
 
-// mustNew builds a workflow from edges and fails the test if
-// construction errors. The returned workflow is ready to Run.
+// mustNew builds an anonymous workflow from edges and fails the
+// test if construction errors. The returned workflow is ready to
+// Run; persistence is disabled.
 func mustNew(t *testing.T, edges []Edge) *Workflow {
 	t.Helper()
-	w, err := New(edges)
+	w, err := New("", edges)
 	if err != nil {
 		t.Fatalf("New: %v", err)
 	}


### PR DESCRIPTION
Builds on #829 (HITL pause). Adds `Workflow.Resume`, which routes a
user-supplied response back into a paused workflow node and forwards
it to the node's successors as their input (handoff mode). RunState
is persisted to `session.State` so a paused workflow survives across
processes — Resume on a follow-up turn loads the prior state and
picks up where Run left off.

The `workflowagent.New` wrapper auto-dispatches between `Run` and
`Resume` by inspecting the inbound user content for a
FunctionResponse targeting a previously-emitted RequestInput.
Detection mirrors `tool/toolconfirmation`'s convention: a
synthesised FunctionCall with name `adk_request_workflow_input`
correlated by ID, so the agent runtime's generic
FunctionResponse-by-ID dispatch routes the reply with no
runtime-side changes.

Re-entry mode (a paused node re-runs on resume with the response
delivered via context) is intentionally left for the next PR.

## Test plan

- [x] `go build ./...` clean
- [x] `go test ./workflow/... ./agent/workflowagent/...` — all pass
- [x] 8 new tests covering the canonical round-trip,
  cross-instance state restoration, idempotent resume, no-matching-
  response guard, schema validation pass/fail, fan-out, and the
  fresh-turn-not-mistaken-for-resume guard