### PR TITLE
feat(workflow): add dynamic-node orchestration

### DIFF
--- a/agent/workflowagent/hitl_test.go
+++ b/agent/workflowagent/hitl_test.go
@@ -265,6 +265,73 @@ func TestWorkflowAgent_FreshTurn_NotMistakenForResume(t *testing.T) {
 	}
 }
 
+// TestWorkflowAgent_RunThenResume_DynamicNodeOrchestrator verifies
+// that a child RequestedInput inside a dynamic-node orchestrator
+// (called via workflow.RunNode) transitions the orchestrator to
+// NodeWaiting, so Workflow.Resume matches by InterruptID and the
+// orchestrator re-enters to produce the final output.
+func TestWorkflowAgent_RunThenResume_DynamicNodeOrchestrator(t *testing.T) {
+	const interruptID = "ask_name_dyn"
+
+	asker := newHitlNode("ask_name", func(ctx agent.InvocationContext, _ any, yield func(*session.Event, error) bool) {
+		nc, ok := ctx.(workflow.NodeContext)
+		if ok {
+			if resp, ok := nc.ResumedInput(interruptID); ok {
+				ev := session.NewEvent(ctx.InvocationID())
+				ev.Output = resp
+				yield(ev, nil)
+				return
+			}
+		}
+		yield(workflow.NewRequestInputEvent(ctx, session.RequestInput{
+			InterruptID: interruptID,
+			Message:     "What's your name?",
+		}), nil)
+	})
+
+	orchestrator := workflow.NewDynamicNode[string, string]("hitl_demo",
+		func(nc workflow.NodeContext, _ string, _ func(*session.Event) error) (string, error) {
+			out, err := workflow.RunNode[any](nc, asker, nil)
+			if err != nil {
+				// Pause: err is ErrNodeInterrupted (swallowed by dynamicNode.Run).
+				// Resume: err is nil and out is the child's response.
+				return "", err
+			}
+			name, _ := out.(string)
+			if name == "" {
+				name = "stranger"
+			}
+			return "Hello, " + name + "!", nil
+		},
+		workflow.NodeConfig{},
+	)
+
+	a := makeAgent(t, workflow.Chain(workflow.Start, orchestrator))
+	sess := newFakeSession()
+
+	// Turn 1: fresh Run; orchestrator schedules asker; asker pauses.
+	turn1 := runFreshTurn(t, sess, a, "start")
+	if got := findRequest(turn1); got != interruptID {
+		t.Fatalf("turn 1 RequestedInput = %q, want %q", got, interruptID)
+	}
+
+	// Turn 2: resume with the reply.
+	turn2 := drainAgent(t, sess, a.Run(newMockCtx(sess, a, resumeMessage(interruptID, "Wolo"))), nil)
+	if got := findRequest(turn2); got != "" {
+		t.Errorf("turn 2 unexpectedly emitted a RequestedInput: %q", got)
+	}
+
+	var got any
+	for _, ev := range turn2 {
+		if ev.Output != nil && ev.NodeInfo != nil && ev.NodeInfo.Path == "hitl_demo" {
+			got = ev.Output
+		}
+	}
+	if want := "Hello, Wolo!"; got != want {
+		t.Errorf("orchestrator output = %v, want %q", got, want)
+	}
+}
+
 // =============================================================================
 // Test fixtures and helpers
 // =============================================================================

--- a/session/session.go
+++ b/session/session.go
@@ -130,6 +130,26 @@ type Event struct {
 
 	// Output is the generic data output from a workflow node.
 	Output any
+
+	// NodeInfo carries workflow-node metadata for events emitted
+	// inside a workflow. Nil for non-workflow events.
+	NodeInfo *NodeInfo `json:"nodeInfo,omitempty"`
+}
+
+// NodeInfo carries the per-event metadata identifying which node in
+// a workflow activation emitted it.
+//
+// TODO(wolo): adk-python's NodeInfo also has OutputFor []string
+// (fan-in re-attribution) and MessageAsOutput bool (content-as-output
+// shorthand). Add as the corresponding features land in adk-go.
+type NodeInfo struct {
+	// Path is the composite path of the emitting node within its
+	// workflow activation. Empty for top-level static nodes;
+	// "<parent_path>/<child_name>@<run_id>" for dynamic children.
+	// The scheduler uses it to scope per-activation Output/Routes
+	// invariants to the emitter, allowing dynamic nodes to forward
+	// children's terminal events alongside their own.
+	Path string `json:"path,omitempty"`
 }
 
 // RequestInput describes a single human-in-the-loop prompt emitted

