### PR TITLE
Wait for tool confirmation before sending responses

### DIFF
--- a/agent/remoteagent/v2/a2a_e2e_test.go
+++ b/agent/remoteagent/v2/a2a_e2e_test.go
@@ -113,14 +113,6 @@ func TestA2AInputRequired(t *testing.T) {
 					p.SetMeta(adka2a.ToA2AMetaKey("type"), "function_call")
 					return p
 				}(),
-				func() *a2a.Part {
-					p := a2a.NewDataPart(map[string]any{
-						"name":     approvalToolName,
-						"response": map[string]any{"status": string(approvalStatusPending)},
-					})
-					p.SetMeta(adka2a.ToA2AMetaKey("type"), "function_response")
-					return p
-				}(),
 			},
 			wantSecondArtifactParts: a2a.ContentParts{
 				func() *a2a.Part {
@@ -289,7 +281,6 @@ func TestA2AMultiHopInputRequired(t *testing.T) {
 				genai.NewPartFromFunctionResponse(transferToolName, nil),
 				genai.NewPartFromText(modelTextRequiresApproval),
 				genai.NewPartFromFunctionCall(approvalToolName, nil),
-				genai.NewPartFromFunctionResponse(approvalToolName, map[string]any{"status": string(approvalStatusPending)}),
 			}, []string{}),
 			wantSecondArtifactParts: a2a.ContentParts{
 				func() *a2a.Part {

--- a/internal/llminternal/base_flow.go
+++ b/internal/llminternal/base_flow.go
@@ -652,17 +652,23 @@ func (f *Flow) runOneStep(ctx agent.InvocationContext) iter.Seq2[*session.Event,
 			}
 
 			toolConfirmationEvent := generateRequestConfirmationEvent(ctx, modelResponseEvent, ev)
-
-			// Yield function responses before confirmation requests so consumers that
-			// pause for user approval still persist completed tool results.
-			if !yield(ev, nil) {
-				return
-			}
-
 			if toolConfirmationEvent != nil {
+				ev = removeRequestedConfirmationResponses(ev)
+				if ev != nil {
+					// Keep completed tool responses, but do not send placeholder
+					// responses for tool calls that still need user confirmation.
+					if !yield(ev, nil) {
+						return
+					}
+				}
 				if !yield(toolConfirmationEvent, nil) {
 					return
 				}
+				if ev == nil {
+					return
+				}
+			} else if !yield(ev, nil) {
+				return
 			}
 
 			// If the model response is structured, yield it as a final model response event.
@@ -1238,6 +1244,28 @@ func (f *Flow) handleFunctionCalls(ctx agent.InvocationContext, toolsDict map[st
 		return mergedEvent, err
 	}
 	return mergedEvent, nil
+}
+
+func removeRequestedConfirmationResponses(ev *session.Event) *session.Event {
+	if ev == nil || ev.LLMResponse.Content == nil || len(ev.Actions.RequestedToolConfirmations) == 0 {
+		return ev
+	}
+
+	parts := ev.LLMResponse.Content.Parts[:0]
+	for _, part := range ev.LLMResponse.Content.Parts {
+		if part.FunctionResponse != nil {
+			if _, ok := ev.Actions.RequestedToolConfirmations[part.FunctionResponse.ID]; ok {
+				continue
+			}
+		}
+		parts = append(parts, part)
+	}
+	if len(parts) == 0 {
+		return nil
+	}
+	ev.LLMResponse.Content.Parts = parts
+	ev.Actions.RequestedToolConfirmations = nil
+	return ev
 }
 
 func (f *Flow) runOnToolErrorCallbacks(toolCtx agent.Context, tool tool.Tool, fArgs map[string]any, err error) (map[string]any, error) {

--- a/internal/llminternal/parallel_function_call_hitl_test.go
+++ b/internal/llminternal/parallel_function_call_hitl_test.go
@@ -107,8 +107,8 @@ func (m *hitlMockModel) GenerateContent(ctx context.Context, req *model.LLMReque
 //     SkipSummarization flag, which halts LLM generation immediately after tool responses are returned.
 //     The runner yields:
 //     a) A model response event containing the two original parallel function calls.
-//     b) A merged function response event containing the placeholder (unexecuted) tool responses.
-//     c) An aggregated tool confirmation event containing two adk_request_confirmation wrapper calls.
+//     b) An aggregated tool confirmation event containing two adk_request_confirmation wrapper calls.
+//     No function response is returned for the pending tool calls yet.
 //  2. Turn 2: The client simulates user confirmation by returning confirmation responses matching
 //     the unique wrapper call IDs. The RequestConfirmationRequestProcessor detects these, matches
 //     them back to the original tools, and concurrently executes the sensitive tools in parallel
@@ -173,12 +173,11 @@ func TestParallelFunctionCallsWithHITL(t *testing.T) {
 		turn1Events = append(turn1Events, ev)
 	}
 
-	// Expecting exactly 3 events:
+	// Expecting exactly 2 events:
 	// 1. ModelResponseEvent (yielding the two function calls secure_call_1 and secure_call_2)
-	// 2. Merged function response event (returning placeholder executed: false responses)
-	// 3. ToolConfirmationEvent (yielding two adk_request_confirmation calls)
-	if len(turn1Events) != 3 {
-		t.Fatalf("Expected 3 events in Turn 1, got %d", len(turn1Events))
+	// 2. ToolConfirmationEvent (yielding two adk_request_confirmation calls)
+	if len(turn1Events) != 2 {
+		t.Fatalf("Expected 2 events in Turn 1, got %d", len(turn1Events))
 	}
 
 	// Verify that the model event contains our parallel calls
@@ -187,35 +186,8 @@ func TestParallelFunctionCallsWithHITL(t *testing.T) {
 		t.Errorf("Expected model event to contain 2 parts (function calls), got %d", len(modelEvent.Content.Parts))
 	}
 
-	// Verify that the merged function response event contains the placeholder unexecuted responses
-	placeholderRespEvent := turn1Events[1]
-	if len(placeholderRespEvent.Content.Parts) != 2 {
-		t.Errorf("Expected placeholder function response event to contain 2 parts, got %d", len(placeholderRespEvent.Content.Parts))
-	}
-
-	expectedPlaceholders := []*genai.Part{
-		{
-			FunctionResponse: &genai.FunctionResponse{
-				Name:     "secure_action",
-				ID:       "secure_call_1",
-				Response: map[string]any{"error": `error tool "secure_action" requires confirmation, please approve or reject`},
-			},
-		},
-		{
-			FunctionResponse: &genai.FunctionResponse{
-				Name:     "secure_action",
-				ID:       "secure_call_2",
-				Response: map[string]any{"error": `error tool "secure_action" requires confirmation, please approve or reject`},
-			},
-		},
-	}
-
-	if diff := cmp.Diff(expectedPlaceholders, placeholderRespEvent.Content.Parts); diff != "" {
-		t.Errorf("Mismatch in placeholder tool responses (-want +got):\n%s", diff)
-	}
-
 	// Verify that the tool confirmation event has the confirmation wrapper calls
-	confirmEvent := turn1Events[2]
+	confirmEvent := turn1Events[1]
 	if len(confirmEvent.Content.Parts) != 2 {
 		t.Errorf("Expected tool confirmation event to contain 2 wrapper function calls, got %d", len(confirmEvent.Content.Parts))
 	}
@@ -383,11 +355,11 @@ func TestParallelFunctionCallsWithPartialHITL(t *testing.T) {
 		turn1Events = append(turn1Events, ev)
 	}
 
-	if len(turn1Events) != 3 {
-		t.Fatalf("Expected 3 events in Turn 1, got %d", len(turn1Events))
+	if len(turn1Events) != 2 {
+		t.Fatalf("Expected 2 events in Turn 1, got %d", len(turn1Events))
 	}
 
-	confirmEvent := turn1Events[2]
+	confirmEvent := turn1Events[1]
 	var confirmCallID1, confirmCallID2 string
 	for _, p := range confirmEvent.Content.Parts {
 		origCall, err := toolconfirmation.OriginalCallFrom(p.FunctionCall)

--- a/tool/functiontool/function_test.go
+++ b/tool/functiontool/function_test.go
@@ -585,9 +585,6 @@ func TestToolConfirmation(t *testing.T) {
 			args: map[string]any{"Num": 1},
 			want: []*genai.Content{
 				genai.NewContentFromFunctionCall("test_tool", map[string]any{"Num": 1}, "model"),
-				genai.NewContentFromFunctionResponse("test_tool", map[string]any{
-					"error": errors.New("error tool \"test_tool\" requires confirmation, please approve or reject"),
-				}, "user"),
 				genai.NewContentFromFunctionCall(toolconfirmation.FunctionCallName, map[string]any{
 					"originalFunctionCall": &genai.FunctionCall{
 						Args: map[string]any{"Num": 1},
@@ -609,9 +606,6 @@ func TestToolConfirmation(t *testing.T) {
 			confirmFunctionResponse: &genai.FunctionResponse{Name: toolconfirmation.FunctionCallName, Response: map[string]any{"confirmed": true}},
 			want: []*genai.Content{
 				genai.NewContentFromFunctionCall("test_tool", map[string]any{"Num": 1}, "model"),
-				genai.NewContentFromFunctionResponse("test_tool", map[string]any{
-					"error": errors.New("error tool \"test_tool\" requires confirmation, please approve or reject"),
-				}, "user"),
 				genai.NewContentFromFunctionCall(toolconfirmation.FunctionCallName, map[string]any{
 					"originalFunctionCall": &genai.FunctionCall{
 						Args: map[string]any{"Num": 1},
@@ -634,9 +628,6 @@ func TestToolConfirmation(t *testing.T) {
 			confirmFunctionResponse: &genai.FunctionResponse{Name: toolconfirmation.FunctionCallName, Response: map[string]any{"confirmed": false}},
 			want: []*genai.Content{
 				genai.NewContentFromFunctionCall("test_tool", map[string]any{"Num": 1}, "model"),
-				genai.NewContentFromFunctionResponse("test_tool", map[string]any{
-					"error": errors.New("error tool \"test_tool\" requires confirmation, please approve or reject"),
-				}, "user"),
 				genai.NewContentFromFunctionCall(toolconfirmation.FunctionCallName, map[string]any{
 					"originalFunctionCall": &genai.FunctionCall{
 						Args: map[string]any{"Num": 1},
@@ -676,9 +667,6 @@ func TestToolConfirmation(t *testing.T) {
 			args: map[string]any{"Num": 4},
 			want: []*genai.Content{
 				genai.NewContentFromFunctionCall("test_tool", map[string]any{"Num": 4}, "model"),
-				genai.NewContentFromFunctionResponse("test_tool", map[string]any{
-					"error": errors.New("error tool \"test_tool\" requires confirmation, please approve or reject"),
-				}, "user"),
 				genai.NewContentFromFunctionCall(toolconfirmation.FunctionCallName, map[string]any{
 					"originalFunctionCall": &genai.FunctionCall{
 						Args: map[string]any{"Num": 4},
@@ -702,9 +690,6 @@ func TestToolConfirmation(t *testing.T) {
 			confirmFunctionResponse: &genai.FunctionResponse{Name: toolconfirmation.FunctionCallName, Response: map[string]any{"confirmed": true}},
 			want: []*genai.Content{
 				genai.NewContentFromFunctionCall("test_tool", map[string]any{"Num": 4}, "model"),
-				genai.NewContentFromFunctionResponse("test_tool", map[string]any{
-					"error": errors.New("error tool \"test_tool\" requires confirmation, please approve or reject"),
-				}, "user"),
 				genai.NewContentFromFunctionCall(toolconfirmation.FunctionCallName, map[string]any{
 					"originalFunctionCall": &genai.FunctionCall{
 						Args: map[string]any{"Num": 4},
@@ -729,9 +714,6 @@ func TestToolConfirmation(t *testing.T) {
 			confirmFunctionResponse: &genai.FunctionResponse{Name: toolconfirmation.FunctionCallName, Response: map[string]any{"confirmed": false}},
 			want: []*genai.Content{
 				genai.NewContentFromFunctionCall("test_tool", map[string]any{"Num": 4}, "model"),
-				genai.NewContentFromFunctionResponse("test_tool", map[string]any{
-					"error": errors.New("error tool \"test_tool\" requires confirmation, please approve or reject"),
-				}, "user"),
 				genai.NewContentFromFunctionCall(toolconfirmation.FunctionCallName, map[string]any{
 					"originalFunctionCall": &genai.FunctionCall{
 						Args: map[string]any{"Num": 4},
@@ -866,7 +848,7 @@ func TestToolConfirmation(t *testing.T) {
 	}
 }
 
-func TestToolConfirmationYieldsFunctionResponseBeforeConfirmation(t *testing.T) {
+func TestToolConfirmationDoesNotYieldPendingResponseBeforeConfirmation(t *testing.T) {
 	mockModel := &testutil.MockModel{
 		Responses: []*genai.Content{
 			genai.NewContentFromFunctionCall("test_tool", map[string]any{"Num": 1}, genai.RoleModel),
@@ -891,7 +873,7 @@ func TestToolConfirmationYieldsFunctionResponseBeforeConfirmation(t *testing.T) 
 	}
 
 	runner := testutil.NewTestAgentRunner(t, a)
-	sawFunctionResponse := false
+	sawConfirmation := false
 
 	for got, err := range runner.Run(t, "id", "message") {
 		// The mock model emits a sentinel error once exhausted; treat any
@@ -902,18 +884,17 @@ func TestToolConfirmationYieldsFunctionResponseBeforeConfirmation(t *testing.T) 
 
 		for _, part := range got.Content.Parts {
 			if part.FunctionResponse != nil && part.FunctionResponse.Name == "test_tool" {
-				sawFunctionResponse = true
+				t.Fatal("pending tool response was yielded before confirmation")
 			}
 			if part.FunctionCall != nil && part.FunctionCall.Name == toolconfirmation.FunctionCallName {
-				if !sawFunctionResponse {
-					t.Fatal("confirmation was yielded before the tool function response")
-				}
-				return
+				sawConfirmation = true
 			}
 		}
 	}
 
-	t.Fatal("expected confirmation event")
+	if !sawConfirmation {
+		t.Fatal("expected confirmation event")
+	}
 }
 
 // Mock types for TArgs and TResults

--- a/tool/mcptoolset/set_test.go
+++ b/tool/mcptoolset/set_test.go
@@ -419,9 +419,6 @@ func TestMCPToolSetConfirmation(t *testing.T) {
 			city: "Lisbon",
 			want: []*genai.Content{
 				genai.NewContentFromFunctionCall(toolName, map[string]any{"city": "Lisbon"}, "model"),
-				genai.NewContentFromFunctionResponse(toolName, map[string]any{
-					"error": errors.New("error tool \"get_weather\" requires confirmation, please approve or reject"),
-				}, "user"),
 				genai.NewContentFromFunctionCall(toolconfirmation.FunctionCallName, map[string]any{
 					"originalFunctionCall": &genai.FunctionCall{
 						Args: map[string]any{"city": "Lisbon"},
@@ -442,9 +439,6 @@ func TestMCPToolSetConfirmation(t *testing.T) {
 			confirmFunctionResponse: &genai.FunctionResponse{Name: toolconfirmation.FunctionCallName, Response: map[string]any{"confirmed": true}},
 			want: []*genai.Content{
 				genai.NewContentFromFunctionCall(toolName, map[string]any{"city": "Lisbon"}, "model"),
-				genai.NewContentFromFunctionResponse(toolName, map[string]any{
-					"error": errors.New("error tool \"get_weather\" requires confirmation, please approve or reject"),
-				}, "user"),
 				genai.NewContentFromFunctionCall(toolconfirmation.FunctionCallName, map[string]any{
 					"originalFunctionCall": &genai.FunctionCall{
 						Args: map[string]any{"city": "Lisbon"},
@@ -469,9 +463,6 @@ func TestMCPToolSetConfirmation(t *testing.T) {
 			confirmFunctionResponse: &genai.FunctionResponse{Name: toolconfirmation.FunctionCallName, Response: map[string]any{"confirmed": false}},
 			want: []*genai.Content{
 				genai.NewContentFromFunctionCall(toolName, map[string]any{"city": "Lisbon"}, "model"),
-				genai.NewContentFromFunctionResponse(toolName, map[string]any{
-					"error": errors.New("error tool \"get_weather\" requires confirmation, please approve or reject"),
-				}, "user"),
 				genai.NewContentFromFunctionCall(toolconfirmation.FunctionCallName, map[string]any{
 					"originalFunctionCall": &genai.FunctionCall{
 						Args: map[string]any{"city": "Lisbon"},
@@ -527,9 +518,6 @@ func TestMCPToolSetConfirmation(t *testing.T) {
 			city: "Lisbon",
 			want: []*genai.Content{
 				genai.NewContentFromFunctionCall(toolName, map[string]any{"city": "Lisbon"}, "model"),
-				genai.NewContentFromFunctionResponse(toolName, map[string]any{
-					"error": errors.New("error tool \"get_weather\" requires confirmation, please approve or reject"),
-				}, "user"),
 				genai.NewContentFromFunctionCall(toolconfirmation.FunctionCallName, map[string]any{
 					"originalFunctionCall": &genai.FunctionCall{
 						Args: map[string]any{"city": "Lisbon"},
@@ -549,9 +537,6 @@ func TestMCPToolSetConfirmation(t *testing.T) {
 			city: "Lisbon",
 			want: []*genai.Content{
 				genai.NewContentFromFunctionCall(toolName, map[string]any{"city": "Lisbon"}, "model"),
-				genai.NewContentFromFunctionResponse(toolName, map[string]any{
-					"error": errors.New("error tool \"get_weather\" requires confirmation, please approve or reject"),
-				}, "user"),
 				genai.NewContentFromFunctionCall(toolconfirmation.FunctionCallName, map[string]any{
 					"originalFunctionCall": &genai.FunctionCall{
 						Args: map[string]any{"city": "Lisbon"},
@@ -572,9 +557,6 @@ func TestMCPToolSetConfirmation(t *testing.T) {
 			confirmFunctionResponse: &genai.FunctionResponse{Name: toolconfirmation.FunctionCallName, Response: map[string]any{"confirmed": true}},
 			want: []*genai.Content{
 				genai.NewContentFromFunctionCall(toolName, map[string]any{"city": "Lisbon"}, "model"),
-				genai.NewContentFromFunctionResponse(toolName, map[string]any{
-					"error": errors.New("error tool \"get_weather\" requires confirmation, please approve or reject"),
-				}, "user"),
 				genai.NewContentFromFunctionCall(toolconfirmation.FunctionCallName, map[string]any{
 					"originalFunctionCall": &genai.FunctionCall{
 						Args: map[string]any{"city": "Lisbon"},
@@ -599,9 +581,6 @@ func TestMCPToolSetConfirmation(t *testing.T) {
 			confirmFunctionResponse: &genai.FunctionResponse{Name: toolconfirmation.FunctionCallName, Response: map[string]any{"confirmed": false}},
 			want: []*genai.Content{
 				genai.NewContentFromFunctionCall(toolName, map[string]any{"city": "Lisbon"}, "model"),
-				genai.NewContentFromFunctionResponse(toolName, map[string]any{
-					"error": errors.New("error tool \"get_weather\" requires confirmation, please approve or reject"),
-				}, "user"),
 				genai.NewContentFromFunctionCall(toolconfirmation.FunctionCallName, map[string]any{
 					"originalFunctionCall": &genai.FunctionCall{
 						Args: map[string]any{"city": "Lisbon"},


### PR DESCRIPTION
## Summary
- stop emitting placeholder function responses for tool calls that are waiting on HITL confirmation
- keep the adk_request_confirmation event as the pending client signal
- update functiontool, MCP toolset, parallel HITL, and A2A expectations

Fixes #876

## Testing
- go test ./internal/llminternal ./tool/functiontool ./tool/mcptoolset
- go test ./agent/remoteagent/v2 ./internal/llminternal ./tool/functiontool ./tool/mcptoolset
- go test ./runner ./agent/... ./internal/llminternal ./tool/...
- git diff --check

Note: go test ./... exposed an unrelated transient ordering failure in server/adkrest/internal/services TestDebugTelemetryGetSpansBySessionID; rerunning that package-specific test passed.