### PR TITLE
feat(workflow): add WithMaxConcurrency option to cap graph-scheduled …

### DIFF
--- a/workflow/max_concurrency_test.go
+++ b/workflow/max_concurrency_test.go
@@ -1,0 +1,188 @@
+// Copyright 2026 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package workflow
+
+import (
+	"errors"
+	"fmt"
+	"sync/atomic"
+	"testing"
+	"time"
+
+	"google.golang.org/adk/agent"
+)
+
+// bumpPeak increments inFlight, updates peak if the new value is
+// higher, and returns a closure that decrements inFlight when
+// called. Used by tests that observe peak concurrency.
+func bumpPeak(inFlight, peak *atomic.Int32) func() {
+	now := inFlight.Add(1)
+	for {
+		p := peak.Load()
+		if now <= p || peak.CompareAndSwap(p, now) {
+			break
+		}
+	}
+	return func() { inFlight.Add(-1) }
+}
+
+// fanOutFromStart builds N Edge{Start, nodes[i]} edges.
+func fanOutFromStart(nodes []Node) []Edge {
+	edges := make([]Edge, 0, len(nodes))
+	for _, n := range nodes {
+		edges = append(edges, Edge{From: Start, To: n})
+	}
+	return edges
+}
+
+// TestMaxConcurrency_Caps verifies that a fan-out wider than the
+// configured cap never exceeds the cap in the number of nodes
+// running simultaneously.
+func TestMaxConcurrency_Caps(t *testing.T) {
+	const fanOut = 6
+	const cap = 2
+
+	mockCtx := newSeededMockCtx(t)
+	var inFlight, peak atomic.Int32
+
+	releases := make([]chan struct{}, fanOut)
+	nodes := make([]Node, fanOut)
+	for i := range fanOut {
+		i := i
+		releases[i] = make(chan struct{})
+		nodes[i] = newBlockingNode(fmt.Sprintf("N%d", i), func() {
+			defer bumpPeak(&inFlight, &peak)()
+			<-releases[i]
+		})
+	}
+
+	w, err := New("", fanOutFromStart(nodes), WithMaxConcurrency(cap))
+	if err != nil {
+		t.Fatalf("New: %v", err)
+	}
+
+	done := make(chan struct{})
+	go func() {
+		defer close(done)
+		drain(t, w.Run(mockCtx))
+	}()
+
+	// Wait until cap nodes are admitted, then release them
+	// one by one so the scheduler dispatches queued nodes
+	// into their slots without ever exceeding the cap.
+	deadline := time.Now().Add(2 * time.Second)
+	for time.Now().Before(deadline) && inFlight.Load() != cap {
+		time.Sleep(time.Millisecond)
+	}
+	if got := inFlight.Load(); got != cap {
+		t.Fatalf("after warmup: inFlight = %d, want %d (cap not enforced)", got, cap)
+	}
+	for i := range fanOut {
+		close(releases[i])
+	}
+	<-done
+
+	if got := peak.Load(); got > cap {
+		t.Errorf("peak in-flight = %d, want <= %d (cap violated)", got, cap)
+	}
+}
+
+// TestMaxConcurrency_PendingDispatchedFIFO verifies that queued
+// activations are dispatched in arrival order: a fan-out with
+// cap=1 must run in strict sequence.
+func TestMaxConcurrency_PendingDispatchedFIFO(t *testing.T) {
+	const fanOut = 4
+	mockCtx := newSeededMockCtx(t)
+
+	var order atomic.Int32
+	starts := make([]int32, fanOut)
+	nodes := make([]Node, fanOut)
+	for i := range fanOut {
+		i := i
+		nodes[i] = NewFunctionNode(
+			fmt.Sprintf("N%d", i),
+			func(ctx agent.InvocationContext, input any) (string, error) {
+				starts[i] = order.Add(1)
+				return "ok", nil
+			},
+			defaultNodeConfig,
+		)
+	}
+	w, err := New("", fanOutFromStart(nodes), WithMaxConcurrency(1))
+	if err != nil {
+		t.Fatalf("New: %v", err)
+	}
+
+	drain(t, w.Run(mockCtx))
+
+	for i := range fanOut {
+		if want := int32(i + 1); starts[i] != want {
+			t.Errorf("N%d start order = %d, want %d (FIFO violated)", i, starts[i], want)
+		}
+	}
+}
+
+// TestMaxConcurrency_RetryRespectsLimit verifies that a node
+// scheduled via the retry path also goes through the
+// concurrency-cap gate. Without the gate, a retry could squeeze
+// in while a sibling is still in-flight under cap=1.
+func TestMaxConcurrency_RetryRespectsLimit(t *testing.T) {
+	mockCtx := newSeededMockCtx(t)
+	var inFlight, peak atomic.Int32
+
+	var flakyCalls atomic.Int32
+	flaky := NewFunctionNode("flaky",
+		func(ctx agent.InvocationContext, input any) (string, error) {
+			defer bumpPeak(&inFlight, &peak)()
+			// Hold long enough that, if the cap were broken, a
+			// sibling could sneak in.
+			time.Sleep(20 * time.Millisecond)
+			if flakyCalls.Add(1) == 1 {
+				return "", errors.New("retryable")
+			}
+			return "ok", nil
+		},
+		NodeConfig{
+			RetryConfig: &RetryConfig{
+				MaxAttempts:   3,
+				InitialDelay:  10 * time.Millisecond,
+				MaxDelay:      10 * time.Millisecond,
+				BackoffFactor: 1.0,
+				ShouldRetry:   func(error) bool { return true },
+			},
+		},
+	)
+	stable := NewFunctionNode("stable",
+		func(ctx agent.InvocationContext, input any) (string, error) {
+			defer bumpPeak(&inFlight, &peak)()
+			time.Sleep(20 * time.Millisecond)
+			return "ok", nil
+		},
+		defaultNodeConfig,
+	)
+
+	w, err := New("", fanOutFromStart([]Node{flaky, stable}), WithMaxConcurrency(1))
+	if err != nil {
+		t.Fatalf("New: %v", err)
+	}
+	drain(t, w.Run(mockCtx))
+
+	if got := peak.Load(); got > 1 {
+		t.Errorf("peak in-flight = %d, want <= 1 (retry bypassed cap)", got)
+	}
+	if got := flakyCalls.Load(); got < 2 {
+		t.Errorf("flaky calls = %d, want >= 2 (retry never happened)", got)
+	}
+}

