### PR TITLE
feat(workflow): add dynamic-workflow scaffolding (NodeContext, error, scheduler)

### DIFF
--- a/workflow/dynamic_scheduler.go
+++ b/workflow/dynamic_scheduler.go
@@ -1,0 +1,148 @@
+// Copyright 2026 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package workflow
+
+import (
+	"fmt"
+	"strconv"
+	"strings"
+	"sync"
+
+	"google.golang.org/adk/session"
+)
+
+// dynamicSubScheduler runs the children of one dynamic-node activation.
+type dynamicSubScheduler struct {
+	parentPath string
+	parentCtx  NodeContext
+	emitUp     func(*session.Event) error
+
+	// mu protects runCountByChild.
+	mu sync.Mutex
+	// runCountByChild seeds the auto-counter for each child name —
+	// the n-th invocation of any given name gets runID
+	// strconv.Itoa(n).
+	runCountByChild map[string]int
+}
+
+func newDynamicSubScheduler(parent NodeContext, parentPath string, emitUp func(*session.Event) error) *dynamicSubScheduler {
+	return &dynamicSubScheduler{
+		parentPath:      parentPath,
+		parentCtx:       parent,
+		emitUp:          emitUp,
+		runCountByChild: map[string]int{},
+	}
+}
+
+// runNode executes child once, forwards its events upstream, and
+// classifies the outcome. HITL surfaces as ErrNodeInterrupted; runtime
+// failure as ErrNodeFailed; a child that fails after requesting input
+// surfaces as ErrNodeFailed (matches adk-python precedence).
+//
+// Session, invocation metadata, and cancellation come from s.parentCtx
+// captured at sub-scheduler construction. customRunID is empty to use
+// the auto-counter, or a user-supplied stable id (validated against
+// the rules in validateCustomRunID).
+//
+// Fresh execution only; resume support lands in a follow-up PR.
+func (s *dynamicSubScheduler) runNode(child Node, input any, customRunID string) (any, error) {
+	name := child.Name()
+	runID, err := s.resolveRunID(name, customRunID)
+	if err != nil {
+		return nil, &NodeRunError{ChildName: name, Cause: err}
+	}
+	childPath := s.parentPath + "/" + name + "@" + runID
+	childCtx := newDynamicNodeContext(s.parentCtx, childPath, runID, s)
+
+	var (
+		out         any
+		interrupted bool
+	)
+	for ev, evErr := range child.Run(childCtx, input) {
+		if evErr != nil {
+			// Child error wins over any prior interrupt.
+			return nil, &NodeRunError{
+				ChildName: name, ChildPath: childPath, RunID: runID,
+				Cause: fmt.Errorf("%w: %v", ErrNodeFailed, evErr),
+			}
+		}
+		if ev == nil {
+			continue
+		}
+		if ev.RequestedInput != nil {
+			interrupted = true
+		}
+		if ev.Output != nil {
+			out = ev.Output
+		}
+		if err := s.emitUp(ev); err != nil {
+			return nil, &NodeRunError{
+				ChildName: name, ChildPath: childPath, RunID: runID,
+				Cause: fmt.Errorf("%w: emitUp: %v", ErrNodeFailed, err),
+			}
+		}
+	}
+
+	if interrupted {
+		return nil, &NodeRunError{
+			ChildName: name, ChildPath: childPath, RunID: runID,
+			Cause: ErrNodeInterrupted,
+		}
+	}
+	return out, nil
+}
+
+// resolveRunID validates a user-supplied id, or returns the next
+// per-child-name counter value under lock.
+func (s *dynamicSubScheduler) resolveRunID(childName, custom string) (string, error) {
+	if custom != "" {
+		if err := validateCustomRunID(custom); err != nil {
+			return "", err
+		}
+		return custom, nil
+	}
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	s.runCountByChild[childName]++
+	return strconv.Itoa(s.runCountByChild[childName]), nil
+}
+
+// validateCustomRunID rejects empty ids, purely-numeric ids (collide
+// with the auto-counter), and ids containing the composite-path
+// separators / and @.
+func validateCustomRunID(id string) error {
+	if id == "" {
+		return fmt.Errorf("%w: empty", ErrInvalidRunID)
+	}
+	if isAllDigits(id) {
+		return fmt.Errorf("%w: %q is purely numeric (reserved for auto-counter)", ErrInvalidRunID, id)
+	}
+	if strings.ContainsAny(id, "/@") {
+		return fmt.Errorf("%w: %q contains reserved separator (/ or @)", ErrInvalidRunID, id)
+	}
+	return nil
+}
+
+// isAllDigits checks ASCII digits only by design: the auto-counter
+// emits ASCII digits, so collision is only possible with ASCII numeric
+// ids.
+func isAllDigits(s string) bool {
+	for _, r := range s {
+		if r < '0' || r > '9' {
+			return false
+		}
+	}
+	return true
+}

