### PR TITLE
feat(telemetry): Instrument nodes and workflows

### DIFF
--- a/agent/agent.go
+++ b/agent/agent.go
@@ -161,7 +161,7 @@ func (a *agent) SubAgents() []Agent {
 
 func (a *agent) Run(ctx InvocationContext) iter.Seq2[*session.Event, error] {
 	return func(yield func(*session.Event, error) bool) {
-		spanCtx, span := telemetry.StartInvokeAgentSpan(ctx, a, ctx.Session().ID(), ctx.InvocationID())
+		spanCtx, span := telemetry.StartNodeSpan(ctx, ctx, telemetry.OperationAgent{Agent: a})
 		yield, endSpan := telemetry.WrapYield(span, yield, func(span trace.Span, event *session.Event, err error) {
 			telemetry.TraceAgentResult(span, telemetry.TraceAgentResultParams{
 				ResponseEvent: event,

--- a/agent/workflowagent/workflow.go
+++ b/agent/workflowagent/workflow.go
@@ -16,11 +16,13 @@ package workflowagent
 
 import (
 	"encoding/json"
+	"fmt"
 	"iter"
 
 	"google.golang.org/genai"
 
 	"google.golang.org/adk/agent"
+	agentinternal "google.golang.org/adk/internal/agent"
 	"google.golang.org/adk/internal/utils"
 	"google.golang.org/adk/session"
 	"google.golang.org/adk/workflow"
@@ -50,7 +52,7 @@ func New(cfg Config) (agent.Agent, error) {
 
 	wa := &workflowAgent{workflow: w}
 
-	return agent.New(agent.Config{
+	wfAgent, err := agent.New(agent.Config{
 		Name:                 cfg.Name,
 		Description:          cfg.Description,
 		SubAgents:            cfg.SubAgents,
@@ -58,6 +60,22 @@ func New(cfg Config) (agent.Agent, error) {
 		AfterAgentCallbacks:  cfg.AfterAgentCallbacks,
 		Run:                  wa.run,
 	})
+	if err != nil {
+		return nil, err
+	}
+
+	// Tag the agent state so the telemetry layer can emit
+	// "invoke_workflow <name>" spans instead of "invoke_agent <name>"
+	// for workflow-backed agents.
+	internalAgent, ok := wfAgent.(agentinternal.Agent)
+	if !ok {
+		return nil, fmt.Errorf("internal error: failed to convert to internal agent")
+	}
+	state := agentinternal.Reveal(internalAgent)
+	state.AgentType = agentinternal.TypeWorkflowAgent
+	state.Config = cfg
+
+	return wfAgent, nil
 }
 
 // workflowAgent is the wrapper that dispatches between

--- a/internal/agent/state.go
+++ b/internal/agent/state.go
@@ -31,6 +31,7 @@ const (
 	TypeLoopAgent       Type = "LoopAgent"
 	TypeSequentialAgent Type = "SequentialAgent"
 	TypeParallelAgent   Type = "ParallelAgent"
+	TypeWorkflowAgent   Type = "WorkflowAgent"
 	TypeCustomAgent     Type = "CustomAgent"
 	TypeRemoteAgent     Type = "RemoteAgent"
 )

--- a/internal/telemetry/functionaltest/workflow_telemetry_schema_test.go
+++ b/internal/telemetry/functionaltest/workflow_telemetry_schema_test.go
@@ -1,0 +1,81 @@
+// Copyright 2026 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package functionaltest_test
+
+import (
+	"strings"
+	"testing"
+
+	"github.com/google/go-cmp/cmp"
+	sdklog "go.opentelemetry.io/otel/sdk/log"
+	sdktrace "go.opentelemetry.io/otel/sdk/trace"
+	"go.opentelemetry.io/otel/sdk/trace/tracetest"
+
+	"google.golang.org/adk/agent"
+	"google.golang.org/adk/agent/workflowagent"
+	"google.golang.org/adk/internal/telemetry"
+	"google.golang.org/adk/internal/telemetry/telemetrytest"
+	"google.golang.org/adk/internal/telemetry/telemetrytestcase"
+	"google.golang.org/adk/workflow"
+)
+
+// TestTelemetrySchema_WorkflowChain runs the
+// [telemetrytestcase.WorkflowChainCase] scenario end-to-end and
+// asserts the emitted span tree matches the expected shape. No LLM
+// is involved so no log records are emitted; the test still
+// installs an in-memory log exporter so a regression that suddenly
+// starts emitting events would be caught by the cmp.Diff against
+// the empty-Logs expectation.
+//
+// Hermetic: no network calls, no LLMs, no GCP.
+//
+// Mirrors test_telemetry_schema in
+// adk-python/tests/unittests/telemetry/test_node_functional.py.
+func TestTelemetrySchema_WorkflowChain(t *testing.T) {
+	spanExp := tracetest.NewInMemoryExporter()
+	telemetry.OverrideTracerForTesting(t, sdktrace.NewTracerProvider(sdktrace.WithSyncer(spanExp)))
+
+	logExp := telemetrytest.NewInMemoryLogExporter()
+	telemetry.OverrideLoggerForTesting(t, sdklog.NewLoggerProvider(
+		sdklog.WithProcessor(sdklog.NewSimpleProcessor(logExp)),
+	))
+
+	upperFn := func(_ agent.InvocationContext, in string) (string, error) {
+		return strings.ToUpper(in), nil
+	}
+	suffixFn := func(_ agent.InvocationContext, in string) (string, error) {
+		return in + " IS AWESOME!", nil
+	}
+
+	nodeCfg := workflow.NodeConfig{RetryConfig: workflow.DefaultRetryConfig()}
+	upperNode := workflow.NewFunctionNode("upper_node", upperFn, nodeCfg)
+	suffixNode := workflow.NewFunctionNode("suffix_node", suffixFn, nodeCfg)
+
+	wfAgent, err := workflowagent.New(workflowagent.Config{
+		Name:        "my_workflow",
+		Description: "uppercases input then appends a suffix",
+		Edges:       workflow.Chain(workflow.Start, upperNode, suffixNode),
+	})
+	if err != nil {
+		t.Fatalf("workflowagent.New: %v", err)
+	}
+
+	telemetrytest.RunScenario(t, wfAgent, "hello")
+
+	got := telemetrytest.BuildDigests(t, spanExp.GetSpans(), logExp.Records())
+	if diff := cmp.Diff(telemetrytestcase.WorkflowChainCase, got); diff != "" {
+		t.Errorf("telemetry mismatch (-want +got):\n%s", diff)
+	}
+}

--- a/internal/telemetry/node_tracing.go
+++ b/internal/telemetry/node_tracing.go
@@ -1,0 +1,148 @@
+// Copyright 2026 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package telemetry
+
+import (
+	"context"
+	"fmt"
+
+	"go.opentelemetry.io/otel/attribute"
+	semconv "go.opentelemetry.io/otel/semconv/v1.36.0"
+	"go.opentelemetry.io/otel/trace"
+	"go.opentelemetry.io/otel/trace/noop"
+
+	agentinternal "google.golang.org/adk/internal/agent"
+	"google.golang.org/adk/session"
+)
+
+// gen_ai.operation.name attribute values for the agent / workflow /
+// node spans. These mirror the values set by adk-python's
+// node_tracing module.
+const (
+	invokeWorkflowOperationName = "invoke_workflow"
+	invokeNodeOperationName     = "invoke_node"
+)
+
+// Attribute keys not yet in the Go semconv package; the string
+// literals match the keys used by adk-python.
+var (
+	genAIWorkflowName = attribute.Key("gen_ai.workflow.name")
+	genAINodeName     = attribute.Key("gen_ai.node.name")
+)
+
+// Operation is the internal sum-type which describes what can be used to start a span.
+type Operation interface {
+	isOperation()
+}
+
+// AgentLike is the minimal contract telemetry needs to describe a BaseAgent.
+type AgentLike interface {
+	Name() string
+	Description() string
+}
+
+// WorkflowNodeLike is the minimal contract telemetry needs to describe a workflow BaseNode.
+type WorkflowNodeLike interface {
+	Name() string
+}
+
+// OperationAgent is the [Operation] variant for an agent invocation.
+// concrete span name (invoke_agent vs invoke_workflow) is decided
+// inside [StartNodeSpan] by peeking at the agent's internal
+// State.AgentType.
+type OperationAgent struct {
+	Agent AgentLike
+}
+
+func (OperationAgent) isOperation() {}
+
+// OperationNode is the [Operation] variant for a workflow BaseNode activation.
+type OperationNode struct {
+	Node WorkflowNodeLike
+}
+
+func (OperationNode) isOperation() {}
+
+// InvocationContext is the minimal copy of agent.InvocationContext necessary for telemetry.
+type InvocationContext interface {
+	Session() session.Session
+	InvocationID() string
+}
+
+// StartNodeSpan emits an OpenTelemetry span and returns a derived context with the new Span.
+// Emits:
+// - invoke_workflow <workflow_name> if provided with [OperationNode] or workflow agent.
+// - invoke_agent <agent_name> if provided with non-workflow agent.
+// - invoke_node <node_name> if provided with a generic node.
+// - otherwise doesn't start any new span and returns the input context unchanged.
+func StartNodeSpan(ctx context.Context, ictx InvocationContext, op Operation) (context.Context, trace.Span) {
+	switch o := op.(type) {
+	case OperationAgent:
+		if isWorkflowAgent(o.Agent) {
+			return startInvokeWorkflowSpan(ctx, ictx, o.Agent)
+		}
+		return startInvokeAgentSpan(ctx, ictx, o.Agent)
+	case OperationNode:
+		return startInvokeNodeSpan(ctx, ictx, o.Node)
+	default:
+		return ctx, noop.Span{}
+	}
+}
+
+func isWorkflowAgent(a AgentLike) bool {
+	internal, ok := a.(agentinternal.Agent)
+	if !ok {
+		return false
+	}
+	return agentinternal.Reveal(internal).AgentType == agentinternal.TypeWorkflowAgent
+}
+
+// sessionID returns ictx.Session().ID() or "" if the
+// InvocationContext has no session attached. Tolerates nil
+// sessions because workflow tests construct mock invocation
+// contexts without one.
+func sessionID(ictx InvocationContext) string {
+	s := ictx.Session()
+	if s == nil {
+		return ""
+	}
+	return s.ID()
+}
+
+func startInvokeAgentSpan(ctx context.Context, ictx InvocationContext, a AgentLike) (context.Context, trace.Span) {
+	return tracer.Start(ctx, fmt.Sprintf("invoke_agent %s", a.Name()), trace.WithAttributes(
+		gcpVertexAgentInvocationID.String(ictx.InvocationID()), // used by adk-web
+		semconv.GenAIOperationNameInvokeAgent,
+		semconv.GenAIAgentDescription(a.Description()),
+		semconv.GenAIAgentName(a.Name()),
+		semconv.GenAIConversationID(sessionID(ictx)),
+	))
+}
+
+func startInvokeWorkflowSpan(ctx context.Context, ictx InvocationContext, w AgentLike) (context.Context, trace.Span) {
+	return tracer.Start(ctx, fmt.Sprintf("invoke_workflow %s", w.Name()), trace.WithAttributes(
+		semconv.GenAIOperationNameKey.String(invokeWorkflowOperationName),
+		genAIWorkflowName.String(w.Name()),
+		semconv.GenAIConversationID(sessionID(ictx)),
+	))
+}
+
+func startInvokeNodeSpan(ctx context.Context, ictx InvocationContext, n WorkflowNodeLike) (context.Context, trace.Span) {
+	return tracer.Start(ctx, fmt.Sprintf("invoke_node %s", n.Name()), trace.WithAttributes(
+		semconv.GenAIOperationNameKey.String(invokeNodeOperationName),
+		genAINodeName.String(n.Name()),
+		semconv.GenAIConversationID(sessionID(ictx)),
+	))
+}

--- a/internal/telemetry/telemetry.go
+++ b/internal/telemetry/telemetry.go
@@ -70,26 +70,6 @@ func OverrideTracerForTesting(t interface{ Cleanup(func()) }, tp trace.TracerPro
 	t.Cleanup(func() { tracer = original })
 }
 
-type agent interface {
-	Name() string
-	Description() string
-}
-
-// StartInvokeAgentSpan starts a new semconv invoke_agent span.
-// It returns a new context with the span and the span itself.
-func StartInvokeAgentSpan(ctx context.Context, agent agent, sessionID, invocationID string) (context.Context, trace.Span) {
-	agentName := agent.Name()
-	spanCtx, span := tracer.Start(ctx, fmt.Sprintf("invoke_agent %s", agentName), trace.WithAttributes(
-		gcpVertexAgentInvocationID.String(invocationID), // used by adk-web
-		semconv.GenAIOperationNameInvokeAgent,
-		semconv.GenAIAgentDescription(agent.Description()),
-		semconv.GenAIAgentName(agentName),
-		semconv.GenAIConversationID(sessionID),
-	))
-
-	return spanCtx, span
-}
-
 type TraceAgentResultParams struct {
 	ResponseEvent *session.Event
 	Error         error

--- a/internal/telemetry/telemetry_test.go
+++ b/internal/telemetry/telemetry_test.go
@@ -29,6 +29,7 @@ import (
 	"go.opentelemetry.io/otel/trace/noop"
 	"google.golang.org/genai"
 
+	agentinternal "google.golang.org/adk/internal/agent"
 	"google.golang.org/adk/model"
 	"google.golang.org/adk/session"
 )
@@ -105,20 +106,57 @@ func TestWrapYield_MultipleCalls(t *testing.T) {
 
 var errTest = errors.New("test error")
 
-type mockAgent struct{}
-
-func (a *mockAgent) Name() string {
-	return "test-agent"
+// fakeAgent satisfies both [AgentLike] and [agentinternal.Agent]
+// by embedding [agentinternal.State] (which provides the unexported
+// internal() method required by the Agent interface). Used by
+// node-tracing tests to drive [StartNodeSpan] without spinning up
+// a real agent.
+type fakeAgent struct {
+	agentinternal.State
+	name        string
+	description string
 }
 
-func (a *mockAgent) Description() string {
-	return "test-agent-description"
+func (f *fakeAgent) Name() string        { return f.name }
+func (f *fakeAgent) Description() string { return f.description }
+
+// fakeInvocationContext satisfies [InvocationContext]. The session
+// is built lazily from the in-memory service so the conversation
+// ID attribute matches sessionID exactly.
+type fakeInvocationContext struct {
+	t            *testing.T
+	sessionID    string
+	invocationID string
+	sess         session.Session
 }
+
+func (f *fakeInvocationContext) Session() session.Session {
+	if f.sess == nil {
+		svc := session.InMemoryService()
+		resp, err := svc.Create(context.Background(), &session.CreateRequest{
+			AppName:   "test_app",
+			UserID:    "test_user",
+			SessionID: f.sessionID,
+		})
+		if err != nil {
+			f.t.Fatalf("session create: %v", err)
+		}
+		f.sess = resp.Session
+	}
+	return f.sess
+}
+
+func (f *fakeInvocationContext) InvocationID() string { return f.invocationID }
 
 func TestInvokeAgent(t *testing.T) {
 	sessionID := "test-session"
 	invocationID := "test-invocation-id"
-	agent := &mockAgent{}
+	a := &fakeAgent{
+		State:       agentinternal.State{AgentType: agentinternal.TypeLLMAgent},
+		name:        "test-agent",
+		description: "test-agent-description",
+	}
+	ictx := &fakeInvocationContext{t: t, sessionID: sessionID, invocationID: invocationID}
 	tests := []struct {
 		name         string
 		resultParams TraceAgentResultParams
@@ -163,7 +201,7 @@ func TestInvokeAgent(t *testing.T) {
 			exporter := setupTestTracer(t)
 			ctx := t.Context()
 
-			_, span := StartInvokeAgentSpan(ctx, agent, sessionID, invocationID)
+			_, span := StartNodeSpan(ctx, ictx, OperationAgent{Agent: a})
 			TraceAgentResult(span, tc.resultParams)
 			span.End()
 

--- a/internal/telemetry/telemetrytestcase/workflow_chain.go
+++ b/internal/telemetry/telemetrytestcase/workflow_chain.go
@@ -1,0 +1,48 @@
+// Copyright 2026 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package telemetrytestcase
+
+import (
+	"google.golang.org/adk/internal/telemetry/telemetrytest"
+)
+
+// WorkflowChainCase is the expected root span for the canonical
+// "workflowagent chaining two FunctionNodes" scenario.
+var WorkflowChainCase = &telemetrytest.SpanDigest{
+	Name: "invoke_workflow my_workflow",
+	Attributes: map[string]any{
+		"gen_ai.operation.name":  "invoke_workflow",
+		"gen_ai.workflow.name":   "my_workflow",
+		"gen_ai.conversation.id": telemetrytest.PRESENT,
+	},
+	Children: []*telemetrytest.SpanDigest{
+		{
+			Name: "invoke_node upper_node",
+			Attributes: map[string]any{
+				"gen_ai.operation.name":  "invoke_node",
+				"gen_ai.node.name":       "upper_node",
+				"gen_ai.conversation.id": telemetrytest.PRESENT,
+			},
+		},
+		{
+			Name: "invoke_node suffix_node",
+			Attributes: map[string]any{
+				"gen_ai.operation.name":  "invoke_node",
+				"gen_ai.node.name":       "suffix_node",
+				"gen_ai.conversation.id": telemetrytest.PRESENT,
+			},
+		},
+	},
+}

--- a/workflow/node_context.go
+++ b/workflow/node_context.go
@@ -15,6 +15,8 @@
 package workflow
 
 import (
+	"context"
+
 	"google.golang.org/adk/agent"
 )
 
@@ -118,5 +120,21 @@ func (c *nodeContext) WithBranch(branch string) NodeContext {
 		path:              c.path,
 		runID:             c.runID,
 		subScheduler:      c.subScheduler,
+	}
+}
+
+// WithContext preserves the nodeContext wrapper when callers derive
+// a new context from this one (e.g. when the scheduler attaches an
+// OpenTelemetry span context). Without this override, the base
+// invocationContext.WithContext would return a *invocationContext
+// and silently drop the resumeInputs map, breaking re-entry resume
+// activations and any other workflow-specific accessors.
+func (c *nodeContext) WithContext(ctx context.Context) agent.InvocationContext {
+	return &nodeContext{
+		c.InvocationContext.WithContext(ctx),
+		c.resumeInputs,
+		c.path,
+		c.runID,
+		c.subScheduler,
 	}
 }

--- a/workflow/scheduler.go
+++ b/workflow/scheduler.go
@@ -21,7 +21,12 @@ import (
 	"sync"
 	"time"
 
+	"go.opentelemetry.io/otel/codes"
+	"go.opentelemetry.io/otel/trace"
+	"go.opentelemetry.io/otel/trace/noop"
+
 	"google.golang.org/adk/agent"
+	"google.golang.org/adk/internal/telemetry"
 	"google.golang.org/adk/session"
 )
 
@@ -331,6 +336,9 @@ func runNode(
 ) {
 	defer wg.Done()
 
+	span, ctx := startNodeSpan(ctx, n)
+	defer span.End()
+
 	// completion holds the final completionItem. It is sent in the
 	// outer defer so panic recovery, normal exit, and cancellation
 	// all funnel through the same send path.
@@ -338,6 +346,10 @@ func runNode(
 	defer func() {
 		if r := recover(); r != nil {
 			completion.err = fmt.Errorf("node %q panicked: %v", name, r)
+		}
+		if completion.err != nil && !errors.Is(completion.err, context.Canceled) {
+			span.RecordError(completion.err)
+			span.SetStatus(codes.Error, completion.err.Error())
 		}
 		out <- completion
 	}()
@@ -776,4 +788,13 @@ func aggregatePredecessorBranches(g *graph, state *RunState, target Node) []stri
 		branches = append(branches, br)
 	}
 	return branches
+}
+
+func startNodeSpan(ctx agent.InvocationContext, n Node) (trace.Span, agent.InvocationContext) {
+	if n == Start {
+		// Don't create span for the Start node.
+		return noop.Span{}, ctx
+	}
+	spanCtx, span := telemetry.StartNodeSpan(ctx, ctx, telemetry.OperationNode{Node: n})
+	return span, ctx.WithContext(spanCtx)
 }


### PR DESCRIPTION
### Instrument workflows and nodes

Instruments V2 `Workflows` and `Nodes`.

Prior to this change, running:
```sh
go run ./examples/workflow/basic console -otel_to_cloud
```
produced no telemetry.

After this change, the following trace data is emitted:
<img width="2554" height="1281" alt="image" src="https://github.com/user-attachments/assets/466fec05-0139-4180-bf6b-786cb7abeecc" />

### Testing Plan

**Unit Tests:**

- [x] I have added or updated unit tests for my change.
- [x] All unit tests pass locally.

**Manual End-to-End (E2E) Tests:**

1. Run the basic node example
```sh
export GOOGLE_CLOUD_PROJECT=your_gcp_project
go run ./examples/workflow/basic console -otel_to_cloud
```
2. Ctrl+C to flush the OpenTelemetry spans
3. Navigate to https://pantheon.corp.google.com/traces/explorer
4. Observe saved trace

### Checklist

- [x] I have read the [CONTRIBUTING.md](./CONTRIBUTING.md) document.
- [x] I have performed a self-review of my own code.
- [x] I have commented my code, particularly in hard-to-understand areas.
- [x] I have added tests that prove my fix is effective or that my feature works.
- [x] New and existing unit tests pass locally with my changes.
- [x] I have manually tested my changes end-to-end.
- [x] Any dependent changes have been merged and published in downstream modules.

### Additional context

_Add any other context or screenshots about the feature request here._

