### PR TITLE
fix replay_plugin: empty llmresponses and normalize function formatting before comparing.

### DIFF
--- a/internal/configurable/conformance/replayplugin/replay_plugin.go
+++ b/internal/configurable/conformance/replayplugin/replay_plugin.go
@@ -129,6 +129,10 @@ func (p *replayPlugin) beforeModel(ctx agent.CallbackContext, req *model.LLMRequ
 		return nil, err
 	}
 
+	if len(recording.LLMResponses) == 0 {
+		return nil, fmt.Errorf("no LLM responses found in recording")
+	}
+
 	return recording.LLMResponses[0], nil
 }
 
@@ -425,6 +429,17 @@ func verifyLLMRequestMatch(expectedLLMRequest, actualLLMRequest *model.LLMReques
 		cmpopts.EquateEmpty(),
 	}
 
+	for _, toolAny := range expectedLLMRequest.Tools {
+		if funcDecl, ok := toolAny.(*genai.FunctionDeclaration); ok {
+			funcDecl.Description = normalizeDescription(funcDecl.Description)
+		}
+	}
+	for _, toolAny := range actualLLMRequest.Tools {
+		if funcDecl, ok := toolAny.(*genai.FunctionDeclaration); ok {
+			funcDecl.Description = normalizeDescription(funcDecl.Description)
+		}
+	}
+
 	if transferToolAny, ok := expectedLLMRequest.Tools["transfer_to_agent"]; ok {
 		transferTool := transferToolAny.(*genai.FunctionDeclaration)
 		transferTool.Description = `Transfer the question to another agent.
@@ -434,10 +449,19 @@ This tool hands off control to another agent when it's more suitable to answer t
 	if expectedLLMRequest.Config != nil {
 		for _, tool := range expectedLLMRequest.Config.Tools {
 			for _, funcDecl := range tool.FunctionDeclarations {
+				funcDecl.Description = normalizeDescription(funcDecl.Description)
 				if funcDecl.Name == "transfer_to_agent" {
 					funcDecl.Description = `Transfer the question to another agent.
 This tool hands off control to another agent when it's more suitable to answer the user's question according to the agent's description.`
 				}
+			}
+		}
+	}
+
+	if actualLLMRequest.Config != nil {
+		for _, tool := range actualLLMRequest.Config.Tools {
+			for _, funcDecl := range tool.FunctionDeclarations {
+				funcDecl.Description = normalizeDescription(funcDecl.Description)
 			}
 		}
 	}
@@ -579,4 +603,20 @@ func verifyToolCallMatch(expectedToolCall *genai.FunctionCall, toolName string, 
 	}
 
 	return nil
+}
+
+func normalizeDescription(desc string) string {
+	lines := strings.Split(desc, "\n")
+	var cleaned []string
+	for _, line := range lines {
+		cleaned = append(cleaned, strings.TrimSpace(line))
+	}
+	// Remove empty lines at the start and end
+	for len(cleaned) > 0 && cleaned[0] == "" {
+		cleaned = cleaned[1:]
+	}
+	for len(cleaned) > 0 && cleaned[len(cleaned)-1] == "" {
+		cleaned = cleaned[:len(cleaned)-1]
+	}
+	return strings.Join(cleaned, "\n")
 }

--- a/internal/configurable/conformance/replayplugin/replay_plugin.go
+++ b/internal/configurable/conformance/replayplugin/replay_plugin.go
@@ -130,7 +130,7 @@ func (p *replayPlugin) beforeModel(ctx agent.CallbackContext, req *model.LLMRequ
 	}
 
 	if len(recording.LLMResponses) == 0 {
-		return nil, fmt.Errorf("no LLM responses found in recording")
+		return nil, fmt.Errorf("no LLM responses found in recording for agent %q", agentName)
 	}
 
 	return recording.LLMResponses[0], nil

