### PR TITLE
feat: adka2a structured error propagation

### DIFF
--- a/agent/remoteagent/v2/a2a_e2e_test.go
+++ b/agent/remoteagent/v2/a2a_e2e_test.go
@@ -1199,3 +1199,53 @@ func TestA2AMultiHopInputRequiredCancellation(t *testing.T) {
 		t.Fatalf("remoteTask.Status.State = %q, want %q", remoteTask.Status.State, a2a.TaskStateCanceled)
 	}
 }
+
+func TestA2AMultiHopStructuredErrorPropagation(t *testing.T) {
+	// Server B with structured error serialization logic
+	structuredErr := a2a.NewDataPart(map[string]any{"error_type": "auth_required"})
+	serverB := startA2AServer(adka2a.NewExecutor(adka2a.ExecutorConfig{
+		RunnerConfig: runner.Config{
+			AppName: "broken",
+			Agent: utils.Must(agent.New(agent.Config{
+				Name: "broken",
+				Run: func(ic agent.InvocationContext) iter.Seq2[*session.Event, error] {
+					return func(yield func(*session.Event, error) bool) {
+						yield(nil, a2a.ErrUnauthorized)
+					}
+				},
+			})),
+			SessionService: session.InMemoryService(),
+		},
+		AfterExecuteCallback: func(ctx adka2a.ExecutorContext, finalEvent *a2a.TaskStatusUpdateEvent, err error) error {
+			if errors.Is(err, a2a.ErrUnauthorized) {
+				finalEvent.Status.Message = a2a.NewMessage(a2a.MessageRoleAgent, structuredErr)
+			}
+			return nil
+		},
+	}))
+	defer serverB.Close()
+
+	// Server A, default configuration
+	remoteAgent := newA2ARemoteAgent(t, "broken-remote", serverB)
+	rootAgent := newRootAgent("root", remoteAgent)
+	executorA := newAgentExecutor(rootAgent, nil, adka2a.OutputArtifactPerRun)
+	serverA := startA2AServer(executorA)
+	defer serverA.Close()
+
+	// Send message
+	clientA := newA2AClient(t, serverA)
+	msg1 := a2a.NewMessage(a2a.MessageRoleUser, a2a.NewTextPart("Hello"))
+	task1 := mustSendMessage(t, clientA, msg1)
+	if task1.Status.State != a2a.TaskStateFailed {
+		t.Fatalf("task1.Status.State = %q, want %q", task1.Status.State, a2a.TaskStateFailed)
+	}
+	if len(task1.Status.Message.Parts) != 2 {
+		t.Fatalf("len(task1.Status.Message.Parts) = %d, want len([error text, extra parts]) = 2", len(task1.Status.Message.Parts))
+	}
+	if !strings.Contains(task1.Status.Message.Parts[0].Text(), "a2a task failed") {
+		t.Fatalf("status.Message.Parts[0].Text() = %s, want contain %q", task1.Status.Message.Parts[0].Text(), "a2a task failed")
+	}
+	if diff := cmp.Diff(task1.Status.Message.Parts[1].Data(), structuredErr.Data()); diff != "" {
+		t.Fatalf("wrong structured error part (-want,+got):\n%s", diff)
+	}
+}

--- a/agent/remoteagent/v2/a2a_e2e_test.go
+++ b/agent/remoteagent/v2/a2a_e2e_test.go
@@ -1218,7 +1218,7 @@ func TestA2AMultiHopStructuredErrorPropagation(t *testing.T) {
 		},
 		AfterExecuteCallback: func(ctx adka2a.ExecutorContext, finalEvent *a2a.TaskStatusUpdateEvent, err error) error {
 			if errors.Is(err, a2a.ErrUnauthorized) {
-				finalEvent.Status.Message = a2a.NewMessage(a2a.MessageRoleAgent, structuredErr)
+				finalEvent.Status.Message.Parts = append(finalEvent.Status.Message.Parts, structuredErr)
 			}
 			return nil
 		},
