### PR TITLE
docs(examples/workflow): add a WithUseAsOutput sample

### DIFF
--- a/examples/workflow/README.md
+++ b/examples/workflow/README.md
@@ -37,6 +37,7 @@ export GOOGLE_CLOUD_LOCATION=your-region
 | [`dynamic/basic`](./dynamic/basic) | Dynamic | Orchestrate children imperatively in Go via `NewDynamicNode` + `RunNode` | No |
 | [`dynamic/hitl`](./dynamic/hitl) | Dynamic | Dynamic orchestrator that pauses for human input and resumes | No |
 | [`dynamic/llm`](./dynamic/llm) | Dynamic | Dynamic orchestrator invoking an `LlmAgent` node via `RunNode` | Yes |
+| [`dynamic/use_as_output`](./dynamic/use_as_output) | Dynamic | Promote a child's output to the orchestrator's own with `WithUseAsOutput` | Yes |
 
 ## Core concepts at a glance
 

--- a/examples/workflow/dynamic/use_as_output/README.md
+++ b/examples/workflow/dynamic/use_as_output/README.md
@@ -8,7 +8,8 @@ ordinary `return`.
 
 - **Concept:** Promote a child's output to the parent dynamic node's terminal
   output with `workflow.RunNode(..., workflow.WithUseAsOutput())`.
-- **Needs LLM?** Yes (Gemini), on the delegating branch only
+- **Needs LLM?** Yes (Gemini). Only the delegating branch calls the model, but
+  credentials are needed to start either one.
 
 ## Goal
 
@@ -18,11 +19,12 @@ That works, but it emits the same content twice: once on the child's event and
 once on the orchestrator's terminal event.
 
 `WithUseAsOutput()` removes the second one. The child's event is stamped as the
-parent's output and the parent emits no terminal event of its own, so an
-`LlmAgent` child's reply reaches the caller exactly once, authored by the agent
-rather than by the workflow.
+parent's output and the parent emits no terminal event of its own, so the
+`LlmAgent` child's reply is carried by exactly one event, authored by the agent
+rather than by the workflow. The console prints the reply once either way, so
+the saving shows up in the event stream and not in the transcript below.
 
-The sample puts both behaviors in one node so the difference is visible from the
+The sample puts both branches in one node so either can be exercised from the
 console: type a request mentioning an email to take the delegating branch, or
 anything else to take the plain-return branch.
 
@@ -41,6 +43,11 @@ export GOOGLE_CLOUD_PROJECT=your-project
 export GOOGLE_CLOUD_LOCATION=your-region   # e.g. us-central1
 ```
 
+The model client is built at startup, before the guard runs, so with neither set
+the sample exits with `api key is required for Google AI backend` instead of
+showing a prompt. That applies to the out-of-scope branch too, even though it
+never calls the model.
+
 ## Workflow
 
 ```mermaid
@@ -50,17 +57,18 @@ graph LR
         Start((Start)) --> A[Dynamic Node: assistant]
         A -.->|"2. guard runs in Go"| Q{"is request in scope?"}
         Q -.->|"3a. yes: RunNode + WithUseAsOutput"| D[Agent Node: drafter LLM]
-        D -.->|"the drafter's own event is the output"| End((End))
+        D -.->|"4. the drafter's own event is the output"| End((End))
         Q -.->|"3b. no: plain return, no model call"| End
     end
     User -- "1. request" --> Start
-    End -- "4. reply" --> User
+    End -- "5. reply" --> User
 ```
 
-Solid arrows are static graph edges. Everything dotted happens inside the
-orchestrator's Go body: the `isEmailRequest` guard, the imperative `RunNode`
-call, and the output each branch produces. Exactly one of `3a` and `3b` runs per
-turn.
+`Start → assistant` is the only static graph edge, drawn solid. The dotted
+arrows are the orchestrator's Go body at work: the `isEmailRequest` guard, the
+imperative `RunNode` call, and the output each branch produces. `End` marks the
+end of the run rather than a node — `assistant` is the last node in the graph.
+Exactly one of `3a` and `3b` runs per turn.
 
 ## Running the sample
 
@@ -77,12 +85,12 @@ runs does not — it is decided in Go.
 User -> what is the weather today
 Agent -> Out of scope. Ask me to draft an email.
 
-User -> email the team that Friday standup is cancelled
-Agent -> Subject: Cancelled: Friday Standup
+User -> email the team that Friday standup is canceled
+Agent -> Subject: Canceled: Friday Standup Meeting
 Hi Team,
-Please note that our standup meeting scheduled for this Friday is cancelled. We will resume our regular standup schedule on Monday.
-If you have any urgent updates or blockers before the weekend, please feel free to share them in our team chat.
-Best regards,
+Please note that our daily standup meeting scheduled for this Friday is canceled.
+If you have any urgent updates or blockers, please share them in our team chat. We will resume our regular standup schedule on Monday.
+Have a great weekend,
 [Your Name]
 ```
 
