### PR TITLE
feat(workflow): branch isolation across static, parallel, and dynamic schedulers

### DIFF
--- a/internal/context/invocation_context.go
+++ b/internal/context/invocation_context.go
@@ -113,14 +113,12 @@ func (c *InvocationContext) WithContext(ctx context.Context) agent.InvocationCon
 	return &newCtx
 }
 
-// WithBranch returns a copy of c with Branch replaced. Used by the
-// workflow scheduler at fan-out to give each successor its own
-// branch so the LLM history filter
-// (internal/llminternal/contents_processor.go:eventBelongsToBranch)
-// scopes events per parallel branch.
+// WithBranch returns a copy of c with Branch replaced. Useful for
+// callers that need to scope the LLM flow's history filter per
+// parallel branch.
 //
-// Not part of the agent.InvocationContext interface today; promote
-// to the interface only when a non-workflow caller needs it.
+// Not part of the agent.InvocationContext interface; promote if
+// more implementers need it.
 func (c *InvocationContext) WithBranch(branch string) *InvocationContext {
 	newCtx := *c
 	newCtx.params.Branch = branch

--- a/internal/context/invocation_context.go
+++ b/internal/context/invocation_context.go
@@ -113,6 +113,20 @@ func (c *InvocationContext) WithContext(ctx context.Context) agent.InvocationCon
 	return &newCtx
 }
 
+// WithBranch returns a copy of c with Branch replaced. Used by the
+// workflow scheduler at fan-out to give each successor its own
+// branch so the LLM history filter
+// (internal/llminternal/contents_processor.go:eventBelongsToBranch)
+// scopes events per parallel branch.
+//
+// Not part of the agent.InvocationContext interface today; promote
+// to the interface only when a non-workflow caller needs it.
+func (c *InvocationContext) WithBranch(branch string) *InvocationContext {
+	newCtx := *c
+	newCtx.params.Branch = branch
+	return &newCtx
+}
+
 // ResumedInput always returns (nil, false) for the base
 // invocation context. Implementations that carry a resume payload
 // override this method.

--- a/internal/context/invocation_context.go
+++ b/internal/context/invocation_context.go
@@ -113,18 +113,6 @@ func (c *InvocationContext) WithContext(ctx context.Context) agent.InvocationCon
 	return &newCtx
 }
 
-// WithBranch returns a copy of c with Branch replaced. Useful for
-// callers that need to scope the LLM flow's history filter per
-// parallel branch.
-//
-// Not part of the agent.InvocationContext interface; promote if
-// more implementers need it.
-func (c *InvocationContext) WithBranch(branch string) *InvocationContext {
-	newCtx := *c
-	newCtx.params.Branch = branch
-	return &newCtx
-}
-
 // ResumedInput always returns (nil, false) for the base
 // invocation context. Implementations that carry a resume payload
 // override this method.

