### PR TITLE
feat(workflow): introduce NodeContext interface

### DIFF
--- a/workflow/node_context.go
+++ b/workflow/node_context.go
@@ -14,16 +14,55 @@
 
 package workflow
 
-import "google.golang.org/adk/agent"
+import (
+	"context"
 
-// nodeContext is the per-node InvocationContext seen inside Node.Run.
-// It wraps the workflow's incoming agent.InvocationContext and
-// surfaces the human-input responses the scheduler injected for a
-// re-entry resume activation (ResumedInput).
+	"google.golang.org/adk/agent"
+)
+
+// NodeContext is the per-node context seen inside Node.Run, and (in the
+// upcoming dynamic-workflows API) inside dynamic-node orchestrator
+// function bodies. It extends agent.InvocationContext with
+// workflow-specific accessors.
 //
-// TODO(wolo): replace once context-unification work lands. The
-// wrapper exists today only to surface workflow-specific accessors
-// that the base interface does not have.
+// The interface shape is forward-compatible with the in-flight
+// context-unification work (see adk-go PRs in the ToolContext /
+// CallbackContext series): like those, NodeContext is an interface
+// whose concrete implementation stays unexported, so that future
+// unification can swap the backing type without breaking users.
+type NodeContext interface {
+	agent.InvocationContext
+
+	// ResumedInput returns the response payload associated with the
+	// given InterruptID for a re-entry resume activation. Returns
+	// (nil, false) on fresh activations, on handoff resume, and when
+	// the InterruptID does not match any payload supplied by the
+	// resuming caller.
+	ResumedInput(interruptID string) (any, bool)
+
+	// Path returns the composite path of the currently-executing
+	// node. For top-level static nodes it is the empty string. For
+	// dynamic children scheduled via the upcoming workflow.RunNode
+	// API it will be "<parent_path>/<child_name>@<run_id>"; until
+	// that API lands, Path always returns "".
+	Path() string
+
+	// RunID returns the per-invocation identifier of the current
+	// node. Empty for top-level static activations. Populated by the
+	// dynamic sub-scheduler when this is a dynamic child.
+	RunID() string
+
+	// WithGoCtx returns a NodeContext whose underlying
+	// context.Context is replaced by ctx. Session, invocation
+	// metadata, and resume inputs are preserved. Used to integrate
+	// with errgroup, http request scopes, and other code that
+	// expects to drive cancellation via a *context.Context.
+	WithGoCtx(ctx context.Context) NodeContext
+}
+
+// nodeContext is the unexported NodeContext implementation. It wraps
+// the workflow's incoming agent.InvocationContext and carries the
+// resume payloads the scheduler injected for a re-entry activation.
 type nodeContext struct {
 	agent.InvocationContext
 
@@ -34,6 +73,9 @@ type nodeContext struct {
 	// asker via this map).
 	resumeInputs map[string]any
 }
+
+// Compile-time assertion that *nodeContext satisfies NodeContext.
+var _ NodeContext = (*nodeContext)(nil)
 
 // newNodeContext returns a nodeContext wrapping parent. resumeInputs
 // is nil for non-resume activations.
@@ -55,4 +97,26 @@ func (c *nodeContext) ResumedInput(interruptID string) (any, bool) {
 	}
 	v, ok := c.resumeInputs[interruptID]
 	return v, ok
+}
+
+// Path implements NodeContext. Returns "" today; populated by the
+// dynamic sub-scheduler in a future change.
+func (c *nodeContext) Path() string {
+	return ""
+}
+
+// RunID implements NodeContext. Returns "" today; populated by the
+// dynamic sub-scheduler in a future change.
+func (c *nodeContext) RunID() string {
+	return ""
+}
+
+// WithGoCtx returns a NodeContext whose underlying context.Context is
+// replaced by ctx, delegating to InvocationContext.WithContext and
+// preserving resumeInputs.
+func (c *nodeContext) WithGoCtx(ctx context.Context) NodeContext {
+	return &nodeContext{
+		InvocationContext: c.InvocationContext.WithContext(ctx),
+		resumeInputs:      c.resumeInputs,
+	}
 }

--- a/workflow/node_context_test.go
+++ b/workflow/node_context_test.go
@@ -15,9 +15,8 @@
 package workflow
 
 import (
+	"context"
 	"testing"
-
-	"google.golang.org/adk/agent"
 )
 
 func TestNodeContext_ResumedInput(t *testing.T) {
@@ -40,7 +39,86 @@ func TestNodeContext_ResumedInput(t *testing.T) {
 			t.Errorf("ResumedInput(\"approval\") = (%v, %v), want (\"yes\", true)", v, ok)
 		}
 	})
