### PR TITLE
cmd/adkgo: support Agent Engine secret env vars

### DIFF
--- a/cmd/adkgo/internal/deploy/agentengine/agentengine.go
+++ b/cmd/adkgo/internal/deploy/agentengine/agentengine.go
@@ -56,6 +56,7 @@ type agentEngineServiceFlags struct {
 	serverPort    int
 	agentEngineID string
 	memoryBank    memoryBankFlags
+	secrets       []string
 }
 
 type buildFlags struct {
@@ -104,11 +105,50 @@ func init() {
 	agentEngineCmd.PersistentFlags().StringVarP(&flags.source.entryPointPath, "entry_point_path", "e", "", "Path to an entry point (go 'main')")
 	agentEngineCmd.PersistentFlags().StringVarP(&flags.source.sourceDir, "source_dir", "d", "", "Directory to archive, defaults to current working directory")
 	agentEngineCmd.PersistentFlags().StringVar(&flags.agentEngine.agentEngineID, "agent_engine_id", "", "ID of the Agent Engine instance to update if it exists (default: \"\", which means a new instance will be created).")
+	agentEngineCmd.PersistentFlags().StringArrayVar(&flags.agentEngine.secrets, "secret", nil, "Secret env var mapping in ENV=SECRET:VERSION format. Repeat this flag to pass multiple secrets.")
 	agentEngineCmd.PersistentFlags().BoolVar(&flags.agentEngine.memoryBank.deploy, "mem_deploy", false, "If set to true then memory bank will be deployed too")
 	agentEngineCmd.PersistentFlags().StringVar(&flags.agentEngine.memoryBank.model, "mem_model", "publishers/google/models/gemini-2.5-flash", "Name of the model to be used for memory generation - for list you can GET"+
 		" https://${LOCATION_ID}-aiplatform.googleapis.com/v1beta1/publishers/google/models. It will be prefixed with projects/<project_name>/locations/<region> forming for instance full model name like "+
 		" 'projects/project_name/locations/us-central1/publishers/google/models/gemini-2.5-flash'")
 	agentEngineCmd.PersistentFlags().DurationVar(&flags.agentEngine.memoryBank.ttl, "mem_ttl", time.Hour*24*365, "Time-To-Live for memories")
+}
+
+func parseSecretEnvVars(secrets []string) ([]*aiplatformpb.SecretEnvVar, error) {
+	var secretEnvVars []*aiplatformpb.SecretEnvVar
+	for _, secret := range secrets {
+		envName, secretRef, ok := strings.Cut(secret, "=")
+		if !ok || envName == "" || secretRef == "" {
+			return nil, fmt.Errorf("invalid secret %q: expected ENV=SECRET:VERSION", secret)
+		}
+		secretName, secretVersion, ok := strings.Cut(secretRef, ":")
+		if !ok || secretName == "" || secretVersion == "" {
+			return nil, fmt.Errorf("invalid secret %q: expected ENV=SECRET:VERSION", secret)
+		}
+		secretEnvVars = append(secretEnvVars, &aiplatformpb.SecretEnvVar{
+			Name: envName,
+			SecretRef: &aiplatformpb.SecretRef{
+				Secret:  secretName,
+				Version: secretVersion,
+			},
+		})
+	}
+	return secretEnvVars, nil
+}
+
+func (f *deployAgentEngineFlags) deploymentSpec() (*aiplatformpb.ReasoningEngineSpec_DeploymentSpec, error) {
+	secretEnvVars, err := parseSecretEnvVars(f.agentEngine.secrets)
+	if err != nil {
+		return nil, err
+	}
+	return &aiplatformpb.ReasoningEngineSpec_DeploymentSpec{
+		Env: []*aiplatformpb.EnvVar{
+			{Name: "GOOGLE_CLOUD_REGION", Value: f.gcloud.region},
+			{Name: "NUM_WORKERS", Value: "1"},
+			{Name: "GOOGLE_CLOUD_AGENT_ENGINE_ENABLE_TELEMETRY", Value: "true"},
+			{Name: "OTEL_INSTRUMENTATION_GENAI_CAPTURE_MESSAGE_CONTENT", Value: "true"},
+		},
+		SecretEnv: secretEnvVars,
+	}, nil
 }
 
 // computeFlags uses command line arguments to create a full config
@@ -253,6 +293,10 @@ func (f *deployAgentEngineFlags) gcloudDeployToAgentEngine() error {
 				return fmt.Errorf("cannot marshal methods: %w", err)
 			}
 			p("Methods:", string(methodsJSON))
+			deploymentSpec, err := f.deploymentSpec()
+			if err != nil {
+				return err
+			}
 
 			req := &aiplatformpb.CreateReasoningEngineRequest{
 				Parent: parent,
@@ -272,15 +316,8 @@ func (f *deployAgentEngineFlags) gcloudDeployToAgentEngine() error {
 							},
 						},
 						AgentFramework: "google-adk",
-						DeploymentSpec: &aiplatformpb.ReasoningEngineSpec_DeploymentSpec{
-							Env: []*aiplatformpb.EnvVar{
-								{Name: "GOOGLE_CLOUD_REGION", Value: f.gcloud.region},
-								{Name: "NUM_WORKERS", Value: "1"},
-								{Name: "GOOGLE_CLOUD_AGENT_ENGINE_ENABLE_TELEMETRY", Value: "true"},
-								{Name: "OTEL_INSTRUMENTATION_GENAI_CAPTURE_MESSAGE_CONTENT", Value: "true"},
-							},
-						},
-						ClassMethods: methods,
+						DeploymentSpec: deploymentSpec,
+						ClassMethods:   methods,
 					},
 				},
 			}
