### PR TITLE
feat: add JoinNode fan-in barrier to workflow engine

### DIFF
--- a/workflow/graph.go
+++ b/workflow/graph.go
@@ -18,19 +18,22 @@ package workflow
 // Built once at workflow construction; queried by the engine at
 // dispatch time.
 type graph struct {
-	successors map[Node][]Edge
+	successors   map[Node][]Edge
+	predecessors map[Node][]Edge
 }
 
-// newGraph indexes edges by source node so successor lookups are
-// O(1) at dispatch time. The returned graph references the input
-// edges by value; mutating the input edge slice afterwards does not
-// affect the graph.
+// newGraph indexes edges by source and target node so successor
+// and predecessor lookups are both O(1) at dispatch time. The
+// returned graph references the input edges by value; mutating the
+// input edge slice afterwards does not affect the graph.
 func newGraph(edges []Edge) *graph {
 	succ := make(map[Node][]Edge)
+	pred := make(map[Node][]Edge)
 	for _, edge := range edges {
 		succ[edge.From] = append(succ[edge.From], edge)
+		pred[edge.To] = append(pred[edge.To], edge)
 	}
-	return &graph{successors: succ}
+	return &graph{successors: succ, predecessors: pred}
 }
 
 // successorsOf returns the outgoing edges for a node.