--- a/workflow/dynamic_scheduler_test.go
+++ b/workflow/dynamic_scheduler_test.go
@@ -1,0 +1,259 @@
+// Copyright 2026 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package workflow
+
+import (
+	"errors"
+	"iter"
+	"strconv"
+	"sync"
+	"testing"
+
+	"google.golang.org/adk/agent"
+	"google.golang.org/adk/session"
+)
+
+func TestValidateCustomRunID(t *testing.T) {
+	tests := []struct {
+		id      string
+		wantErr bool
+	}{
+		{"", true},    // empty
+		{"123", true}, // purely numeric
+		{"0", true},   // purely numeric
+		{"a/b", true}, // contains /
+		{"a@b", true}, // contains @
+		{"order-7", false},
+		{"abc", false},
+		{"v2-attempt-3", false},
+		{"7a", false}, // mixed
+	}
+	for _, tc := range tests {
+		t.Run(tc.id, func(t *testing.T) {
+			err := validateCustomRunID(tc.id)
+			if (err != nil) != tc.wantErr {
+				t.Errorf("validateCustomRunID(%q) err = %v, wantErr = %v", tc.id, err, tc.wantErr)
+			}
+			if err != nil && !errors.Is(err, ErrInvalidRunID) {
+				t.Errorf("validateCustomRunID(%q) err = %v, want errors.Is ErrInvalidRunID", tc.id, err)
+			}
+		})
+	}
+}
+
+func TestSubScheduler_Counter_AutoIncrementsPerChildName(t *testing.T) {
+	sub := newDynamicSubScheduler(newTopLevelCtx(t), "parent", noopEmit)
+
+	for i := 1; i <= 3; i++ {
+		got, err := sub.resolveRunID("childA", "")
+		if err != nil {
+			t.Fatalf("resolveRunID childA #%d: %v", i, err)
+		}
+		if got != strconv.Itoa(i) {
+			t.Errorf("childA #%d got %q, want %q", i, got, strconv.Itoa(i))
+		}
+	}
+	// Independent counter per child name.
+	got, _ := sub.resolveRunID("childB", "")
+	if got != "1" {
+		t.Errorf("childB first invocation got %q, want \"1\"", got)
+	}
+}
+
+func TestSubScheduler_Counter_ConcurrentSafe(t *testing.T) {
+	sub := newDynamicSubScheduler(newTopLevelCtx(t), "parent", noopEmit)
+	const goroutines = 64
+
+	var wg sync.WaitGroup
+	wg.Add(goroutines)
+	seen := sync.Map{}
+	for i := 0; i < goroutines; i++ {
+		go func() {
+			defer wg.Done()
+			id, err := sub.resolveRunID("worker", "")
+			if err != nil {
+				t.Errorf("resolveRunID: %v", err)
+				return
+			}
+			if _, dup := seen.LoadOrStore(id, struct{}{}); dup {
+				t.Errorf("duplicate run id %q", id)
+			}
+		}()
+	}
+	wg.Wait()
+}
+
+func TestSubScheduler_Counter_CustomIDDoesNotIncrement(t *testing.T) {
+	sub := newDynamicSubScheduler(newTopLevelCtx(t), "parent", noopEmit)
+
+	if _, err := sub.resolveRunID("c", "order-1"); err != nil {
+		t.Fatalf("custom id: %v", err)
+	}
+	got, _ := sub.resolveRunID("c", "")
+	if got != "1" {
+		t.Errorf("auto id after custom got %q, want \"1\" (custom must not bump counter)", got)
+	}
+}
+
+func TestSubScheduler_RunNode_FreshExecution(t *testing.T) {
+	child := newStubNode("greeter", "hello")
+	var forwarded []*session.Event
+	sub := newDynamicSubScheduler(newTopLevelCtx(t), "wf", func(ev *session.Event) error {
+		forwarded = append(forwarded, ev)
+		return nil
+	})
+
+	out, err := sub.runNode(child, "world", "")
+	if err != nil {
+		t.Fatalf("runNode: %v", err)
+	}
+	if out != "hello" {
+		t.Errorf("output = %v, want \"hello\"", out)
+	}
+	if len(forwarded) != 1 {
+		t.Fatalf("forwarded events = %d, want 1", len(forwarded))
+	}
+	if forwarded[0].Output != "hello" {
+		t.Errorf("forwarded event Output = %v, want \"hello\"", forwarded[0].Output)
+	}
+}
+
+func TestSubScheduler_RunNode_CustomIDInPath(t *testing.T) {
+	child := newStubNode("processor", nil)
+	sub := newDynamicSubScheduler(newTopLevelCtx(t), "wf", noopEmit)
+
+	if _, err := sub.runNode(child, nil, "order-42"); err != nil {
+		t.Fatalf("runNode: %v", err)
+	}
+	// The child must have observed its NodeContext populated with the
+	// composite path; verify via the stub's captured context.
+	if got, want := child.lastPath, "wf/processor@order-42"; got != want {
+		t.Errorf("child Path() = %q, want %q", got, want)
+	}
+}
+
+func TestSubScheduler_RunNode_HITLReturnsInterrupted(t *testing.T) {
+	child := newRequestInputNode("asker", "approve?")
+	var forwarded []*session.Event
+	sub := newDynamicSubScheduler(newTopLevelCtx(t), "wf", func(ev *session.Event) error {
+		forwarded = append(forwarded, ev)
+		return nil
+	})
+
+	_, err := sub.runNode(child, nil, "")
+	if !errors.Is(err, ErrNodeInterrupted) {
+		t.Fatalf("err = %v, want ErrNodeInterrupted", err)
+	}
+	var nre *NodeRunError
+	if !errors.As(err, &nre) {
+		t.Fatalf("err is not *NodeRunError: %v", err)
+	}
+	if nre.ChildPath != "wf/asker@1" {
+		t.Errorf("ChildPath = %q, want %q", nre.ChildPath, "wf/asker@1")
+	}
+	if len(forwarded) != 1 || forwarded[0].RequestedInput == nil {
+		t.Errorf("forwarded events = %+v, want 1 RequestedInput event", forwarded)
+	}
+}
+
+func TestSubScheduler_RunNode_ErrorWinsOverInterrupt(t *testing.T) {
+	child := newInterruptThenFailNode("flaky")
+	sub := newDynamicSubScheduler(newTopLevelCtx(t), "wf", noopEmit)
+
+	_, err := sub.runNode(child, nil, "")
+	if !errors.Is(err, ErrNodeFailed) {
+		t.Errorf("err = %v, want ErrNodeFailed", err)
+	}
+	if errors.Is(err, ErrNodeInterrupted) {
+		t.Errorf("err = %v; ErrNodeInterrupted must not leak when child fails after RequestInput", err)
+	}
+}
+
+// =============================================================================
+// Test fixtures and helpers
+// =============================================================================
+
+func noopEmit(*session.Event) error { return nil }
+
+func newTopLevelCtx(t *testing.T) *nodeContext {
+	t.Helper()
+	return newNodeContext(newMockCtx(t), nil)
+}
+
+// stubNode emits one Event{Output: out} and exits.
+type stubNode struct {
+	BaseNode
+	out      any
+	lastPath string
+}
+
+func newStubNode(name string, out any) *stubNode {
+	return &stubNode{
+		BaseNode: NewBaseNode(name, "", NodeConfig{}),
+		out:      out,
+	}
+}
+
+func (n *stubNode) Run(ctx agent.InvocationContext, _ any) iter.Seq2[*session.Event, error] {
+	if nc, ok := ctx.(NodeContext); ok {
+		n.lastPath = nc.Path()
+	}
+	out := n.out
+	return func(yield func(*session.Event, error) bool) {
+		yield(&session.Event{Output: out}, nil)
+	}
+}
+
+// requestInputNode emits one RequestedInput event and exits cleanly.
+type requestInputNode struct {
+	BaseNode
+	message string
+}
+
+func newRequestInputNode(name, msg string) *requestInputNode {
+	return &requestInputNode{
+		BaseNode: NewBaseNode(name, "", NodeConfig{}),
+		message:  msg,
+	}
+}
+
+func (n *requestInputNode) Run(agent.InvocationContext, any) iter.Seq2[*session.Event, error] {
+	return func(yield func(*session.Event, error) bool) {
+		yield(&session.Event{
+			RequestedInput: &session.RequestInput{
+				InterruptID: "iid-1",
+				Message:     n.message,
+			},
+		}, nil)
+	}
+}
+
+// interruptThenFailNode yields RequestedInput, then yields an error.
+type interruptThenFailNode struct{ BaseNode }
+
+func newInterruptThenFailNode(name string) *interruptThenFailNode {
+	return &interruptThenFailNode{BaseNode: NewBaseNode(name, "", NodeConfig{})}
+}
+
+func (n *interruptThenFailNode) Run(agent.InvocationContext, any) iter.Seq2[*session.Event, error] {
+	return func(yield func(*session.Event, error) bool) {
+		if !yield(&session.Event{
+			RequestedInput: &session.RequestInput{InterruptID: "iid", Message: "ask"},
+		}, nil) {
+			return
+		}
+		yield(nil, errors.New("boom"))
+	}
+}