+
+	t.Run("unmatched InterruptID returns (nil, false)", func(t *testing.T) {
+		c := newNodeContext(parent, map[string]any{"approval": "yes"})
+		if v, ok := c.ResumedInput("missing"); v != nil || ok {
+			t.Errorf("ResumedInput(\"missing\") = (%v, %v), want (nil, false)", v, ok)
+		}
+	})
 }
 
-// Compile-time assertion: *nodeContext satisfies agent.InvocationContext.
-var _ agent.InvocationContext = (*nodeContext)(nil)
+func TestNodeContext_PathAndRunID(t *testing.T) {
+	// Today Path and RunID always return "" — the dynamic sub-scheduler
+	// (future change) will populate them for dynamic children. These
+	// tests pin the current contract so a regression that accidentally
+	// changes the default is caught early.
+	c := newNodeContext(newMockCtx(t), nil)
+	if got := c.Path(); got != "" {
+		t.Errorf("Path() = %q, want empty for top-level static activation", got)
+	}
+	if got := c.RunID(); got != "" {
+		t.Errorf("RunID() = %q, want empty for top-level static activation", got)
+	}
+}
+
+func TestNodeContext_WithGoCtx(t *testing.T) {
+	parent := newMockCtx(t)
+	resume := map[string]any{"approval": "yes"}
+	c := newNodeContext(parent, resume)
+
+	// Swap the underlying context.Context.
+	swappedCtx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+	swapped := c.WithGoCtx(swappedCtx)
+
+	t.Run("returns a new instance", func(t *testing.T) {
+		// Must not return the same pointer — WithGoCtx is documented
+		// as returning a new NodeContext.
+		if any(swapped) == any(c) {
+			t.Errorf("WithGoCtx returned the same NodeContext; want a new instance")
+		}
+	})
+
+	t.Run("underlying ctx is swapped", func(t *testing.T) {
+		// InvocationContext embeds context.Context directly. We can't
+		// pointer-compare interfaces, so we verify the swap via
+		// behavior: cancelling swappedCtx must propagate to the new
+		// NodeContext's Done channel; the parent's must remain open.
+		cancel()
+		select {
+		case <-swapped.Done():
+			// expected
+		default:
+			t.Errorf("WithGoCtx-returned NodeContext did not observe ctx cancellation; ctx was not swapped")
+		}
+		// Parent's ctx (t.Context) must NOT have been cancelled.
+		select {
+		case <-c.Done():
+			t.Errorf("original NodeContext was cancelled; WithGoCtx must return a new instance, not mutate the original")
+		default:
+			// expected
+		}
+	})
+
+	t.Run("resume inputs preserved", func(t *testing.T) {
+		if v, ok := swapped.ResumedInput("approval"); !ok || v != "yes" {
+			t.Errorf("after WithGoCtx, ResumedInput(\"approval\") = (%v, %v), want (\"yes\", true)", v, ok)
+		}
+	})
+
+	t.Run("invocation metadata preserved", func(t *testing.T) {
+		if got := swapped.InvocationID(); got != parent.InvocationID() {
+			t.Errorf("InvocationID after WithGoCtx = %q, want %q", got, parent.InvocationID())
+		}
+	})
+
+	t.Run("Path and RunID still empty after swap", func(t *testing.T) {
+		if got := swapped.Path(); got != "" {
+			t.Errorf("Path after WithGoCtx = %q, want empty", got)
+		}
+		if got := swapped.RunID(); got != "" {
+			t.Errorf("RunID after WithGoCtx = %q, want empty", got)
+		}
+	})
+}


### PR DESCRIPTION
### Problem

The per-node context inside `Node.Run` is currently the unexported
struct `*nodeContext`, which prevents downstream call sites from
naming the type and blocks the upcoming dynamic-workflows API
(`workflow.RunNode`, dynamic sub-scheduler) from exposing
node-scoped accessors like child path and per-invocation run ID.

### Solution

Promote `nodeContext` to an exported `NodeContext` interface
extending `agent.InvocationContext`, keeping the concrete
implementation unexported so future context-unification work (cf. the
in-flight `ToolContext` / `CallbackContext` series) can swap the
backing type without breaking users. Three new accessors are added:
`Path()` and `RunID()` are forward-compat placeholders returning `""`
today (the dynamic sub-scheduler will populate them in a follow-up),
while `WithGoCtx(ctx)` is functional now and lets callers replace the
underlying `context.Context` (e.g. for `errgroup` or HTTP request
scopes) while preserving invocation metadata and resume inputs.
Tests pin the current contract for `Path`/`RunID` so accidental
defaults are caught, and cover `WithGoCtx` end-to-end: cancellation
propagates to the new instance, the original is not mutated, and
resume inputs plus invocation metadata are preserved across the
swap.