@@ -350,6 +387,10 @@ func (f *deployAgentEngineFlags) gcloudUpdateAgentEngine() error {
 				return fmt.Errorf("cannot marshal methods: %w", err)
 			}
 			p("Methods:", string(methodsJSON))
+			deploymentSpec, err := f.deploymentSpec()
+			if err != nil {
+				return err
+			}
 
 			req := &aiplatformpb.UpdateReasoningEngineRequest{
 				ReasoningEngine: &aiplatformpb.ReasoningEngine{
@@ -371,6 +412,10 @@ func (f *deployAgentEngineFlags) gcloudUpdateAgentEngine() error {
 					},
 				},
 				UpdateMask: &fieldmaskpb.FieldMask{Paths: []string{"spec.source_code_spec", "spec.class_methods"}},
+			}
+			if len(f.agentEngine.secrets) > 0 {
+				req.ReasoningEngine.Spec.DeploymentSpec = deploymentSpec
+				req.UpdateMask.Paths = append(req.UpdateMask.Paths, "spec.deployment_spec")
 			}
 
 			if f.agentEngine.memoryBank.deploy {

--- a/cmd/adkgo/internal/deploy/agentengine/agentengine.go
+++ b/cmd/adkgo/internal/deploy/agentengine/agentengine.go
@@ -57,6 +57,7 @@ type agentEngineServiceFlags struct {
 	serverPort    int
 	agentEngineID string
 	memoryBank    memoryBankFlags
+	secrets       []string
 }
 
 type buildFlags struct {
@@ -105,11 +106,50 @@ func init() {
 	agentEngineCmd.PersistentFlags().StringVarP(&flags.source.entryPointPath, "entry_point_path", "e", "", "Path to an entry point (go 'main')")
 	agentEngineCmd.PersistentFlags().StringVarP(&flags.source.sourceDir, "source_dir", "d", "", "Directory to archive, defaults to current working directory")
 	agentEngineCmd.PersistentFlags().StringVar(&flags.agentEngine.agentEngineID, "agent_engine_id", "", "ID of the Agent Engine instance to update if it exists (default: \"\", which means a new instance will be created).")
+	agentEngineCmd.PersistentFlags().StringArrayVar(&flags.agentEngine.secrets, "secret", nil, "Secret env var mapping in ENV=SECRET:VERSION format. Repeat this flag to pass multiple secrets.")
 	agentEngineCmd.PersistentFlags().BoolVar(&flags.agentEngine.memoryBank.deploy, "mem_deploy", false, "If set to true then memory bank will be deployed too")
 	agentEngineCmd.PersistentFlags().StringVar(&flags.agentEngine.memoryBank.model, "mem_model", "publishers/google/models/gemini-2.5-flash", "Name of the model to be used for memory generation - for list you can GET"+
 		" https://${LOCATION_ID}-aiplatform.googleapis.com/v1beta1/publishers/google/models. It will be prefixed with projects/<project_name>/locations/<region> forming for instance full model name like "+
 		" 'projects/project_name/locations/us-central1/publishers/google/models/gemini-2.5-flash'")
 	agentEngineCmd.PersistentFlags().DurationVar(&flags.agentEngine.memoryBank.ttl, "mem_ttl", time.Hour*24*365, "Time-To-Live for memories")
+}
+
+func parseSecretEnvVars(secrets []string) ([]*aiplatformpb.SecretEnvVar, error) {
+	var secretEnvVars []*aiplatformpb.SecretEnvVar
+	for _, secret := range secrets {
+		envName, secretRef, ok := strings.Cut(secret, "=")
+		if !ok || envName == "" || secretRef == "" {
+			return nil, fmt.Errorf("invalid secret %q: expected ENV=SECRET:VERSION", secret)
+		}
+		secretName, secretVersion, ok := strings.Cut(secretRef, ":")
+		if !ok || secretName == "" || secretVersion == "" {
+			return nil, fmt.Errorf("invalid secret %q: expected ENV=SECRET:VERSION", secret)
+		}
+		secretEnvVars = append(secretEnvVars, &aiplatformpb.SecretEnvVar{
+			Name: envName,
+			SecretRef: &aiplatformpb.SecretRef{
+				Secret:  secretName,
+				Version: secretVersion,
+			},
+		})
+	}
+	return secretEnvVars, nil
+}
+
+func (f *deployAgentEngineFlags) deploymentSpec() (*aiplatformpb.ReasoningEngineSpec_DeploymentSpec, error) {
+	secretEnvVars, err := parseSecretEnvVars(f.agentEngine.secrets)
+	if err != nil {
+		return nil, err
+	}
+	return &aiplatformpb.ReasoningEngineSpec_DeploymentSpec{
+		Env: []*aiplatformpb.EnvVar{
+			{Name: "GOOGLE_CLOUD_REGION", Value: f.gcloud.region},
+			{Name: "NUM_WORKERS", Value: "1"},
+			{Name: "GOOGLE_CLOUD_AGENT_ENGINE_ENABLE_TELEMETRY", Value: "true"},
+			{Name: "OTEL_INSTRUMENTATION_GENAI_CAPTURE_MESSAGE_CONTENT", Value: "true"},
+		},
+		SecretEnv: secretEnvVars,
+	}, nil
 }
 
 // computeFlags uses command line arguments to create a full config
@@ -254,6 +294,10 @@ func (f *deployAgentEngineFlags) gcloudDeployToAgentEngine() error {
 				return fmt.Errorf("cannot marshal methods: %w", err)
 			}
 			p("Methods:", string(methodsJSON))
+			deploymentSpec, err := f.deploymentSpec()
+			if err != nil {
+				return err
+			}
 
 			req := &aiplatformpb.CreateReasoningEngineRequest{
 				Parent: parent,
@@ -273,15 +317,8 @@ func (f *deployAgentEngineFlags) gcloudDeployToAgentEngine() error {
 							},
 						},
 						AgentFramework: "google-adk",
-						DeploymentSpec: &aiplatformpb.ReasoningEngineSpec_DeploymentSpec{
-							Env: []*aiplatformpb.EnvVar{
-								{Name: "GOOGLE_CLOUD_REGION", Value: f.gcloud.region},
-								{Name: "NUM_WORKERS", Value: "1"},
-								{Name: "GOOGLE_CLOUD_AGENT_ENGINE_ENABLE_TELEMETRY", Value: "true"},
-								{Name: "OTEL_INSTRUMENTATION_GENAI_CAPTURE_MESSAGE_CONTENT", Value: "true"},
-							},
-						},
-						ClassMethods: methods,
+						DeploymentSpec: deploymentSpec,
+						ClassMethods:   methods,
 					},
 				},
 			}