--- a/workflow/errors.go
+++ b/workflow/errors.go
@@ -1,0 +1,76 @@
+// Copyright 2026 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package workflow
+
+import (
+	"errors"
+	"fmt"
+)
+
+var (
+	// ErrNodeFailed wraps a child node's runtime failure after retries.
+	ErrNodeFailed = errors.New("workflow: dynamic child failed")
+
+	// ErrNodeInterrupted wraps a child node's HITL pause request.
+	ErrNodeInterrupted = errors.New("workflow: dynamic child interrupted")
+
+	// ErrInvalidRunNodeContext is returned by RunNode when ctx is not
+	// the NodeContext of a currently-executing dynamic node.
+	ErrInvalidRunNodeContext = errors.New("workflow: RunNode called outside a dynamic node")
+
+	// ErrInvalidRunID rejects a custom run id that would collide
+	// with the auto-counter: purely numeric ids are reserved.
+	ErrInvalidRunID = errors.New("workflow: invalid run id")
+
+	// ErrParallelHITLUnsupported rejects two children of one
+	// activation interrupting concurrently — at most one pending HITL
+	// per activation.
+	ErrParallelHITLUnsupported = errors.New("workflow: parallel HITL is not supported")
+)
+
+// NodeRunError wraps a sentinel with the failing child's identity.
+// Use errors.As to recover the fields.
+type NodeRunError struct {
+	// ChildName is the child's Node.Name(), e.g. "fixer_agent".
+	ChildName string
+	// ChildPath is the composite path, e.g. "code_workflow/fixer_agent@2".
+	ChildPath string
+	// RunID is the per-invocation identifier, auto-counter or
+	// user-supplied via WithRunID.
+	RunID string
+	Cause error
+}
+
+// Error formats as "workflow: dynamic child <path>: <cause>".
+func (e *NodeRunError) Error() string {
+	if e == nil {
+		return "<nil>"
+	}
+	path := e.ChildPath
+	if path == "" {
+		path = e.ChildName
+	}
+	if e.Cause == nil {
+		return fmt.Sprintf("workflow: dynamic child %s: <nil cause>", path)
+	}
+	return fmt.Sprintf("workflow: dynamic child %s: %v", path, e.Cause)
+}
+
+func (e *NodeRunError) Unwrap() error {
+	if e == nil {
+		return nil
+	}
+	return e.Cause
+}

