### PR TITLE
fix: serialize ArtifactDelta in Vertex AI session service round-trip

### DIFF
--- a/session/vertexai/vertexai_client.go
+++ b/session/vertexai/vertexai_client.go
@@ -253,12 +253,18 @@ func (c *vertexAiClient) appendEvent(ctx context.Context, appName, sessionID str
 
 	var eventState *aiplatformpb.EventActions
 	// Convert and set the initial state if provided
-	if len(event.Actions.StateDelta) > 0 {
-		sessionState, err := structpb.NewStruct(event.Actions.StateDelta)
-		if err != nil {
-			return fmt.Errorf("failed to convert state to structpb: %w", err)
+	if len(event.Actions.StateDelta) > 0 || len(event.Actions.ArtifactDelta) > 0 {
+		eventState = &aiplatformpb.EventActions{}
+		if len(event.Actions.StateDelta) > 0 {
+			sessionState, err := structpb.NewStruct(event.Actions.StateDelta)
+			if err != nil {
+				return fmt.Errorf("failed to convert state to structpb: %w", err)
+			}
+			eventState.StateDelta = sessionState
 		}
-		eventState = &aiplatformpb.EventActions{StateDelta: sessionState}
+		if len(event.Actions.ArtifactDelta) > 0 {
+			eventState.ArtifactDelta = toInt32Map(event.Actions.ArtifactDelta)
+		}
 	}
 
 	content, err := createAiplatformpbContent(event)
@@ -328,7 +334,8 @@ func (c *vertexAiClient) listSessionEvents(ctx context.Context, appName, session
 			InvocationID: rpcResp.InvocationId,
 			Author:       rpcResp.Author,
 			Actions: session.EventActions{
-				StateDelta: filterNilValues(rpcResp.Actions.StateDelta.AsMap()),
+				StateDelta:    filterNilValues(rpcResp.Actions.StateDelta.AsMap()),
+				ArtifactDelta: toInt64Map(rpcResp.Actions.GetArtifactDelta()),
 			},
 			LLMResponse: model.LLMResponse{
 				Content:      content,
@@ -780,6 +787,32 @@ func createGroundingMetadata(metadata *aiplatformpb.GroundingMetadata) *genai.Gr
 		out.GroundingSupports = supports
 	}
 
+	return out
+}
+
+// toInt32Map converts a map[string]int64 to map[string]int32.
+// Used when writing ArtifactDelta to the proto (int64 → int32).
+func toInt32Map(m map[string]int64) map[string]int32 {
+	if len(m) == 0 {
+		return nil
+	}
+	out := make(map[string]int32, len(m))
+	for k, v := range m {
+		out[k] = int32(v)
+	}
+	return out
+}
+
+// toInt64Map converts a map[string]int32 to map[string]int64.
+// Used when reading ArtifactDelta from the proto (int32 → int64).
+func toInt64Map(m map[string]int32) map[string]int64 {
+	if len(m) == 0 {
+		return nil
+	}
+	out := make(map[string]int64, len(m))
+	for k, v := range m {
+		out[k] = int64(v)
+	}
 	return out
 }
 

--- a/session/vertexai/vertexai_test.go
+++ b/session/vertexai/vertexai_test.go
@@ -169,3 +169,191 @@ func TestAiplatformToGenaiContentPreservesFunctionIDs(t *testing.T) {
 		t.Errorf("FunctionResponse.ID = %q, want %q", got, want)
 	}
 }
+
+func TestToInt32Map(t *testing.T) {
+	tests := []struct {
+		name string
+		in   map[string]int64
+		want map[string]int32
+	}{
+		{
+			name: "nil map",
+			in:   nil,
+			want: nil,
+		},
+		{
+			name: "empty map",
+			in:   map[string]int64{},
+			want: nil,
+		},
+		{
+			name: "single entry",
+			in:   map[string]int64{"chart.html": 1},
+			want: map[string]int32{"chart.html": 1},
+		},
+		{
+			name: "multiple entries",
+			in:   map[string]int64{"a.txt": 1, "b.png": 3},
+			want: map[string]int32{"a.txt": 1, "b.png": 3},
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got := toInt32Map(tt.in)
+			if len(got) != len(tt.want) {
+				t.Fatalf("toInt32Map() len = %d, want %d", len(got), len(tt.want))
+			}
+			for k, wantV := range tt.want {
+				if gotV, ok := got[k]; !ok || gotV != wantV {
+					t.Errorf("toInt32Map()[%q] = %d, want %d", k, gotV, wantV)
+				}
+			}
+		})
+	}
+}
+
+func TestToInt64Map(t *testing.T) {
+	tests := []struct {
+		name string
+		in   map[string]int32
+		want map[string]int64
+	}{
+		{
+			name: "nil map",
+			in:   nil,
+			want: nil,
+		},
+		{
+			name: "empty map",
+			in:   map[string]int32{},
+			want: nil,
+		},
+		{
+			name: "single entry",
+			in:   map[string]int32{"chart.html": 1},
+			want: map[string]int64{"chart.html": 1},
+		},
+		{
+			name: "multiple entries",
+			in:   map[string]int32{"a.txt": 1, "b.png": 3},
+			want: map[string]int64{"a.txt": 1, "b.png": 3},
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got := toInt64Map(tt.in)
+			if len(got) != len(tt.want) {
+				t.Fatalf("toInt64Map() len = %d, want %d", len(got), len(tt.want))
+			}
+			for k, wantV := range tt.want {
+				if gotV, ok := got[k]; !ok || gotV != wantV {
+					t.Errorf("toInt64Map()[%q] = %d, want %d", k, gotV, wantV)
+				}
+			}
+		})
+	}
+}
+
+func TestAppendEventSerializesArtifactDelta(t *testing.T) {
+	// This test verifies that createAiplatformpbContent and the event
+	// construction in appendEvent correctly handle ArtifactDelta.
+	// We test the serialization path by constructing the EventActions
+	// the same way appendEvent does.
+	tests := []struct {
+		name          string
+		stateDelta    map[string]any
+		artifactDelta map[string]int64
+		wantNilAction bool
+		wantArtifact  map[string]int32
+	}{
+		{
+			name:          "only artifact delta",
+			stateDelta:    nil,
+			artifactDelta: map[string]int64{"chart.html": 1},
+			wantNilAction: false,
+			wantArtifact:  map[string]int32{"chart.html": 1},
+		},
+		{
+			name:          "both state and artifact delta",
+			stateDelta:    map[string]any{"key": "value"},
+			artifactDelta: map[string]int64{"file.txt": 2},
+			wantNilAction: false,
+			wantArtifact:  map[string]int32{"file.txt": 2},
+		},
+		{
+			name:          "neither state nor artifact delta",
+			stateDelta:    nil,
+			artifactDelta: nil,
+			wantNilAction: true,
+			wantArtifact:  nil,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			// Replicate the appendEvent logic for constructing EventActions
+			var eventState *aiplatformpb.EventActions
+			if len(tt.stateDelta) > 0 || len(tt.artifactDelta) > 0 {
+				eventState = &aiplatformpb.EventActions{}
+				if len(tt.stateDelta) > 0 {
+					sessionState, err := structpb.NewStruct(tt.stateDelta)
+					if err != nil {
+						t.Fatalf("structpb.NewStruct() failed: %v", err)
+					}
+					eventState.StateDelta = sessionState
+				}
+				if len(tt.artifactDelta) > 0 {
+					eventState.ArtifactDelta = toInt32Map(tt.artifactDelta)
+				}
+			}
+
+			if tt.wantNilAction {
+				if eventState != nil {
+					t.Fatal("expected nil EventActions, got non-nil")
+				}
+				return
+			}
+
+			if eventState == nil {
+				t.Fatal("expected non-nil EventActions, got nil")
+			}
+
+			gotArtifact := eventState.GetArtifactDelta()
+			if len(gotArtifact) != len(tt.wantArtifact) {
+				t.Fatalf("ArtifactDelta len = %d, want %d", len(gotArtifact), len(tt.wantArtifact))
+			}
+			for k, wantV := range tt.wantArtifact {
+				if gotV, ok := gotArtifact[k]; !ok || gotV != wantV {
+					t.Errorf("ArtifactDelta[%q] = %d, want %d", k, gotV, wantV)
+				}
+			}
+		})
+	}
+}
+
+func TestListSessionEventsDeserializesArtifactDelta(t *testing.T) {
+	// Simulate what listSessionEvents does when reading back ArtifactDelta
+	// from a proto SessionEvent.
+	pbActions := &aiplatformpb.EventActions{
+		ArtifactDelta: map[string]int32{
+			"chart.html": 1,
+			"data.csv":   2,
+		},
+	}
+
+	got := toInt64Map(pbActions.GetArtifactDelta())
+
+	want := map[string]int64{
+		"chart.html": 1,
+		"data.csv":   2,
+	}
+
+	if len(got) != len(want) {
+		t.Fatalf("ArtifactDelta len = %d, want %d", len(got), len(want))
+	}
+	for k, wantV := range want {
+		if gotV, ok := got[k]; !ok || gotV != wantV {
+			t.Errorf("ArtifactDelta[%q] = %d, want %d", k, gotV, wantV)
+		}
+	}
+}


