### PR TITLE
test(telemetry): add instrumentation functional tests 

### DIFF
--- a/examples/tools/multipletools/main.go
+++ b/examples/tools/multipletools/main.go
@@ -107,11 +107,11 @@ func main() {
 		log.Fatalf("Failed to create agent: %v", err)
 	}
 
+	// Save message content in OpenTelemetry logs
+	os.Setenv("OTEL_INSTRUMENTATION_GENAI_CAPTURE_MESSAGE_CONTENT", "true")
+
 	config := &launcher.Config{
 		AgentLoader: agent.NewSingleLoader(a),
-		TelemetryOptions: []telemetry.Option{
-			telemetry.WithGenAICaptureMessageContent(true),
-		},
 	}
 
 	l := full.NewLauncher()

--- a/internal/telemetry/functionaltest/agent_telemetry_schema_test.go
+++ b/internal/telemetry/functionaltest/agent_telemetry_schema_test.go
@@ -1,0 +1,150 @@
+// Copyright 2026 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package functionaltest_test
+
+import (
+	"testing"
+
+	"github.com/google/go-cmp/cmp"
+	sdklog "go.opentelemetry.io/otel/sdk/log"
+	sdktrace "go.opentelemetry.io/otel/sdk/trace"
+	"go.opentelemetry.io/otel/sdk/trace/tracetest"
+	"google.golang.org/genai"
+
+	"google.golang.org/adk/agent"
+	"google.golang.org/adk/agent/llmagent"
+	"google.golang.org/adk/internal/telemetry"
+	"google.golang.org/adk/internal/telemetry/telemetrytest"
+	"google.golang.org/adk/internal/telemetry/telemetrytestcase"
+	"google.golang.org/adk/internal/testutil"
+	"google.golang.org/adk/tool"
+	"google.golang.org/adk/tool/functiontool"
+)
+
+// captureMessageContentEnvVar is the OpenTelemetry-spec env var
+// that controls whether ADK emits full message content in log
+// records or elides it for privacy.
+const captureMessageContentEnvVar = "OTEL_INSTRUMENTATION_GENAI_CAPTURE_MESSAGE_CONTENT"
+
+// TestTelemetrySchema_AgentWithTool runs the canonical
+// "llmagent with one FunctionTool" scenario end-to-end and asserts
+// the emitted span+log tree matches the expected shape exactly.
+// Parametrized over the
+// OTEL_INSTRUMENTATION_GENAI_CAPTURE_MESSAGE_CONTENT env var:
+// the "elided" subtest expects the production default (no message
+// content in log bodies); the "capture_content" subtest expects
+// the full decoded JSON content. Hermetic: no network calls, no
+// GCP, no live model.
+//
+// Mirrors test_telemetry_schema in
+// adk-python/tests/unittests/telemetry/test_functional.py.
+func TestTelemetrySchema_AgentWithTool(t *testing.T) {
+	tests := []struct {
+		name           string
+		captureContent bool
+		want           *telemetrytest.SpanDigest
+	}{
+		{
+			name:           "elided",
+			captureContent: false,
+			want:           telemetrytestcase.AgentWithToolCase,
+		},
+		{
+			name:           "capture_content",
+			captureContent: true,
+			want:           telemetrytestcase.AgentWithToolCaptureContentCase,
+		},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			if tc.captureContent {
+				t.Setenv(captureMessageContentEnvVar, "true")
+			} else {
+				t.Setenv(captureMessageContentEnvVar, "")
+			}
+
+			// Install in-memory tracer + logger so the test sees
+			// every span/log without depending on global OTel state.
+			spanExp := tracetest.NewInMemoryExporter()
+			telemetry.OverrideTracerForTesting(t, sdktrace.NewTracerProvider(sdktrace.WithSyncer(spanExp)))
+
+			logExp := telemetrytest.NewInMemoryLogExporter()
+			telemetry.OverrideLoggerForTesting(t, sdklog.NewLoggerProvider(
+				sdklog.WithProcessor(sdklog.NewSimpleProcessor(logExp)),
+			))
+
+			rootAgent := newAgentWithToolScenario(t)
+			telemetrytest.RunScenario(t, rootAgent, "hello")
+
+			got := telemetrytest.BuildDigests(t, spanExp.GetSpans(), logExp.Records())
+			if diff := cmp.Diff(tc.want, got); diff != "" {
+				t.Errorf("telemetry mismatch (-want +got):\n%s", diff)
+			}
+		})
+	}
+}
+
+// newAgentWithToolScenario constructs the canonical llmagent +
+// 1 FunctionTool + 2 LLM turns scenario. The first turn returns a
+// function call to the tool; the second turn returns the final
+// text response. The expected telemetry shape for this scenario
+// is declared in telemetrytestcase.AgentWithToolCase (and its
+// capture-content variant).
+func newAgentWithToolScenario(t *testing.T) agent.Agent {
+	t.Helper()
+	mockModel := &testutil.MockModel{
+		Responses: []*genai.Content{
+			{
+				Role: "model",
+				Parts: []*genai.Part{{
+					FunctionCall: &genai.FunctionCall{
+						Name: "some_tool",
+						Args: map[string]any{"arg1": "val1"},
+					},
+				}},
+			},
+			{
+				Role:  "model",
+				Parts: []*genai.Part{{Text: "text response"}},
+			},
+		},
+	}
+
+	type Args struct {
+		Arg1 string `json:"arg1"`
+	}
+	sampleTool, err := functiontool.New(functiontool.Config{
+		Name:        "some_tool",
+		Description: "A sample tool.",
+	}, func(_ tool.Context, in Args) (string, error) {
+		return "processed " + in.Arg1, nil
+	})
+	if err != nil {
+		t.Fatalf("functiontool.New: %v", err)
+	}
+
+	rootAgent, err := llmagent.New(llmagent.Config{
+		Name:        "some_root_agent",
+		Description: "A sample root agent.",
+		Model:       mockModel,
+		Instruction: "you are helpful",
+		Tools:       []tool.Tool{sampleTool},
+	})
+	if err != nil {
+		t.Fatalf("llmagent.New: %v", err)
+	}
+	return rootAgent
+}

