### PR TITLE
feat(workflow): add ValidateOutput method to Node interface

### DIFF
--- a/workflow/base_node.go
+++ b/workflow/base_node.go
@@ -88,3 +88,18 @@ func defaultValidateInput(in any, schema *jsonschema.Resolved) (any, error) {
 	}
 	return typeutil.ConvertToWithJSONSchema[any, any](in, schema)
 }
+
+// ValidateOutput validates the output against the node's output schema.
+func (b BaseNode) ValidateOutput(out any) (any, error) {
+	return defaultValidateOutput(out, b.outputSchema)
+}
+
+func defaultValidateOutput(out any, schema *jsonschema.Resolved) (any, error) {
+	if schema == nil {
+		return out, nil
+	}
+	if err := schema.Validate(out); err != nil {
+		return nil, err
+	}
+	return out, nil
+}

--- a/workflow/base_node_test.go
+++ b/workflow/base_node_test.go
@@ -27,6 +27,11 @@ import (
 var (
 	_ Node = (*startNode)(nil)
 	_ Node = (*FunctionNode)(nil)
+	_ Node = (*AgentNode)(nil)
+	_ Node = (*ToolNode)(nil)
+	_ Node = (*JoinNode)(nil)
+	_ Node = (*ParallelWorker)(nil)
+	_ Node = (*WorkflowNode)(nil)
 )
 
 func TestNewBaseNode_RoundTrip(t *testing.T) {
@@ -130,6 +135,16 @@ func TestBaseNode_NilSchemas(t *testing.T) {
 	if diff := cmp.Diff(input, got); diff != "" {
 		t.Errorf("ValidateInput mismatch (-want +got):\n%s", diff)
 	}
+
+	// ValidateOutput with nil schema is a passthrough.
+	output := map[string]any{"value": "world"}
+	gotOut, err := b.ValidateOutput(output)
+	if err != nil {
+		t.Fatalf("ValidateOutput failed: %v", err)
+	}
+	if diff := cmp.Diff(output, gotOut); diff != "" {
+		t.Errorf("ValidateOutput mismatch (-want +got):\n%s", diff)
+	}
 }
 
 func TestBaseNode_WithSchemas(t *testing.T) {
@@ -171,5 +186,22 @@ func TestBaseNode_WithSchemas(t *testing.T) {
 	_, err = b.ValidateInput(invalidInput)
 	if err == nil {
 		t.Error("expected ValidateInput to fail on invalid input type, but succeeded")
+	}
+
+	// Valid output is returned unchanged.
+	output := map[string]any{"value": "world"}
+	gotOut, err := b.ValidateOutput(output)
+	if err != nil {
+		t.Fatalf("ValidateOutput failed on valid output: %v", err)
+	}
+	if diff := cmp.Diff(output, gotOut); diff != "" {
+		t.Errorf("ValidateOutput mismatch (-want +got):\n%s", diff)
+	}
+
+	// Invalid output fails validation.
+	invalidOutput := map[string]any{"value": 123}
+	_, err = b.ValidateOutput(invalidOutput)
+	if err == nil {
+		t.Error("expected ValidateOutput to fail on invalid output type, but succeeded")
 	}
 }

--- a/workflow/edgebuilder_test.go
+++ b/workflow/edgebuilder_test.go
@@ -129,6 +129,10 @@ func (n *dummyNode) ValidateInput(input any) (any, error) {
 	return input, nil
 }
 
+func (n *dummyNode) ValidateOutput(output any) (any, error) {
+	return output, nil
+}
+
 func (n *dummyNode) Run(ctx agent.InvocationContext, input any) iter.Seq2[*session.Event, error] {
 	return func(yield func(*session.Event, error) bool) {}
 }

--- a/workflow/workflow.go
+++ b/workflow/workflow.go
@@ -44,6 +44,10 @@ type Node interface {
 	// It returns the validated input (which might be coerced/parsed/transformed) or an error.
 	// It will be called by the scheduler before Run on every activation.
 	ValidateInput(input any) (any, error)
+	// ValidateOutput validates and optionally coerces/transforms an output emitted by the node.
+	// It returns the validated output (which might be coerced/parsed/transformed) or an error.
+	// The scheduler invokes it on every yielded event with a non-nil output, before forwarding it to the consumer.
+	ValidateOutput(output any) (any, error)
 	Run(ctx agent.InvocationContext, input any) iter.Seq2[*session.Event, error]
 }
 
@@ -122,6 +126,10 @@ func (s *startNode) InputSchema() *jsonschema.Resolved  { return nil }
 func (s *startNode) OutputSchema() *jsonschema.Resolved { return nil }
 func (s *startNode) ValidateInput(input any) (any, error) {
 	return input, nil
+}
+
+func (s *startNode) ValidateOutput(output any) (any, error) {
+	return output, nil
 }
 
 func (s *startNode) Run(ctx agent.InvocationContext, input any) iter.Seq2[*session.Event, error] {


### PR DESCRIPTION
Completes the symmetric input/output validation contract on the Node interface, alongside the existing ValidateInput. The scheduler is expected to invoke ValidateOutput on every yielded event whose output is non-nil before forwarding the event to the consumer (wired up in a follow-up).

Interface and conformance
- Add ValidateOutput(output any) (any, error) to the Node interface.
- Add explicit stubs on the two implementations that do not embed BaseNode: startNode and the test-only dummyNode.
- Extend the compile-time Node-conformance assertions in base_node_test.go to cover AgentNode, ToolNode, JoinNode, ParallelWorker, and WorkflowNode.
