### PR TITLE
Support caller-provided Vertex AI session IDs

### DIFF
--- a/session/vertexai/service_test.go
+++ b/session/vertexai/service_test.go
@@ -44,7 +44,7 @@ func Test_vertexaiService(t *testing.T) {
 		SupportsUserProvidedSessionID: false,
 		ProvidesServerAssignedEventID: true,
 		AppName:                       EngineId,
-	} // VertexAI forbids custom IDs
+	} // The replay suite uses server-assigned IDs; custom ID proto mapping is covered by unit tests.
 	session_test.RunServiceTests(t, opts, func(t *testing.T) session.Service {
 		name := strings.ReplaceAll(t.Name(), "/", "_")
 		s, _ := emptyService(t, name, false)

--- a/session/vertexai/vertexai.go
+++ b/session/vertexai/vertexai.go
@@ -56,9 +56,6 @@ func (s *vertexAiService) Create(ctx context.Context, req *session.CreateRequest
 	if req.AppName == "" || req.UserID == "" {
 		return nil, fmt.Errorf("app_name and user_id are required, got app_name: %q, user_id: %q", req.AppName, req.UserID)
 	}
-	if req.SessionID != "" {
-		return nil, fmt.Errorf("user-provided Session id is not supported for VertexAISessionService: %q", req.SessionID)
-	}
 	sess, err := s.client.createSession(ctx, req)
 	if err != nil {
 		return nil, fmt.Errorf("failed to create session: %w", err)

--- a/session/vertexai/vertexai_client.go
+++ b/session/vertexai/vertexai_client.go
@@ -64,6 +64,39 @@ func (c *vertexAiClient) Close() error {
 }
 
 func (c *vertexAiClient) createSession(ctx context.Context, req *session.CreateRequest) (*localSession, error) {
+	reasoningEngine, err := c.getReasoningEngineID(req.AppName)
+	if err != nil {
+		return nil, err
+	}
+	aeData := &vertexaiutil.AgentEngineData{
+		Location:        c.agentEngineData.Location,
+		ProjectID:       c.agentEngineData.ProjectID,
+		ReasoningEngine: reasoningEngine,
+	}
+	rpcReq, err := createSessionRequest(vertexaiutil.AgentEngineResource(aeData), req)
+	if err != nil {
+		return nil, err
+	}
+	lro, err := c.rpcClient.CreateSession(ctx, rpcReq)
+	if err != nil {
+		return nil, fmt.Errorf("error creating session: %w", err)
+	}
+
+	sessionID := req.SessionID
+	if sessionID == "" {
+		sessionID, err = sessionIDByOperationName(lro.Name())
+		if err != nil {
+			return nil, fmt.Errorf("error creating session: %w", err)
+		}
+	}
+	createdSession, err := c.waitForOperation(ctx, req.AppName, req.UserID, sessionID)
+	if err != nil {
+		return nil, fmt.Errorf("LRO for CreateSession failed: %w", err)
+	}
+	return createdSession, nil
+}
+
+func createSessionRequest(parent string, req *session.CreateRequest) (*aiplatformpb.CreateSessionRequest, error) {
 	pbSession := &aiplatformpb.Session{
 		UserId: req.UserID,
 	}
@@ -76,33 +109,11 @@ func (c *vertexAiClient) createSession(ctx context.Context, req *session.CreateR
 		pbSession.SessionState = stateStruct
 	}
 
-	reasoningEngine, err := c.getReasoningEngineID(req.AppName)
-	if err != nil {
-		return nil, err
-	}
-	aeData := &vertexaiutil.AgentEngineData{
-		Location:        c.agentEngineData.Location,
-		ProjectID:       c.agentEngineData.ProjectID,
-		ReasoningEngine: reasoningEngine,
-	}
-	rpcReq := &aiplatformpb.CreateSessionRequest{
-		Parent:  vertexaiutil.AgentEngineResource(aeData),
-		Session: pbSession,
-	}
-	lro, err := c.rpcClient.CreateSession(ctx, rpcReq)
-	if err != nil {
-		return nil, fmt.Errorf("error creating session: %w", err)
-	}
-
-	sessionID, err := sessionIDByOperationName(lro.Name())
-	if err != nil {
-		return nil, fmt.Errorf("error creating session: %w", err)
-	}
-	createdSession, err := c.waitForOperation(ctx, req.AppName, req.UserID, sessionID)
-	if err != nil {
-		return nil, fmt.Errorf("LRO for CreateSession failed: %w", err)
-	}
-	return createdSession, nil
+	return &aiplatformpb.CreateSessionRequest{
+		Parent:    parent,
+		Session:   pbSession,
+		SessionId: req.SessionID,
+	}, nil
 }
 
 func isNotFoundError(err error) bool {

--- a/session/vertexai/vertexai_test.go
+++ b/session/vertexai/vertexai_test.go
@@ -17,6 +17,7 @@ package vertexai
 import (
 	"testing"
 
+	"google.golang.org/adk/session"
 	"google.golang.org/adk/util/vertexai"
 
 	"google.golang.org/genai"
@@ -167,5 +168,28 @@ func TestAiplatformToGenaiContentPreservesFunctionIDs(t *testing.T) {
 	}
 	if got, want := functionResponse.ID, "call-123"; got != want {
 		t.Errorf("FunctionResponse.ID = %q, want %q", got, want)
+	}
+}
+
+func TestCreateSessionRequest_UserProvidedSessionID(t *testing.T) {
+	got, err := createSessionRequest("projects/test/locations/us-central1/reasoningEngines/123", &session.CreateRequest{
+		AppName:   "test-app",
+		UserID:    "test-user",
+		SessionID: "a2a-context-id",
+		State: map[string]any{
+			"key": "value",
+		},
+	})
+	if err != nil {
+		t.Fatalf("createSessionRequest() error = %v", err)
+	}
+	if got.SessionId != "a2a-context-id" {
+		t.Errorf("SessionId = %q, want %q", got.SessionId, "a2a-context-id")
+	}
+	if got.Session.GetUserId() != "test-user" {
+		t.Errorf("Session.UserId = %q, want %q", got.Session.GetUserId(), "test-user")
+	}
+	if got.Session.GetSessionState().AsMap()["key"] != "value" {
+		t.Errorf("SessionState[key] = %v, want %q", got.Session.GetSessionState().AsMap()["key"], "value")
 	}
 }


### PR DESCRIPTION
## Summary
- allow Vertex AI session service Create to accept caller-provided SessionID values
- pass SessionID through to Vertex AI CreateSessionRequest.SessionId
- wait on the caller-provided ID when one is supplied instead of deriving the ID from the LRO name

Fixes #870

## Why
A2A executions use the A2A context ID as the ADK session ID. The Vertex AI session service rejected that ID locally even though the Vertex AI API supports session_id on create requests, causing A2A agents backed by Vertex AI sessions to fail before the RPC.

## Testing
- go test ./session/vertexai
- go test ./session/vertexai ./server/adka2a/v2 ./agent/remoteagent/v2
- go test ./session/... ./server/agentengine/... ./server/adkrest/controllers/...
- git diff --check