--- a/workflow/errors_test.go
+++ b/workflow/errors_test.go
@@ -1,0 +1,86 @@
+// Copyright 2026 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package workflow
+
+import (
+	"strings"
+	"testing"
+)
+
+func TestSentinels_HaveWorkflowPrefix(t *testing.T) {
+	sentinels := map[string]error{
+		"ErrNodeFailed":              ErrNodeFailed,
+		"ErrNodeInterrupted":         ErrNodeInterrupted,
+		"ErrInvalidRunNodeContext":   ErrInvalidRunNodeContext,
+		"ErrInvalidRunID":            ErrInvalidRunID,
+		"ErrParallelHITLUnsupported": ErrParallelHITLUnsupported,
+	}
+	for name, err := range sentinels {
+		t.Run(name, func(t *testing.T) {
+			if !strings.HasPrefix(err.Error(), "workflow:") {
+				t.Errorf("%s.Error() = %q; want prefix \"workflow:\"", name, err.Error())
+			}
+		})
+	}
+}
+
+func TestNodeRunError_Unwrap(t *testing.T) {
+	t.Run("returns Cause", func(t *testing.T) {
+		nre := &NodeRunError{Cause: ErrNodeFailed}
+		if got := nre.Unwrap(); got != ErrNodeFailed {
+			t.Errorf("Unwrap() = %v, want %v", got, ErrNodeFailed)
+		}
+	})
+	t.Run("nil receiver returns nil", func(t *testing.T) {
+		var nre *NodeRunError
+		if got := nre.Unwrap(); got != nil {
+			t.Errorf("(*NodeRunError)(nil).Unwrap() = %v, want nil", got)
+		}
+	})
+}
+
+func TestNodeRunError_Error(t *testing.T) {
+	t.Run("includes ChildPath and cause", func(t *testing.T) {
+		nre := &NodeRunError{ChildPath: "code_workflow/fixer@2", Cause: ErrNodeFailed}
+		s := nre.Error()
+		if !strings.Contains(s, "code_workflow/fixer@2") {
+			t.Errorf("Error() = %q, want to contain ChildPath", s)
+		}
+		if !strings.Contains(s, ErrNodeFailed.Error()) {
+			t.Errorf("Error() = %q, want to contain cause message", s)
+		}
+	})
+
+	t.Run("falls back to ChildName when ChildPath empty", func(t *testing.T) {
+		nre := &NodeRunError{ChildName: "fixer", Cause: ErrNodeInterrupted}
+		s := nre.Error()
+		if !strings.Contains(s, "fixer") {
+			t.Errorf("Error() = %q, want to contain ChildName when ChildPath unset", s)
+		}
+	})
+
+	t.Run("nil cause does not panic", func(t *testing.T) {
+		nre := &NodeRunError{ChildPath: "x/y@1"}
+		_ = nre.Error()
+	})
+
+	t.Run("nil receiver does not panic", func(t *testing.T) {
+		var nre *NodeRunError
+		_ = nre.Error()
+	})
+}
+
+// Compile-time: *NodeRunError implements error.
+var _ error = (*NodeRunError)(nil)