@@ -1242,8 +1242,8 @@ func TestA2AMultiHopStructuredErrorPropagation(t *testing.T) {
 	if len(task1.Status.Message.Parts) != 2 {
 		t.Fatalf("len(task1.Status.Message.Parts) = %d, want len([error text, extra parts]) = 2", len(task1.Status.Message.Parts))
 	}
-	if !strings.Contains(task1.Status.Message.Parts[0].Text(), "a2a task failed") {
-		t.Fatalf("status.Message.Parts[0].Text() = %s, want contain %q", task1.Status.Message.Parts[0].Text(), "a2a task failed")
+	if !strings.Contains(task1.Status.Message.Parts[0].Text(), a2a.ErrUnauthorized.Error()) {
+		t.Fatalf("status.Message.Parts[0].Text() = %s, want contain %q", task1.Status.Message.Parts[0].Text(), a2a.ErrUnauthorized.Error())
 	}
 	if diff := cmp.Diff(task1.Status.Message.Parts[1].Data(), structuredErr.Data()); diff != "" {
 		t.Fatalf("wrong structured error part (-want,+got):\n%s", diff)

--- a/server/adka2a/v2/events.go
+++ b/server/adka2a/v2/events.go
@@ -410,6 +410,6 @@ func convertStatusMessage(ctx agent.InvocationContext, event a2a.Event, status a
 	return &convertedStatusMessage{
 		errorMessage:       errMessage,
 		parts:              filterNilParts(convertedParts),
-		longRunningToolIDs: getLongRunningToolIDs(status.Message.Parts, convertedParts),
+		longRunningToolIDs: getLongRunningToolIDs(parts, convertedParts),
 	}, nil
 }

--- a/server/adka2a/v2/events.go
+++ b/server/adka2a/v2/events.go
@@ -394,7 +394,7 @@ func convertStatusMessage(ctx agent.InvocationContext, event a2a.Event, status a
 	}
 	errMessage := ""
 	parts := status.Message.Parts
-	if len(parts) > 0 && parts[0].Text() != "" {
+	if status.State == a2a.TaskStateFailed && len(parts) > 0 && parts[0].Text() != "" {
 		errMessage = parts[0].Text()
 
 		isErrMessage, _ := parts[0].Metadata[metadataIsErrMessageKey].(bool)

--- a/server/adka2a/v2/events.go
+++ b/server/adka2a/v2/events.go
@@ -254,20 +254,19 @@ func taskToEvent(ctx agent.InvocationContext, task *a2a.Task, partConverter A2AP
 
 	event := NewRemoteAgentEvent(ctx)
 
-	if task.Status.Message != nil {
-		allMsgParts, err := convertParts(ctx, task, task.Status.Message.Parts, partConverter)
-		if err != nil {
-			return nil, fmt.Errorf("failed to convert status message parts: %w", err)
-		}
-		lrtIDs := getLongRunningToolIDs(task.Status.Message.Parts, allMsgParts)
-		msgParts := filterNilParts(allMsgParts)
+	convertedStatusMsg, err := convertStatusMessage(ctx, task, task.Status, partConverter)
+	if err != nil {
+		return nil, err
+	}
+	parts = append(parts, convertedStatusMsg.parts...)
+	longRunningToolIDs = append(longRunningToolIDs, convertedStatusMsg.longRunningToolIDs...)
 
-		if task.Status.State == a2a.TaskStateFailed && len(msgParts) == 1 && msgParts[0].Text != "" {
-			event.ErrorMessage = msgParts[0].Text
+	if task.Status.State == a2a.TaskStateFailed {
+		if convertedStatusMsg.errorMessage != "" {
+			event.ErrorMessage = convertedStatusMsg.errorMessage
 		} else {
-			parts = append(parts, msgParts...)
+			event.ErrorMessage = "a2a task failed"
 		}
-		longRunningToolIDs = append(longRunningToolIDs, lrtIDs...)
 	}
 
 	isTerminal := task.Status.State.Terminal() || task.Status.State == a2a.TaskStateInputRequired
@@ -294,25 +293,25 @@ func finalTaskStatusUpdateToEvent(ctx agent.InvocationContext, update *a2a.TaskS
 
 	event := NewRemoteAgentEvent(ctx)
 
-	var allParts []*genai.Part
-	var err error
-	if update.Status.Message != nil {
-		allParts, err = convertParts(ctx, update, update.Status.Message.Parts, partConverter)
-		if err != nil {
-			return nil, fmt.Errorf("failed to convert status message parts: %w", err)
+	convertedStatusMsg, err := convertStatusMessage(ctx, update, update.Status, partConverter)
+	if err != nil {
+		return nil, err
+	}
+	if len(convertedStatusMsg.parts) > 0 {
+		event.Content = genai.NewContentFromParts(convertedStatusMsg.parts, genai.RoleModel)
+	}
+	event.LongRunningToolIDs = convertedStatusMsg.longRunningToolIDs
+
+	if update.Status.State == a2a.TaskStateFailed {
+		if convertedStatusMsg.errorMessage != "" {
+			event.ErrorMessage = convertedStatusMsg.errorMessage
+		} else {
+			event.ErrorMessage = "a2a task failed"
 		}
 	}
-	parts := filterNilParts(allParts)
-	if update.Status.State == a2a.TaskStateFailed && len(parts) == 1 && parts[0].Text != "" {
-		event.ErrorMessage = parts[0].Text
-	} else if len(parts) > 0 {
-		event.Content = genai.NewContentFromParts(parts, genai.RoleModel)
-	}
+
 	if err := processA2AMeta(update, event); err != nil {
 		return nil, fmt.Errorf("metadata processing failed: %w", err)
-	}
-	if update.Status.Message != nil {
-		event.LongRunningToolIDs = getLongRunningToolIDs(update.Status.Message.Parts, allParts)
 	}
 	event.TurnComplete = true
 	return event, nil
@@ -381,4 +380,36 @@ func filterNilParts(parts []*genai.Part) []*genai.Part {
 		}
 	}
 	return result
+}
+
+type convertedStatusMessage struct {
+	errorMessage       string
+	parts              []*genai.Part
+	longRunningToolIDs []string
+}
+
+func convertStatusMessage(ctx agent.InvocationContext, event a2a.Event, status a2a.TaskStatus, partConverter A2APartConverter) (*convertedStatusMessage, error) {
+	if status.Message == nil {
+		return &convertedStatusMessage{}, nil
+	}
+	errMessage := ""
+	parts := status.Message.Parts
+	if len(parts) > 0 && parts[0].Text() != "" {
+		errMessage = parts[0].Text()
+
+		isErrMessage, _ := parts[0].Metadata[metadataIsErrMessageKey].(bool)
+		if isErrMessage {
+			parts = parts[1:]
+		}
+	}
+
+	convertedParts, err := convertParts(ctx, event, parts, partConverter)
+	if err != nil {
+		return nil, fmt.Errorf("failed to convert status message parts: %w", err)
+	}
+	return &convertedStatusMessage{
+		errorMessage:       errMessage,
+		parts:              filterNilParts(convertedParts),
+		longRunningToolIDs: getLongRunningToolIDs(status.Message.Parts, convertedParts),
+	}, nil
 }

--- a/server/adka2a/v2/events_test.go
+++ b/server/adka2a/v2/events_test.go
@@ -611,7 +611,7 @@ func TestToSessionEvent(t *testing.T) {
 				TaskID:    taskID,
 				ContextID: contextID,
 				Status: a2a.TaskStatus{
-					State: a2a.TaskStateInputRequired,
+					State: a2a.TaskStateFailed,
 					Message: a2a.NewMessage(a2a.MessageRoleAgent,
 						&a2a.Part{Content: a2a.Text("requesting input"), Metadata: map[string]any{metadataIsErrMessageKey: true}},
 						func() *a2a.Part {
@@ -627,6 +627,7 @@ func TestToSessionEvent(t *testing.T) {
 					Content: genai.NewContentFromParts([]*genai.Part{
 						{FunctionCall: &genai.FunctionCall{ID: "tool_lr", Name: "LongRunning", Args: map[string]any{}}},
 					}, genai.RoleModel),
+					ErrorMessage:   "requesting input",
 					CustomMetadata: map[string]any{customMetaTaskIDKey: string(taskID), customMetaContextIDKey: contextID},
 					TurnComplete:   true,
 				},

--- a/server/adka2a/v2/events_test.go
+++ b/server/adka2a/v2/events_test.go
@@ -419,6 +419,7 @@ func TestToSessionEvent(t *testing.T) {
 			},
 			want: &session.Event{
 				LLMResponse: model.LLMResponse{
+					Content:      genai.NewContentFromParts([]*genai.Part{genai.NewPartFromText("failed with an error")}, genai.RoleModel),
 					ErrorMessage: "failed with an error",
 					CustomMetadata: map[string]any{
 						customMetaTaskIDKey:    string(taskID),
@@ -483,7 +484,7 @@ func TestToSessionEvent(t *testing.T) {
 			},
 		},
 		{
-			name: "task with single-part text status",
+			name: "failed task with single-part text status",
 			input: &a2a.Task{
 				ID:        taskID,
 				ContextID: contextID,
@@ -494,7 +495,109 @@ func TestToSessionEvent(t *testing.T) {
 			},
 			want: &session.Event{
 				LLMResponse: model.LLMResponse{
+					Content:        genai.NewContentFromParts([]*genai.Part{genai.NewPartFromText("failed with an error")}, genai.RoleModel),
 					ErrorMessage:   "failed with an error",
+					CustomMetadata: map[string]any{customMetaTaskIDKey: string(taskID), customMetaContextIDKey: contextID},
+					TurnComplete:   true,
+				},
+				Author: agentName,
+				Branch: branch,
+			},
+		},
+		{
+			name: "completed task with single-part text status",
+			input: &a2a.Task{
+				ID:        taskID,
+				ContextID: contextID,
+				Status: a2a.TaskStatus{
+					State:   a2a.TaskStateCompleted,
+					Message: &a2a.Message{Parts: a2a.ContentParts{a2a.NewTextPart("failed with an error")}},
+				},
+			},
+			want: &session.Event{
+				LLMResponse: model.LLMResponse{
+					Content:        genai.NewContentFromParts([]*genai.Part{genai.NewPartFromText("failed with an error")}, genai.RoleModel),
+					CustomMetadata: map[string]any{customMetaTaskIDKey: string(taskID), customMetaContextIDKey: contextID},
+					TurnComplete:   true,
+				},
+				Author: agentName,
+				Branch: branch,
+			},
+		},
+		{
+			name: "failed task with a multi-part status",
+			input: &a2a.Task{
+				ID:        taskID,
+				ContextID: contextID,
+				Status: a2a.TaskStatus{
+					State: a2a.TaskStateFailed,
+					Message: a2a.NewMessage(a2a.MessageRoleAgent,
+						a2a.NewTextPart("failed with an error"),
+						a2a.NewTextPart("extra details"),
+					),
+				},
+			},
+			want: &session.Event{
+				LLMResponse: model.LLMResponse{
+					ErrorMessage: "failed with an error",
+					Content: genai.NewContentFromParts([]*genai.Part{
+						genai.NewPartFromText("failed with an error"),
+						genai.NewPartFromText("extra details"),
+					}, genai.RoleModel),
+					CustomMetadata: map[string]any{customMetaTaskIDKey: string(taskID), customMetaContextIDKey: contextID},
+					TurnComplete:   true,
+				},
+				Author: agentName,
+				Branch: branch,
+			},
+		},
+		{
+			name: "failed task status with a multi-part status",
+			input: &a2a.TaskStatusUpdateEvent{
+				TaskID:    taskID,
+				ContextID: contextID,
+				Status: a2a.TaskStatus{
+					State: a2a.TaskStateFailed,
+					Message: a2a.NewMessage(a2a.MessageRoleAgent,
+						a2a.NewTextPart("failed with an error"),
+						a2a.NewDataPart(map[string]any{"structured": true}),
+					),
+				},
+			},
+			want: &session.Event{
+				LLMResponse: model.LLMResponse{
+					ErrorMessage: "failed with an error",
+					Content: genai.NewContentFromParts([]*genai.Part{
+						genai.NewPartFromText("failed with an error"),
+						{InlineData: &genai.Blob{
+							Data:     []byte(`<a2a_datapart_json>{"structured":true}</a2a_datapart_json>`),
+							MIMEType: "text/plain",
+						}},
+					}, genai.RoleModel),
+					CustomMetadata: map[string]any{customMetaTaskIDKey: string(taskID), customMetaContextIDKey: contextID},
+					TurnComplete:   true,
+				},
+				Author: agentName,
+				Branch: branch,
+			},
+		},
+		{
+			name: "failed task status metadataIsErrMessageKey not in content",
+			input: &a2a.TaskStatusUpdateEvent{
+				TaskID:    taskID,
+				ContextID: contextID,
+				Status: a2a.TaskStatus{
+					State: a2a.TaskStateFailed,
+					Message: a2a.NewMessage(a2a.MessageRoleAgent,
+						&a2a.Part{Content: a2a.Text("failed with an error"), Metadata: map[string]any{metadataIsErrMessageKey: true}},
+						a2a.NewTextPart("extra details"),
+					),
+				},
+			},
+			want: &session.Event{
+				LLMResponse: model.LLMResponse{
+					ErrorMessage:   "failed with an error",
+					Content:        genai.NewContentFromParts([]*genai.Part{genai.NewPartFromText("extra details")}, genai.RoleModel),
 					CustomMetadata: map[string]any{customMetaTaskIDKey: string(taskID), customMetaContextIDKey: contextID},
 					TurnComplete:   true,
 				},

--- a/server/adka2a/v2/events_test.go
+++ b/server/adka2a/v2/events_test.go
@@ -605,6 +605,36 @@ func TestToSessionEvent(t *testing.T) {
 				Branch: branch,
 			},
 		},
+		{
+			name: "input-required task status with err message and long-running tool",
+			input: &a2a.TaskStatusUpdateEvent{
+				TaskID:    taskID,
+				ContextID: contextID,
+				Status: a2a.TaskStatus{
+					State: a2a.TaskStateInputRequired,
+					Message: a2a.NewMessage(a2a.MessageRoleAgent,
+						&a2a.Part{Content: a2a.Text("requesting input"), Metadata: map[string]any{metadataIsErrMessageKey: true}},
+						func() *a2a.Part {
+							p := a2a.NewDataPart(map[string]any{"id": "tool_lr", "name": "LongRunning", "args": map[string]any{}})
+							p.Metadata = map[string]any{a2aDataPartMetaTypeKey: a2aDataPartTypeFunctionCall, a2aDataPartMetaLongRunningKey: true}
+							return p
+						}(),
+					),
+				},
+			},
+			want: &session.Event{
+				LLMResponse: model.LLMResponse{
+					Content: genai.NewContentFromParts([]*genai.Part{
+						{FunctionCall: &genai.FunctionCall{ID: "tool_lr", Name: "LongRunning", Args: map[string]any{}}},
+					}, genai.RoleModel),
+					CustomMetadata: map[string]any{customMetaTaskIDKey: string(taskID), customMetaContextIDKey: contextID},
+					TurnComplete:   true,
+				},
+				LongRunningToolIDs: []string{"tool_lr"},
+				Author:             agentName,
+				Branch:             branch,
+			},
+		},
 	}
 
 	ignoreFields := []cmp.Option{

--- a/server/adka2a/v2/executor_test.go
+++ b/server/adka2a/v2/executor_test.go
@@ -111,7 +111,10 @@ func TestExecutor_Execute(t *testing.T) {
 			wantEvents: []a2a.Event{
 				newFinalStatusUpdate(
 					task, a2a.TaskStateFailed,
-					a2a.NewMessageForTask(a2a.MessageRoleAgent, task, a2a.NewTextPart("failed to create a session: session creation failed")),
+					a2a.NewMessageForTask(a2a.MessageRoleAgent, task, &a2a.Part{
+						Content:  a2a.Text("failed to create a session: session creation failed"),
+						Metadata: map[string]any{metadataIsErrMessageKey: true},
+					}),
 				),
 			},
 		},
@@ -180,7 +183,10 @@ func TestExecutor_Execute(t *testing.T) {
 				a2a.NewArtifactEvent(task, a2a.NewTextPart("Hello")),
 				newFinalStatusUpdate(
 					task, a2a.TaskStateFailed,
-					a2a.NewMessageForTask(a2a.MessageRoleAgent, task, a2a.NewTextPart("agent run failed: OOF")),
+					a2a.NewMessageForTask(a2a.MessageRoleAgent, task, &a2a.Part{
+						Content:  a2a.Text("agent run failed: OOF"),
+						Metadata: map[string]any{metadataIsErrMessageKey: true},
+					}),
 				),
 			},
 		},

--- a/server/adka2a/v2/metadata.go
+++ b/server/adka2a/v2/metadata.go
@@ -37,6 +37,7 @@ var (
 	metadataUsageKey           = ToA2AMetaKey("usage_metadata")
 	metadataCustomMetaKey      = ToA2AMetaKey("custom_metadata")
 	metadataPartialKey         = ToA2AMetaKey("partial")
+	metadataIsErrMessageKey    = ToA2AMetaKey("is_error_message")
 )
 
 // ToA2AMetaKey adds a prefix used to differentiate ADK-related values stored in Metadata an A2A event.

--- a/server/adka2a/v2/processor.go
+++ b/server/adka2a/v2/processor.go
@@ -185,9 +185,8 @@ func toTaskFailedUpdateEvent(task a2a.TaskInfoProvider, cause error, meta map[st
 }
 
 func errorFromResponse(resp *model.LLMResponse) error {
-	if resp.ErrorCode != "" {
-		return fmt.Errorf("llm error response (code %s): %q", resp.ErrorCode, resp.ErrorMessage)
-	} else {
+	if resp.ErrorCode == "" {
 		return fmt.Errorf("llm error response: %q", resp.ErrorMessage)
 	}
+	return fmt.Errorf("llm error response (code %s): %q", resp.ErrorCode, resp.ErrorMessage)
 }

--- a/server/adka2a/v2/processor.go
+++ b/server/adka2a/v2/processor.go
@@ -81,17 +81,6 @@ func (p *eventProcessor) process(ctx context.Context, event *session.Event) (*a2
 		return nil, err
 	}
 
-	resp := event.LLMResponse
-	if resp.ErrorCode != "" || resp.ErrorMessage != "" {
-		// TODO(yarolegovich): consider merging responses if multiple errors can be produced during an invocation
-		if p.failedEvent == nil {
-			// terminal event might add additional keys to its metadata when it's dispatched and these changes should
-			// not be reflected in this event's metadata
-			terminalEventMeta := maps.Clone(eventMeta)
-			p.failedEvent = toTaskFailedUpdateEvent(p.reqCtx, errorFromResponse(&resp), terminalEventMeta)
-		}
-	}
-
 	event, err = p.inputRequiredProcessor.process(ctx, event)
 	if err != nil {
 		return nil, fmt.Errorf("input required processing failed: %w", err)
@@ -101,10 +90,22 @@ func (p *eventProcessor) process(ctx context.Context, event *session.Event) (*a2
 	if err != nil {
 		return nil, err
 	}
+
+	resp := event.LLMResponse
+	if resp.ErrorCode != "" || resp.ErrorMessage != "" {
+		// TODO(yarolegovich): consider merging responses if multiple errors can be produced during an invocation
+		if p.failedEvent == nil {
+			// terminal event might add additional keys to its metadata when it's dispatched and these changes should
+			// not be reflected in this event's metadata
+			terminalEventMeta := maps.Clone(eventMeta)
+			p.failedEvent = toTaskFailedUpdateEvent(p.reqCtx, errorFromResponse(&resp), terminalEventMeta)
+			p.failedEvent.Status.Message.Parts = append(p.failedEvent.Status.Message.Parts, parts...)
+		}
+	}
+
 	if len(parts) == 0 {
 		return nil, nil
 	}
-
 	result, err := p.eventToArtifact.transform(event, parts, eventMeta)
 	if err != nil {
 		return nil, err
@@ -175,12 +176,18 @@ func (p *eventProcessor) convertParts(ctx context.Context, event *session.Event)
 }
 
 func toTaskFailedUpdateEvent(task a2a.TaskInfoProvider, cause error, meta map[string]any) *a2a.TaskStatusUpdateEvent {
-	msg := a2a.NewMessageForTask(a2a.MessageRoleAgent, task, a2a.NewTextPart(cause.Error()))
+	msgPart := a2a.NewTextPart(cause.Error())
+	msgPart.Metadata = map[string]any{metadataIsErrMessageKey: true}
+	msg := a2a.NewMessageForTask(a2a.MessageRoleAgent, task, msgPart)
 	ev := a2a.NewStatusUpdateEvent(task, a2a.TaskStateFailed, msg)
 	ev.Metadata = meta
 	return ev
 }
 
 func errorFromResponse(resp *model.LLMResponse) error {
-	return fmt.Errorf("llm error response: %q", resp.ErrorMessage)
+	if resp.ErrorCode != "" {
+		return fmt.Errorf("llm error response (code %s): %q", resp.ErrorCode, resp.ErrorMessage)
+	} else {
+		return fmt.Errorf("llm error response: %q", resp.ErrorMessage)
+	}
 }

--- a/server/agentengine/internal/helper/encode.go
+++ b/server/agentengine/internal/helper/encode.go
@@ -145,7 +145,7 @@ func convertSnake(path, indent string, o any) (any, error) {
 			return map[string]any{}, nil
 		}
 		return res, nil
-	case reflect.Ptr:
+	case reflect.Pointer:
 		if v.IsNil() {
 			return nil, nil
 		}


### PR DESCRIPTION
These was no way to propagate structured errors to clients using adka2a integration. The logic was relying only on `ErrorMessage`, meaning only text could be passed down to the caller.

This PR changes it such that `ErrorMessage` gets put as the first Status.Message text part to preserve backward compatibility and additionally all event content parts get appended to the list of parts. A metadata flag is introduced to mark this error and differentiate it from content parts. 

Now developers can implement an `AfterExecuteCallback` which will convert an error to a structured format and it will propagate in Status.Message to the original client.