### PR TITLE
fix: accept metadata-only SSE chunks instead of aborting stream in StreamingResponseAggregator

### DIFF
--- a/internal/llminternal/converters/converters.go
+++ b/internal/llminternal/converters/converters.go
@@ -56,9 +56,17 @@ func Genai2LLMResponse(res *genai.GenerateContentResponse) *model.LLMResponse {
 			ModelVersion:  res.ModelVersion,
 		}
 	}
+	// no candidates, no prompt feedback.
+	// Sometimes gemini-3* invoked via aiplatform (VertexAI) sends empty entries at the beginning.
+	// sample stream of SSE chunks (first 3):
+	// data: {"candidates": [{"content": {"role": "model","parts": [{"text": ""}]}}],"usageMetadata": {"trafficType": "ON_DEMAND"},"modelVersion": "gemini-3.1-flash-lite","createTime": "2026-05-28T09:40:03.380865Z","responseId": "REDACTED"}
+	//
+	// data: {"usageMetadata": {"trafficType": "ON_DEMAND"},"modelVersion": "gemini-3.1-flash-lite","createTime": "2026-05-28T09:40:03.380865Z","responseId": "REDACTED"}
+	//
+	// data: {"usageMetadata": {"trafficType": "ON_DEMAND"},"modelVersion": "gemini-3.1-flash-lite","createTime": "2026-05-28T09:40:03.380865Z","responseId": "REDACTED"}
+	// we should treat them as valid, empty responses and let the downstream to process usageMetadata
 	return &model.LLMResponse{
-		ErrorCode:     "UNKNOWN_ERROR",
-		ErrorMessage:  "Unknown error.",
+		Content:       &genai.Content{Parts: []*genai.Part{}, Role: "model"},
 		UsageMetadata: usageMetadata,
 		ModelVersion:  res.ModelVersion,
 	}

