### PR TITLE
Experimental - get NodeContext from ToolContext

### DIFF
--- a/internal/workflowinternal/single_turn_tool.go
+++ b/internal/workflowinternal/single_turn_tool.go
@@ -9,3 +9,9 @@ func NewSingleTurnTool(a agent.Agent) (tool.Tool, error) {
 	// TODO: implement
 	return nil, nil
 }
+
+//func (t *singleTurnTool) Run(ctx tool.Context, args any) (map[string]any, error) {
+// nc, ok := workflow.NodeContextFromGoContext(ctx)
+// node, err := workflow.NewAgentNode(t.agent, workflow.NodeConfig{})
+// out, err := workflow.RunNode[any](nc, node, nodeInput)
+//}

--- a/workflow/dynamic_scheduler.go
+++ b/workflow/dynamic_scheduler.go
@@ -64,6 +64,16 @@ func (s *dynamicSubScheduler) runNode(child Node, input any, customRunID string)
 	childPath := s.parentPath + "/" + name + "@" + runID
 	childCtx := newDynamicNodeContext(s.parentCtx, childPath, runID, s)
 
+	// EXPERIMENTAL: stash childCtx (a *nodeContext with non-nil
+	// subScheduler) in the embedded context.Context so tools running
+	// inside an LlmAgent that is itself running as this dynamic
+	// child can recover the NodeContext via
+	// workflow.NodeContextFromGoContext. See
+	// scheduleResumedNode for the static-node equivalent.
+	childCtx.InvocationContext = childCtx.InvocationContext.WithContext(
+		WithNodeContext(childCtx.InvocationContext, childCtx),
+	)
+
 	var (
 		out         any
 		interrupted bool

--- a/workflow/node_context_bridge.go
+++ b/workflow/node_context_bridge.go
@@ -1,0 +1,45 @@
+// Copyright 2026 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package workflow
+
+import "context"
+
+// EXPERIMENTAL: temporary bridge that lets runnable tools recover
+// the surrounding NodeContext from a tool.Context value chain
+// without modifying the tool.Context interface. Will be removed
+// once the CallbackContext / ToolContext unification (see TODO in
+// node_context.go) lands.
+type nodeContextKey struct{}
+
+// WithNodeContext returns a derived Go context that carries nc under
+// an opaque key, recoverable via NodeContextFromGoContext from any
+// descendant context.Context. The scheduler calls this on every
+// per-node activation.
+func WithNodeContext(parent context.Context, nc NodeContext) context.Context {
+	if parent == nil || nc == nil {
+		return parent
+	}
+	return context.WithValue(parent, nodeContextKey{}, nc)
+}
+
+// NodeContextFromGoContext returns the NodeContext stashed by
+// WithNodeContext, or (nil, false) if none is present on ctx.
+func NodeContextFromGoContext(ctx context.Context) (NodeContext, bool) {
+	if ctx == nil {
+		return nil, false
+	}
+	nc, ok := ctx.Value(nodeContextKey{}).(NodeContext)
+	return nc, ok
+}

--- a/workflow/node_context_bridge_test.go
+++ b/workflow/node_context_bridge_test.go
@@ -1,0 +1,55 @@
+// Copyright 2026 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package workflow
+
+import (
+	"context"
+	"testing"
+)
+
+// TestWithNodeContext_SurvivesDerivedContext pins the core property
+// the bridge exists for: a NodeContext stashed via WithNodeContext
+// must survive arbitrary downstream context.Context derivations
+// (context.WithCancel, context.WithValue, ...) because the
+// scheduler -> AgentNode -> LlmAgent -> Flow -> tool.Context chain
+// produces exactly those derivations along the way (per-node
+// WithCancel in scheduleResumedNode; telemetry span ctx wrap in
+// Flow.handleFunctionCalls; the embedded context.Context in every
+// InvocationContext built along the path).
+//
+// If this test regresses, NodeContextFromGoContext(toolCtx)
+// lookups in runnable tools will silently return (nil, false) at
+// runtime and the tools will fall back to their no-NodeContext
+// path.
+func TestWithNodeContext_SurvivesDerivedContext(t *testing.T) {
+	sentinel := &nodeContext{}
+	parent := WithNodeContext(context.Background(), sentinel)
+
+	// Simulate a WithCancel (NewInvocationContext does effectively
+	// this when called with the per-node nodeCtx).
+	derived, cancel := context.WithCancel(parent)
+	defer cancel()
+
+	// And a WithValue layer on top (telemetry span ctx does this).
+	derived = context.WithValue(derived, struct{ k string }{"span"}, "stub")
+
+	got, ok := NodeContextFromGoContext(derived)
+	if !ok {
+		t.Fatal("NodeContext lost across WithCancel + WithValue derivations")
+	}
+	if got != NodeContext(sentinel) {
+		t.Errorf("Derived context returned wrong NodeContext: got %p, want %p", got, sentinel)
+	}
+}

--- a/workflow/node_context_propagation_test.go
+++ b/workflow/node_context_propagation_test.go
@@ -1,0 +1,114 @@
+// Copyright 2026 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package workflow
+
+import (
+	"context"
+	"errors"
+	"iter"
+	"testing"
+
+	"google.golang.org/adk/agent"
+	"google.golang.org/adk/session"
+)
+
+var errFnNodeNeedsNodeContext = errors.New("fnNode: ctx is not a NodeContext")
+
+// End-to-end check that a child of a dynamic-node activation can
+// recover its own NodeContext via NodeContextFromGoContext — the
+// path runnable tools rely on to reach the sub-scheduler from
+// tool.Context.
+func TestNodeContextPropagation_DynamicChildEmbedsItself(t *testing.T) {
+	var captured NodeContext
+
+	inner := newFnNode("inner", func(ctx NodeContext) (any, error) {
+		nc, ok := NodeContextFromGoContext(ctx)
+		if !ok {
+			t.Errorf("inner: NodeContext not recovered from go context value")
+			return nil, nil
+		}
+		captured = nc
+		return "ok", nil
+	})
+
+	orchestrator := NewDynamicNode[string, string]("orch",
+		func(ctx NodeContext, _ string, _ func(*session.Event) error) (string, error) {
+			return RunNode[string](ctx, inner, nil)
+		},
+		NodeConfig{},
+	)
+
+	if _, err := drainDynamicWithErr(t, orchestrator, ""); err != nil {
+		t.Fatalf("orchestrator error: %v", err)
+	}
+	if captured == nil {
+		t.Fatal("inner did not recover any NodeContext")
+	}
+}
+
+// Top-level (static) activations stash a NodeContext too, even
+// though their RunNode would be rejected for lack of a
+// sub-scheduler — consumers can still detect "inside a workflow
+// node" and react accordingly.
+func TestNodeContextPropagation_StaticActivationStashed(t *testing.T) {
+	// Mini-replication of scheduler.scheduleResumedNode's stash
+	// sequence; avoids the full scheduler loop.
+	parent := newMockCtx(t)
+	perNodeCtx := newNodeContext(parent.WithContext(context.Background()), nil)
+	perNodeCtx.InvocationContext = perNodeCtx.InvocationContext.WithContext(
+		WithNodeContext(perNodeCtx.InvocationContext, perNodeCtx),
+	)
+
+	nc, ok := NodeContextFromGoContext(perNodeCtx)
+	if !ok {
+		t.Fatal("static activation did not stash NodeContext on its own embedded context")
+	}
+	if nc != NodeContext(perNodeCtx) {
+		t.Errorf("recovered NodeContext != perNodeCtx (%p vs %p)", nc, perNodeCtx)
+	}
+}
+
+// --- test helpers ---
+
+// fnNode adapts a func(NodeContext) callback into a Node that emits
+// a single Output event on success.
+type fnNode struct {
+	BaseNode
+	fn func(NodeContext) (any, error)
+}
+
+func newFnNode(name string, fn func(NodeContext) (any, error)) *fnNode {
+	return &fnNode{
+		BaseNode: NewBaseNode(name, "", NodeConfig{}),
+		fn:       fn,
+	}
+}
+
+func (n *fnNode) Run(ctx agent.InvocationContext, input any) iter.Seq2[*session.Event, error] {
+	return func(yield func(*session.Event, error) bool) {
+		// dynamic_scheduler passes *nodeContext as agent.InvocationContext.
+		nc, ok := ctx.(NodeContext)
+		if !ok {
+			yield(nil, errFnNodeNeedsNodeContext)
+			return
+		}
+		out, err := n.fn(nc)
+		if err != nil {
+			yield(nil, err)
+			return
+		}
+		yield(&session.Event{Output: out}, nil)
+	}
+}

--- a/workflow/scheduler.go
+++ b/workflow/scheduler.go
@@ -254,6 +254,21 @@ func (s *scheduler) scheduleResumedNode(n Node, input any, triggeredBy string, r
 	}
 	perNodeCtx := newNodeContext(s.parentCtx.WithContext(nodeCtx), resumeInputs)
 
+	// EXPERIMENTAL: stash perNodeCtx in the embedded context.Context
+	// so tools running inside an LlmAgent that is itself running as
+	// this node can recover the NodeContext via
+	// workflow.NodeContextFromGoContext. The value rides through
+	// every downstream NewInvocationContext / WithContext call by
+	// virtue of context.Context value-chain propagation.
+	//
+	// See WithNodeContext / NodeContextFromGoContext in
+	// node_context_bridge.go. Top-level static activations have
+	// subScheduler == nil, so RunNode will still reject them; the
+	// stash is harmless in that case.
+	perNodeCtx.InvocationContext = perNodeCtx.InvocationContext.WithContext(
+		WithNodeContext(perNodeCtx.InvocationContext, perNodeCtx),
+	)
+
 	ns := s.state.EnsureNode(name)
 	ns.Status = NodeRunning
 	ns.Input = input


### PR DESCRIPTION
Experimental: workaround to be able to get NodeContext from ToolContext