--- a/internal/telemetry/functionaltest/doc.go
+++ b/internal/telemetry/functionaltest/doc.go
@@ -1,0 +1,38 @@
+// Copyright 2026 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+// Package functionaltest contains hermetic functional tests for ADK
+// telemetry: each Test* function builds a real ADK agent
+// (llmagent, workflowagent, ...) backed by a hermetic
+// [google.golang.org/adk/internal/testutil.MockModel], drives it
+// through a real Runner, and asserts the emitted span tree + log
+// records against the expected shape declared in the
+// telemetrytestcase package.
+//
+// Layout:
+//
+//   - The expected shapes (SpanDigest + LogDigest literals) live in
+//     internal/telemetry/telemetrytestcase, one file per scenario.
+//   - The helpers used to build the digests, install the
+//     in-memory tracer/logger, and stand in for the LLM live in
+//     internal/telemetry/telemetrytest.
+//   - This package only holds the runners: scenario setup +
+//     comparison code, so failures in this package always indicate
+//     either a regression in the production code or a stale
+//     expectation in telemetrytestcase.
+//
+// The package lives outside internal/telemetry to avoid import
+// cycles (the runners pull in agent/llmagent, agent/workflowagent,
+// runner, etc., which transitively import internal/telemetry).
+package functionaltest

--- a/internal/telemetry/logger.go
+++ b/internal/telemetry/logger.go
@@ -17,8 +17,8 @@ package telemetry
 import (
 	"context"
 	"encoding/json"
+	"os"
 	"strings"
-	"sync/atomic"
 
 	"go.opentelemetry.io/otel/log"
 	"go.opentelemetry.io/otel/log/global"
@@ -29,17 +29,17 @@ import (
 	"google.golang.org/adk/model"
 )
 
-// genAICaptureMessageContent is true if message content should be elided. False by default.
-var genAICaptureMessageContent atomic.Bool
+// captureMessageContentEnvVar is the OpenTelemetry-spec env var
+// that controls whether ADK emits full message content in log
+// records (true) or elides it for privacy (anything else,
+// including unset). Defined by
+// https://opentelemetry.io/docs/specs/semconv/registry/attributes/gen-ai/.
+const captureMessageContentEnvVar = "OTEL_INSTRUMENTATION_GENAI_CAPTURE_MESSAGE_CONTENT"
 
-// SetGenAICaptureMessageContent sets whether message content should be elided.
-func SetGenAICaptureMessageContent(capture bool) {
-	genAICaptureMessageContent.Store(capture)
-}
-
-// getGenAICaptureMessageContent returns whether message content should be elided.
+// getGenAICaptureMessageContent reports whether message content
+// should be captured in log records.
 func getGenAICaptureMessageContent() bool {
-	return genAICaptureMessageContent.Load()
+	return strings.TrimSpace(os.Getenv(captureMessageContentEnvVar)) == "true"
 }
 
 const elidedContent = "<elided>"
@@ -49,6 +49,19 @@ var otelLogger = global.GetLoggerProvider().Logger(
 	log.WithSchemaURL(semconv.SchemaURL),
 	log.WithInstrumentationVersion(version.Version),
 )
+
+// OverrideLoggerForTesting replaces the package-level otelLogger
+// with one derived from lp for the duration of the calling test.
+// The original logger is restored via t.Cleanup.
+func OverrideLoggerForTesting(t interface{ Cleanup(func()) }, lp log.LoggerProvider) {
+	original := otelLogger
+	otelLogger = lp.Logger(
+		systemName,
+		log.WithSchemaURL(semconv.SchemaURL),
+		log.WithInstrumentationVersion(version.Version),
+	)
+	t.Cleanup(func() { otelLogger = original })
+}
 
 // LogRequest logs the request to the model - the system message and user messages.
 // It iterates over the request contents and logs each as a separate event.

--- a/internal/telemetry/logger_test.go
+++ b/internal/telemetry/logger_test.go
@@ -576,7 +576,7 @@ func TestSpanIDPropagation(t *testing.T) {
 	}
 }
 
