### PR TITLE
fix: align WorkflowInputFunctionCallName with adk-python

### DIFF
--- a/workflow/request_input.go
+++ b/workflow/request_input.go
@@ -28,7 +28,12 @@ import (
 // by-ID dispatch can route the user's follow-up reply back to the
 // workflow agent that issued the request. Mirrors
 // toolconfirmation.FunctionCallName.
-const WorkflowInputFunctionCallName = "adk_request_workflow_input"
+//
+// This is a wire-format identifier shared with other ADK runtimes
+// and must not be changed without coordinated updates across them;
+// a session recorded by one runtime must round-trip through any
+// other runtime's resume dispatch.
+const WorkflowInputFunctionCallName = "adk_request_input"
 
 // NewRequestInputEvent constructs a session.Event that asks the
 // surrounding workflow to pause and surface a human-input prompt.


### PR DESCRIPTION
The Go workflow runtime synthesises a FunctionCall part on every RequestInput event so the generic FunctionResponse-by-ID dispatch can route the user's follow-up reply back to the agent that issued the request. The synthesised call's Name was 'adk_request_workflow_input'.

adk-python uses 'adk_request_input' for the equivalent constant (REQUEST_INPUT_FUNCTION_CALL_NAME in
google/adk/workflow/utils/_workflow_hitl_utils.py). The divergence broke cross-runtime HITL workflows: a session recorded by Python (with function_call.name='adk_request_input' in the interrupt event) could not be replayed in Go, because Go-side conformance compare would see 'adk_request_workflow_input' and flag the mismatch. The reverse direction is broken too — a function_response addressed by name to 'adk_request_input' from a Python-authored spec.yaml could not be routed to a Go workflow agent's pending interrupt.


Discovered while preparing the first cross-language conformance test for graph-based Workflow + HITL.
