### PR TITLE
refactor: replace StateDelta output tracking with direct Event.Output field usage

### DIFF
--- a/agent/llmagent/llmagent.go
+++ b/agent/llmagent/llmagent.go
@@ -470,6 +470,7 @@ func (a *llmAgent) maybeSaveOutputToState(event *session.Event) {
 		}
 
 		event.Actions.StateDelta[a.OutputKey] = result
+		event.Output = result
 	}
 }
 

--- a/agent/llmagent/llmagent_test.go
+++ b/agent/llmagent/llmagent_test.go
@@ -15,6 +15,7 @@
 package llmagent_test
 
 import (
+	"context"
 	"errors"
 	"fmt"
 	"iter"
@@ -22,6 +23,7 @@ import (
 	"path/filepath"
 	"strings"
 	"testing"
+	"time"
 
 	"github.com/google/go-cmp/cmp"
 	"google.golang.org/genai"
@@ -34,6 +36,8 @@ import (
 	"google.golang.org/adk/session"
 	"google.golang.org/adk/tool"
 	"google.golang.org/adk/tool/functiontool"
+	"google.golang.org/adk/workflow"
+	"google.golang.org/adk/internal/agent/runconfig"
 )
 
 const modelName = "gemini-2.5-flash"
@@ -1192,4 +1196,105 @@ func TestFindAgent(t *testing.T) {
 			}
 		})
 	}
+}
+
+func TestLLMAgent_WorkflowIntegration_OutputPropagatesToSuccessor(t *testing.T) {
+	// 1. mock LLM returning "hello world"
+	testLLM := &testutil.MockModel{
+		Responses: []*genai.Content{
+			genai.NewContentFromText("hello world", genai.RoleModel),
+		},
+	}
+
+	// 2. LLMAgent with OutputKey="result"
+	a, err := llmagent.New(llmagent.Config{
+		Name:      "llm_agent",
+		Model:     testLLM,
+		OutputKey: "result",
+	})
+	if err != nil {
+		t.Fatalf("failed to create llm agent: %v", err)
+	}
+
+	// 3. wrap in AgentNode
+	agentNode, err := workflow.NewAgentNode(a, workflow.NodeConfig{})
+	if err != nil {
+		t.Fatalf("failed to create agent node: %v", err)
+	}
+
+	// 4. Chain(Start, agentNode, fnNode), where fnNode asserts on input
+	var gotInput any
+	fnNode := workflow.NewFunctionNode("receiver", func(ctx agent.InvocationContext, in any) (any, error) {
+		gotInput = in
+		return nil, nil
+	}, workflow.NodeConfig{})
+
+	edges := workflow.Chain(workflow.Start, agentNode, fnNode)
+	w, err := workflow.New("test_workflow", edges)
+	if err != nil {
+		t.Fatalf("failed to create workflow: %v", err)
+	}
+
+	// Run the workflow. We need a mock context and session.
+	runCtx := runconfig.ToContext(t.Context(), &runconfig.RunConfig{})
+	mockCtx := &mockInvocationContext{
+		Context: runCtx,
+		sess:    &mockSession{id: "test-session-id"},
+	}
+
+	events := w.Run(mockCtx)
+	for ev, err := range events {
+		if err != nil {
+			t.Fatalf("workflow run failed: %v", err)
+		}
+		_ = ev
+	}
+
+	// 5. assert: fnNode got "hello world"
+	if diff := cmp.Diff("hello world", gotInput); diff != "" {
+		t.Errorf("fnNode got unexpected input (-want +got):\n%s", diff)
+	}
+}
+
+type mockEvents struct{}
+
+func (m mockEvents) All() iter.Seq[*session.Event] {
+	return func(yield func(*session.Event) bool) {}
+}
+func (m mockEvents) Len() int                { return 0 }
+func (m mockEvents) At(i int) *session.Event { return nil }
+
+type mockSession struct {
+	id string
+}
+
+func (m *mockSession) ID() string                { return m.id }
+func (m *mockSession) AppName() string           { return "test-app" }
+func (m *mockSession) UserID() string            { return "test-user" }
+func (m *mockSession) State() session.State      { return nil }
+func (m *mockSession) Events() session.Events    { return mockEvents{} }
+func (m *mockSession) LastUpdateTime() time.Time { return time.Now() }
+
+type mockInvocationContext struct {
+	context.Context
+	sess        session.Session
+	userContent *genai.Content
+}
+
+func (m *mockInvocationContext) Session() session.Session        { return m.sess }
+func (m *mockInvocationContext) InvocationID() string            { return "test-invocation-id" }
+func (m *mockInvocationContext) UserContent() *genai.Content     { return m.userContent }
+func (m *mockInvocationContext) ResumedInput(string) (any, bool) { return nil, false }
+func (m *mockInvocationContext) Agent() agent.Agent              { return nil }
+func (m *mockInvocationContext) Artifacts() agent.Artifacts      { return nil }
+func (m *mockInvocationContext) Memory() agent.Memory            { return nil }
+func (m *mockInvocationContext) Branch() string                  { return "" }
+func (m *mockInvocationContext) RunConfig() *agent.RunConfig     { return nil }
+func (m *mockInvocationContext) Ended() bool                     { return false }
+func (m *mockInvocationContext) EndInvocation()                  {}
+
+func (m *mockInvocationContext) WithContext(ctx context.Context) agent.InvocationContext {
+	cp := *m
+	cp.Context = ctx
+	return &cp
 }