--- a/workflow/node_context.go
+++ b/workflow/node_context.go
@@ -14,29 +14,56 @@
 
 package workflow
 
-import "google.golang.org/adk/agent"
+import (
+	"google.golang.org/adk/agent"
+)
 
-// nodeContext is the per-node InvocationContext seen inside Node.Run.
-// It wraps the workflow's incoming agent.InvocationContext and
-// surfaces the human-input responses the scheduler injected for a
-// re-entry resume activation (ResumedInput).
+// NodeContext is the per-node context seen inside Node.Run and inside
+// dynamic-node orchestrator bodies. It extends agent.InvocationContext
+// with workflow-specific accessors.
 //
-// TODO(wolo): replace once context-unification work lands. The
-// wrapper exists today only to surface workflow-specific accessors
-// that the base interface does not have.
+// TODO(wolo): unify with the in-flight context-unification work
+// (CallbackContext / ToolContext series).
+type NodeContext interface {
+	agent.InvocationContext
+
+	// ResumedInput returns the response payload for a re-entry resume
+	// activation keyed by InterruptID, or (nil, false) otherwise.
+	ResumedInput(interruptID string) (any, bool)
+
+	// Path returns the composite path of the currently-executing node.
+	// Empty for top-level static nodes; "<parent_path>/<child_name>@<run_id>"
+	// for dynamic children.
+	Path() string
+
+	// RunID returns the per-invocation identifier. Empty for top-level
+	// static nodes; auto-counter or user-supplied via WithRunID for
+	// dynamic children.
+	RunID() string
+}
+
+// nodeContext is the unexported NodeContext implementation.
 type nodeContext struct {
 	agent.InvocationContext
 
-	// resumeInputs carries the user-supplied response payloads for
-	// a re-entry resume activation, keyed by InterruptID. Nil on
-	// fresh activations and on handoff resume (where the response
-	// flows to the successor as its input rather than back to the
-	// asker via this map).
+	// resumeInputs are keyed by InterruptID. Nil on fresh activations
+	// and on handoff resume.
 	resumeInputs map[string]any
+
+	// path and runID are populated for dynamic children, empty for
+	// top-level static activations.
+	path  string
+	runID string
+
+	// subScheduler is non-nil only when this context belongs to a
+	// dynamic-node activation; RunNode uses it to schedule children.
+	subScheduler *dynamicSubScheduler
 }
 