--- a/internal/llminternal/stream_aggregator.go
+++ b/internal/llminternal/stream_aggregator.go
@@ -16,7 +16,6 @@ package llminternal
 
 import (
 	"context"
-	"fmt"
 	"iter"
 	"maps"
 	"reflect"
@@ -60,8 +59,10 @@ func NewStreamingResponseAggregator() *streamingResponseAggregator {
 func (s *streamingResponseAggregator) ProcessResponse(ctx context.Context, genResp *genai.GenerateContentResponse) iter.Seq2[*model.LLMResponse, error] {
 	return func(yield func(*model.LLMResponse, error) bool) {
 		if len(genResp.Candidates) == 0 {
-			// shouldn't happen?
-			yield(nil, fmt.Errorf("empty response"))
+			// Vertex AI occasionally emits leading SSE chunks that contain only
+			// response metadata (createTime, modelVersion, usageMetadata, etc.)
+			// but no Candidates. These are valid and should be skipped; the actual
+			// content arrives in subsequent chunks.
 			return
 		}
 		candidate := genResp.Candidates[0]

--- a/internal/llminternal/stream_aggregator.go
+++ b/internal/llminternal/stream_aggregator.go
@@ -58,16 +58,11 @@ func NewStreamingResponseAggregator() *streamingResponseAggregator {
 // also yielding an aggregated response if the GenerateContentResponse has zero parts or is audio data
 func (s *streamingResponseAggregator) ProcessResponse(ctx context.Context, genResp *genai.GenerateContentResponse) iter.Seq2[*model.LLMResponse, error] {
 	return func(yield func(*model.LLMResponse, error) bool) {
-		if len(genResp.Candidates) == 0 {
-			// Vertex AI occasionally emits leading SSE chunks that contain only
-			// response metadata (createTime, modelVersion, usageMetadata, etc.)
-			// but no Candidates. These are valid and should be skipped; the actual
-			// content arrives in subsequent chunks.
-			return
-		}
-		candidate := genResp.Candidates[0]
 		resp := converters.Genai2LLMResponse(genResp)
-		resp.TurnComplete = candidate.FinishReason != ""
+		if len(genResp.Candidates) > 0 {
+			candidate := genResp.Candidates[0]
+			resp.TurnComplete = candidate.FinishReason != ""
+		}
 		// Aggregate the response and check if an intermediate event to yield was created
 		if aggrResp := s.aggregateResponse(resp); aggrResp != nil {
 			if !yield(aggrResp, nil) {

--- a/internal/llminternal/stream_aggregator_test.go
+++ b/internal/llminternal/stream_aggregator_test.go
@@ -1001,6 +1001,53 @@ func TestPartialFunctionCallsNotExecutedInNoneStreamingMode(t *testing.T) {
 	}
 }
 
+func TestMetadataOnlyChunkDoesNotAbortStream(t *testing.T) {
+	aggregator := llminternal.NewStreamingResponseAggregator()
+	ctx := t.Context()
+
+	// Simulate the leading metadata-only SSE chunk that Vertex AI emits for
+	// gemini-3-flash-preview + googleSearch grounding: no Candidates at all.
+	metadataChunk := &genai.GenerateContentResponse{
+		// Candidates is intentionally nil / empty.
+		UsageMetadata: &genai.GenerateContentResponseUsageMetadata{},
+	}
+
+	// The real content arrives in the next chunk.
+	contentChunk := &genai.GenerateContentResponse{
+		Candidates: []*genai.Candidate{
+			{
+				Content: &genai.Content{
+					Role:  "model",
+					Parts: []*genai.Part{{Text: "Here are some movie recommendations."}},
+				},
+				FinishReason: genai.FinishReasonStop,
+			},
+		},
+	}
+
+	for _, chunk := range []*genai.GenerateContentResponse{metadataChunk, contentChunk} {
+		for resp, err := range aggregator.ProcessResponse(ctx, chunk) {
+			if err != nil {
+				t.Fatalf("unexpected error processing chunk: %v", err)
+			}
+			_ = resp
+		}
+	}
+
+	finalResponse := aggregator.Close()
+	if finalResponse == nil {
+		t.Fatal("expected a final aggregated response, got nil")
+	}
+
+	if len(finalResponse.Content.Parts) == 0 {
+		t.Fatal("expected content parts in the final response, got none")
+	}
+
+	if finalResponse.Content.Parts[0].Text != "Here are some movie recommendations." {
+		t.Errorf("unexpected text in final response: %q", finalResponse.Content.Parts[0].Text)
+	}
+}
+
 func TestFinishReasonUnexpectedToolCallPreservesErrorCode(t *testing.T) {
 	aggregator := llminternal.NewStreamingResponseAggregator()
 	ctx := t.Context()

--- a/internal/llminternal/stream_aggregator_test.go
+++ b/internal/llminternal/stream_aggregator_test.go
@@ -1001,6 +1001,61 @@ func TestPartialFunctionCallsNotExecutedInNoneStreamingMode(t *testing.T) {
 	}
 }
 
+func TestMetadataVertexAISSEStream(t *testing.T) {
+	aggregator := llminternal.NewStreamingResponseAggregator()
+	ctx := t.Context()
+
+	emptyTextChunk := &genai.GenerateContentResponse{
+		Candidates: []*genai.Candidate{
+			{Content: genai.NewContentFromText("", "model")}},
+		UsageMetadata: &genai.GenerateContentResponseUsageMetadata{},
+	}
+
+	// Simulate the leading metadata-only SSE chunk that Vertex AI emits for
+	// gemini-3-flash-preview + googleSearch grounding: no Candidates at all.
+	metadataChunk := &genai.GenerateContentResponse{
+		// Candidates is intentionally nil / empty.
+		UsageMetadata: &genai.GenerateContentResponseUsageMetadata{},
+	}
+
+	// The real content arrives in the next chunk.
+	contentChunk := &genai.GenerateContentResponse{
+		Candidates: []*genai.Candidate{
+			{
+				Content: &genai.Content{
+					Role:  "model",
+					Parts: []*genai.Part{{Text: "Here are some movie recommendations."}},
+				},
+				FinishReason: genai.FinishReasonStop,
+			},
+		},
+	}
+
+	stream := []*genai.GenerateContentResponse{emptyTextChunk, metadataChunk, metadataChunk, emptyTextChunk, metadataChunk, metadataChunk, contentChunk}
+
+	for _, chunk := range stream {
+		for resp, err := range aggregator.ProcessResponse(ctx, chunk) {
+			if err != nil {
+				t.Fatalf("unexpected error processing chunk: %v", err)
+			}
+			_ = resp
+		}
+	}
+
+	finalResponse := aggregator.Close()
+	if finalResponse == nil {
+		t.Fatal("expected a final aggregated response, got nil")
+	}
+
+	if len(finalResponse.Content.Parts) == 0 {
+		t.Fatal("expected content parts in the final response, got none")
+	}
+
+	if finalResponse.Content.Parts[0].Text != "Here are some movie recommendations." {
+		t.Errorf("unexpected text in final response: %q", finalResponse.Content.Parts[0].Text)
+	}
+}
+
 func TestMetadataOnlyChunkDoesNotAbortStream(t *testing.T) {
 	aggregator := llminternal.NewStreamingResponseAggregator()
 	ctx := t.Context()

--- a/internal/llminternal/stream_aggregator_test.go
+++ b/internal/llminternal/stream_aggregator_test.go
@@ -1007,7 +1007,8 @@ func TestMetadataVertexAISSEStream(t *testing.T) {
 
 	emptyTextChunk := &genai.GenerateContentResponse{
 		Candidates: []*genai.Candidate{
-			{Content: genai.NewContentFromText("", "model")}},
+			{Content: genai.NewContentFromText("", "model")},
+		},
 		UsageMetadata: &genai.GenerateContentResponseUsageMetadata{},
 	}
 


### PR DESCRIPTION
Modified version of https://github.com/google/adk-go/pull/783

Instead of ignoring the SSE chunks with no candidates, this version accepts them and passes them downstream to further processing (they contain usageMetadata)

