### PR TITLE
Drop trailing stale function responses

### DIFF
--- a/internal/llminternal/contents_processor.go
+++ b/internal/llminternal/contents_processor.go
@@ -295,10 +295,10 @@ SearchLoop: // A label to allow breaking out of the nested loop
 	}
 
 	if functionCallEventIdx == -1 {
-		return nil, fmt.Errorf(
-			"no function call event found for function responses ids: %v",
-			responseIDs,
-		)
+		// The latest response can be a stale client retry after a reconnect or
+		// session restart. Drop only that trailing orphan so earlier valid
+		// history remains usable.
+		return events[:len(events)-1], nil
 	}
 
 	// Collect function response events related to the matching call while

--- a/internal/llminternal/contents_processor_test.go
+++ b/internal/llminternal/contents_processor_test.go
@@ -1338,13 +1338,26 @@ func TestContentsRequestProcessor_Rearrange(t *testing.T) {
 			},
 		},
 		{
-			name: "Error on function response without matching call",
+			name: "Drop trailing orphaned function response after user message",
 			events: []*session.Event{
 				{Author: "user", LLMResponse: model.LLMResponse{Content: &genai.Content{Role: "user", Parts: []*genai.Part{{Text: "Regular message"}}}}},
 				{Author: "user", LLMResponse: model.LLMResponse{Content: &genai.Content{Role: "user", Parts: []*genai.Part{{FunctionResponse: frOrphaned}}}}},
 			},
-			want:    nil,
-			wantErr: "no function call event found",
+			want: []*genai.Content{
+				genai.NewContentFromText("Regular message", "user"),
+			},
+		},
+		{
+			name: "Drop trailing orphaned function response after model reply",
+			events: []*session.Event{
+				{Author: "user", LLMResponse: model.LLMResponse{Content: genai.NewContentFromText("Start", "user")}},
+				{Author: agentName, LLMResponse: model.LLMResponse{Content: genai.NewContentFromText("Ready", "model")}},
+				{Author: "user", LLMResponse: model.LLMResponse{Content: &genai.Content{Role: "user", Parts: []*genai.Part{{FunctionResponse: frOrphaned}}}}},
+			},
+			want: []*genai.Content{
+				genai.NewContentFromText("Start", "user"),
+				genai.NewContentFromText("Ready", "model"),
+			},
 		},
 	}
 


### PR DESCRIPTION
Fixes #760.

## What changed
- When the latest event is an orphaned function response with no matching function call in history, drop only that trailing stale response instead of failing content construction.
- Preserve earlier valid user/model history so the next turn can continue after a retry, reconnect, or session restart.
- Add regression coverage for stale trailing function responses after a user message and after a model reply.

## Why
A replayed stale tool result can leave a dangling function response at the end of session history. Treating that as fatal makes otherwise valid session history unusable, even though the stale response can be safely ignored.

## Validation
- go test ./internal/llminternal
- go test ./internal/llminternal ./agent/llmagent