### PR TITLE
feat: add HITL console launcher support for tool confirmation prompts

### DIFF
--- a/cmd/launcher/console/hitl.go
+++ b/cmd/launcher/console/hitl.go
@@ -22,6 +22,7 @@ import (
 	"google.golang.org/genai"
 
 	"google.golang.org/adk/session"
+	"google.golang.org/adk/tool/toolconfirmation"
 	"google.golang.org/adk/workflow"
 )
 
@@ -77,6 +78,8 @@ func renderInterruptPrompt(p pendingInterrupt) {
 	switch p.name {
 	case workflow.WorkflowInputFunctionCallName:
 		renderWorkflowInputPrompt(p.args)
+	case toolconfirmation.FunctionCallName:
+		renderToolConfirmationPrompt(p.args)
 	default:
 		renderGenericInterruptPrompt(p.name, p.args)
 	}
@@ -93,6 +96,8 @@ func buildInterruptResponse(p pendingInterrupt, userInput string) *genai.Part {
 	switch p.name {
 	case workflow.WorkflowInputFunctionCallName:
 		response = workflowInputResponseFromUserInput(line)
+	case toolconfirmation.FunctionCallName:
+		response = toolConfirmationResponseFromUserInput(line)
 	default:
 		response = genericResponseFromUserInput(line)
 	}
@@ -152,6 +157,39 @@ func workflowInputResponseFromUserInput(line string) map[string]any {
 		return map[string]any{"payload": parsed}
 	}
 	return map[string]any{"payload": line}
+}
+
+// renderToolConfirmationPrompt prints the tool-confirmation
+// prompt, falling back to the original tool name when no hint is
+// provided.
+func renderToolConfirmationPrompt(args map[string]any) {
+	hint := ""
+	if tc, ok := args["toolConfirmation"].(map[string]any); ok {
+		hint, _ = tc["hint"].(string)
+	}
+	if hint == "" {
+		originalName := "unknown"
+		if oc, err := toolconfirmation.OriginalCallFrom(&genai.FunctionCall{Args: args}); err == nil && oc.Name != "" {
+			originalName = oc.Name
+		}
+		hint = "Confirm " + originalName + "?"
+	}
+	fmt.Printf("Agent -> %s\n", hint)
+	fmt.Println("  Type 'yes' to confirm, anything else to reject.")
+}
+
+// toolConfirmationResponseFromUserInput maps yes-ish answers
+// (y/yes/true/confirm, case-insensitive) to {"confirmed": true};
+// everything else (including blank lines) maps to
+// {"confirmed": false}.
+func toolConfirmationResponseFromUserInput(line string) map[string]any {
+	answer := strings.TrimSpace(strings.ToLower(line))
+	switch answer {
+	case "y", "yes", "true", "confirm":
+		return map[string]any{"confirmed": true}
+	default:
+		return map[string]any{"confirmed": false}
+	}
 }
 
 // renderGenericInterruptPrompt is the fallback for HITL kinds the

--- a/cmd/launcher/console/hitl_test.go
+++ b/cmd/launcher/console/hitl_test.go
@@ -25,6 +25,7 @@ import (
 
 	"google.golang.org/adk/model"
 	"google.golang.org/adk/session"
+	"google.golang.org/adk/tool/toolconfirmation"
 	"google.golang.org/adk/workflow"
 )
 
@@ -53,8 +54,9 @@ func captureStdout(t *testing.T, f func()) string {
 // verifies the detection contract: an event is a HITL prompt
 // iff it has a non-empty LongRunningToolIDs and one of its
 // content parts is a FunctionCall whose ID is in that set. The
-// function name is not the discriminator — workflow input and
-// any future kind all flow through the same detection path.
+// function name is not the discriminator — workflow input,
+// tool confirmation, and any future kind all flow through the
+// same detection path.
 func TestCollectPendingInterrupts_DetectionByLongRunningToolIDs(t *testing.T) {
 	tests := []struct {
 		name   string
@@ -117,6 +119,28 @@ func TestCollectPendingInterrupts_DetectionByLongRunningToolIDs(t *testing.T) {
 			},
 			want: []pendingInterrupt{
 				{id: "int-1", name: workflow.WorkflowInputFunctionCallName, args: map[string]any{"message": "ok?"}},
+			},
+		},
+		{
+			name: "tool confirmation on Event.LLMResponse.Content is detected",
+			events: []*session.Event{
+				{
+					LongRunningToolIDs: []string{"conf-1"},
+					LLMResponse: model.LLMResponse{
+						Content: &genai.Content{
+							Parts: []*genai.Part{{
+								FunctionCall: &genai.FunctionCall{
+									ID:   "conf-1",
+									Name: toolconfirmation.FunctionCallName,
+									Args: map[string]any{"toolConfirmation": map[string]any{"hint": "really delete?"}},
+								},
+							}},
+						},
+					},
+				},
+			},
+			want: []pendingInterrupt{
+				{id: "conf-1", name: toolconfirmation.FunctionCallName, args: map[string]any{"toolConfirmation": map[string]any{"hint": "really delete?"}}},
 			},
 		},
 		{
@@ -200,6 +224,41 @@ func TestBuildInterruptResponse_WorkflowInput(t *testing.T) {
 			if !reflect.DeepEqual(part.FunctionResponse.Response, tc.wantResponse) {
 				t.Errorf("Response = %#v, want %#v",
 					part.FunctionResponse.Response, tc.wantResponse)
+			}
+		})
+	}
+}
+
+// TestBuildInterruptResponse_ToolConfirmation verifies the
+// tool-confirmation dispatch: positive answers map to
+// {"confirmed": true}, everything else (including blank lines)
+// to {"confirmed": false}, case-insensitive.
+func TestBuildInterruptResponse_ToolConfirmation(t *testing.T) {
+	tests := []struct {
+		userInput string
+		wantValue bool
+	}{
+		{"yes\n", true},
+		{"YES\n", true},
+		{" Yes \n", true},
+		{"y\n", true},
+		{"true\n", true},
+		{"confirm\n", true},
+		{"no\n", false},
+		{"n\n", false},
+		{"\n", false},
+		{"anything else\n", false},
+	}
+	for _, tc := range tests {
+		t.Run(tc.userInput, func(t *testing.T) {
+			p := pendingInterrupt{id: "c", name: toolconfirmation.FunctionCallName}
+			part := buildInterruptResponse(p, tc.userInput)
+			confirmed, ok := part.FunctionResponse.Response["confirmed"]
+			if !ok {
+				t.Fatalf("Response missing 'confirmed'; got %v", part.FunctionResponse.Response)
+			}
+			if confirmed != tc.wantValue {
+				t.Errorf("confirmed = %v, want %v", confirmed, tc.wantValue)
 			}
 		})
 	}


### PR DESCRIPTION
## Summary

Adds a dedicated renderer and yes/no parser for tool confirmation
interrupts (`toolconfirmation.FunctionCallName`), so the operator
running `adk launcher console` sees a clear confirmation prompt
instead of the generic fallback.

Without this PR tool confirmation still works at the transport
layer (the reply routes back to the tool by FunctionCall.ID), but
the response is shaped as `{"result": <text>}` — which does not
match what `ctx.ToolConfirmation()` reads. Operators have no way
to actually confirm or reject. This PR fixes that by sending the
expected `{"confirmed": bool}` envelope.



## Output format

Aligned with the existing console launcher convention (`Agent ->
` / `User -> `, no brackets, no jargon — same as #845). Example
session:

    User -> Delete my old vacation requests

    Agent -> Delete 3 old vacation requests? This is irreversible.
      Type 'yes' to confirm, anything else to reject.
    User -> yes

    Agent -> Deleted 3 vacation requests.

    User ->

## Test plan

- [x] `go build ./...` clean
- [x] `go test ./cmd/launcher/console/...` — all pass
- [x] `go test -race ./cmd/launcher/console/...` — clean
- [x] 1 new case in
  `TestCollectPendingInterrupts_DetectionByLongRunningToolIDs`
  verifying detection works on a real tool-confirmation event
  (not just the generic mock used by the base PR).
- [x] New `TestBuildInterruptResponse_ToolConfirmation` covers
  10 yes/no variants: `yes`, `YES`, ` Yes ` (whitespace),
  `y`, `true`, `confirm` (all map to `true`), `no`, `n`,
  blank line, arbitrary text (all map to `false`).