### PR TITLE
fix: a2a execution cleanup callback not triggered

### DIFF
--- a/agent/remoteagent/a2a_agent.go
+++ b/agent/remoteagent/a2a_agent.go
@@ -27,7 +27,8 @@ import (
 	"github.com/a2aproject/a2a-go/a2aclient"
 	"github.com/a2aproject/a2a-go/a2aclient/agentcard"
 	"github.com/a2aproject/a2a-go/log"
-	v2a2a "github.com/a2aproject/a2a-go/v2/a2a"
+	a2av2 "github.com/a2aproject/a2a-go/v2/a2a"
+	a2aclientv2 "github.com/a2aproject/a2a-go/v2/a2aclient"
 	"github.com/a2aproject/a2a-go/v2/a2acompat/a2av0"
 
 	"google.golang.org/genai"
@@ -136,13 +137,21 @@ func NewA2A(cfg A2AConfig) (agent.Agent, error) {
 		Description:          cfg.Description,
 		BeforeAgentCallbacks: cfg.BeforeAgentCallbacks,
 		AfterAgentCallbacks:  cfg.AfterAgentCallbacks,
-		ClientProvider: func(ctx context.Context, card *v2a2a.AgentCard) (v2.A2AClient, error) {
-			legacyCard := a2av0.FromV1AgentCard(card)
-			factory := cfg.ClientFactory
-			if factory == nil {
-				factory = a2aclient.NewFactory()
+		ClientProvider: func(ctx context.Context, card *a2av2.AgentCard) (v2.A2AClient, error) {
+			if cfg.ClientFactory == nil {
+				factory := a2aclientv2.NewFactory(
+					a2aclientv2.WithCompatTransport(
+						a2av0.Version, a2av2.TransportProtocolJSONRPC, a2av0.NewJSONRPCTransportFactory(a2av0.JSONRPCTransportConfig{}),
+					),
+					a2aclientv2.WithCompatTransport(
+						a2av0.Version, a2av2.TransportProtocolHTTPJSON, a2av0.NewRESTTransportFactory(a2av0.RESTTransportConfig{}),
+					),
+				)
+				return factory.CreateFromCard(ctx, card)
 			}
-			client, err := factory.CreateFromCard(ctx, legacyCard)
+
+			legacyCard := a2av0.FromV1AgentCard(card)
+			client, err := cfg.ClientFactory.CreateFromCard(ctx, legacyCard)
 			if err != nil {
 				return nil, err
 			}
@@ -155,7 +164,7 @@ func NewA2A(cfg A2AConfig) (agent.Agent, error) {
 	} else if cfg.AgentCardSource != "" {
 		source := cfg.AgentCardSource
 		resolveOpts := cfg.CardResolveOptions
-		v1Cfg.AgentCardProvider = func(ctx context.Context) (*v2a2a.AgentCard, error) {
+		v1Cfg.AgentCardProvider = func(ctx context.Context) (*a2av2.AgentCard, error) {
 			v0Card, err := agentcard.DefaultResolver.Resolve(ctx, source, resolveOpts...)
 			if err != nil {
 				return nil, err
@@ -172,19 +181,8 @@ func NewA2A(cfg A2AConfig) (agent.Agent, error) {
 		v1Cfg.MessageSendConfig = req.Config
 	}
 
-	if cfg.ClientFactory != nil {
-		v1Cfg.ClientProvider = func(ctx context.Context, card *v2a2a.AgentCard) (v2.A2AClient, error) {
-			legacyCard := a2av0.FromV1AgentCard(card)
-			client, err := cfg.ClientFactory.CreateFromCard(ctx, legacyCard)
-			if err != nil {
-				return nil, err
-			}
-			return &compatClient{client: client}, nil
-		}
-	}
-
 	if cfg.Converter != nil {
-		v1Cfg.Converter = func(ctx agent.InvocationContext, req *v2a2a.SendMessageRequest, event v2a2a.Event, err error) (*session.Event, error) {
+		v1Cfg.Converter = func(ctx agent.InvocationContext, req *a2av2.SendMessageRequest, event a2av2.Event, err error) (*session.Event, error) {
 			legacyReq := a2av0.FromV1SendMessageRequest(req)
 			var legacyEvent a2a.Event
 			if event != nil {
@@ -201,7 +199,7 @@ func NewA2A(cfg A2AConfig) (agent.Agent, error) {
 	if cfg.BeforeRequestCallbacks != nil {
 		v1Cfg.BeforeRequestCallbacks = make([]v2.BeforeA2ARequestCallback, 0, len(cfg.BeforeRequestCallbacks))
 		for _, cb := range cfg.BeforeRequestCallbacks {
-			v1Cfg.BeforeRequestCallbacks = append(v1Cfg.BeforeRequestCallbacks, func(ctx agent.CallbackContext, req *v2a2a.SendMessageRequest) (*session.Event, error) {
+			v1Cfg.BeforeRequestCallbacks = append(v1Cfg.BeforeRequestCallbacks, func(ctx agent.CallbackContext, req *a2av2.SendMessageRequest) (*session.Event, error) {
 				legacyReq := a2av0.FromV1SendMessageRequest(req)
 				resp, err := cb(ctx, legacyReq)
 				if resp != nil || err != nil { // short-circuit, no need to convert the request back
@@ -221,7 +219,7 @@ func NewA2A(cfg A2AConfig) (agent.Agent, error) {
 	if cfg.AfterRequestCallbacks != nil {
 		v1Cfg.AfterRequestCallbacks = make([]v2.AfterA2ARequestCallback, 0, len(cfg.AfterRequestCallbacks))
 		for _, cb := range cfg.AfterRequestCallbacks {
-			v1Cfg.AfterRequestCallbacks = append(v1Cfg.AfterRequestCallbacks, func(ctx agent.CallbackContext, req *v2a2a.SendMessageRequest, resp *session.Event, err error) (*session.Event, error) {
+			v1Cfg.AfterRequestCallbacks = append(v1Cfg.AfterRequestCallbacks, func(ctx agent.CallbackContext, req *a2av2.SendMessageRequest, resp *session.Event, err error) (*session.Event, error) {
 				legacyReq := a2av0.FromV1SendMessageRequest(req)
 				newResp, newErr := cb(ctx, legacyReq, resp, err)
 				if newResp != nil || newErr != nil { // short-circuit, no need to convert the request back
@@ -239,7 +237,7 @@ func NewA2A(cfg A2AConfig) (agent.Agent, error) {
 	}
 
 	if cfg.A2APartConverter != nil {
-		v1Cfg.A2APartConverter = func(ctx context.Context, a2aEvent v2a2a.Event, part *v2a2a.Part) (*genai.Part, error) {
+		v1Cfg.A2APartConverter = func(ctx context.Context, a2aEvent a2av2.Event, part *a2av2.Part) (*genai.Part, error) {
 			legacyEvent, convErr := a2av0.FromV1Event(a2aEvent)
 			if convErr != nil {
 				return nil, convErr
@@ -249,7 +247,7 @@ func NewA2A(cfg A2AConfig) (agent.Agent, error) {
 	}
 
 	if cfg.GenAIPartConverter != nil {
-		v1Cfg.GenAIPartConverter = func(ctx context.Context, adkEvent *session.Event, part *genai.Part) (*v2a2a.Part, error) {
+		v1Cfg.GenAIPartConverter = func(ctx context.Context, adkEvent *session.Event, part *genai.Part) (*a2av2.Part, error) {
 			legacyPart, err := cfg.GenAIPartConverter(ctx, adkEvent, part)
 			if err != nil {
 				return nil, err
@@ -259,7 +257,7 @@ func NewA2A(cfg A2AConfig) (agent.Agent, error) {
 	}
 
 	if cfg.RemoteTaskCleanupCallback != nil {
-		v1Cfg.RemoteTaskCleanupCallback = func(ctx context.Context, card *v2a2a.AgentCard, client v2.A2AClient, taskInfo v2a2a.TaskInfo, cause error) {
+		v1Cfg.RemoteTaskCleanupCallback = func(ctx context.Context, card *a2av2.AgentCard, client v2.A2AClient, taskInfo a2av2.TaskInfo, cause error) {
 			legacyCard := a2av0.FromV1AgentCard(card)
 			legacyTaskInfo := a2a.TaskInfo{TaskID: a2a.TaskID(taskInfo.TaskID), ContextID: taskInfo.ContextID}
 
@@ -295,7 +293,7 @@ type compatClient struct {
 	client *a2aclient.Client
 }
 
-func (s *compatClient) SendMessage(ctx context.Context, req *v2a2a.SendMessageRequest) (v2a2a.SendMessageResult, error) {
+func (s *compatClient) SendMessage(ctx context.Context, req *a2av2.SendMessageRequest) (a2av2.SendMessageResult, error) {
 	legacyResp, err := s.client.SendMessage(ctx, a2av0.FromV1SendMessageRequest(req))
 	if err != nil {
 		return nil, err
@@ -304,15 +302,15 @@ func (s *compatClient) SendMessage(ctx context.Context, req *v2a2a.SendMessageRe
 	if err != nil {
 		return nil, err
 	}
-	res, ok := v1Event.(v2a2a.SendMessageResult)
+	res, ok := v1Event.(a2av2.SendMessageResult)
 	if !ok {
 		return nil, fmt.Errorf("converted event does not implement SendMessageResult: %T", v1Event)
 	}
 	return res, nil
 }
 
-func (s *compatClient) SendStreamingMessage(ctx context.Context, req *v2a2a.SendMessageRequest) iter.Seq2[v2a2a.Event, error] {
-	return func(yield func(v2a2a.Event, error) bool) {
+func (s *compatClient) SendStreamingMessage(ctx context.Context, req *a2av2.SendMessageRequest) iter.Seq2[a2av2.Event, error] {
+	return func(yield func(a2av2.Event, error) bool) {
 		for legacyEvent, err := range s.client.SendStreamingMessage(ctx, a2av0.FromV1SendMessageRequest(req)) {
 			if err != nil {
 				yield(nil, err)
@@ -330,7 +328,7 @@ func (s *compatClient) SendStreamingMessage(ctx context.Context, req *v2a2a.Send
 	}
 }
 
-func (s *compatClient) CancelTask(ctx context.Context, req *v2a2a.CancelTaskRequest) (*v2a2a.Task, error) {
+func (s *compatClient) CancelTask(ctx context.Context, req *a2av2.CancelTaskRequest) (*a2av2.Task, error) {
 	legacyResp, err := s.client.CancelTask(ctx, a2av0.FromV1CancelTaskRequest(req))
 	if err != nil {
 		return nil, err

--- a/agent/remoteagent/a2a_agent.go
+++ b/agent/remoteagent/a2a_agent.go
@@ -136,6 +136,18 @@ func NewA2A(cfg A2AConfig) (agent.Agent, error) {
 		Description:          cfg.Description,
 		BeforeAgentCallbacks: cfg.BeforeAgentCallbacks,
 		AfterAgentCallbacks:  cfg.AfterAgentCallbacks,
+		ClientProvider: func(ctx context.Context, card *v2a2a.AgentCard) (v2.A2AClient, error) {
+			legacyCard := a2av0.FromV1AgentCard(card)
+			factory := cfg.ClientFactory
+			if factory == nil {
+				factory = a2aclient.NewFactory()
+			}
+			client, err := factory.CreateFromCard(ctx, legacyCard)
+			if err != nil {
+				return nil, err
+			}
+			return &compatClient{client: client}, nil
+		},
 	}
 
 	if cfg.AgentCard != nil {

--- a/agent/remoteagent/a2a_agent_compat_test.go
+++ b/agent/remoteagent/a2a_agent_compat_test.go
@@ -530,7 +530,7 @@ func newV0Card(serverURL string) *legacyA2A.AgentCard {
 	return a2av0.FromV1AgentCard(&v2a2a.AgentCard{
 		SupportedInterfaces: []*v2a2a.AgentInterface{
 			{
-				URL: serverURL,
+				URL:             serverURL,
 				ProtocolBinding: v2a2a.TransportProtocolJSONRPC,
 				ProtocolVersion: a2av0.Version,
 			},
@@ -638,7 +638,7 @@ func newLegacyA2AClient(t *testing.T, server *testA2AServer) *legacyAClient.Clie
 	return client
 }
 
-func newA2ARemoteAgent(t *testing.T, name string, server *testA2AServer, clientFactory *legacyAClient.Factory) agent.Agent {
+func newA2ARemoteAgent(t *testing.T, name string, server *testA2AServer) agent.Agent {
 	t.Helper()
 	card := newV0Card(server.Server.URL)
 
@@ -708,7 +708,7 @@ func TestCompat_A2ACleanupPropagation(t *testing.T) {
 	defer serverB.Close()
 
 	// Root server connects to server B through remote subagent
-	remoteAgentB := newA2ARemoteAgent(t, "remote-agent-b", serverB, legacyAClient.NewFactory())
+	remoteAgentB := newA2ARemoteAgent(t, "remote-agent-b", serverB)
 	rootA := newRootAgent("agent-b", remoteAgentB)
 
 	// A2A Execution Cleanup callback

--- a/agent/remoteagent/a2a_agent_compat_test.go
+++ b/agent/remoteagent/a2a_agent_compat_test.go
@@ -24,12 +24,14 @@ import (
 	legacyA2A "github.com/a2aproject/a2a-go/a2a"
 	legacyAClient "github.com/a2aproject/a2a-go/a2aclient"
 	legacyASrv "github.com/a2aproject/a2a-go/a2asrv"
+	legacyEQ "github.com/a2aproject/a2a-go/a2asrv/eventqueue"
 	v2a2a "github.com/a2aproject/a2a-go/v2/a2a"
 	"github.com/a2aproject/a2a-go/v2/a2acompat/a2av0"
 	v2asrv "github.com/a2aproject/a2a-go/v2/a2asrv"
 	"google.golang.org/genai"
 
 	"google.golang.org/adk/agent"
+	"google.golang.org/adk/agent/llmagent"
 	icontext "google.golang.org/adk/internal/context"
 	"google.golang.org/adk/internal/utils"
 	"google.golang.org/adk/model"
@@ -524,6 +526,19 @@ func newLegacyCard(serverURL string) *legacyA2A.AgentCard {
 	})
 }
 
+func newV0Card(serverURL string) *legacyA2A.AgentCard {
+	return a2av0.FromV1AgentCard(&v2a2a.AgentCard{
+		SupportedInterfaces: []*v2a2a.AgentInterface{
+			{
+				URL: serverURL,
+				ProtocolBinding: v2a2a.TransportProtocolJSONRPC,
+				ProtocolVersion: a2av0.Version,
+			},
+		},
+		Capabilities: v2a2a.AgentCapabilities{Streaming: true},
+	})
+}
+
 func newInvocationContext(t *testing.T, events []*session.Event) agent.InvocationContext {
 	t.Helper()
 	ctx := t.Context()
@@ -565,4 +580,231 @@ func runAndCollect(ic agent.InvocationContext, agnt agent.Agent) ([]*session.Eve
 		collected = append(collected, ev)
 	}
 	return collected, nil
+}
+
+type mockLegacyExecutor struct {
+	executeFn func(ctx context.Context, reqCtx *legacyASrv.RequestContext, queue legacyEQ.Queue) error
+	cancelFn  func(ctx context.Context, reqCtx *legacyASrv.RequestContext, queue legacyEQ.Queue) error
+	cleanupFn func(ctx context.Context, reqCtx *legacyASrv.RequestContext, result legacyA2A.SendMessageResult, err error)
+}
+
+var (
+	_ legacyASrv.AgentExecutor         = (*mockLegacyExecutor)(nil)
+	_ legacyASrv.AgentExecutionCleaner = (*mockLegacyExecutor)(nil)
+
+	transferToolName      = "transfer_to_agent"
+	modelTextRootTransfer = "transferring... please hold... beepboop..."
+)
+
+type testA2AServer struct {
+	*httptest.Server
+	handler legacyASrv.RequestHandler
+}
+
+func (e *mockLegacyExecutor) Execute(ctx context.Context, reqCtx *legacyASrv.RequestContext, queue legacyEQ.Queue) error {
+	if e.executeFn != nil {
+		return e.executeFn(ctx, reqCtx, queue)
+	}
+	return nil
+}
+
+func (e *mockLegacyExecutor) Cancel(ctx context.Context, reqCtx *legacyASrv.RequestContext, queue legacyEQ.Queue) error {
+	if e.cancelFn != nil {
+		return e.cancelFn(ctx, reqCtx, queue)
+	}
+	return queue.Write(ctx, legacyA2A.NewStatusUpdateEvent(reqCtx, legacyA2A.TaskStateCanceled, nil))
+}
+
+func (e *mockLegacyExecutor) Cleanup(ctx context.Context, reqCtx *legacyASrv.RequestContext, result legacyA2A.SendMessageResult, err error) {
+	if e.cleanupFn != nil {
+		e.cleanupFn(ctx, reqCtx, result, err)
+	}
+}
+
+func startLegacyA2AServer(t *testing.T, executor legacyASrv.AgentExecutor) *testA2AServer {
+	t.Helper()
+	handler := legacyASrv.NewHandler(executor)
+	server := httptest.NewServer(legacyASrv.NewJSONRPCHandler(handler))
+	return &testA2AServer{Server: server, handler: handler}
+}
+
+func newLegacyA2AClient(t *testing.T, server *testA2AServer) *legacyAClient.Client {
+	t.Helper()
+	card := newV0Card(server.Server.URL)
+	client, err := legacyAClient.NewFromCard(t.Context(), card)
+	if err != nil {
+		t.Fatalf("legacyAClient.NewFromCard() error = %v", err)
+	}
+	return client
+}
+
+func newA2ARemoteAgent(t *testing.T, name string, server *testA2AServer, clientFactory *legacyAClient.Factory) agent.Agent {
+	t.Helper()
+	card := newV0Card(server.Server.URL)
+
+	return utils.Must(NewA2A(A2AConfig{AgentCard: card, Name: name}))
+}
+
+type llmStub struct {
+	name            string
+	generateContent func(ctx context.Context, req *model.LLMRequest, stream bool) iter.Seq2[*model.LLMResponse, error]
+}
+
+func (d *llmStub) Name() string {
+	return d.name
+}
+
+func (d *llmStub) GenerateContent(ctx context.Context, req *model.LLMRequest, stream bool) iter.Seq2[*model.LLMResponse, error] {
+	return d.generateContent(ctx, req, stream)
+}
+
+func newRootAgent(name string, subAgent agent.Agent) agent.Agent {
+	return utils.Must(llmagent.New(llmagent.Config{
+		Name:      name,
+		SubAgents: []agent.Agent{subAgent},
+		Model: &llmStub{
+			name: name + "-model",
+			generateContent: func(ctx context.Context, req *model.LLMRequest, stream bool) iter.Seq2[*model.LLMResponse, error] {
+				return func(yield func(*model.LLMResponse, error) bool) {
+					yield(&model.LLMResponse{
+						Content: genai.NewContentFromParts([]*genai.Part{
+							genai.NewPartFromText(modelTextRootTransfer),
+							genai.NewPartFromFunctionCall(transferToolName, map[string]any{"agent_name": subAgent.Name()}),
+						}, genai.RoleModel),
+					}, nil)
+				}
+			},
+		},
+	}))
+}
+
+func TestCompat_A2ACleanupPropagation(t *testing.T) {
+	// Remote A2A server publishes a submitted task and start generating artifact updates
+	// until it detects a context cancelation
+	remoteTaskIDChan, remoteCleanupCalledChan := make(chan legacyA2A.TaskID, 1), make(chan struct{}, 2)
+	serverB := startLegacyA2AServer(t, &mockLegacyExecutor{
+		cancelFn: func(ctx context.Context, reqCtx *legacyASrv.RequestContext, queue legacyEQ.Queue) error {
+			event := legacyA2A.NewStatusUpdateEvent(reqCtx, legacyA2A.TaskStateCanceled, nil)
+			event.Final = true
+			return queue.Write(ctx, event)
+		},
+		executeFn: func(ctx context.Context, reqCtx *legacyASrv.RequestContext, queue legacyEQ.Queue) error {
+			remoteTaskIDChan <- reqCtx.TaskID
+			if err := queue.Write(ctx, legacyA2A.NewSubmittedTask(reqCtx, reqCtx.Message)); err != nil {
+				return err
+			}
+			for ctx.Err() == nil {
+				if err := queue.Write(ctx, legacyA2A.NewArtifactEvent(reqCtx, legacyA2A.TextPart{Text: "foo"})); err != nil {
+					return err
+				}
+				time.Sleep(1 * time.Millisecond)
+			}
+			return queue.Write(ctx, legacyA2A.NewStatusUpdateEvent(reqCtx, legacyA2A.TaskStateCompleted, nil))
+		},
+		cleanupFn: func(ctx context.Context, reqCtx *legacyASrv.RequestContext, result legacyA2A.SendMessageResult, cause error) {
+			remoteCleanupCalledChan <- struct{}{}
+		},
+	})
+	defer serverB.Close()
+
+	// Root server connects to server B through remote subagent
+	remoteAgentB := newA2ARemoteAgent(t, "remote-agent-b", serverB, legacyAClient.NewFactory())
+	rootA := newRootAgent("agent-b", remoteAgentB)
+
+	// A2A Execution Cleanup callback
+	executorCleanupCalledChan := make(chan struct{}, 2)
+	executorA := adka2a.NewExecutor(adka2a.ExecutorConfig{
+		OutputMode: adka2a.OutputArtifactPerEvent,
+		RunnerConfig: runner.Config{
+			AppName:        rootA.Name(),
+			SessionService: session.InMemoryService(),
+			Agent:          rootA,
+		},
+		A2AExecutionCleanupCallback: func(ctx context.Context, reqCtx *legacyASrv.RequestContext, subAgentCards []*legacyA2A.AgentCard, result legacyA2A.SendMessageResult, cause error) {
+			executorCleanupCalledChan <- struct{}{}
+		},
+		RunConfig: agent.RunConfig{StreamingMode: agent.StreamingModeSSE},
+	})
+
+	serverA := startLegacyA2AServer(t, executorA)
+	defer serverA.Close()
+
+	client := newLegacyA2AClient(t, serverA)
+
+	// Send a streaming message in a detached goroutine, passing status update through chan
+	statusUpdateEventChan := make(chan legacyA2A.Event, 10)
+	go func() {
+		defer close(statusUpdateEventChan)
+		msg := legacyA2A.NewMessage(legacyA2A.MessageRoleUser, legacyA2A.TextPart{Text: "work"})
+		for event, err := range client.SendStreamingMessage(t.Context(), &legacyA2A.MessageSendParams{Message: msg}) {
+			if err != nil {
+				t.Errorf("client.SendStreamingMessage() error = %v", err)
+				return
+			}
+			if _, ok := event.(*legacyA2A.TaskArtifactUpdateEvent); ok {
+				continue
+			}
+			statusUpdateEventChan <- event
+		}
+	}()
+
+	// Issue a task cancellation request
+	taskID := (<-statusUpdateEventChan).TaskInfo().TaskID
+	cancelResultChan := make(chan *legacyA2A.Task, 1)
+	go func() {
+		defer close(cancelResultChan)
+		task, err := client.CancelTask(t.Context(), &legacyA2A.TaskIDParams{ID: taskID})
+		if err != nil {
+			t.Errorf("client.CancelTask() error = %v", err)
+			return
+		}
+		cancelResultChan <- task
+	}()
+
+	// Check the streaming message sender got a cancelled state task in their response
+	var lastStreamingUpdate legacyA2A.Event
+	for event := range statusUpdateEventChan {
+		lastStreamingUpdate = event
+	}
+	if tu, ok := lastStreamingUpdate.(*legacyA2A.TaskStatusUpdateEvent); ok {
+		if tu.Status.State != legacyA2A.TaskStateCanceled {
+			t.Errorf("lastStreamingUpdate.Status.State = %q, want %q", tu.Status.State, legacyA2A.TaskStateCanceled)
+		}
+	} else {
+		t.Fatalf("type(lastStreamingUpdate) = %T, want *a2a.TaskStatusUpdateEvent", lastStreamingUpdate)
+	}
+
+	// Check subagent task got cancelled when the parent task was cancelled.
+	// Reads from channel twice because cleanup gets called both for cancelation and execution.
+	timeout := time.After(5 * time.Second)
+	for range 2 {
+		select {
+		case <-remoteCleanupCalledChan:
+		case <-timeout:
+			t.Fatalf("remote cleanup was not called")
+		}
+	}
+	var remoteTaskID legacyA2A.TaskID
+	select {
+	case remoteTaskID = <-remoteTaskIDChan:
+	case <-time.After(1 * time.Second):
+		t.Fatal("server B was never reached; remoteTaskIDChan is empty")
+	}
+
+	for range 2 {
+		select {
+		case <-executorCleanupCalledChan:
+		case <-timeout:
+			t.Fatalf("executor cleanup was not called")
+		}
+	}
+
+	remoteClient := newLegacyA2AClient(t, serverB)
+	remoteTask, err := remoteClient.GetTask(t.Context(), &legacyA2A.TaskQueryParams{ID: remoteTaskID})
+	if err != nil {
+		t.Fatalf("remoteClient.GetTask() error = %v", err)
+	}
+	if remoteTask.Status.State != legacyA2A.TaskStateCanceled {
+		t.Errorf("remoteTask.Status.State = %q, want %q", remoteTask.Status.State, legacyA2A.TaskStateCanceled)
+	}
 }

--- a/agent/remoteagent/v2/a2a_e2e_test.go
+++ b/agent/remoteagent/v2/a2a_e2e_test.go
@@ -410,7 +410,18 @@ func TestA2ACleanupPropagation(t *testing.T) {
 	// Root server connects to server B through remote subagent
 	remoteAgentB := newA2ARemoteAgent(t, "remote-agent-b", serverB)
 	rootA := newRootAgent("agent-b", remoteAgentB)
-	executorA := newAgentExecutor(rootA, nil, adka2a.OutputArtifactPerEvent)
+	executorCleanupCalledChan := make(chan struct{}, 2)
+	executorA := adka2a.NewExecutor(adka2a.ExecutorConfig{
+		OutputMode: adka2a.OutputArtifactPerRun,
+		RunnerConfig: runner.Config{
+			AppName:        rootA.Name(),
+			SessionService: session.InMemoryService(),
+			Agent:          rootA,
+		},
+		A2AExecutionCleanupCallback: func(ctx context.Context, reqCtx *a2asrv.ExecutorContext, subAgentCards []*a2a.AgentCard, result a2a.SendMessageResult, cause error) {
+			executorCleanupCalledChan <- struct{}{}
+		},
+	})
 	serverA := startA2AServer(executorA)
 	defer serverA.Close()
 
@@ -461,9 +472,23 @@ func TestA2ACleanupPropagation(t *testing.T) {
 
 	// Check subagent task got cancelled when the parent task was cancelled.
 	// Reads from channel twice because cleanup gets called both for cancelation and execution.
-	<-remoteCleanupCalledChan
-	<-remoteCleanupCalledChan
+	timeout := time.After(5 * time.Second)
+	for range 2 {
+		select {
+		case <-remoteCleanupCalledChan:
+		case <-timeout:
+			t.Fatalf("remote cleanup was not called")
+		}
+	}
 	remoteTaskID := <-remoteTaskIDChan
+
+	for range 2 {
+		select {
+		case <-executorCleanupCalledChan:
+		case <-timeout:
+			t.Fatalf("executor cleanup was not called")
+		}
+	}
 	remoteClient := newA2AClient(t, serverB)
 	remoteTask, err := remoteClient.GetTask(t.Context(), &a2a.GetTaskRequest{ID: remoteTaskID})
 	if err != nil {

--- a/server/adka2a/executor.go
+++ b/server/adka2a/executor.go
@@ -130,7 +130,10 @@ type ExecutorConfig struct {
 	A2AExecutionCleanupCallback A2AExecutionCleanupCallback
 }
 
-var _ a2asrv.AgentExecutor = (*Executor)(nil)
+var (
+	_ a2asrv.AgentExecutor         = (*Executor)(nil)
+	_ a2asrv.AgentExecutionCleaner = (*Executor)(nil)
+)
 
 // Executor is the legacy AgentExecutor implementation which delegates to [v2.Executor].
 type Executor struct {
@@ -294,6 +297,28 @@ func (e *Executor) Cancel(ctx context.Context, reqCtx *a2asrv.RequestContext, qu
 	}
 
 	return nil
+}
+
+func (e *Executor) Cleanup(ctx context.Context, reqCtx *a2asrv.RequestContext, result a2a.SendMessageResult, cause error) {
+	execCtx, err := toExecutorContext(ctx, reqCtx)
+	if err != nil {
+		log.Warn(ctx, "failed to convert request context to executor context", "error", err)
+		return
+	}
+
+	v2Event, err := a2av0.ToV1Event(result)
+	if err != nil {
+		log.Warn(ctx, "failed to convert result to v2 event", "error", err)
+		return
+	}
+
+	v2Result, ok := v2Event.(a2av2.SendMessageResult)
+	if !ok {
+		log.Warn(ctx, "converted event is not SendMessageResult", "type", fmt.Sprintf("%T", v2Event))
+		return
+	}
+
+	e.impl.Cleanup(ctx, execCtx, v2Result, cause)
 }
 
 // ExecutorContext provides read-only information about the context of an A2A agent execution.


### PR DESCRIPTION
The legacy adka2a.Executor did not invoke A2AExecutionCleanupCallback because it did not implement a2asrv.AgentExecutionCleaner (Cleanup function) 

Implemented Cleanup on adka2a.Executor, converting the legacy request context / result to v2 types and delegating to the underlying v2 executor.

In a2a_agent.go if ClientFactory is not provided, will default to creating v0 sdk ClientFactory

Added a test to verify end to end cleanup propagation.