-// newNodeContext returns a nodeContext wrapping parent. resumeInputs
-// is nil for non-resume activations.
+// Compile-time: *nodeContext implements NodeContext.
+var _ NodeContext = (*nodeContext)(nil)
+
+// newNodeContext wraps parent for a top-level (static) activation.
 func newNodeContext(parent agent.InvocationContext, resumeInputs map[string]any) *nodeContext {
 	return &nodeContext{
 		InvocationContext: parent,
@@ -44,11 +71,27 @@ func newNodeContext(parent agent.InvocationContext, resumeInputs map[string]any)
 	}
 }
 
-// ResumedInput returns the response payload associated with the
-// given InterruptID for a re-entry resume activation. Returns
-// (nil, false) on fresh activations, on handoff resume, and when
-// the InterruptID does not match any payload supplied by the
-// resuming caller.
+// newDynamicNodeContext wraps parent for either a dynamic-node
+// activation or one of its children, attaching path, runID, and the
+// sub-scheduler RunNode reaches from the orchestrator body. Children
+// pass the sub-scheduler's counter (or WithRunID) value as runID; a
+// dynamic node's own activation passes runID="" — it is not itself a
+// sub-scheduler child. Child inherits resumeInputs so HITL responses
+// reach dynamic children.
+func newDynamicNodeContext(parent NodeContext, path, runID string, sub *dynamicSubScheduler) *nodeContext {
+	var inherited map[string]any
+	if p, ok := parent.(*nodeContext); ok {
+		inherited = p.resumeInputs
+	}
+	return &nodeContext{
+		InvocationContext: parent,
+		resumeInputs:      inherited,
+		path:              path,
+		runID:             runID,
+		subScheduler:      sub,
+	}
+}
+
 func (c *nodeContext) ResumedInput(interruptID string) (any, bool) {
 	if c.resumeInputs == nil {
 		return nil, false
@@ -56,3 +99,6 @@ func (c *nodeContext) ResumedInput(interruptID string) (any, bool) {
 	v, ok := c.resumeInputs[interruptID]
 	return v, ok
 }
+
+func (c *nodeContext) Path() string  { return c.path }
+func (c *nodeContext) RunID() string { return c.runID }

--- a/workflow/node_context_test.go
+++ b/workflow/node_context_test.go
@@ -16,8 +16,6 @@ package workflow
 
 import (
 	"testing"
-
-	"google.golang.org/adk/agent"
 )
 
 func TestNodeContext_ResumedInput(t *testing.T) {
@@ -40,7 +38,70 @@ func TestNodeContext_ResumedInput(t *testing.T) {
 			t.Errorf("ResumedInput(\"approval\") = (%v, %v), want (\"yes\", true)", v, ok)
 		}
 	})
+
+	t.Run("unmatched InterruptID returns (nil, false)", func(t *testing.T) {
+		c := newNodeContext(parent, map[string]any{"approval": "yes"})
+		if v, ok := c.ResumedInput("missing"); v != nil || ok {
+			t.Errorf("ResumedInput(\"missing\") = (%v, %v), want (nil, false)", v, ok)
+		}
+	})
 }
 
