### PR TITLE
fix: preserve interleaved function events

### DIFF
--- a/internal/llminternal/contents_processor.go
+++ b/internal/llminternal/contents_processor.go
@@ -272,48 +272,86 @@ SearchLoop: // A label to allow breaking out of the nested loop
 		)
 	}
 
-	// Collect function response events related to the matching call while
-	// preserving unrelated tool events that happened in between.
+	// Collect all related function response events *between* the call and the
+	// last response. Preserve unrelated tool events in their original order, so
+	// rearranging a long-running response does not drop valid concurrent tool
+	// history.
 	var responseEventsToMerge []*session.Event
-	resultEvents := events[:functionCallEventIdx+1]
+	var eventsToPreserve []*session.Event
 	for i := functionCallEventIdx + 1; i < len(events)-1; i++ {
 		event := events[i]
-		calls := utils.FunctionCalls(event.Content)
-		if len(calls) > 0 {
-			resultEvents = append(resultEvents, event)
-			continue
+		mergeEvent, preserveEvent := splitEventForLatestFunctionResponse(event, responseIDs)
+		if mergeEvent != nil {
+			responseEventsToMerge = append(responseEventsToMerge, mergeEvent)
 		}
-
-		responses := utils.FunctionResponses(event.Content)
-		if len(responses) == 0 {
-			continue
-		}
-
-		// Check if this event contains any response relevant to our call.
-		isRelated := false
-		for _, res := range responses {
-			if _, exists := responseIDs[res.ID]; exists {
-				isRelated = true
-				break
-			}
-		}
-
-		if isRelated {
-			responseEventsToMerge = append(responseEventsToMerge, event)
-		} else {
-			resultEvents = append(resultEvents, event)
+		if preserveEvent != nil {
+			eventsToPreserve = append(eventsToPreserve, preserveEvent)
 		}
 	}
 
 	// Add the final response event itself to the list to be merged.
 	responseEventsToMerge = append(responseEventsToMerge, events[len(events)-1])
 
+	resultEvents := append([]*session.Event{}, events[:functionCallEventIdx+1]...)
+	resultEvents = append(resultEvents, eventsToPreserve...)
 	mergedEvent, err := mergeFunctionResponseEvents(responseEventsToMerge)
 	if err != nil {
 		return nil, err
 	}
 	resultEvents = append(resultEvents, mergedEvent)
 	return resultEvents, nil
+}
+
+func splitEventForLatestFunctionResponse(event *session.Event, responseIDs map[string]struct{}) (*session.Event, *session.Event) {
+	content := utils.Content(event)
+	if content == nil {
+		return nil, nil
+	}
+
+	hasRelatedResponse := false
+	hasToolPart := false
+	for _, part := range content.Parts {
+		if part == nil {
+			continue
+		}
+		if part.FunctionCall != nil {
+			hasToolPart = true
+			continue
+		}
+		if part.FunctionResponse != nil {
+			hasToolPart = true
+			if _, exists := responseIDs[part.FunctionResponse.ID]; exists {
+				hasRelatedResponse = true
+			}
+		}
+	}
+	if !hasToolPart {
+		return nil, nil
+	}
+
+	var mergeParts []*genai.Part
+	var preserveParts []*genai.Part
+	for _, part := range content.Parts {
+		if part == nil {
+			continue
+		}
+		switch {
+		case part.FunctionResponse != nil:
+			if _, exists := responseIDs[part.FunctionResponse.ID]; exists {
+				mergeParts = append(mergeParts, part)
+			} else {
+				preserveParts = append(preserveParts, part)
+			}
+		case part.FunctionCall != nil:
+			preserveParts = append(preserveParts, part)
+		case hasRelatedResponse:
+			mergeParts = append(mergeParts, part)
+		default:
+			preserveParts = append(preserveParts, part)
+		}
+	}
+
+	return cloneEventWithParts(event, mergeParts), cloneEventWithParts(event, preserveParts)
 }
 
 // rearrangeEventsForFunctionResponsesInHistory reorganizes an entire event history to ensure
@@ -622,4 +660,19 @@ func cloneEvent(e *session.Event) *session.Event {
 	}
 
 	return newEvent
+}
+
+func cloneEventWithParts(e *session.Event, parts []*genai.Part) *session.Event {
+	if len(parts) == 0 {
+		return nil
+	}
+	cloned := cloneEvent(e)
+	if cloned == nil {
+		return nil
+	}
+	if cloned.LLMResponse.Content == nil {
+		cloned.LLMResponse.Content = &genai.Content{}
+	}
+	cloned.LLMResponse.Content.Parts = append([]*genai.Part(nil), parts...)
+	return cloned
 }

--- a/internal/llminternal/contents_processor_test.go
+++ b/internal/llminternal/contents_processor_test.go
@@ -657,6 +657,16 @@ func TestContentsRequestProcessor_Rearrange(t *testing.T) {
 		Name:     "long_running_tool",
 		Response: map[string]any{"status": "completed", "result": "done"},
 	}
+	fcInterleaved := &genai.FunctionCall{
+		ID:   "interleaved_call_456",
+		Name: "lookup_tool",
+		Args: map[string]any{"query": "related work"},
+	}
+	frInterleaved := &genai.FunctionResponse{
+		ID:       "interleaved_call_456",
+		Name:     "lookup_tool",
+		Response: map[string]any{"results": []string{"doc1", "doc2"}},
+	}
 
 	// Mixed LRO/Normal Calls/Responses
 	fcLROMixed := &genai.FunctionCall{
@@ -917,6 +927,24 @@ func TestContentsRequestProcessor_Rearrange(t *testing.T) {
 				genai.NewContentFromText("Request ten vacation days", "user"),
 				NewContentFromFunctionCall(fcHITLDenied, "model"),
 				NewContentFromFunctionResponse(frHITLDeniedFinal, "user"),
+			},
+		},
+		{
+			name: "Rearrangement preserves interleaved unrelated tool events",
+			events: []*session.Event{
+				{Author: "user", LLMResponse: model.LLMResponse{Content: genai.NewContentFromText("Run long process", "user")}},
+				{Author: agentName, LLMResponse: model.LLMResponse{Content: NewContentFromFunctionCall(fcLRO, "model")}},
+				{Author: "user", LLMResponse: model.LLMResponse{Content: NewContentFromFunctionResponse(frLROInter, "user")}},
+				{Author: agentName, LLMResponse: model.LLMResponse{Content: NewContentFromFunctionCall(fcInterleaved, "model")}},
+				{Author: "user", LLMResponse: model.LLMResponse{Content: NewContentFromFunctionResponse(frInterleaved, "user")}},
+				{Author: "user", LLMResponse: model.LLMResponse{Content: NewContentFromFunctionResponse(frLROFinal, "user")}},
+			},
+			want: []*genai.Content{
+				genai.NewContentFromText("Run long process", "user"),
+				NewContentFromFunctionCall(fcLRO, "model"),
+				NewContentFromFunctionResponse(frLROFinal, "user"),
+				NewContentFromFunctionCall(fcInterleaved, "model"),
+				NewContentFromFunctionResponse(frInterleaved, "user"),
 			},
 		},
 		{


### PR DESCRIPTION
Fixes #761

## Summary
- preserve unrelated tool call and response events while rearranging the latest function response
- split related response parts from unrelated tool parts before merging the long-running response batch
- add a regression test for an interleaved long-running response with unrelated tool activity

## Testing
- go test ./internal/llminternal -count=1
- git diff --check