--- a/agent/workflowagent/reentry_test.go
+++ b/agent/workflowagent/reentry_test.go
@@ -297,7 +297,7 @@ func askerForSequence(name string, ids []string, finalOutput any) (*reentryNode,
 
 			// All answered: emit the terminal output.
 			ev := session.NewEvent(ctx.InvocationID())
-			ev.Actions.StateDelta["output"] = finalOutput
+			ev.Output = finalOutput
 			yield(ev, nil)
 		}
 	})

--- a/agent/workflowagent/workflow_test.go
+++ b/agent/workflowagent/workflow_test.go
@@ -147,11 +147,9 @@ func TestWorkflowAgent(t *testing.T) {
 			t.Fatalf("unexpected error: %v", err)
 		}
 
-		if ev.Actions.StateDelta != nil {
-			if out, ok := ev.Actions.StateDelta["output"]; ok {
-				lastOutput = out
-				nodeEvents++
-			}
+		if ev.Output != nil {
+			lastOutput = ev.Output
+			nodeEvents++
 		}
 	}
 

--- a/workflow/agent_node.go
+++ b/workflow/agent_node.go
@@ -27,7 +27,8 @@ import (
 	"google.golang.org/adk/session"
 )
 
-// AgentNode wraps a standard agent.Agent.
+// AgentNode wraps a standard agent.Agent. Wrapped agents should emit their final output via
+// Event.Output to be propagated to successor nodes
 type AgentNode struct {
 	BaseNode
 	agent        agent.Agent
@@ -103,9 +104,9 @@ func (n *AgentNode) Run(ctx agent.InvocationContext, input any) iter.Seq2[*sessi
 
 		// Use existing agent context instead of implementing a new one
 		params := internalcontext.InvocationContextParams{
-			Artifacts:     ctx.Artifacts(),
-			Memory:        ctx.Memory(),
-			Session:       ctx.Session(),
+			Artifacts: ctx.Artifacts(),
+			Memory:    ctx.Memory(),
+			Session:   ctx.Session(),
 			// TODO: branch isolation in a separate PR
 			Branch:        ctx.Branch(),
 			Agent:         n.agent,

--- a/workflow/agent_node_test.go
+++ b/workflow/agent_node_test.go
@@ -54,9 +54,7 @@ func TestAgentNode_New(t *testing.T) {
 		Run: func(ctx agent.InvocationContext) iter.Seq2[*session.Event, error] {
 			return func(yield func(*session.Event, error) bool) {
 				event := session.NewEvent(ctx.InvocationID())
-				event.Actions.StateDelta = map[string]any{
-					"output": map[string]any{"result": "success"},
-				}
+				event.Output = map[string]any{"result": "success"}
 				yield(event, nil)
 			}
 		},
@@ -162,9 +160,7 @@ func TestAgentNode_Run(t *testing.T) {
 								val = uc.Parts[0].Text
 							}
 							event := session.NewEvent(ctx.InvocationID())
-							event.Actions.StateDelta = map[string]any{
-								"output": map[string]any{"result": val},
-							}
+							event.Output = map[string]any{"result": val}
 							yield(event, nil)
 						}
 					},
@@ -200,9 +196,7 @@ func TestAgentNode_Run(t *testing.T) {
 								val = uc.Parts[0].Text
 							}
 							event := session.NewEvent(ctx.InvocationID())
-							event.Actions.StateDelta = map[string]any{
-								"output": val,
-							}
+							event.Output = val
 							yield(event, nil)
 						}
 					},