-// Compile-time assertion: *nodeContext satisfies agent.InvocationContext.
-var _ agent.InvocationContext = (*nodeContext)(nil)
+func TestNodeContext_PathAndRunID(t *testing.T) {
+	t.Run("top-level static returns empty", func(t *testing.T) {
+		c := newNodeContext(newMockCtx(t), nil)
+		if got := c.Path(); got != "" {
+			t.Errorf("Path() = %q, want empty", got)
+		}
+		if got := c.RunID(); got != "" {
+			t.Errorf("RunID() = %q, want empty", got)
+		}
+	})
+
+	t.Run("child populated from constructor", func(t *testing.T) {
+		parent := newNodeContext(newMockCtx(t), nil)
+		child := newDynamicNodeContext(parent, "wf/fixer@2", "2", nil)
+		if got, want := child.Path(), "wf/fixer@2"; got != want {
+			t.Errorf("Path() = %q, want %q", got, want)
+		}
+		if got, want := child.RunID(), "2"; got != want {
+			t.Errorf("RunID() = %q, want %q", got, want)
+		}
+	})
+
+	t.Run("activation populated with empty runID", func(t *testing.T) {
+		parent := newNodeContext(newMockCtx(t), nil)
+		act := newDynamicNodeContext(parent, "city_workflow", "", nil)
+		if got, want := act.Path(), "city_workflow"; got != want {
+			t.Errorf("Path() = %q, want %q", got, want)
+		}
+		if got := act.RunID(); got != "" {
+			t.Errorf("RunID() = %q, want empty for dynamic-node activation", got)
+		}
+	})
+}
+
+func TestNodeContext_DynamicInheritsResumeInputs(t *testing.T) {
+	parent := newNodeContext(newMockCtx(t), map[string]any{"approval": "yes"})
+	sub := &dynamicSubScheduler{}
+
+	t.Run("child", func(t *testing.T) {
+		child := newDynamicNodeContext(parent, "wf/asker@1", "1", sub)
+		if v, ok := child.ResumedInput("approval"); !ok || v != "yes" {
+			t.Errorf("child.ResumedInput(\"approval\") = (%v, %v), want (\"yes\", true)", v, ok)
+		}
+		if child.subScheduler != sub {
+			t.Errorf("subScheduler pointer differs from supplied")
+		}
+	})
+
+	t.Run("activation", func(t *testing.T) {
+		act := newDynamicNodeContext(parent, "city_workflow", "", sub)
+		if v, ok := act.ResumedInput("approval"); !ok || v != "yes" {
+			t.Errorf("act.ResumedInput(\"approval\") = (%v, %v), want (\"yes\", true)", v, ok)
+		}
+		if act.subScheduler != sub {
+			t.Errorf("subScheduler pointer differs from supplied")
+		}
+	})
+}


### PR DESCRIPTION
Adds the foundation the dynamic-workflows track builds on: a public `NodeContext` interface with composite-path support, typed errors, and a per-activation sub-scheduler that runs one child and classifies the outcome.

`workflow.NodeContext` is now an exported interface extending `agent.InvocationContext`, mirroring the interface-not-struct shape of `agent.CallbackContext` and the forthcoming `agent.ToolContext` so future context-unification can swap the backing type without breaking users.

`dynamicSubScheduler` runs one child per call, forwards its events upstream via an `emitUp` callback, derives a composite child path, and classifies the outcome (HITL → `ErrNodeInterrupted`, runtime failure → `ErrNodeFailed`).

Child run ids come from a per-(parent activation, child name) auto-counter protected by a mutex for concurrent `errgroup`-style use; user-supplied custom ids are rejected when empty, purely numeric, or containing the composite-path separators `/` and `@`.


Precedence matches adk-python: a child that fails after emitting `RequestedInput` surfaces as `ErrNodeFailed`, not `ErrNodeInterrupted`.

Resume/replay-skip, parent `NodeWaiting` persistence, parallel HITL detection, and the public `NewDynamicNode` / `RunNode` API stay deferred to follow-up PRs.