-func setup(t *testing.T, elided bool) *inMemoryExporter {
+func setup(t *testing.T, capture bool) *inMemoryExporter {
 	exporter := &inMemoryExporter{}
 	provider := sdklog.NewLoggerProvider(
 		sdklog.WithProcessor(sdklog.NewSimpleProcessor(exporter)),
@@ -587,11 +587,11 @@ func setup(t *testing.T, elided bool) *inMemoryExporter {
 		otelLogger = originalLogger
 	})
 
-	original := getGenAICaptureMessageContent()
-	SetGenAICaptureMessageContent(elided)
-	t.Cleanup(func() {
-		SetGenAICaptureMessageContent(original)
-	})
+	if capture {
+		t.Setenv(captureMessageContentEnvVar, "true")
+	} else {
+		t.Setenv(captureMessageContentEnvVar, "")
+	}
 	return exporter
 }
 

--- a/internal/telemetry/telemetry.go
+++ b/internal/telemetry/telemetry.go
@@ -57,6 +57,19 @@ var tracer trace.Tracer = otel.GetTracerProvider().Tracer(
 	trace.WithSchemaURL(semconv.SchemaURL),
 )
 
+// OverrideTracerForTesting replaces the package-level tracer with one
+// derived from tp for the duration of the calling test. The original
+// tracer is restored via t.Cleanup.
+func OverrideTracerForTesting(t interface{ Cleanup(func()) }, tp trace.TracerProvider) {
+	original := tracer
+	tracer = tp.Tracer(
+		systemName,
+		trace.WithInstrumentationVersion(version.Version),
+		trace.WithSchemaURL(semconv.SchemaURL),
+	)
+	t.Cleanup(func() { tracer = original })
+}
+
 type agent interface {
 	Name() string
 	Description() string

--- a/internal/telemetry/telemetrytest/doc.go
+++ b/internal/telemetry/telemetrytest/doc.go
@@ -1,0 +1,35 @@
+// Copyright 2026 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+// Package telemetrytest provides reusable helpers for hermetic
+// telemetry tests in ADK.
+//
+// Helpers in this package:
+//
+//   - [SpanDigest] / [BuildDigests] / [PRESENT] — capture and
+//     normalise the emitted OTel span tree so tests can compare
+//     against a literal expected shape. Log records nest inside
+//     the SpanDigest of the span they were emitted under via
+//     [SpanDigest.Logs], yielding a single causal tree.
+//   - [LogDigest] / [InMemoryLogExporter] — log-record snapshot
+//     type and the in-memory sink to install via
+//     telemetry.OverrideLoggerForTesting.
+//
+// The expected shapes for each scenario live in the sibling
+// telemetrytestcase package; the runners that drive the agent and
+// compare actual vs expected live in the telemetry/functionaltest
+// test package. Functional tests use the shared
+// [google.golang.org/adk/internal/testutil.MockModel] as the
+// deterministic LLM stand-in.
+package telemetrytest

--- a/internal/telemetry/telemetrytest/log_digest.go
+++ b/internal/telemetry/telemetrytest/log_digest.go
@@ -1,0 +1,138 @@
+// Copyright 2026 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package telemetrytest
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+	"sync"
+
+	"go.opentelemetry.io/otel/log"
+	sdklog "go.opentelemetry.io/otel/sdk/log"
+)
+
+// LogDigest is a deterministic snapshot of one OTel log record:
+// the event name, attributes, and the body decoded to a Go value.
+type LogDigest struct {
+	EventName  string
+	Attributes map[string]any
+	Body       any // JSON-normalized: int64 values are returned as float64
+}
+
+func buildLogDigest(r *sdklog.Record) *LogDigest {
+	attrs := map[string]any{}
+	r.WalkAttributes(func(kv log.KeyValue) bool {
+		attrs[kv.Key] = logValueToAny(kv.Value)
+		return true
+	})
+	return &LogDigest{
+		EventName:  r.EventName(),
+		Attributes: attrs,
+		Body:       jsonRoundTrip(logValueToAny(r.Body())),
+	}
+}
+
+// jsonRoundTrip marshals v to JSON and unmarshals the result back
+// into a fresh any. This normalises:
+//   - numeric types (int64, float64 → float64),
+//   - string-valued bodies (returned as plain Go strings),
+//   - structured bodies (returned as map[string]any / []any).
+//
+// On marshal/unmarshal failure the input value is returned
+// unchanged; cmp.Diff will then surface the unconverted shape and
+// the test author can fix the body rendering.
+func jsonRoundTrip(v any) any {
+	b, err := json.Marshal(v)
+	if err != nil {
+		return v
+	}
+	var out any
+	if err := json.Unmarshal(b, &out); err != nil {
+		return v
+	}
+	return out
+}
+
+// InMemoryLogExporter is a minimal in-memory log record sink for tests.
+type InMemoryLogExporter struct {
+	mu      sync.Mutex
+	records []sdklog.Record
+}
+
+// NewInMemoryLogExporter returns an empty exporter ready for use with sdklog.NewSimpleProcessor.
+func NewInMemoryLogExporter() *InMemoryLogExporter { return &InMemoryLogExporter{} }
+
+// Export implements sdklog.Exporter.
+func (e *InMemoryLogExporter) Export(_ context.Context, records []sdklog.Record) error {
+	e.mu.Lock()
+	defer e.mu.Unlock()
+	for _, r := range records {
+		// Records are pooled by some processors; clone so the
+		// stored copy is stable.
+		e.records = append(e.records, r.Clone())
+	}
+	return nil
+}
+
+// Shutdown implements sdklog.Exporter.
+func (e *InMemoryLogExporter) Shutdown(_ context.Context) error { return nil }
+
+// ForceFlush implements sdklog.Exporter.
+func (e *InMemoryLogExporter) ForceFlush(_ context.Context) error { return nil }
+
+// Records returns a snapshot of the records collected so far, in emit order.
+func (e *InMemoryLogExporter) Records() []sdklog.Record {
+	e.mu.Lock()
+	defer e.mu.Unlock()
+	out := make([]sdklog.Record, len(e.records))
+	copy(out, e.records)
+	return out
+}
+
+// logValueToAny converts an OTel log.Value to a plain Go value
+// (string, int64, float64, bool, []any, map[string]any).
+func logValueToAny(v log.Value) any {
+	switch v.Kind() {
+	case log.KindBool:
+		return v.AsBool()
+	case log.KindFloat64:
+		return v.AsFloat64()
+	case log.KindInt64:
+		return v.AsInt64()
+	case log.KindString:
+		return v.AsString()
+	case log.KindBytes:
+		return v.AsBytes()
+	case log.KindSlice:
+		s := v.AsSlice()
+		out := make([]any, len(s))
+		for i, e := range s {
+			out[i] = logValueToAny(e)
+		}
+		return out
+	case log.KindMap:
+		m := v.AsMap()
+		out := make(map[string]any, len(m))
+		for _, kv := range m {
+			out[kv.Key] = logValueToAny(kv.Value)
+		}
+		return out
+	case log.KindEmpty:
+		return nil
+	default:
+		return fmt.Sprintf("<unknown log.Kind %v>", v.Kind())
+	}
+}

--- a/internal/telemetry/telemetrytest/scenario.go
+++ b/internal/telemetry/telemetrytest/scenario.go
@@ -1,0 +1,62 @@
+// Copyright 2026 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package telemetrytest
+
+import (
+	"context"
+	"testing"
+
+	"google.golang.org/genai"
+
+	"google.golang.org/adk/agent"
+	"google.golang.org/adk/runner"
+	"google.golang.org/adk/session"
+)
+
+// RunScenario drives rootAgent through a single user turn via a
+// real Runner backed by an in-memory session service. Used by
+// every functional telemetry test; kept here rather than in a
+// _test.go file so callers in any external test package can reuse
+// the same scenario harness.
+//
+// Mirrors functional_test_helpers.run_agent_scenario in adk-python.
+func RunScenario(t *testing.T, rootAgent agent.Agent, prompt string) {
+	t.Helper()
+	ctx := context.Background()
+
+	sessSvc := session.InMemoryService()
+	r, err := runner.New(runner.Config{
+		AppName:        "test_app",
+		Agent:          rootAgent,
+		SessionService: sessSvc,
+	})
+	if err != nil {
+		t.Fatalf("runner.New: %v", err)
+	}
+	sess, err := sessSvc.Create(ctx, &session.CreateRequest{
+		AppName: "test_app",
+		UserID:  "test_user",
+	})
+	if err != nil {
+		t.Fatalf("session create: %v", err)
+	}
+
+	msg := genai.NewContentFromText(prompt, genai.RoleUser)
+	for _, err := range r.Run(ctx, "test_user", sess.Session.ID(), msg, agent.RunConfig{}) {
+		if err != nil {
+			t.Fatalf("runner.Run yielded error: %v", err)
+		}
+	}
+}

--- a/internal/telemetry/telemetrytest/span_digest.go
+++ b/internal/telemetry/telemetrytest/span_digest.go
@@ -1,0 +1,170 @@
+// Copyright 2026 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package telemetrytest
+
+import (
+	"sort"
+	"testing"
+
+	"go.opentelemetry.io/otel/attribute"
+	sdklog "go.opentelemetry.io/otel/sdk/log"
+	"go.opentelemetry.io/otel/sdk/trace/tracetest"
+	"go.opentelemetry.io/otel/trace"
+)
+
+// PRESENT is the sentinel used to mark attributes whose value is
+// non-deterministic across runs but whose presence must still be
+// asserted (e.g. invocation_id, session_id).
+const PRESENT = "<PRESENT>"
+
+// nonDeterministicSpanAttributes are span attributes whose VALUE
+// varies run-to-run. [BuildDigests] replaces these with [PRESENT]
+// so the comparison shape is stable while still asserting the key
+// is set.
+var nonDeterministicSpanAttributes = map[string]bool{
+	"gcp.vertex.agent.event_id":       true,
+	"gen_ai.tool.call.id":             true,
+	"gen_ai.conversation.id":          true,
+	"gcp.vertex.agent.invocation_id":  true,
+	"gcp.vertex.agent.session_id":     true,
+	"gcp.vertex.agent.tool_call_args": true, // contains generated arg ids
+	"gcp.vertex.agent.tool_response":  true, // contains generated event ids
+}
+
+// SpanDigest is a deterministic snapshot of a span: name, normalised
+// attributes, child spans, and the log records emitted while the
+// span was active.
+type SpanDigest struct {
+	Name       string
+	Attributes map[string]any
+	Children   []*SpanDigest
+	Logs       []*LogDigest
+}
+
+type spanWithMeta struct {
+	digest    *SpanDigest
+	spanID    trace.SpanID
+	parentID  trace.SpanID
+	startTime int64
+}
+
+// BuildDigests collects the spans and log records into a single
+// tree, attaching each log to the SpanDigest of the span
+// it was emitted under. The scenario MUST produce exactly one root span.
+func BuildDigests(t *testing.T, spans tracetest.SpanStubs, logs []sdklog.Record) *SpanDigest {
+	t.Helper()
+	digests := make([]*spanWithMeta, 0, len(spans))
+	for _, s := range spans {
+		digests = append(digests, buildSpanDigest(s))
+	}
+	digests = attachLogs(digests, logs)
+	roots := linkAndSort(digests)
+	if len(roots) != 1 {
+		t.Fatalf("expected exactly 1 root span, got %d", len(roots))
+	}
+	return roots[0]
+}
+
+func buildSpanDigest(s tracetest.SpanStub) *spanWithMeta {
+	return &spanWithMeta{
+		digest: &SpanDigest{
+			Name:       s.Name,
+			Attributes: normaliseSpanAttributes(s.Attributes),
+		},
+		spanID:    s.SpanContext.SpanID(),
+		parentID:  s.Parent.SpanID(),
+		startTime: s.StartTime.UnixNano(),
+	}
+}
+
+// attachLogs populates the Logs slice of each digest whose SpanID
+// matches a log record's SpanID. Log iteration order is emit
+// order, so the resulting per-span Logs slices end up
+// chronological. Logs not associated with any collected span
+// (e.g. emitted at module init) are dropped silently.
+func attachLogs(digests []*spanWithMeta, logs []sdklog.Record) []*spanWithMeta {
+	bySpanID := make(map[trace.SpanID]*SpanDigest, len(digests))
+	for _, d := range digests {
+		bySpanID[d.spanID] = d.digest
+	}
+	for _, r := range logs {
+		if d, ok := bySpanID[r.SpanID()]; ok {
+			d.Logs = append(d.Logs, buildLogDigest(&r))
+		}
+	}
+	return digests
+}
+
+// linkAndSort assembles the parent→children adjacency, recursively
+// sorts each level by start time (name as tiebreaker), assigns the
+// sorted children to the SpanDigest.Children slices, and returns
+// the roots (spans whose parent was not collected).
+func linkAndSort(digests []*spanWithMeta) []*SpanDigest {
+	bySpanID := make(map[trace.SpanID]*spanWithMeta, len(digests))
+	for _, sw := range digests {
+		bySpanID[sw.spanID] = sw
+	}
+	childrenOf := map[*spanWithMeta][]*spanWithMeta{}
+	var roots []*spanWithMeta
+	for _, sw := range digests {
+		if parent, ok := bySpanID[sw.parentID]; ok {
+			childrenOf[parent] = append(childrenOf[parent], sw)
+		} else {
+			roots = append(roots, sw)
+		}
+	}
+	less := func(a, b *spanWithMeta) bool {
+		if a.startTime != b.startTime {
+			return a.startTime < b.startTime
+		}
+		return a.digest.Name < b.digest.Name
+	}
+	var assignSorted func(sw *spanWithMeta)
+	assignSorted = func(sw *spanWithMeta) {
+		children := childrenOf[sw]
+		if len(children) == 0 {
+			return
+		}
+		sort.SliceStable(children, func(i, j int) bool { return less(children[i], children[j]) })
+		sw.digest.Children = make([]*SpanDigest, len(children))
+		for i, c := range children {
+			sw.digest.Children[i] = c.digest
+			assignSorted(c)
+		}
+	}
+	sort.SliceStable(roots, func(i, j int) bool { return less(roots[i], roots[j]) })
+	out := make([]*SpanDigest, len(roots))
+	for i, r := range roots {
+		assignSorted(r)
+		out[i] = r.digest
+	}
+	return out
+}
+
+// normaliseSpanAttributes converts the OTel attribute slice into a
+// map[string]any with non-deterministic values collapsed to
+// [PRESENT].
+func normaliseSpanAttributes(attrs []attribute.KeyValue) map[string]any {
+	out := make(map[string]any, len(attrs))
+	for _, kv := range attrs {
+		key := string(kv.Key)
+		if nonDeterministicSpanAttributes[key] {
+			out[key] = PRESENT
+			continue
+		}
+		out[key] = kv.Value.AsInterface()
+	}
+	return out
+}

--- a/internal/telemetry/telemetrytestcase/agent_with_tool.go
+++ b/internal/telemetry/telemetrytestcase/agent_with_tool.go
@@ -1,0 +1,116 @@
+// Copyright 2026 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package telemetrytestcase
+
+import (
+	"google.golang.org/adk/internal/telemetry/telemetrytest"
+)
+
+// AgentWithToolCase is the expected root span emitted by the
+// canonical "llmagent with one FunctionTool" scenario.
+var AgentWithToolCase = &telemetrytest.SpanDigest{
+	Name: "invoke_agent some_root_agent",
+	Attributes: map[string]any{
+		"gen_ai.operation.name":          "invoke_agent",
+		"gen_ai.agent.name":              "some_root_agent",
+		"gen_ai.agent.description":       "A sample root agent.",
+		"gen_ai.conversation.id":         telemetrytest.PRESENT,
+		"gcp.vertex.agent.invocation_id": telemetrytest.PRESENT,
+	},
+	Children: []*telemetrytest.SpanDigest{
+		{
+			Name: "generate_content mock",
+			Attributes: map[string]any{
+				"gen_ai.operation.name":          "generate_content",
+				"gen_ai.request.model":           "mock",
+				"gcp.vertex.agent.event_id":      telemetrytest.PRESENT,
+				"gcp.vertex.agent.invocation_id": telemetrytest.PRESENT,
+				// MockModel returns no UsageMetadata, so no token
+				// attrs are set. The mock response carries no
+				// FinishReason; the existing telemetry emits the
+				// empty FinishReason as a single-element string
+				// slice.
+				"gen_ai.response.finish_reasons": []string{""},
+			},
+			Logs: []*telemetrytest.LogDigest{
+				// Content elision is on by default.
+				{
+					EventName:  "gen_ai.system.message",
+					Attributes: map[string]any{},
+					Body:       map[string]any{"content": "<elided>"},
+				},
+				{
+					EventName:  "gen_ai.user.message",
+					Attributes: map[string]any{},
+					Body:       map[string]any{"content": "<elided>"},
+				},
+				{
+					EventName:  "gen_ai.choice",
+					Attributes: map[string]any{},
+					Body:       map[string]any{"content": "<elided>", "index": float64(0)},
+				},
+			},
+		},
+		{
+			Name: "execute_tool some_tool",
+			Attributes: map[string]any{
+				"gen_ai.operation.name":           "execute_tool",
+				"gen_ai.tool.name":                "some_tool",
+				"gen_ai.tool.description":         "A sample tool.",
+				"gen_ai.tool.call.id":             telemetrytest.PRESENT,
+				"gcp.vertex.agent.event_id":       telemetrytest.PRESENT,
+				"gcp.vertex.agent.tool_call_args": telemetrytest.PRESENT,
+				"gcp.vertex.agent.tool_response":  telemetrytest.PRESENT,
+			},
+		},
+		{
+			Name: "generate_content mock",
+			Attributes: map[string]any{
+				"gen_ai.operation.name":          "generate_content",
+				"gen_ai.request.model":           "mock",
+				"gcp.vertex.agent.event_id":      telemetrytest.PRESENT,
+				"gcp.vertex.agent.invocation_id": telemetrytest.PRESENT,
+				"gen_ai.response.finish_reasons": []string{""},
+			},
+			Logs: []*telemetrytest.LogDigest{
+				{
+					EventName:  "gen_ai.system.message",
+					Attributes: map[string]any{},
+					Body:       map[string]any{"content": "<elided>"},
+				},
+				{
+					EventName:  "gen_ai.user.message",
+					Attributes: map[string]any{},
+					Body:       map[string]any{"content": "<elided>"},
+				},
+				{
+					EventName:  "gen_ai.user.message",
+					Attributes: map[string]any{},
+					Body:       map[string]any{"content": "<elided>"},
+				},
+				{
+					EventName:  "gen_ai.user.message",
+					Attributes: map[string]any{},
+					Body:       map[string]any{"content": "<elided>"},
+				},
+				{
+					EventName:  "gen_ai.choice",
+					Attributes: map[string]any{},
+					Body:       map[string]any{"content": "<elided>", "index": float64(0)},
+				},
+			},
+		},
+	},
+}

--- a/internal/telemetry/telemetrytestcase/agent_with_tool_capture_content.go
+++ b/internal/telemetry/telemetrytestcase/agent_with_tool_capture_content.go
@@ -1,0 +1,167 @@
+// Copyright 2026 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package telemetrytestcase
+
+import (
+	"google.golang.org/adk/internal/telemetry/telemetrytest"
+)
+
+// AgentWithToolCaptureContentCase is the expected root span for
+// the same scenario as [AgentWithToolCase] but with content capture
+// enabled, via OTEL_INSTRUMENTATION_GENAI_CAPTURE_MESSAGE_CONTENT env var.
+var AgentWithToolCaptureContentCase = &telemetrytest.SpanDigest{
+	Name: "invoke_agent some_root_agent",
+	Attributes: map[string]any{
+		"gen_ai.operation.name":          "invoke_agent",
+		"gen_ai.agent.name":              "some_root_agent",
+		"gen_ai.agent.description":       "A sample root agent.",
+		"gen_ai.conversation.id":         telemetrytest.PRESENT,
+		"gcp.vertex.agent.invocation_id": telemetrytest.PRESENT,
+	},
+	Children: []*telemetrytest.SpanDigest{
+		{
+			Name: "generate_content mock",
+			Attributes: map[string]any{
+				"gen_ai.operation.name":          "generate_content",
+				"gen_ai.request.model":           "mock",
+				"gcp.vertex.agent.event_id":      telemetrytest.PRESENT,
+				"gcp.vertex.agent.invocation_id": telemetrytest.PRESENT,
+				"gen_ai.response.finish_reasons": []string{""},
+			},
+			Logs: []*telemetrytest.LogDigest{
+				{
+					EventName:  "gen_ai.system.message",
+					Attributes: map[string]any{},
+					Body: map[string]any{
+						"content": "you are helpful\n\nYou are an agent. Your internal name is \"some_root_agent\". The description about you is \"A sample root agent.\".",
+					},
+				},
+				{
+					EventName:  "gen_ai.user.message",
+					Attributes: map[string]any{},
+					Body: map[string]any{
+						"content": map[string]any{
+							"role":  "user",
+							"parts": []any{map[string]any{"text": "hello"}},
+						},
+					},
+				},
+				{
+					EventName:  "gen_ai.choice",
+					Attributes: map[string]any{},
+					// Turn 1: model emits a function call.
+					Body: map[string]any{
+						"index": float64(0),
+						"content": map[string]any{
+							"role": "model",
+							"parts": []any{map[string]any{
+								"functionCall": map[string]any{
+									"name": "some_tool",
+									"args": map[string]any{"arg1": "val1"},
+								},
+							}},
+						},
+					},
+				},
+			},
+		},
+		{
+			Name: "execute_tool some_tool",
+			Attributes: map[string]any{
+				"gen_ai.operation.name":           "execute_tool",
+				"gen_ai.tool.name":                "some_tool",
+				"gen_ai.tool.description":         "A sample tool.",
+				"gen_ai.tool.call.id":             telemetrytest.PRESENT,
+				"gcp.vertex.agent.event_id":       telemetrytest.PRESENT,
+				"gcp.vertex.agent.tool_call_args": telemetrytest.PRESENT,
+				"gcp.vertex.agent.tool_response":  telemetrytest.PRESENT,
+			},
+		},
+		{
+			Name: "generate_content mock",
+			Attributes: map[string]any{
+				"gen_ai.operation.name":          "generate_content",
+				"gen_ai.request.model":           "mock",
+				"gcp.vertex.agent.event_id":      telemetrytest.PRESENT,
+				"gcp.vertex.agent.invocation_id": telemetrytest.PRESENT,
+				"gen_ai.response.finish_reasons": []string{""},
+			},
+			Logs: []*telemetrytest.LogDigest{
+				{
+					EventName:  "gen_ai.system.message",
+					Attributes: map[string]any{},
+					Body: map[string]any{
+						"content": "you are helpful\n\nYou are an agent. Your internal name is \"some_root_agent\". The description about you is \"A sample root agent.\".",
+					},
+				},
+				{
+					EventName:  "gen_ai.user.message",
+					Attributes: map[string]any{},
+					Body: map[string]any{
+						"content": map[string]any{
+							"role":  "user",
+							"parts": []any{map[string]any{"text": "hello"}},
+						},
+					},
+				},
+				{
+					EventName:  "gen_ai.user.message",
+					Attributes: map[string]any{},
+					// Turn 2 carries the model's previous turn
+					// (the function call) as a content entry.
+					Body: map[string]any{
+						"content": map[string]any{
+							"role": "model",
+							"parts": []any{map[string]any{
+								"functionCall": map[string]any{
+									"name": "some_tool",
+									"args": map[string]any{"arg1": "val1"},
+								},
+							}},
+						},
+					},
+				},
+				{
+					EventName:  "gen_ai.user.message",
+					Attributes: map[string]any{},
+					// Turn 2 carries the function-response turn.
+					Body: map[string]any{
+						"content": map[string]any{
+							"role": "user",
+							"parts": []any{map[string]any{
+								"functionResponse": map[string]any{
+									"name":     "some_tool",
+									"response": map[string]any{"result": "processed val1"},
+								},
+							}},
+						},
+					},
+				},
+				{
+					EventName:  "gen_ai.choice",
+					Attributes: map[string]any{},
+					// Turn 2: final text response.
+					Body: map[string]any{
+						"index": float64(0),
+						"content": map[string]any{
+							"role":  "model",
+							"parts": []any{map[string]any{"text": "text response"}},
+						},
+					},
+				},
+			},
+		},
+	},
+}

--- a/internal/telemetry/telemetrytestcase/doc.go
+++ b/internal/telemetry/telemetrytestcase/doc.go
@@ -1,0 +1,29 @@
+// Copyright 2026 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+// Package telemetrytestcase declares the expected telemetry shape
+// (spans + log records nested inside their owning span) emitted by
+// each canonical end-to-end ADK scenario.
+//
+// Each test case lives in its own file and exports exactly one
+// symbol — a *[telemetrytest.SpanDigest] holding the expected root
+// span and its full subtree — so the literal SpanDigest /
+// LogDigest expectations are visible at a glance, undivided by
+// helpers, and the package's exported surface is a 1:1 inventory
+// of the scenarios under test.
+//
+// The actual runners that build the agent, drive a Runner, and
+// compare against the expected digest live in the
+// telemetry/functionaltest test package.
+package telemetrytestcase

--- a/telemetry/config.go
+++ b/telemetry/config.go
@@ -26,10 +26,6 @@ type config struct {
 	// Enables/disables telemetry export to GCP.
 	oTelToCloud bool
 
-	// genAICaptureMessageContent enables/disables logging of message content. The default value is taken from OTEL_INSTRUMENTATION_GENAI_CAPTURE_MESSAGE_CONTENT env variable.
-	// If set to true, the message content will be logged in message body. Otherwise it will be elided.
-	genAICaptureMessageContent bool
-
 	// gcpResourceProject is used as the gcp.project.id resource attribute.
 	// If it's empty, the project will be read from ADC or GOOGLE_CLOUD_PROJECT env variable.
 	gcpResourceProject string
@@ -136,14 +132,6 @@ func WithTracerProvider(tp *sdktrace.TracerProvider) Option {
 func WithLoggerProvider(lp *sdklog.LoggerProvider) Option {
 	return optionFunc(func(cfg *config) error {
 		cfg.loggerProvider = lp
-		return nil
-	})
-}
-
-// WithGenAICaptureMessageContent overrides the default [config.genAICaptureMessageContent].
-func WithGenAICaptureMessageContent(capture bool) Option {
-	return optionFunc(func(cfg *config) error {
-		cfg.genAICaptureMessageContent = capture
 		return nil
 	})
 }

--- a/telemetry/setup_otel.go
+++ b/telemetry/setup_otel.go
@@ -72,9 +72,7 @@ func configure(ctx context.Context, opts ...Option) (*config, error) {
 }
 
 func configFromOpts(opts ...Option) (*config, error) {
-	cfg := &config{
-		genAICaptureMessageContent: strings.TrimSpace(os.Getenv("OTEL_INSTRUMENTATION_GENAI_CAPTURE_MESSAGE_CONTENT")) == "true",
-	}
+	cfg := &config{}
 
 	for _, opt := range opts {
 		if err := opt.apply(cfg); err != nil {
@@ -91,9 +89,8 @@ func newInternal(cfg *config) (*Providers, error) {
 	// TODO(#479) init meter provider
 
 	return &Providers{
-		TracerProvider:             tp,
-		genAICaptureMessageContent: cfg.genAICaptureMessageContent,
-		LoggerProvider:             lp,
+		TracerProvider: tp,
+		LoggerProvider: lp,
 	}, nil
 }
 

--- a/telemetry/telemetry.go
+++ b/telemetry/telemetry.go
@@ -19,8 +19,6 @@ import (
 	"context"
 	"errors"
 
-	internal "google.golang.org/adk/internal/telemetry"
-
 	"go.opentelemetry.io/otel"
 	logglobal "go.opentelemetry.io/otel/log/global"
 	sdklog "go.opentelemetry.io/otel/sdk/log"
@@ -29,7 +27,6 @@ import (
 
 // Providers wraps all telemetry providers and provides [Shutdown] function.
 type Providers struct {
-	genAICaptureMessageContent bool
 	// TracerProvider is the configured TracerProvider or nil.
 	TracerProvider *sdktrace.TracerProvider
 	// LoggerProvider is the configured LoggerProvider or nil.
@@ -54,7 +51,6 @@ func (t *Providers) Shutdown(ctx context.Context) error {
 
 // SetGlobalOtelProviders registers the configured providers as the global OTel providers.
 func (t *Providers) SetGlobalOtelProviders() {
-	internal.SetGenAICaptureMessageContent(t.genAICaptureMessageContent)
 	if t.TracerProvider != nil {
 		otel.SetTracerProvider(t.TracerProvider)
 	}


### PR DESCRIPTION
### Add instrumentation functional tests 

- Related: ADK-Python parity with `tests/unittests/telemetry/test_functional.py`

**Problem:**

ADK-Go has unit tests for individual telemetry helpers (e.g. `LogRequest`,
`StartGenerateContentSpan`), but no end-to-end coverage that asserts the
**shape of the span+log tree** emitted by a realistic agent run. Regressions
that change span ordering, attribute names, parent/child relationships, or
log-event bodies slip past unit tests because each unit test only exercises
a single helper in isolation.

Additionally, the existing `telemetry.WithGenAICaptureMessageContent` option
duplicated the OpenTelemetry-spec env var
`OTEL_INSTRUMENTATION_GENAI_CAPTURE_MESSAGE_CONTENT` and stored the result
in a package-level `atomic.Bool`. That additional global state made hermetic
per-test toggling difficult, and it would also complicate future MT telemetry support.

**Solution:**

Two changes, landed together because they share infrastructure:

1. **Functional test infrastructure** under `internal/telemetry/`:
   - `functionaltest/` — the end-to-end test package. Tests here install
     in-memory span/log exporters, run a real agent through a canned
     scenario, then diff the captured spans+logs against an expected
     fixture using `cmp.Diff`.
   - `telemetrytest/` — reusable helpers: in-memory log exporter,
     span/log "digest" converters that strip non-deterministic fields
     (IDs, timestamps) so fixtures are stable, and a scenario runner.
   - `telemetrytestcase/` — expected-output fixtures keyed per scenario,
     kept in their own package so they can be shared across functional
     tests without import cycles.

2. **Agent functional test** (`TestTelemetrySchema_AgentWithTool`):
   The canonical "llmagent with one `FunctionTool`" scenario, parametrized
   over `OTEL_INSTRUMENTATION_GENAI_CAPTURE_MESSAGE_CONTENT` to cover both
   the elided (production default) and full-content variants. Hermetic:
   no network calls, no live model, no GCP. Mirrors `test_telemetry_schema`
   in `adk-python/tests/unittests/telemetry/test_functional.py`.

Supporting changes inside `internal/telemetry/`:

- Adds `OverrideTracerForTesting` and `OverrideLoggerForTesting` so a test
  can swap in an in-memory provider for its duration via `t.Cleanup`.
- Replaces the `atomic.Bool` + `SetGenAICaptureMessageContent` pair with
  a direct env-var read on every `getGenAICaptureMessageContent` call.
  Tests now flip behaviour via `t.Setenv`; the OS provides the caching.
- Removes the public `telemetry.WithGenAICaptureMessageContent` option
  (and the now-unused `genAICaptureMessageContent` field on `Providers`
  / `config`). Users who were relying on it should set
  `OTEL_INSTRUMENTATION_GENAI_CAPTURE_MESSAGE_CONTENT=true` in the
  environment instead — this is the OTel-spec way of configuring it.

This PR is the **parent** of a follow-up that adds node/workflow telemetry
instrumentation; that PR reuses the same `functionaltest` / `telemetrytest`
infrastructure for its own graph-based scenario.

### Testing Plan

**Unit Tests:**

- [x] I have added or updated unit tests for my change.
- [x] All unit tests pass locally.

New tests:
- `TestTelemetrySchema_AgentWithTool/elided`
- `TestTelemetrySchema_AgentWithTool/capture_content`

Updated tests:
- `internal/telemetry/logger_test.go` — `setup()` now toggles the env var
  via `t.Setenv` instead of calling the removed `SetGenAICaptureMessageContent`.

```
$ go test ./internal/telemetry/... ./telemetry/... -count=1
ok      google.golang.org/adk/internal/telemetry                0.078s
ok      google.golang.org/adk/internal/telemetry/functionaltest 0.087s
?       google.golang.org/adk/internal/telemetry/telemetrytest  [no test files]
?       google.golang.org/adk/internal/telemetry/telemetrytestcase [no test files]
ok      google.golang.org/adk/telemetry                         0.114s
```

**Manual End-to-End (E2E) Tests:**

Not applicable — this PR only adds test infrastructure and a hermetic
functional test; there is no runtime-visible behaviour change other than
the removal of `WithGenAICaptureMessageContent` (see "Breaking change"
below).

### Checklist

- [x] I have read the [CONTRIBUTING.md](./CONTRIBUTING.md) document.
- [x] I have performed a self-review of my own code.
- [x] I have commented my code, particularly in hard-to-understand areas.
- [x] I have added tests that prove my fix is effective or that my feature works.
- [x] New and existing unit tests pass locally with my changes.
- [x] I have manually tested my changes end-to-end.
- [x] Any dependent changes have been merged and published in downstream modules.

### Additional context

**Breaking change:** `telemetry.WithGenAICaptureMessageContent` is removed.
The replacement is the OTel-spec env var
`OTEL_INSTRUMENTATION_GENAI_CAPTURE_MESSAGE_CONTENT=true`. The option had
no other call sites in this repository besides one example
(`examples/tools/multipletools`), which has a pre-existing build break
that should be cleaned up in a separate PR.
