### PR TITLE
fix: Prevent nil deref when a tool doesn't implement tool.Tool.

### DIFF
--- a/internal/llminternal/base_flow.go
+++ b/internal/llminternal/base_flow.go
@@ -470,6 +470,7 @@ func (f *Flow) runOneStep(ctx agent.InvocationContext) iter.Seq2[*session.Event,
 					if !yield(nil, fmt.Errorf("unexpected tool type %T for tool %v", v, k)) {
 						return
 					}
+					continue
 				}
 				tools[k] = tool
 			}


### PR DESCRIPTION
If a tool doesn't implement tool.Tool interface, runOneStep yields an error.
If that error is ignored (yield returns true), we need to skip this tool.
What we were doing so far, however, is we added nil to the map of tools.

If that ever happen in runtime, the code will later crash with nil deref.

I don't know if that could actually happen in context of where runOneStep is used, but anyway, let's handle it properly: added continue, which will skip adding nil to the map and will go to the next tool.