@@ -90,12 +98,20 @@ Best regards,
 
 | Concept | Where |
 |---|---|
-| `workflow.WithUseAsOutput()` | passed to `RunNode` on the in-scope branch, promoting the drafter's output to `assistant`'s terminal output |
+| `workflow.WithUseAsOutput()` | passed to `RunNode` on the in-scope branch, promoting the drafter's output to `assistant`'s terminal output, carried on the drafter's own event |
 | Delegation suppresses the parent's terminal event | the drafter's reply is emitted once, authored by `drafter`, and `assistant` emits no event of its own |
 | Plain return as output | the out-of-scope branch returns a string from the body, which becomes `assistant`'s terminal output |
 | Registering a wrapped agent | `SubAgents: []agent.Agent{drafterAgent}` lets the runner resolve `drafter` as the event author |
 
 ## Notes
+
+### The delegating node is the last node in this graph
+
+A delegated value travels on the child's event and is not recorded as the parent
+node's own output, so a node chained after a delegating dynamic node receives the
+zero value rather than the delegated text — silently, with no error. That is why
+`assistant` has no successor here. Chaining after a plain `RunNode` behaves
+normally, because there the parent emits a terminal event of its own.
 
 ### Why the branch is decided in plain Go
 

--- a/examples/workflow/dynamic/use_as_output/README.md
+++ b/examples/workflow/dynamic/use_as_output/README.md
@@ -51,24 +51,27 @@ never calls the model.
 ## Workflow
 
 ```mermaid
-graph LR
-    User[User]
-    subgraph "ADK Application Workflow"
-        Start((Start)) --> A[Dynamic Node: assistant]
-        A -.->|"2. guard runs in Go"| Q{"is request in scope?"}
-        Q -.->|"3a. yes: RunNode + WithUseAsOutput"| D[Agent Node: drafter LLM]
-        D -.->|"4. the drafter's own event is the output"| End((End))
-        Q -.->|"3b. no: plain return, no model call"| End
+sequenceDiagram
+    actor User
+    participant A as assistant<br/>(dynamic node)
+    participant D as drafter<br/>(LlmAgent node)
+
+    User->>A: request
+    Note over A: isEmailRequest(request) decides in Go,<br/>before any model call
+
+    alt in scope
+        A->>D: RunNode(request, WithUseAsOutput())
+        D-->>User: the drafter's own event carries the output
+        Note over A: assistant emits no event of its own
+    else out of scope
+        A-->>User: assistant returns its own string
     end
-    User -- "1. request" --> Start
-    End -- "5. reply" --> User
 ```
 
-`Start → assistant` is the only static graph edge, drawn solid. The dotted
-arrows are the orchestrator's Go body at work: the `isEmailRequest` guard, the
-imperative `RunNode` call, and the output each branch produces. `End` marks the
-end of the run rather than a node — `assistant` is the last node in the graph.
-Exactly one of `3a` and `3b` runs per turn.
+The arrow back to the user is the whole point: on the delegating branch it
+leaves `drafter`, not `assistant`. `assistant` is also the graph's last node —
+`Start → assistant` is its only static edge, and everything else above happens
+inside the orchestrator's Go body.
 
 ## Running the sample
 
@@ -86,11 +89,12 @@ User -> what is the weather today
 Agent -> Out of scope. Ask me to draft an email.
 
 User -> email the team that Friday standup is canceled
-Agent -> Subject: Canceled: Friday Standup Meeting
+Agent -> Subject: Friday Standup Canceled
 Hi Team,
