### PR TITLE
feat(workflow): AgentNode synthesizes Event.Output from LLM text

### DIFF
--- a/workflow/agent_node.go
+++ b/workflow/agent_node.go
@@ -126,10 +126,39 @@ func (n *AgentNode) Run(ctx agent.InvocationContext, input any) iter.Seq2[*sessi
 				return
 			}
 
+			synthesizeAgentOutput(event)
+
 			// TODO: add output validation
 			if !yield(event, nil) {
 				return
 			}
 		}
 	}
+}
+
+// synthesizeAgentOutput sets Event.Output from concatenated model
+// text on final model responses so RunNode returns the agent's
+// reply instead of the zero value.
+func synthesizeAgentOutput(event *session.Event) {
+	if event == nil || event.Output != nil {
+		return
+	}
+	if !event.IsFinalResponse() {
+		return
+	}
+	content := event.LLMResponse.Content
+	if content == nil || content.Role != "model" {
+		return
+	}
+	var b []byte
+	for _, p := range content.Parts {
+		if p == nil || p.Text == "" || p.Thought {
+			continue
+		}
+		b = append(b, p.Text...)
+	}
+	if len(b) == 0 {
+		return
+	}
+	event.Output = string(b)
 }

--- a/workflow/agent_node_test.go
+++ b/workflow/agent_node_test.go
@@ -24,6 +24,7 @@ import (
 
 	"github.com/google/go-cmp/cmp"
 	"github.com/google/jsonschema-go/jsonschema"
+	"google.golang.org/genai"
 
 	"google.golang.org/adk/agent"
 	"google.golang.org/adk/session"
@@ -379,5 +380,70 @@ func TestAgentNode_WorkflowIntegration(t *testing.T) {
 				}
 			})
 		})
+	}
+}
+
+func TestAgentNode_SynthesizesOutputFromModelText(t *testing.T) {
+	wrapped, err := agent.New(agent.Config{
+		Name: "talky",
+		Run: func(ctx agent.InvocationContext) iter.Seq2[*session.Event, error] {
+			return func(yield func(*session.Event, error) bool) {
+				// Partial must not be promoted to Output.
+				partial := session.NewEvent(ctx.InvocationID())
+				partial.LLMResponse.Partial = true
+				partial.LLMResponse.Content = &genai.Content{
+					Role:  "model",
+					Parts: []*genai.Part{{Text: "Hel"}},
+				}
+				if !yield(partial, nil) {
+					return
+				}
+				// Thought parts are skipped; text parts concatenate.
+				final := session.NewEvent(ctx.InvocationID())
+				final.LLMResponse.Content = &genai.Content{
+					Role: "model",
+					Parts: []*genai.Part{
+						{Text: "thinking…", Thought: true},
+						{Text: "Hello, "},
+						{Text: "world!"},
+					},
+				}
+				yield(final, nil)
+			}
+		},
+	})
+	if err != nil {
+		t.Fatalf("agent.New: %v", err)
+	}
+	node, err := NewAgentNode(wrapped, NodeConfig{})
+	if err != nil {
+		t.Fatalf("NewAgentNode: %v", err)
+	}
+
+	mockCtx := newMockCtx(t)
+	mockCtx.sess = &mockSession{id: "test-session-id"}
+	var (
+		gotPartial *session.Event
+		gotFinal   *session.Event
+	)
+	for ev, err := range node.Run(mockCtx, "ignored") {
+		if err != nil {
+			t.Fatalf("node.Run: %v", err)
+		}
+		if ev.LLMResponse.Partial {
+			gotPartial = ev
+		} else {
+			gotFinal = ev
+		}
+	}
+
+	if gotPartial == nil || gotFinal == nil {
+		t.Fatalf("missing events: partial=%v final=%v", gotPartial, gotFinal)
+	}
+	if gotPartial.Output != nil {
+		t.Errorf("partial event Output = %v, want nil (partials must not be promoted)", gotPartial.Output)
+	}
+	if got, want := gotFinal.Output, "Hello, world!"; got != want {
+		t.Errorf("final event Output = %v, want %q", got, want)
 	}
 }


### PR DESCRIPTION
AgentNode now sets Event.Output from concatenated model text on final agent responses, so RunNode(agentNode, ...) returns the agent's reply instead of the zero value. Without this, dynamic workflows that wrap an LlmAgent via NewAgentNode and call RunNode[string] received "" and could not chain on the agent's output.

Mirrors adk-python's process_llm_agent_output
(workflow/_llm_agent_wrapper.py:251-279) minus the output_schema and output_key side-effects, which have no equivalent here yet.

Partial streaming events are not promoted; thoughts are excluded from the concatenation; the synthesis is skipped when Output is already set so callers retain control.
