### PR TITLE
feat(workflow): add ValidateOutput to Node interface

### DIFF
--- a/workflow/base_node.go
+++ b/workflow/base_node.go
@@ -87,3 +87,6 @@ func defaultValidateInput(in any, schema *jsonschema.Resolved) (any, error) {
 	}
 	return typeutil.ConvertToWithJSONSchema[any, any](in, schema)
 }
+
+// ValidateOutput returns the output unchanged as a default passthrough implementation.
+func (b BaseNode) ValidateOutput(output any) (any, error) { return output, nil }

--- a/workflow/base_node_test.go
+++ b/workflow/base_node_test.go
@@ -27,6 +27,11 @@ import (
 var (
 	_ Node = (*startNode)(nil)
 	_ Node = (*FunctionNode)(nil)
+	_ Node = (*AgentNode)(nil)
+	_ Node = (*ToolNode)(nil)
+	_ Node = (*JoinNode)(nil)
+	_ Node = (*ParallelWorker)(nil)
+	_ Node = (*WorkflowNode)(nil)
 )
 
 func TestNewBaseNode_RoundTrip(t *testing.T) {

--- a/workflow/edgebuilder_test.go
+++ b/workflow/edgebuilder_test.go
@@ -127,6 +127,9 @@ func (n *dummyNode) OutputSchema() *jsonschema.Resolved { return nil }
 func (n *dummyNode) ValidateInput(input any) (any, error) {
 	return input, nil
 }
+func (n *dummyNode) ValidateOutput(output any) (any, error) {
+	return output, nil
+}
 func (n *dummyNode) Run(ctx agent.InvocationContext, input any) iter.Seq2[*session.Event, error] {
 	return func(yield func(*session.Event, error) bool) {}
 }

--- a/workflow/workflow.go
+++ b/workflow/workflow.go
@@ -44,6 +44,10 @@ type Node interface {
 	// It returns the validated input (which might be coerced/parsed/transformed) or an error.
 	// It will be called by the scheduler before Run on every activation.
 	ValidateInput(input any) (any, error)
+	// ValidateOutput validates and optionally coerces/transforms an output emitted by the node.
+	// It returns the validated output (which might be coerced/parsed/transformed) or an error.
+	// The scheduler invokes it on every yielded event with a non-nil output, before forwarding it to the consumer.
+	ValidateOutput(output any) (any, error)
 	Run(ctx agent.InvocationContext, input any) iter.Seq2[*session.Event, error]
 }
 
@@ -122,6 +126,9 @@ func (s *startNode) InputSchema() *jsonschema.Resolved  { return nil }
 func (s *startNode) OutputSchema() *jsonschema.Resolved { return nil }
 func (s *startNode) ValidateInput(input any) (any, error) {
 	return input, nil
+}
+func (s *startNode) ValidateOutput(output any) (any, error) {
+	return output, nil
 }
 
 func (s *startNode) Run(ctx agent.InvocationContext, input any) iter.Seq2[*session.Event, error] {


### PR DESCRIPTION
Extends the Node interface with ValidateOutput(output any) (any, error), completing the symmetric input/output validation contract alongside the existing ValidateInput. The scheduler will invoke ValidateOutput on every yielded event whose output is non-nil, before forwarding the event to the consumer (wired up in a follow-up).