@@ -351,6 +388,10 @@ func (f *deployAgentEngineFlags) gcloudUpdateAgentEngine() error {
 				return fmt.Errorf("cannot marshal methods: %w", err)
 			}
 			p("Methods:", string(methodsJSON))
+			deploymentSpec, err := f.deploymentSpec()
+			if err != nil {
+				return err
+			}
 
 			req := &aiplatformpb.UpdateReasoningEngineRequest{
 				ReasoningEngine: &aiplatformpb.ReasoningEngine{
@@ -372,6 +413,10 @@ func (f *deployAgentEngineFlags) gcloudUpdateAgentEngine() error {
 					},
 				},
 				UpdateMask: &fieldmaskpb.FieldMask{Paths: []string{"spec.source_code_spec", "spec.class_methods"}},
+			}
+			if len(f.agentEngine.secrets) > 0 {
+				req.ReasoningEngine.Spec.DeploymentSpec = deploymentSpec
+				req.UpdateMask.Paths = append(req.UpdateMask.Paths, "spec.deployment_spec")
 			}
 
 			if f.agentEngine.memoryBank.deploy {

--- a/cmd/adkgo/internal/deploy/agentengine/agentengine_test.go
+++ b/cmd/adkgo/internal/deploy/agentengine/agentengine_test.go
@@ -1,0 +1,110 @@
+// Copyright 2026 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package agentengine
+
+import "testing"
+
+func TestParseSecretEnvVars(t *testing.T) {
+	got, err := parseSecretEnvVars([]string{
+		"GOOGLE_API_KEY=gemini-key:latest",
+		"SLACK_TOKEN=slack-token:5",
+	})
+	if err != nil {
+		t.Fatalf("parseSecretEnvVars() returned error: %v", err)
+	}
+	if len(got) != 2 {
+		t.Fatalf("parseSecretEnvVars() returned %d secrets, want 2", len(got))
+	}
+
+	if got[0].Name != "GOOGLE_API_KEY" {
+		t.Errorf("first env name = %q, want GOOGLE_API_KEY", got[0].Name)
+	}
+	if got[0].SecretRef.GetSecret() != "gemini-key" {
+		t.Errorf("first secret = %q, want gemini-key", got[0].SecretRef.GetSecret())
+	}
+	if got[0].SecretRef.GetVersion() != "latest" {
+		t.Errorf("first version = %q, want latest", got[0].SecretRef.GetVersion())
+	}
+
+	if got[1].Name != "SLACK_TOKEN" {
+		t.Errorf("second env name = %q, want SLACK_TOKEN", got[1].Name)
+	}
+	if got[1].SecretRef.GetSecret() != "slack-token" {
+		t.Errorf("second secret = %q, want slack-token", got[1].SecretRef.GetSecret())
+	}
+	if got[1].SecretRef.GetVersion() != "5" {
+		t.Errorf("second version = %q, want 5", got[1].SecretRef.GetVersion())
+	}
+}
+
+func TestParseSecretEnvVarsRejectsInvalidInput(t *testing.T) {
+	tests := []string{
+		"",
+		"GOOGLE_API_KEY",
+		"=gemini-key:latest",
+		"GOOGLE_API_KEY=:latest",
+		"GOOGLE_API_KEY=gemini-key:",
+	}
+	for _, tc := range tests {
+		t.Run(tc, func(t *testing.T) {
+			if _, err := parseSecretEnvVars([]string{tc}); err == nil {
+				t.Fatalf("parseSecretEnvVars(%q) returned nil error, want error", tc)
+			}
+		})
+	}
+}
+
+func TestDeploymentSpecUsesConfiguredSecrets(t *testing.T) {
+	flags := &deployAgentEngineFlags{
+		gcloud: gCloudFlags{
+			region: "us-central1",
+		},
+		agentEngine: agentEngineServiceFlags{
+			secrets: []string{"GOOGLE_API_KEY=gemini-key:latest"},
+		},
+	}
+
+	spec, err := flags.deploymentSpec()
+	if err != nil {
+		t.Fatalf("deploymentSpec() returned error: %v", err)
+	}
+	if len(spec.Env) == 0 {
+		t.Fatalf("deploymentSpec() returned no env vars")
+	}
+	if spec.Env[0].GetName() != "GOOGLE_CLOUD_REGION" || spec.Env[0].GetValue() != "us-central1" {
+		t.Fatalf("first env = %s:%s, want GOOGLE_CLOUD_REGION:us-central1", spec.Env[0].GetName(), spec.Env[0].GetValue())
+	}
+	if len(spec.SecretEnv) != 1 {
+		t.Fatalf("deploymentSpec() returned %d secret env vars, want 1", len(spec.SecretEnv))
+	}
+	if spec.SecretEnv[0].GetName() != "GOOGLE_API_KEY" {
+		t.Errorf("secret env name = %q, want GOOGLE_API_KEY", spec.SecretEnv[0].GetName())
+	}
+	if spec.SecretEnv[0].GetSecretRef().GetSecret() != "gemini-key" {
+		t.Errorf("secret ref = %q, want gemini-key", spec.SecretEnv[0].GetSecretRef().GetSecret())
+	}
+}
+
+func TestDeploymentSpecAllowsNoSecrets(t *testing.T) {
+	flags := &deployAgentEngineFlags{}
+
+	spec, err := flags.deploymentSpec()
+	if err != nil {
+		t.Fatalf("deploymentSpec() returned error: %v", err)
+	}
+	if len(spec.SecretEnv) != 0 {
+		t.Fatalf("deploymentSpec() returned %d secret env vars, want 0", len(spec.SecretEnv))
+	}
+}


### PR DESCRIPTION
Fixes #849.

Summary:
- Add repeatable `--secret ENV=SECRET:VERSION` support to `adkgo deploy agentengine`.
- Use the configured secrets for Agent Engine `SecretEnv` instead of always requiring a `GOOGLE_API_KEY` secret.
- Apply configured secrets when updating an existing Agent Engine as well as when creating one.
- Add unit coverage for secret parsing and deployment spec construction.

Users who still want to provide the Gemini API key can pass:

```sh
adkgo deploy agentengine --secret GOOGLE_API_KEY=GOOGLE_API_KEY:latest ...
```

Tests:
- `go test ./cmd/adkgo/internal/deploy/agentengine`
- `go test ./cmd/adkgo/internal/deploy/agentengine -run 'TestParseSecretEnvVars|TestDeploymentSpec' -count=10`\n- `go test ./cmd/adkgo/...`\n- `go run ./cmd/adkgo deploy agentengine --help | rg -- '--secret|Agent Engine|Deploys'`\n- `git diff --check`