### PR TITLE
Context unification agent/context + internal/contenxt/callback_context

### DIFF
--- a/agent/agent.go
+++ b/agent/agent.go
@@ -249,7 +249,7 @@ func runBeforeAgentCallbacks(ctx InvocationContext) (*session.Event, error) {
 	pluginManager := pluginManagerFromContext(ctx)
 
 	actions := &session.EventActions{StateDelta: make(map[string]any), ArtifactDelta: make(map[string]int64)}
-	callbackCtx := NewCallbackContext(ctx, false, actions)
+	callbackCtx := NewCallbackContext(ctx, actions)
 
 	if pluginManager != nil {
 		content, err := pluginManager.RunBeforeAgentCallback(callbackCtx)
@@ -308,7 +308,7 @@ func runAfterAgentCallbacks(ctx InvocationContext) (*session.Event, error) {
 	pluginManager := pluginManagerFromContext(ctx)
 
 	actions := &session.EventActions{StateDelta: make(map[string]any), ArtifactDelta: make(map[string]int64)}
-	callbackCtx := NewCallbackContext(ctx, false, actions)
+	callbackCtx := NewCallbackContext(ctx, actions)
 
 	if pluginManager != nil {
 		content, err := pluginManager.RunAfterAgentCallback(callbackCtx)

--- a/agent/agent.go
+++ b/agent/agent.go
@@ -248,11 +248,8 @@ func runBeforeAgentCallbacks(ctx InvocationContext) (*session.Event, error) {
 	agent := ctx.Agent()
 	pluginManager := pluginManagerFromContext(ctx)
 
-	callbackCtx := &callbackContext{
-		Context:           ctx,
-		invocationContext: ctx,
-		actions:           &session.EventActions{StateDelta: make(map[string]any), ArtifactDelta: make(map[string]int64)},
-	}
+	callbackCtx := NewCallbackContext(ctx, false, nil, nil)
+	callbackActions := EventActionsOf(callbackCtx)
 
 	if pluginManager != nil {
 		content, err := pluginManager.RunBeforeAgentCallback(callbackCtx)
@@ -266,7 +263,7 @@ func runBeforeAgentCallbacks(ctx InvocationContext) (*session.Event, error) {
 			}
 			event.Author = agent.Name()
 			event.Branch = ctx.Branch()
-			event.Actions = *callbackCtx.actions
+			event.Actions = *callbackActions
 			ctx.EndInvocation()
 			return event, nil
 		}
@@ -287,17 +284,17 @@ func runBeforeAgentCallbacks(ctx InvocationContext) (*session.Event, error) {
 		}
 		event.Author = agent.Name()
 		event.Branch = ctx.Branch()
-		event.Actions = *callbackCtx.actions
+		event.Actions = *callbackActions
 		ctx.EndInvocation()
 		return event, nil
 	}
 
 	// check if has delta create event with it
-	if len(callbackCtx.actions.StateDelta) > 0 {
+	if len(callbackActions.StateDelta) > 0 {
 		event := session.NewEvent(ctx.InvocationID())
 		event.Author = agent.Name()
 		event.Branch = ctx.Branch()
-		event.Actions = *callbackCtx.actions
+		event.Actions = *callbackActions
 		return event, nil
 	}
 
@@ -310,11 +307,8 @@ func runAfterAgentCallbacks(ctx InvocationContext) (*session.Event, error) {
 	agent := ctx.Agent()
 	pluginManager := pluginManagerFromContext(ctx)
 
-	callbackCtx := &callbackContext{
-		Context:           ctx,
-		invocationContext: ctx,
-		actions:           &session.EventActions{StateDelta: make(map[string]any), ArtifactDelta: make(map[string]int64)},
-	}
+	callbackCtx := NewCallbackContext(ctx, false, nil, nil)
+	callbackActions := EventActionsOf(callbackCtx)
 
 	if pluginManager != nil {
 		content, err := pluginManager.RunAfterAgentCallback(callbackCtx)
@@ -328,7 +322,7 @@ func runAfterAgentCallbacks(ctx InvocationContext) (*session.Event, error) {
 			}
 			event.Author = agent.Name()
 			event.Branch = ctx.Branch()
-			event.Actions = *callbackCtx.actions
+			event.Actions = *callbackActions
 			return event, nil
 		}
 	}
@@ -348,99 +342,21 @@ func runAfterAgentCallbacks(ctx InvocationContext) (*session.Event, error) {
 		}
 		event.Author = agent.Name()
 		event.Branch = ctx.Branch()
-		event.Actions = *callbackCtx.actions
+		event.Actions = *callbackActions
 		// TODO set context invocation ended
 		// ctx.invocationEnded = true
 		return event, nil
 	}
 
 	// check if has delta create event with it
-	if len(callbackCtx.actions.StateDelta) > 0 {
+	if len(callbackActions.StateDelta) > 0 {
 		event := session.NewEvent(ctx.InvocationID())
 		event.Author = agent.Name()
 		event.Branch = ctx.Branch()
-		event.Actions = *callbackCtx.actions
+		event.Actions = *callbackActions
 		return event, nil
 	}
 	return nil, nil
-}
-
-// TODO: unify with internal/context.callbackContext
-
-type callbackContext struct {
-	context.Context
-	invocationContext InvocationContext
-	actions           *session.EventActions
-}
-
-func (c *callbackContext) AgentName() string {
-	return c.invocationContext.Agent().Name()
-}
-
-func (c *callbackContext) ReadonlyState() session.ReadonlyState {
-	return c.invocationContext.Session().State()
-}
-
-func (c *callbackContext) State() session.State {
-	return &callbackContextState{ctx: c}
-}
-
-func (c *callbackContext) Artifacts() Artifacts {
-	return c.invocationContext.Artifacts()
-}
-
-func (c *callbackContext) InvocationID() string {
-	return c.invocationContext.InvocationID()
-}
-
-func (c *callbackContext) UserContent() *genai.Content {
-	return c.invocationContext.UserContent()
-}
-
-// AppName implements CallbackContext.
-func (c *callbackContext) AppName() string {
-	return c.invocationContext.Session().AppName()
-}
-
-// Branch implements CallbackContext.
-func (c *callbackContext) Branch() string {
-	return c.invocationContext.Branch()
-}
-
-// SessionID implements CallbackContext.
-func (c *callbackContext) SessionID() string {
-	return c.invocationContext.Session().ID()
-}
-
-// UserID implements CallbackContext.
-func (c *callbackContext) UserID() string {
-	return c.invocationContext.Session().UserID()
-}
-
-var _ CallbackContext = (*callbackContext)(nil)
-
-type callbackContextState struct {
-	ctx *callbackContext
-}
-
-func (c *callbackContextState) Get(key string) (any, error) {
-	if c.ctx.actions != nil && c.ctx.actions.StateDelta != nil {
-		if val, ok := c.ctx.actions.StateDelta[key]; ok {
-			return val, nil
-		}
-	}
-	return c.ctx.invocationContext.Session().State().Get(key)
-}
-
-func (c *callbackContextState) Set(key string, val any) error {
-	if c.ctx.actions != nil && c.ctx.actions.StateDelta != nil {
-		c.ctx.actions.StateDelta[key] = val
-	}
-	return c.ctx.invocationContext.Session().State().Set(key, val)
-}
-
-func (c *callbackContextState) All() iter.Seq2[string, any] {
-	return c.ctx.invocationContext.Session().State().All()
 }
 
 type invocationContext struct {

--- a/agent/agent.go
+++ b/agent/agent.go
@@ -248,8 +248,8 @@ func runBeforeAgentCallbacks(ctx InvocationContext) (*session.Event, error) {
 	agent := ctx.Agent()
 	pluginManager := pluginManagerFromContext(ctx)
 
-	callbackCtx := NewCallbackContext(ctx, false, nil, nil)
-	callbackActions := EventActionsOf(callbackCtx)
+	actions := &session.EventActions{StateDelta: make(map[string]any), ArtifactDelta: make(map[string]int64)}
+	callbackCtx := NewCallbackContext(ctx, false, actions)
 
 	if pluginManager != nil {
 		content, err := pluginManager.RunBeforeAgentCallback(callbackCtx)
@@ -263,7 +263,7 @@ func runBeforeAgentCallbacks(ctx InvocationContext) (*session.Event, error) {
 			}
 			event.Author = agent.Name()
 			event.Branch = ctx.Branch()
-			event.Actions = *callbackActions
+			event.Actions = *actions
 			ctx.EndInvocation()
 			return event, nil
 		}
@@ -284,17 +284,17 @@ func runBeforeAgentCallbacks(ctx InvocationContext) (*session.Event, error) {
 		}
 		event.Author = agent.Name()
 		event.Branch = ctx.Branch()
-		event.Actions = *callbackActions
+		event.Actions = *actions
 		ctx.EndInvocation()
 		return event, nil
 	}
 
 	// check if has delta create event with it
-	if len(callbackActions.StateDelta) > 0 {
+	if len(actions.StateDelta) > 0 {
 		event := session.NewEvent(ctx.InvocationID())
 		event.Author = agent.Name()
 		event.Branch = ctx.Branch()
-		event.Actions = *callbackActions
+		event.Actions = *actions
 		return event, nil
 	}
 
@@ -307,8 +307,8 @@ func runAfterAgentCallbacks(ctx InvocationContext) (*session.Event, error) {
 	agent := ctx.Agent()
 	pluginManager := pluginManagerFromContext(ctx)
 
-	callbackCtx := NewCallbackContext(ctx, false, nil, nil)
-	callbackActions := EventActionsOf(callbackCtx)
+	actions := &session.EventActions{StateDelta: make(map[string]any), ArtifactDelta: make(map[string]int64)}
+	callbackCtx := NewCallbackContext(ctx, false, actions)
 
 	if pluginManager != nil {
 		content, err := pluginManager.RunAfterAgentCallback(callbackCtx)
@@ -322,7 +322,7 @@ func runAfterAgentCallbacks(ctx InvocationContext) (*session.Event, error) {
 			}
 			event.Author = agent.Name()
 			event.Branch = ctx.Branch()
-			event.Actions = *callbackActions
+			event.Actions = *actions
 			return event, nil
 		}
 	}
@@ -342,18 +342,18 @@ func runAfterAgentCallbacks(ctx InvocationContext) (*session.Event, error) {
 		}
 		event.Author = agent.Name()
 		event.Branch = ctx.Branch()
-		event.Actions = *callbackActions
+		event.Actions = *actions
 		// TODO set context invocation ended
 		// ctx.invocationEnded = true
 		return event, nil
 	}
 
 	// check if has delta create event with it
-	if len(callbackActions.StateDelta) > 0 {
+	if len(actions.StateDelta) > 0 {
 		event := session.NewEvent(ctx.InvocationID())
 		event.Author = agent.Name()
 		event.Branch = ctx.Branch()
-		event.Actions = *callbackActions
+		event.Actions = *actions
 		return event, nil
 	}
 	return nil, nil

--- a/agent/callback_context.go
+++ b/agent/callback_context.go
@@ -25,11 +25,8 @@ import (
 )
 
 // NewCallbackContext returns CallbackContext initialized with provided actions.
-// If trackArtifactDeltas is true, the returned context's Artifacts().Save(...)
-// wrapper records each saved artifact's version into the underlying
-// EventActions.ArtifactDelta so the resulting Event reflects the saves.
 // actions may be nil; if so, a new session.EventActions is created with empty StateDelta and ArtifactDelta
-func NewCallbackContext(ic InvocationContext, trackArtifactDeltas bool, actions *session.EventActions) CallbackContext {
+func NewCallbackContext(ic InvocationContext, actions *session.EventActions) CallbackContext {
 	if actions == nil {
 		actions = &session.EventActions{StateDelta: make(map[string]any), ArtifactDelta: make(map[string]int64)}
 	}
@@ -38,11 +35,25 @@ func NewCallbackContext(ic InvocationContext, trackArtifactDeltas bool, actions 
 		Context:           ic,
 		invocationContext: ic,
 		actions:           actions,
+		artifacts:         ic.Artifacts(),
 	}
-	if trackArtifactDeltas {
-		cc.artifacts = &trackedArtifacts{Artifacts: ic.Artifacts(), actions: actions}
-	} else {
-		cc.artifacts = ic.Artifacts()
+	return cc
+}
+
+// NewCallbackContextWithArtifactTracking returns CallbackContext initialized with provided actions.
+// the returned context's Artifacts().Save(...) wrapper records each saved artifact's version into the underlying
+// EventActions.ArtifactDelta so the resulting Event reflects the saves.
+// actions may be nil; if so, a new session.EventActions is created with empty StateDelta and ArtifactDelta
+func NewCallbackContextWithArtifactTracking(ic InvocationContext, actions *session.EventActions) CallbackContext {
+	if actions == nil {
+		actions = &session.EventActions{StateDelta: make(map[string]any), ArtifactDelta: make(map[string]int64)}
+	}
+
+	cc := &callbackContext{
+		Context:           ic,
+		invocationContext: ic,
+		actions:           actions,
+		artifacts:         &trackedArtifacts{Artifacts: ic.Artifacts(), actions: actions},
 	}
 	return cc
 }

--- a/agent/callback_context.go
+++ b/agent/callback_context.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.
@@ -24,28 +24,16 @@ import (
 	"google.golang.org/adk/session"
 )
 
-// NewCallbackContext returns a CallbackContext backed by the given invocation
-// context. The returned context is suitable for passing to user agent / model /
-// tool callbacks.
-//
+// NewCallbackContext returns CallbackContext initialized with provided actions.
 // If trackArtifactDeltas is true, the returned context's Artifacts().Save(...)
 // wrapper records each saved artifact's version into the underlying
 // EventActions.ArtifactDelta so the resulting Event reflects the saves.
-//
-// stateDelta and artifactDelta may be nil; if non-nil they are used as the
-// initial backing maps for the EventActions on this context (allowing callers
-// that aggregate deltas across multiple callbacks to share storage).
-//
-// The returned concrete type carries the underlying *session.EventActions; use
-// EventActionsOf to retrieve it.
-func NewCallbackContext(ic InvocationContext, trackArtifactDeltas bool, stateDelta map[string]any, artifactDelta map[string]int64) CallbackContext {
-	if stateDelta == nil {
-		stateDelta = make(map[string]any)
+// actions may be nil; if so, a new session.EventActions is created with empty StateDelta and ArtifactDelta
+func NewCallbackContext(ic InvocationContext, trackArtifactDeltas bool, actions *session.EventActions) CallbackContext {
+	if actions == nil {
+		actions = &session.EventActions{StateDelta: make(map[string]any), ArtifactDelta: make(map[string]int64)}
 	}
-	if artifactDelta == nil {
-		artifactDelta = make(map[string]int64)
-	}
-	actions := &session.EventActions{StateDelta: stateDelta, ArtifactDelta: artifactDelta}
+
 	cc := &callbackContext{
 		Context:           ic,
 		invocationContext: ic,
@@ -59,22 +47,7 @@ func NewCallbackContext(ic InvocationContext, trackArtifactDeltas bool, stateDel
 	return cc
 }
 
-// EventActionsOf returns the *session.EventActions backing a CallbackContext
-// produced by NewCallbackContext, or nil if the context was not produced by
-// NewCallbackContext.
-func EventActionsOf(c CallbackContext) *session.EventActions {
-	cc, ok := c.(*callbackContext)
-	if !ok {
-		return nil
-	}
-	return cc.actions
-}
-
 // callbackContext is the single concrete implementation of CallbackContext.
-//
-// Its Artifacts() return value may optionally wrap the underlying Artifacts to
-// record saved artifact versions into the EventActions.ArtifactDelta, depending
-// on the trackArtifactDeltas flag passed to NewCallbackContext.
 type callbackContext struct {
 	context.Context
 	invocationContext InvocationContext

--- a/agent/callback_context.go
+++ b/agent/callback_context.go
@@ -1,0 +1,173 @@
+// Copyright 2025 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package agent
+
+import (
+	"context"
+	"iter"
+
+	"google.golang.org/genai"
+
+	"google.golang.org/adk/artifact"
+	"google.golang.org/adk/session"
+)
+
+// NewCallbackContext returns a CallbackContext backed by the given invocation
+// context. The returned context is suitable for passing to user agent / model /
+// tool callbacks.
+//
+// If trackArtifactDeltas is true, the returned context's Artifacts().Save(...)
+// wrapper records each saved artifact's version into the underlying
+// EventActions.ArtifactDelta so the resulting Event reflects the saves.
+//
+// stateDelta and artifactDelta may be nil; if non-nil they are used as the
+// initial backing maps for the EventActions on this context (allowing callers
+// that aggregate deltas across multiple callbacks to share storage).
+//
+// The returned concrete type carries the underlying *session.EventActions; use
+// EventActionsOf to retrieve it.
+func NewCallbackContext(ic InvocationContext, trackArtifactDeltas bool, stateDelta map[string]any, artifactDelta map[string]int64) CallbackContext {
+	if stateDelta == nil {
+		stateDelta = make(map[string]any)
+	}
+	if artifactDelta == nil {
+		artifactDelta = make(map[string]int64)
+	}
+	actions := &session.EventActions{StateDelta: stateDelta, ArtifactDelta: artifactDelta}
+	cc := &callbackContext{
+		Context:           ic,
+		invocationContext: ic,
+		actions:           actions,
+	}
+	if trackArtifactDeltas {
+		cc.artifacts = &trackedArtifacts{Artifacts: ic.Artifacts(), actions: actions}
+	} else {
+		cc.artifacts = ic.Artifacts()
+	}
+	return cc
+}
+
+// EventActionsOf returns the *session.EventActions backing a CallbackContext
+// produced by NewCallbackContext, or nil if the context was not produced by
+// NewCallbackContext.
+func EventActionsOf(c CallbackContext) *session.EventActions {
+	cc, ok := c.(*callbackContext)
+	if !ok {
+		return nil
+	}
+	return cc.actions
+}
+
+// callbackContext is the single concrete implementation of CallbackContext.
+//
+// Its Artifacts() return value may optionally wrap the underlying Artifacts to
+// record saved artifact versions into the EventActions.ArtifactDelta, depending
+// on the trackArtifactDeltas flag passed to NewCallbackContext.
+type callbackContext struct {
+	context.Context
+	invocationContext InvocationContext
+	artifacts         Artifacts
+	actions           *session.EventActions
+}
+
+func (c *callbackContext) AgentName() string {
+	return c.invocationContext.Agent().Name()
+}
+
+func (c *callbackContext) ReadonlyState() session.ReadonlyState {
+	return c.invocationContext.Session().State()
+}
+
+func (c *callbackContext) State() session.State {
+	return &callbackContextState{ctx: c}
+}
+
+func (c *callbackContext) Artifacts() Artifacts {
+	return c.artifacts
+}
+
+func (c *callbackContext) InvocationID() string {
+	return c.invocationContext.InvocationID()
+}
+
+func (c *callbackContext) UserContent() *genai.Content {
+	return c.invocationContext.UserContent()
+}
+
+func (c *callbackContext) AppName() string {
+	return c.invocationContext.Session().AppName()
+}
+
+func (c *callbackContext) Branch() string {
+	return c.invocationContext.Branch()
+}
+
+func (c *callbackContext) SessionID() string {
+	return c.invocationContext.Session().ID()
+}
+
+func (c *callbackContext) UserID() string {
+	return c.invocationContext.Session().UserID()
+}
+
+var _ CallbackContext = (*callbackContext)(nil)
+
+// callbackContextState is a session.State implementation backed by the
+// callback context's EventActions.StateDelta and the underlying session state.
+type callbackContextState struct {
+	ctx *callbackContext
+}
+
+func (c *callbackContextState) Get(key string) (any, error) {
+	if c.ctx.actions != nil && c.ctx.actions.StateDelta != nil {
+		if val, ok := c.ctx.actions.StateDelta[key]; ok {
+			return val, nil
+		}
+	}
+	return c.ctx.invocationContext.Session().State().Get(key)
+}
+
+func (c *callbackContextState) Set(key string, val any) error {
+	if c.ctx.actions != nil && c.ctx.actions.StateDelta != nil {
+		c.ctx.actions.StateDelta[key] = val
+	}
+	return c.ctx.invocationContext.Session().State().Set(key, val)
+}
+
+func (c *callbackContextState) All() iter.Seq2[string, any] {
+	return c.ctx.invocationContext.Session().State().All()
+}
+
+// trackedArtifacts wraps an Artifacts to record each successful Save into the
+// supplied EventActions.ArtifactDelta.
+type trackedArtifacts struct {
+	Artifacts
+	actions *session.EventActions
+}
+
+func (a *trackedArtifacts) Save(ctx context.Context, name string, data *genai.Part) (*artifact.SaveResponse, error) {
+	resp, err := a.Artifacts.Save(ctx, name, data)
+	if err != nil {
+		return resp, err
+	}
+	if a.actions != nil {
+		if a.actions.ArtifactDelta == nil {
+			a.actions.ArtifactDelta = make(map[string]int64)
+		}
+		// TODO: RWLock, check the version stored is newer in case multiple tools save the same file.
+		a.actions.ArtifactDelta[name] = resp.Version
+	}
+	return resp, nil
+}

--- a/internal/context/callback_context.go
+++ b/internal/context/callback_context.go
@@ -23,7 +23,7 @@ import (
 // related callbacks. The returned context's Artifacts().Save tracks each saved
 // artifact's version into the underlying EventActions.ArtifactDelta.
 func NewCallbackContext(ctx agent.InvocationContext) agent.CallbackContext {
-	return agent.NewCallbackContext(ctx, true, nil)
+	return agent.NewCallbackContextWithArtifactTracking(ctx, nil)
 }
 
 // NewCallbackContextWithDelta returns a CallbackContext that uses the given
@@ -32,5 +32,5 @@ func NewCallbackContext(ctx agent.InvocationContext) agent.CallbackContext {
 // artifact's version into artifactDelta.
 func NewCallbackContextWithDelta(ctx agent.InvocationContext, stateDelta map[string]any, artifactDelta map[string]int64) agent.CallbackContext {
 	actions := &session.EventActions{StateDelta: stateDelta, ArtifactDelta: artifactDelta}
-	return agent.NewCallbackContext(ctx, true, actions)
+	return agent.NewCallbackContextWithArtifactTracking(ctx, actions)
 }

--- a/internal/context/callback_context.go
+++ b/internal/context/callback_context.go
@@ -15,111 +15,20 @@
 package context
 
 import (
-	"context"
-	"iter"
-
-	"google.golang.org/genai"
-
 	"google.golang.org/adk/agent"
-	"google.golang.org/adk/artifact"
-	"google.golang.org/adk/session"
 )
 
-type internalArtifacts struct {
-	agent.Artifacts
-	eventActions *session.EventActions
-}
-
-func (ia *internalArtifacts) Save(ctx context.Context, name string, data *genai.Part) (*artifact.SaveResponse, error) {
-	resp, err := ia.Artifacts.Save(ctx, name, data)
-	if err != nil {
-		return resp, err
-	}
-	if ia.eventActions != nil {
-		if ia.eventActions.ArtifactDelta == nil {
-			ia.eventActions.ArtifactDelta = make(map[string]int64)
-		}
-		// TODO: RWLock, check the version stored is newer in case multiple tools save the same file.
-		ia.eventActions.ArtifactDelta[name] = resp.Version
-	}
-	return resp, nil
-}
-
+// NewCallbackContext returns a CallbackContext suitable for model, tool, and
+// related callbacks. The returned context's Artifacts().Save tracks each saved
+// artifact's version into the underlying EventActions.ArtifactDelta.
 func NewCallbackContext(ctx agent.InvocationContext) agent.CallbackContext {
-	return newCallbackContext(ctx, make(map[string]any), make(map[string]int64))
+	return agent.NewCallbackContext(ctx, true, nil, nil)
 }
 
+// NewCallbackContextWithDelta returns a CallbackContext that uses the given
+// stateDelta and artifactDelta maps as the initial backing storage for its
+// EventActions. The returned context's Artifacts().Save tracks each saved
+// artifact's version into artifactDelta.
 func NewCallbackContextWithDelta(ctx agent.InvocationContext, stateDelta map[string]any, artifactDelta map[string]int64) agent.CallbackContext {
-	return newCallbackContext(ctx, stateDelta, artifactDelta)
-}
-
-func newCallbackContext(ctx agent.InvocationContext, stateDelta map[string]any, artifactDelta map[string]int64) *callbackContext {
-	rCtx := NewReadonlyContext(ctx)
-	eventActions := &session.EventActions{StateDelta: stateDelta, ArtifactDelta: artifactDelta}
-	return &callbackContext{
-		ReadonlyContext: rCtx,
-		invocationCtx:   ctx,
-		eventActions:    eventActions,
-		artifacts: &internalArtifacts{
-			Artifacts:    ctx.Artifacts(),
-			eventActions: eventActions,
-		},
-	}
-}
-
-// TODO: unify with agent.callbackContext
-
-type callbackContext struct {
-	agent.ReadonlyContext
-	artifacts     *internalArtifacts
-	invocationCtx agent.InvocationContext
-	eventActions  *session.EventActions
-}
-
-func (c *callbackContext) Artifacts() agent.Artifacts {
-	return c.artifacts
-}
-
-func (c *callbackContext) AgentName() string {
-	return c.invocationCtx.Agent().Name()
-}
-
-func (c *callbackContext) ReadonlyState() session.ReadonlyState {
-	return c.invocationCtx.Session().State()
-}
-
-func (c *callbackContext) State() session.State {
-	return &callbackContextState{ctx: c}
-}
-
-func (c *callbackContext) InvocationID() string {
-	return c.invocationCtx.InvocationID()
-}
-
-func (c *callbackContext) UserContent() *genai.Content {
-	return c.invocationCtx.UserContent()
-}
-
-type callbackContextState struct {
-	ctx *callbackContext
-}
-
-func (c *callbackContextState) Get(key string) (any, error) {
-	if c.ctx.eventActions != nil && c.ctx.eventActions.StateDelta != nil {
-		if val, ok := c.ctx.eventActions.StateDelta[key]; ok {
-			return val, nil
-		}
-	}
-	return c.ctx.invocationCtx.Session().State().Get(key)
-}
-
-func (c *callbackContextState) Set(key string, val any) error {
-	if c.ctx.eventActions != nil && c.ctx.eventActions.StateDelta != nil {
-		c.ctx.eventActions.StateDelta[key] = val
-	}
-	return c.ctx.invocationCtx.Session().State().Set(key, val)
-}
-
-func (c *callbackContextState) All() iter.Seq2[string, any] {
-	return c.ctx.invocationCtx.Session().State().All()
+	return agent.NewCallbackContext(ctx, true, stateDelta, artifactDelta)
 }

--- a/internal/context/callback_context.go
+++ b/internal/context/callback_context.go
@@ -16,13 +16,14 @@ package context
 
 import (
 	"google.golang.org/adk/agent"
+	"google.golang.org/adk/session"
 )
 
 // NewCallbackContext returns a CallbackContext suitable for model, tool, and
 // related callbacks. The returned context's Artifacts().Save tracks each saved
 // artifact's version into the underlying EventActions.ArtifactDelta.
 func NewCallbackContext(ctx agent.InvocationContext) agent.CallbackContext {
-	return agent.NewCallbackContext(ctx, true, nil, nil)
+	return agent.NewCallbackContext(ctx, true, nil)
 }
 
 // NewCallbackContextWithDelta returns a CallbackContext that uses the given
@@ -30,5 +31,6 @@ func NewCallbackContext(ctx agent.InvocationContext) agent.CallbackContext {
 // EventActions. The returned context's Artifacts().Save tracks each saved
 // artifact's version into artifactDelta.
 func NewCallbackContextWithDelta(ctx agent.InvocationContext, stateDelta map[string]any, artifactDelta map[string]int64) agent.CallbackContext {
-	return agent.NewCallbackContext(ctx, true, stateDelta, artifactDelta)
+	actions := &session.EventActions{StateDelta: stateDelta, ArtifactDelta: artifactDelta}
+	return agent.NewCallbackContext(ctx, true, actions)
 }


### PR DESCRIPTION
Two independent context with slightly different functionality are merged into one.
The functional difference is maintained by providing a bool flag while the callback context is created. 

### Testing Plan


**Unit Tests:**

- [ ] I have added or updated unit tests for my change.
- [X ] All unit tests pass locally.

**Manual End-to-End (E2E) Tests:**

Manual tests using the examples. 

### Checklist

- [X ] I have read the [CONTRIBUTING.md](./CONTRIBUTING.md) document.
- [X ] I have performed a self-review of my own code.
- [X ] I have commented my code, particularly in hard-to-understand areas.
- [ ] I have added tests that prove my fix is effective or that my feature works.
- [X ] New and existing unit tests pass locally with my changes.
- [X ] I have manually tested my changes end-to-end.
- [X ] Any dependent changes have been merged and published in downstream modules.