--- a/workflow/resume.go
+++ b/workflow/resume.go
@@ -80,7 +80,7 @@ func (w *Workflow) Resume(
 			return
 		}
 
-		s := newScheduler(ctx, w.graph)
+		s := newScheduler(ctx, w.graph, w.maxConcurrency)
 		s.state = state
 
 		// Resume runs in two passes so that when one call

--- a/workflow/scheduler.go
+++ b/workflow/scheduler.go
@@ -93,6 +93,30 @@ type scheduler struct {
 	wg         sync.WaitGroup
 
 	parentCtx agent.InvocationContext
+
+	// maxConcurrency caps len(runsByName); 0 disables the cap.
+	// When at the cap, scheduleResumedNode enqueues into
+	// pendingQueue (status NodePending) and the consumer drains
+	// pendingQueue via tryDispatchPending on each completion.
+	// Set once at construction; immutable thereafter.
+	maxConcurrency int
+
+	// pendingQueue holds activations queued while the
+	// concurrency cap is saturated. FIFO; nodes are dispatched
+	// in arrival order as in-flight nodes complete. Owned by the
+	// consumer goroutine.
+	pendingQueue []pendingActivation
+}
+
+// pendingActivation is a deferred scheduleResumedNode call kept on
+// the consumer-owned pendingQueue while the concurrency cap is
+// saturated. Drained by tryDispatchPending on each completion.
+type pendingActivation struct {
+	node         Node
+	input        any
+	triggeredBy  string
+	branch       string
+	resumeInputs map[string]any // nil for non-resume schedules
 }
 
 // nodeRun is the per-node consumer-side accumulator. It buffers the
@@ -196,16 +220,23 @@ func (retryItem) isQueueItem() {}
 // newScheduler returns an initialised scheduler ready for the
 // consumer to drive. The caller is responsible for seeding the
 // initial trigger (typically Start with the user input).
