### PR TITLE
feat: add generic Output field to session events and persist via storage layer

### DIFF
--- a/server/adkrest/internal/models/event.go
+++ b/server/adkrest/internal/models/event.go
@@ -51,6 +51,7 @@ type Event struct {
 	FinishReason       genai.FinishReason                          `json:"finishReason,omitempty"`
 	ModelVersion       string                                      `json:"modelVersion,omitempty"`
 	Actions            EventActions                                `json:"actions"`
+	Output             any                                         `json:"output,omitempty"`
 }
 
 // ToSessionEvent maps Event data struct to session.Event
@@ -61,6 +62,7 @@ func ToSessionEvent(event Event) *session.Event {
 		Branch:             event.Branch,
 		Author:             event.Author,
 		LongRunningToolIDs: event.LongRunningToolIDs,
+		Output:             event.Output,
 		LLMResponse: model.LLMResponse{
 			AvgLogprobs:       event.AvgLogprobs,
 			Content:           event.Content,
@@ -93,6 +95,7 @@ func FromSessionEvent(event session.Event) Event {
 		Author:             event.Author,
 		Partial:            event.Partial,
 		LongRunningToolIDs: event.LongRunningToolIDs,
+		Output:             event.Output,
 		AvgLogprobs:        event.LLMResponse.AvgLogprobs,
 		Content:            event.LLMResponse.Content,
 		GroundingMetadata:  event.LLMResponse.GroundingMetadata,

--- a/session/database/storage_session.go
+++ b/session/database/storage_session.go
@@ -80,6 +80,7 @@ type storageEvent struct {
 	Actions                []byte
 	LongRunningToolIDsJSON dynamicJSON
 	RoutesJSON             dynamicJSON
+	OutputJSON             dynamicJSON
 	Branch                 *string
 	Timestamp              time.Time `gorm:"precision:6"`
 
@@ -142,6 +143,14 @@ func createStorageEvent(session session.Session, event *session.Event) (*storage
 			return nil, fmt.Errorf("failed to marshal event route: %w", err)
 		}
 		storageEv.RoutesJSON = routesJSON
+	}
+
+	if event.Output != nil {
+		outputJSON, err := json.Marshal(event.Output)
+		if err != nil {
+			return nil, fmt.Errorf("failed to marshal output: %w", err)
+		}
+		storageEv.OutputJSON = outputJSON
 	}
 
 	// Handle optional fields by taking the address of the value.
@@ -266,6 +275,13 @@ func createEventFromStorageEvent(se *storageEvent) (*session.Event, error) {
 		}
 	}
 
+	var output any
+	if se.OutputJSON != nil {
+		if err := json.Unmarshal([]byte(se.OutputJSON), &output); err != nil {
+			return nil, fmt.Errorf("failed to unmarshal output: %w", err)
+		}
+	}
+
 	// --- Handle simple pointer fields (dereference or use zero value) ---
 	// Use the helper to safely get the value or its zero-value default
 	branch := derefOrZero(se.Branch)
@@ -285,6 +301,7 @@ func createEventFromStorageEvent(se *storageEvent) (*session.Event, error) {
 		LongRunningToolIDs: toolIDs,
 		Routes:             routes,
 		Branch:             branch,
+		Output:             output,
 		LLMResponse: model.LLMResponse{
 			Content:           content,
 			GroundingMetadata: groundingMetadata,

--- a/session/inmemory.go
+++ b/session/inmemory.go
@@ -239,6 +239,7 @@ func (s *inMemoryService) AppendEvent(ctx context.Context, curSession Session, e
 		},
 		LongRunningToolIDs: slices.Clone(event.LongRunningToolIDs),
 		LLMResponse:        event.LLMResponse,
+		Output:             event.Output,
 	}
 
 	// update the in-memory session service

--- a/session/session.go
+++ b/session/session.go
@@ -127,6 +127,9 @@ type Event struct {
 	//
 	// At most one event per node activation may carry this field.
 	RequestedInput *RequestInput
+
+	// Output is the generic data output from a workflow node.
+	Output any
 }
 
 // RequestInput describes a single human-in-the-loop prompt emitted

--- a/workflow/function_node.go
+++ b/workflow/function_node.go
@@ -110,6 +110,7 @@ func (n *FunctionNode) Run(ctx agent.InvocationContext, input any) iter.Seq2[*se
 		}
 
 		event := session.NewEvent(ctx.InvocationID())
+		event.Output = output
 		event.Actions.StateDelta["output"] = output
 		if s, ok := output.(string); ok {
 			event.Content = &genai.Content{

--- a/workflow/function_node_test.go
+++ b/workflow/function_node_test.go
@@ -118,6 +118,10 @@ func TestNewFunctionNodeWithSchema(t *testing.T) {
 					t.Fatal("expected output in state delta")
 				}
 
+				if diff := cmp.Diff(output, ev.Output); diff != "" {
+					t.Errorf("ev.Output mismatch (-stateDelta +Output):\n%s", diff)
+				}
+
 				if diff := cmp.Diff(tc.wantOutput, output); diff != "" {
 					t.Errorf("output mismatch (-want +got):\n%s", diff)
 				}

--- a/workflow/tool_node.go
+++ b/workflow/tool_node.go
@@ -135,6 +135,7 @@ func (n *toolNode) Run(ctx agent.InvocationContext, input any) iter.Seq2[*sessio
 
 		event := session.NewEvent(ctx.InvocationID())
 		event.Actions = *eventActions
+		event.Output = toolOutput
 		event.Actions.StateDelta["output"] = toolOutput
 
 		// If output is a string, set it as content for convenience (similar to FunctionNode).

--- a/workflow/tool_node_test.go
+++ b/workflow/tool_node_test.go
@@ -245,6 +245,10 @@ func TestToolNode_Run(t *testing.T) {
 					t.Fatal("expected output in state delta")
 				}
 
+				if diff := cmp.Diff(output, ev.Output); diff != "" {
+					t.Errorf("ev.Output mismatch (-stateDelta +Output):\n%s", diff)
+				}
+
 				got = tc.extract(t, output)
 			}
 


### PR DESCRIPTION
### Description

This pull request introduces a generic `Output` field to `session.Event` to directly store the structured output generated by workflow nodes (such as function and tool nodes) on the event itself. It also implements corresponding support for serialization, persistence across both database (GORM) and in-memory storage layers, and exposure via the REST API.

### Key Changes

- **Core Session & REST Models**:
  - Added the `Output any` field to `session.Event` (`session/session.go`).
  - Updated the REST payload definition in `server/adkrest/internal/models/event.go` to include `Output`, updating the `ToSessionEvent` and `FromSessionEvent` mapping functions to support the new field.

- **Storage and Persistence Layer**:
  - Expanded `storageEvent` in `session/database/storage_session.go` to include `OutputJSON` for database serialization and deserialization.
  - Updated the in-memory session service (`session/inmemory.go`) to copy the `Output` field when cloning events.

- **Workflow Nodes**:
  - Updated `FunctionNode.Run` (`workflow/function_node.go`) to record the node's `output` to the event's `Output` field.
  - Updated `toolNode.Run` (`workflow/tool_node.go`) to record the execution's `toolOutput` to the event's `Output` field.

- **Test Verification**:
  - Enhanced tests in `workflow/function_node_test.go` and `workflow/tool_node_test.go` to assert that the populated `event.Output` aligns with the state delta output.
