### PR TITLE
fix: convert unsupported artifact MIME types to text

### DIFF
--- a/tool/loadartifactstool/load_artifacts_tool.go
+++ b/tool/loadartifactstool/load_artifacts_tool.go
@@ -21,6 +21,7 @@ import (
 	"context"
 	"encoding/json"
 	"fmt"
+	"strings"
 
 	"golang.org/x/sync/errgroup"
 	"google.golang.org/genai"
@@ -31,6 +32,22 @@ import (
 	"google.golang.org/adk/model"
 	"google.golang.org/adk/tool"
 )
+
+var geminiSupportedInlineMIMEPrefixes = []string{
+	"image/",
+	"audio/",
+	"video/",
+}
+
+var geminiSupportedInlineMIMETypes = map[string]bool{
+	"application/pdf": true,
+}
+
+var textLikeMIMETypes = map[string]bool{
+	"application/csv":  true,
+	"application/json": true,
+	"application/xml":  true,
+}
 
 // artifactsTool is a tool that loads artifacts and adds them to the session.
 type artifactsTool struct {
@@ -213,8 +230,58 @@ func (t *artifactsTool) loadIndividualArtifact(ctx context.Context, artifactsSer
 	return &genai.Content{
 		Parts: []*genai.Part{
 			genai.NewPartFromText("Artifact " + artifactName + " is:"),
-			resp.Part,
+			safePartForLLM(resp.Part, artifactName),
 		},
 		Role: genai.RoleUser,
 	}, nil
+}
+
+func normalizeMIMEType(mimeType string) string {
+	mimeType, _, _ = strings.Cut(mimeType, ";")
+	return strings.TrimSpace(mimeType)
+}
+
+func isInlineMIMETypeSupported(mimeType string) bool {
+	normalized := normalizeMIMEType(mimeType)
+	if normalized == "" {
+		return false
+	}
+	if geminiSupportedInlineMIMETypes[normalized] {
+		return true
+	}
+	for _, prefix := range geminiSupportedInlineMIMEPrefixes {
+		if strings.HasPrefix(normalized, prefix) {
+			return true
+		}
+	}
+	return false
+}
+
+func safePartForLLM(part *genai.Part, artifactName string) *genai.Part {
+	if part == nil || part.InlineData == nil {
+		return part
+	}
+	if isInlineMIMETypeSupported(part.InlineData.MIMEType) {
+		return part
+	}
+
+	mimeType := normalizeMIMEType(part.InlineData.MIMEType)
+	if mimeType == "" {
+		mimeType = "application/octet-stream"
+	}
+	data := part.InlineData.Data
+	if data == nil {
+		return genai.NewPartFromText(fmt.Sprintf("[Artifact: %s, type: %s. No inline data was provided.]", artifactName, mimeType))
+	}
+	if strings.HasPrefix(mimeType, "text/") || textLikeMIMETypes[mimeType] {
+		return genai.NewPartFromText(strings.ToValidUTF8(string(data), "\uFFFD"))
+	}
+
+	sizeKB := float64(len(data)) / 1024
+	return genai.NewPartFromText(fmt.Sprintf(
+		"[Binary artifact: %s, type: %s, size: %.1f KB. Content cannot be displayed inline.]",
+		artifactName,
+		mimeType,
+		sizeKB,
+	))
 }

--- a/tool/loadartifactstool/load_artifacts_tool_test.go
+++ b/tool/loadartifactstool/load_artifacts_tool_test.go
@@ -277,6 +277,109 @@ func TestLoadArtifactsTool_ProcessRequest_Artifacts_OtherFunctionCall(t *testing
 	}
 }
 
+func TestLoadArtifactsTool_ProcessRequest_UnsupportedTextLikeMIME_ConvertsToText(t *testing.T) {
+	loadArtifactsTool := loadartifactstool.New()
+	tc := createToolContext(t)
+	artifactName := "data.csv"
+	csvContent := "col1,col2\n1,2\n"
+	if _, err := tc.Artifacts().Save(t.Context(), artifactName, genai.NewPartFromBytes([]byte(csvContent), "application/csv")); err != nil {
+		t.Fatalf("Failed to save artifact %s: %v", artifactName, err)
+	}
+
+	llmRequest := loadArtifactsRequest(artifactName)
+	requestProcessor, ok := loadArtifactsTool.(toolinternal.RequestProcessor)
+	if !ok {
+		t.Fatal("loadArtifactsTool does not implement RequestProcessor")
+	}
+
+	if err := requestProcessor.ProcessRequest(tc, llmRequest); err != nil {
+		t.Fatalf("ProcessRequest failed: %v", err)
+	}
+
+	appendedContent := llmRequest.Contents[1]
+	artifactPart := appendedContent.Parts[1]
+	if artifactPart.InlineData != nil {
+		t.Fatalf("Expected artifact to be converted to text, got inline data: %v", artifactPart.InlineData)
+	}
+	if artifactPart.Text != csvContent {
+		t.Errorf("Converted artifact text: got %q, want %q", artifactPart.Text, csvContent)
+	}
+}
+
+func TestLoadArtifactsTool_ProcessRequest_SupportedMIME_KeepsInlineData(t *testing.T) {
+	loadArtifactsTool := loadartifactstool.New()
+	tc := createToolContext(t)
+	artifactName := "file.pdf"
+	pdfBytes := []byte("%PDF-1.4")
+	if _, err := tc.Artifacts().Save(t.Context(), artifactName, genai.NewPartFromBytes(pdfBytes, "application/pdf")); err != nil {
+		t.Fatalf("Failed to save artifact %s: %v", artifactName, err)
+	}
+
+	llmRequest := loadArtifactsRequest(artifactName)
+	requestProcessor, ok := loadArtifactsTool.(toolinternal.RequestProcessor)
+	if !ok {
+		t.Fatal("loadArtifactsTool does not implement RequestProcessor")
+	}
+
+	if err := requestProcessor.ProcessRequest(tc, llmRequest); err != nil {
+		t.Fatalf("ProcessRequest failed: %v", err)
+	}
+
+	artifactPart := llmRequest.Contents[1].Parts[1]
+	if artifactPart.InlineData == nil {
+		t.Fatal("Expected supported artifact to keep inline data")
+	}
+	if artifactPart.InlineData.MIMEType != "application/pdf" {
+		t.Errorf("Inline data MIMEType: got %q, want %q", artifactPart.InlineData.MIMEType, "application/pdf")
+	}
+	if diff := cmp.Diff(pdfBytes, artifactPart.InlineData.Data); diff != "" {
+		t.Errorf("Inline data diff (-want +got):\n%s", diff)
+	}
+}
+
+func TestLoadArtifactsTool_ProcessRequest_UnsupportedBinaryMIME_ConvertsToPlaceholder(t *testing.T) {
+	loadArtifactsTool := loadartifactstool.New()
+	tc := createToolContext(t)
+	artifactName := "slides.pptx"
+	if _, err := tc.Artifacts().Save(t.Context(), artifactName, genai.NewPartFromBytes([]byte{1, 2, 3}, "application/vnd.openxmlformats-officedocument.presentationml.presentation")); err != nil {
+		t.Fatalf("Failed to save artifact %s: %v", artifactName, err)
+	}
+
+	llmRequest := loadArtifactsRequest(artifactName)
+	requestProcessor, ok := loadArtifactsTool.(toolinternal.RequestProcessor)
+	if !ok {
+		t.Fatal("loadArtifactsTool does not implement RequestProcessor")
+	}
+
+	if err := requestProcessor.ProcessRequest(tc, llmRequest); err != nil {
+		t.Fatalf("ProcessRequest failed: %v", err)
+	}
+
+	artifactPart := llmRequest.Contents[1].Parts[1]
+	if artifactPart.InlineData != nil {
+		t.Fatalf("Expected artifact to be converted to text, got inline data: %v", artifactPart.InlineData)
+	}
+	want := "[Binary artifact: slides.pptx, type: application/vnd.openxmlformats-officedocument.presentationml.presentation, size: 0.0 KB. Content cannot be displayed inline.]"
+	if artifactPart.Text != want {
+		t.Errorf("Converted artifact text: got %q, want %q", artifactPart.Text, want)
+	}
+}
+
+func loadArtifactsRequest(artifactName string) *model.LLMRequest {
+	return &model.LLMRequest{
+		Contents: []*genai.Content{
+			{
+				Role: "model",
+				Parts: []*genai.Part{
+					genai.NewPartFromFunctionResponse("load_artifacts", map[string]any{
+						"artifact_names": []string{artifactName},
+					}),
+				},
+			},
+		},
+	}
+}
+
 func createToolContext(t *testing.T) tool.Context {
 	t.Helper()
 


### PR DESCRIPTION
Fixes #864

## Summary

`LoadArtifactsTool` currently appends loaded artifact parts directly into the next model request. This can produce invalid requests when an artifact is stored as inline data with a MIME type that Gemini does not support inline.

This change adds a model-safe conversion step before appending loaded artifacts:

- preserves supported inline media: `image/*`, `audio/*`, `video/*`, `application/pdf`
- converts text-like inline data to text parts: `text/*`, `application/csv`, `application/json`, `application/xml`
- replaces unsupported binary inline data with a short placeholder containing artifact name, MIME type, and size

The behavior mirrors the ADK Python fix from google/adk-python#4028 / fdc98d5c.

## Tests

- `go test ./tool/loadartifactstool`