--- a/workflow/agent_node.go
+++ b/workflow/agent_node.go
@@ -105,8 +105,7 @@ func (n *AgentNode) Run(ctx agent.InvocationContext, input any) iter.Seq2[*sessi
 		// Use existing agent context instead of implementing a new one.
 		// Branch is inherited from ctx so the agent runs under the
 		// activation's branch; the scheduler assigns sub-branches at
-		// fan-out (workflow/scheduler.go) and the LLM history filter
-		// (internal/llminternal/contents_processor.go) scopes events
+		// fan-out, and the LLM flow's history filter scopes events
 		// by branch prefix.
 		params := internalcontext.InvocationContextParams{
 			Artifacts:     ctx.Artifacts(),

--- a/workflow/agent_node.go
+++ b/workflow/agent_node.go
@@ -102,12 +102,16 @@ func (n *AgentNode) Run(ctx agent.InvocationContext, input any) iter.Seq2[*sessi
 			}
 		}
 
-		// Use existing agent context instead of implementing a new one
+		// Use existing agent context instead of implementing a new one.
+		// Branch is inherited from ctx so the agent runs under the
+		// activation's branch; the scheduler assigns sub-branches at
+		// fan-out (workflow/scheduler.go) and the LLM history filter
+		// (internal/llminternal/contents_processor.go) scopes events
+		// by branch prefix.
 		params := internalcontext.InvocationContextParams{
-			Artifacts: ctx.Artifacts(),
-			Memory:    ctx.Memory(),
-			Session:   ctx.Session(),
-			// TODO: branch isolation in a separate PR
+			Artifacts:     ctx.Artifacts(),
+			Memory:        ctx.Memory(),
+			Session:       ctx.Session(),
 			Branch:        ctx.Branch(),
 			Agent:         n.agent,
 			UserContent:   userContent,

--- a/workflow/branch.go
+++ b/workflow/branch.go
@@ -19,7 +19,6 @@ import (
 	"strings"
 
 	"google.golang.org/adk/agent"
-	icontext "google.golang.org/adk/internal/context"
 )
 
 // Branch composition helpers for the static, parallel, and dynamic
@@ -51,31 +50,22 @@ func deriveSubBranch(parent, segment string) string {
 }
 
 // withBranch returns ctx wrapped with branch as its Branch().
-// Today the only implementer of agent.InvocationContext is
-// *icontext.InvocationContext, so the common path is a single type
-// assertion + WithBranch. Anything else falls back to a small
-// adapter that overrides only Branch() — sufficient for tests that
-// supply a hand-rolled MockInvocationContext.
+// Implemented as a small adapter that overrides only Branch() and
+// delegates the rest of the interface to the embedded ctx.
 func withBranch(ctx agent.InvocationContext, branch string) agent.InvocationContext {
 	if ctx.Branch() == branch {
 		return ctx
 	}
-	if ic, ok := ctx.(*icontext.InvocationContext); ok {
-		return ic.WithBranch(branch)
-	}
 	return &branchOverride{InvocationContext: ctx, branch: branch}
 }
 
-// branchOverride wraps any InvocationContext and overrides Branch().
-// Used as a fallback when ctx is not the canonical
-// *icontext.InvocationContext implementation (currently only test
-// mocks). All other interface methods delegate to the embedded
-// value.
+// branchOverride wraps an InvocationContext and overrides Branch().
+// All other interface methods delegate to the embedded value.
 //
 // WithContext is overridden so the branch survives a subsequent
 // context-cancellation wrap. Without this, a caller that does
 // ctx.WithContext(cancelCtx) would get an InvocationContext whose
-// Branch() returns the inner mock's branch (empty), silently
+// Branch() returns the inner ctx's branch (empty), silently
 // losing the override.
 type branchOverride struct {
 	agent.InvocationContext

--- a/workflow/branch.go
+++ b/workflow/branch.go
@@ -1,0 +1,160 @@
+// Copyright 2026 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package workflow
+
+import (
+	"strings"
+
+	"google.golang.org/adk/agent"
+	icontext "google.golang.org/adk/internal/context"
+)
+
+// Branch composition helpers for the static, parallel, and dynamic
+// schedulers. Branches are dot-separated strings identifying the
+// position of an in-flight node within an invocation's parallel
+// execution tree. The LLM history filter
+// (internal/llminternal/contents_processor.go:eventBelongsToBranch)
+// uses prefix matching with explicit dot delimiter to scope events:
+// an agent on branch "a.b" sees events on branches "" (root), "a"
+// (ancestor), and "a.b" (self) but not "a.c" (sibling).
+//
+// Mirrors adk-python's logic in:
+//   - src/google/adk/workflow/_node_runner.py:198-209 (sub-branch derivation)
+//   - src/google/adk/workflow/_workflow.py:59-71 (common-prefix)
+//   - src/google/adk/flows/llm_flows/contents.py:885-900 (matching)
+
+// deriveSubBranch appends segment to parent with the dot delimiter.
+// An empty parent yields the bare segment (root + segment), keeping
+// the resulting string non-dot-prefixed; an empty segment is a
+// no-op returning parent unchanged.
+//
+// segment is expected to be a stable identifier — Python uses
+// "<node_name>@<run_id>" — but this helper does not impose a shape.
+// Callers that need uniqueness across replays must supply a stable
+// run id (auto-counter or WithRunID for dynamic; index+1 for
+// ParallelWorker; "<successor>@1" for static fan-out).
+func deriveSubBranch(parent, segment string) string {
+	if segment == "" {
+		return parent
+	}
+	if parent == "" {
+		return segment
+	}
+	return parent + "." + segment
+}
+
+// withBranch returns ctx wrapped with branch as its Branch().
+// Today the only implementer of agent.InvocationContext is
+// *icontext.InvocationContext, so the common path is a single type
+// assertion + WithBranch. Anything else falls back to a small
+// adapter that overrides only Branch() — sufficient for tests that
+// supply a hand-rolled MockInvocationContext.
+func withBranch(ctx agent.InvocationContext, branch string) agent.InvocationContext {
+	if ctx.Branch() == branch {
+		return ctx
+	}
+	if ic, ok := ctx.(*icontext.InvocationContext); ok {
+		return ic.WithBranch(branch)
+	}
+	return &branchOverride{InvocationContext: ctx, branch: branch}
+}
+
+// branchOverride wraps any InvocationContext and overrides Branch().
+// Used as a fallback when ctx is not the canonical
+// *icontext.InvocationContext implementation (currently only test
+// mocks). All other interface methods delegate to the embedded
+// value.
+//
+// Caveat: callers that chain WithContext on a branchOverride get
+// back the *inner* type's WithContext result, which loses the
+// branch override. The scheduler does not do this — it calls
+// WithContext first to set up the per-node cancellation, then
+// withBranch once — so the chaining hazard does not arise in
+// practice. If a future caller needs both, it must call withBranch
+// last.
+type branchOverride struct {
+	agent.InvocationContext
+	branch string
+}
+
+func (b *branchOverride) Branch() string { return b.branch }
+
+// deriveChildBranch composes the branch for a dynamically-scheduled
+// child given the parent's branch and the RunNode options. Mirrors
+// adk-python's logic in _node_runner._create_child_context
+// (_node_runner.py:198-209).
+//
+// Algorithm:
+//   - base = overrideBranch if non-empty, else parentBranch
+//   - useSubBranch=true → base.<name>@<runID> (or bare <name>@<runID>
+//     when base is empty)
+//   - useSubBranch=false → base unchanged
+//
+// Note: overrideBranch="" is treated as "no override" (Go does not
+// distinguish nil from empty string the way Python distinguishes
+// None from ""); see WithOverrideBranch godoc for the rationale.
+func deriveChildBranch(parentBranch, name, runID string, useSubBranch bool, overrideBranch string) string {
+	base := parentBranch
+	if overrideBranch != "" {
+		base = overrideBranch
+	}
+	if useSubBranch {
+		return deriveSubBranch(base, name+"@"+runID)
+	}
+	return base
+}
+
+// commonBranchPrefix returns the longest dot-delimited prefix shared
+// by all input branches. Used by JoinNode to derive its own branch
+// from the branches of its predecessors so the join "returns up the
+// tree" to the deepest common ancestor.
+//
+// Behavior:
+//   - Empty input → "" (root).
+//   - Any input branch == "" → "" (root contains everything).
+//   - All inputs identical → that exact value.
+//   - Otherwise the longest shared dot-segment prefix.
+//
+// Note that segment-aware comparison is intentional: branches "a"
+// and "ab" share no prefix (zero common segments), not "a"-as-string.
+// This matches Python's segment-split behaviour at _workflow.py:63-71.
+func commonBranchPrefix(branches []string) string {
+	if len(branches) == 0 {
+		return ""
+	}
+	splits := make([][]string, len(branches))
+	minLen := -1
+	for i, b := range branches {
+		if b == "" {
+			return ""
+		}
+		segs := strings.Split(b, ".")
+		splits[i] = segs
+		if minLen < 0 || len(segs) < minLen {
+			minLen = len(segs)
+		}
+	}
+	commonCount := 0
+	for i := 0; i < minLen; i++ {
+		seg := splits[0][i]
+		for _, s := range splits[1:] {
+			if s[i] != seg {
+				return strings.Join(splits[0][:commonCount], ".")
+			}
+		}
+		commonCount++
+	}
+	return strings.Join(splits[0][:commonCount], ".")
+}

--- a/workflow/branch.go
+++ b/workflow/branch.go
@@ -25,26 +25,20 @@ import (
 // Branch composition helpers for the static, parallel, and dynamic
 // schedulers. Branches are dot-separated strings identifying the
 // position of an in-flight node within an invocation's parallel
-// execution tree. The LLM history filter
-// (internal/llminternal/contents_processor.go:eventBelongsToBranch)
-// uses prefix matching with explicit dot delimiter to scope events:
-// an agent on branch "a.b" sees events on branches "" (root), "a"
+// execution tree. The LLM flow processor's history filter uses
+// prefix matching with explicit dot delimiter to scope events: an
+// agent on branch "a.b" sees events on branches "" (root), "a"
 // (ancestor), and "a.b" (self) but not "a.c" (sibling).
-//
-// Mirrors adk-python's logic in:
-//   - src/google/adk/workflow/_node_runner.py:198-209 (sub-branch derivation)
-//   - src/google/adk/workflow/_workflow.py:59-71 (common-prefix)
-//   - src/google/adk/flows/llm_flows/contents.py:885-900 (matching)
 
 // deriveSubBranch appends segment to parent with the dot delimiter.
 // An empty parent yields the bare segment (root + segment), keeping
 // the resulting string non-dot-prefixed; an empty segment is a
 // no-op returning parent unchanged.
 //
-// segment is expected to be a stable identifier — Python uses
-// "<node_name>@<run_id>" — but this helper does not impose a shape.
-// Callers that need uniqueness across replays must supply a stable
-// run id (auto-counter or WithRunID for dynamic; index+1 for
+// segment is expected to be a stable identifier (callers commonly
+// use "<node_name>@<run_id>") but this helper does not impose a
+// shape. Callers that need uniqueness across replays must supply a
+// stable run id (auto-counter or WithRunID for dynamic; index+1 for
 // ParallelWorker; "<successor>@1" for static fan-out).
 func deriveSubBranch(parent, segment string) string {
 	if segment == "" {
@@ -79,9 +73,10 @@ func withBranch(ctx agent.InvocationContext, branch string) agent.InvocationCont
 // value.
 //
 // WithContext is overridden so the branch survives a subsequent
-// context-cancellation wrap (e.g. ParallelWorker calls
-// ctx.WithContext(cancelCtx) on its input, and the resulting ctx
-// must still carry the override when callers later read Branch()).
+// context-cancellation wrap. Without this, a caller that does
+// ctx.WithContext(cancelCtx) would get an InvocationContext whose
+// Branch() returns the inner mock's branch (empty), silently
+// losing the override.
 type branchOverride struct {
 	agent.InvocationContext
 	branch string
@@ -100,9 +95,7 @@ func (b *branchOverride) WithContext(ctx context.Context) agent.InvocationContex
 }
 
 // deriveChildBranch composes the branch for a dynamically-scheduled
-// child given the parent's branch and the RunNode options. Mirrors
-// adk-python's logic in _node_runner._create_child_context
-// (_node_runner.py:198-209).
+// child given the parent's branch and the RunNode options.
 //
 // Algorithm:
 //   - base = overrideBranch if non-empty, else parentBranch
@@ -110,9 +103,9 @@ func (b *branchOverride) WithContext(ctx context.Context) agent.InvocationContex
 //     when base is empty)
 //   - useSubBranch=false → base unchanged
 //
-// Note: overrideBranch="" is treated as "no override" (Go does not
-// distinguish nil from empty string the way Python distinguishes
-// None from ""); see WithOverrideBranch godoc for the rationale.
+// Note: overrideBranch="" is treated as "no override" (Go lacks an
+// optional string type that would distinguish unset from
+// explicitly-empty); see WithOverrideBranch godoc for the rationale.
 func deriveChildBranch(parentBranch, name, runID string, useSubBranch bool, overrideBranch string) string {
 	base := parentBranch
 	if overrideBranch != "" {
@@ -137,7 +130,6 @@ func deriveChildBranch(parentBranch, name, runID string, useSubBranch bool, over
 //
 // Note that segment-aware comparison is intentional: branches "a"
 // and "ab" share no prefix (zero common segments), not "a"-as-string.
-// This matches Python's segment-split behaviour at _workflow.py:63-71.
 func commonBranchPrefix(branches []string) string {
 	if len(branches) == 0 {
 		return ""

--- a/workflow/branch.go
+++ b/workflow/branch.go
@@ -15,6 +15,7 @@
 package workflow
 
 import (
+	"context"
 	"strings"
 
 	"google.golang.org/adk/agent"
@@ -77,19 +78,26 @@ func withBranch(ctx agent.InvocationContext, branch string) agent.InvocationCont
 // mocks). All other interface methods delegate to the embedded
 // value.
 //
-// Caveat: callers that chain WithContext on a branchOverride get
-// back the *inner* type's WithContext result, which loses the
-// branch override. The scheduler does not do this — it calls
-// WithContext first to set up the per-node cancellation, then
-// withBranch once — so the chaining hazard does not arise in
-// practice. If a future caller needs both, it must call withBranch
-// last.
+// WithContext is overridden so the branch survives a subsequent
+// context-cancellation wrap (e.g. ParallelWorker calls
+// ctx.WithContext(cancelCtx) on its input, and the resulting ctx
+// must still carry the override when callers later read Branch()).
 type branchOverride struct {
 	agent.InvocationContext
 	branch string
 }
 
 func (b *branchOverride) Branch() string { return b.branch }
+
+// WithContext returns a branchOverride wrapping the inner
+// InvocationContext's WithContext result so the branch override is
+// preserved through context-cancellation wrapping.
+func (b *branchOverride) WithContext(ctx context.Context) agent.InvocationContext {
+	return &branchOverride{
+		InvocationContext: b.InvocationContext.WithContext(ctx),
+		branch:            b.branch,
+	}
+}
 
 // deriveChildBranch composes the branch for a dynamically-scheduled
 // child given the parent's branch and the RunNode options. Mirrors

--- a/workflow/branch.go
+++ b/workflow/branch.go
@@ -93,9 +93,8 @@ func (b *branchOverride) WithContext(ctx context.Context) agent.InvocationContex
 //     when base is empty)
 //   - useSubBranch=false → base unchanged
 //
-// Note: overrideBranch="" is treated as "no override" (Go lacks an
-// optional string type that would distinguish unset from
-// explicitly-empty); see WithOverrideBranch godoc for the rationale.
+// Note: overrideBranch="" is treated as "no override"; see
+// WithOverrideBranch godoc.
 func deriveChildBranch(parentBranch, name, runID string, useSubBranch bool, overrideBranch string) string {
 	base := parentBranch
 	if overrideBranch != "" {

--- a/workflow/branch_isolation_test.go
+++ b/workflow/branch_isolation_test.go
@@ -23,33 +23,15 @@ import (
 	"google.golang.org/adk/session"
 )
 
-// TestRunNode_SequentialFanOut_WithUseSubBranch_DistinctBranches is
-// the post-Phase 3 form of the original branch-isolation Phase 0
-// reproducer. It verifies that opting into WithUseSubBranch() at
-// each RunNode call produces distinct per-child branches so
-// downstream LlmAgent children, reading session.Events() filtered
-// by branch
-// (internal/llminternal/contents_processor.go:eventBelongsToBranch),
-// no longer see each other's events.
-//
-// History: in Phase 0 (before this plan started) this test was
-// XFAILed and pinned the "all children share Branch == \"\"" bug.
-// Phase 3 added WithUseSubBranch / WithOverrideBranch options;
-// applying WithUseSubBranch() at the call site is the
-// Python-equivalent fix.
-//
-// The companion test
-// TestRunNode_SequentialFanOut_NoOption_StillSharesBranch below
-// pins that *omitting* the option keeps the old inherit-parent
-// behaviour, matching Python's default (use_sub_branch=False).
+// TestRunNode_SequentialFanOut_WithUseSubBranch_DistinctBranches
+// verifies that opting into WithUseSubBranch() at each RunNode call
+// produces distinct per-child branches.
 //
 // Why sequential (not errgroup): per req §5.1 D-Emit-Sequential,
 // emit / RunNode are single-goroutine only. Running fan-out via
 // errgroup violates the iter.Seq2 contract (concurrent yield calls
 // from multiple goroutines) and races on the event-collection slice
-// inside drainDynamicWithErr. A future PR may add a parallel
-// reproducer once each goroutine gets its own sub-context; for
-// branch derivation correctness the sequential form is sufficient.
+// inside drainDynamicWithErr.
 func TestRunNode_SequentialFanOut_WithUseSubBranch_DistinctBranches(t *testing.T) {
 	const (
 		childName = "peeker"
@@ -111,10 +93,9 @@ func TestRunNode_SequentialFanOut_WithUseSubBranch_DistinctBranches(t *testing.T
 }
 
 // TestRunNode_SequentialFanOut_NoOption_StillSharesBranch pins the
-// Python-default behaviour (use_sub_branch=False): without the
-// opt-in, children inherit the orchestrator's branch verbatim. This
-// preserves backward compatibility for code that relies on inherited
-// branches.
+// default behaviour: without the opt-in, children inherit the
+// orchestrator's branch verbatim. This preserves backward
+// compatibility for code that relies on inherited branches.
 func TestRunNode_SequentialFanOut_NoOption_StillSharesBranch(t *testing.T) {
 	const (
 		childName = "peeker"

--- a/workflow/branch_isolation_test.go
+++ b/workflow/branch_isolation_test.go
@@ -1,0 +1,167 @@
+// Copyright 2026 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package workflow
+
+import (
+	"fmt"
+	"sort"
+	"testing"
+
+	"google.golang.org/adk/agent"
+	"google.golang.org/adk/session"
+)
+
+// TestRunNode_SequentialFanOut_WithUseSubBranch_DistinctBranches is
+// the post-Phase 3 form of the original branch-isolation Phase 0
+// reproducer. It verifies that opting into WithUseSubBranch() at
+// each RunNode call produces distinct per-child branches so
+// downstream LlmAgent children, reading session.Events() filtered
+// by branch
+// (internal/llminternal/contents_processor.go:eventBelongsToBranch),
+// no longer see each other's events.
+//
+// History: in Phase 0 (before this plan started) this test was
+// XFAILed and pinned the "all children share Branch == \"\"" bug.
+// Phase 3 added WithUseSubBranch / WithOverrideBranch options;
+// applying WithUseSubBranch() at the call site is the
+// Python-equivalent fix.
+//
+// The companion test
+// TestRunNode_SequentialFanOut_NoOption_StillSharesBranch below
+// pins that *omitting* the option keeps the old inherit-parent
+// behaviour, matching Python's default (use_sub_branch=False).
+//
+// Why sequential (not errgroup): per req §5.1 D-Emit-Sequential,
+// emit / RunNode are single-goroutine only. Running fan-out via
+// errgroup violates the iter.Seq2 contract (concurrent yield calls
+// from multiple goroutines) and races on the event-collection slice
+// inside drainDynamicWithErr. A future PR may add a parallel
+// reproducer once each goroutine gets its own sub-context; for
+// branch derivation correctness the sequential form is sufficient.
+func TestRunNode_SequentialFanOut_WithUseSubBranch_DistinctBranches(t *testing.T) {
+	const (
+		childName = "peeker"
+		nItems    = 3
+	)
+
+	var seenBranches []string
+	peekerNode := NewFunctionNode(
+		childName,
+		func(ctx agent.InvocationContext, input string) (string, error) {
+			seenBranches = append(seenBranches, ctx.Branch())
+			return input, nil
+		},
+		NodeConfig{},
+	)
+
+	orch := NewDynamicNode[any, []string](
+		"orch",
+		func(ctx NodeContext, _ any, _ func(*session.Event) error) ([]string, error) {
+			items := []string{"a", "b", "c"}
+			results := make([]string, len(items))
+			for i, item := range items {
+				out, err := RunNode[string](ctx, peekerNode, item,
+					WithUseSubBranch(),
+					WithRunID(fmt.Sprintf("custom-%d", i+1)))
+				if err != nil {
+					return nil, err
+				}
+				results[i] = out
+			}
+			return results, nil
+		},
+		NodeConfig{},
+	)
+
+	_, err := drainDynamicWithErr(t, orch, nil)
+	if err != nil {
+		t.Fatalf("orchestrator: %v", err)
+	}
+
+	if got, want := len(seenBranches), nItems; got != want {
+		t.Fatalf("got %d peeker invocations, want %d", got, want)
+	}
+
+	// Parent (orchestrator) runs on root branch "" (mock ctx); each
+	// child sub-branch is bare "<childName>@<customRunID>".
+	sort.Strings(seenBranches)
+	wantBranches := []string{
+		childName + "@custom-1",
+		childName + "@custom-2",
+		childName + "@custom-3",
+	}
+	for i, want := range wantBranches {
+		if seenBranches[i] != want {
+			t.Errorf("seenBranches[%d] = %q, want %q",
+				i, seenBranches[i], want)
+		}
+	}
+}
+
+// TestRunNode_SequentialFanOut_NoOption_StillSharesBranch pins the
+// Python-default behaviour (use_sub_branch=False): without the
+// opt-in, children inherit the orchestrator's branch verbatim. This
+// preserves backward compatibility for code that relies on inherited
+// branches.
+func TestRunNode_SequentialFanOut_NoOption_StillSharesBranch(t *testing.T) {
+	const (
+		childName = "peeker"
+		nItems    = 3
+	)
+
+	var seenBranches []string
+	peekerNode := NewFunctionNode(
+		childName,
+		func(ctx agent.InvocationContext, input string) (string, error) {
+			seenBranches = append(seenBranches, ctx.Branch())
+			return input, nil
+		},
+		NodeConfig{},
+	)
+
+	orch := NewDynamicNode[any, []string](
+		"orch",
+		func(ctx NodeContext, _ any, _ func(*session.Event) error) ([]string, error) {
+			items := []string{"a", "b", "c"}
+			results := make([]string, len(items))
+			for i, item := range items {
+				out, err := RunNode[string](ctx, peekerNode, item,
+					WithRunID(fmt.Sprintf("custom-%d", i+1)))
+				if err != nil {
+					return nil, err
+				}
+				results[i] = out
+			}
+			return results, nil
+		},
+		NodeConfig{},
+	)
+
+	_, err := drainDynamicWithErr(t, orch, nil)
+	if err != nil {
+		t.Fatalf("orchestrator: %v", err)
+	}
+
+	if got, want := len(seenBranches), nItems; got != want {
+		t.Fatalf("got %d peeker invocations, want %d", got, want)
+	}
+	for i, b := range seenBranches {
+		if b != "" {
+			t.Errorf("seenBranches[%d] = %q, want \"\" "+
+				"(without WithUseSubBranch the child should inherit "+
+				"the orchestrator's root branch)", i, b)
+		}
+	}
+}

--- a/workflow/branch_isolation_test.go
+++ b/workflow/branch_isolation_test.go
@@ -16,6 +16,7 @@ package workflow
 
 import (
 	"fmt"
+	"slices"
 	"sort"
 	"testing"
 
@@ -23,84 +24,72 @@ import (
 	"google.golang.org/adk/session"
 )
 
-// TestRunNode_SequentialFanOut_WithUseSubBranch_DistinctBranches
-// verifies that opting into WithUseSubBranch() at each RunNode call
-// produces distinct per-child branches.
+// TestRunNode_SequentialFanOut_BranchesFromOptions drives a
+// dynamic orchestrator that sequentially calls RunNode three times
+// on the same child and verifies the per-call Branch() observed by
+// the child as a function of the RunNode options passed.
 //
 // Why sequential (not errgroup): per req §5.1 D-Emit-Sequential,
 // emit / RunNode are single-goroutine only. Running fan-out via
 // errgroup violates the iter.Seq2 contract (concurrent yield calls
 // from multiple goroutines) and races on the event-collection slice
 // inside drainDynamicWithErr.
-func TestRunNode_SequentialFanOut_WithUseSubBranch_DistinctBranches(t *testing.T) {
-	const (
-		childName = "peeker"
-		nItems    = 3
-	)
+func TestRunNode_SequentialFanOut_BranchesFromOptions(t *testing.T) {
+	const childName = "peeker"
 
-	var seenBranches []string
-	peekerNode := NewFunctionNode(
-		childName,
-		func(ctx agent.InvocationContext, input string) (string, error) {
-			seenBranches = append(seenBranches, ctx.Branch())
-			return input, nil
+	tests := []struct {
+		name string
+		// extraOpts are appended after the per-call WithRunID; nil
+		// or empty means "inherit parent branch" (no opt-in).
+		extraOpts []RunNodeOption
+		// wantBranches is the sorted list of Branch() values the
+		// child should observe across the three sequential calls.
+		wantBranches []string
+	}{
+		{
+			// Opt-in: each child sees a distinct sub-branch of the
+			// form "<childName>@<customRunID>" off the
+			// orchestrator's root branch.
+			name:      "WithUseSubBranch_DistinctBranches",
+			extraOpts: []RunNodeOption{WithUseSubBranch()},
+			wantBranches: []string{
+				childName + "@custom-1",
+				childName + "@custom-2",
+				childName + "@custom-3",
+			},
 		},
-		NodeConfig{},
-	)
+		{
+			// Default behaviour: without the opt-in, children
+			// inherit the orchestrator's branch verbatim
+			// (backward-compat contract for callers relying on
+			// inherited branches).
+			name:         "NoOption_StillSharesBranch",
+			extraOpts:    nil,
+			wantBranches: []string{"", "", ""},
+		},
+	}
 
-	orch := NewDynamicNode[any, []string](
-		"orch",
-		func(ctx NodeContext, _ any, _ func(*session.Event) error) ([]string, error) {
-			items := []string{"a", "b", "c"}
-			results := make([]string, len(items))
-			for i, item := range items {
-				out, err := RunNode[string](ctx, peekerNode, item,
-					WithUseSubBranch(),
-					WithRunID(fmt.Sprintf("custom-%d", i+1)))
-				if err != nil {
-					return nil, err
-				}
-				results[i] = out
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			seenBranches := runSequentialFanOut(t, childName, tc.extraOpts)
+			sort.Strings(seenBranches)
+			if !slices.Equal(seenBranches, tc.wantBranches) {
+				t.Errorf("seenBranches = %q, want %q",
+					seenBranches, tc.wantBranches)
 			}
-			return results, nil
-		},
-		NodeConfig{},
-	)
-
-	_, err := drainDynamicWithErr(t, orch, nil)
-	if err != nil {
-		t.Fatalf("orchestrator: %v", err)
-	}
-
-	if got, want := len(seenBranches), nItems; got != want {
-		t.Fatalf("got %d peeker invocations, want %d", got, want)
-	}
-
-	// Parent (orchestrator) runs on root branch "" (mock ctx); each
-	// child sub-branch is bare "<childName>@<customRunID>".
-	sort.Strings(seenBranches)
-	wantBranches := []string{
-		childName + "@custom-1",
-		childName + "@custom-2",
-		childName + "@custom-3",
-	}
-	for i, want := range wantBranches {
-		if seenBranches[i] != want {
-			t.Errorf("seenBranches[%d] = %q, want %q",
-				i, seenBranches[i], want)
-		}
+		})
 	}
 }
 
-// TestRunNode_SequentialFanOut_NoOption_StillSharesBranch pins the
-// default behaviour: without the opt-in, children inherit the
-// orchestrator's branch verbatim. This preserves backward
-// compatibility for code that relies on inherited branches.
-func TestRunNode_SequentialFanOut_NoOption_StillSharesBranch(t *testing.T) {
-	const (
-		childName = "peeker"
-		nItems    = 3
-	)
+// runSequentialFanOut drives a dynamic orchestrator that sequentially
+// invokes a peeker child three times (items "a"/"b"/"c"), passing
+// WithRunID("custom-N") plus the caller-supplied extraOpts on each
+// call, and returns the Branch() values the child observed in call
+// order. Fails the test if the orchestrator errors or invokes the
+// child a wrong number of times.
+func runSequentialFanOut(t *testing.T, childName string, extraOpts []RunNodeOption) []string {
+	t.Helper()
+	const nItems = 3
 
 	var seenBranches []string
 	peekerNode := NewFunctionNode(
@@ -118,8 +107,10 @@ func TestRunNode_SequentialFanOut_NoOption_StillSharesBranch(t *testing.T) {
 			items := []string{"a", "b", "c"}
 			results := make([]string, len(items))
 			for i, item := range items {
-				out, err := RunNode[string](ctx, peekerNode, item,
-					WithRunID(fmt.Sprintf("custom-%d", i+1)))
+				opts := append([]RunNodeOption{
+					WithRunID(fmt.Sprintf("custom-%d", i+1)),
+				}, extraOpts...)
+				out, err := RunNode[string](ctx, peekerNode, item, opts...)
 				if err != nil {
 					return nil, err
 				}
@@ -130,19 +121,11 @@ func TestRunNode_SequentialFanOut_NoOption_StillSharesBranch(t *testing.T) {
 		NodeConfig{},
 	)
 
-	_, err := drainDynamicWithErr(t, orch, nil)
-	if err != nil {
+	if _, err := drainDynamicWithErr(t, orch, nil); err != nil {
 		t.Fatalf("orchestrator: %v", err)
 	}
-
 	if got, want := len(seenBranches), nItems; got != want {
 		t.Fatalf("got %d peeker invocations, want %d", got, want)
 	}
-	for i, b := range seenBranches {
-		if b != "" {
-			t.Errorf("seenBranches[%d] = %q, want \"\" "+
-				"(without WithUseSubBranch the child should inherit "+
-				"the orchestrator's root branch)", i, b)
-		}
-	}
+	return seenBranches
 }

--- a/workflow/branch_test.go
+++ b/workflow/branch_test.go
@@ -1,0 +1,89 @@
+// Copyright 2026 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package workflow
+
+import "testing"
+
+func TestDeriveSubBranch(t *testing.T) {
+	tests := []struct {
+		name, parent, segment, want string
+	}{
+		{"root_and_segment", "", "child@1", "child@1"},
+		{"parent_and_segment", "wf", "child@1", "wf.child@1"},
+		{"nested_parent", "wf.outer@1", "child@2", "wf.outer@1.child@2"},
+		{"empty_segment_noop", "wf", "", "wf"},
+		{"empty_both", "", "", ""},
+	}
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			got := deriveSubBranch(tc.parent, tc.segment)
+			if got != tc.want {
+				t.Errorf("deriveSubBranch(%q, %q) = %q, want %q",
+					tc.parent, tc.segment, got, tc.want)
+			}
+		})
+	}
+}
+
+func TestCommonBranchPrefix(t *testing.T) {
+	tests := []struct {
+		name     string
+		branches []string
+		want     string
+	}{
+		{"empty_input", nil, ""},
+		{"single_branch", []string{"a.b.c"}, "a.b.c"},
+		{"single_empty_branch", []string{""}, ""},
+		{"any_empty_short_circuits_to_root", []string{"a.b", "", "a.b.c"}, ""},
+		{"identical_branches", []string{"a.b", "a.b", "a.b"}, "a.b"},
+		{"shared_prefix_one_segment", []string{"a.b", "a.c"}, "a"},
+		{"shared_prefix_two_segments", []string{"a.b.c", "a.b.d"}, "a.b"},
+		{"no_common_prefix", []string{"a", "b"}, ""},
+		{
+			// segment-aware comparison: "a" and "ab" share NO segments
+			// (not "a" as string prefix).
+			name:     "string_prefix_but_no_segment_prefix",
+			branches: []string{"a", "ab"},
+			want:     "",
+		},
+		{
+			// Mixed depth: deeper branches still share the shallower prefix.
+			name:     "mixed_depth",
+			branches: []string{"a.b", "a.b.c.d"},
+			want:     "a.b",
+		},
+		{
+			// Three branches, deepest common is two segments.
+			name:     "three_branches_two_common",
+			branches: []string{"a.b.x", "a.b.y", "a.b.z.w"},
+			want:     "a.b",
+		},
+		{
+			// First segment differs → root.
+			name:     "first_segment_differs",
+			branches: []string{"a.b.c", "x.b.c"},
+			want:     "",
+		},
+	}
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			got := commonBranchPrefix(tc.branches)
+			if got != tc.want {
+				t.Errorf("commonBranchPrefix(%v) = %q, want %q",
+					tc.branches, got, tc.want)
+			}
+		})
+	}
+}

--- a/workflow/dynamic_scheduler.go
+++ b/workflow/dynamic_scheduler.go
@@ -49,29 +49,24 @@ func newDynamicSubScheduler(parent NodeContext, parentPath string, emitUp func(*
 // runNode executes child once, forwards its events upstream, and
 // classifies the outcome. HITL surfaces as ErrNodeInterrupted; runtime
 // failure as ErrNodeFailed; a child that fails after requesting input
-// surfaces as ErrNodeFailed (matches adk-python precedence).
+// surfaces as ErrNodeFailed.
 //
 // Session, invocation metadata, and cancellation come from s.parentCtx
-// captured at sub-scheduler construction. customRunID is empty to use
-// the auto-counter, or a user-supplied stable id (validated against
-// the rules in validateCustomRunID). useSubBranch and overrideBranch
-// derive the child's Branch():
-//
-//   - base = overrideBranch if non-empty, else parentCtx.Branch()
-//   - useSubBranch=true → child.Branch = base + "." + name@runID (or
-//     just name@runID when base is empty)
-//   - useSubBranch=false → child.Branch = base
-//
-// overrideBranch="" is treated as "no override" — see
-// WithOverrideBranch godoc.
-func (s *dynamicSubScheduler) runNode(child Node, input any, customRunID string, useSubBranch bool, overrideBranch string) (any, error) {
+// captured at sub-scheduler construction. opts carries the resolved
+// per-call configuration assembled from RunNode's variadic
+// RunNodeOption arguments: opts.customRunID is empty to use the
+// auto-counter or a user-supplied stable id (validated against the
+// rules in validateCustomRunID); opts.useSubBranch and
+// opts.overrideBranch derive the child's Branch() via
+// deriveChildBranch.
+func (s *dynamicSubScheduler) runNode(child Node, input any, opts runNodeOptions) (any, error) {
 	name := child.Name()
-	runID, err := s.resolveRunID(name, customRunID)
+	runID, err := s.resolveRunID(name, opts.customRunID)
 	if err != nil {
 		return nil, &NodeRunError{ChildName: name, Cause: err}
 	}
 	childPath := s.parentPath + "/" + name + "@" + runID
-	childBranch := deriveChildBranch(s.parentCtx.Branch(), name, runID, useSubBranch, overrideBranch)
+	childBranch := deriveChildBranch(s.parentCtx.Branch(), name, runID, opts.useSubBranch, opts.overrideBranch)
 	childCtx := newDynamicNodeContext(s.parentCtx.WithBranch(childBranch), childPath, runID, s)
 
 	// EXPERIMENTAL: stash childCtx (a *nodeContext with non-nil

--- a/workflow/dynamic_scheduler.go
+++ b/workflow/dynamic_scheduler.go
@@ -54,15 +54,25 @@ func newDynamicSubScheduler(parent NodeContext, parentPath string, emitUp func(*
 // Session, invocation metadata, and cancellation come from s.parentCtx
 // captured at sub-scheduler construction. customRunID is empty to use
 // the auto-counter, or a user-supplied stable id (validated against
-// the rules in validateCustomRunID).
-func (s *dynamicSubScheduler) runNode(child Node, input any, customRunID string) (any, error) {
+// the rules in validateCustomRunID). useSubBranch and overrideBranch
+// derive the child's Branch():
+//
+//   - base = overrideBranch if non-empty, else parentCtx.Branch()
+//   - useSubBranch=true → child.Branch = base + "." + name@runID (or
+//     just name@runID when base is empty)
+//   - useSubBranch=false → child.Branch = base
+//
+// overrideBranch="" is treated as "no override" — see
+// WithOverrideBranch godoc.
+func (s *dynamicSubScheduler) runNode(child Node, input any, customRunID string, useSubBranch bool, overrideBranch string) (any, error) {
 	name := child.Name()
 	runID, err := s.resolveRunID(name, customRunID)
 	if err != nil {
 		return nil, &NodeRunError{ChildName: name, Cause: err}
 	}
 	childPath := s.parentPath + "/" + name + "@" + runID
-	childCtx := newDynamicNodeContext(s.parentCtx, childPath, runID, s)
+	childBranch := deriveChildBranch(s.parentCtx.Branch(), name, runID, useSubBranch, overrideBranch)
+	childCtx := newDynamicNodeContext(s.parentCtx.WithBranch(childBranch), childPath, runID, s)
 
 	// EXPERIMENTAL: stash childCtx (a *nodeContext with non-nil
 	// subScheduler) in the embedded context.Context so tools running

--- a/workflow/dynamic_scheduler_test.go
+++ b/workflow/dynamic_scheduler_test.go
@@ -115,7 +115,7 @@ func TestSubScheduler_RunNode_FreshExecution(t *testing.T) {
 		return nil
 	})
 
-	out, err := sub.runNode(child, "world", "")
+	out, err := sub.runNode(child, "world", "", false, "")
 	if err != nil {
 		t.Fatalf("runNode: %v", err)
 	}
@@ -134,7 +134,7 @@ func TestSubScheduler_RunNode_CustomIDInPath(t *testing.T) {
 	child := newStubNode("processor", nil)
 	sub := newDynamicSubScheduler(newTopLevelCtx(t), "wf", noopEmit)
 
-	if _, err := sub.runNode(child, nil, "order-42"); err != nil {
+	if _, err := sub.runNode(child, nil, "order-42", false, ""); err != nil {
 		t.Fatalf("runNode: %v", err)
 	}
 	// The child must have observed its NodeContext populated with the
@@ -152,7 +152,7 @@ func TestSubScheduler_RunNode_HITLReturnsInterrupted(t *testing.T) {
 		return nil
 	})
 
-	_, err := sub.runNode(child, nil, "")
+	_, err := sub.runNode(child, nil, "", false, "")
 	if !errors.Is(err, ErrNodeInterrupted) {
 		t.Fatalf("err = %v, want ErrNodeInterrupted", err)
 	}
@@ -172,7 +172,7 @@ func TestSubScheduler_RunNode_ErrorWinsOverInterrupt(t *testing.T) {
 	child := newInterruptThenFailNode("flaky")
 	sub := newDynamicSubScheduler(newTopLevelCtx(t), "wf", noopEmit)
 
-	_, err := sub.runNode(child, nil, "")
+	_, err := sub.runNode(child, nil, "", false, "")
 	if !errors.Is(err, ErrNodeFailed) {
 		t.Errorf("err = %v, want ErrNodeFailed", err)
 	}
@@ -195,8 +195,9 @@ func newTopLevelCtx(t *testing.T) *nodeContext {
 // stubNode emits one Event{Output: out} and exits.
 type stubNode struct {
 	BaseNode
-	out      any
-	lastPath string
+	out        any
+	lastPath   string
+	lastBranch string
 }
 
 func newStubNode(name string, out any) *stubNode {
@@ -210,6 +211,7 @@ func (n *stubNode) Run(ctx agent.InvocationContext, _ any) iter.Seq2[*session.Ev
 	if nc, ok := ctx.(NodeContext); ok {
 		n.lastPath = nc.Path()
 	}
+	n.lastBranch = ctx.Branch()
 	out := n.out
 	return func(yield func(*session.Event, error) bool) {
 		yield(&session.Event{Output: out}, nil)

--- a/workflow/dynamic_scheduler_test.go
+++ b/workflow/dynamic_scheduler_test.go
@@ -115,7 +115,7 @@ func TestSubScheduler_RunNode_FreshExecution(t *testing.T) {
 		return nil
 	})
 
-	out, err := sub.runNode(child, "world", "", false, "")
+	out, err := sub.runNode(child, "world", runNodeOptions{})
 	if err != nil {
 		t.Fatalf("runNode: %v", err)
 	}
@@ -134,7 +134,7 @@ func TestSubScheduler_RunNode_CustomIDInPath(t *testing.T) {
 	child := newStubNode("processor", nil)
 	sub := newDynamicSubScheduler(newTopLevelCtx(t), "wf", noopEmit)
 
-	if _, err := sub.runNode(child, nil, "order-42", false, ""); err != nil {
+	if _, err := sub.runNode(child, nil, runNodeOptions{customRunID: "order-42"}); err != nil {
 		t.Fatalf("runNode: %v", err)
 	}
 	// The child must have observed its NodeContext populated with the
@@ -152,7 +152,7 @@ func TestSubScheduler_RunNode_HITLReturnsInterrupted(t *testing.T) {
 		return nil
 	})
 
-	_, err := sub.runNode(child, nil, "", false, "")
+	_, err := sub.runNode(child, nil, runNodeOptions{})
 	if !errors.Is(err, ErrNodeInterrupted) {
 		t.Fatalf("err = %v, want ErrNodeInterrupted", err)
 	}
@@ -172,7 +172,7 @@ func TestSubScheduler_RunNode_ErrorWinsOverInterrupt(t *testing.T) {
 	child := newInterruptThenFailNode("flaky")
 	sub := newDynamicSubScheduler(newTopLevelCtx(t), "wf", noopEmit)
 
-	_, err := sub.runNode(child, nil, "", false, "")
+	_, err := sub.runNode(child, nil, runNodeOptions{})
 	if !errors.Is(err, ErrNodeFailed) {
 		t.Errorf("err = %v, want ErrNodeFailed", err)
 	}

--- a/workflow/node_context.go
+++ b/workflow/node_context.go
@@ -40,6 +40,11 @@ type NodeContext interface {
 	// static nodes; auto-counter or user-supplied via WithRunID for
 	// dynamic children.
 	RunID() string
+
+	// WithBranch returns a NodeContext whose Branch() returns the
+	// given value; all other fields (path, runID, subScheduler,
+	// resumeInputs, embedded InvocationContext) are preserved.
+	WithBranch(branch string) NodeContext
 }
 
 // nodeContext is the unexported NodeContext implementation.
@@ -102,3 +107,16 @@ func (c *nodeContext) ResumedInput(interruptID string) (any, bool) {
 
 func (c *nodeContext) Path() string  { return c.path }
 func (c *nodeContext) RunID() string { return c.runID }
+
+func (c *nodeContext) WithBranch(branch string) NodeContext {
+	// Reuse the package-level withBranch helper to swap Branch on
+	// the underlying InvocationContext; preserve the NodeContext
+	// envelope (path, runID, resumeInputs, subScheduler) unchanged.
+	return &nodeContext{
+		InvocationContext: withBranch(c.InvocationContext, branch),
+		resumeInputs:      c.resumeInputs,
+		path:              c.path,
+		runID:             c.runID,
+		subScheduler:      c.subScheduler,
+	}
+}

--- a/workflow/parallel_worker.go
+++ b/workflow/parallel_worker.go
@@ -19,6 +19,7 @@ import (
 	"fmt"
 	"iter"
 	"reflect"
+	"strconv"
 	"sync"
 	"time"
 
@@ -99,6 +100,17 @@ func (n *ParallelWorker) Run(ctx agent.InvocationContext, input any) iter.Seq2[*
 
 		resCh := make(chan workerResult, nItems)
 
+		// Branch isolation: derive a per-item sub-branch so each
+		// worker's wrapped node sees an isolated event history
+		// (the LLM contents-processor filter scopes by branch
+		// prefix). Mirrors adk-python _parallel_worker.py:96-102
+		// which passes use_sub_branch=True on ctx.run_node so the
+		// dynamic scheduler generates a fresh sub-branch per item.
+		// Run id mirrors Python's auto-counter ("1", "2", ...) so
+		// items 0..N-1 receive sub-branches name@1..name@N.
+		parentBranch := workerCtx.Branch()
+		wrappedName := n.wrapped.Name()
+
 		for i := 0; i < nItems; i++ {
 			item := v.Index(i).Interface()
 
@@ -111,7 +123,9 @@ func (n *ParallelWorker) Run(ctx agent.InvocationContext, input any) iter.Seq2[*
 				}
 			}
 
-			go n.runWorker(workerCtx, i, item, sem, resCh, &wg)
+			itemBranch := deriveSubBranch(parentBranch, wrappedName+"@"+strconv.Itoa(i+1))
+			itemCtx := withBranch(workerCtx, itemBranch)
+			go n.runWorker(itemCtx, i, item, sem, resCh, &wg)
 		}
 
 		// Goroutine to close channel when all workers are done

--- a/workflow/parallel_worker.go
+++ b/workflow/parallel_worker.go
@@ -101,13 +101,9 @@ func (n *ParallelWorker) Run(ctx agent.InvocationContext, input any) iter.Seq2[*
 		resCh := make(chan workerResult, nItems)
 
 		// Branch isolation: derive a per-item sub-branch so each
-		// worker's wrapped node sees an isolated event history
-		// (the LLM contents-processor filter scopes by branch
-		// prefix). Mirrors adk-python _parallel_worker.py:96-102
-		// which passes use_sub_branch=True on ctx.run_node so the
-		// dynamic scheduler generates a fresh sub-branch per item.
-		// Run id mirrors Python's auto-counter ("1", "2", ...) so
-		// items 0..N-1 receive sub-branches name@1..name@N.
+		// worker's wrapped node sees an isolated event history (the
+		// LLM flow's history filter scopes by branch prefix). Items
+		// 0..N-1 receive sub-branches name@1..name@N.
 		parentBranch := workerCtx.Branch()
 		wrappedName := n.wrapped.Name()
 

--- a/workflow/parallel_worker_branch_test.go
+++ b/workflow/parallel_worker_branch_test.go
@@ -15,6 +15,7 @@
 package workflow
 
 import (
+	"errors"
 	"sort"
 	"sync"
 	"testing"
@@ -24,14 +25,9 @@ import (
 
 // TestParallelWorker_PerItemSubBranch verifies that ParallelWorker
 // gives each of its N concurrent workers a distinct sub-branch of
-// the form "<wrapped>@<i+1>", so a downstream LlmAgent reading
-// session.Events() filtered by branch
-// (internal/llminternal/contents_processor.go:eventBelongsToBranch)
-// no longer sees sibling-worker events in its prompt history.
-//
-// Mirrors adk-python _parallel_worker.py:96-102 which passes
-// use_sub_branch=True on ctx.run_node so the dynamic scheduler
-// derives a fresh sub-branch per item.
+// the form "<wrapped>@<i+1>", so a downstream LlmAgent reading the
+// session event log under the LLM flow's branch-prefix filter no
+// longer sees sibling-worker events in its prompt history.
 func TestParallelWorker_PerItemSubBranch(t *testing.T) {
 	const wrappedName = "summarize"
 
@@ -138,21 +134,17 @@ func TestParallelWorker_SubBranchUnderNonRootParent(t *testing.T) {
 func TestParallelWorker_RetryKeepsSameBranch(t *testing.T) {
 	const wrappedName = "flaky"
 
+	errAlwaysFail := errors.New("force retry")
 	var (
 		mu               sync.Mutex
-		attemptsByBranch = map[string][]int{}
-		attempts         int
+		attemptsByBranch = map[string]int{}
 	)
 	wrapped := NewFunctionNode(wrappedName,
 		func(ctx agent.InvocationContext, input string) (string, error) {
 			mu.Lock()
-			attempts++
-			attempt := attempts
-			attemptsByBranch[ctx.Branch()] = append(attemptsByBranch[ctx.Branch()], attempt)
+			attemptsByBranch[ctx.Branch()]++
 			mu.Unlock()
-			// Always fail; the retry loop in runWorker will
-			// re-invoke this function on the same ctx.
-			return "", errRetryablePhase2
+			return "", errAlwaysFail
 		}, defaultNodeConfig)
 
 	cfg := NodeConfig{RetryConfig: &RetryConfig{MaxAttempts: 3}}
@@ -162,31 +154,26 @@ func TestParallelWorker_RetryKeepsSameBranch(t *testing.T) {
 	}
 
 	mockCtx := newMockCtx(t)
-	events := pw.Run(mockCtx, []any{"a"})
-	for _, err := range events {
-		// We expect the worker to ultimately fail after retries.
-		_ = err
+	var gotErr error
+	for _, runErr := range pw.Run(mockCtx, []any{"a"}) {
+		if runErr != nil {
+			gotErr = runErr
+		}
+	}
+	if gotErr == nil {
+		t.Fatal("expected wrapped node to ultimately fail after retries, got nil error")
 	}
 
 	if got := len(attemptsByBranch); got != 1 {
 		t.Fatalf("attemptsByBranch keys = %d, want 1 "+
 			"(retries must share one branch); got %+v", got, attemptsByBranch)
 	}
-	for branch, attemptList := range attemptsByBranch {
+	for branch, count := range attemptsByBranch {
 		if branch != wrappedName+"@1" {
 			t.Errorf("retry branch = %q, want %q", branch, wrappedName+"@1")
 		}
-		if len(attemptList) < 2 {
-			t.Errorf("retry attempts under %q = %v, want ≥2", branch, attemptList)
+		if count < 2 {
+			t.Errorf("retry attempts under %q = %d, want ≥2", branch, count)
 		}
 	}
 }
-
-// errRetryablePhase2 is a sentinel for the retry test above to
-// trigger ShouldRetry's positive path without interfering with
-// other tests' error matching.
-type phase2RetryErr struct{}
-
-func (phase2RetryErr) Error() string { return "phase2 retry test" }
-
-var errRetryablePhase2 = phase2RetryErr{}

--- a/workflow/parallel_worker_branch_test.go
+++ b/workflow/parallel_worker_branch_test.go
@@ -1,0 +1,192 @@
+// Copyright 2026 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package workflow
+
+import (
+	"sort"
+	"sync"
+	"testing"
+
+	"google.golang.org/adk/agent"
+)
+
+// TestParallelWorker_PerItemSubBranch verifies that ParallelWorker
+// gives each of its N concurrent workers a distinct sub-branch of
+// the form "<wrapped>@<i+1>", so a downstream LlmAgent reading
+// session.Events() filtered by branch
+// (internal/llminternal/contents_processor.go:eventBelongsToBranch)
+// no longer sees sibling-worker events in its prompt history.
+//
+// Mirrors adk-python _parallel_worker.py:96-102 which passes
+// use_sub_branch=True on ctx.run_node so the dynamic scheduler
+// derives a fresh sub-branch per item.
+func TestParallelWorker_PerItemSubBranch(t *testing.T) {
+	const wrappedName = "summarize"
+
+	var (
+		mu           sync.Mutex
+		seenBranches []string
+	)
+	wrapped := NewFunctionNode(wrappedName,
+		func(ctx agent.InvocationContext, input string) (string, error) {
+			mu.Lock()
+			seenBranches = append(seenBranches, ctx.Branch())
+			mu.Unlock()
+			return input + "-done", nil
+		}, defaultNodeConfig)
+
+	pw, err := NewParallelWorker("pw", wrapped, 0, defaultNodeConfig)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	mockCtx := newMockCtx(t)
+	events := pw.Run(mockCtx, []any{"a", "b", "c"})
+	for _, err := range events {
+		if err != nil {
+			t.Fatalf("Run error: %v", err)
+		}
+	}
+
+	if got, want := len(seenBranches), 3; got != want {
+		t.Fatalf("seenBranches len = %d, want %d", got, want)
+	}
+
+	// Parent (mockCtx) is on root branch "" — each worker's
+	// sub-branch is the bare "<wrappedName>@<i+1>".
+	sort.Strings(seenBranches)
+	wantBranches := []string{
+		wrappedName + "@1",
+		wrappedName + "@2",
+		wrappedName + "@3",
+	}
+	for i, want := range wantBranches {
+		if seenBranches[i] != want {
+			t.Errorf("seenBranches[%d] = %q, want %q",
+				i, seenBranches[i], want)
+		}
+	}
+}
+
+// TestParallelWorker_SubBranchUnderNonRootParent verifies that
+// ParallelWorker correctly appends the per-item segment to a non-
+// empty parent branch (e.g. when ParallelWorker itself sits inside
+// another fan-out and runs under a sub-branch).
+func TestParallelWorker_SubBranchUnderNonRootParent(t *testing.T) {
+	const wrappedName = "worker"
+
+	var (
+		mu           sync.Mutex
+		seenBranches []string
+	)
+	wrapped := NewFunctionNode(wrappedName,
+		func(ctx agent.InvocationContext, input string) (string, error) {
+			mu.Lock()
+			seenBranches = append(seenBranches, ctx.Branch())
+			mu.Unlock()
+			return input, nil
+		}, defaultNodeConfig)
+
+	pw, err := NewParallelWorker("pw", wrapped, 0, defaultNodeConfig)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	// Simulate ParallelWorker running under a parent branch
+	// "outer@1" (e.g. one branch of a static fan-out).
+	parentCtx := withBranch(newMockCtx(t), "outer@1")
+
+	events := pw.Run(parentCtx, []any{"x", "y"})
+	for _, err := range events {
+		if err != nil {
+			t.Fatalf("Run error: %v", err)
+		}
+	}
+
+	if got, want := len(seenBranches), 2; got != want {
+		t.Fatalf("seenBranches len = %d, want %d", got, want)
+	}
+	sort.Strings(seenBranches)
+	wantBranches := []string{
+		"outer@1." + wrappedName + "@1",
+		"outer@1." + wrappedName + "@2",
+	}
+	for i, want := range wantBranches {
+		if seenBranches[i] != want {
+			t.Errorf("seenBranches[%d] = %q, want %q",
+				i, seenBranches[i], want)
+		}
+	}
+}
+
+// TestParallelWorker_RetryKeepsSameBranch verifies that a retried
+// item runs under the same sub-branch as the original attempt — the
+// branch is captured into the per-item context once before the
+// retry loop in runWorker.
+func TestParallelWorker_RetryKeepsSameBranch(t *testing.T) {
+	const wrappedName = "flaky"
+
+	var (
+		mu               sync.Mutex
+		attemptsByBranch = map[string][]int{}
+		attempts         int
+	)
+	wrapped := NewFunctionNode(wrappedName,
+		func(ctx agent.InvocationContext, input string) (string, error) {
+			mu.Lock()
+			attempts++
+			attempt := attempts
+			attemptsByBranch[ctx.Branch()] = append(attemptsByBranch[ctx.Branch()], attempt)
+			mu.Unlock()
+			// Always fail; the retry loop in runWorker will
+			// re-invoke this function on the same ctx.
+			return "", errRetryablePhase2
+		}, defaultNodeConfig)
+
+	cfg := NodeConfig{RetryConfig: &RetryConfig{MaxAttempts: 3}}
+	pw, err := NewParallelWorker("pw", wrapped, 0, cfg)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	mockCtx := newMockCtx(t)
+	events := pw.Run(mockCtx, []any{"a"})
+	for _, err := range events {
+		// We expect the worker to ultimately fail after retries.
+		_ = err
+	}
+
+	if got := len(attemptsByBranch); got != 1 {
+		t.Fatalf("attemptsByBranch keys = %d, want 1 "+
+			"(retries must share one branch); got %+v", got, attemptsByBranch)
+	}
+	for branch, attemptList := range attemptsByBranch {
+		if branch != wrappedName+"@1" {
+			t.Errorf("retry branch = %q, want %q", branch, wrappedName+"@1")
+		}
+		if len(attemptList) < 2 {
+			t.Errorf("retry attempts under %q = %v, want ≥2", branch, attemptList)
+		}
+	}
+}
+
+// errRetryablePhase2 is a sentinel for the retry test above to
+// trigger ShouldRetry's positive path without interfering with
+// other tests' error matching.
+type phase2RetryErr struct{}
+
+func (phase2RetryErr) Error() string { return "phase2 retry test" }
+
+var errRetryablePhase2 = phase2RetryErr{}

--- a/workflow/resume.go
+++ b/workflow/resume.go
@@ -150,7 +150,7 @@ func (w *Workflow) Resume(
 					ns.ResumedInputs = map[string]any{}
 				}
 				ns.ResumedInputs[interruptID] = resp
-				s.scheduleResumedNode(node, ns.Input, ns.TriggeredBy, ns.ResumedInputs)
+				s.scheduleResumedNode(node, ns.Input, ns.TriggeredBy, ns.Branch, ns.ResumedInputs)
 			} else {
 				// Handoff mode: promote the asker as if it had
 				// emitted resp as its output. Recording Output
@@ -175,8 +175,15 @@ func (w *Workflow) Resume(
 			// opaque to the routing layer. Successors reached via
 			// an unconditional edge or via the Default route fire
 			// as usual.
-			for _, succ := range findSuccessors(s.graph, s.state, h.node, h.resp, nil) {
-				s.scheduleNode(succ.node, succ.input, succ.triggeredBy)
+			// Handoff successors inherit the asker's branch so the
+			// downstream LLM history filter still scopes correctly
+			// when a parallel branch resumes via handoff.
+			parentBranch := ""
+			if ns := s.state.Nodes[h.node.Name()]; ns != nil {
+				parentBranch = ns.Branch
+			}
+			for _, succ := range findSuccessors(s.graph, s.state, h.node, h.resp, nil, parentBranch) {
+				s.scheduleNode(succ.node, succ.input, succ.triggeredBy, succ.branch)
 			}
 		}
 

--- a/workflow/run_node.go
+++ b/workflow/run_node.go
@@ -59,11 +59,9 @@ func WithUseSubBranch() RunNodeOption {
 // Combinable with WithUseSubBranch: the override sets the base,
 // and the sub-branch segment "<childName>@<runID>" is appended.
 //
-// Empty branch is treated as "no override" — callers wanting to
-// force root should pass WithUseSubBranch() alone (which derives a
-// fresh sub-branch off root). Go lacks an optional string type
-// that would distinguish unset from explicitly-empty, so the
-// empty case is folded into "no override".
+// Empty branch is treated as "no override". To force root, pass
+// WithUseSubBranch() alone, which derives a fresh sub-branch off
+// root.
 func WithOverrideBranch(branch string) RunNodeOption {
 	return func(o *runNodeOptions) { o.overrideBranch = branch }
 }

--- a/workflow/run_node.go
+++ b/workflow/run_node.go
@@ -16,14 +16,17 @@ package workflow
 
 import "fmt"
 
-// RunNodeOption configures a single RunNode call. Today only WithRunID
-// exists; the option set will grow to mirror adk-python's ctx.run_node
-// kwargs (use_as_output for output delegation, override_isolation_scope,
-// per-call timeout/retry overrides, etc.) as those features land.
+// RunNodeOption configures a single RunNode call. The option set
+// mirrors a subset of adk-python's ctx.run_node kwargs; additional
+// options (use_as_output, override_isolation_scope, per-call
+// timeout/retry overrides, etc.) will be added as those features
+// land.
 type RunNodeOption func(*runNodeOptions)
 
 type runNodeOptions struct {
-	customRunID string
+	customRunID    string
+	useSubBranch   bool
+	overrideBranch string
 }
 
 // WithRunID overrides the auto-generated counter with a stable
@@ -37,6 +40,46 @@ type runNodeOptions struct {
 // (https://adk.dev/graphs/dynamic/#custom-execution-ids).
 func WithRunID(id string) RunNodeOption {
 	return func(o *runNodeOptions) { o.customRunID = id }
+}
+
+// WithUseSubBranch derives a per-child sub-branch of the form
+// "<parentBranch>.<childName>@<runID>" (or just "<childName>@<runID>"
+// at root) for the child activation. Equivalent to adk-python's
+// use_sub_branch=True kwarg on ctx.run_node.
+//
+// Use this when the caller runs multiple concurrent or independent
+// children that should not see each other's events in their LLM
+// prompt history. Without it, every RunNode child inherits the
+// orchestrator's branch and an LlmAgent child would see sibling
+// events through the history filter
+// (internal/llminternal/contents_processor.go:eventBelongsToBranch).
+//
+// Combinable with WithOverrideBranch: the override sets the *base*,
+// and use_sub_branch appends the segment to it.
+func WithUseSubBranch() RunNodeOption {
+	return func(o *runNodeOptions) { o.useSubBranch = true }
+}
+
+// WithOverrideBranch replaces the inherited branch verbatim,
+// regardless of WithUseSubBranch. Useful for nested dispatch
+// patterns (e.g. chat coordinator → task agent) where the parent
+// assigns a specific branch label by convention.
+//
+// Combinable with WithUseSubBranch: the override sets the base,
+// and use_sub_branch appends "<childName>@<runID>" to it.
+//
+// Empty branch is treated as "no override" — callers wanting to
+// force root should pass WithUseSubBranch() alone (which derives a
+// fresh sub-branch off root). This is the one intentional
+// divergence from adk-python's override_branch=None vs "" semantics
+// (_node_runner.py:198-209), motivated by Go's lack of an optional
+// string type and the rarity of the use-it-as-force-root case
+// (no tests or samples in adk-python exercise override_branch="").
+//
+// Mirrors adk-python's override_branch kwarg on ctx.run_node
+// (agents/context.py:417, _node_runner.py:198-209).
+func WithOverrideBranch(branch string) RunNodeOption {
+	return func(o *runNodeOptions) { o.overrideBranch = branch }
 }
 
 // RunNode schedules child as a sub-node of the currently-executing
@@ -62,7 +105,7 @@ func RunNode[OUT any](ctx NodeContext, child Node, input any, opts ...RunNodeOpt
 		opt(&o)
 	}
 
-	rawOut, err := nc.subScheduler.runNode(child, input, o.customRunID)
+	rawOut, err := nc.subScheduler.runNode(child, input, o.customRunID, o.useSubBranch, o.overrideBranch)
 	if err != nil {
 		return zero, err
 	}

--- a/workflow/run_node.go
+++ b/workflow/run_node.go
@@ -91,7 +91,7 @@ func RunNode[OUT any](ctx NodeContext, child Node, input any, opts ...RunNodeOpt
 		opt(&o)
 	}
 
-	rawOut, err := nc.subScheduler.runNode(child, input, o.customRunID, o.useSubBranch, o.overrideBranch)
+	rawOut, err := nc.subScheduler.runNode(child, input, o)
 	if err != nil {
 		return zero, err
 	}

--- a/workflow/run_node.go
+++ b/workflow/run_node.go
@@ -16,11 +16,7 @@ package workflow
 
 import "fmt"
 
-// RunNodeOption configures a single RunNode call. The option set
-// mirrors a subset of adk-python's ctx.run_node kwargs; additional
-// options (use_as_output, override_isolation_scope, per-call
-// timeout/retry overrides, etc.) will be added as those features
-// land.
+// RunNodeOption configures a single RunNode call.
 type RunNodeOption func(*runNodeOptions)
 
 type runNodeOptions struct {
@@ -35,27 +31,22 @@ type runNodeOptions struct {
 // non-digit character (purely numeric ids collide with the
 // auto-counter), and exclude the composite-path separators '/' and
 // '@'. Violations surface as ErrInvalidRunID from RunNode.
-//
-// Mirrors adk-python's run_id kwarg
-// (https://adk.dev/graphs/dynamic/#custom-execution-ids).
 func WithRunID(id string) RunNodeOption {
 	return func(o *runNodeOptions) { o.customRunID = id }
 }
 
 // WithUseSubBranch derives a per-child sub-branch of the form
 // "<parentBranch>.<childName>@<runID>" (or just "<childName>@<runID>"
-// at root) for the child activation. Equivalent to adk-python's
-// use_sub_branch=True kwarg on ctx.run_node.
+// at root) for the child activation.
 //
 // Use this when the caller runs multiple concurrent or independent
 // children that should not see each other's events in their LLM
 // prompt history. Without it, every RunNode child inherits the
 // orchestrator's branch and an LlmAgent child would see sibling
-// events through the history filter
-// (internal/llminternal/contents_processor.go:eventBelongsToBranch).
+// events through the LLM flow's history filter.
 //
-// Combinable with WithOverrideBranch: the override sets the *base*,
-// and use_sub_branch appends the segment to it.
+// Combinable with WithOverrideBranch: the override sets the base,
+// and the sub-branch segment is appended to it.
 func WithUseSubBranch() RunNodeOption {
 	return func(o *runNodeOptions) { o.useSubBranch = true }
 }
@@ -66,18 +57,13 @@ func WithUseSubBranch() RunNodeOption {
 // assigns a specific branch label by convention.
 //
 // Combinable with WithUseSubBranch: the override sets the base,
-// and use_sub_branch appends "<childName>@<runID>" to it.
+// and the sub-branch segment "<childName>@<runID>" is appended.
 //
 // Empty branch is treated as "no override" — callers wanting to
 // force root should pass WithUseSubBranch() alone (which derives a
-// fresh sub-branch off root). This is the one intentional
-// divergence from adk-python's override_branch=None vs "" semantics
-// (_node_runner.py:198-209), motivated by Go's lack of an optional
-// string type and the rarity of the use-it-as-force-root case
-// (no tests or samples in adk-python exercise override_branch="").
-//
-// Mirrors adk-python's override_branch kwarg on ctx.run_node
-// (agents/context.py:417, _node_runner.py:198-209).
+// fresh sub-branch off root). Go lacks an optional string type
+// that would distinguish unset from explicitly-empty, so the
+// empty case is folded into "no override".
 func WithOverrideBranch(branch string) RunNodeOption {
 	return func(o *runNodeOptions) { o.overrideBranch = branch }
 }

--- a/workflow/run_node.go
+++ b/workflow/run_node.go
@@ -31,6 +31,9 @@ type runNodeOptions struct {
 // non-digit character (purely numeric ids collide with the
 // auto-counter), and exclude the composite-path separators '/' and
 // '@'. Violations surface as ErrInvalidRunID from RunNode.
+//
+// Mirrors adk-python's run_id kwarg
+// (https://adk.dev/graphs/dynamic/#custom-execution-ids).
 func WithRunID(id string) RunNodeOption {
 	return func(o *runNodeOptions) { o.customRunID = id }
 }

--- a/workflow/run_node_test.go
+++ b/workflow/run_node_test.go
@@ -183,12 +183,19 @@ func TestRunNode_SequentialFanOut_PerSibling_DistinctBranches(t *testing.T) {
 	// re-use the same node twice to exercise the per-name counter.
 	var got []string
 	runInOrchestrator[string](t, func(ctx NodeContext) (string, error) {
-		_, _ = RunNode[string](ctx, c1, nil, WithUseSubBranch())
+		if _, err := RunNode[string](ctx, c1, nil, WithUseSubBranch()); err != nil {
+			return "", err
+		}
 		got = append(got, c1.lastBranch)
-		_, _ = RunNode[string](ctx, c1, nil, WithUseSubBranch())
+		if _, err := RunNode[string](ctx, c1, nil, WithUseSubBranch()); err != nil {
+			return "", err
+		}
 		got = append(got, c1.lastBranch)
 		return "", nil
 	})
+	if len(got) != 2 {
+		t.Fatalf("got %d branches, want 2 (orchestrator may have errored mid-loop)", len(got))
+	}
 	want := []string{"c@1", "c@2"}
 	if got[0] != want[0] || got[1] != want[1] {
 		t.Errorf("observed branches = %v, want %v "+

--- a/workflow/run_node_test.go
+++ b/workflow/run_node_test.go
@@ -160,10 +160,9 @@ func TestRunNode_WithOverrideBranch_PlusUseSubBranch_AppendsToOverride(t *testin
 }
 
 func TestRunNode_WithOverrideBranch_Empty_TreatedAsNoOverride(t *testing.T) {
-	// Per WithOverrideBranch godoc, empty string is treated as
-	// "no override" (one documented divergence from Python). This
-	// test pins that behaviour: even with WithUseSubBranch the
-	// sub-branch derives off the inherited (empty) parent branch.
+	// Empty WithOverrideBranch is a no-op (per WithOverrideBranch
+	// godoc): even combined with WithUseSubBranch the sub-branch
+	// derives off the inherited parent branch.
 	child := newStubNode("c", "x")
 	runInOrchestrator[string](t, func(ctx NodeContext) (string, error) {
 		return RunNode[string](ctx, child, nil,

--- a/workflow/run_node_test.go
+++ b/workflow/run_node_test.go
@@ -103,6 +103,100 @@ func TestRunNode_NilChildOutput_ReturnsZero(t *testing.T) {
 	}
 }
 
+func TestRunNode_DefaultInheritsParentBranch(t *testing.T) {
+	child := newStubNode("c", "x")
+	runInOrchestrator[string](t, func(ctx NodeContext) (string, error) {
+		return RunNode[string](ctx, child, nil)
+	})
+	// MockInvocationContext yields Branch() == "", and the
+	// orchestrator inherits it, so the child must also see "".
+	if got := child.lastBranch; got != "" {
+		t.Errorf("child Branch() = %q, want \"\" (inherits parent at root)", got)
+	}
+}
+
+func TestRunNode_WithUseSubBranch_AppendsSegment(t *testing.T) {
+	child := newStubNode("c", "x")
+	runInOrchestrator[string](t, func(ctx NodeContext) (string, error) {
+		return RunNode[string](ctx, child, nil, WithUseSubBranch())
+	})
+	// Parent branch is "" (root); sub-branch is bare "<name>@<runID>".
+	// Auto-counter assigns runID "1" for the first call.
+	if got, want := child.lastBranch, "c@1"; got != want {
+		t.Errorf("child Branch() = %q, want %q (use_sub_branch at root)", got, want)
+	}
+}
+
+func TestRunNode_WithUseSubBranch_PlusCustomRunID(t *testing.T) {
+	child := newStubNode("c", "x")
+	runInOrchestrator[string](t, func(ctx NodeContext) (string, error) {
+		return RunNode[string](ctx, child, nil, WithUseSubBranch(), WithRunID("order-42"))
+	})
+	if got, want := child.lastBranch, "c@order-42"; got != want {
+		t.Errorf("child Branch() = %q, want %q", got, want)
+	}
+}
+
+func TestRunNode_WithOverrideBranch_ReplacesBase(t *testing.T) {
+	child := newStubNode("c", "x")
+	runInOrchestrator[string](t, func(ctx NodeContext) (string, error) {
+		return RunNode[string](ctx, child, nil, WithOverrideBranch("custom_branch"))
+	})
+	if got, want := child.lastBranch, "custom_branch"; got != want {
+		t.Errorf("child Branch() = %q, want %q", got, want)
+	}
+}
+
+func TestRunNode_WithOverrideBranch_PlusUseSubBranch_AppendsToOverride(t *testing.T) {
+	child := newStubNode("c", "x")
+	runInOrchestrator[string](t, func(ctx NodeContext) (string, error) {
+		return RunNode[string](ctx, child, nil,
+			WithOverrideBranch("base"),
+			WithUseSubBranch())
+	})
+	if got, want := child.lastBranch, "base.c@1"; got != want {
+		t.Errorf("child Branch() = %q, want %q (override is base, use_sub_branch appends)", got, want)
+	}
+}
+
+func TestRunNode_WithOverrideBranch_Empty_TreatedAsNoOverride(t *testing.T) {
+	// Per WithOverrideBranch godoc, empty string is treated as
+	// "no override" (one documented divergence from Python). This
+	// test pins that behaviour: even with WithUseSubBranch the
+	// sub-branch derives off the inherited (empty) parent branch.
+	child := newStubNode("c", "x")
+	runInOrchestrator[string](t, func(ctx NodeContext) (string, error) {
+		return RunNode[string](ctx, child, nil,
+			WithOverrideBranch(""),
+			WithUseSubBranch())
+	})
+	if got, want := child.lastBranch, "c@1"; got != want {
+		t.Errorf("child Branch() = %q, want %q (empty override is a no-op)", got, want)
+	}
+}
+
+func TestRunNode_SequentialFanOut_PerSibling_DistinctBranches(t *testing.T) {
+	// Two children scheduled sequentially with WithUseSubBranch get
+	// distinct sub-branches via the auto-counter — child name + "@1",
+	// child name + "@2", etc. (counter is per child name, not global).
+	c1 := newStubNode("c", "first")
+	// re-use the same node twice to exercise the per-name counter.
+	var got []string
+	runInOrchestrator[string](t, func(ctx NodeContext) (string, error) {
+		_, _ = RunNode[string](ctx, c1, nil, WithUseSubBranch())
+		got = append(got, c1.lastBranch)
+		_, _ = RunNode[string](ctx, c1, nil, WithUseSubBranch())
+		got = append(got, c1.lastBranch)
+		return "", nil
+	})
+	want := []string{"c@1", "c@2"}
+	if got[0] != want[0] || got[1] != want[1] {
+		t.Errorf("observed branches = %v, want %v "+
+			"(per-(name) auto-counter must produce distinct sub-branches)",
+			got, want)
+	}
+}
+
 // --- test helpers ---
 
 // runInOrchestrator drives orchestratorFn inside a dynamic node so that

--- a/workflow/scheduler.go
+++ b/workflow/scheduler.go
@@ -225,11 +225,10 @@ func buildNodesByName(g *graph) map[string]Node {
 // it returns (success, error, panic, or cancellation).
 //
 // branch is the composite branch string this activation runs under;
-// empty means inherit the workflow's root branch. Branch is used
-// (1) to scope LLM history visibility via
-// internal/llminternal/contents_processor.go:eventBelongsToBranch
-// and (2) to stamp Event.Branch on emitted events when the node
-// itself does not set it.
+// empty means inherit the workflow's root branch. Branch scopes
+// LLM history visibility (via the flow processor's branch-prefix
+// filter) and gets stamped onto every emitted event when the node
+// leaves Event.Branch empty.
 //
 // scheduleNode runs only on the consumer goroutine.
 func (s *scheduler) scheduleNode(n Node, input any, triggeredBy, branch string) {
@@ -468,14 +467,10 @@ func (s *scheduler) handleEvent(it eventItem) {
 		return
 	}
 	// Stamp the activation's branch onto events that did not set one.
-	// Mirrors Python _node_runner._enrich_event (_node_runner.py:400-401).
-	// Nodes that explicitly set Event.Branch are respected; nodes that
-	// emit Event{Branch: ""} are interpreted as "use the activation's
-	// branch" (matching the Go default-value model — Python uses
-	// Optional and treats "" as a sentinel for "intentionally unscoped",
-	// which the LlmAgent flow currently emits via ctx.Branch() ==
-	// internal/llminternal/base_flow.go:931, never as an explicit
-	// override).
+	// Nodes that explicitly set Event.Branch are respected; nodes
+	// that emit Event{Branch: ""} use the activation's branch by
+	// default (Go has no way to distinguish "unset" from "explicit
+	// empty" on a string field).
 	if it.ev.Branch == "" && nr.branch != "" {
 		it.ev.Branch = nr.branch
 	}
@@ -645,7 +640,7 @@ type successor struct {
 //
 // JoinNode successors are gated by appendSuccessor; see its docs.
 //
-// Branch derivation (Python parity, _workflow.py:692-727):
+// Branch derivation:
 //
 //   - When this activation fans out to >1 successor, each non-Join
 //     successor is given a sub-branch

--- a/workflow/scheduler.go
+++ b/workflow/scheduler.go
@@ -260,10 +260,10 @@ func (s *scheduler) scheduleResumedNode(n Node, input any, triggeredBy, branch s
 	} else {
 		nodeCtx, cancel = context.WithCancel(s.parentCtx)
 	}
-	// Order matters: WithContext sets up per-node cancellation
-	// (returns *icontext.InvocationContext via the typed
-	// implementation), then withBranch overrides Branch() on the
-	// same concrete type. Reversing would lose the cancellation.
+	// Order matters: WithContext sets up per-node cancellation on
+	// the underlying InvocationContext; withBranch then wraps the
+	// result in branchOverride. Reversing would either lose the
+	// cancellation context or strip the branch override.
 	wrapped := withBranch(s.parentCtx.WithContext(nodeCtx), branch)
 	perNodeCtx := newNodeContext(wrapped, resumeInputs)
 

--- a/workflow/scheduler.go
+++ b/workflow/scheduler.go
@@ -105,6 +105,7 @@ type nodeRun struct {
 	hasOutput    bool                  // distinguishes "no output yet" from "output was nil"
 	inputRequest *session.RequestInput // at most one human-input request; multiple is an error
 	err          error                 // set on duplicate output, duplicate routing event, or duplicate input request
+	branch       string                // composite branch assigned at scheduling; used to stamp Event.Branch when the node leaves it empty
 }
 
 // recordErr stores err as the accumulator's first error. Subsequent
@@ -182,6 +183,7 @@ type retryItem struct {
 	node        Node
 	input       any
 	triggeredBy string
+	branch      string
 }
 
 func (retryItem) isQueueItem() {}
@@ -222,9 +224,16 @@ func buildNodesByName(g *graph) map[string]Node {
 // wrapper is responsible for pushing exactly one completionItem when
 // it returns (success, error, panic, or cancellation).
 //
+// branch is the composite branch string this activation runs under;
+// empty means inherit the workflow's root branch. Branch is used
+// (1) to scope LLM history visibility via
+// internal/llminternal/contents_processor.go:eventBelongsToBranch
+// and (2) to stamp Event.Branch on emitted events when the node
+// itself does not set it.
+//
 // scheduleNode runs only on the consumer goroutine.
-func (s *scheduler) scheduleNode(n Node, input any, triggeredBy string) {
-	s.scheduleResumedNode(n, input, triggeredBy, nil)
+func (s *scheduler) scheduleNode(n Node, input any, triggeredBy, branch string) {
+	s.scheduleResumedNode(n, input, triggeredBy, branch, nil)
 }
 
 // scheduleResumedNode is like scheduleNode but additionally
@@ -235,7 +244,7 @@ func (s *scheduler) scheduleNode(n Node, input any, triggeredBy string) {
 // behaviour as scheduleNode.
 //
 // scheduleResumedNode runs only on the consumer goroutine.
-func (s *scheduler) scheduleResumedNode(n Node, input any, triggeredBy string, resumeInputs map[string]any) {
+func (s *scheduler) scheduleResumedNode(n Node, input any, triggeredBy, branch string, resumeInputs map[string]any) {
 	name := n.Name()
 
 	// Per-node context: WithTimeout when Config().Timeout > 0,
@@ -252,7 +261,12 @@ func (s *scheduler) scheduleResumedNode(n Node, input any, triggeredBy string, r
 	} else {
 		nodeCtx, cancel = context.WithCancel(s.parentCtx)
 	}
-	perNodeCtx := newNodeContext(s.parentCtx.WithContext(nodeCtx), resumeInputs)
+	// Order matters: WithContext sets up per-node cancellation
+	// (returns *icontext.InvocationContext via the typed
+	// implementation), then withBranch overrides Branch() on the
+	// same concrete type. Reversing would lose the cancellation.
+	wrapped := withBranch(s.parentCtx.WithContext(nodeCtx), branch)
+	perNodeCtx := newNodeContext(wrapped, resumeInputs)
 
 	// EXPERIMENTAL: stash perNodeCtx in the embedded context.Context
 	// so tools running inside an LlmAgent that is itself running as
@@ -273,7 +287,8 @@ func (s *scheduler) scheduleResumedNode(n Node, input any, triggeredBy string, r
 	ns.Status = NodeRunning
 	ns.Input = input
 	ns.TriggeredBy = triggeredBy
-	s.runsByName[name] = &nodeRun{}
+	ns.Branch = branch
+	s.runsByName[name] = &nodeRun{branch: branch}
 
 	s.runCancels[name] = cancel
 	s.wg.Add(1)
@@ -282,11 +297,13 @@ func (s *scheduler) scheduleResumedNode(n Node, input any, triggeredBy string, r
 }
 
 // scheduleRetry schedules a retry for node n after the given delay.
-func (s *scheduler) scheduleRetry(n Node, input any, triggeredBy string, delay time.Duration) {
+// branch is preserved across attempts so retries do not silently
+// move the node to a different branch.
+func (s *scheduler) scheduleRetry(n Node, input any, triggeredBy, branch string, delay time.Duration) {
 	timer := time.AfterFunc(delay, func() {
 		go func() {
 			select {
-			case s.eventQueue <- retryItem{node: n, input: input, triggeredBy: triggeredBy}:
+			case s.eventQueue <- retryItem{node: n, input: input, triggeredBy: triggeredBy, branch: branch}:
 			case <-s.parentCtx.Done():
 			}
 		}()
@@ -415,7 +432,7 @@ func (s *scheduler) run(yield func(*session.Event, error) bool) {
 		case retryItem:
 			delete(s.retryTimers, it.node.Name())
 			if !draining {
-				s.scheduleNode(it.node, it.input, it.triggeredBy)
+				s.scheduleNode(it.node, it.input, it.triggeredBy, it.branch)
 			}
 		}
 	}
@@ -449,6 +466,18 @@ func (s *scheduler) handleEvent(it eventItem) {
 	}
 	if it.ev == nil {
 		return
+	}
+	// Stamp the activation's branch onto events that did not set one.
+	// Mirrors Python _node_runner._enrich_event (_node_runner.py:400-401).
+	// Nodes that explicitly set Event.Branch are respected; nodes that
+	// emit Event{Branch: ""} are interpreted as "use the activation's
+	// branch" (matching the Go default-value model — Python uses
+	// Optional and treats "" as a sentinel for "intentionally unscoped",
+	// which the LlmAgent flow currently emits via ctx.Branch() ==
+	// internal/llminternal/base_flow.go:931, never as an explicit
+	// override).
+	if it.ev.Branch == "" && nr.branch != "" {
+		it.ev.Branch = nr.branch
 	}
 	var path string
 	if it.ev.NodeInfo != nil {
@@ -517,7 +546,7 @@ func (s *scheduler) handleCompletion(it completionItem, scheduleSuccessors bool)
 				if ShouldRetry(cfg.RetryConfig, it.err, ns.Attempt) {
 					delay := CalculateDelay(cfg.RetryConfig, ns.Attempt)
 					ns.Status = NodePending
-					s.scheduleRetry(currentNode, ns.Input, ns.TriggeredBy, delay)
+					s.scheduleRetry(currentNode, ns.Input, ns.TriggeredBy, ns.Branch, delay)
 					// Return nil to continue the scheduler loop. Successors will
 					// be scheduled only when a retry attempt eventually succeeds
 					// and reaches the bottom of this function.
@@ -577,8 +606,8 @@ func (s *scheduler) handleCompletion(it completionItem, scheduleSuccessors bool)
 		input = ns.Input
 	}
 
-	for _, succ := range findSuccessors(s.graph, s.state, currentNode, input, routingEv) {
-		s.scheduleNode(succ.node, succ.input, succ.triggeredBy)
+	for _, succ := range findSuccessors(s.graph, s.state, currentNode, input, routingEv, ns.Branch) {
+		s.scheduleNode(succ.node, succ.input, succ.triggeredBy, succ.branch)
 	}
 	return nil
 }
@@ -587,10 +616,15 @@ func (s *scheduler) handleCompletion(it completionItem, scheduleSuccessors bool)
 // findSuccessors. The triggeredBy field carries the upstream
 // node's name for persistence on NodeState (used by Resume to
 // reconstruct the activation chain across pause/resume turns).
+// The branch field carries the composite branch string the
+// successor should run under — empty for chains that inherit the
+// parent's branch, populated when fan-out derives a sub-branch or
+// when JoinNode resolves its common predecessor prefix.
 type successor struct {
 	node        Node
 	input       any
 	triggeredBy string
+	branch      string
 }
 
 // findSuccessors evaluates the outgoing edges of currentNode against
@@ -610,7 +644,21 @@ type successor struct {
 //     deliberate decision not to continue, not an error.
 //
 // JoinNode successors are gated by appendSuccessor; see its docs.
-func findSuccessors(g *graph, state *RunState, currentNode Node, input any, event *session.Event) []successor {
+//
+// Branch derivation (Python parity, _workflow.py:692-727):
+//
+//   - When this activation fans out to >1 successor, each non-Join
+//     successor is given a sub-branch
+//     "<parentBranch>.<successorName>@1" (run_id "1" because the
+//     static scheduler does not auto-counter activations of the
+//     same name within one fan-out; loop-back routing re-enters the
+//     same node and the sub-branch stays stable).
+//   - When this activation has a single successor, the successor
+//     inherits parentBranch unchanged.
+//   - JoinNode successors compute their own branch in
+//     appendSuccessor as the common dot-prefix of the branches of
+//     all completed predecessors — see aggregatePredecessorBranches.
+func findSuccessors(g *graph, state *RunState, currentNode Node, input any, event *session.Event, parentBranch string) []successor {
 	succs := g.successorsOf(currentNode)
 	if len(succs) == 0 {
 		return nil
@@ -625,7 +673,7 @@ func findSuccessors(g *graph, state *RunState, currentNode Node, input any, even
 			continue
 		}
 		if edge.Route == nil {
-			out = appendSuccessor(out, g, state, edge.To, input, from)
+			out = appendSuccessor(out, g, state, edge.To, input, from, parentBranch)
 			added[edge.To] = struct{}{}
 			continue
 		}
@@ -634,32 +682,64 @@ func findSuccessors(g *graph, state *RunState, currentNode Node, input any, even
 			continue
 		}
 		if event != nil && edge.Route.Matches(event) {
-			out = appendSuccessor(out, g, state, edge.To, input, from)
+			out = appendSuccessor(out, g, state, edge.To, input, from, parentBranch)
 			added[edge.To] = struct{}{}
 			concreteMatched = true
 		}
 	}
 	if !concreteMatched && defaultRouteNode != nil {
-		out = appendSuccessor(out, g, state, defaultRouteNode, input, from)
+		out = appendSuccessor(out, g, state, defaultRouteNode, input, from, parentBranch)
+	}
+	// Second pass: if we fanned out to more than one successor,
+	// stamp a sub-branch onto each non-Join entry whose branch is
+	// still the inherited parentBranch. JoinNode entries already
+	// carry their common-prefix branch from appendSuccessor and
+	// must not be re-derived.
+	if len(out) > 1 {
+		for i, s := range out {
+			if _, isJoin := s.node.(*JoinNode); isJoin {
+				continue
+			}
+			if s.branch != parentBranch {
+				continue
+			}
+			out[i].branch = deriveSubBranch(parentBranch, s.node.Name()+"@1")
+		}
 	}
 	return out
 }
 
 // appendSuccessor records a routing match in the dispatch list.
-// Non-JoinNode targets are recorded as-is. A *JoinNode target is
-// recorded only when every declared predecessor has completed;
-// its input is replaced with the aggregated predecessor outputs.
-// A barrier-blocked JoinNode is silently skipped — a later
-// predecessor completion re-evaluates the barrier.
-func appendSuccessor(out []successor, g *graph, state *RunState, target Node, input any, triggeredBy string) []successor {
+// Non-JoinNode targets are recorded with parentBranch as their
+// initial branch; findSuccessors may upgrade to a sub-branch in a
+// second pass if this activation fanned out.
+//
+// A *JoinNode target is recorded only when every declared
+// predecessor has completed; its input is replaced with the
+// aggregated predecessor outputs, and its branch is the common
+// dot-prefix of all predecessor branches. A barrier-blocked
+// JoinNode is silently skipped — a later predecessor completion
+// re-evaluates the barrier.
+func appendSuccessor(out []successor, g *graph, state *RunState, target Node, input any, triggeredBy, parentBranch string) []successor {
 	if _, isJoin := target.(*JoinNode); !isJoin {
-		return append(out, successor{node: target, input: input, triggeredBy: triggeredBy})
+		return append(out, successor{
+			node:        target,
+			input:       input,
+			triggeredBy: triggeredBy,
+			branch:      parentBranch,
+		})
 	}
 	aggregated, ok := aggregatePredecessorOutputs(g, state, target)
 	if !ok {
 		return out
 	}
-	return append(out, successor{node: target, input: aggregated, triggeredBy: triggeredBy})
+	joinBranch := commonBranchPrefix(aggregatePredecessorBranches(g, state, target))
+	return append(out, successor{
+		node:        target,
+		input:       aggregated,
+		triggeredBy: triggeredBy,
+		branch:      joinBranch,
+	})
 }
 
 // aggregatePredecessorOutputs returns a map of predecessor name to
@@ -679,4 +759,28 @@ func aggregatePredecessorOutputs(g *graph, state *RunState, target Node) (map[st
 		aggregated[name] = ns.Output
 	}
 	return aggregated, true
+}
+
+// aggregatePredecessorBranches returns the branch strings recorded
+// for every predecessor of target. Order is the graph's
+// predecessor-edge order, which is deterministic per construction.
+// Callers feed the result into commonBranchPrefix to compute the
+// join's own branch.
+//
+// Assumes appendSuccessor's caller has already verified all
+// predecessors are NodeCompleted (via aggregatePredecessorOutputs
+// returning ok); a missing entry contributes "" which conservatively
+// short-circuits the common-prefix to root.
+func aggregatePredecessorBranches(g *graph, state *RunState, target Node) []string {
+	predEdges := g.predecessorsOf(target)
+	branches := make([]string, 0, len(predEdges))
+	for _, edge := range predEdges {
+		name := edge.From.Name()
+		var br string
+		if ns := state.Nodes[name]; ns != nil {
+			br = ns.Branch
+		}
+		branches = append(branches, br)
+	}
+	return branches
 }

--- a/workflow/scheduler.go
+++ b/workflow/scheduler.go
@@ -466,11 +466,9 @@ func (s *scheduler) handleEvent(it eventItem) {
 	if it.ev == nil {
 		return
 	}
-	// Stamp the activation's branch onto events that did not set one.
-	// Nodes that explicitly set Event.Branch are respected; nodes
-	// that emit Event{Branch: ""} use the activation's branch by
-	// default (Go has no way to distinguish "unset" from "explicit
-	// empty" on a string field).
+	// Stamp the activation's branch onto events that left
+	// Event.Branch empty; nodes that set a non-empty Event.Branch
+	// keep it.
 	if it.ev.Branch == "" && nr.branch != "" {
 		it.ev.Branch = nr.branch
 	}

--- a/workflow/scheduler_branch_test.go
+++ b/workflow/scheduler_branch_test.go
@@ -15,7 +15,6 @@
 package workflow
 
 import (
-	"sort"
 	"sync"
 	"testing"
 
@@ -23,9 +22,8 @@ import (
 )
 
 // branchRecorder returns a FunctionNode that captures the
-// ctx.Branch() string into *seen at execution time. Used by the
-// scheduler-branch tests to verify what branch the scheduler
-// assigned to each activation.
+// ctx.Branch() string into *seen at execution time, keyed by node
+// name.
 func branchRecorder(name string, mu *sync.Mutex, seen *map[string]string) *FunctionNode {
 	return NewFunctionNode(name,
 		func(ctx agent.InvocationContext, input any) (string, error) {
@@ -66,8 +64,7 @@ func TestScheduler_SingleSuccessorChain_InheritsRootBranch(t *testing.T) {
 
 // TestScheduler_MultipleSuccessors_AssignsSubBranches verifies that
 // fan-out from one node to N successors derives sub-branches of the
-// form "<successor>@1" for each branch. Mirrors Python
-// _workflow.py:692 where use_sub_branch = len(next_nodes) > 1.
+// form "<successor>@1" for each branch.
 func TestScheduler_MultipleSuccessors_AssignsSubBranches(t *testing.T) {
 	mockCtx := newSeededMockCtx(t)
 	var mu sync.Mutex
@@ -208,10 +205,10 @@ func TestScheduler_JoinNode_NestedFanOut(t *testing.T) {
 	if got, want := seen["leaf2"], "leaf2@1"; got != want {
 		t.Errorf("seen[leaf2] = %q, want %q", got, want)
 	}
-	// Common prefix of "leaf1@1" and "leaf2@1" is "" (no shared segments)
-	// — because outer is on the *root* branch, its successors' sub-branches
-	// share no parent segment. This matches Python: the join joins back to
-	// the deepest common ancestor, which here is root.
+	// Common prefix of "leaf1@1" and "leaf2@1" is "" (no shared
+	// segments) — because outer is on the *root* branch, its
+	// successors' sub-branches share no parent segment, so the join
+	// returns to root (deepest common ancestor).
 	if got, want := seen["handler"], ""; got != want {
 		t.Errorf("seen[handler] = %q, want %q", got, want)
 	}
@@ -219,8 +216,7 @@ func TestScheduler_JoinNode_NestedFanOut(t *testing.T) {
 
 // TestScheduler_EventsAreBranchStamped verifies that the scheduler
 // stamps Event.Branch on every emitted event using the activation's
-// branch when the node itself leaves Event.Branch empty (mirrors
-// Python's _enrich_event behaviour in _node_runner.py:400-401).
+// branch when the node itself leaves Event.Branch empty.
 func TestScheduler_EventsAreBranchStamped(t *testing.T) {
 	mockCtx := newSeededMockCtx(t)
 	var mu sync.Mutex
@@ -255,49 +251,6 @@ func TestScheduler_EventsAreBranchStamped(t *testing.T) {
 				t.Errorf("event from %q has Branch = %q, want %q",
 					author, got, wantBranch)
 			}
-		}
-	}
-}
-
-// TestScheduler_AllNodeStateBranchesPersisted verifies that the
-// scheduler records each activation's branch in NodeState.Branch so
-// resume after pause can reconstruct the same branch tree.
-func TestScheduler_AllNodeStateBranchesPersisted(t *testing.T) {
-	mockCtx := newSeededMockCtx(t)
-	var mu sync.Mutex
-	seen := map[string]string{}
-
-	a := branchRecorder("a", &mu, &seen)
-	b := branchRecorder("b", &mu, &seen)
-	c := branchRecorder("c", &mu, &seen)
-
-	w := mustNew(t, []Edge{
-		{From: Start, To: a},
-		{From: Start, To: b},
-		{From: Start, To: c},
-	})
-
-	drain(t, w.Run(mockCtx))
-
-	// We can't reach the scheduler's internal state.Nodes from
-	// outside w.Run, but the branch_test for the helper logic
-	// covers the recording path. Here we sanity-check that the
-	// observed branches from the ctx side match what the scheduler
-	// should have written to NodeState (the latter is verified
-	// implicitly by the existing resume tests, which would break
-	// if NodeState.Branch were not preserved).
-	got := make([]string, 0, len(seen))
-	for _, v := range seen {
-		got = append(got, v)
-	}
-	sort.Strings(got)
-	want := []string{"a@1", "b@1", "c@1"}
-	if len(got) != len(want) {
-		t.Fatalf("seen branches = %v, want %v", got, want)
-	}
-	for i := range want {
-		if got[i] != want[i] {
-			t.Errorf("seen[%d] = %q, want %q", i, got[i], want[i])
 		}
 	}
 }

--- a/workflow/scheduler_branch_test.go
+++ b/workflow/scheduler_branch_test.go
@@ -1,0 +1,303 @@
+// Copyright 2026 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package workflow
+
+import (
+	"sort"
+	"sync"
+	"testing"
+
+	"google.golang.org/adk/agent"
+)
+
+// branchRecorder returns a FunctionNode that captures the
+// ctx.Branch() string into *seen at execution time. Used by the
+// scheduler-branch tests to verify what branch the scheduler
+// assigned to each activation.
+func branchRecorder(name string, mu *sync.Mutex, seen *map[string]string) *FunctionNode {
+	return NewFunctionNode(name,
+		func(ctx agent.InvocationContext, input any) (string, error) {
+			mu.Lock()
+			(*seen)[name] = ctx.Branch()
+			mu.Unlock()
+			return name + "-done", nil
+		}, defaultNodeConfig)
+}
+
+// TestScheduler_SingleSuccessorChain_InheritsRootBranch verifies
+// that a linear chain (one successor per node) keeps every
+// activation on the root branch — sub-branches are only derived at
+// fan-out, not on every edge.
+func TestScheduler_SingleSuccessorChain_InheritsRootBranch(t *testing.T) {
+	mockCtx := newSeededMockCtx(t)
+	var mu sync.Mutex
+	seen := map[string]string{}
+
+	a := branchRecorder("a", &mu, &seen)
+	b := branchRecorder("b", &mu, &seen)
+	c := branchRecorder("c", &mu, &seen)
+
+	w := mustNew(t, []Edge{
+		{From: Start, To: a},
+		{From: a, To: b},
+		{From: b, To: c},
+	})
+
+	drain(t, w.Run(mockCtx))
+
+	for _, name := range []string{"a", "b", "c"} {
+		if got := seen[name]; got != "" {
+			t.Errorf("seen[%q] = %q, want \"\" (chain inherits root)", name, got)
+		}
+	}
+}
+
+// TestScheduler_MultipleSuccessors_AssignsSubBranches verifies that
+// fan-out from one node to N successors derives sub-branches of the
+// form "<successor>@1" for each branch. Mirrors Python
+// _workflow.py:692 where use_sub_branch = len(next_nodes) > 1.
+func TestScheduler_MultipleSuccessors_AssignsSubBranches(t *testing.T) {
+	mockCtx := newSeededMockCtx(t)
+	var mu sync.Mutex
+	seen := map[string]string{}
+
+	a := branchRecorder("a", &mu, &seen)
+	b := branchRecorder("b", &mu, &seen)
+	c := branchRecorder("c", &mu, &seen)
+
+	// START fans out to a + b + c.
+	w := mustNew(t, []Edge{
+		{From: Start, To: a},
+		{From: Start, To: b},
+		{From: Start, To: c},
+	})
+
+	drain(t, w.Run(mockCtx))
+
+	want := map[string]string{
+		"a": "a@1",
+		"b": "b@1",
+		"c": "c@1",
+	}
+	for name, wantBranch := range want {
+		if got := seen[name]; got != wantBranch {
+			t.Errorf("seen[%q] = %q, want %q (fan-out should derive sub-branch)",
+				name, got, wantBranch)
+		}
+	}
+}
+
+// TestScheduler_FanOutChainedDeeperBranches verifies that after a
+// fan-out, successors of each branch continue to extend their
+// branch when they themselves fan out further.
+func TestScheduler_FanOutChainedDeeperBranches(t *testing.T) {
+	mockCtx := newSeededMockCtx(t)
+	var mu sync.Mutex
+	seen := map[string]string{}
+
+	a := branchRecorder("a", &mu, &seen)
+	// a fans out to b1+b2 within its sub-branch.
+	b1 := branchRecorder("b1", &mu, &seen)
+	b2 := branchRecorder("b2", &mu, &seen)
+
+	w := mustNew(t, []Edge{
+		{From: Start, To: a}, // a stays on root (single successor)
+		{From: a, To: b1},    // a fans out: b1 and b2 get sub-branches
+		{From: a, To: b2},
+	})
+
+	drain(t, w.Run(mockCtx))
+
+	if got, want := seen["a"], ""; got != want {
+		t.Errorf("seen[a] = %q, want %q (root, since START's only successor is a)", got, want)
+	}
+	if got, want := seen["b1"], "b1@1"; got != want {
+		t.Errorf("seen[b1] = %q, want %q", got, want)
+	}
+	if got, want := seen["b2"], "b2@1"; got != want {
+		t.Errorf("seen[b2] = %q, want %q", got, want)
+	}
+}
+
+// TestScheduler_JoinNode_UsesCommonPrefix verifies that when a
+// JoinNode fires after a fan-out of its predecessors, the join
+// activation runs on the common branch prefix of its predecessors
+// (which in the simple case is the parent of the fan-out).
+func TestScheduler_JoinNode_UsesCommonPrefix(t *testing.T) {
+	mockCtx := newSeededMockCtx(t)
+	var mu sync.Mutex
+	seen := map[string]string{}
+
+	branchA := branchRecorder("branchA", &mu, &seen)
+	branchB := branchRecorder("branchB", &mu, &seen)
+	join := NewJoinNode("join")
+	handler := branchRecorder("handler", &mu, &seen)
+
+	w := mustNew(t, []Edge{
+		{From: Start, To: branchA}, // fan-out: branchA and branchB get sub-branches
+		{From: Start, To: branchB},
+		{From: branchA, To: join},
+		{From: branchB, To: join},
+		{From: join, To: handler}, // single successor; handler inherits join's branch
+	})
+
+	drain(t, w.Run(mockCtx))
+
+	// Predecessors are on their own sub-branches.
+	if got, want := seen["branchA"], "branchA@1"; got != want {
+		t.Errorf("seen[branchA] = %q, want %q", got, want)
+	}
+	if got, want := seen["branchB"], "branchB@1"; got != want {
+		t.Errorf("seen[branchB] = %q, want %q", got, want)
+	}
+	// Join's branch is the common prefix of "branchA@1" and "branchB@1",
+	// which share no dot-separated segments → root.
+	// The handler inherits the join's branch (single successor).
+	if got, want := seen["handler"], ""; got != want {
+		t.Errorf("seen[handler] = %q, want %q (common prefix of branchA@1/branchB@1 is root)", got, want)
+	}
+}
+
+// TestScheduler_JoinNode_NestedFanOut verifies the common-prefix
+// behaviour when predecessors share a deeper ancestor branch. After
+// fan-out, predecessors that themselves shared an outer branch
+// produce a join on that outer branch (not all the way back to
+// root).
+func TestScheduler_JoinNode_NestedFanOut(t *testing.T) {
+	mockCtx := newSeededMockCtx(t)
+	var mu sync.Mutex
+	seen := map[string]string{}
+
+	// outer is a single successor of START → stays on root.
+	outer := branchRecorder("outer", &mu, &seen)
+	// outer fans out to leaf1 + leaf2 → each gets sub-branch.
+	leaf1 := branchRecorder("leaf1", &mu, &seen)
+	leaf2 := branchRecorder("leaf2", &mu, &seen)
+	join := NewJoinNode("join")
+	handler := branchRecorder("handler", &mu, &seen)
+
+	w := mustNew(t, []Edge{
+		{From: Start, To: outer},
+		{From: outer, To: leaf1},
+		{From: outer, To: leaf2},
+		{From: leaf1, To: join},
+		{From: leaf2, To: join},
+		{From: join, To: handler},
+	})
+
+	drain(t, w.Run(mockCtx))
+
+	if got, want := seen["outer"], ""; got != want {
+		t.Errorf("seen[outer] = %q, want %q", got, want)
+	}
+	if got, want := seen["leaf1"], "leaf1@1"; got != want {
+		t.Errorf("seen[leaf1] = %q, want %q", got, want)
+	}
+	if got, want := seen["leaf2"], "leaf2@1"; got != want {
+		t.Errorf("seen[leaf2] = %q, want %q", got, want)
+	}
+	// Common prefix of "leaf1@1" and "leaf2@1" is "" (no shared segments)
+	// — because outer is on the *root* branch, its successors' sub-branches
+	// share no parent segment. This matches Python: the join joins back to
+	// the deepest common ancestor, which here is root.
+	if got, want := seen["handler"], ""; got != want {
+		t.Errorf("seen[handler] = %q, want %q", got, want)
+	}
+}
+
+// TestScheduler_EventsAreBranchStamped verifies that the scheduler
+// stamps Event.Branch on every emitted event using the activation's
+// branch when the node itself leaves Event.Branch empty (mirrors
+// Python's _enrich_event behaviour in _node_runner.py:400-401).
+func TestScheduler_EventsAreBranchStamped(t *testing.T) {
+	mockCtx := newSeededMockCtx(t)
+	var mu sync.Mutex
+	seen := map[string]string{}
+
+	a := branchRecorder("a", &mu, &seen)
+	b := branchRecorder("b", &mu, &seen)
+
+	w := mustNew(t, []Edge{
+		{From: Start, To: a},
+		{From: Start, To: b},
+	})
+
+	events := drain(t, w.Run(mockCtx))
+
+	gotByAuthor := map[string][]string{}
+	for _, ev := range events {
+		if ev.Author == "" {
+			continue
+		}
+		gotByAuthor[ev.Author] = append(gotByAuthor[ev.Author], ev.Branch)
+	}
+
+	for _, author := range []string{"a", "b"} {
+		branches, ok := gotByAuthor[author]
+		if !ok {
+			continue // node may have emitted no events with author set
+		}
+		wantBranch := author + "@1"
+		for _, got := range branches {
+			if got != wantBranch {
+				t.Errorf("event from %q has Branch = %q, want %q",
+					author, got, wantBranch)
+			}
+		}
+	}
+}
+
+// TestScheduler_AllNodeStateBranchesPersisted verifies that the
+// scheduler records each activation's branch in NodeState.Branch so
+// resume after pause can reconstruct the same branch tree.
+func TestScheduler_AllNodeStateBranchesPersisted(t *testing.T) {
+	mockCtx := newSeededMockCtx(t)
+	var mu sync.Mutex
+	seen := map[string]string{}
+
+	a := branchRecorder("a", &mu, &seen)
+	b := branchRecorder("b", &mu, &seen)
+	c := branchRecorder("c", &mu, &seen)
+
+	w := mustNew(t, []Edge{
+		{From: Start, To: a},
+		{From: Start, To: b},
+		{From: Start, To: c},
+	})
+
+	drain(t, w.Run(mockCtx))
+
+	// We can't reach the scheduler's internal state.Nodes from
+	// outside w.Run, but the branch_test for the helper logic
+	// covers the recording path. Here we sanity-check that the
+	// observed branches from the ctx side match what the scheduler
+	// should have written to NodeState (the latter is verified
+	// implicitly by the existing resume tests, which would break
+	// if NodeState.Branch were not preserved).
+	got := make([]string, 0, len(seen))
+	for _, v := range seen {
+		got = append(got, v)
+	}
+	sort.Strings(got)
+	want := []string{"a@1", "b@1", "c@1"}
+	if len(got) != len(want) {
+		t.Fatalf("seen branches = %v, want %v", got, want)
+	}
+	for i := range want {
+		if got[i] != want[i] {
+			t.Errorf("seen[%d] = %q, want %q", i, got[i], want[i])
+		}
+	}
+}

--- a/workflow/state.go
+++ b/workflow/state.go
@@ -98,6 +98,17 @@ type NodeState struct {
 	// the current Input. Empty for the initial START activation.
 	TriggeredBy string `json:"triggeredBy,omitempty"`
 
+	// Branch is the composite branch string assigned to this
+	// activation at scheduling time. Empty for nodes that inherit
+	// the root branch (single-successor chains); populated for
+	// nodes scheduled after a fan-out and for JoinNodes resolving
+	// the common branch prefix of their predecessors.
+	//
+	// Persisted so resume can reconstruct the same branch tree on
+	// re-entry, which is required for JoinNode's common-prefix
+	// derivation to remain stable across pause/resume turns.
+	Branch string `json:"branch,omitempty"`
+
 	// PendingRequest, when non-nil, carries the human-input request
 	// the node emitted before pausing. Non-nil iff Status ==
 	// NodeWaiting and the wait was caused by a human-input request

--- a/workflow/workflow.go
+++ b/workflow/workflow.go
@@ -191,10 +191,13 @@ func (w *Workflow) Run(ctx agent.InvocationContext) iter.Seq2[*session.Event, er
 		input := userInput(ctx)
 
 		s := newScheduler(ctx, w.graph)
-		// Seed: schedule START with the user-supplied input.
+		// Seed: schedule START with the user-supplied input. START
+		// itself runs at the workflow's root branch (inherits
+		// ctx.Branch()); its successors derive sub-branches when
+		// the START fan-out has more than one edge.
 		startState := s.state.EnsureNode(Start.Name())
 		startState.Input = input
-		s.scheduleNode(Start, input, "")
+		s.scheduleNode(Start, input, "", ctx.Branch())
 
 		s.run(yield)
 


### PR DESCRIPTION
Adds branch derivation across the three workflow schedulers so the
LLM flow's branch-prefix history filter (already present in
`contents_processor.go`) actually scopes events per parallel branch
instead of seeing every node run on the empty root branch.

Before this PR, `Event.Branch` and `InvocationContext.Branch()`
existed and the filter respected them, but no scheduler ever
derived a non-empty branch — so an `LlmAgent` wrapped by
`ParallelWorker` (or by a hand-written `errgroup` fan-out) saw
every sibling worker's events in its prompt history.

The **static scheduler** now derives `<successor>@1` sub-branches
at fan-out, computes the longest common dot-prefix of predecessor
branches for `JoinNode`, stamps `Event.Branch` when the node leaves
it empty, and persists each activation's branch on `NodeState` for
resume. The **`ParallelWorker`** replaces its single shared
`workerCtx` with per-iteration sub-contexts derived as
`<parent>.<wrapped>@<i+1>`. The **dynamic sub-scheduler** gains
two opt-in `RunNode` options — `WithUseSubBranch()` and
`WithOverrideBranch(base)` — for dynamic-node bodies that want to
isolate child activations.