--- a/workflow/dynamic_node.go
+++ b/workflow/dynamic_node.go
@@ -1,0 +1,183 @@
+// Copyright 2026 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package workflow
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"iter"
+
+	"github.com/google/jsonschema-go/jsonschema"
+	"google.golang.org/adk/agent"
+	"google.golang.org/adk/internal/typeutil"
+	"google.golang.org/adk/session"
+)
+
+// DynamicFn is the orchestrator body of a dynamic node. emit publishes
+// mid-body events (state updates, HITL requests, progress); the return
+// value becomes the node's terminal Event.Output.
+type DynamicFn[IN, OUT any] = func(ctx NodeContext, in IN, emit func(*session.Event) error) (OUT, error)
+
+type dynamicNode[IN, OUT any] struct {
+	BaseNode
+	fn           DynamicFn[IN, OUT]
+	inputSchema  *jsonschema.Resolved
+	outputSchema *jsonschema.Resolved
+}
+
+// NewDynamicNode wraps fn as a workflow Node whose execution order is
+// expressed as Go code calling RunNode for each child. cfg.RerunOnResume
+// defaults to &true when nil (needed so resume can re-enter the
+// orchestrator and deliver cached child results); explicit &false is
+// respected.
+func NewDynamicNode[IN, OUT any](name string, fn DynamicFn[IN, OUT], cfg NodeConfig) Node {
+	return newDynamicNodeWithResolvedSchemas[IN, OUT](name, fn, nil, nil, applyDynamicDefaults(cfg))
+}
+
+// NewDynamicNodeWithSchema is the explicit-schema variant.
+func NewDynamicNodeWithSchema[IN, OUT any](
+	name string,
+	fn DynamicFn[IN, OUT],
+	inputSchema, outputSchema *jsonschema.Schema,
+	cfg NodeConfig,
+) (Node, error) {
+	var ischema *jsonschema.Resolved
+	if inputSchema != nil {
+		r, err := inputSchema.Resolve(nil)
+		if err != nil {
+			return nil, fmt.Errorf("resolving input schema: %w", err)
+		}
+		ischema = r
+	}
+	var oschema *jsonschema.Resolved
+	if outputSchema != nil {
+		r, err := outputSchema.Resolve(nil)
+		if err != nil {
+			return nil, fmt.Errorf("resolving output schema: %w", err)
+		}
+		oschema = r
+	}
+	return newDynamicNodeWithResolvedSchemas[IN, OUT](name, fn, ischema, oschema, applyDynamicDefaults(cfg)), nil
+}
+
+func newDynamicNodeWithResolvedSchemas[IN, OUT any](
+	name string,
+	fn DynamicFn[IN, OUT],
+	inputSchema, outputSchema *jsonschema.Resolved,
+	cfg NodeConfig,
+) *dynamicNode[IN, OUT] {
+	return &dynamicNode[IN, OUT]{
+		BaseNode:     NewBaseNode(name, "", cfg),
+		fn:           fn,
+		inputSchema:  inputSchema,
+		outputSchema: outputSchema,
+	}
+}
+
+func applyDynamicDefaults(cfg NodeConfig) NodeConfig {
+	if cfg.RerunOnResume == nil {
+		t := true
+		cfg.RerunOnResume = &t
+	}
+	return cfg
+}
+
+func (n *dynamicNode[IN, OUT]) Run(ctx agent.InvocationContext, input any) iter.Seq2[*session.Event, error] {
+	return func(yield func(*session.Event, error) bool) {
+		parentNC, ok := ctx.(NodeContext)
+		if !ok {
+			yield(nil, fmt.Errorf("dynamic node %q: scheduler did not supply a NodeContext", n.Name()))
+			return
+		}
+
+		typedInput, err := n.coerceInput(input)
+		if err != nil {
+			yield(nil, err)
+			return
+		}
+
+		emit := makeEmit(yield, parentNC)
+		sub := newDynamicSubScheduler(parentNC, n.composePath(parentNC), emit)
+		orchestratorCtx := newDynamicNodeContext(parentNC, sub.parentPath, "", sub)
+
+		out, err := n.fn(orchestratorCtx, typedInput, emit)
+		if err != nil {
+			// HITL: the RequestedInput was already forwarded upstream;
+			// swallow the sentinel so the engine sees only the pause event.
+			if errors.Is(err, ErrNodeInterrupted) {
+				return
+			}
+			yield(nil, err)
+			return
+		}
+
+		ev := session.NewEvent(parentNC.InvocationID())
+		ev.Output = out
+		ev.NodeInfo = &session.NodeInfo{Path: sub.parentPath}
+		// TODO(wolo): validate out against n.outputSchema before yielding,
+		// mirroring function_node.go:87-92.
+		yield(ev, nil)
+	}
+}
+
+// coerceInput converts the raw input to IN, using a typeutil JSON
+// roundtrip as a fallback (mirrors FunctionNode for tool-node →
+// dynamic-node edges where the upstream emits map[string]any).
+func (n *dynamicNode[IN, OUT]) coerceInput(input any) (IN, error) {
+	var zero IN
+	if input == nil {
+		return zero, nil
+	}
+	if v, ok := input.(IN); ok {
+		return v, nil
+	}
+	typed, err := typeutil.ConvertToWithJSONSchema[any, IN](input, n.inputSchema)
+	if err != nil {
+		return zero, fmt.Errorf("dynamic node %q: invalid input type, expected %T: %w", n.Name(), zero, err)
+	}
+	return typed, nil
+}
+
+// composePath returns this dynamic node's own composite path. Top-level
+// activations get the bare Name(); nested dynamic nodes append.
+func (n *dynamicNode[IN, OUT]) composePath(parent NodeContext) string {
+	if p := parent.Path(); p != "" {
+		return p + "/" + n.Name()
+	}
+	return n.Name()
+}
+
+// makeEmit wraps yield as an emit callback. Contract: nil return =
+// delivered, non-nil = orchestrator must stop (calling yield after
+// it returned false is a runtime error per the iter spec).
+//
+// When yield returns false without ctx cancellation (no current
+// consumer triggers this, but the contract must not depend on it),
+// return context.Canceled as a stand-in.
+func makeEmit(yield func(*session.Event, error) bool, parentCtx NodeContext) func(*session.Event) error {
+	return func(ev *session.Event) error {
+		if err := parentCtx.Err(); err != nil {
+			return err
+		}
+		if !yield(ev, nil) {
+			if err := parentCtx.Err(); err != nil {
+				return err
+			}
+			return context.Canceled
+		}
+		return nil
+	}
+}