-Please note that our daily standup meeting scheduled for this Friday is canceled.
-If you have any urgent updates or blockers, please share them in our team chat. We will resume our regular standup schedule on Monday.
-Have a great weekend,
+Please note that our standup meeting this Friday is canceled.
+If you have any urgent updates or blockers to share, please post them in our team channel. Otherwise, we will resume our regular schedule next week.
+Have a great weekend!
+Best regards,
 [Your Name]
 ```
 
@@ -131,5 +135,5 @@ stamped for the whole ancestor chain.
 
 ### Tunable: pick a different model
 
-Edit `gemini-flash-latest` in `main.go` to whatever model your credentials have
+Edit `gemini-3.5-flash` in `main.go` to whatever model your credentials have
 access to. The drafter prompt is short and any modern Gemini model handles it.

--- a/examples/workflow/dynamic/use_as_output/README.md
+++ b/examples/workflow/dynamic/use_as_output/README.md
@@ -1,0 +1,119 @@
+# Dynamic workflow + output delegation
+
+A dynamic orchestrator that hands its terminal output to a child node instead
+of producing one. An in-scope request is delegated to an `LlmAgent` child with
+`workflow.WithUseAsOutput()`, so the agent's own event *is* the orchestrator's
+output. An out-of-scope request is answered by the orchestrator itself with an
+ordinary `return`.
+
+- **Concept:** Promote a child's output to the parent dynamic node's terminal
+  output with `workflow.RunNode(..., workflow.WithUseAsOutput())`.
+- **Needs LLM?** Yes (Gemini), on the delegating branch only
+
+## Goal
+
+By default a dynamic node's output is whatever its Go body returns, so
+delegating to a child means capturing the child's value and returning it again.
+That works, but it emits the same content twice: once on the child's event and
+once on the orchestrator's terminal event.
+
+`WithUseAsOutput()` removes the second one. The child's event is stamped as the
+parent's output and the parent emits no terminal event of its own, so an
+`LlmAgent` child's reply reaches the caller exactly once, authored by the agent
+rather than by the workflow.
+
+The sample puts both behaviors in one node so the difference is visible from the
+console: type a request mentioning an email to take the delegating branch, or
+anything else to take the plain-return branch.
+
+## Authentication
+
+The model client reads its config from the environment, so set one of:
+
+```bash
+# Option A — Gemini API key
+export GOOGLE_API_KEY=...
+
+# Option B — Vertex AI via gcloud Application Default Credentials
+gcloud auth application-default login
+export GOOGLE_GENAI_USE_VERTEXAI=true
+export GOOGLE_CLOUD_PROJECT=your-project
+export GOOGLE_CLOUD_LOCATION=your-region   # e.g. us-central1
+```
+
+## Workflow
+
+```mermaid
+graph LR
+    User[User]
+    subgraph "ADK Application Workflow"
+        Start((Start)) --> A[Dynamic Node: assistant]
+        A -.->|"2. guard runs in Go"| Q{"is request in scope?"}
+        Q -.->|"3a. yes: RunNode + WithUseAsOutput"| D[Agent Node: drafter LLM]
+        D -.->|"the drafter's own event is the output"| End((End))
+        Q -.->|"3b. no: plain return, no model call"| End
+    end
+    User -- "1. request" --> Start
+    End -- "4. reply" --> User
+```
+
+Solid arrows are static graph edges. Everything dotted happens inside the
+orchestrator's Go body: the `isEmailRequest` guard, the imperative `RunNode`
+call, and the output each branch produces. Exactly one of `3a` and `3b` runs per
+turn.
+
+## Running the sample
+
+```bash
+go run ./examples/workflow/dynamic/use_as_output/ console
+```
+
+## Example session
+
+The email wording comes from the model, so it varies between runs. Which branch
+runs does not — it is decided in Go.
+
+```text
+User -> what is the weather today
+Agent -> Out of scope. Ask me to draft an email.
+
+User -> email the team that Friday standup is cancelled
+Agent -> Subject: Cancelled: Friday Standup
+Hi Team,
+Please note that our standup meeting scheduled for this Friday is cancelled. We will resume our regular standup schedule on Monday.
+If you have any urgent updates or blockers before the weekend, please feel free to share them in our team chat.
+Best regards,
+[Your Name]
+```
+
+## What it shows
+
+| Concept | Where |
+|---|---|
+| `workflow.WithUseAsOutput()` | passed to `RunNode` on the in-scope branch, promoting the drafter's output to `assistant`'s terminal output |
+| Delegation suppresses the parent's terminal event | the drafter's reply is emitted once, authored by `drafter`, and `assistant` emits no event of its own |
+| Plain return as output | the out-of-scope branch returns a string from the body, which becomes `assistant`'s terminal output |
+| Registering a wrapped agent | `SubAgents: []agent.Agent{drafterAgent}` lets the runner resolve `drafter` as the event author |
+
+## Notes
+
+### Why the branch is decided in plain Go
+
+The guard is a substring check on the user's request, not a model call or a
+length check on generated text. That keeps both branches reachable on demand, so
+the run above reproduces. A guard that depends on model output would make which
+branch runs vary per run, which is the wrong property for a sample whose whole
+point is the difference between the two branches.
+
+### One delegation per activation
+
+`WithUseAsOutput()` may be used on at most one child per parent activation. A
+second delegating `RunNode` call in the same body fails with
+`workflow.ErrOutputAlreadyDelegated`. Delegation also chains: if the delegated
+child is itself a dynamic node that delegates, the innermost child's event is
+stamped for the whole ancestor chain.
+
+### Tunable: pick a different model
+
+Edit `gemini-flash-latest` in `main.go` to whatever model your credentials have
+access to. The drafter prompt is short and any modern Gemini model handles it.

--- a/examples/workflow/dynamic/use_as_output/main.go
+++ b/examples/workflow/dynamic/use_as_output/main.go
@@ -93,7 +93,6 @@ func main() {
 			if err != nil {
 				return "", err
 			}
-			log.Println("Draft: ", len(draft))
 			if len(draft) <= maxDraftChars {
 				// Happy path: delegate so the sender's confirmation
 				// becomes orchestrate's output and flows downstream.

--- a/examples/workflow/dynamic/use_as_output/main.go
+++ b/examples/workflow/dynamic/use_as_output/main.go
@@ -37,7 +37,7 @@ import (
 )
 
 // Drafts longer than this are sent back to the reviser.
-const maxDraftChars = 400
+const maxDraftChars = 60
 
 func main() {
 	ctx := context.Background()
@@ -78,20 +78,22 @@ func main() {
 
 	// sender mocks delivery; a real system would call the outbound
 	// mail API here.
-	senderNode := workflow.NewFunctionNode("sender",
+	senderNode := workflow.NewFunctionNode(
+		"sender",
 		func(_ agent.InvocationContext, approvedDraft string) (string, error) {
 			return "EMAIL SENT — " + approvedDraft, nil
 		},
 		workflow.NodeConfig{},
 	)
 
-	orchestrate := workflow.NewDynamicNode[string, string]("orchestrate",
+	orchestrate := workflow.NewDynamicNode[string, string](
+		"orchestrate",
 		func(nc workflow.NodeContext, topic string, _ func(*session.Event) error) (string, error) {
 			draft, err := workflow.RunNode[string](nc, drafterNode, topic)
 			if err != nil {
 				return "", err
 			}
-
+			log.Println("Draft: ", len(draft))
 			if len(draft) <= maxDraftChars {
 				// Happy path: delegate so the sender's confirmation
 				// becomes orchestrate's output and flows downstream.
@@ -110,7 +112,8 @@ func main() {
 		workflow.NodeConfig{},
 	)
 
-	report := workflow.NewFunctionNode("report",
+	report := workflow.NewFunctionNode(
+		"report",
 		func(_ agent.InvocationContext, orchestrateOutput string) (string, error) {
 			return "REPORT: " + strings.TrimSpace(orchestrateOutput), nil
 		},

--- a/examples/workflow/dynamic/use_as_output/main.go
+++ b/examples/workflow/dynamic/use_as_output/main.go
@@ -1,0 +1,135 @@
+// Copyright 2026 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+// Conditional dispatch with WithUseAsOutput: an email drafter
+// generates a draft; the orchestrator either delegates to a sender
+// (happy path, WithUseAsOutput) or runs a reviser and composes its
+// own feedback (revise path, plain return).
+package main
+
+import (
+	"context"
+	"log"
+	"os"
+	"strings"
+
+	"google.golang.org/genai"
+
+	"google.golang.org/adk/agent"
+	"google.golang.org/adk/agent/llmagent"
+	"google.golang.org/adk/agent/workflowagent"
+	"google.golang.org/adk/cmd/launcher"
+	"google.golang.org/adk/cmd/launcher/full"
+	"google.golang.org/adk/model/gemini"
+	"google.golang.org/adk/session"
+	"google.golang.org/adk/workflow"
+)
+
+// Drafts longer than this are sent back to the reviser.
+const maxDraftChars = 400
+
+func main() {
+	ctx := context.Background()
+
+	model, err := gemini.NewModel(ctx, "gemini-3.1-flash-lite", &genai.ClientConfig{})
+	if err != nil {
+		log.Fatalf("gemini.NewModel: %v", err)
+	}
+
+	drafterAgent, err := llmagent.New(llmagent.Config{
+		Name:        "drafter",
+		Model:       model,
+		Description: "Drafts a short business email from a topic.",
+		Instruction: "Write a concise, polite business email about the topic the user provides.",
+	})
+	if err != nil {
+		log.Fatalf("llmagent.New drafter: %v", err)
+	}
+	drafterNode, err := workflow.NewAgentNode(drafterAgent, workflow.NodeConfig{})
+	if err != nil {
+		log.Fatalf("workflow.NewAgentNode drafter: %v", err)
+	}
+
+	reviserAgent, err := llmagent.New(llmagent.Config{
+		Name:        "reviser",
+		Model:       model,
+		Description: "Suggests how to shorten an over-long email draft.",
+		Instruction: "The user will send you an email draft that is too long. " +
+			"Reply with a one-paragraph suggestion on how to shorten it.",
+	})
+	if err != nil {
+		log.Fatalf("llmagent.New reviser: %v", err)
+	}
+	reviserNode, err := workflow.NewAgentNode(reviserAgent, workflow.NodeConfig{})
+	if err != nil {
+		log.Fatalf("workflow.NewAgentNode reviser: %v", err)
+	}
+
+	// sender mocks delivery; a real system would call the outbound
+	// mail API here.
+	senderNode := workflow.NewFunctionNode("sender",
+		func(_ agent.InvocationContext, approvedDraft string) (string, error) {
+			return "EMAIL SENT — " + approvedDraft, nil
+		},
+		workflow.NodeConfig{},
+	)
+
+	orchestrate := workflow.NewDynamicNode[string, string]("orchestrate",
+		func(nc workflow.NodeContext, topic string, _ func(*session.Event) error) (string, error) {
+			draft, err := workflow.RunNode[string](nc, drafterNode, topic)
+			if err != nil {
+				return "", err
+			}
+
+			if len(draft) <= maxDraftChars {
+				// Happy path: delegate so the sender's confirmation
+				// becomes orchestrate's output and flows downstream.
+				return workflow.RunNode[string](nc, senderNode, draft, workflow.WithUseAsOutput())
+			}
+
+			// Revise path: no WithUseAsOutput; the composed string
+			// below is what downstream sees.
+			feedback, err := workflow.RunNode[string](nc, reviserNode, draft)
+			if err != nil {
+				return "", err
+			}
+			return "NEEDS REVISION — original draft: " + draft +
+				" | reviser feedback: " + feedback, nil
+		},
+		workflow.NodeConfig{},
+	)
+
+	report := workflow.NewFunctionNode("report",
+		func(_ agent.InvocationContext, orchestrateOutput string) (string, error) {
+			return "REPORT: " + strings.TrimSpace(orchestrateOutput), nil
+		},
+		workflow.NodeConfig{},
+	)
+
+	wa, err := workflowagent.New(workflowagent.Config{
+		Name:        "use_as_output_sample",
+		Description: "Conditional dispatch: send-or-revise email workflow.",
+		Edges:       workflow.Chain(workflow.Start, orchestrate, report),
+	})
+	if err != nil {
+		log.Fatalf("workflowagent.New: %v", err)
+	}
+
+	l := full.NewLauncher()
+	if err := l.Execute(ctx, &launcher.Config{
+		AgentLoader: agent.NewSingleLoader(wa),
+	}, os.Args[1:]); err != nil {
+		log.Fatalf("Run failed: %v\n\n%s", err, l.CommandLineSyntax())
+	}
+}

--- a/examples/workflow/dynamic/use_as_output/main.go
+++ b/examples/workflow/dynamic/use_as_output/main.go
@@ -80,7 +80,7 @@ func main() {
 	// mail API here.
 	senderNode := workflow.NewFunctionNode(
 		"sender",
-		func(_ agent.InvocationContext, approvedDraft string) (string, error) {
+		func(_ agent.Context, approvedDraft string) (string, error) {
 			return "EMAIL SENT — " + approvedDraft, nil
 		},
 		workflow.NodeConfig{},
@@ -113,7 +113,7 @@ func main() {
 
 	report := workflow.NewFunctionNode(
 		"report",
-		func(_ agent.InvocationContext, orchestrateOutput string) (string, error) {
+		func(_ agent.Context, orchestrateOutput string) (string, error) {
 			return "REPORT: " + strings.TrimSpace(orchestrateOutput), nil
 		},
 		workflow.NodeConfig{},
@@ -122,7 +122,11 @@ func main() {
 	wa, err := workflowagent.New(workflowagent.Config{
 		Name:        "use_as_output_sample",
 		Description: "Conditional dispatch: send-or-revise email workflow.",
-		Edges:       workflow.Chain(workflow.Start, orchestrate, report),
+		// Register the wrapped LlmAgents so the runner can resolve
+		// their event authors; the sender is a FunctionNode, not an
+		// agent.Agent, so it is not listed here.
+		SubAgents: []agent.Agent{drafterAgent, reviserAgent},
+		Edges:     workflow.Chain(workflow.Start, orchestrate, report),
 	})
 	if err != nil {
 		log.Fatalf("workflowagent.New: %v", err)

--- a/examples/workflow/dynamic/use_as_output/main.go
+++ b/examples/workflow/dynamic/use_as_output/main.go
@@ -1,0 +1,106 @@
+// Copyright 2026 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+// Conditional output delegation in a dynamic workflow. The orchestrator
+// decides in plain Go whether a request is in scope: an in-scope request is
+// delegated to an LlmAgent child with workflow.WithUseAsOutput, so the agent's
+// own event becomes the orchestrator's terminal output, while an out-of-scope
+// request is answered by the orchestrator itself with an ordinary return.
+package main
+
+import (
+	"context"
+	"log"
+	"os"
+	"strings"
+
+	"google.golang.org/genai"
+
+	"google.golang.org/adk/v2/agent"
+	"google.golang.org/adk/v2/agent/llmagent"
+	"google.golang.org/adk/v2/agent/workflowagent"
+	"google.golang.org/adk/v2/cmd/launcher"
+	"google.golang.org/adk/v2/cmd/launcher/full"
+	"google.golang.org/adk/v2/model/gemini"
+	"google.golang.org/adk/v2/session"
+	"google.golang.org/adk/v2/workflow"
+)
+
+func main() {
+	ctx := context.Background()
+
+	model, err := gemini.NewModel(ctx, "gemini-flash-latest", &genai.ClientConfig{})
+	if err != nil {
+		log.Fatalf("gemini.NewModel: %v", err)
+	}
+
+	drafterAgent, err := llmagent.New(llmagent.Config{
+		Name:        "drafter",
+		Model:       model,
+		Description: "Writes a short business email for a request.",
+		Instruction: "Write a concise, polite business email for the request the user provides. " +
+			"Reply with the email text only.",
+	})
+	if err != nil {
+		log.Fatalf("llmagent.New: %v", err)
+	}
+	drafterNode, err := workflow.NewAgentNode(drafterAgent, workflow.NodeConfig{})
+	if err != nil {
+		log.Fatalf("workflow.NewAgentNode: %v", err)
+	}
+
+	assistant := workflow.NewDynamicNode[string, string]("assistant",
+		func(nc agent.Context, request string, _ func(*session.Event) error) (string, error) {
+			if !isEmailRequest(request) {
+				// No delegation, so the string returned here becomes the
+				// node's terminal output. The model is never called.
+				return "Out of scope. Ask me to draft an email.", nil
+			}
+			// WithUseAsOutput hands the terminal output to the child: the
+			// drafter's own event carries it and this node emits no event of
+			// its own, so the reply is not repeated in a second event. The
+			// value returned here is discarded.
+			return workflow.RunNode[string](nc, drafterNode, request, workflow.WithUseAsOutput())
+		},
+		workflow.NodeConfig{},
+	)
+
+	wa, err := workflowagent.New(workflowagent.Config{
+		Name:        "use_as_output_sample",
+		Description: "Delegates the orchestrator's output to an LlmAgent child, or returns its own.",
+		// Registering the wrapped LlmAgent lets the runner resolve its event
+		// author. Without it the runner logs "Event from an unknown agent"
+		// on every delegated turn.
+		SubAgents: []agent.Agent{drafterAgent},
+		Edges:     workflow.Chain(workflow.Start, assistant),
+	})
+	if err != nil {
+		log.Fatalf("workflowagent.New: %v", err)
+	}
+
+	l := full.NewLauncher()
+	if err := l.Execute(ctx, &launcher.Config{
+		AgentLoader: agent.NewSingleLoader(wa),
+	}, os.Args[1:]); err != nil {
+		log.Fatalf("Run failed: %v\n\n%s", err, l.CommandLineSyntax())
+	}
+}
+
+// isEmailRequest gates the delegating branch. The check is deliberately
+// trivial and runs before any model call, so the reader can pick either branch
+// from the console: the sample is about which node produces the output, not
+// about how the decision is made.
+func isEmailRequest(request string) bool {
+	return strings.Contains(strings.ToLower(request), "email")
+}

--- a/examples/workflow/dynamic/use_as_output/main.go
+++ b/examples/workflow/dynamic/use_as_output/main.go
@@ -81,7 +81,7 @@ func main() {
 		Description: "Delegates the orchestrator's output to an LlmAgent child, or returns its own.",
 		// Registering the wrapped LlmAgent lets the runner resolve its event
 		// author. Without it the runner logs "Event from an unknown agent"
-		// on every delegated turn.
+		// on every turn after a delegated one, when it walks the history.
 		SubAgents: []agent.Agent{drafterAgent},
 		Edges:     workflow.Chain(workflow.Start, assistant),
 	})

--- a/examples/workflow/dynamic/use_as_output/main.go
+++ b/examples/workflow/dynamic/use_as_output/main.go
@@ -40,7 +40,7 @@ import (
 func main() {
 	ctx := context.Background()
 
-	model, err := gemini.NewModel(ctx, "gemini-flash-latest", &genai.ClientConfig{})
+	model, err := gemini.NewModel(ctx, "gemini-3.5-flash", &genai.ClientConfig{})
 	if err != nil {
 		log.Fatalf("gemini.NewModel: %v", err)
 	}


### PR DESCRIPTION
## Problem

The workflow examples cover dynamic orchestration (`dynamic/basic`) and calling an `LlmAgent` from a dynamic body (`dynamic/llm`), but none of them shows output delegation. `workflow.WithUseAsOutput()` promotes a child's output to the parent dynamic node's terminal output. Without it the same value rides two events, the child's own event and the orchestrator's terminal event. With it only the child's event carries the value, stamped for both node paths, so an `LlmAgent`'s reply reaches the caller authored by the agent instead of being restated by the workflow. There was no runnable sample for the option and no entry for it in the workflow example index.

## Summary

Adds `examples/workflow/dynamic/use_as_output/` and registers it in `examples/workflow/README.md`. The layout follows the sibling samples: a `main.go` plus a README with concept bullets, goal, auth block, Mermaid diagram, run command, example session, and a "what it shows" table.

A single orchestrator holds both behaviors so the contrast is visible from the console. An in-scope request is delegated to an `LlmAgent` child with `WithUseAsOutput()`. Anything else is answered by the orchestrator's own `return`, without calling the model at all.

Which branch runs is decided by a substring check on the user's request rather than by anything the model produces, and that is deliberate. An earlier draft gated on the length of the generated email, so the delegating branch — the only thing the sample exists to show — never ran: drafts measured 412 and 506 characters against a 60-character threshold. A guard evaluated in Go before the model call keeps both branches reachable on demand and makes the session in the README reproduce.

The orchestrator is the last node in the graph, which is the shape that works today. A successor placed after a delegating dynamic node receives the zero value instead of the delegated output, which is a separate engine defect and out of scope here.