@@ -271,12 +265,7 @@ func TestAgentNode_Run(t *testing.T) {
 				}
 				count++
 
-				output, ok := ev.Actions.StateDelta["output"]
-				if !ok {
-					t.Fatal("expected output in state delta")
-				}
-
-				got = tc.extract(t, output)
+				got = tc.extract(t, ev.Output)
 			}
 
 			if tc.wantErr != "" {
@@ -340,9 +329,7 @@ func TestAgentNode_WorkflowIntegration(t *testing.T) {
 						}
 
 						event := session.NewEvent(ctx.InvocationID())
-						event.Actions.StateDelta = map[string]any{
-							"output": map[string]any{"result": val * 2},
-						}
+						event.Output = map[string]any{"result": val * 2}
 						yield(event, nil)
 					}
 				},
@@ -382,10 +369,8 @@ func TestAgentNode_WorkflowIntegration(t *testing.T) {
 					if err != nil {
 						t.Fatalf("workflow failed: %v", err)
 					}
-					if ev.Actions.StateDelta != nil {
-						if out, ok := ev.Actions.StateDelta["output"]; ok {
-							outB = out
-						}
+					if ev.Output != nil {
+						outB = ev.Output
 					}
 				}
 

--- a/workflow/function_node.go
+++ b/workflow/function_node.go
@@ -111,7 +111,6 @@ func (n *FunctionNode) Run(ctx agent.InvocationContext, input any) iter.Seq2[*se
 
 		event := session.NewEvent(ctx.InvocationID())
 		event.Output = output
-		event.Actions.StateDelta["output"] = output
 		if s, ok := output.(string); ok {
 			event.Content = &genai.Content{
 				Parts: []*genai.Part{{Text: s}},

--- a/workflow/function_node_test.go
+++ b/workflow/function_node_test.go
@@ -113,16 +113,7 @@ func TestNewFunctionNodeWithSchema(t *testing.T) {
 					t.Fatal("expected error, got nil")
 				}
 
-				output, ok := ev.Actions.StateDelta["output"]
-				if !ok {
-					t.Fatal("expected output in state delta")
-				}
-
-				if diff := cmp.Diff(output, ev.Output); diff != "" {
-					t.Errorf("ev.Output mismatch (-stateDelta +Output):\n%s", diff)
-				}
-
-				if diff := cmp.Diff(tc.wantOutput, output); diff != "" {
+				if diff := cmp.Diff(tc.wantOutput, ev.Output); diff != "" {
 					t.Errorf("output mismatch (-want +got):\n%s", diff)
 				}
 			}

--- a/workflow/hitl_test.go
+++ b/workflow/hitl_test.go
@@ -219,7 +219,7 @@ func TestScheduler_HitlNode_ConcurrentBranches_PausesOnlyWhenAllNonRunning(t *te
 	})
 	plainNode := newHitlNode("plain", func(ctx agent.InvocationContext, _ any, yield func(*session.Event, error) bool) {
 		ev := session.NewEvent(ctx.InvocationID())
-		ev.Actions.StateDelta["output"] = "done"
+		ev.Output = "done"
 		yield(ev, nil)
 	})
 	plainDownstream := newHitlNode("plain_downstream", func(ctx agent.InvocationContext, _ any, yield func(*session.Event, error) bool) {

--- a/workflow/join_node.go
+++ b/workflow/join_node.go
@@ -45,7 +45,7 @@ func NewJoinNode(name string) *JoinNode {
 func (n *JoinNode) Run(ctx agent.InvocationContext, input any) iter.Seq2[*session.Event, error] {
 	return func(yield func(*session.Event, error) bool) {
 		event := session.NewEvent(ctx.InvocationID())
-		event.Actions.StateDelta["output"] = input
+		event.Output = input
 		yield(event, nil)
 	}
 }

--- a/workflow/join_node_test.go
+++ b/workflow/join_node_test.go
@@ -148,7 +148,7 @@ func TestJoinNode_BarrierSkipsUntilAllPredecessorsComplete(t *testing.T) {
 
 // TestJoinNode_RunIsPassthrough pins the JoinNode contract
 // independently of the engine: given an aggregated input map,
-// the node emits exactly one event whose StateDelta["output"]
+// the node emits exactly one event whose Output
 // equals the input. This is the property the orchestrator relies
 // on when treating JoinNode as a no-op aggregator.
 func TestJoinNode_RunIsPassthrough(t *testing.T) {
@@ -161,12 +161,9 @@ func TestJoinNode_RunIsPassthrough(t *testing.T) {
 	if len(events) != 1 {
 		t.Fatalf("expected 1 event, got %d", len(events))
 	}
-	got, ok := events[0].Actions.StateDelta["output"]
-	if !ok {
-		t.Fatalf("event has no StateDelta[output]; got %#v", events[0].Actions.StateDelta)
-	}
+	got := events[0].Output
 	if !reflect.DeepEqual(got, input) {
-		t.Errorf("StateDelta[output] = %#v, want %#v (verbatim)", got, input)
+		t.Errorf("Output = %#v, want %#v (verbatim)", got, input)
 	}
 }
 

--- a/workflow/retry_loop_test.go
+++ b/workflow/retry_loop_test.go
@@ -40,7 +40,7 @@ func (n *retryLoopTestNode) Run(ctx agent.InvocationContext, input any) iter.Seq
 		calls := n.calls.Add(1)
 
 		// Make 2 failing calls and one successful call in each execution of the node.
-		if calls % 3 != 0 {
+		if calls%3 != 0 {
 			yield(nil, fmt.Errorf("fail attempt %d", calls))
 			return
 		}
@@ -52,7 +52,7 @@ func (n *retryLoopTestNode) Run(ctx agent.InvocationContext, input any) iter.Seq
 		} else {
 			ev.Routes = []string{"loop"}
 		}
-		ev.Actions.StateDelta["output"] = fmt.Sprintf("%v:%s", input, n.Name())
+		ev.Output = fmt.Sprintf("%v:%s", input, n.Name())
 		yield(ev, nil)
 	}
 }
@@ -97,7 +97,7 @@ func TestScheduler_RetryLoop(t *testing.T) {
 
 	wantOutputs := []string{"seed:A", "seed:A:A", "seed:A:A:Finish"}
 	gotOutputs := outputsOf(events)
-	
+
 	if diff := cmp.Diff(wantOutputs, gotOutputs); diff != "" {
 		t.Errorf("outputs mismatch (-want +got):\n%s", diff)
 	}

--- a/workflow/scheduler.go
+++ b/workflow/scheduler.go
@@ -101,7 +101,7 @@ type scheduler struct {
 // the error at completion.
 type nodeRun struct {
 	routingEvent *session.Event        // at most one; multiple is an error
-	output       any                   // single StateDelta["output"]; nil if hasOutput is false
+	output       any                   // single Event.Output; nil if hasOutput is false
 	hasOutput    bool                  // distinguishes "no output yet" from "output was nil"
 	inputRequest *session.RequestInput // at most one human-input request; multiple is an error
 	err          error                 // set on duplicate output, duplicate routing event, or duplicate input request
@@ -432,10 +432,8 @@ func (s *scheduler) handleEvent(it eventItem) {
 	if it.ev.RequestedInput != nil {
 		nr.setInputRequest(it.ev.RequestedInput, it.nodeName)
 	}
-	if it.ev.Actions.StateDelta != nil {
-		if out, ok := it.ev.Actions.StateDelta["output"]; ok {
-			nr.setOutput(out, it.nodeName)
-		}
+	if it.ev.Output != nil {
+		nr.setOutput(it.ev.Output, it.nodeName)
 	}
 }
 

--- a/workflow/scheduler_test.go
+++ b/workflow/scheduler_test.go
@@ -216,7 +216,7 @@ func TestScheduler_NodeTimeout(t *testing.T) {
 }
 
 // TestScheduler_MultipleOutputsFailNode verifies that a node which
-// yields more than one event carrying StateDelta["output"] fails
+// yields more than one event carrying Output fails
 // the workflow with ErrMultipleOutputs (matching adk-python's
 // "single output per node" contract). The first output value is
 // preserved; subsequent ones trip the accumulator error.
@@ -233,7 +233,7 @@ func TestScheduler_MultipleOutputsFailNode(t *testing.T) {
 }
 
 // TestScheduler_ProgressEventsThenSingleOutputSucceed verifies
-// that events with no StateDelta["output"] (progress / status
+// that events with no Output (progress / status
 // events) do not consume the single-output budget. A node may
 // yield many such events followed by exactly one output event
 // without violating the contract.
@@ -251,11 +251,8 @@ func TestScheduler_ProgressEventsThenSingleOutputSucceed(t *testing.T) {
 		t.Fatalf("event count = %d, want %d", got, want)
 	}
 	last := events[len(events)-1]
-	if last.Actions.StateDelta == nil {
-		t.Fatal("last event has nil StateDelta")
-	}
-	if got, want := fmt.Sprint(last.Actions.StateDelta["output"]), "final"; got != want {
-		t.Errorf("last event output = %q, want %q", got, want)
+	if got, want := fmt.Sprint(last.Output), "final"; got != want {
+		t.Errorf("last event Output = %q, want %q", got, want)
 	}
 }
 
@@ -291,17 +288,15 @@ func drainErr(t *testing.T, seq iter.Seq2[*session.Event, error]) error {
 	return firstErr
 }
 
-// outputsOf extracts the StateDelta["output"] string from each event,
+// outputsOf extracts the Output string from each event,
 // sorted to make assertions order-independent across concurrent runs.
 func outputsOf(events []*session.Event) []string {
 	out := make([]string, 0, len(events))
 	for _, ev := range events {
-		if ev == nil || ev.Actions.StateDelta == nil {
+		if ev == nil || ev.Output == nil {
 			continue
 		}
-		if v, ok := ev.Actions.StateDelta["output"]; ok {
-			out = append(out, fmt.Sprint(v))
-		}
+		out = append(out, fmt.Sprint(ev.Output))
 	}
 	sort.Strings(out)
 	return out
@@ -328,7 +323,7 @@ func (n *recordingNode) Run(ctx agent.InvocationContext, input any) iter.Seq2[*s
 		<-n.released
 		ev := session.NewEvent(ctx.InvocationID())
 		out := fmt.Sprintf("%v:%s", input, n.Name())
-		ev.Actions.StateDelta["output"] = out
+		ev.Output = out
 		yield(ev, nil)
 	}
 }
@@ -353,7 +348,7 @@ func (n *blockingNode) Run(ctx agent.InvocationContext, _ any) iter.Seq2[*sessio
 	return func(yield func(*session.Event, error) bool) {
 		n.work()
 		ev := session.NewEvent(ctx.InvocationID())
-		ev.Actions.StateDelta["output"] = n.Name()
+		ev.Output = n.Name()
 		yield(ev, nil)
 	}
 }
@@ -401,7 +396,7 @@ func (n *cancelObservingNode) Run(ctx agent.InvocationContext, _ any) iter.Seq2[
 }
 
 // multiOutputNode yields one event per supplied output value, each
-// carrying StateDelta["output"]. Used to exercise the
+// carrying Output. Used to exercise the
 // single-output-per-node constraint.
 type multiOutputNode struct {
 	BaseNode
@@ -419,7 +414,7 @@ func (n *multiOutputNode) Run(ctx agent.InvocationContext, _ any) iter.Seq2[*ses
 	return func(yield func(*session.Event, error) bool) {
 		for _, out := range n.outputs {
 			ev := session.NewEvent(ctx.InvocationID())
-			ev.Actions.StateDelta["output"] = out
+			ev.Output = out
 			if !yield(ev, nil) {
 				return
 			}
@@ -448,13 +443,12 @@ func (n *progressThenOutputNode) Run(ctx agent.InvocationContext, _ any) iter.Se
 	return func(yield func(*session.Event, error) bool) {
 		for range n.progressCount {
 			ev := session.NewEvent(ctx.InvocationID())
-			// progress event: no StateDelta["output"]
 			if !yield(ev, nil) {
 				return
 			}
 		}
 		final := session.NewEvent(ctx.InvocationID())
-		final.Actions.StateDelta["output"] = n.finalOutput
+		final.Output = n.finalOutput
 		yield(final, nil)
 	}
 }
@@ -487,7 +481,7 @@ func TestScheduler_RetryNode(t *testing.T) {
 		t.Fatalf("expected 1 event, got %d", len(events))
 	}
 
-	out := fmt.Sprint(events[0].Actions.StateDelta["output"])
+	out := fmt.Sprint(events[0].Output)
 	if out != "seed:retryNode" {
 		t.Errorf("output = %q, want %q", out, "seed:retryNode")
 	}
@@ -549,7 +543,7 @@ func (n *retryTestNode) Run(ctx agent.InvocationContext, input any) iter.Seq2[*s
 		}
 		ev := session.NewEvent(ctx.InvocationID())
 		out := fmt.Sprintf("%v:%s", input, n.Name())
-		ev.Actions.StateDelta["output"] = out
+		ev.Output = out
 		yield(ev, nil)
 	}
 }

--- a/workflow/state.go
+++ b/workflow/state.go
@@ -90,7 +90,7 @@ type NodeState struct {
 	Input any `json:"input,omitempty"`
 
 	// Output is the value the node emitted via
-	// Actions.StateDelta["output"]. Set when Status transitions
+	// Event.Output. Set when Status transitions
 	// to NodeCompleted.
 	Output any `json:"output,omitempty"`
 
@@ -105,7 +105,7 @@ type NodeState struct {
 	PendingRequest *session.RequestInput `json:"pendingRequest,omitempty"`
 
 	// Attempt is the number of times this node has been failed.
-	Attempt int `json:"attempt,omitempty"`	
+	Attempt int `json:"attempt,omitempty"`
 
 	// ResumedInputs accumulates response payloads for re-entry-mode
 	// nodes that yield RequestInput more than once during a single

--- a/workflow/tool_node.go
+++ b/workflow/tool_node.go
@@ -136,7 +136,6 @@ func (n *toolNode) Run(ctx agent.InvocationContext, input any) iter.Seq2[*sessio
 		event := session.NewEvent(ctx.InvocationID())
 		event.Actions = *eventActions
 		event.Output = toolOutput
-		event.Actions.StateDelta["output"] = toolOutput
 
 		// If output is a string, set it as content for convenience (similar to FunctionNode).
 		if s, ok := toolOutput.(string); ok {

--- a/workflow/tool_node_test.go
+++ b/workflow/tool_node_test.go
@@ -240,16 +240,7 @@ func TestToolNode_Run(t *testing.T) {
 				}
 				count++
 
-				output, ok := ev.Actions.StateDelta["output"]
-				if !ok {
-					t.Fatal("expected output in state delta")
-				}
-
-				if diff := cmp.Diff(output, ev.Output); diff != "" {
-					t.Errorf("ev.Output mismatch (-stateDelta +Output):\n%s", diff)
-				}
-
-				got = tc.extract(t, output)
+				got = tc.extract(t, ev.Output)
 			}
 
 			if tc.wantErr != "" {
@@ -331,10 +322,8 @@ func TestToolNode_WorkflowIntegration(t *testing.T) {
 					if err != nil {
 						t.Fatalf("workflow failed: %v", err)
 					}
-					if ev.Actions.StateDelta != nil {
-						if out, ok := ev.Actions.StateDelta["output"]; ok {
-							outB = out
-						}
+					if ev.Output != nil {
+						outB = ev.Output
 					}
 				}
 

--- a/workflow/workflow_test.go
+++ b/workflow/workflow_test.go
@@ -109,12 +109,8 @@ func TestFunctionNode(t *testing.T) {
 		}
 		count++
 
-		output, ok := ev.Actions.StateDelta["output"]
-		if !ok {
-			t.Errorf("expected output in state delta")
-		}
-		if output != "HELLO" {
-			t.Errorf("expected output 'HELLO', got %v", output)
+		if ev.Output != "HELLO" {
+			t.Errorf("expected Output 'HELLO', got %v", ev.Output)
 		}
 	}
 
@@ -158,10 +154,8 @@ func TestSequentialWorkflow(t *testing.T) {
 		}
 		count++
 
-		if ev.Actions.StateDelta != nil {
-			if out, ok := ev.Actions.StateDelta["output"]; ok {
-				lastOutput = out
-			}
+		if ev.Output != nil {
+			lastOutput = ev.Output
 		}
 	}
 


### PR DESCRIPTION
# Refactor: Direct Node Output Tracking via Event.Output

## Summary
This PR refactors the workflow execution framework to track and retrieve node outputs directly through the dedicated `Event.Output` field, rather than storing it as an entry in `Event.Actions.StateDelta["output"]`.

## Changes

### Core Refactoring
- **`workflow/scheduler.go`**: Updated `handleEvent` to retrieve node outputs directly from `Event.Output` instead of querying `Event.Actions.StateDelta["output"]`.
- **`workflow/function_node.go` & `workflow/tool_node.go`**: Removed the logic that replicates outputs into `event.Actions.StateDelta["output"]`, fully migrating to the `event.Output` assignment.

### Test Modifications
Updated mock nodes, helpers, and test suites to assert and assign values via `event.Output`:
- **`workflow/*_test.go`**: Updated `TestScheduler_*`, `TestToolNode_*`, `TestFunctionNode`, `TestSequentialWorkflow`, and test nodes (e.g., `recordingNode`, `multiOutputNode`, `progressThenOutputNode`) to use `ev.Output`.
- **`agent/workflowagent/*_test.go`**: Adjusted state assertions and simulated node handlers within `reentry_test.go` and `workflow_test.go` to verify `Output` directly.

## Verification
- Verified that all tests in the workspace compile and pass:
  ```bash
  go test ./...