--- a/workflow/dynamic_node_test.go
+++ b/workflow/dynamic_node_test.go
@@ -1,0 +1,292 @@
+// Copyright 2026 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package workflow
+
+import (
+	"errors"
+	"iter"
+	"testing"
+
+	"google.golang.org/adk/agent"
+	"google.golang.org/adk/session"
+)
+
+func TestNewDynamicNode_DefaultsRerunOnResume(t *testing.T) {
+	fn := func(NodeContext, string, func(*session.Event) error) (string, error) {
+		return "", nil
+	}
+	n := NewDynamicNode[string, string]("d", fn, NodeConfig{})
+	rr := n.Config().RerunOnResume
+	if rr == nil || !*rr {
+		t.Errorf("RerunOnResume = %v, want &true (default)", rr)
+	}
+}
+
+func TestNewDynamicNode_RespectsExplicitFalse(t *testing.T) {
+	f := false
+	fn := func(NodeContext, string, func(*session.Event) error) (string, error) {
+		return "", nil
+	}
+	n := NewDynamicNode[string, string]("d", fn, NodeConfig{RerunOnResume: &f})
+	if rr := n.Config().RerunOnResume; rr == nil || *rr {
+		t.Errorf("RerunOnResume = %v, want &false (explicit override)", rr)
+	}
+}
+
+func TestDynamicNode_Sequential_RunNodeChain(t *testing.T) {
+	stepA := newStubNode("stepA", "from A")
+	stepB := newStubNode("stepB", "from B")
+
+	orchestrator := NewDynamicNode[string, string]("orch",
+		func(ctx NodeContext, _ string, _ func(*session.Event) error) (string, error) {
+			outA, err := RunNode[string](ctx, stepA, "ignored")
+			if err != nil {
+				return "", err
+			}
+			outB, err := RunNode[string](ctx, stepB, outA)
+			if err != nil {
+				return "", err
+			}
+			return outA + " | " + outB, nil
+		},
+		NodeConfig{},
+	)
+
+	events := drainDynamic(t, orchestrator, "input")
+	last := events[len(events)-1]
+	if last.Output != "from A | from B" {
+		t.Errorf("terminal Output = %v, want %q", last.Output, "from A | from B")
+	}
+}
+
+func TestDynamicNode_TypedInput(t *testing.T) {
+	type Req struct{ Name string }
+
+	var observed Req
+	orchestrator := NewDynamicNode[Req, string]("orch",
+		func(_ NodeContext, in Req, _ func(*session.Event) error) (string, error) {
+			observed = in
+			return "ok", nil
+		},
+		NodeConfig{},
+	)
+
+	drainDynamic(t, orchestrator, Req{Name: "alice"})
+	if observed.Name != "alice" {
+		t.Errorf("observed Req.Name = %q, want %q", observed.Name, "alice")
+	}
+}
+
+func TestDynamicNode_TypedInput_JSONFallback(t *testing.T) {
+	// Upstream produces map[string]any (e.g. a tool node). Constructor
+	// coerces to the typed struct via typeutil JSON roundtrip.
+	type Req struct {
+		Name string `json:"name"`
+		N    int    `json:"n"`
+	}
+
+	var observed Req
+	orchestrator := NewDynamicNode[Req, string]("orch",
+		func(_ NodeContext, in Req, _ func(*session.Event) error) (string, error) {
+			observed = in
+			return "ok", nil
+		},
+		NodeConfig{},
+	)
+
+	drainDynamic(t, orchestrator, map[string]any{"name": "bob", "n": 7})
+	if observed.Name != "bob" || observed.N != 7 {
+		t.Errorf("observed = %+v, want {Name:bob N:7}", observed)
+	}
+}
+
+func TestDynamicNode_EmitMidBody(t *testing.T) {
+	orchestrator := NewDynamicNode[string, string]("orch",
+		func(_ NodeContext, _ string, emit func(*session.Event) error) (string, error) {
+			if err := emit(&session.Event{Actions: session.EventActions{
+				StateDelta: map[string]any{"progress": "halfway"},
+			}}); err != nil {
+				return "", err
+			}
+			return "done", nil
+		},
+		NodeConfig{},
+	)
+
+	events := drainDynamic(t, orchestrator, "")
+	if len(events) < 2 {
+		t.Fatalf("got %d events, want >= 2 (mid-body emit + terminal)", len(events))
+	}
+	if got, want := events[0].Actions.StateDelta["progress"], "halfway"; got != want {
+		t.Errorf("first event StateDelta progress = %v, want %q", got, want)
+	}
+	if events[len(events)-1].Output != "done" {
+		t.Errorf("terminal Output = %v, want \"done\"", events[len(events)-1].Output)
+	}
+}
+
+func TestDynamicNode_HITL_SwallowsInterrupt(t *testing.T) {
+	// Pause already reached the engine via the forwarded
+	// RequestedInput event; Run must not also yield the sentinel.
+	asker := newRequestInputNode("asker", "approve?")
+	orchestrator := NewDynamicNode[string, string]("orch",
+		func(ctx NodeContext, _ string, _ func(*session.Event) error) (string, error) {
+			_, err := RunNode[string](ctx, asker, nil)
+			return "", err
+		},
+		NodeConfig{},
+	)
+
+	events, runErr := drainDynamicWithErr(t, orchestrator, "")
+	if runErr != nil {
+		t.Errorf("Run yielded error %v; want nil (HITL swallowed)", runErr)
+	}
+	if !hasRequestedInput(events) {
+		t.Errorf("expected RequestedInput event in stream, got %+v", events)
+	}
+}
+
+func TestDynamicNode_ChildFailure_PropagatesError(t *testing.T) {
+	failer := newFailingNode("failer", errors.New("boom"))
+	orchestrator := NewDynamicNode[string, string]("orch",
+		func(ctx NodeContext, _ string, _ func(*session.Event) error) (string, error) {
+			_, err := RunNode[string](ctx, failer, nil)
+			return "", err
+		},
+		NodeConfig{},
+	)
+
+	_, runErr := drainDynamicWithErr(t, orchestrator, "")
+	if !errors.Is(runErr, ErrNodeFailed) {
+		t.Errorf("Run error = %v, want errors.Is ErrNodeFailed", runErr)
+	}
+}
+
+func TestDynamicNode_TerminalOutputEvent(t *testing.T) {
+	orchestrator := NewDynamicNode[string, int]("orch",
+		func(NodeContext, string, func(*session.Event) error) (int, error) {
+			return 42, nil
+		},
+		NodeConfig{},
+	)
+	events := drainDynamic(t, orchestrator, "")
+	last := events[len(events)-1]
+	if last.Output != 42 {
+		t.Errorf("Output = %v, want 42", last.Output)
+	}
+}
+
+// TestDynamicNode_Integration_ChildAndParentOutputs verifies that
+// when a dynamic orchestrator calls a child via RunNode, both the
+// child's terminal output event and the parent's own terminal output
+// reach the workflow stream without the top-level scheduler rejecting
+// the pair as "multiple outputs per activation".
+func TestDynamicNode_Integration_ChildAndParentOutputs(t *testing.T) {
+	helloNode := NewFunctionNode("hello_node",
+		func(_ agent.InvocationContext, _ string) (string, error) {
+			return "Hello World", nil
+		},
+		NodeConfig{},
+	)
+	orch := NewDynamicNode[string, string]("my_workflow",
+		func(ctx NodeContext, _ string, _ func(*session.Event) error) (string, error) {
+			return RunNode[string](ctx, helloNode, "hello")
+		},
+		NodeConfig{},
+	)
+
+	w, err := New("root", Chain(Start, orch))
+	if err != nil {
+		t.Fatalf("workflow.New: %v", err)
+	}
+
+	var outputs []any
+	for ev, err := range w.Run(newMockCtx(t)) {
+		if err != nil {
+			t.Fatalf("workflow.Run error: %v", err)
+		}
+		if ev != nil && ev.Output != nil {
+			outputs = append(outputs, ev.Output)
+		}
+	}
+	if len(outputs) != 2 {
+		t.Fatalf("got %d output events, want 2 (child + parent terminal); outputs=%v", len(outputs), outputs)
+	}
+	for _, out := range outputs {
+		if out != "Hello World" {
+			t.Errorf("output = %v, want %q", out, "Hello World")
+		}
+	}
+}
+
+func TestNewDynamicNodeWithSchema_NilSchemasOK(t *testing.T) {
+	fn := func(NodeContext, string, func(*session.Event) error) (string, error) { return "", nil }
+	if _, err := NewDynamicNodeWithSchema[string, string]("d", fn, nil, nil, NodeConfig{}); err != nil {
+		t.Errorf("nil schemas should construct cleanly, got %v", err)
+	}
+}
+
+// --- test helpers ---
+
+func drainDynamic(t *testing.T, n Node, input any) []*session.Event {
+	t.Helper()
+	events, err := drainDynamicWithErr(t, n, input)
+	if err != nil {
+		t.Fatalf("Run error: %v", err)
+	}
+	return events
+}
+
+func drainDynamicWithErr(t *testing.T, n Node, input any) ([]*session.Event, error) {
+	t.Helper()
+	parent := newNodeContext(newMockCtx(t), nil)
+	var events []*session.Event
+	for ev, err := range n.Run(parent, input) {
+		if err != nil {
+			return events, err
+		}
+		if ev != nil {
+			events = append(events, ev)
+		}
+	}
+	return events, nil
+}
+
+func hasRequestedInput(events []*session.Event) bool {
+	for _, ev := range events {
+		if ev.RequestedInput != nil {
+			return true
+		}
+	}
+	return false
+}
+
+type failingNode struct {
+	BaseNode
+	err error
+}
+
+func newFailingNode(name string, err error) *failingNode {
+	return &failingNode{
+		BaseNode: NewBaseNode(name, "", NodeConfig{}),
+		err:      err,
+	}
+}
+
+func (n *failingNode) Run(agent.InvocationContext, any) iter.Seq2[*session.Event, error] {
+	return func(yield func(*session.Event, error) bool) {
+		yield(nil, n.err)
+	}
+}