@@ -40,4 +43,12 @@ func newGraph(edges []Edge) *graph {
 // callers.
 func (g *graph) successorsOf(n Node) []Edge {
 	return g.successors[n]
+}
+
+// predecessorsOf returns the incoming edges for a node. Returns
+// nil if n has no incoming edges (including the case where n is
+// not in the graph at all). The returned slice is owned by the
+// graph and must not be mutated by callers.
+func (g *graph) predecessorsOf(n Node) []Edge {
+	return g.predecessors[n]
 }

--- a/workflow/join_node.go
+++ b/workflow/join_node.go
@@ -1,0 +1,51 @@
+// Copyright 2026 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package workflow
+
+import (
+	"iter"
+
+	"google.golang.org/adk/agent"
+	"google.golang.org/adk/session"
+)
+
+// JoinNode is a fan-in barrier. It is activated exactly once,
+// after every predecessor declared by the graph edges has
+// completed, and receives those predecessors' outputs as a single
+// map[string]any keyed by predecessor name. Its own output is
+// that map, emitted verbatim.
+//
+// All incoming edges feed the barrier; conditional routing into a
+// JoinNode is a configuration error, because the barrier waits
+// for every declared predecessor and a route-skipped predecessor
+// never fires.
+type JoinNode struct {
+	BaseNode
+}
+
+// NewJoinNode returns a JoinNode with the given name.
+func NewJoinNode(name string) *JoinNode {
+	return &JoinNode{BaseNode: NewBaseNode(name, "", NodeConfig{})}
+}
+
+// Run satisfies the Node interface. See JoinNode for the
+// aggregation contract.
+func (n *JoinNode) Run(ctx agent.InvocationContext, input any) iter.Seq2[*session.Event, error] {
+	return func(yield func(*session.Event, error) bool) {
+		event := session.NewEvent(ctx.InvocationID())
+		event.Actions.StateDelta["output"] = input
+		yield(event, nil)
+	}
+}

--- a/workflow/join_node_test.go
+++ b/workflow/join_node_test.go
@@ -1,0 +1,234 @@
+// Copyright 2026 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package workflow
+
+import (
+	"reflect"
+	"sort"
+	"testing"
+
+	"google.golang.org/adk/agent"
+)
+
+// TestJoinNode_E2E_FanInTwoBranches verifies that with two
+// parallel predecessors the JoinNode is activated once with the
+// aggregated map; the downstream consumer observes it verbatim.
+func TestJoinNode_E2E_FanInTwoBranches(t *testing.T) {
+	mockCtx := newSeededMockCtx(t)
+
+	branchA := constNode("branchA", "A-result")
+	branchB := constNode("branchB", "B-result")
+	join := NewJoinNode("join")
+	var seen any
+	handler := inputRecorder("handler", &seen)
+
+	w := mustNew(t, []Edge{
+		{From: Start, To: branchA},
+		{From: Start, To: branchB},
+		{From: branchA, To: join},
+		{From: branchB, To: join},
+		{From: join, To: handler},
+	})
+
+	drain(t, w.Run(mockCtx))
+
+	gotMap, ok := seen.(map[string]any)
+	if !ok {
+		t.Fatalf("handler input = %T %#v, want map[string]any", seen, seen)
+	}
+	wantMap := map[string]any{
+		"branchA": "A-result",
+		"branchB": "B-result",
+	}
+	if !reflect.DeepEqual(gotMap, wantMap) {
+		t.Errorf("handler input = %#v, want %#v", gotMap, wantMap)
+	}
+}
+
+// TestJoinNode_E2E_FanInThreeBranches scales the canonical case
+// to three predecessors to verify the dispatch list does not
+// special-case the two-predecessor count.
+func TestJoinNode_E2E_FanInThreeBranches(t *testing.T) {
+	mockCtx := newSeededMockCtx(t)
+
+	a := constNode("a", "va")
+	b := constNode("b", "vb")
+	c := constNode("c", "vc")
+	join := NewJoinNode("join")
+	var seen any
+	handler := inputRecorder("handler", &seen)
+
+	w := mustNew(t, []Edge{
+		{From: Start, To: a},
+		{From: Start, To: b},
+		{From: Start, To: c},
+		{From: a, To: join},
+		{From: b, To: join},
+		{From: c, To: join},
+		{From: join, To: handler},
+	})
+
+	drain(t, w.Run(mockCtx))
+
+	m, _ := seen.(map[string]any)
+	var seenKeys []string
+	for k := range m {
+		seenKeys = append(seenKeys, k)
+	}
+	sort.Strings(seenKeys)
+	if want := []string{"a", "b", "c"}; !reflect.DeepEqual(seenKeys, want) {
+		t.Errorf("handler input keys = %v, want %v", seenKeys, want)
+	}
+}
+
+// TestJoinNode_BarrierSkipsUntilAllPredecessorsComplete pins the
+// barrier semantics directly. With branchA fast and branchB slow
+// (a fresh-channel block lifted by a separate goroutine), the
+// handler must not see partial aggregation: the join is not
+// triggered when only A has completed.
+func TestJoinNode_BarrierSkipsUntilAllPredecessorsComplete(t *testing.T) {
+	mockCtx := newSeededMockCtx(t)
+
+	bBlocker := make(chan struct{})
+	branchA := NewFunctionNode("branchA",
+		func(ctx agent.InvocationContext, _ any) (string, error) {
+			// Release B once A's function body returns. The
+			// barrier must hold until B also completes, so the
+			// handler runs exactly once with both outputs.
+			close(bBlocker)
+			return "a", nil
+		}, defaultNodeConfig)
+	branchB := NewFunctionNode("branchB",
+		func(ctx agent.InvocationContext, _ any) (string, error) {
+			<-bBlocker
+			return "b", nil
+		}, defaultNodeConfig)
+	join := NewJoinNode("join")
+
+	handlerCalls := 0
+	var handlerInput any
+	handler := NewFunctionNode("handler",
+		func(ctx agent.InvocationContext, input any) (string, error) {
+			handlerCalls++
+			handlerInput = input
+			return "ok", nil
+		}, defaultNodeConfig)
+
+	w := mustNew(t, []Edge{
+		{From: Start, To: branchA},
+		{From: Start, To: branchB},
+		{From: branchA, To: join},
+		{From: branchB, To: join},
+		{From: join, To: handler},
+	})
+
+	drain(t, w.Run(mockCtx))
+
+	if handlerCalls != 1 {
+		t.Fatalf("handler ran %d times, want exactly 1", handlerCalls)
+	}
+	got, _ := handlerInput.(map[string]any)
+	want := map[string]any{"branchA": "a", "branchB": "b"}
+	if !reflect.DeepEqual(got, want) {
+		t.Errorf("handler input = %#v, want %#v", got, want)
+	}
+}
+
+// TestJoinNode_RunIsPassthrough pins the JoinNode contract
+// independently of the engine: given an aggregated input map,
+// the node emits exactly one event whose StateDelta["output"]
+// equals the input. This is the property the orchestrator relies
+// on when treating JoinNode as a no-op aggregator.
+func TestJoinNode_RunIsPassthrough(t *testing.T) {
+	mockCtx := newSeededMockCtx(t)
+	n := NewJoinNode("join")
+
+	input := map[string]any{"a": "x", "b": 42}
+	events := drain(t, n.Run(mockCtx, input))
+
+	if len(events) != 1 {
+		t.Fatalf("expected 1 event, got %d", len(events))
+	}
+	got, ok := events[0].Actions.StateDelta["output"]
+	if !ok {
+		t.Fatalf("event has no StateDelta[output]; got %#v", events[0].Actions.StateDelta)
+	}
+	if !reflect.DeepEqual(got, input) {
+		t.Errorf("StateDelta[output] = %#v, want %#v (verbatim)", got, input)
+	}
+}
+
+// TestJoinNode_PredecessorWithNilOutput pins the aggregation
+// contract for a predecessor whose recorded Output is nil: the
+// aggregated map carries the predecessor's name with a nil value,
+// and the join activates normally — the barrier counts
+// completions, not outputs.
+func TestJoinNode_PredecessorWithNilOutput(t *testing.T) {
+	mockCtx := newSeededMockCtx(t)
+
+	branchA := constNode("branchA", "A-result")
+	branchNil := NewFunctionNode("branchNil",
+		func(ctx agent.InvocationContext, _ any) (any, error) {
+			return nil, nil
+		}, defaultNodeConfig)
+	join := NewJoinNode("join")
+	var seen any
+	handler := inputRecorder("handler", &seen)
+
+	w := mustNew(t, []Edge{
+		{From: Start, To: branchA},
+		{From: Start, To: branchNil},
+		{From: branchA, To: join},
+		{From: branchNil, To: join},
+		{From: join, To: handler},
+	})
+
+	drain(t, w.Run(mockCtx))
+
+	gotMap, ok := seen.(map[string]any)
+	if !ok {
+		t.Fatalf("handler input = %T %#v, want map[string]any", seen, seen)
+	}
+	wantMap := map[string]any{
+		"branchA":   "A-result",
+		"branchNil": nil,
+	}
+	if !reflect.DeepEqual(gotMap, wantMap) {
+		t.Errorf("handler input = %#v, want %#v", gotMap, wantMap)
+	}
+}
+
+// =============================================================================
+// Test fixtures and helpers
+// =============================================================================
+
+// constNode returns a FunctionNode that ignores its input and
+// yields the given string value.
+func constNode(name, value string) *FunctionNode {
+	return NewFunctionNode(name,
+		func(agent.InvocationContext, any) (string, error) { return value, nil },
+		defaultNodeConfig)
+}
+
+// inputRecorder returns a FunctionNode that stores its input in
+// *seen and yields "done". Use it for the terminal consumer of a
+// graph when the assertion only inspects the input it observed.
+func inputRecorder(name string, seen *any) *FunctionNode {
+	return NewFunctionNode(name,
+		func(_ agent.InvocationContext, input any) (string, error) {
+			*seen = input
+			return "done", nil
+		}, defaultNodeConfig)
+}

--- a/workflow/resume.go
+++ b/workflow/resume.go
@@ -83,6 +83,19 @@ func (w *Workflow) Resume(
 		s := newScheduler(ctx, w.graph)
 		s.state = state
 
+		// Resume runs in two passes so that when one call
+		// satisfies several askers feeding a JoinNode, the
+		// barrier sees every predecessor as NodeCompleted
+		// before it is evaluated. Re-entry-mode askers are
+		// unaffected — they re-run rather than complete here.
+		type deferredHandoff struct {
+			node Node
+			resp any
+		}
+		var deferredHandoffs []deferredHandoff
+
+		// Pass 1: dispatch every waiting asker matched by
+		// responses (handoff → defer; re-entry → reschedule now).
 		scheduled := 0
 		for name, ns := range state.Nodes {
 			if ns.Status != NodeWaiting || ns.PendingRequest == nil {
@@ -139,21 +152,32 @@ func (w *Workflow) Resume(
 				ns.ResumedInputs[interruptID] = resp
 				s.scheduleResumedNode(node, ns.Input, ns.TriggeredBy, ns.ResumedInputs)
 			} else {
-				// Handoff mode: schedule each successor with the
-				// response as its input, exactly as if the asker
-				// had emitted it as output. Reuses findSuccessors
-				// so routing, fan-out and fan-in invariants apply
-				// uniformly. findSuccessors is called with
-				// event=nil, so successors reached only via a
-				// concrete Route (StringRoute etc.) do not fire —
-				// the response is opaque to the routing layer.
-				// Successors reached via an unconditional edge or
-				// via the Default route fire as usual.
-				for _, succ := range findSuccessors(s.graph, node, resp, nil) {
-					s.scheduleNode(succ.node, succ.input, succ.triggeredBy)
-				}
+				// Handoff mode: promote the asker as if it had
+				// emitted resp as its output. Recording Output
+				// lets the join barrier read it back without a
+				// special case for "completed via resume".
+				ns.Status = NodeCompleted
+				ns.Output = resp
+				deferredHandoffs = append(deferredHandoffs, deferredHandoff{
+					node: node, resp: resp,
+				})
 			}
 			scheduled++
+		}
+
+		// Pass 2: walk successors of the deferred handoffs.
+		// All matched askers are now NodeCompleted, so any
+		// downstream JoinNode sees a settled predecessor set.
+		for _, h := range deferredHandoffs {
+			// findSuccessors is called with event=nil, so
+			// successors reached only via a concrete Route
+			// (StringRoute etc.) do not fire — the response is
+			// opaque to the routing layer. Successors reached via
+			// an unconditional edge or via the Default route fire
+			// as usual.
+			for _, succ := range findSuccessors(s.graph, s.state, h.node, h.resp, nil) {
+				s.scheduleNode(succ.node, succ.input, succ.triggeredBy)
+			}
 		}
 
 		if scheduled == 0 {

--- a/workflow/scheduler.go
+++ b/workflow/scheduler.go
@@ -516,6 +516,9 @@ func (s *scheduler) handleCompletion(it completionItem, scheduleSuccessors bool)
 
 	ns.Status = NodeCompleted
 	ns.Attempt = 0
+	if nr != nil && nr.hasOutput {
+		ns.Output = nr.output
+	}
 	// Release the accumulated re-entry response history; the node
 	// has finished and a future activation (if any, e.g. via
 	// loop-back routing) starts a fresh lifecycle.
@@ -544,7 +547,7 @@ func (s *scheduler) handleCompletion(it completionItem, scheduleSuccessors bool)
 		input = ns.Input
 	}
 
-	for _, succ := range findSuccessors(s.graph, currentNode, input, routingEv) {
+	for _, succ := range findSuccessors(s.graph, s.state, currentNode, input, routingEv) {
 		s.scheduleNode(succ.node, succ.input, succ.triggeredBy)
 	}
 	return nil
@@ -573,8 +576,11 @@ type successor struct {
 //     Default edge fans out to both targets.
 //   - If every outgoing edge has a concrete Route and none matched,
 //     and no Default is present, the workflow silently dead-ends at
-//     this node — by design, mirroring adk-python's routing semantics.
-func findSuccessors(g *graph, currentNode Node, input any, event *session.Event) []successor {
+//     this node. The absence of a matching route is treated as a
+//     deliberate decision not to continue, not an error.
+//
+// JoinNode successors are gated by appendSuccessor; see its docs.
+func findSuccessors(g *graph, state *RunState, currentNode Node, input any, event *session.Event) []successor {
 	succs := g.successorsOf(currentNode)
 	if len(succs) == 0 {
 		return nil
@@ -589,7 +595,7 @@ func findSuccessors(g *graph, currentNode Node, input any, event *session.Event)
 			continue
 		}
 		if edge.Route == nil {
-			out = append(out, successor{node: edge.To, input: input, triggeredBy: from})
+			out = appendSuccessor(out, g, state, edge.To, input, from)
 			added[edge.To] = struct{}{}
 			continue
 		}
@@ -598,13 +604,49 @@ func findSuccessors(g *graph, currentNode Node, input any, event *session.Event)
 			continue
 		}
 		if event != nil && edge.Route.Matches(event) {
-			out = append(out, successor{node: edge.To, input: input, triggeredBy: from})
+			out = appendSuccessor(out, g, state, edge.To, input, from)
 			added[edge.To] = struct{}{}
 			concreteMatched = true
 		}
 	}
 	if !concreteMatched && defaultRouteNode != nil {
-		out = append(out, successor{node: defaultRouteNode, input: input, triggeredBy: from})
+		out = appendSuccessor(out, g, state, defaultRouteNode, input, from)
 	}
 	return out
+}
+
+// appendSuccessor records a routing match in the dispatch list.
+// Non-JoinNode targets are recorded as-is. A *JoinNode target is
+// recorded only when every declared predecessor has completed;
+// its input is replaced with the aggregated predecessor outputs.
+// A barrier-blocked JoinNode is silently skipped — a later
+// predecessor completion re-evaluates the barrier.
+func appendSuccessor(out []successor, g *graph, state *RunState, target Node, input any, triggeredBy string) []successor {
+	if _, isJoin := target.(*JoinNode); !isJoin {
+		return append(out, successor{node: target, input: input, triggeredBy: triggeredBy})
+	}
+	aggregated, ok := aggregatePredecessorOutputs(g, state, target)
+	if !ok {
+		return out
+	}
+	return append(out, successor{node: target, input: aggregated, triggeredBy: triggeredBy})
+}
+
+// aggregatePredecessorOutputs returns a map of predecessor name to
+// recorded Output for every predecessor of target. Returns
+// (nil, false) if any predecessor is not yet NodeCompleted; a
+// predecessor that completed without an output contributes a nil
+// value (same as the absence the predecessor itself emitted).
+func aggregatePredecessorOutputs(g *graph, state *RunState, target Node) (map[string]any, bool) {
+	predEdges := g.predecessorsOf(target)
+	aggregated := make(map[string]any, len(predEdges))
+	for _, edge := range predEdges {
+		name := edge.From.Name()
+		ns := state.Nodes[name]
+		if ns == nil || ns.Status != NodeCompleted {
+			return nil, false
+		}
+		aggregated[name] = ns.Output
+	}
+	return aggregated, true
 }

--- a/workflow/state.go
+++ b/workflow/state.go
@@ -75,12 +75,12 @@ const (
 // of these for every node the engine has touched.
 //
 // JSON-marshallable: NodeState is persisted across pause/resume
-// turns via session.State (see persistence.go). The Input and
-// PendingRequest.Payload fields are typed any and must therefore
-// be JSON-encodable for the persisted state to round-trip. Nodes
-// that need to carry binary data across a pause should store the
-// bytes via agent.Artifacts and stash a URI string in place of
-// the bytes, mirroring how the Live API surfaces audio.
+// turns via session.State (see persistence.go). The Input, Output,
+// and PendingRequest.Payload fields are typed any and must
+// therefore be JSON-encodable for the persisted state to
+// round-trip. Nodes that need to carry binary data across a pause
+// should store the bytes via agent.Artifacts and stash a URI
+// string in place of the bytes.
 type NodeState struct {
 	// Status is the current lifecycle position. See NodeStatus.
 	Status NodeStatus `json:"status"`
@@ -88,6 +88,11 @@ type NodeState struct {
 	// Input is the value most recently handed to the node's Run
 	// method. It is set when the node is scheduled.
 	Input any `json:"input,omitempty"`
+
+	// Output is the value the node emitted via
+	// Actions.StateDelta["output"]. Set when Status transitions
+	// to NodeCompleted.
+	Output any `json:"output,omitempty"`
 
 	// TriggeredBy is the name of the upstream node that produced
 	// the current Input. Empty for the initial START activation.


### PR DESCRIPTION
Adds `JoinNode`, a fan-in barrier that activates exactly once after every graph-declared predecessor has
completed, receiving their outputs as a `map[string]any` keyed by
predecessor name. The node is a pass-through that emits the aggregated
map verbatim.

The barrier is enforced at dispatch time, not by parking the JoinNode in
`NodeWaiting`: `findSuccessors` consults the run state, and a JoinNode
target is skipped until every predecessor is `NodeCompleted`. A later
predecessor completion re-evaluates and fires the Join then.

`NodeState.Output` is now recorded by `handleCompletion` so the barrier
has a source of truth for each predecessor's value, and `Workflow.Resume`
runs in two passes when one call satisfies several askers feeding the
same Join — all askers are promoted to `NodeCompleted` before any
successor walk, so the barrier sees the full settled set.

## Test plan

- [x] `go test -race ./workflow/...` — all pass
- [x] 5 new tests covering: two-branch fan-in, three-branch fan-in,
  barrier holds until the slow branch completes, passthrough contract,
  and the build-time guard against an unreachable JoinNode