--- a/internal/configurable/conformance/replayplugin/replay_plugin_internal_test.go
+++ b/internal/configurable/conformance/replayplugin/replay_plugin_internal_test.go
@@ -1,0 +1,80 @@
+// Copyright 2026 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package replayplugin
+
+import "testing"
+
+func TestNormalizeDescription(t *testing.T) {
+	tests := []struct {
+		name     string
+		input    string
+		expected string
+	}{
+		{
+			name:     "Simple single line",
+			input:    "Simple description",
+			expected: "Simple description",
+		},
+		{
+			name:     "Single line with leading and trailing spaces",
+			input:    "   Simple description   ",
+			expected: "Simple description",
+		},
+		{
+			name:     "Multiple lines with indentation",
+			input:    "  Line 1  \n  Line 2  ",
+			expected: "Line 1\nLine 2",
+		},
+		{
+			name:     "Empty lines at start and end",
+			input:    "\n\nLine 1\nLine 2\n\n",
+			expected: "Line 1\nLine 2",
+		},
+		{
+			name:     "Whitespace-only lines at start and end",
+			input:    "   \n  \nLine 1\nLine 2\n  \n   ",
+			expected: "Line 1\nLine 2",
+		},
+		{
+			name:     "Empty lines in the middle are preserved",
+			input:    "Line 1\n\nLine 2",
+			expected: "Line 1\n\nLine 2",
+		},
+		{
+			name:     "Empty input",
+			input:    "",
+			expected: "",
+		},
+		{
+			name:     "Whitespace-only input",
+			input:    "    \n   \n  ",
+			expected: "",
+		},
+		{
+			name:     "Complex formatting with tabs and newlines",
+			input:    "\t\n  Line 1 \t \n\tLine 2\n  \t\n",
+			expected: "Line 1\nLine 2",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			actual := normalizeDescription(tt.input)
+			if actual != tt.expected {
+				t.Errorf("normalizeDescription(%q) = %q; want %q", tt.input, actual, tt.expected)
+			}
+		})
+	}
+}

--- a/internal/configurable/conformance/replayplugin/replay_plugin_test.go
+++ b/internal/configurable/conformance/replayplugin/replay_plugin_test.go
@@ -121,6 +121,83 @@ recordings:
 		}
 	})
 
+	t.Run("BeforeModelCallback_WithSingleLlmResponse_ReturnsRecordedResponse", func(t *testing.T) {
+		plugin, mockSession, _ := setup(t)
+		tempDir := t.TempDir()
+
+		// 1. Create recording file with singular llm_response instead of plural llm_responses
+		recordingsYaml := `
+recordings:
+  - user_message_index: 0
+    agent_name: "test_agent"
+    llm_recording:
+      llm_request:
+        model: "gemini-2.0-flash"
+        contents:
+          - role: "user"
+            parts:
+              - text: "Hello"
+      llm_response:
+        content:
+          role: "model"
+          parts:
+            - text: "Recorded response"
+`
+		createRecordingsFile(t, tempDir, recordingsYaml)
+
+		// 2. Setup replay config
+		err := mockSession.State().Set("_adk_replay_config", map[string]any{
+			"dir":                tempDir,
+			"user_message_index": 0,
+		})
+		if err != nil {
+			t.Fatalf("unexpected error: %v", err)
+		}
+
+		// 3. Load recordings (BeforeRunCallback)
+		invContext := &MockInvocationContext{
+			session:      mockSession,
+			invocationID: "test-invocation",
+		}
+		_, err = plugin.BeforeRunCallback()(invContext)
+		if err != nil {
+			t.Fatalf("unexpected error: %v", err)
+		}
+
+		// 4. Call BeforeModelCallback with matching request
+		cbContext := &MockCallbackContext{
+			state:        mockSession.State(),
+			invocationID: "test-invocation",
+			agentName:    "test_agent",
+		}
+
+		request := &model.LLMRequest{
+			Model: "gemini-2.0-flash",
+			Contents: []*genai.Content{
+				{
+					Role:  "user",
+					Parts: []*genai.Part{{Text: "Hello"}},
+				},
+			},
+		}
+
+		result, err := plugin.BeforeModelCallback()(cbContext, request)
+		// 5. Verify
+		if err != nil {
+			t.Fatalf("unexpected error: %v", err)
+		}
+		if result == nil {
+			t.Fatal("expected non-nil result")
+		}
+		if result.Content == nil {
+			t.Fatal("expected non-nil result.Content")
+		}
+
+		if got := result.Content.Parts[0].Text; got != "Recorded response" {
+			t.Errorf("expected %q, got %q", "Recorded response", got)
+		}
+	})
+
 	t.Run("BeforeModelCallback_RequestMismatch_ReturnsEmpty", func(t *testing.T) {
 		plugin, mockSession, _ := setup(t)
 		tempDir := t.TempDir()

--- a/internal/configurable/conformance/replayplugin/yaml_utils.go
+++ b/internal/configurable/conformance/replayplugin/yaml_utils.go
@@ -86,6 +86,21 @@ func fixTypeMismatches(n *yaml.Node) {
 						},
 					}
 				}
