### PR TITLE
feat: add llm_step span to group generate_content and execute_tool wi…

### DIFF
--- a/internal/llminternal/base_flow.go
+++ b/internal/llminternal/base_flow.go
@@ -423,6 +423,13 @@ func (f *Flow) runOneStep(ctx agent.InvocationContext) iter.Seq2[*session.Event,
 			return
 		}
 
+		// Create a step-level span to group generate_content and execute_tool
+		// spans within the same iteration, establishing correct parent-child
+		// hierarchy for observability backends.
+		stepCtx, stepSpan := telemetry.StartTrace(ctx, "llm_step")
+		defer stepSpan.End()
+		ctx = ctx.WithContext(stepCtx)
+
 		req := &model.LLMRequest{
 			Model: f.Model.Name(),
 		}


### PR DESCRIPTION
### Description

[issue] https://github.com/google/adk-go/issues/857

#### Problem

Currently, `generate_content` and `execute_tool` spans are all created as **direct children of the `invoke_agent` span** (flat siblings). This makes it impossible for observability backends (Langfuse, Jaeger, etc.) to correctly display the causal relationship between an LLM call and the tool execution it triggered.

For a simple tool-calling flow ("What's the weather in Shanghai?"), the span tree looks like:

```
invoke_agent weather_time_agent
  ├── generate_content deepseek-v4-pro    (Step 1)
  ├── generate_content deepseek-v4-pro    (Step 2)
  └── execute_tool get_city_weather
```

Observability backends display these in start-time order (or even worse, in export-batch order), making it appear as if two LLM calls happened before the tool was ever invoked.

#### Root Cause

In `internal/llminternal/base_flow.go`, `runOneStep()` passes the `invoke_agent`-level context to both `callLLM()` (which creates `generate_content` spans) and `handleFunctionCalls()` (which creates `execute_tool` spans). Since the `generate_content` span is already ended before `handleFunctionCalls` runs, there is no intermediate span to establish a parent-child grouping.

#### Fix

This PR introduces a **`llm_step` span** at the beginning of each `runOneStep()` iteration. All operations within that iteration — including `generate_content` and `execute_tool` — become children of this step span.

**After the fix**, the span tree becomes:

```
invoke_agent weather_time_agent
  ├── llm_step                              (iteration 1)
  │     ├── generate_content deepseek-v4-pro
  │     └── execute_tool get_city_weather
  └── llm_step                              (iteration 2)
        └── generate_content deepseek-v4-pro
```

#### Changes

- **`internal/llminternal/base_flow.go`**: Added `telemetry.StartTrace(ctx, "llm_step")` at the top of `runOneStep()` and updated the context so all downstream spans are children of the step span.

#### Compatibility

- The Langfuse enrichment plugin matches pending LLM calls by the **parent span ID** of `generate_content` spans. Before this change, that parent was `invoke_agent`; after this change, it becomes `llm_step`. Since the `beforeModel` callback also sees the same `llm_step` span in its context (via `SpanFromContext`), the matching logic remains correct with zero changes to the plugin code.
- No behavioral change to agent execution — the step span is purely observability overhead.
- Existing tests pass without modification.