--- a/workflow/dynamic_scheduler.go
+++ b/workflow/dynamic_scheduler.go
@@ -55,8 +55,6 @@ func newDynamicSubScheduler(parent NodeContext, parentPath string, emitUp func(*
 // captured at sub-scheduler construction. customRunID is empty to use
 // the auto-counter, or a user-supplied stable id (validated against
 // the rules in validateCustomRunID).
-//
-// Fresh execution only; resume support lands in a follow-up PR.
 func (s *dynamicSubScheduler) runNode(child Node, input any, customRunID string) (any, error) {
 	name := child.Name()
 	runID, err := s.resolveRunID(name, customRunID)
@@ -80,6 +78,15 @@ func (s *dynamicSubScheduler) runNode(child Node, input any, customRunID string)
 		}
 		if ev == nil {
 			continue
+		}
+		// Stamp NodeInfo.Path so the top scheduler scopes the
+		// child's Output/Routes to the child (not the parent's
+		// accumulator). RequestedInput is promoted to the parent —
+		// see scheduler.handleEvent. Skip if the child already
+		// stamped NodeInfo (nested dynamic node yielding its own
+		// terminal event, dynamic_node.go).
+		if ev.NodeInfo == nil {
+			ev.NodeInfo = &session.NodeInfo{Path: childPath}
 		}
 		if ev.RequestedInput != nil {
 			interrupted = true

--- a/workflow/run_node.go
+++ b/workflow/run_node.go
@@ -1,0 +1,78 @@
+// Copyright 2026 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package workflow
+
+import "fmt"
+
+// RunNodeOption configures a single RunNode call. Today only WithRunID
+// exists; the option set will grow to mirror adk-python's ctx.run_node
+// kwargs (use_as_output for output delegation, override_isolation_scope,
+// per-call timeout/retry overrides, etc.) as those features land.
+type RunNodeOption func(*runNodeOptions)
+
+type runNodeOptions struct {
+	customRunID string
+}
+
+// WithRunID overrides the auto-generated counter with a stable
+// user-supplied identifier — useful for reorderable lists keyed by
+// e.g. an order id. id must be non-empty, contain at least one
+// non-digit character (purely numeric ids collide with the
+// auto-counter), and exclude the composite-path separators '/' and
+// '@'. Violations surface as ErrInvalidRunID from RunNode.
+//
+// Mirrors adk-python's run_id kwarg
+// (https://adk.dev/graphs/dynamic/#custom-execution-ids).
+func WithRunID(id string) RunNodeOption {
+	return func(o *runNodeOptions) { o.customRunID = id }
+}
+
+// RunNode schedules child as a sub-node of the currently-executing
+// dynamic node and returns its typed output. ctx must be the
+// NodeContext passed into the enclosing dynamic node's body.
+//
+// On failure:
+//   - errors.Is(err, ErrNodeInterrupted): child paused for HITL.
+//   - errors.Is(err, ErrNodeFailed): child errored after retries;
+//     errors.As recovers *NodeRunError with diagnostics.
+//   - ErrInvalidRunNodeContext, ErrInvalidRunID: misuse.
+//   - ctx.Err(): parent cancellation.
+func RunNode[OUT any](ctx NodeContext, child Node, input any, opts ...RunNodeOption) (OUT, error) {
+	var zero OUT
+
+	nc, ok := ctx.(*nodeContext)
+	if !ok || nc.subScheduler == nil {
+		return zero, ErrInvalidRunNodeContext
+	}
+
+	var o runNodeOptions
+	for _, opt := range opts {
+		opt(&o)
+	}
+
+	rawOut, err := nc.subScheduler.runNode(child, input, o.customRunID)
+	if err != nil {
+		return zero, err
+	}
+	if rawOut == nil {
+		return zero, nil
+	}
+	typed, ok := rawOut.(OUT)
+	if !ok {
+		return zero, fmt.Errorf("workflow.RunNode: child %q output type %T does not satisfy expected %T",
+			child.Name(), rawOut, zero)
+	}
+	return typed, nil
+}

--- a/workflow/run_node_test.go
+++ b/workflow/run_node_test.go
@@ -1,0 +1,140 @@
+// Copyright 2026 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package workflow
+
+import (
+	"errors"
+	"strings"
+	"testing"
+
+	"google.golang.org/adk/session"
+)
+
+func TestRunNode_ErrInvalidRunNodeContext_OnStaticContext(t *testing.T) {
+	ctx := newNodeContext(newMockCtx(t), nil) // no subScheduler attached
+	_, err := RunNode[string](ctx, newStubNode("c", "x"), nil)
+	if !errors.Is(err, ErrInvalidRunNodeContext) {
+		t.Errorf("err = %v, want ErrInvalidRunNodeContext", err)
+	}
+}
+
+func TestRunNode_ReturnsTypedOutput(t *testing.T) {
+	child := newStubNode("c", "hello")
+	got := runInOrchestrator[string](t, func(ctx NodeContext) (string, error) {
+		return RunNode[string](ctx, child, nil)
+	})
+	if got != "hello" {
+		t.Errorf("RunNode output = %q, want %q", got, "hello")
+	}
+}
+
+func TestRunNode_OutputTypeMismatch(t *testing.T) {
+	child := newStubNode("c", 42) // emits int
+	_, err := runInOrchestratorWithErr[string](t, func(ctx NodeContext) (string, error) {
+		return RunNode[string](ctx, child, nil) // expects string
+	})
+	if err == nil {
+		t.Fatal("expected error for type mismatch, got nil")
+	}
+	if !strings.Contains(err.Error(), "does not satisfy expected") {
+		t.Errorf("err = %v, want type-mismatch message", err)
+	}
+}
+
+func TestRunNode_PropagatesErrNodeInterrupted(t *testing.T) {
+	asker := newRequestInputNode("asker", "approve?")
+	_, err := runInOrchestratorWithErr[string](t, func(ctx NodeContext) (string, error) {
+		return RunNode[string](ctx, asker, nil)
+	})
+	if !errors.Is(err, ErrNodeInterrupted) {
+		t.Errorf("err = %v, want errors.Is ErrNodeInterrupted", err)
+	}
+}
+
+func TestRunNode_PropagatesErrNodeFailed(t *testing.T) {
+	failer := newFailingNode("failer", errors.New("boom"))
+	_, err := runInOrchestratorWithErr[string](t, func(ctx NodeContext) (string, error) {
+		return RunNode[string](ctx, failer, nil)
+	})
+	if !errors.Is(err, ErrNodeFailed) {
+		t.Errorf("err = %v, want errors.Is ErrNodeFailed", err)
+	}
+}
+
+func TestRunNode_WithRunID_AppearsInChildPath(t *testing.T) {
+	child := newStubNode("processor", "")
+	runInOrchestrator[string](t, func(ctx NodeContext) (string, error) {
+		return RunNode[string](ctx, child, nil, WithRunID("order-42"))
+	})
+	if got, want := child.lastPath, "orch/processor@order-42"; got != want {
+		t.Errorf("child Path() = %q, want %q", got, want)
+	}
+}
+
+func TestRunNode_WithRunID_InvalidRejected(t *testing.T) {
+	child := newStubNode("c", "")
+	_, err := runInOrchestratorWithErr[string](t, func(ctx NodeContext) (string, error) {
+		return RunNode[string](ctx, child, nil, WithRunID("123")) // purely numeric
+	})
+	if !errors.Is(err, ErrInvalidRunID) {
+		t.Errorf("err = %v, want errors.Is ErrInvalidRunID", err)
+	}
+}
+
+func TestRunNode_NilChildOutput_ReturnsZero(t *testing.T) {
+	child := newStubNode("c", nil)
+	got := runInOrchestrator[string](t, func(ctx NodeContext) (string, error) {
+		return RunNode[string](ctx, child, nil)
+	})
+	if got != "" {
+		t.Errorf("nil child output → OUT = %q, want \"\" (zero)", got)
+	}
+}
+
+// --- test helpers ---
+
+// runInOrchestrator drives orchestratorFn inside a dynamic node so that
+// the RunNode calls inside have a valid NodeContext + sub-scheduler.
+func runInOrchestrator[OUT any](t *testing.T, orchestratorFn func(NodeContext) (OUT, error)) OUT {
+	t.Helper()
+	got, err := runInOrchestratorWithErr[OUT](t, orchestratorFn)
+	if err != nil {
+		t.Fatalf("orchestrator error: %v", err)
+	}
+	return got
+}
+
+func runInOrchestratorWithErr[OUT any](t *testing.T, orchestratorFn func(NodeContext) (OUT, error)) (OUT, error) {
+	t.Helper()
+	var (
+		got    OUT
+		gotErr error
+	)
+	n := NewDynamicNode[string, OUT]("orch",
+		func(ctx NodeContext, _ string, _ func(*session.Event) error) (OUT, error) {
+			got, gotErr = orchestratorFn(ctx)
+			if gotErr != nil {
+				return got, gotErr
+			}
+			return got, nil
+		},
+		NodeConfig{},
+	)
+	_, runErr := drainDynamicWithErr(t, n, "")
+	if runErr != nil {
+		return got, runErr
+	}
+	return got, gotErr
+}

--- a/workflow/scheduler.go
+++ b/workflow/scheduler.go
@@ -32,8 +32,8 @@ const defaultEventQueueCapacity = 16
 
 var (
 	// ErrMultipleOutputs is returned when a node yields more than
-	// one event whose Actions.StateDelta carries an "output" key.
-	// A node activation may emit at most one output value.
+	// one event with Event.Output set. A node activation may emit
+	// at most one output value.
 	ErrMultipleOutputs = errors.New("workflow: node produced multiple events with output values; only one event per execution can carry output")
 
 	// ErrMultipleRoutingEvents is returned when a node yields more
@@ -413,9 +413,18 @@ func (s *scheduler) run(yield func(*session.Event, error) bool) {
 	}
 }
 
-// handleEvent updates the per-node accumulator and is called once
-// per event. The event itself has already been read from the queue
-// and will be yielded to the caller by the consumer loop.
+// handleEvent updates the per-node accumulator. The event has
+// already been read from the queue and will be yielded to the
+// caller by the consumer loop.
+//
+// Descendant events (NodeInfo.Path != it.nodeName) are dynamic-node
+// children forwarded by the sub-scheduler. Their Output/Routes
+// belong to the child, not the parent — skip the parent accumulator.
+//
+// RequestedInput is the exception: the child's pause unwinds the
+// orchestrator (dynamic_scheduler.go runNode), and Workflow.Resume
+// matches InterruptID against the parent's NodeState.PendingRequest,
+// so the parent must transition to NodeWaiting on a descendant pause.
 func (s *scheduler) handleEvent(it eventItem) {
 	nr := s.runsByName[it.nodeName]
 	if nr == nil {
@@ -426,11 +435,19 @@ func (s *scheduler) handleEvent(it eventItem) {
 	if it.ev == nil {
 		return
 	}
-	if it.ev.Routes != nil {
-		nr.setRoutingEvent(it.ev, it.nodeName)
+	var path string
+	if it.ev.NodeInfo != nil {
+		path = it.ev.NodeInfo.Path
 	}
+	isDescendant := path != "" && path != it.nodeName
 	if it.ev.RequestedInput != nil {
 		nr.setInputRequest(it.ev.RequestedInput, it.nodeName)
+	}
+	if isDescendant {
+		return
+	}
+	if it.ev.Routes != nil {
+		nr.setRoutingEvent(it.ev, it.nodeName)
 	}
 	if it.ev.Output != nil {
 		nr.setOutput(it.ev.Output, it.nodeName)


### PR DESCRIPTION
Wires the user-facing API for dynamic workflows on top of the
sub-scheduler skeleton from the previous PR. A dynamic node's
execution order is expressed as Go code (loops, branches, goroutines)
that calls other nodes inline via `RunNode`, branches on their typed
output, and pauses for HITL input.

The public surface:

- `workflow.NewDynamicNode[IN, OUT](name, fn, cfg)` — orchestrator
  constructor; `cfg.RerunOnResume` defaults to `&true` (an explicit
  `&false` is respected).
- `workflow.RunNode[OUT](ctx, child, input, opts...)` — generic
  helper for scheduling a child. Returns its typed output, or
  `errors.Is`-matchable `ErrNodeInterrupted` / `ErrNodeFailed`.
- `workflow.WithRunID(id)` — option overriding the auto-counter
  with a stable id (rejected if empty, purely numeric, or
  containing `/` or `@`).
- `session.NodeInfo` — substruct on `Event` carrying the emitting
  node's composite path; shape mirrors adk-python's `event.nodeInfo`.

The scheduler's `handleEvent` scopes per-activation `Output`/`Routes`
invariants by `NodeInfo.Path`, so a dynamic node forwarding a child's
terminal output plus its own no longer trips `ErrMultipleOutputs`.
Descendant `RequestedInput` events are promoted onto the parent's
accumulator so `Workflow.Resume` matches the InterruptID against the
parent's `NodeState.PendingRequest` — enabling HITL inside a dynamic
orchestrator.

Stacked on the sub-scheduler skeleton PR; follow-ups add
resume/replay-skip, broader parent re-entry scenarios, and parallel
HITL detection.

Tested: `go build ./...`, `go test -race ./workflow/...
./agent/workflowagent/...`, `gofmt -l` clean. Coverage includes
constructor defaults and overrides, sequential `RunNode` chains,
typed-input coercion (direct + JSON fallback), mid-body emit, HITL
swallow, error propagation, terminal output, plus end-to-end tests
for child+parent output forwarding and HITL round-trip via
`Workflow.Run` + `Workflow.Resume`.