-func newScheduler(parent agent.InvocationContext, g *graph) *scheduler {
+//
+// maxConcurrency caps len(runsByName) at any point in time:
+// scheduleResumedNode enqueues into pendingQueue when the cap is
+// reached, and the consumer drains the queue via
+// tryDispatchPending as in-flight nodes complete. 0 disables the
+// cap (unlimited).
+func newScheduler(parent agent.InvocationContext, g *graph, maxConcurrency int) *scheduler {
 	return &scheduler{
-		state:       NewRunState(),
-		graph:       g,
-		nodesByName: buildNodesByName(g),
-		runsByName:  map[string]*nodeRun{},
-		runCancels:  map[string]context.CancelFunc{},
-		retryTimers: map[string]*time.Timer{},
-		eventQueue:  make(chan queueItem, defaultEventQueueCapacity),
-		parentCtx:   parent,
+		state:          NewRunState(),
+		graph:          g,
+		nodesByName:    buildNodesByName(g),
+		runsByName:     map[string]*nodeRun{},
+		runCancels:     map[string]context.CancelFunc{},
+		retryTimers:    map[string]*time.Timer{},
+		eventQueue:     make(chan queueItem, defaultEventQueueCapacity),
+		parentCtx:      parent,
+		maxConcurrency: maxConcurrency,
 	}
 }
 
@@ -235,9 +266,34 @@ func buildNodesByName(g *graph) map[string]Node {
 // filter) and gets stamped onto every emitted event when the node
 // leaves Event.Branch empty.
 //
+// When the engine's max-concurrency cap is reached, the activation
+// is enqueued instead of started; the node enters NodePending and
+// the scheduler dispatches it as in-flight nodes complete.
+//
 // scheduleNode runs only on the consumer goroutine.
 func (s *scheduler) scheduleNode(n Node, input any, triggeredBy, branch string) {
 	s.scheduleResumedNode(n, input, triggeredBy, branch, nil)
+}
+
+// atConcurrencyLimit reports whether the number of in-flight
+// activations has reached the configured cap. Always false when
+// maxConcurrency is 0 (unlimited).
+func (s *scheduler) atConcurrencyLimit() bool {
+	return s.maxConcurrency > 0 && len(s.runsByName) >= s.maxConcurrency
+}
+
+// tryDispatchPending starts as many queued activations as the
+// current concurrency budget allows. FIFO over pendingQueue;
+// stops when the queue is empty or the cap is reached again.
+//
+// Called after every completion (and after retry-timer expiry)
+// to make room-becoming-available immediately observable.
+func (s *scheduler) tryDispatchPending() {
+	for len(s.pendingQueue) > 0 && !s.atConcurrencyLimit() {
+		next := s.pendingQueue[0]
+		s.pendingQueue = s.pendingQueue[1:]
+		s.startNode(next.node, next.input, next.triggeredBy, next.branch, next.resumeInputs)
+	}
 }
 
 // scheduleResumedNode is like scheduleNode but additionally
@@ -247,8 +303,38 @@ func (s *scheduler) scheduleNode(n Node, input any, triggeredBy, branch string) 
 // InterruptID; nil disables re-entry semantics and yields the same
 // behaviour as scheduleNode.
 //
+// When the engine's max-concurrency cap is reached, the
+// activation is enqueued onto pendingQueue and the node enters
+// NodePending instead of starting immediately. tryDispatchPending
+// drains the queue as in-flight nodes complete.
+//
 // scheduleResumedNode runs only on the consumer goroutine.
 func (s *scheduler) scheduleResumedNode(n Node, input any, triggeredBy, branch string, resumeInputs map[string]any) {
+	if s.atConcurrencyLimit() {
+		name := n.Name()
+		ns := s.state.EnsureNode(name)
+		ns.Status = NodePending
+		ns.Input = input
+		ns.TriggeredBy = triggeredBy
+		ns.Branch = branch
+		s.pendingQueue = append(s.pendingQueue, pendingActivation{
+			node:         n,
+			input:        input,
+			triggeredBy:  triggeredBy,
+			branch:       branch,
+			resumeInputs: resumeInputs,
+		})
+		return
+	}
+	s.startNode(n, input, triggeredBy, branch, resumeInputs)
+}
+
+// startNode is the unguarded core of scheduleResumedNode: it
+// creates the per-node context, registers bookkeeping, and
+// launches the runner goroutine. Always honours the call; the
+// concurrency-cap check is done by scheduleResumedNode (the
+// public entry point) before reaching here.
+func (s *scheduler) startNode(n Node, input any, triggeredBy, branch string, resumeInputs map[string]any) {
 	name := n.Name()
 
 	// Per-node context: WithTimeout when Config().Timeout > 0,
@@ -380,6 +466,11 @@ func runNode(
 // before observing ctx.Done(); the consumer continues draining
 // until runsByName is empty.
 //
+// Also drops the pendingQueue so queued (NodePending) activations
+// do not start after cancellation. Their NodeState is left as
+// NodePending — the surrounding RunState snapshot preserves the
+// fact that they were ready-but-not-yet-started.
+//
 // cancelAll runs only on the consumer goroutine.
 func (s *scheduler) cancelAll() {
 	for _, cancel := range s.runCancels {
@@ -389,6 +480,7 @@ func (s *scheduler) cancelAll() {
 		t.Stop()
 	}
 	s.retryTimers = nil
+	s.pendingQueue = nil
 }
 
 // run is the single-consumer loop. It drains the eventQueue, applies
@@ -439,6 +531,11 @@ func (s *scheduler) run(yield func(*session.Event, error) bool) {
 					draining = true
 					s.cancelAll()
 				}
+			}
+			// A slot just freed up; promote any queued
+			// activations to running.
+			if !draining {
+				s.tryDispatchPending()
 			}
 		case retryItem:
 			delete(s.retryTimers, it.node.Name())

--- a/workflow/workflow.go
+++ b/workflow/workflow.go
@@ -136,6 +136,38 @@ type Workflow struct {
 	// workflow's RunState is persisted in session.State. Empty
 	// disables persistence. Set at construction by New.
 	name string
+
+	// maxConcurrency caps the number of graph-scheduled nodes that
+	// may run concurrently within a single Run invocation. 0
+	// (the default) means unlimited. Set via WithMaxConcurrency.
+	maxConcurrency int
+}
+
+// Option configures a Workflow at construction time. Pass options
+// as trailing variadic arguments to New.
+type Option func(*workflowOptions)
+
+// workflowOptions holds the resolved settings derived from the
+// caller's Option list. Zero values mean "no override / use
+// engine defaults".
+type workflowOptions struct {
+	maxConcurrency int
+}
+
+// WithMaxConcurrency caps how many graph-scheduled nodes may run
+// concurrently in a single Workflow invocation; nodes beyond the
+// cap queue as NodePending. n <= 0 disables the cap (unlimited).
+//
+// Does NOT apply to dynamic sub-nodes invoked via workflow.RunNode
+// from inside a DynamicNode body — they are awaited inline by the
+// parent and gating them would deadlock.
+func WithMaxConcurrency(n int) Option {
+	return func(o *workflowOptions) {
+		if n < 0 {
+			n = 0
+		}
+		o.maxConcurrency = n
+	}
 }
 
 // New creates a new Workflow engine with the given name and edges.
@@ -151,7 +183,10 @@ type Workflow struct {
 // An empty name disables persistence: the workflow runs normally
 // but its RunState is neither saved nor loaded, so Resume on a
 // follow-up turn will find nothing to resume from.
-func New(name string, edges []Edge) (*Workflow, error) {
+//
+// Optional Option values configure engine behaviour
+// (concurrency cap, etc.); see WithMaxConcurrency.
+func New(name string, edges []Edge, opts ...Option) (*Workflow, error) {
 	if err := validateNodes(edges); err != nil {
 		return nil, err
 	}
@@ -169,7 +204,15 @@ func New(name string, edges []Edge) (*Workflow, error) {
 	if err := validateWorkflow(graph); err != nil {
 		return nil, err
 	}
-	return &Workflow{graph: graph, name: name}, nil
+	var o workflowOptions
+	for _, opt := range opts {
+		opt(&o)
+	}
+	return &Workflow{
+		graph:          graph,
+		name:           name,
+		maxConcurrency: o.maxConcurrency,
+	}, nil
 }
 
 // Name returns the workflow's persistence-namespacing name as set
@@ -199,7 +242,7 @@ func (w *Workflow) Run(ctx agent.InvocationContext) iter.Seq2[*session.Event, er
 // This is used by WorkflowNode to run nested workflows.
 func (w *Workflow) RunNode(ctx agent.InvocationContext, input any) iter.Seq2[*session.Event, error] {
 	return func(yield func(*session.Event, error) bool) {
-		s := newScheduler(ctx, w.graph)
+		s := newScheduler(ctx, w.graph, w.maxConcurrency)
 		// Seed: schedule START with the supplied input.
 		startState := s.state.EnsureNode(Start.Name())
 		startState.Input = input


### PR DESCRIPTION
Adds a workflow-level concurrency cap that limits how many nodes may
run concurrently within a single `Workflow` invocation. When the cap
is reached, additional ready-to-run nodes enter `NodePending` and
queue in FIFO order; the scheduler drains the queue as in-flight
nodes complete.

Mirrors adk-python's `Workflow.max_concurrency` 

## API

```go
w, err := workflow.New("my_workflow", edges, workflow.WithMaxConcurrency(4))
```

- `n > 0`: cap is enforced.
- `n == 0` (default): unlimited — no behavioural change for existing callers.
- `n < 0`: clamped to 0 (unlimited); defensive.