### PR DESCRIPTION
## Summary

`appendEvent` and `listSessionEvents` in `session/vertexai/vertexai_client.go` serialize only `EventActions.StateDelta` — `ArtifactDelta` is silently dropped on round-trip. Any tool that saves an artifact via `toolCtx.Artifacts().Save(...)` ends up with an in-memory event whose `ArtifactDelta` is populated, but after the runner persists the event via the Vertex AI session service and a later `Get` / `ListEvents` reads it back, `ArtifactDelta` is `nil`.

The wire format (`aiplatformpb.EventActions`) already supports this via the `ArtifactDelta` field (proto field 3, `map<string, int32>`). This change adds the missing field mapping in both directions, with `int64↔int32` conversion since the ADK model uses `int64` while the proto uses `int32`.

## Changes

- **`appendEvent`**: Now serializes `ArtifactDelta` alongside `StateDelta` into `aiplatformpb.EventActions`
- **`listSessionEvents`**: Now deserializes `ArtifactDelta` from the proto response back into `session.EventActions`
- **`toInt32Map` / `toInt64Map`**: New helpers to convert between `map[string]int64` (ADK model) and `map[string]int32` (proto wire format)
- **Tests**: Unit tests for conversion helpers, serialization path, and deserialization path

## Testing

- All new unit tests pass
- Full `session/vertexai` integration test suite passes (32s)

Fixes #902