+			case "llmresponse":
+				if valueNode.Kind == yaml.MappingNode {
+					origCopy := &yaml.Node{
+						Kind:    valueNode.Kind,
+						Style:   valueNode.Style,
+						Tag:     valueNode.Tag,
+						Value:   valueNode.Value,
+						Content: valueNode.Content,
+					}
+					valueNode.Kind = yaml.SequenceNode
+					valueNode.Tag = "!!seq"
+					valueNode.Value = ""
+					valueNode.Content = []*yaml.Node{origCopy}
+				}
+				keyNode.Value = "llmresponses"
 			}
 
 			// Recurse into the value to catch nested structures

--- a/internal/configurable/conformance/replayplugin/yaml_utils.go
+++ b/internal/configurable/conformance/replayplugin/yaml_utils.go
@@ -88,17 +88,11 @@ func fixTypeMismatches(n *yaml.Node) {
 				}
 			case "llmresponse":
 				if valueNode.Kind == yaml.MappingNode {
-					origCopy := &yaml.Node{
-						Kind:    valueNode.Kind,
-						Style:   valueNode.Style,
-						Tag:     valueNode.Tag,
-						Value:   valueNode.Value,
-						Content: valueNode.Content,
-					}
+					origCopy := *valueNode
 					valueNode.Kind = yaml.SequenceNode
 					valueNode.Tag = "!!seq"
 					valueNode.Value = ""
-					valueNode.Content = []*yaml.Node{origCopy}
+					valueNode.Content = []*yaml.Node{&origCopy}
 				}
 				keyNode.Value = "llmresponses"
 			}


### PR DESCRIPTION
## Fix Conformance Replay Plugin: Singular `llm_response` Parsing & Description Normalization

### Summary
This change addresses two key issues in the conformance test replay verification suite to ensure consistent behavior and prevent panics during test playback.

### Key Changes

1. **Singular `llm_response` Normalization**
   - Updated the YAML parsing utilities (`yaml_utils.go`) to dynamically catch and convert the singular `llm_response` key (often generated in YAML recordings) into the plural `llm_responses` array format under `fixTypeMismatches`.
   - Adds unit test coverage ensuring that recordings using the singular `llm_response` format are correctly loaded and parsed without error.

2. **Nil/Empty Response Safety Check**
   - Added a safety check to the replay plugin's `beforeModel` callback to return a clean error if `recording.LLMResponses` is empty, preventing out-of-bounds indexing panics during matching.

3. **Whitespace and Indentation Normalization for Tool Descriptions**
   - Added a `normalizeDescription` helper to strip leading/trailing whitespace on each line of a tool or function declaration description and trim empty leading/trailing lines.
   - Applied this normalization to both expected and actual `LLMRequest` configurations before comparing them with `cmp.Diff`. This prevents false failures caused by minor formatting differences in multi-line string indentation across Python and Go configurations.

***