### PR TITLE
fix: Stop ignoring request Decode error in runtime.

### DIFF
--- a/server/adkrest/controllers/runtime.go
+++ b/server/adkrest/controllers/runtime.go
@@ -230,11 +230,8 @@ func (c *RuntimeAPIController) getRunner(req models.RunAgentRequest) (*runner.Ru
 	}, nil
 }
 
-func decodeRequestBody(req *http.Request) (decodedReq models.RunAgentRequest, err error) {
+func decodeRequestBody(req *http.Request) (models.RunAgentRequest, error) {
 	var runAgentRequest models.RunAgentRequest
-	defer func() {
-		err = req.Body.Close()
-	}()
 	d := json.NewDecoder(req.Body)
 	d.DisallowUnknownFields()
 	if err := d.Decode(&runAgentRequest); err != nil {


### PR DESCRIPTION
When d.Decode returned an error, we were overriding it (with nil in most cases). This was not intended.

The documentation for http.Request.Body mentions:
> The Server will close the request body.
> The ServeHTTP Handler does not need to.

Given there is no need to Close the Body in the first place, we just remove this defer.