### PR TITLE
fix: avoid nil run config panic in callLLM

### DIFF
--- a/internal/llminternal/base_flow.go
+++ b/internal/llminternal/base_flow.go
@@ -778,7 +778,8 @@ func (f *Flow) callLLM(ctx agent.InvocationContext, req *model.LLMRequest, state
 		// to help with slicing the billing reports on a per-agent basis.
 
 		// TODO: RunLive mode when invocation_context.run_config.support_cfc is true.
-		useStream := runconfig.FromContext(ctx).StreamingMode == runconfig.StreamingModeSSE
+		runCfg := ctx.RunConfig()
+		useStream := runCfg != nil && runCfg.StreamingMode == agent.StreamingModeSSE
 
 		for resp, err := range generateContent(ctx, f.Model, req, useStream) {
 			if err != nil {

--- a/internal/llminternal/base_flow_test.go
+++ b/internal/llminternal/base_flow_test.go
@@ -15,7 +15,9 @@
 package llminternal
 
 import (
+	"context"
 	"errors"
+	"iter"
 	"testing"
 
 	"github.com/google/go-cmp/cmp"
@@ -769,5 +771,33 @@ func TestIsThoughtOnlyTurn(t *testing.T) {
 				t.Errorf("isThoughtOnlyTurn = %v, want %v", got, tc.want)
 			}
 		})
+	}
+}
+
+func TestCallLLMUsesInvocationRunConfig(t *testing.T) {
+	var gotStream bool
+	f := &Flow{
+		Model: &mockModelForTest{
+			name: "test-model",
+			generateContent: func(_ context.Context, _ *model.LLMRequest, stream bool) iter.Seq2[*model.LLMResponse, error] {
+				gotStream = stream
+				return func(yield func(*model.LLMResponse, error) bool) {
+					yield(&model.LLMResponse{}, nil)
+				}
+			},
+		},
+	}
+	ctx := icontext.NewInvocationContext(t.Context(), icontext.InvocationContextParams{
+		RunConfig: &agent.RunConfig{StreamingMode: agent.StreamingModeSSE},
+	})
+
+	for _, err := range f.callLLM(ctx, &model.LLMRequest{}, nil, nil) {
+		if err != nil {
+			t.Fatalf("callLLM() error = %v", err)
+		}
+	}
+
+	if !gotStream {
+		t.Fatal("callLLM() did not use streaming mode from InvocationContext.RunConfig()")
 	}
 }


### PR DESCRIPTION
Fixes #586.

## What changed
- Read streaming mode for regular LLM calls from `InvocationContext.RunConfig()` instead of directly dereferencing the internal runconfig context value.
- Treat a missing run config as non-streaming.
- Add a regression test covering SSE mode when no internal runconfig value is installed on the context.

## Why
Custom `agent.InvocationContext` implementations can provide `RunConfig()` without also carrying the internal runconfig context value. The old code dereferenced `runconfig.FromContext(ctx)` directly and could panic before the model call.

## Validation
- `go test ./internal/llminternal -run 'TestCallLLMUsesInvocationRunConfig|TestPreprocess_Toolset'`\n- `go test ./internal/llminternal ./agent/llmagent`\n- `git diff --check`