### PR TITLE
feat(workflow): wire scheduler-side output validation with Content fa…

### DIFF
--- a/agent/agent.go
+++ b/agent/agent.go
@@ -509,6 +509,11 @@ func (c *invocationContext) WithContext(ctx context.Context) InvocationContext {
 // that overrides the method when running inside a workflow.Node.
 func (c *invocationContext) TriggeredBy() string { return "" }
 
+// ResumedInput always returns (nil, false) for the base
+// invocation context. Implementations that carry a resume payload
+// override this method.
+func (c *invocationContext) ResumedInput(string) (any, bool) { return nil, false }
+
 func pluginManagerFromContext(ctx context.Context) pluginManager {
 	a := ctx.Value(plugincontext.PluginManagerCtxKey)
 	m, ok := a.(pluginManager)

--- a/agent/agent.go
+++ b/agent/agent.go
@@ -504,11 +504,6 @@ func (c *invocationContext) WithContext(ctx context.Context) InvocationContext {
 	return &newCtx
 }
 
-// TriggeredBy returns "" for non-workflow invocation contexts. The
-// workflow engine wraps this context in a private per-node context
-// that overrides the method when running inside a workflow.Node.
-func (c *invocationContext) TriggeredBy() string { return "" }
-
 // ResumedInput always returns (nil, false) for the base
 // invocation context. Implementations that carry a resume payload
 // override this method.

--- a/agent/agent.go
+++ b/agent/agent.go
@@ -504,6 +504,11 @@ func (c *invocationContext) WithContext(ctx context.Context) InvocationContext {
 	return &newCtx
 }
 
+// TriggeredBy returns "" for non-workflow invocation contexts. The
+// workflow engine wraps this context in a private per-node context
+// that overrides the method when running inside a workflow.Node.
+func (c *invocationContext) TriggeredBy() string { return "" }
+
 func pluginManagerFromContext(ctx context.Context) pluginManager {
 	a := ctx.Value(plugincontext.PluginManagerCtxKey)
 	m, ok := a.(pluginManager)

--- a/agent/agent.go
+++ b/agent/agent.go
@@ -161,7 +161,7 @@ func (a *agent) SubAgents() []Agent {
 
 func (a *agent) Run(ctx InvocationContext) iter.Seq2[*session.Event, error] {
 	return func(yield func(*session.Event, error) bool) {
-		spanCtx, span := telemetry.StartInvokeAgentSpan(ctx, a, ctx.Session().ID(), ctx.InvocationID())
+		spanCtx, span := telemetry.StartNodeSpan(ctx, ctx, telemetry.OperationAgent{Agent: a})
 		yield, endSpan := telemetry.WrapYield(span, yield, func(span trace.Span, event *session.Event, err error) {
 			telemetry.TraceAgentResult(span, telemetry.TraceAgentResultParams{
 				ResponseEvent: event,

--- a/agent/context.go
+++ b/agent/context.go
@@ -96,6 +96,14 @@ type InvocationContext interface {
 	// Ended returns whether the invocation has ended.
 	Ended() bool
 
+	// TriggeredBy returns the name of the upstream node whose output
+	// scheduled the current node activation, when this context is
+	// running inside a workflow.Node. Returns "" outside a workflow
+	// (e.g. in plain agent runs) and for the initial workflow START
+	// activation. The workflow engine populates this via an internal
+	// per-node context wrapper.
+	TriggeredBy() string
+
 	// WithContext returns a new instance of the context with overridden embedded context.
 	// NOTE: This is a temporary solution and will be removed later. The proper solution
 	// we plan is to stop embedding go context in adk context types and split it.

--- a/agent/context.go
+++ b/agent/context.go
@@ -96,14 +96,6 @@ type InvocationContext interface {
 	// Ended returns whether the invocation has ended.
 	Ended() bool
 
-	// TriggeredBy returns the name of the upstream node whose output
-	// scheduled the current node activation, when this context is
-	// running inside a workflow.Node. Returns "" outside a workflow
-	// (e.g. in plain agent runs) and for the initial workflow START
-	// activation. The workflow engine populates this via an internal
-	// per-node context wrapper.
-	TriggeredBy() string
-
 	// ResumedInput returns the user-supplied response payload
 	// associated with the given InterruptID for the current
 	// activation, or (nil, false) if none. Implementations that

--- a/agent/context.go
+++ b/agent/context.go
@@ -104,6 +104,12 @@ type InvocationContext interface {
 	// per-node context wrapper.
 	TriggeredBy() string
 
+	// ResumedInput returns the user-supplied response payload
+	// associated with the given InterruptID for the current
+	// activation, or (nil, false) if none. Implementations that
+	// do not carry resume payloads always return (nil, false).
+	ResumedInput(interruptID string) (any, bool)
+
 	// WithContext returns a new instance of the context with overridden embedded context.
 	// NOTE: This is a temporary solution and will be removed later. The proper solution
 	// we plan is to stop embedding go context in adk context types and split it.

--- a/agent/llmagent/llmagent.go
+++ b/agent/llmagent/llmagent.go
@@ -470,6 +470,7 @@ func (a *llmAgent) maybeSaveOutputToState(event *session.Event) {
 		}
 
 		event.Actions.StateDelta[a.OutputKey] = result
+		event.Output = result
 	}
 }
 

--- a/agent/llmagent/llmagent.go
+++ b/agent/llmagent/llmagent.go
@@ -25,6 +25,7 @@ import (
 	agentinternal "google.golang.org/adk/internal/agent"
 	icontext "google.golang.org/adk/internal/context"
 	"google.golang.org/adk/internal/llminternal"
+	"google.golang.org/adk/internal/workflowinternal"
 	"google.golang.org/adk/model"
 	"google.golang.org/adk/session"
 	"google.golang.org/adk/tool"
@@ -76,6 +77,7 @@ func New(cfg Config) (agent.Agent, error) {
 
 		State: llminternal.State{
 			Model:                    cfg.Model,
+			Mode:                     cfg.Mode,
 			GenerateContentConfig:    cfg.GenerateContentConfig,
 			Tools:                    cfg.Tools,
 			Toolsets:                 cfg.Toolsets,
@@ -123,7 +125,57 @@ func New(cfg Config) (agent.Agent, error) {
 	state.AgentType = agentinternal.TypeLLMAgent
 	state.Config = cfg
 
+	if err := installTaskTools(a); err != nil {
+		return nil, err
+	}
+
 	return a, nil
+}
+
+func installTaskTools(a *llmAgent) error {
+	state := llminternal.Reveal(a)
+
+	if state.Mode == llminternal.ModeTask {
+		finishTool, err := workflowinternal.NewFinishTaskTool(a)
+		if err != nil {
+			return fmt.Errorf("installing `finish_task` tool for agent %q: %w", a.Name(), err)
+		}
+		state.Tools = append(state.Tools, finishTool)
+	}
+
+	for _, sub := range a.SubAgents() {
+		subInternal, ok := sub.(llminternal.Agent)
+		if !ok {
+			continue
+		}
+		subState := llminternal.Reveal(subInternal)
+		if subState.Mode == llminternal.ModeUnset {
+			subState.Mode = llminternal.ModeChat
+		}
+
+		switch subState.Mode {
+		case llminternal.ModeSingleTurn:
+			t, err := workflowinternal.NewSingleTurnTool(sub)
+			if err != nil {
+				return fmt.Errorf(
+					"failed to install `single_turn` agent tool for sub-agent %q of %q: %w",
+					sub.Name(), a.Name(), err,
+				)
+			}
+			state.Tools = append(state.Tools, t)
+		case llminternal.ModeTask:
+			t, err := workflowinternal.NewTaskAgentTool(sub)
+			if err != nil {
+				return fmt.Errorf(
+					"failed to install `task` agent tool for sub-agent %q of %q: %w",
+					sub.Name(), a.Name(), err,
+				)
+			}
+			state.Tools = append(state.Tools, t)
+		}
+	}
+
+	return nil
 }
 
 // Config of the LLMAgent.
@@ -280,7 +332,32 @@ type Config struct {
 	// - Extracts agent reply for later use, such as in tools, callbacks, etc.
 	// - Connects agents to coordinate with each other.
 	OutputKey string
+
+	// Mode is the delegation mode for this agent.
+	//
+	// Options:
+	//   ModeChat: Standard chat agent reachable via transfer_to_agent.
+	//   ModeTask: Task agent that chats with the user to accomplish a task.
+	//   ModeSingleTurn: Agents that complete a task without chatting with the user.
+	//
+	// Default value is ModeChat as a sub-agent, ModeSingleTurn as a node in a workflow.
+	Mode Mode
 }
+
+// Mode is the delegation mode of an LLMAgent. See [Config.Mode] for details.
+type Mode = llminternal.Mode
+
+const (
+	// ModeUnset means the mode has not been set explicitly.
+	ModeUnset = llminternal.ModeUnset
+	// ModeChat is the standard chat agent reachable via transfer_to_agent.
+	ModeChat = llminternal.ModeChat
+	// ModeTask is a task agent that chats with the user to accomplish a task.
+	ModeTask = llminternal.ModeTask
+	// ModeSingleTurn is an agent that completes a task without chatting with
+	// the user.
+	ModeSingleTurn = llminternal.ModeSingleTurn
+)
 
 // BeforeModelCallback that is called before sending a request to the model.
 //

--- a/agent/llmagent/llmagent_test.go
+++ b/agent/llmagent/llmagent_test.go
@@ -15,6 +15,7 @@
 package llmagent_test
 
 import (
+	"context"
 	"errors"
 	"fmt"
 	"iter"
@@ -22,6 +23,7 @@ import (
 	"path/filepath"
 	"strings"
 	"testing"
+	"time"
 
 	"github.com/google/go-cmp/cmp"
 	"google.golang.org/genai"
@@ -34,6 +36,8 @@ import (
 	"google.golang.org/adk/session"
 	"google.golang.org/adk/tool"
 	"google.golang.org/adk/tool/functiontool"
+	"google.golang.org/adk/workflow"
+	"google.golang.org/adk/internal/agent/runconfig"
 )
 
 const modelName = "gemini-2.5-flash"
@@ -1192,4 +1196,105 @@ func TestFindAgent(t *testing.T) {
 			}
 		})
 	}
+}
+
+func TestLLMAgent_WorkflowIntegration_OutputPropagatesToSuccessor(t *testing.T) {
+	// 1. mock LLM returning "hello world"
+	testLLM := &testutil.MockModel{
+		Responses: []*genai.Content{
+			genai.NewContentFromText("hello world", genai.RoleModel),
+		},
+	}
+
+	// 2. LLMAgent with OutputKey="result"
+	a, err := llmagent.New(llmagent.Config{
+		Name:      "llm_agent",
+		Model:     testLLM,
+		OutputKey: "result",
+	})
+	if err != nil {
+		t.Fatalf("failed to create llm agent: %v", err)
+	}
+
+	// 3. wrap in AgentNode
+	agentNode, err := workflow.NewAgentNode(a, workflow.NodeConfig{})
+	if err != nil {
+		t.Fatalf("failed to create agent node: %v", err)
+	}
+
+	// 4. Chain(Start, agentNode, fnNode), where fnNode asserts on input
+	var gotInput any
+	fnNode := workflow.NewFunctionNode("receiver", func(ctx agent.InvocationContext, in any) (any, error) {
+		gotInput = in
+		return nil, nil
+	}, workflow.NodeConfig{})
+
+	edges := workflow.Chain(workflow.Start, agentNode, fnNode)
+	w, err := workflow.New("test_workflow", edges)
+	if err != nil {
+		t.Fatalf("failed to create workflow: %v", err)
+	}
+
+	// Run the workflow. We need a mock context and session.
+	runCtx := runconfig.ToContext(t.Context(), &runconfig.RunConfig{})
+	mockCtx := &mockInvocationContext{
+		Context: runCtx,
+		sess:    &mockSession{id: "test-session-id"},
+	}
+
+	events := w.Run(mockCtx)
+	for ev, err := range events {
+		if err != nil {
+			t.Fatalf("workflow run failed: %v", err)
+		}
+		_ = ev
+	}
+
+	// 5. assert: fnNode got "hello world"
+	if diff := cmp.Diff("hello world", gotInput); diff != "" {
+		t.Errorf("fnNode got unexpected input (-want +got):\n%s", diff)
+	}
+}
+
+type mockEvents struct{}
+
+func (m mockEvents) All() iter.Seq[*session.Event] {
+	return func(yield func(*session.Event) bool) {}
+}
+func (m mockEvents) Len() int                { return 0 }
+func (m mockEvents) At(i int) *session.Event { return nil }
+
+type mockSession struct {
+	id string
+}
+
+func (m *mockSession) ID() string                { return m.id }
+func (m *mockSession) AppName() string           { return "test-app" }
+func (m *mockSession) UserID() string            { return "test-user" }
+func (m *mockSession) State() session.State      { return nil }
+func (m *mockSession) Events() session.Events    { return mockEvents{} }
+func (m *mockSession) LastUpdateTime() time.Time { return time.Now() }
+
+type mockInvocationContext struct {
+	context.Context
+	sess        session.Session
+	userContent *genai.Content
+}
+
+func (m *mockInvocationContext) Session() session.Session        { return m.sess }
+func (m *mockInvocationContext) InvocationID() string            { return "test-invocation-id" }
+func (m *mockInvocationContext) UserContent() *genai.Content     { return m.userContent }
+func (m *mockInvocationContext) ResumedInput(string) (any, bool) { return nil, false }
+func (m *mockInvocationContext) Agent() agent.Agent              { return nil }
+func (m *mockInvocationContext) Artifacts() agent.Artifacts      { return nil }
+func (m *mockInvocationContext) Memory() agent.Memory            { return nil }
+func (m *mockInvocationContext) Branch() string                  { return "" }
+func (m *mockInvocationContext) RunConfig() *agent.RunConfig     { return nil }
+func (m *mockInvocationContext) Ended() bool                     { return false }
+func (m *mockInvocationContext) EndInvocation()                  {}
+
+func (m *mockInvocationContext) WithContext(ctx context.Context) agent.InvocationContext {
+	cp := *m
+	cp.Context = ctx
+	return &cp
 }

--- a/agent/workflowagent/hitl_test.go
+++ b/agent/workflowagent/hitl_test.go
@@ -1,0 +1,555 @@
+// Copyright 2026 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package workflowagent
+
+import (
+	"context"
+	"errors"
+	"iter"
+	"sync"
+	"sync/atomic"
+	"testing"
+
+	"github.com/google/jsonschema-go/jsonschema"
+	"google.golang.org/genai"
+
+	"google.golang.org/adk/agent"
+	"google.golang.org/adk/session"
+	"google.golang.org/adk/workflow"
+)
+
+// =============================================================================
+// Tests
+// =============================================================================
+
+// TestWorkflowAgent_RunThenResume_Handoff exercises the canonical
+// round-trip: a fresh Run pauses on a node that requested input,
+// and a follow-up Resume turn delivers the response which flows
+// to the asker's successor as its input.
+func TestWorkflowAgent_RunThenResume_Handoff(t *testing.T) {
+	var handlerInput atomic.Value
+	asker := newAskerNode("approve_or_reject", "Please decide", nil)
+	handler := newStringHandlerNode("handler", &handlerInput)
+
+	a := makeAgent(t, workflow.Chain(workflow.Start, asker, handler))
+	sess := newFakeSession()
+
+	// Turn 1: fresh Run; should pause with a RequestedInput.
+	turn1 := runFreshTurn(t, sess, a, "draft")
+	if got := findRequest(turn1); got != "approve_or_reject" {
+		t.Fatalf("turn 1 RequestedInput = %q, want %q", got, "approve_or_reject")
+	}
+	if v := handlerInput.Load(); v != nil {
+		t.Errorf("handler ran during turn 1; got input %v, want it not to run", v)
+	}
+
+	// Turn 2: resume with a payload; handler should run and
+	// receive the payload as its input.
+	turn2 := drainAgent(t, sess, a.Run(newMockCtx(sess, a, resumeMessage("approve_or_reject", "approve"))), nil)
+	if findRequest(turn2) != "" {
+		t.Errorf("turn 2 unexpectedly emitted a RequestedInput")
+	}
+	if got, want := handlerInput.Load(), "approve"; got != want {
+		t.Errorf("handler input = %v, want %q", got, want)
+	}
+}
+
+// TestWorkflowAgent_Resume_RestoresStateFromSession verifies that
+// the run state survives between agent instances backed by the
+// same session: after Run, a fresh agent built from the same
+// edges (simulating a process restart) can still Resume.
+func TestWorkflowAgent_Resume_RestoresStateFromSession(t *testing.T) {
+	var handlerCalled atomic.Bool
+
+	// makeNodes returns fresh node instances per agent so the test
+	// proves resume goes through session.State, not through any
+	// shared in-memory references between a1 and a2.
+	makeNodes := func() (workflow.Node, workflow.Node) {
+		return newAskerNode("human_approval", "approve?", nil),
+			newFlagHandlerNode("handler", &handlerCalled)
+	}
+
+	sess := newFakeSession()
+
+	// First agent instance: Run → pause.
+	asker1, handler1 := makeNodes()
+	a1 := makeAgent(t, workflow.Chain(workflow.Start, asker1, handler1))
+	turn1 := runFreshTurn(t, sess, a1, "draft")
+	if findRequest(turn1) != "human_approval" {
+		t.Fatalf("first agent did not pause as expected")
+	}
+
+	// Second agent instance, same session: Resume.
+	asker2, handler2 := makeNodes()
+	a2 := makeAgent(t, workflow.Chain(workflow.Start, asker2, handler2))
+	drainAgent(t, sess, a2.Run(newMockCtx(sess, a2, resumeMessage("human_approval", "yes"))), nil)
+	if !handlerCalled.Load() {
+		t.Error("handler did not run after resume on a fresh agent instance")
+	}
+}
+
+// TestWorkflowAgent_Resume_Idempotent verifies that two Resume
+// calls with the same payload run the handler only once.
+func TestWorkflowAgent_Resume_Idempotent(t *testing.T) {
+	var handlerRuns atomic.Int32
+	asker := newAskerNode("approve", "?", nil)
+	handler := newCountingHandlerNode("handler", &handlerRuns)
+
+	a := makeAgent(t, workflow.Chain(workflow.Start, asker, handler))
+	sess := newFakeSession()
+
+	runFreshTurn(t, sess, a, "x")
+	// First resume: matches the waiting node, runs the handler.
+	drainAgent(t, sess, a.Run(newMockCtx(sess, a, resumeMessage("approve", "yes"))), nil)
+	// Second resume with the same payload: PendingRequest was
+	// consumed by the first call, so no waiting node matches and
+	// Resume yields ErrNothingToResume rather than re-running.
+	drainAgent(t, sess, a.Run(newMockCtx(sess, a, resumeMessage("approve", "yes"))), workflow.ErrNothingToResume)
+
+	if got := handlerRuns.Load(); got != 1 {
+		t.Errorf("handler runs = %d, want 1 (duplicate Resume must not re-run the handler)", got)
+	}
+}
+
+// TestWorkflowAgent_Resume_NoMatchingResponse verifies the
+// stale-response signal: a Resume turn that carries a
+// FunctionResponse for an InterruptID that does not match any
+// waiting node yields ErrNothingToResume so the caller can
+// distinguish a no-op resume from a real one (e.g. show "your
+// reply targets a stale request" in the UI).
+func TestWorkflowAgent_Resume_NoMatchingResponse(t *testing.T) {
+	asker := newAskerNode("real_id", "?", nil)
+
+	a := makeAgent(t, workflow.Chain(workflow.Start, asker))
+	sess := newFakeSession()
+
+	// Pause once.
+	runFreshTurn(t, sess, a, "x")
+
+	// Submit a FunctionResponse for an unknown ID. detectResume
+	// will see the magic name, load state, build a responses map,
+	// but no waiting node will match — Resume yields
+	// ErrNothingToResume so the caller can distinguish the
+	// successful-but-no-effect case from a real resume.
+	turn := drainAgent(t, sess, a.Run(newMockCtx(sess, a, resumeMessage("unknown_id", "x"))), workflow.ErrNothingToResume)
+	if findRequest(turn) != "" {
+		t.Errorf("unmatched resume produced a new RequestedInput; got %v", turn)
+	}
+}
+
+// TestWorkflowAgent_Resume_SchemaValidation_Pass verifies that a
+// response payload conforming to ResponseSchema is delivered to
+// the handler unchanged (the validator coerces but here the
+// shape already matches).
+func TestWorkflowAgent_Resume_SchemaValidation_Pass(t *testing.T) {
+	var handlerInput atomic.Value
+	asker := newAskerNode("approval", "decide", approvalSchema())
+	handler := newMapHandlerNode("handler", &handlerInput)
+
+	a := makeAgent(t, workflow.Chain(workflow.Start, asker, handler))
+	sess := newFakeSession()
+
+	runFreshTurn(t, sess, a, "x")
+	drainAgent(t, sess, a.Run(newMockCtx(sess, a, resumeMessage("approval", map[string]any{"approved": true}))), nil)
+
+	got, ok := handlerInput.Load().(map[string]any)
+	if !ok || got["approved"] != true {
+		t.Errorf("handler input = %v, want map with approved=true", handlerInput.Load())
+	}
+}
+
+// TestWorkflowAgent_Resume_SchemaValidation_Fail verifies that a
+// response payload that violates ResponseSchema surfaces
+// ErrInvalidResumeResponse and leaves the node parked, so a
+// follow-up turn with a corrected payload still works.
+func TestWorkflowAgent_Resume_SchemaValidation_Fail(t *testing.T) {
+	var handlerRuns atomic.Int32
+	asker := newAskerNode("approval", "decide", approvalSchema())
+	handler := newCountingHandlerNode("handler", &handlerRuns)
+
+	a := makeAgent(t, workflow.Chain(workflow.Start, asker, handler))
+	sess := newFakeSession()
+
+	// Pause.
+	runFreshTurn(t, sess, a, "x")
+
+	// Submit invalid payload (string instead of {approved: bool}).
+	drainAgent(t, sess, a.Run(newMockCtx(sess, a, resumeMessage("approval", "not an object"))), workflow.ErrInvalidResumeResponse)
+	if handlerRuns.Load() != 0 {
+		t.Fatal("handler ran despite schema validation failure")
+	}
+
+	// Retry with valid payload — should succeed.
+	drainAgent(t, sess, a.Run(newMockCtx(sess, a, resumeMessage("approval", map[string]any{"approved": true}))), nil)
+	if handlerRuns.Load() != 1 {
+		t.Errorf("handler runs after retry = %d, want 1", handlerRuns.Load())
+	}
+}
+
+// TestWorkflowAgent_Resume_FanOut verifies that a handoff resume
+// from an asker with multiple successors fans out the response
+// to every successor, exactly as a normal output would.
+func TestWorkflowAgent_Resume_FanOut(t *testing.T) {
+	var hits atomic.Int32
+	asker := newAskerNode("fan", "?", nil)
+	h1 := newCountingHandlerNode("h1", &hits)
+	h2 := newCountingHandlerNode("h2", &hits)
+	h3 := newCountingHandlerNode("h3", &hits)
+
+	a := makeAgent(t, []workflow.Edge{
+		{From: workflow.Start, To: asker},
+		{From: asker, To: h1},
+		{From: asker, To: h2},
+		{From: asker, To: h3},
+	})
+	sess := newFakeSession()
+
+	runFreshTurn(t, sess, a, "x")
+	drainAgent(t, sess, a.Run(newMockCtx(sess, a, resumeMessage("fan", "go"))), nil)
+
+	if got := hits.Load(); got != 3 {
+		t.Errorf("successor hits = %d, want 3", got)
+	}
+}
+
+// TestWorkflowAgent_FreshTurn_NotMistakenForResume verifies the
+// detectResume guard: a fresh user message that happens to have
+// no FunctionResponse part does NOT trip the resume path even if
+// a RunState is persisted (e.g. from a paused or completed prior
+// workflow). Important because session.State may carry leftover
+// state from previous runs.
+func TestWorkflowAgent_FreshTurn_NotMistakenForResume(t *testing.T) {
+	var firstRun atomic.Bool
+	var secondRun atomic.Bool
+
+	// Custom asker (not newAskerNode) because each instance must
+	// flip its own flag before the request is yielded, so the
+	// test can detect that the asker truly re-ran on turn 2.
+	makeAsker := func(flag *atomic.Bool) workflow.Node {
+		return newHitlNode("asker", func(ctx agent.InvocationContext, _ any, yield func(*session.Event, error) bool) {
+			flag.Store(true)
+			yield(workflow.NewRequestInputEvent(ctx, session.RequestInput{
+				InterruptID: "ask",
+				Message:     "?",
+			}), nil)
+		})
+	}
+
+	a := makeAgent(t, workflow.Chain(workflow.Start, makeAsker(&firstRun)))
+	sess := newFakeSession()
+
+	// Turn 1: fresh; pauses.
+	runFreshTurn(t, sess, a, "x")
+	if !firstRun.Load() {
+		t.Fatal("asker did not run on turn 1")
+	}
+
+	// Turn 2: another fresh user message (no FunctionResponse).
+	// detectResume should return false; Workflow.Run is invoked.
+	a2 := makeAgent(t, workflow.Chain(workflow.Start, makeAsker(&secondRun)))
+	runFreshTurn(t, sess, a2, "fresh")
+	if !secondRun.Load() {
+		t.Error("a fresh user message was misinterpreted as a resume; asker did not run on turn 2")
+	}
+}
+
+// =============================================================================
+// Test fixtures and helpers
+// =============================================================================
+
+// fakeSession is a minimal session.Session implementation that
+// faithfully models the AppendEvent-gated state contract used by
+// session.InMemoryService and persistent backends: state mutations
+// are applied only when applyStateDelta is called for an event
+// (the unit-test analogue of session.Service.AppendEvent), never
+// via direct State.Set from inside the agent.
+//
+// drainAgent (this file) calls applyStateDelta for every event the
+// agent yields, simulating what the runner does in production.
+type fakeSession struct {
+	session.Session
+	state *fakeSessionState
+}
+
+func newFakeSession() *fakeSession {
+	return &fakeSession{state: &fakeSessionState{m: map[string]any{}}}
+}
+
+func (s *fakeSession) ID() string           { return "test-session-id" }
+func (s *fakeSession) State() session.State { return s.state }
+
+// applyStateDelta merges any Actions.StateDelta on the supplied
+// event into the underlying state map. Mirrors what
+// inMemoryService.AppendEvent does for session-scoped (no
+// app:/user:/temp: prefix) keys; HITL persistence uses such keys.
+func (s *fakeSession) applyStateDelta(ev *session.Event) {
+	if ev == nil || len(ev.Actions.StateDelta) == 0 {
+		return
+	}
+	s.state.mu.Lock()
+	defer s.state.mu.Unlock()
+	for k, v := range ev.Actions.StateDelta {
+		s.state.m[k] = v
+	}
+}
+
+// fakeSessionState exposes session.State semantics with one subtle
+// constraint compared to the real services: callers that bypass
+// the runner cannot mutate state via Set; they must construct an
+// event with Actions.StateDelta and route it through
+// fakeSession.applyStateDelta instead. Get reflects the
+// AppendEvent-applied view.
+type fakeSessionState struct {
+	mu sync.Mutex
+	m  map[string]any
+}
+
+func (s *fakeSessionState) Get(key string) (any, error) {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	v, ok := s.m[key]
+	if !ok {
+		return nil, session.ErrStateKeyNotExist
+	}
+	return v, nil
+}
+
+// Set is a no-op writer in this mock to surface accidental direct
+// modification. Production code must route state changes through
+// Event.Actions.StateDelta. Tests that need to pre-seed state can
+// write directly to the underlying map via the fakeSession
+// constructor.
+func (s *fakeSessionState) Set(key string, value any) error {
+	// Intentionally not persisted: real session services do not
+	// propagate direct Set from inside an invocation either.
+	// Returning nil keeps the call non-fatal so production code
+	// that defensively writes through State.Set still compiles
+	// and runs.
+	return nil
+}
+
+func (s *fakeSessionState) All() iter.Seq2[string, any] {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	snapshot := make(map[string]any, len(s.m))
+	for k, v := range s.m {
+		snapshot[k] = v
+	}
+	return func(yield func(string, any) bool) {
+		for k, v := range snapshot {
+			if !yield(k, v) {
+				return
+			}
+		}
+	}
+}
+
+// hitlNode is a custom Node used by the HITL resume tests. The
+// Run callback is supplied per test so each scenario can shape
+// its own emission pattern.
+type hitlNode struct {
+	workflow.BaseNode
+	run func(ctx agent.InvocationContext, input any, yield func(*session.Event, error) bool)
+}
+
+func newHitlNode(name string, run func(ctx agent.InvocationContext, input any, yield func(*session.Event, error) bool)) *hitlNode {
+	return &hitlNode{
+		BaseNode: workflow.NewBaseNode(name, "", workflow.NodeConfig{}),
+		run:      run,
+	}
+}
+
+func (n *hitlNode) Run(ctx agent.InvocationContext, input any) iter.Seq2[*session.Event, error] {
+	return func(yield func(*session.Event, error) bool) {
+		n.run(ctx, input, yield)
+	}
+}
+
+// makeAgent builds a workflowagent with the given edges and the
+// canonical "test_workflow" name (the name is what
+// session.State persistence is keyed by).
+func makeAgent(t *testing.T, edges []workflow.Edge) agent.Agent {
+	t.Helper()
+	a, err := New(Config{Name: "test_workflow", Edges: edges})
+	if err != nil {
+		t.Fatalf("workflowagent.New: %v", err)
+	}
+	return a
+}
+
+// newMockCtx returns an InvocationContext suitable for driving the
+// workflow agent. The same session is reused across calls so
+// pause/resume round-trips through fakeSessionState as they would
+// in production.
+func newMockCtx(sess session.Session, agt agent.Agent, msg *genai.Content) *MockInvocationContext {
+	return &MockInvocationContext{
+		Context:     context.TODO(),
+		sess:        sess,
+		userContent: msg,
+		myAgent:     agt,
+	}
+}
+
+// drainAgent consumes the agent's iter.Seq2, collecting events,
+// and applies each event's StateDelta to sess. The applyStateDelta
+// step replaces the AppendEvent-side state propagation that the
+// real runner performs; without it state writes from the agent
+// would never become visible to subsequent calls. Fails the test
+// if the iterator yields a non-nil error that the test did not
+// opt into via wantErr.
+func drainAgent(t *testing.T, sess *fakeSession, seq iter.Seq2[*session.Event, error], wantErr error) []*session.Event {
+	t.Helper()
+	var got []*session.Event
+	var sawErr error
+	for ev, err := range seq {
+		if err != nil {
+			if sawErr == nil {
+				sawErr = err
+			}
+			continue
+		}
+		got = append(got, ev)
+		sess.applyStateDelta(ev)
+	}
+	switch {
+	case wantErr == nil && sawErr != nil:
+		t.Fatalf("unexpected error from agent: %v", sawErr)
+	case wantErr != nil && sawErr == nil:
+		t.Fatalf("expected error %v, got none", wantErr)
+	case wantErr != nil && !errors.Is(sawErr, wantErr):
+		t.Fatalf("expected error %v, got %v", wantErr, sawErr)
+	}
+	return got
+}
+
+// findRequest scans events for the first one carrying a
+// RequestedInput and returns the InterruptID it carried, or "" if
+// none was found.
+func findRequest(events []*session.Event) string {
+	for _, ev := range events {
+		if ev != nil && ev.RequestedInput != nil {
+			return ev.RequestedInput.InterruptID
+		}
+	}
+	return ""
+}
+
+// resumeMessage builds a user message carrying a FunctionResponse
+// that targets a previously-emitted RequestInput.
+func resumeMessage(interruptID string, payload any) *genai.Content {
+	return &genai.Content{
+		Parts: []*genai.Part{{
+			FunctionResponse: &genai.FunctionResponse{
+				ID:   interruptID,
+				Name: workflow.WorkflowInputFunctionCallName,
+				Response: map[string]any{
+					"payload": payload,
+				},
+			},
+		}},
+	}
+}
+
+// newAskerNode returns a hitlNode whose Run yields a single
+// RequestInput event carrying the given InterruptID, message, and
+// optional schema, then exits. This is the canonical "asker"
+// pattern: a node that pauses the workflow waiting for human input.
+func newAskerNode(interruptID, message string, schema *jsonschema.Schema) *hitlNode {
+	return newHitlNode("asker", func(ctx agent.InvocationContext, _ any, yield func(*session.Event, error) bool) {
+		yield(workflow.NewRequestInputEvent(ctx, session.RequestInput{
+			InterruptID:    interruptID,
+			Message:        message,
+			ResponseSchema: schema,
+		}), nil)
+	})
+}
+
+// runFreshTurn drives the agent through a single turn whose
+// inbound user content is plain text (no FunctionResponse). Used
+// to seed the canonical "first turn" of pause/resume tests where
+// the actual text payload does not matter.
+func runFreshTurn(t *testing.T, sess *fakeSession, a agent.Agent, text string) []*session.Event {
+	t.Helper()
+	return drainAgent(t, sess, a.Run(newMockCtx(sess, a, &genai.Content{
+		Parts: []*genai.Part{{Text: text}},
+	})), nil)
+}
+
+// newStringHandlerNode returns a FunctionNode that stores its
+// string input into dst and returns "handled:<input>".
+func newStringHandlerNode(name string, dst *atomic.Value) workflow.Node {
+	return workflow.NewFunctionNode(
+		name,
+		func(_ agent.InvocationContext, input string) (string, error) {
+			dst.Store(input)
+			return "handled:" + input, nil
+		},
+		workflow.NodeConfig{},
+	)
+}
+
+// newMapHandlerNode returns a FunctionNode that stores its
+// map[string]any input into dst and returns nil.
+func newMapHandlerNode(name string, dst *atomic.Value) workflow.Node {
+	return workflow.NewFunctionNode(
+		name,
+		func(_ agent.InvocationContext, input map[string]any) (any, error) {
+			dst.Store(input)
+			return nil, nil
+		},
+		workflow.NodeConfig{},
+	)
+}
+
+// newCountingHandlerNode returns a FunctionNode that increments counter
+// each time it runs. Input is typed any so the helper accepts
+// payloads of any shape without coercion.
+func newCountingHandlerNode(name string, counter *atomic.Int32) workflow.Node {
+	return workflow.NewFunctionNode(
+		name,
+		func(_ agent.InvocationContext, _ any) (any, error) {
+			counter.Add(1)
+			return nil, nil
+		},
+		workflow.NodeConfig{},
+	)
+}
+
+// newFlagHandlerNode returns a FunctionNode that sets flag to true
+// each time it runs. Input is typed any so the helper accepts
+// payloads of any shape without coercion.
+func newFlagHandlerNode(name string, flag *atomic.Bool) workflow.Node {
+	return workflow.NewFunctionNode(
+		name,
+		func(_ agent.InvocationContext, _ any) (any, error) {
+			flag.Store(true)
+			return nil, nil
+		},
+		workflow.NodeConfig{},
+	)
+}
+
+// approvalSchema returns the canonical schema for an "approval"
+// payload: an object with a single required boolean field named
+// "approved". Shared across the SchemaValidation tests.
+func approvalSchema() *jsonschema.Schema {
+	return &jsonschema.Schema{
+		Type: "object",
+		Properties: map[string]*jsonschema.Schema{
+			"approved": {Type: "boolean"},
+		},
+		Required: []string{"approved"},
+	}
+}

--- a/agent/workflowagent/hitl_test.go
+++ b/agent/workflowagent/hitl_test.go
@@ -265,6 +265,73 @@ func TestWorkflowAgent_FreshTurn_NotMistakenForResume(t *testing.T) {
 	}
 }
 
+// TestWorkflowAgent_RunThenResume_DynamicNodeOrchestrator verifies
+// that a child RequestedInput inside a dynamic-node orchestrator
+// (called via workflow.RunNode) transitions the orchestrator to
+// NodeWaiting, so Workflow.Resume matches by InterruptID and the
+// orchestrator re-enters to produce the final output.
+func TestWorkflowAgent_RunThenResume_DynamicNodeOrchestrator(t *testing.T) {
+	const interruptID = "ask_name_dyn"
+
+	asker := newHitlNode("ask_name", func(ctx agent.InvocationContext, _ any, yield func(*session.Event, error) bool) {
+		nc, ok := ctx.(workflow.NodeContext)
+		if ok {
+			if resp, ok := nc.ResumedInput(interruptID); ok {
+				ev := session.NewEvent(ctx.InvocationID())
+				ev.Output = resp
+				yield(ev, nil)
+				return
+			}
+		}
+		yield(workflow.NewRequestInputEvent(ctx, session.RequestInput{
+			InterruptID: interruptID,
+			Message:     "What's your name?",
+		}), nil)
+	})
+
+	orchestrator := workflow.NewDynamicNode[string, string]("hitl_demo",
+		func(nc workflow.NodeContext, _ string, _ func(*session.Event) error) (string, error) {
+			out, err := workflow.RunNode[any](nc, asker, nil)
+			if err != nil {
+				// Pause: err is ErrNodeInterrupted (swallowed by dynamicNode.Run).
+				// Resume: err is nil and out is the child's response.
+				return "", err
+			}
+			name, _ := out.(string)
+			if name == "" {
+				name = "stranger"
+			}
+			return "Hello, " + name + "!", nil
+		},
+		workflow.NodeConfig{},
+	)
+
+	a := makeAgent(t, workflow.Chain(workflow.Start, orchestrator))
+	sess := newFakeSession()
+
+	// Turn 1: fresh Run; orchestrator schedules asker; asker pauses.
+	turn1 := runFreshTurn(t, sess, a, "start")
+	if got := findRequest(turn1); got != interruptID {
+		t.Fatalf("turn 1 RequestedInput = %q, want %q", got, interruptID)
+	}
+
+	// Turn 2: resume with the reply.
+	turn2 := drainAgent(t, sess, a.Run(newMockCtx(sess, a, resumeMessage(interruptID, "Wolo"))), nil)
+	if got := findRequest(turn2); got != "" {
+		t.Errorf("turn 2 unexpectedly emitted a RequestedInput: %q", got)
+	}
+
+	var got any
+	for _, ev := range turn2 {
+		if ev.Output != nil && ev.NodeInfo != nil && ev.NodeInfo.Path == "hitl_demo" {
+			got = ev.Output
+		}
+	}
+	if want := "Hello, Wolo!"; got != want {
+		t.Errorf("orchestrator output = %v, want %q", got, want)
+	}
+}
+
 // =============================================================================
 // Test fixtures and helpers
 // =============================================================================

--- a/agent/workflowagent/reentry_test.go
+++ b/agent/workflowagent/reentry_test.go
@@ -16,6 +16,7 @@ package workflowagent
 
 import (
 	"iter"
+	"reflect"
 	"sync"
 	"sync/atomic"
 	"testing"
@@ -143,6 +144,54 @@ func TestWorkflowAgent_ReEntry_DefaultModeIsHandoff(t *testing.T) {
 	}
 	if got := handlerInput.Load(); got != "approve" {
 		t.Errorf("handler input = %v, want %q (handoff mode delivers response as next-node input)", got, "approve")
+	}
+}
+
+// TestWorkflowAgent_ReEntry_AccumulatesResumeInputs verifies that
+// a re-entry-mode node which yields RequestInput more than once
+// across resume cycles sees every prior response on every
+// subsequent activation, not only the most recent one.
+//
+// Scenario: asker walks through ask_1, ask_2, ask_3. After each
+// resume it must see every response answered so far. After the
+// third resume it observes all three and emits a final output.
+func TestWorkflowAgent_ReEntry_AccumulatesResumeInputs(t *testing.T) {
+	asker, acts := askerForSequence("asker", []string{"ask_1", "ask_2", "ask_3"}, "all answered")
+
+	var handlerInput atomic.Value
+	handler := newStringHandlerNode("handler", &handlerInput)
+
+	a := makeAgent(t, workflow.Chain(workflow.Start, asker, handler))
+	sess := newFakeSession()
+
+	turn1 := runFreshTurn(t, sess, a, "draft")
+	if got := findRequest(turn1); got != "ask_1" {
+		t.Fatalf("turn 1 RequestedInput = %q, want %q", got, "ask_1")
+	}
+	resumeAndExpect(t, sess, a, "ask_1", "yes", "ask_2")
+	resumeAndExpect(t, sess, a, "ask_2", "ok", "ask_3")
+	resumeAndExpect(t, sess, a, "ask_3", "approve", "")
+
+	if got := handlerInput.Load(); got != "all answered" {
+		t.Errorf("handler input = %v, want %q", got, "all answered")
+	}
+
+	// Per-activation accumulation: each row is what the asker
+	// must have observed on its i-th run.
+	wantResumed := []map[string]any{
+		{},                              // turn 1: fresh, nothing answered yet
+		{"ask_1": "yes"},                // turn 2: after first reply
+		{"ask_1": "yes", "ask_2": "ok"}, // turn 3
+		{"ask_1": "yes", "ask_2": "ok", "ask_3": "approve"}, // turn 4: all three visible
+	}
+	if got := acts.count(); got != len(wantResumed) {
+		t.Fatalf("activations = %d, want %d", got, len(wantResumed))
+	}
+	for i, want := range wantResumed {
+		act, _ := acts.at(i)
+		if !reflect.DeepEqual(act.resumed, want) {
+			t.Errorf("activation %d resumed = %v, want %v", i, act.resumed, want)
+		}
 	}
 }
 

--- a/agent/workflowagent/reentry_test.go
+++ b/agent/workflowagent/reentry_test.go
@@ -1,0 +1,275 @@
+// Copyright 2026 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package workflowagent
+
+import (
+	"iter"
+	"sync"
+	"sync/atomic"
+	"testing"
+
+	"google.golang.org/adk/agent"
+	"google.golang.org/adk/session"
+	"google.golang.org/adk/workflow"
+)
+
+// TestWorkflowAgent_ReEntry_ResumesAtSameNode verifies the canonical
+// re-entry round-trip: the asker is re-activated on resume, sees
+// the response via ResumedInput, and produces an output that flows
+// to its successor.
+func TestWorkflowAgent_ReEntry_ResumesAtSameNode(t *testing.T) {
+	asker, acts := askerForSequence("asker", []string{"decide"}, "decision")
+
+	var handlerInput atomic.Value
+	handler := newStringHandlerNode("handler", &handlerInput)
+
+	a := makeAgent(t, workflow.Chain(workflow.Start, asker, handler))
+	sess := newFakeSession()
+
+	// Turn 1: fresh; asker pauses with RequestedInput "decide".
+	turn1 := runFreshTurn(t, sess, a, "draft")
+	if got := findRequest(turn1); got != "decide" {
+		t.Fatalf("turn 1 RequestedInput = %q, want %q", got, "decide")
+	}
+
+	// Turn 2: resume; asker re-runs, emits output, handler runs.
+	resumeAndExpect(t, sess, a, "decide", "approve", "")
+
+	if got, want := acts.count(), 2; got != want {
+		t.Fatalf("activations = %d, want %d (one initial + one re-entry)", got, want)
+	}
+	if act, _ := acts.at(1); act.resumed["decide"] != "approve" {
+		t.Errorf("re-entry resumed[\"decide\"] = %v, want %q", act.resumed["decide"], "approve")
+	}
+	if got, want := handlerInput.Load(), "decision"; got != want {
+		t.Errorf("handler input = %v, want %q", got, want)
+	}
+}
+
+// TestWorkflowAgent_ReEntry_PreservesOriginalInput verifies that on
+// re-entry the asker receives the SAME input value it saw on its
+// first activation, not the user's response. The response is
+// delivered separately via ResumedInput.
+func TestWorkflowAgent_ReEntry_PreservesOriginalInput(t *testing.T) {
+	asker, acts := askerForSequence("asker", []string{"decide"}, "ack")
+
+	a := makeAgent(t, workflow.Chain(workflow.Start, asker))
+	sess := newFakeSession()
+
+	// Turn 1: fresh, asker sees "draft" as input.
+	runFreshTurn(t, sess, a, "draft")
+
+	// Turn 2: resume with response "approve". Asker re-runs and
+	// must see "draft" again as input (not "approve").
+	resumeAndExpect(t, sess, a, "decide", "approve", "")
+
+	if got, want := acts.count(), 2; got != want {
+		t.Fatalf("activations = %d, want %d", got, want)
+	}
+	first, _ := acts.at(0)
+	second, _ := acts.at(1)
+	if first.input != "draft" {
+		t.Errorf("initial activation input = %v, want %q", first.input, "draft")
+	}
+	if second.input != "draft" {
+		t.Errorf("re-entry activation input = %v, want %q (must preserve original input, not the response)", second.input, "draft")
+	}
+}
+
+// TestWorkflowAgent_ReEntry_NoSuccessorBeforeOutput verifies that a
+// re-entry asker's downstream successor only fires once the
+// re-entry activation actually emits an output event. (Compare to
+// handoff mode, where the successor would fire immediately on
+// resume even without a re-entry activation.)
+func TestWorkflowAgent_ReEntry_NoSuccessorBeforeOutput(t *testing.T) {
+	var handlerCount atomic.Int32
+
+	asker, _ := askerForSequence("asker", []string{"decide"}, "ack")
+	handler := newCountingHandlerNode("handler", &handlerCount)
+
+	a := makeAgent(t, workflow.Chain(workflow.Start, asker, handler))
+	sess := newFakeSession()
+
+	// Pause turn: handler must not have fired.
+	runFreshTurn(t, sess, a, "x")
+	if got := handlerCount.Load(); got != 0 {
+		t.Errorf("handler ran during pause turn; count = %d", got)
+	}
+
+	// Resume turn: asker re-runs and emits output; handler runs once.
+	resumeAndExpect(t, sess, a, "decide", "yes", "")
+	if got := handlerCount.Load(); got != 1 {
+		t.Errorf("handler runs after re-entry = %d, want 1", got)
+	}
+}
+
+// TestWorkflowAgent_ReEntry_DefaultModeIsHandoff confirms that a
+// node without RerunOnResume = true uses handoff mode on resume:
+// the response flows to the successor as its input and the asker
+// does not re-run.
+func TestWorkflowAgent_ReEntry_DefaultModeIsHandoff(t *testing.T) {
+	var askerActivations atomic.Int32
+
+	asker := newHitlNode("asker", func(ctx agent.InvocationContext, _ any, yield func(*session.Event, error) bool) {
+		askerActivations.Add(1)
+		yield(workflow.NewRequestInputEvent(ctx, session.RequestInput{
+			InterruptID: "decide",
+			Message:     "?",
+		}), nil)
+	})
+	var handlerInput atomic.Value
+	handler := newStringHandlerNode("handler", &handlerInput)
+
+	a := makeAgent(t, workflow.Chain(workflow.Start, asker, handler))
+	sess := newFakeSession()
+
+	runFreshTurn(t, sess, a, "x")
+	drainAgent(t, sess, a.Run(newMockCtx(sess, a, resumeMessage("decide", "approve"))), nil)
+
+	if got := askerActivations.Load(); got != 1 {
+		t.Errorf("asker activations = %d, want 1 (handoff mode must NOT re-activate the asker)", got)
+	}
+	if got := handlerInput.Load(); got != "approve" {
+		t.Errorf("handler input = %v, want %q (handoff mode delivers response as next-node input)", got, "approve")
+	}
+}
+
+// --- test helpers below ---------------------------------------------------
+
+// reentryNode is a custom Node with NodeConfig.RerunOnResume = true
+// whose Run body is supplied by the test via runFn. Each test
+// decides what to do on the first activation (typically yield a
+// RequestInput) and on re-entry (read ctx.ResumedInput, emit an
+// output).
+type reentryNode struct {
+	workflow.BaseNode
+	runFn func(ctx agent.InvocationContext, input any) iter.Seq2[*session.Event, error]
+}
+
+func newReentryNode(name string, runFn func(agent.InvocationContext, any) iter.Seq2[*session.Event, error]) *reentryNode {
+	return &reentryNode{
+		BaseNode: workflow.NewBaseNode(name, "", workflow.NodeConfig{RerunOnResume: ptrTrue()}),
+		runFn:    runFn,
+	}
+}
+
+func (n *reentryNode) Run(ctx agent.InvocationContext, input any) iter.Seq2[*session.Event, error] {
+	return n.runFn(ctx, input)
+}
+
+// reentryActivation records what a re-entry asker observed during
+// a single Run call: the input it received and the snapshot of
+// resume-input payloads visible to it via ctx.ResumedInput.
+type reentryActivation struct {
+	input   any
+	resumed map[string]any
+}
+
+// activations is a concurrent-safe ordered log of reentryActivation
+// entries, used by tests to assert what an asker observed on each
+// of its successive activations (initial run + N re-entries).
+type activations struct {
+	mu   sync.Mutex
+	list []reentryActivation
+}
+
+func (a *activations) record(input any, resumed map[string]any) {
+	a.mu.Lock()
+	defer a.mu.Unlock()
+	a.list = append(a.list, reentryActivation{input: input, resumed: resumed})
+}
+
+func (a *activations) at(i int) (reentryActivation, bool) {
+	a.mu.Lock()
+	defer a.mu.Unlock()
+	if i < 0 || i >= len(a.list) {
+		return reentryActivation{}, false
+	}
+	return a.list[i], true
+}
+
+func (a *activations) count() int {
+	a.mu.Lock()
+	defer a.mu.Unlock()
+	return len(a.list)
+}
+
+// snapshotResumed reads ctx.ResumedInput for each of ids and
+// returns the subset that the scheduler currently exposes. Missing
+// IDs are omitted from the map so test assertions can compare
+// against literal map[string]any{"id": value} expectations.
+func snapshotResumed(ctx agent.InvocationContext, ids ...string) map[string]any {
+	out := map[string]any{}
+	for _, id := range ids {
+		if v, ok := ctx.ResumedInput(id); ok {
+			out[id] = v
+		}
+	}
+	return out
+}
+
+// askerForSequence builds a reentryNode that walks through ids,
+// pausing on each with a RequestInput. On every activation it
+// records what input and resumed map it saw; once every id has a
+// response it emits a final output event carrying finalOutput.
+//
+// Use it for tests that exercise multi-step ask-then-observe
+// patterns without the per-test ceremony of branching on which
+// question is next or maintaining a per-test activation counter.
+func askerForSequence(name string, ids []string, finalOutput any) (*reentryNode, *activations) {
+	acts := &activations{}
+	node := newReentryNode(name, func(ctx agent.InvocationContext, input any) iter.Seq2[*session.Event, error] {
+		return func(yield func(*session.Event, error) bool) {
+			resumed := snapshotResumed(ctx, ids...)
+			acts.record(input, resumed)
+
+			// Pause on the first id we haven't seen a response for.
+			for _, id := range ids {
+				if _, answered := resumed[id]; !answered {
+					yield(workflow.NewRequestInputEvent(ctx, session.RequestInput{
+						InterruptID: id,
+						Message:     id,
+					}), nil)
+					return
+				}
+			}
+
+			// All answered: emit the terminal output.
+			ev := session.NewEvent(ctx.InvocationID())
+			ev.Actions.StateDelta["output"] = finalOutput
+			yield(ev, nil)
+		}
+	})
+	return node, acts
+}
+
+// resumeAndExpect performs one resume turn replying to replyID
+// with replyValue, then asserts the next pause (if any) carries
+// the expected InterruptID. Pass wantNextRequest = "" to assert
+// that the workflow did not pause again (i.e. the resume turn
+// completed without yielding another RequestInput).
+func resumeAndExpect(t *testing.T, sess *fakeSession, a agent.Agent, replyID string, replyValue any, wantNextRequest string) []*session.Event {
+	t.Helper()
+	events := drainAgent(t, sess, a.Run(newMockCtx(sess, a, resumeMessage(replyID, replyValue))), nil)
+	if got := findRequest(events); got != wantNextRequest {
+		t.Fatalf("after resume %q=%v: RequestedInput = %q, want %q", replyID, replyValue, got, wantNextRequest)
+	}
+	return events
+}
+
+func ptrTrue() *bool {
+	t := true
+	return &t
+}

--- a/agent/workflowagent/reentry_test.go
+++ b/agent/workflowagent/reentry_test.go
@@ -297,7 +297,7 @@ func askerForSequence(name string, ids []string, finalOutput any) (*reentryNode,
 
 			// All answered: emit the terminal output.
 			ev := session.NewEvent(ctx.InvocationID())
-			ev.Actions.StateDelta["output"] = finalOutput
+			ev.Output = finalOutput
 			yield(ev, nil)
 		}
 	})

--- a/agent/workflowagent/workflow.go
+++ b/agent/workflowagent/workflow.go
@@ -31,7 +31,10 @@ type Config struct {
 
 // New creates a new Workflow agent.
 func New(cfg Config) (agent.Agent, error) {
-	w := workflow.New(cfg.Edges)
+	w, err := workflow.New(cfg.Edges)
+	if err != nil {
+		return nil, err
+	}
 
 	return agent.New(agent.Config{
 		Name:                 cfg.Name,

--- a/agent/workflowagent/workflow.go
+++ b/agent/workflowagent/workflow.go
@@ -21,16 +21,24 @@ import (
 
 // Config is the configuration for creating a new Workflow agent.
 type Config struct {
-	AgentConfig agent.Config
-	Edges       []workflow.Edge
+	Name                 string
+	Description          string
+	SubAgents            []agent.Agent
+	BeforeAgentCallbacks []agent.BeforeAgentCallback
+	AfterAgentCallbacks  []agent.AfterAgentCallback
+	Edges                []workflow.Edge
 }
 
 // New creates a new Workflow agent.
 func New(cfg Config) (agent.Agent, error) {
 	w := workflow.New(cfg.Edges)
 
-	agentCfg := cfg.AgentConfig
-	agentCfg.Run = w.Run
-
-	return agent.New(agentCfg)
+	return agent.New(agent.Config{
+		Name:                 cfg.Name,
+		Description:          cfg.Description,
+		SubAgents:            cfg.SubAgents,
+		BeforeAgentCallbacks: cfg.BeforeAgentCallbacks,
+		AfterAgentCallbacks:  cfg.AfterAgentCallbacks,
+		Run:                  w.Run,
+	})
 }

--- a/agent/workflowagent/workflow.go
+++ b/agent/workflowagent/workflow.go
@@ -1,0 +1,36 @@
+// Copyright 2026 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package workflowagent
+
+import (
+	"google.golang.org/adk/agent"
+	"google.golang.org/adk/workflow"
+)
+
+// Config is the configuration for creating a new Workflow agent.
+type Config struct {
+	AgentConfig agent.Config
+	Edges       []workflow.Edge
+}
+
+// New creates a new Workflow agent.
+func New(cfg Config) (agent.Agent, error) {
+	w := workflow.New(cfg.Edges)
+
+	agentCfg := cfg.AgentConfig
+	agentCfg.Run = w.Run
+
+	return agent.New(agentCfg)
+}

--- a/agent/workflowagent/workflow.go
+++ b/agent/workflowagent/workflow.go
@@ -15,7 +15,14 @@
 package workflowagent
 
 import (
+	"encoding/json"
+	"iter"
+
+	"google.golang.org/genai"
+
 	"google.golang.org/adk/agent"
+	"google.golang.org/adk/internal/utils"
+	"google.golang.org/adk/session"
 	"google.golang.org/adk/workflow"
 )
 
@@ -29,12 +36,19 @@ type Config struct {
 	Edges                []workflow.Edge
 }
 
-// New creates a new Workflow agent.
+// New creates a new Workflow agent. A single returned agent
+// instance can serve many concurrent sessions: the per-invocation
+// run state lives in session.State, not on the agent. A paused
+// workflow resumes on a follow-up turn when the user submits a
+// FunctionResponse targeting the InterruptID emitted by the
+// paused node.
 func New(cfg Config) (agent.Agent, error) {
-	w, err := workflow.New(cfg.Edges)
+	w, err := workflow.New(cfg.Name, cfg.Edges)
 	if err != nil {
 		return nil, err
 	}
+
+	wa := &workflowAgent{workflow: w}
 
 	return agent.New(agent.Config{
 		Name:                 cfg.Name,
@@ -42,6 +56,99 @@ func New(cfg Config) (agent.Agent, error) {
 		SubAgents:            cfg.SubAgents,
 		BeforeAgentCallbacks: cfg.BeforeAgentCallbacks,
 		AfterAgentCallbacks:  cfg.AfterAgentCallbacks,
-		Run:                  w.Run,
+		Run:                  wa.run,
 	})
+}
+
+// workflowAgent is the wrapper that dispatches between
+// Workflow.Run (fresh turn) and Workflow.Resume (resume turn).
+// The dispatch decision is made by inspecting ctx.UserContent for
+// a FunctionResponse targeting a previously-emitted RequestInput.
+// The workflow's RunState lives in session.State, not on this
+// struct, so a single *workflowAgent safely services many
+// concurrent sessions.
+type workflowAgent struct {
+	workflow *workflow.Workflow
+}
+
+// run is the agent.Config.Run callback. It dispatches between
+// Workflow.Resume (when the inbound user content carries a
+// FunctionResponse to a previously-emitted RequestInput) and
+// Workflow.Run (every other turn).
+func (a *workflowAgent) run(ctx agent.InvocationContext) iter.Seq2[*session.Event, error] {
+	return func(yield func(*session.Event, error) bool) {
+		if responses, state, ok := a.detectResume(ctx); ok {
+			for ev, err := range a.workflow.Resume(ctx, state, responses) {
+				if !yield(ev, err) {
+					return
+				}
+			}
+			return
+		}
+		for ev, err := range a.workflow.Run(ctx) {
+			if !yield(ev, err) {
+				return
+			}
+		}
+	}
+}
+
+// detectResume inspects the inbound user message for FunctionResponses
+// targeting a previously-emitted RequestInput. Returns the
+// responses map keyed by InterruptID (suitable for
+// Workflow.Resume), the RunState loaded from session, and true if
+// this turn is a resume; (nil, nil, false) for a fresh turn.
+func (a *workflowAgent) detectResume(ctx agent.InvocationContext) (map[string]any, *workflow.RunState, bool) {
+	frs := utils.FunctionResponses(ctx.UserContent())
+	if len(frs) == 0 {
+		return nil, nil, false
+	}
+
+	responses := map[string]any{}
+	for _, fr := range frs {
+		if fr.Name != workflow.WorkflowInputFunctionCallName {
+			continue
+		}
+		responses[fr.ID] = decodeWorkflowInputResponse(fr)
+	}
+	if len(responses) == 0 {
+		return nil, nil, false
+	}
+
+	state, err := workflow.LoadRunState(ctx.Session(), a.workflow.Name())
+	if err != nil || state == nil {
+		// No persisted state means there is nothing to resume;
+		// fall through to a fresh Workflow.Run.
+		return nil, nil, false
+	}
+
+	return responses, state, true
+}
+
+// decodeWorkflowInputResponse extracts the user-supplied payload
+// from a FunctionResponse targeting a workflow input request.
+//
+// Three accepted shapes, in priority order:
+//
+//  1. {"response": <value>}  — when value is a string, it is
+//     parsed as JSON and the result returned; if the string is
+//     not valid JSON it is returned verbatim. When value is any
+//     other type, it is returned as-is.
+//  2. {"payload": <any>}     — value returned verbatim.
+//  3. anything else           — the whole Response map is returned.
+func decodeWorkflowInputResponse(fr *genai.FunctionResponse) any {
+	if raw, ok := fr.Response["response"]; ok {
+		if s, isStr := raw.(string); isStr {
+			var decoded any
+			if err := json.Unmarshal([]byte(s), &decoded); err == nil {
+				return decoded
+			}
+			return s
+		}
+		return raw
+	}
+	if payload, ok := fr.Response["payload"]; ok {
+		return payload
+	}
+	return fr.Response
 }

--- a/agent/workflowagent/workflow.go
+++ b/agent/workflowagent/workflow.go
@@ -16,11 +16,13 @@ package workflowagent
 
 import (
 	"encoding/json"
+	"fmt"
 	"iter"
 
 	"google.golang.org/genai"
 
 	"google.golang.org/adk/agent"
+	agentinternal "google.golang.org/adk/internal/agent"
 	"google.golang.org/adk/internal/utils"
 	"google.golang.org/adk/session"
 	"google.golang.org/adk/workflow"
@@ -50,7 +52,7 @@ func New(cfg Config) (agent.Agent, error) {
 
 	wa := &workflowAgent{workflow: w}
 
-	return agent.New(agent.Config{
+	wfAgent, err := agent.New(agent.Config{
 		Name:                 cfg.Name,
 		Description:          cfg.Description,
 		SubAgents:            cfg.SubAgents,
@@ -58,6 +60,22 @@ func New(cfg Config) (agent.Agent, error) {
 		AfterAgentCallbacks:  cfg.AfterAgentCallbacks,
 		Run:                  wa.run,
 	})
+	if err != nil {
+		return nil, err
+	}
+
+	// Tag the agent state so the telemetry layer can emit
+	// "invoke_workflow <name>" spans instead of "invoke_agent <name>"
+	// for workflow-backed agents.
+	internalAgent, ok := wfAgent.(agentinternal.Agent)
+	if !ok {
+		return nil, fmt.Errorf("internal error: failed to convert to internal agent")
+	}
+	state := agentinternal.Reveal(internalAgent)
+	state.AgentType = agentinternal.TypeWorkflowAgent
+	state.Config = cfg
+
+	return wfAgent, nil
 }
 
 // workflowAgent is the wrapper that dispatches between

--- a/agent/workflowagent/workflow_test.go
+++ b/agent/workflowagent/workflow_test.go
@@ -101,7 +101,6 @@ func (m *MockInvocationContext) Branch() string                  { return "" }
 func (m *MockInvocationContext) RunConfig() *agent.RunConfig     { return nil }
 func (m *MockInvocationContext) Ended() bool                     { return false }
 func (m *MockInvocationContext) EndInvocation()                  {}
-func (m *MockInvocationContext) TriggeredBy() string             { return "" }
 func (m *MockInvocationContext) ResumedInput(string) (any, bool) { return nil, false }
 
 func TestWorkflowAgent(t *testing.T) {

--- a/agent/workflowagent/workflow_test.go
+++ b/agent/workflowagent/workflow_test.go
@@ -21,6 +21,7 @@ import (
 	"testing"
 	"time"
 
+	"github.com/google/go-cmp/cmp"
 	"google.golang.org/genai"
 
 	"google.golang.org/adk/agent"
@@ -37,6 +38,12 @@ type MockSession struct {
 
 func (m MockSession) ID() string {
 	return "test-session-id"
+}
+
+// State returns nil; the workflow persistence helpers handle a nil
+// session.State by treating the session as non-persisting.
+func (m MockSession) State() session.State {
+	return nil
 }
 
 // MockInvocationContext is a minimal implementation of agent.InvocationContext for testing.
@@ -134,25 +141,109 @@ func TestWorkflowAgent(t *testing.T) {
 	events := myWorkflow.Run(mockCtx)
 
 	var lastOutput any
-	count := 0
+	nodeEvents := 0
 	for ev, err := range events {
 		if err != nil {
 			t.Fatalf("unexpected error: %v", err)
 		}
-		count++
 
 		if ev.Actions.StateDelta != nil {
 			if out, ok := ev.Actions.StateDelta["output"]; ok {
 				lastOutput = out
+				nodeEvents++
 			}
 		}
 	}
 
-	if count != 2 {
-		t.Errorf("expected 2 events, got %d", count)
+	// One output event per FunctionNode (upper, suffix); Start is
+	// a no-op sentinel and emits nothing.
+	if nodeEvents != 2 {
+		t.Errorf("expected 2 node-output events, got %d", nodeEvents)
 	}
 
 	if lastOutput != "HELLO done" {
 		t.Errorf("expected last output 'HELLO done', got %v", lastOutput)
+	}
+}
+
+func TestDecodeWorkflowInputResponse(t *testing.T) {
+	tests := []struct {
+		name string
+		fr   *genai.FunctionResponse
+		want any
+	}{
+		{
+			name: "ResponseShape_JSONObject",
+			fr: &genai.FunctionResponse{
+				Response: map[string]any{"response": `{"approved":true}`},
+			},
+			want: map[string]any{"approved": true},
+		},
+		{
+			name: "ResponseShape_JSONScalar",
+			fr: &genai.FunctionResponse{
+				Response: map[string]any{"response": `42`},
+			},
+			want: float64(42), // json.Unmarshal decodes JSON numbers to float64
+		},
+		{
+			name: "ResponseShape_InvalidJSONFallsBackToRawString",
+			fr: &genai.FunctionResponse{
+				Response: map[string]any{"response": "not valid json"},
+			},
+			want: "not valid json",
+		},
+		{
+			name: "ResponseShape_NonStringValueReturnedVerbatim",
+			fr: &genai.FunctionResponse{
+				Response: map[string]any{"response": map[string]any{"already": "decoded"}},
+			},
+			want: map[string]any{"already": "decoded"},
+		},
+		{
+			name: "PayloadShape_StringPayload",
+			fr: &genai.FunctionResponse{
+				Response: map[string]any{"payload": "yes"},
+			},
+			want: "yes",
+		},
+		{
+			name: "PayloadShape_StructuredPayload",
+			fr: &genai.FunctionResponse{
+				Response: map[string]any{"payload": map[string]any{"k": "v"}},
+			},
+			want: map[string]any{"k": "v"},
+		},
+		{
+			name: "PriorityOrder_ResponseWinsOverPayload",
+			fr: &genai.FunctionResponse{
+				Response: map[string]any{
+					"response": `"from-response"`,
+					"payload":  "from-payload",
+				},
+			},
+			want: "from-response",
+		},
+		{
+			name: "Fallback_NeitherKey_ReturnsRawMap",
+			fr: &genai.FunctionResponse{
+				Response: map[string]any{"custom": "shape"},
+			},
+			want: map[string]any{"custom": "shape"},
+		},
+		{
+			name: "Fallback_EmptyResponseMap",
+			fr:   &genai.FunctionResponse{Response: map[string]any{}},
+			want: map[string]any{},
+		},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			got := decodeWorkflowInputResponse(tc.fr)
+			if diff := cmp.Diff(tc.want, got); diff != "" {
+				t.Errorf("decodeWorkflowInputResponse(%+v) mismatch (-want +got):\n%s", tc.fr.Response, diff)
+			}
+		})
 	}
 }

--- a/agent/workflowagent/workflow_test.go
+++ b/agent/workflowagent/workflow_test.go
@@ -28,6 +28,8 @@ import (
 	"google.golang.org/adk/workflow"
 )
 
+var defaultNodeConfig = workflow.NodeConfig{}
+
 // MockSession is a minimal implementation of session.Session for testing.
 type MockSession struct {
 	session.Session
@@ -106,8 +108,8 @@ func TestWorkflowAgent(t *testing.T) {
 		return input + " done", nil
 	}
 
-	nodeA := workflow.NewFunctionNode("upper", upperFn)
-	nodeB := workflow.NewFunctionNode("suffix", suffixFn)
+	nodeA := workflow.NewFunctionNode("upper", upperFn, defaultNodeConfig)
+	nodeB := workflow.NewFunctionNode("suffix", suffixFn, defaultNodeConfig)
 
 	edges := workflow.Chain(workflow.Start, nodeA, nodeB)
 

--- a/agent/workflowagent/workflow_test.go
+++ b/agent/workflowagent/workflow_test.go
@@ -109,12 +109,10 @@ func TestWorkflowAgent(t *testing.T) {
 	nodeA := workflow.NewFunctionNode("upper", upperFn)
 	nodeB := workflow.NewFunctionNode("suffix", suffixFn)
 
-	edges := workflow.Chain(workflow.START, nodeA, nodeB)
+	edges := workflow.Chain(workflow.Start, nodeA, nodeB)
 
 	myWorkflow, err := New(Config{
-		AgentConfig: agent.Config{
-			Name: "test_workflow",
-		},
+		Name:  "test_workflow",
 		Edges: edges,
 	})
 	if err != nil {

--- a/agent/workflowagent/workflow_test.go
+++ b/agent/workflowagent/workflow_test.go
@@ -1,0 +1,157 @@
+// Copyright 2026 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package workflowagent
+
+import (
+	"context"
+	"fmt"
+	"strings"
+	"testing"
+	"time"
+
+	"google.golang.org/genai"
+
+	"google.golang.org/adk/agent"
+	"google.golang.org/adk/session"
+	"google.golang.org/adk/workflow"
+)
+
+// MockSession is a minimal implementation of session.Session for testing.
+type MockSession struct {
+	session.Session
+}
+
+func (m MockSession) ID() string {
+	return "test-session-id"
+}
+
+// MockInvocationContext is a minimal implementation of agent.InvocationContext for testing.
+type MockInvocationContext struct {
+	context.Context
+	sess        session.Session
+	userContent *genai.Content
+	myAgent     agent.Agent
+}
+
+func (m *MockInvocationContext) Session() session.Session {
+	return m.sess
+}
+
+func (m *MockInvocationContext) InvocationID() string {
+	return "test-invocation-id"
+}
+
+func (m *MockInvocationContext) UserContent() *genai.Content {
+	return m.userContent
+}
+
+func (m *MockInvocationContext) Agent() agent.Agent {
+	return m.myAgent
+}
+
+func (m *MockInvocationContext) WithContext(ctx context.Context) agent.InvocationContext {
+	return &MockInvocationContext{
+		Context:     ctx,
+		sess:        m.sess,
+		userContent: m.userContent,
+		myAgent:     m.myAgent,
+	}
+}
+
+func (m *MockInvocationContext) Deadline() (deadline time.Time, ok bool) {
+	return m.Context.Deadline()
+}
+
+func (m *MockInvocationContext) Done() <-chan struct{} {
+	return m.Context.Done()
+}
+
+func (m *MockInvocationContext) Err() error {
+	return m.Context.Err()
+}
+
+func (m *MockInvocationContext) Value(key any) any {
+	return m.Context.Value(key)
+}
+
+func (m *MockInvocationContext) Artifacts() agent.Artifacts { return nil }
+func (m *MockInvocationContext) Memory() agent.Memory       { return nil }
+func (m *MockInvocationContext) Branch() string             { return "" }
+func (m *MockInvocationContext) RunConfig() *agent.RunConfig { return nil }
+func (m *MockInvocationContext) Ended() bool                { return false }
+func (m *MockInvocationContext) EndInvocation()             {}
+
+func TestWorkflowAgent(t *testing.T) {
+	upperFn := func(ctx agent.InvocationContext, input any) (string, error) {
+		s, ok := input.(string)
+		if !ok {
+			return "", fmt.Errorf("expected string input")
+		}
+		return strings.ToUpper(s), nil
+	}
+
+	suffixFn := func(ctx agent.InvocationContext, input string) (string, error) {
+		return input + " done", nil
+	}
+
+	nodeA := workflow.NewFunctionNode("upper", upperFn)
+	nodeB := workflow.NewFunctionNode("suffix", suffixFn)
+
+	edges := workflow.Chain(workflow.START, nodeA, nodeB)
+
+	myWorkflow, err := New(Config{
+		AgentConfig: agent.Config{
+			Name: "test_workflow",
+		},
+		Edges: edges,
+	})
+	if err != nil {
+		t.Fatalf("failed to create workflow agent: %v", err)
+	}
+
+	mockCtx := &MockInvocationContext{
+		Context: context.TODO(),
+		sess:    MockSession{},
+		userContent: &genai.Content{
+			Parts: []*genai.Part{{Text: "hello"}},
+		},
+		myAgent: myWorkflow,
+	}
+
+	events := myWorkflow.Run(mockCtx)
+
+	var lastOutput any
+	count := 0
+	for ev, err := range events {
+		if err != nil {
+			t.Fatalf("unexpected error: %v", err)
+		}
+		count++
+
+		if ev.Actions.StateDelta != nil {
+			if out, ok := ev.Actions.StateDelta["output"]; ok {
+				lastOutput = out
+			}
+		}
+	}
+
+	if count != 2 {
+		t.Errorf("expected 2 events, got %d", count)
+	}
+
+	if lastOutput != "HELLO done" {
+		t.Errorf("expected last output 'HELLO done', got %v", lastOutput)
+	}
+}

--- a/agent/workflowagent/workflow_test.go
+++ b/agent/workflowagent/workflow_test.go
@@ -95,13 +95,14 @@ func (m *MockInvocationContext) Value(key any) any {
 	return m.Context.Value(key)
 }
 
-func (m *MockInvocationContext) Artifacts() agent.Artifacts  { return nil }
-func (m *MockInvocationContext) Memory() agent.Memory        { return nil }
-func (m *MockInvocationContext) Branch() string              { return "" }
-func (m *MockInvocationContext) RunConfig() *agent.RunConfig { return nil }
-func (m *MockInvocationContext) Ended() bool                 { return false }
-func (m *MockInvocationContext) EndInvocation()              {}
-func (m *MockInvocationContext) TriggeredBy() string         { return "" }
+func (m *MockInvocationContext) Artifacts() agent.Artifacts      { return nil }
+func (m *MockInvocationContext) Memory() agent.Memory            { return nil }
+func (m *MockInvocationContext) Branch() string                  { return "" }
+func (m *MockInvocationContext) RunConfig() *agent.RunConfig     { return nil }
+func (m *MockInvocationContext) Ended() bool                     { return false }
+func (m *MockInvocationContext) EndInvocation()                  {}
+func (m *MockInvocationContext) TriggeredBy() string             { return "" }
+func (m *MockInvocationContext) ResumedInput(string) (any, bool) { return nil, false }
 
 func TestWorkflowAgent(t *testing.T) {
 	upperFn := func(ctx agent.InvocationContext, input any) (string, error) {

--- a/agent/workflowagent/workflow_test.go
+++ b/agent/workflowagent/workflow_test.go
@@ -86,12 +86,12 @@ func (m *MockInvocationContext) Value(key any) any {
 	return m.Context.Value(key)
 }
 
-func (m *MockInvocationContext) Artifacts() agent.Artifacts { return nil }
-func (m *MockInvocationContext) Memory() agent.Memory       { return nil }
-func (m *MockInvocationContext) Branch() string             { return "" }
+func (m *MockInvocationContext) Artifacts() agent.Artifacts  { return nil }
+func (m *MockInvocationContext) Memory() agent.Memory        { return nil }
+func (m *MockInvocationContext) Branch() string              { return "" }
 func (m *MockInvocationContext) RunConfig() *agent.RunConfig { return nil }
-func (m *MockInvocationContext) Ended() bool                { return false }
-func (m *MockInvocationContext) EndInvocation()             {}
+func (m *MockInvocationContext) Ended() bool                 { return false }
+func (m *MockInvocationContext) EndInvocation()              {}
 
 func TestWorkflowAgent(t *testing.T) {
 	upperFn := func(ctx agent.InvocationContext, input any) (string, error) {

--- a/agent/workflowagent/workflow_test.go
+++ b/agent/workflowagent/workflow_test.go
@@ -94,6 +94,7 @@ func (m *MockInvocationContext) Branch() string              { return "" }
 func (m *MockInvocationContext) RunConfig() *agent.RunConfig { return nil }
 func (m *MockInvocationContext) Ended() bool                 { return false }
 func (m *MockInvocationContext) EndInvocation()              {}
+func (m *MockInvocationContext) TriggeredBy() string         { return "" }
 
 func TestWorkflowAgent(t *testing.T) {
 	upperFn := func(ctx agent.InvocationContext, input any) (string, error) {

--- a/agent/workflowagent/workflow_test.go
+++ b/agent/workflowagent/workflow_test.go
@@ -147,11 +147,9 @@ func TestWorkflowAgent(t *testing.T) {
 			t.Fatalf("unexpected error: %v", err)
 		}
 
-		if ev.Actions.StateDelta != nil {
-			if out, ok := ev.Actions.StateDelta["output"]; ok {
-				lastOutput = out
-				nodeEvents++
-			}
+		if ev.Output != nil {
+			lastOutput = ev.Output
+			nodeEvents++
 		}
 	}
 

--- a/cmd/launcher/console/console.go
+++ b/cmd/launcher/console/console.go
@@ -99,7 +99,7 @@ func (l *consoleLauncher) Run(ctx context.Context, config *launcher.Config) erro
 
 	rootAgent := config.AgentLoader.RootAgent()
 
-	session := resp.Session
+	sess := resp.Session
 
 	r, err := runner.New(runner.Config{
 		AppName:         appName,
@@ -144,6 +144,14 @@ func (l *consoleLauncher) Run(ctx context.Context, config *launcher.Config) erro
 		}
 	}
 
+	// pendingInterrupts carries human-input prompts the agent
+	// emitted on the previous turn. While non-empty, the next
+	// stdin read is interpreted as the answer to its head; once
+	// every prompt has an answer the assembled FunctionResponse
+	// content is sent as the next "user message" turn.
+	var pendingInterrupts []pendingInterrupt
+	var pendingResponses []*genai.Part
+
 	for {
 		select {
 		case <-ctx.Done():
@@ -156,7 +164,33 @@ func (l *consoleLauncher) Run(ctx context.Context, config *launcher.Config) erro
 			log.Fatal(err)
 		case userInput := <-inputChan:
 
-			userMsg := genai.NewContentFromText(userInput, genai.RoleUser)
+			var userMsg *genai.Content
+			if len(pendingInterrupts) > 0 {
+				// Answer the head of the queue; loop back if more
+				// prompts remain.
+				current := pendingInterrupts[0]
+				pendingInterrupts = pendingInterrupts[1:]
+				pendingResponses = append(pendingResponses, buildInterruptResponse(current, userInput))
+				if len(pendingInterrupts) > 0 {
+					renderInterruptPrompt(pendingInterrupts[0])
+					continue
+				}
+				// All answers collected. Bundle every
+				// FunctionResponse into one user Content; the
+				// workflow runtime routes each to its waiting
+				// node by FunctionResponse.ID.
+				// TODO: legacy non-workflow agents still pick
+				// one agent from the first FunctionResponse.ID
+				// and drop the rest.
+				userMsg = &genai.Content{
+					Role:  string(genai.RoleUser),
+					Parts: pendingResponses,
+				}
+				pendingResponses = nil
+			} else {
+				userMsg = genai.NewContentFromText(userInput, genai.RoleUser)
+			}
+
 			streamingMode := l.config.streamingMode
 			if streamingMode == "" {
 				streamingMode = defaultStreamingMode
@@ -164,12 +198,14 @@ func (l *consoleLauncher) Run(ctx context.Context, config *launcher.Config) erro
 
 			fmt.Print("\nAgent -> ")
 			prevText := ""
-			for event, err := range r.Run(ctx, userID, session.ID(), userMsg, agent.RunConfig{
+			var collectedEvents []*session.Event
+			for event, err := range r.Run(ctx, userID, sess.ID(), userMsg, agent.RunConfig{
 				StreamingMode: streamingMode,
 			}) {
 				if err != nil {
 					fmt.Printf("\nAGENT_ERROR: %v\n", err)
 				} else {
+					collectedEvents = append(collectedEvents, event)
 					if event.LLMResponse.Content == nil {
 						continue
 					}
@@ -198,6 +234,16 @@ func (l *consoleLauncher) Run(ctx context.Context, config *launcher.Config) erro
 
 					prevText = ""
 				}
+			}
+
+			// If the turn paused on any long-running interrupts,
+			// render the first prompt; the next stdin read will
+			// be its answer.
+			pendingInterrupts = collectPendingInterrupts(collectedEvents)
+			if len(pendingInterrupts) > 0 {
+				fmt.Println()
+				renderInterruptPrompt(pendingInterrupts[0])
+				continue
 			}
 			fmt.Print("\nUser -> ")
 		}

--- a/cmd/launcher/console/hitl.go
+++ b/cmd/launcher/console/hitl.go
@@ -1,0 +1,186 @@
+// Copyright 2026 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package console
+
+import (
+	"encoding/json"
+	"fmt"
+	"strings"
+
+	"google.golang.org/genai"
+
+	"google.golang.org/adk/session"
+	"google.golang.org/adk/workflow"
+)
+
+// pendingInterrupt is one HITL prompt the agent emitted on the
+// previous turn that still needs a user reply on the next. The
+// id+name pair come from a FunctionCall part whose ID appears
+// in Event.LongRunningToolIDs.
+type pendingInterrupt struct {
+	id   string
+	name string
+	args map[string]any
+}
+
+// collectPendingInterrupts scans events for FunctionCall parts
+// referenced from LongRunningToolIDs on the same event and
+// returns them in order of appearance.
+func collectPendingInterrupts(events []*session.Event) []pendingInterrupt {
+	var out []pendingInterrupt
+	for _, ev := range events {
+		if ev == nil || len(ev.LongRunningToolIDs) == 0 {
+			continue
+		}
+		lr := map[string]struct{}{}
+		for _, id := range ev.LongRunningToolIDs {
+			lr[id] = struct{}{}
+		}
+		c := ev.Content
+		if c == nil {
+			continue
+		}
+		for _, p := range c.Parts {
+			fc := p.FunctionCall
+			if fc == nil {
+				continue
+			}
+			if _, isInterrupt := lr[fc.ID]; !isInterrupt {
+				continue
+			}
+			out = append(out, pendingInterrupt{
+				id:   fc.ID,
+				name: fc.Name,
+				args: fc.Args,
+			})
+		}
+	}
+	return out
+}
+
+// renderInterruptPrompt prints the pending interrupt and a
+// "User -> " input prompt to stdout. The caller reads the user's
+// reply and passes it to buildInterruptResponse.
+func renderInterruptPrompt(p pendingInterrupt) {
+	switch p.name {
+	case workflow.WorkflowInputFunctionCallName:
+		renderWorkflowInputPrompt(p.args)
+	default:
+		renderGenericInterruptPrompt(p.name, p.args)
+	}
+	fmt.Print("User -> ")
+}
+
+// buildInterruptResponse converts the operator's one-line input
+// into a FunctionResponse part keyed by the interrupt's id and
+// name. Same per-name dispatch as renderInterruptPrompt.
+func buildInterruptResponse(p pendingInterrupt, userInput string) *genai.Part {
+	line := strings.TrimRight(userInput, "\r\n")
+
+	var response map[string]any
+	switch p.name {
+	case workflow.WorkflowInputFunctionCallName:
+		response = workflowInputResponseFromUserInput(line)
+	default:
+		response = genericResponseFromUserInput(line)
+	}
+	return &genai.Part{
+		FunctionResponse: &genai.FunctionResponse{
+			ID:       p.id,
+			Name:     p.name,
+			Response: response,
+		},
+	}
+}
+
+// renderWorkflowInputPrompt prints the workflow request prompt.
+// Args carry the fields populated by workflow.NewRequestInputEvent:
+// interruptId, message, payload, responseSchema.
+func renderWorkflowInputPrompt(args map[string]any) {
+	msg, _ := args["message"].(string)
+	if msg == "" {
+		msg = "Input requested"
+	}
+	fmt.Printf("Agent -> %s\n", msg)
+	if payload, ok := args["payload"]; ok && payload != nil {
+		// Strings (incl. those that survived a JSON persistence
+		// roundtrip) print raw to avoid the noisy "\"escaped\""
+		// form. Other values render as pretty JSON aligned under
+		// the "  Payload: " label: prefix="  " puts continuation
+		// lines (incl. the closing brace) at the label's column,
+		// and indent="  " adds two spaces per nesting level — so
+		// top-level keys sit two columns inside the opening brace.
+		if s, ok := payload.(string); ok {
+			fmt.Printf("  Payload: %s\n", s)
+		} else if pretty, err := json.MarshalIndent(payload, "  ", "  "); err == nil {
+			fmt.Printf("  Payload: %s\n", pretty)
+		} else {
+			fmt.Printf("  Payload: %v\n", payload)
+		}
+	}
+	if schema, ok := args["responseSchema"]; ok && schema != nil {
+		if pretty, err := json.Marshal(schema); err == nil {
+			fmt.Printf("  Expected response schema: %s\n", pretty)
+		}
+	}
+}
+
+// workflowInputResponseFromUserInput shapes a one-line operator
+// reply into a workflow-input FunctionResponse payload. Tries
+// JSON first; a parsed object is returned verbatim so the
+// operator can submit a fully-structured response, scalars and
+// arrays are wrapped under "payload", and unparseable input is
+// passed through under "payload" too.
+func workflowInputResponseFromUserInput(line string) map[string]any {
+	var parsed any
+	if err := json.Unmarshal([]byte(line), &parsed); err == nil {
+		if asMap, ok := parsed.(map[string]any); ok {
+			return asMap
+		}
+		return map[string]any{"payload": parsed}
+	}
+	return map[string]any{"payload": line}
+}
+
+// renderGenericInterruptPrompt is the fallback for HITL kinds the
+// launcher does not specifically recognise. Prints the kind name
+// and the raw args so the operator can compose a sensible
+// response by hand.
+func renderGenericInterruptPrompt(name string, args map[string]any) {
+	fmt.Printf("Agent -> waiting for response (kind: %s)\n", name)
+	if len(args) > 0 {
+		if pretty, err := json.Marshal(args); err == nil {
+			fmt.Printf("  Args: %s\n", pretty)
+		} else {
+			fmt.Printf("  Args: %v\n", args)
+		}
+	}
+}
+
+// genericResponseFromUserInput shapes the operator's reply for
+// HITL kinds without a dedicated parser. A parsed JSON object is
+// returned verbatim so the operator can submit a fully-structured
+// response; scalars and arrays are wrapped under "result"; raw
+// text falls back to "result" too.
+func genericResponseFromUserInput(line string) map[string]any {
+	var parsed any
+	if err := json.Unmarshal([]byte(line), &parsed); err == nil {
+		if asMap, ok := parsed.(map[string]any); ok {
+			return asMap
+		}
+		return map[string]any{"result": parsed}
+	}
+	return map[string]any{"result": line}
+}

--- a/cmd/launcher/console/hitl_test.go
+++ b/cmd/launcher/console/hitl_test.go
@@ -1,0 +1,331 @@
+// Copyright 2026 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package console
+
+import (
+	"io"
+	"os"
+	"reflect"
+	"strings"
+	"testing"
+
+	"google.golang.org/genai"
+
+	"google.golang.org/adk/model"
+	"google.golang.org/adk/session"
+	"google.golang.org/adk/workflow"
+)
+
+// captureStdout runs f with os.Stdout redirected to a pipe and
+// returns everything f wrote.
+func captureStdout(t *testing.T, f func()) string {
+	t.Helper()
+	orig := os.Stdout
+	r, w, err := os.Pipe()
+	if err != nil {
+		t.Fatalf("os.Pipe: %v", err)
+	}
+	os.Stdout = w
+	done := make(chan string, 1)
+	go func() {
+		b, _ := io.ReadAll(r)
+		done <- string(b)
+	}()
+	f()
+	w.Close()
+	os.Stdout = orig
+	return <-done
+}
+
+// TestCollectPendingInterrupts_DetectionByLongRunningToolIDs
+// verifies the detection contract: an event is a HITL prompt
+// iff it has a non-empty LongRunningToolIDs and one of its
+// content parts is a FunctionCall whose ID is in that set. The
+// function name is not the discriminator — workflow input and
+// any future kind all flow through the same detection path.
+func TestCollectPendingInterrupts_DetectionByLongRunningToolIDs(t *testing.T) {
+	tests := []struct {
+		name   string
+		events []*session.Event
+		want   []pendingInterrupt
+	}{
+		{
+			name:   "empty event list",
+			events: nil,
+			want:   nil,
+		},
+		{
+			name: "event with FunctionCall but no LongRunningToolIDs is not an interrupt",
+			events: []*session.Event{
+				{
+					LLMResponse: model.LLMResponse{
+						Content: &genai.Content{
+							Parts: []*genai.Part{{
+								FunctionCall: &genai.FunctionCall{ID: "x", Name: "regular_tool"},
+							}},
+						},
+					},
+				},
+			},
+			want: nil,
+		},
+		{
+			name: "event with LongRunningToolIDs but no matching FunctionCall is not an interrupt",
+			events: []*session.Event{
+				{
+					LongRunningToolIDs: []string{"abc"},
+					LLMResponse: model.LLMResponse{
+						Content: &genai.Content{
+							Parts: []*genai.Part{{
+								FunctionCall: &genai.FunctionCall{ID: "different_id", Name: "unmatched"},
+							}},
+						},
+					},
+				},
+			},
+			want: nil,
+		},
+		{
+			name: "workflow input on Event.LLMResponse.Content is detected",
+			events: []*session.Event{
+				{
+					LongRunningToolIDs: []string{"int-1"},
+					LLMResponse: model.LLMResponse{
+						Content: &genai.Content{
+							Parts: []*genai.Part{{
+								FunctionCall: &genai.FunctionCall{
+									ID:   "int-1",
+									Name: workflow.WorkflowInputFunctionCallName,
+									Args: map[string]any{"message": "ok?"},
+								},
+							}},
+						},
+					},
+				},
+			},
+			want: []pendingInterrupt{
+				{id: "int-1", name: workflow.WorkflowInputFunctionCallName, args: map[string]any{"message": "ok?"}},
+			},
+		},
+		{
+			name: "multiple events, only ones with matching IDs surface",
+			events: []*session.Event{
+				{LLMResponse: model.LLMResponse{Content: &genai.Content{Parts: []*genai.Part{{Text: "intro"}}}}},
+				{
+					LongRunningToolIDs: []string{"int-2"},
+					LLMResponse: model.LLMResponse{
+						Content: &genai.Content{
+							Parts: []*genai.Part{{FunctionCall: &genai.FunctionCall{ID: "int-2", Name: "x"}}},
+						},
+					},
+				},
+				{LLMResponse: model.LLMResponse{Content: &genai.Content{Parts: []*genai.Part{{Text: "outro"}}}}},
+			},
+			want: []pendingInterrupt{
+				{id: "int-2", name: "x", args: nil},
+			},
+		},
+	}
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			got := collectPendingInterrupts(tc.events)
+			if !reflect.DeepEqual(got, tc.want) {
+				t.Errorf("collectPendingInterrupts() = %#v, want %#v", got, tc.want)
+			}
+		})
+	}
+}
+
+// TestBuildInterruptResponse_WorkflowInput verifies the
+// workflow-input dispatch: a JSON object reply is returned
+// verbatim (the operator submitted the final shape); scalars,
+// arrays, and raw text are wrapped under "payload".
+func TestBuildInterruptResponse_WorkflowInput(t *testing.T) {
+	tests := []struct {
+		name         string
+		userInput    string
+		wantResponse map[string]any
+	}{
+		{
+			name:         "raw text is wrapped under payload",
+			userInput:    "approve\n",
+			wantResponse: map[string]any{"payload": "approve"},
+		},
+		{
+			name:         "JSON object is returned verbatim (no wrapper)",
+			userInput:    `{"approved": true, "days": 3}` + "\n",
+			wantResponse: map[string]any{"approved": true, "days": float64(3)},
+		},
+		{
+			name:         "JSON scalar is wrapped under payload",
+			userInput:    "42\n",
+			wantResponse: map[string]any{"payload": float64(42)},
+		},
+		{
+			name:         "JSON array is wrapped under payload",
+			userInput:    `[1, 2, "three"]` + "\n",
+			wantResponse: map[string]any{"payload": []any{float64(1), float64(2), "three"}},
+		},
+		{
+			name:         "trailing CR is stripped",
+			userInput:    "approve\r\n",
+			wantResponse: map[string]any{"payload": "approve"},
+		},
+	}
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			p := pendingInterrupt{id: "x", name: workflow.WorkflowInputFunctionCallName}
+			part := buildInterruptResponse(p, tc.userInput)
+			if part.FunctionResponse == nil {
+				t.Fatalf("expected FunctionResponse part, got %+v", part)
+			}
+			if got, want := part.FunctionResponse.ID, "x"; got != want {
+				t.Errorf("ID = %q, want %q", got, want)
+			}
+			if got, want := part.FunctionResponse.Name, workflow.WorkflowInputFunctionCallName; got != want {
+				t.Errorf("Name = %q, want %q", got, want)
+			}
+			if !reflect.DeepEqual(part.FunctionResponse.Response, tc.wantResponse) {
+				t.Errorf("Response = %#v, want %#v",
+					part.FunctionResponse.Response, tc.wantResponse)
+			}
+		})
+	}
+}
+
+// TestBuildInterruptResponse_GenericFallback verifies the catch-all
+// path used for any long-running call name the launcher does not
+// specifically know about.
+func TestBuildInterruptResponse_GenericFallback(t *testing.T) {
+	tests := []struct {
+		name         string
+		userInput    string
+		wantResponse map[string]any
+	}{
+		{
+			name:         "raw text is wrapped under result",
+			userInput:    "some_value\n",
+			wantResponse: map[string]any{"result": "some_value"},
+		},
+		{
+			name:         "JSON object is returned verbatim (no wrapper)",
+			userInput:    `{"foo": "bar"}` + "\n",
+			wantResponse: map[string]any{"foo": "bar"},
+		},
+		{
+			name:         "JSON scalar is wrapped under result",
+			userInput:    "42\n",
+			wantResponse: map[string]any{"result": float64(42)},
+		},
+		{
+			name:         "JSON array is wrapped under result",
+			userInput:    `[1, 2]` + "\n",
+			wantResponse: map[string]any{"result": []any{float64(1), float64(2)}},
+		},
+	}
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			p := pendingInterrupt{id: "g", name: "some_unknown_kind"}
+			part := buildInterruptResponse(p, tc.userInput)
+			if !reflect.DeepEqual(part.FunctionResponse.Response, tc.wantResponse) {
+				t.Errorf("Response = %#v, want %#v",
+					part.FunctionResponse.Response, tc.wantResponse)
+			}
+		})
+	}
+}
+
+// TestRenderWorkflowInputPrompt_PayloadFormatting locks in the
+// payload-rendering contract:
+//
+//   - a string payload prints raw (no surrounding quotes, no
+//     escapes) so a value that survived a JSON roundtrip stays
+//     human-readable;
+//   - an object payload prints as JSON aligned under the
+//     "  Payload: " label: top-level keys are indented 4 spaces
+//     (2-space label column + 2-space JSON indent) and the closing
+//     brace sits at the 2-space label column. Drop the prefix and
+//     keys/brace collapse left of the label, producing visually
+//     broken output.
+func TestRenderWorkflowInputPrompt_PayloadFormatting(t *testing.T) {
+	tests := []struct {
+		name         string
+		args         map[string]any
+		wantContains []string
+		wantAbsent   []string
+	}{
+		{
+			name: "string payload prints raw, no escaped quotes",
+			args: map[string]any{
+				"message": "approve?",
+				"payload": "hello world",
+			},
+			wantContains: []string{
+				"Agent -> approve?\n",
+				"  Payload: hello world\n",
+			},
+			wantAbsent: []string{`"hello world"`, `\"`},
+		},
+		{
+			name: "object payload is indented under the Payload label",
+			args: map[string]any{
+				"message": "ok?",
+				"payload": map[string]any{"user": "alice", "days": float64(5)},
+			},
+			// Expected exact form. prefix="  " is appended at the
+			// start of every continuation line; indent="  " adds
+			// one more level for object keys. So keys land at
+			// column 4 ("    \"days\"") and the closing brace
+			// at column 2 ("  }"):
+			//   Agent -> ok?
+			//     Payload: {
+			//         "days": 5,
+			//         "user": "alice"
+			//       }
+			// (Go map keys serialise in sorted order, so "days"
+			// precedes "user".)
+			wantContains: []string{
+				"  Payload: {\n",
+				"\n    \"days\": 5",
+				"\n    \"user\": \"alice\"",
+				"\n  }\n",
+			},
+			// Without prefix="  ", keys would land flush at
+			// column 2 (one indent level, no prefix) and the
+			// closing brace at column 0; assert neither happens.
+			wantAbsent: []string{
+				"\n  \"days\"",
+				"\n}\n",
+			},
+		},
+	}
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			out := captureStdout(t, func() {
+				renderWorkflowInputPrompt(tc.args)
+			})
+			for _, s := range tc.wantContains {
+				if !strings.Contains(out, s) {
+					t.Errorf("output missing %q\nfull output:\n%s", s, out)
+				}
+			}
+			for _, s := range tc.wantAbsent {
+				if strings.Contains(out, s) {
+					t.Errorf("output contains forbidden %q\nfull output:\n%s", s, out)
+				}
+			}
+		})
+	}
+}

--- a/examples/tools/multipletools/main.go
+++ b/examples/tools/multipletools/main.go
@@ -107,11 +107,11 @@ func main() {
 		log.Fatalf("Failed to create agent: %v", err)
 	}
 
+	// Save message content in OpenTelemetry logs
+	os.Setenv("OTEL_INSTRUMENTATION_GENAI_CAPTURE_MESSAGE_CONTENT", "true")
+
 	config := &launcher.Config{
 		AgentLoader: agent.NewSingleLoader(a),
-		TelemetryOptions: []telemetry.Option{
-			telemetry.WithGenAICaptureMessageContent(true),
-		},
 	}
 
 	l := full.NewLauncher()

--- a/examples/tools/multipletools/main.go
+++ b/examples/tools/multipletools/main.go
@@ -28,7 +28,6 @@ import (
 	"google.golang.org/adk/cmd/launcher"
 	"google.golang.org/adk/cmd/launcher/full"
 	"google.golang.org/adk/model/gemini"
-	"google.golang.org/adk/telemetry"
 	"google.golang.org/adk/tool"
 	"google.golang.org/adk/tool/agenttool"
 	"google.golang.org/adk/tool/functiontool"

--- a/examples/workflow/basic/main.go
+++ b/examples/workflow/basic/main.go
@@ -44,8 +44,11 @@ func main() {
 	}
 
 	// 2. Create Nodes
-	nodeA := workflow.NewFunctionNode("upper", upperFn)
-	nodeB := workflow.NewFunctionNode("suffix", suffixFn)
+	nodeConfig := workflow.NodeConfig{
+		RetryConfig: workflow.DefaultRetryConfig(),
+	}
+	nodeA := workflow.NewFunctionNode("upper", upperFn, nodeConfig)
+	nodeB := workflow.NewFunctionNode("suffix", suffixFn, nodeConfig)
 
 	// 3. Define flow (Edges)
 	edges := workflow.Chain(workflow.Start, nodeA, nodeB)

--- a/examples/workflow/basic/main.go
+++ b/examples/workflow/basic/main.go
@@ -48,15 +48,13 @@ func main() {
 	nodeB := workflow.NewFunctionNode("suffix", suffixFn)
 
 	// 3. Define flow (Edges)
-	edges := workflow.Chain(workflow.START, nodeA, nodeB)
+	edges := workflow.Chain(workflow.Start, nodeA, nodeB)
 
 	// 4. Create Workflow Agent
 	myWorkflow, err := workflowagent.New(workflowagent.Config{
-		AgentConfig: agent.Config{
-			Name:        "simple_sequence_workflow",
-			Description: "Converts string to uppercase and appends a suffix",
-		},
-		Edges: edges,
+		Name:        "simple_sequence_workflow",
+		Description: "Converts string to uppercase and appends a suffix",
+		Edges:       edges,
 	})
 	if err != nil {
 		log.Fatalf("failed to create workflow: %v", err)

--- a/examples/workflow/dynamic/basic/main.go
+++ b/examples/workflow/dynamic/basic/main.go
@@ -1,0 +1,69 @@
+// Copyright 2026 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+// Dynamic workflow example: a parent dynamic node orchestrates a single
+// child via workflow.RunNode. Mirrors the "Get started" snippet from
+// https://adk.dev/graphs/dynamic/.
+package main
+
+import (
+	"context"
+	"log"
+	"os"
+
+	"google.golang.org/adk/agent"
+	"google.golang.org/adk/agent/workflowagent"
+	"google.golang.org/adk/cmd/launcher"
+	"google.golang.org/adk/cmd/launcher/full"
+	"google.golang.org/adk/session"
+	"google.golang.org/adk/workflow"
+)
+
+func main() {
+	ctx := context.Background()
+
+	// Child node: returns a greeting. Equivalent to the Python
+	// @node(name="hello_node") def my_node(node_input): return "Hello World".
+	helloNode := workflow.NewFunctionNode("hello_node",
+		func(_ agent.InvocationContext, _ string) (string, error) {
+			return "Hello World", nil
+		},
+		workflow.NodeConfig{},
+	)
+
+	// Parent dynamic node: orchestrates children via RunNode.
+	// RerunOnResume defaults to &true (required for dynamic nodes).
+	myWorkflow := workflow.NewDynamicNode[string, string]("my_workflow",
+		func(ctx workflow.NodeContext, _ string, _ func(*session.Event) error) (string, error) {
+			return workflow.RunNode[string](ctx, helloNode, "hello")
+		},
+		workflow.NodeConfig{},
+	)
+
+	wa, err := workflowagent.New(workflowagent.Config{
+		Name:        "dynamic_workflow_sample",
+		Description: "Minimal dynamic workflow: parent orchestrator calls one child via RunNode.",
+		Edges:       workflow.Chain(workflow.Start, myWorkflow),
+	})
+	if err != nil {
+		log.Fatalf("workflowagent.New: %v", err)
+	}
+
+	l := full.NewLauncher()
+	if err := l.Execute(ctx, &launcher.Config{
+		AgentLoader: agent.NewSingleLoader(wa),
+	}, os.Args[1:]); err != nil {
+		log.Fatalf("Run failed: %v\n\n%s", err, l.CommandLineSyntax())
+	}
+}

--- a/examples/workflow/dynamic/hitl/main.go
+++ b/examples/workflow/dynamic/hitl/main.go
@@ -1,0 +1,117 @@
+// Copyright 2026 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+// Dynamic workflow + HITL example: a dynamic orchestrator pauses for
+// human input via workflow.RunNode, then resumes and greets the user.
+// Demonstrates the re-entry resume pattern: dynamic nodes default to
+// RerunOnResume=&true, so the orchestrator body is re-invoked from the
+// top after the human replies, and the reply is delivered via
+// NodeContext.ResumedInput.
+//
+//	go run ./examples/workflow/dynamic/hitl/ console
+//
+//	User -> start
+//	Agent -> [HITL input] What's your name?
+//	User -> Alice
+//	Agent -> Hello, Alice!
+//
+// Compare with examples/workflow/hitl_simple/: the static-chain
+// variant of the same scenario. Both rely on the console launcher's
+// HITL support to render the prompt and forward the reply.
+package main
+
+import (
+	"context"
+	"fmt"
+	"iter"
+	"log"
+	"os"
+
+	"google.golang.org/genai"
+
+	"google.golang.org/adk/agent"
+	"google.golang.org/adk/agent/workflowagent"
+	"google.golang.org/adk/cmd/launcher"
+	"google.golang.org/adk/cmd/launcher/full"
+	"google.golang.org/adk/session"
+	"google.golang.org/adk/workflow"
+)
+
+// askName is an inline workflow.Node that pauses with a RequestInput
+// asking for the user's name. We can't use FunctionNode because its
+// "input → output" shape does not cover RequestInput emission.
+type askName struct {
+	workflow.BaseNode
+}
+
+func newAskName() *askName {
+	return &askName{
+		BaseNode: workflow.NewBaseNode("ask_name", "asks the user for their name", workflow.NodeConfig{}),
+	}
+}
+
+func (n *askName) Run(ctx agent.InvocationContext, _ any) iter.Seq2[*session.Event, error] {
+	return func(yield func(*session.Event, error) bool) {
+		yield(workflow.NewRequestInputEvent(ctx, session.RequestInput{
+			InterruptID: "ask_name",
+			Message:     "What's your name?",
+		}), nil)
+	}
+}
+
+func main() {
+	ctx := context.Background()
+
+	ask := newAskName()
+
+	greeter := workflow.NewDynamicNode[string, string]("hitl_demo",
+		func(nc workflow.NodeContext, _ string, emit func(*session.Event) error) (string, error) {
+			// Resume re-entry: the reply is in ResumedInput.
+			if reply, ok := nc.ResumedInput("ask_name"); ok {
+				name, _ := reply.(string)
+				if name == "" {
+					name = "stranger"
+				}
+				greeting := fmt.Sprintf("Hello, %s!", name)
+				// Emit Content so the console renders the greeting; the
+				// terminal Output below is for downstream nodes / state.
+				ev := session.NewEvent(nc.InvocationID())
+				ev.Content = &genai.Content{Parts: []*genai.Part{{Text: greeting}}}
+				if err := emit(ev); err != nil {
+					return "", err
+				}
+				return greeting, nil
+			}
+			_, err := workflow.RunNode[any](nc, ask, nil)
+			return "", err
+		},
+		workflow.NodeConfig{},
+	)
+
+	wa, err := workflowagent.New(workflowagent.Config{
+		Name:        "dynamic_hitl_sample",
+		Description: "Minimal dynamic workflow that pauses for human input via RunNode + ResumedInput.",
+		Edges:       workflow.Chain(workflow.Start, greeter),
+	})
+	if err != nil {
+		log.Fatalf("workflowagent.New: %v", err)
+	}
+
+	l := full.NewLauncher()
+	if err := l.Execute(ctx, &launcher.Config{
+		AgentLoader: agent.NewSingleLoader(wa),
+	}, os.Args[1:]); err != nil {
+		log.Fatalf("Run failed: %v\n\n%s", err, l.CommandLineSyntax())
+	}
+}

--- a/examples/workflow/dynamic/llm/main.go
+++ b/examples/workflow/dynamic/llm/main.go
@@ -1,0 +1,90 @@
+// Copyright 2026 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+// Dynamic workflow + LLM example: a dynamic orchestrator calls a single
+// LlmAgent-backed node via workflow.RunNode. Demonstrates the smallest
+// useful composition of NewDynamicNode, NewAgentNode, and RunNode.
+package main
+
+import (
+	"context"
+	"log"
+	"os"
+
+	"google.golang.org/genai"
+
+	"google.golang.org/adk/agent"
+	"google.golang.org/adk/agent/llmagent"
+	"google.golang.org/adk/agent/workflowagent"
+	"google.golang.org/adk/cmd/launcher"
+	"google.golang.org/adk/cmd/launcher/full"
+	"google.golang.org/adk/model/gemini"
+	"google.golang.org/adk/session"
+	"google.golang.org/adk/workflow"
+)
+
+func main() {
+	ctx := context.Background()
+
+	model, err := gemini.NewModel(ctx, "gemini-3.1-flash-lite", &genai.ClientConfig{})
+	if err != nil {
+		log.Fatalf("gemini.NewModel: %v", err)
+	}
+
+	// Greeter LLM agent: takes whatever the user typed and replies with a
+	// one-sentence greeting. The exact prompt is intentionally tiny so the
+	// example stays focused on the dynamic/AgentNode composition.
+	greeterAgent, err := llmagent.New(llmagent.Config{
+		Name:        "greeter",
+		Model:       model,
+		Description: "Greets the user in one short sentence.",
+		Instruction: "You are a friendly assistant. Greet the user in exactly one short sentence.",
+	})
+	if err != nil {
+		log.Fatalf("llmagent.New: %v", err)
+	}
+
+	// Wrap the agent as a workflow.Node so it can be invoked from inside a
+	// dynamic orchestrator body via workflow.RunNode.
+	greeterNode, err := workflow.NewAgentNode(greeterAgent, workflow.NodeConfig{})
+	if err != nil {
+		log.Fatalf("workflow.NewAgentNode: %v", err)
+	}
+
+	// Dynamic orchestrator: expresses execution order as Go code. Here it
+	// just calls the greeter once and returns its output. The same shape
+	// scales to multi-step pipelines, branching, loops, etc.
+	myWorkflow := workflow.NewDynamicNode[string, string]("greeter_workflow",
+		func(nc workflow.NodeContext, in string, _ func(*session.Event) error) (string, error) {
+			return workflow.RunNode[string](nc, greeterNode, in)
+		},
+		workflow.NodeConfig{},
+	)
+
+	wa, err := workflowagent.New(workflowagent.Config{
+		Name:        "dynamic_llm_sample",
+		Description: "Minimal dynamic workflow that invokes one LlmAgent via RunNode.",
+		Edges:       workflow.Chain(workflow.Start, myWorkflow),
+	})
+	if err != nil {
+		log.Fatalf("workflowagent.New: %v", err)
+	}
+
+	l := full.NewLauncher()
+	if err := l.Execute(ctx, &launcher.Config{
+		AgentLoader: agent.NewSingleLoader(wa),
+	}, os.Args[1:]); err != nil {
+		log.Fatalf("Run failed: %v\n\n%s", err, l.CommandLineSyntax())
+	}
+}

--- a/examples/workflow/hitl_simple/main.go
+++ b/examples/workflow/hitl_simple/main.go
@@ -1,0 +1,124 @@
+// Copyright 2026 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+// hitl_simple is the minimal end-to-end HITL workflow for
+// verifying the console launcher's pause/resume support.
+// No LLM, no API key, no streaming — just two workflow nodes:
+//
+//	Start → ask_name → greet
+//
+// The ask_name node yields a RequestInput that pauses the
+// workflow. The console launcher renders the prompt; the user's
+// reply is delivered to greet as its input.
+//
+//	go run ./examples/workflow/hitl_simple/ console
+//
+//	User -> hello
+//	Agent -> What's your name?
+//	User -> Alice
+//	Agent -> Hello, Alice!
+//	User ->
+package main
+
+import (
+	"context"
+	"fmt"
+	"iter"
+	"log"
+	"os"
+
+	"google.golang.org/genai"
+
+	"google.golang.org/adk/agent"
+	"google.golang.org/adk/agent/workflowagent"
+	"google.golang.org/adk/cmd/launcher"
+	"google.golang.org/adk/cmd/launcher/full"
+	"google.golang.org/adk/session"
+	"google.golang.org/adk/workflow"
+)
+
+// inlineNode wraps a closure as a workflow.Node so we can yield
+// RequestInput (FunctionNode's "input → output" shape does not
+// cover that).
+type inlineNode struct {
+	workflow.BaseNode
+	run func(agent.InvocationContext, any) iter.Seq2[*session.Event, error]
+}
+
+func (n *inlineNode) Run(ctx agent.InvocationContext, input any) iter.Seq2[*session.Event, error] {
+	return n.run(ctx, input)
+}
+
+func mkNode(name, desc string, run func(agent.InvocationContext, any) iter.Seq2[*session.Event, error]) *inlineNode {
+	return &inlineNode{BaseNode: workflow.NewBaseNode(name, desc, workflow.NodeConfig{}), run: run}
+}
+
+// askName pauses the workflow with a RequestInput asking for the
+// user's name. The handoff resume delivers the reply as the next
+// node's input.
+func askName(ctx agent.InvocationContext, _ any) iter.Seq2[*session.Event, error] {
+	return func(yield func(*session.Event, error) bool) {
+		yield(workflow.NewRequestInputEvent(ctx, session.RequestInput{
+			InterruptID: "ask_name",
+			Message:     "What's your name?",
+		}), nil)
+	}
+}
+
+// greet receives the user's reply (as plain text) and yields one
+// event with the greeting as both the workflow output (StateDelta)
+// and Content (so the console launcher prints it).
+func greet(ctx agent.InvocationContext, input any) iter.Seq2[*session.Event, error] {
+	return func(yield func(*session.Event, error) bool) {
+		name, _ := input.(string)
+		if name == "" {
+			name = "stranger"
+		}
+		msg := fmt.Sprintf("Hello, %s!", name)
+		ev := session.NewEvent(ctx.InvocationID())
+		ev.Output = msg
+		ev.Content = &genai.Content{
+			Parts: []*genai.Part{{Text: msg}},
+		}
+		yield(ev, nil)
+	}
+}
+
+func main() {
+	ctx := context.Background()
+
+	ask := mkNode("ask_name", "asks the user for their name", askName)
+	hello := mkNode("greet", "greets the user by name", greet)
+
+	edges := workflow.Chain(workflow.Start, ask, hello)
+
+	rootAgent, err := workflowagent.New(workflowagent.Config{
+		Name:        "hitl_simple",
+		Description: "minimal HITL workflow for console launcher verification",
+		Edges:       edges,
+	})
+	if err != nil {
+		log.Fatalf("failed to create workflow agent: %v", err)
+	}
+
+	log.Printf("hitl_simple sample ready — type anything to start, then answer the prompt")
+
+	launcherCfg := &launcher.Config{
+		AgentLoader: agent.NewSingleLoader(rootAgent),
+	}
+	l := full.NewLauncher()
+	if err := l.Execute(ctx, launcherCfg, os.Args[1:]); err != nil {
+		log.Fatalf("Run failed: %v\n\n%s", err, l.CommandLineSyntax())
+	}
+}

--- a/examples/workflow/main.go
+++ b/examples/workflow/main.go
@@ -1,0 +1,74 @@
+// Copyright 2026 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package main
+
+import (
+	"context"
+	"log"
+	"os"
+	"strings"
+
+	"google.golang.org/adk/agent"
+	"google.golang.org/adk/agent/workflowagent"
+	"google.golang.org/adk/cmd/launcher"
+	"google.golang.org/adk/cmd/launcher/full"
+	"google.golang.org/adk/workflow"
+)
+
+func main() {
+	ctx := context.Background()
+
+	// 1. Define functions for nodes
+	// The first node will receive the user message as input (string).
+	upperFn := func(ctx agent.InvocationContext, input string) (string, error) {
+		if input == "" {
+			return "No input received", nil
+		}
+		return strings.ToUpper(input), nil
+	}
+
+	suffixFn := func(ctx agent.InvocationContext, input string) (string, error) {
+		return input + " IS AWESOME!", nil
+	}
+
+	// 2. Create Nodes
+	nodeA := workflow.NewFunctionNode("upper", upperFn)
+	nodeB := workflow.NewFunctionNode("suffix", suffixFn)
+
+	// 3. Define flow (Edges)
+	edges := workflow.Chain(workflow.START, nodeA, nodeB)
+
+	// 4. Create Workflow Agent
+	myWorkflow, err := workflowagent.New(workflowagent.Config{
+		AgentConfig: agent.Config{
+			Name:        "simple_sequence_workflow",
+			Description: "Converts string to uppercase and appends a suffix",
+		},
+		Edges: edges,
+	})
+	if err != nil {
+		log.Fatalf("failed to create workflow: %v", err)
+	}
+
+	log.Printf("Successfully created root agent: %s", myWorkflow.Name())
+
+	config := &launcher.Config{
+		AgentLoader: agent.NewSingleLoader(myWorkflow),
+	}
+	l := full.NewLauncher()
+	if err = l.Execute(ctx, config, os.Args[1:]); err != nil {
+		log.Fatalf("Run failed: %v\n\n%s", err, l.CommandLineSyntax())
+	}
+}

--- a/internal/agent/state.go
+++ b/internal/agent/state.go
@@ -31,6 +31,7 @@ const (
 	TypeLoopAgent       Type = "LoopAgent"
 	TypeSequentialAgent Type = "SequentialAgent"
 	TypeParallelAgent   Type = "ParallelAgent"
+	TypeWorkflowAgent   Type = "WorkflowAgent"
 	TypeCustomAgent     Type = "CustomAgent"
 	TypeRemoteAgent     Type = "RemoteAgent"
 )

--- a/internal/configurable/conformance/replayplugin/replay_plugin_test.go
+++ b/internal/configurable/conformance/replayplugin/replay_plugin_test.go
@@ -477,6 +477,7 @@ func (m *MockInvocationContext) RunConfig() *agent.RunConfig                    
 func (m *MockInvocationContext) EndInvocation()                                          {}
 func (m *MockInvocationContext) Ended() bool                                             { return false }
 func (m *MockInvocationContext) WithContext(ctx context.Context) agent.InvocationContext { return m }
+func (m *MockInvocationContext) TriggeredBy() string                                     { return "" }
 func (m *MockInvocationContext) Value(key any) any                                       { return nil }
 func (m *MockInvocationContext) Deadline() (deadline time.Time, ok bool)                 { return time.Time{}, false }
 func (m *MockInvocationContext) Done() <-chan struct{}                                   { return nil }

--- a/internal/configurable/conformance/replayplugin/replay_plugin_test.go
+++ b/internal/configurable/conformance/replayplugin/replay_plugin_test.go
@@ -478,6 +478,7 @@ func (m *MockInvocationContext) EndInvocation()                                 
 func (m *MockInvocationContext) Ended() bool                                             { return false }
 func (m *MockInvocationContext) WithContext(ctx context.Context) agent.InvocationContext { return m }
 func (m *MockInvocationContext) TriggeredBy() string                                     { return "" }
+func (m *MockInvocationContext) ResumedInput(string) (any, bool)                         { return nil, false }
 func (m *MockInvocationContext) Value(key any) any                                       { return nil }
 func (m *MockInvocationContext) Deadline() (deadline time.Time, ok bool)                 { return time.Time{}, false }
 func (m *MockInvocationContext) Done() <-chan struct{}                                   { return nil }

--- a/internal/configurable/conformance/replayplugin/replay_plugin_test.go
+++ b/internal/configurable/conformance/replayplugin/replay_plugin_test.go
@@ -477,7 +477,6 @@ func (m *MockInvocationContext) RunConfig() *agent.RunConfig                    
 func (m *MockInvocationContext) EndInvocation()                                          {}
 func (m *MockInvocationContext) Ended() bool                                             { return false }
 func (m *MockInvocationContext) WithContext(ctx context.Context) agent.InvocationContext { return m }
-func (m *MockInvocationContext) TriggeredBy() string                                     { return "" }
 func (m *MockInvocationContext) ResumedInput(string) (any, bool)                         { return nil, false }
 func (m *MockInvocationContext) Value(key any) any                                       { return nil }
 func (m *MockInvocationContext) Deadline() (deadline time.Time, ok bool)                 { return time.Time{}, false }

--- a/internal/context/invocation_context.go
+++ b/internal/context/invocation_context.go
@@ -113,4 +113,9 @@ func (c *InvocationContext) WithContext(ctx context.Context) agent.InvocationCon
 	return &newCtx
 }
 
+// TriggeredBy returns "" for non-workflow invocation contexts. The
+// workflow engine wraps this context in a private per-node context
+// that overrides the method when running inside a workflow.Node.
+func (c *InvocationContext) TriggeredBy() string { return "" }
+
 var _ agent.InvocationContext = (*InvocationContext)(nil)

--- a/internal/context/invocation_context.go
+++ b/internal/context/invocation_context.go
@@ -118,4 +118,9 @@ func (c *InvocationContext) WithContext(ctx context.Context) agent.InvocationCon
 // that overrides the method when running inside a workflow.Node.
 func (c *InvocationContext) TriggeredBy() string { return "" }
 
+// ResumedInput always returns (nil, false) for the base
+// invocation context. Implementations that carry a resume payload
+// override this method.
+func (c *InvocationContext) ResumedInput(string) (any, bool) { return nil, false }
+
 var _ agent.InvocationContext = (*InvocationContext)(nil)

--- a/internal/context/invocation_context.go
+++ b/internal/context/invocation_context.go
@@ -113,11 +113,6 @@ func (c *InvocationContext) WithContext(ctx context.Context) agent.InvocationCon
 	return &newCtx
 }
 
-// TriggeredBy returns "" for non-workflow invocation contexts. The
-// workflow engine wraps this context in a private per-node context
-// that overrides the method when running inside a workflow.Node.
-func (c *InvocationContext) TriggeredBy() string { return "" }
-
 // ResumedInput always returns (nil, false) for the base
 // invocation context. Implementations that carry a resume payload
 // override this method.

--- a/internal/llminternal/agent.go
+++ b/internal/llminternal/agent.go
@@ -27,8 +27,19 @@ type Agent interface {
 	internal() *State
 }
 
+type Mode string
+
+const (
+	ModeUnset      Mode = ""
+	ModeChat       Mode = "chat"
+	ModeTask       Mode = "task"
+	ModeSingleTurn Mode = "single_turn"
+)
+
 type State struct {
 	Model model.LLM
+
+	Mode Mode
 
 	Tools    []tool.Tool
 	Toolsets []tool.Toolset

--- a/internal/llminternal/functions_test.go
+++ b/internal/llminternal/functions_test.go
@@ -55,6 +55,8 @@ func (m *mockInvocationContext) Branch() string {
 	return m.branch
 }
 
+func (m *mockInvocationContext) TriggeredBy() string { return "" }
+
 func TestGenerateRequestConfirmationEvent(t *testing.T) {
 	confirmingFunctionCall := &genai.FunctionCall{
 		ID:   "call_1",

--- a/internal/llminternal/functions_test.go
+++ b/internal/llminternal/functions_test.go
@@ -55,7 +55,8 @@ func (m *mockInvocationContext) Branch() string {
 	return m.branch
 }
 
-func (m *mockInvocationContext) TriggeredBy() string { return "" }
+func (m *mockInvocationContext) TriggeredBy() string             { return "" }
+func (m *mockInvocationContext) ResumedInput(string) (any, bool) { return nil, false }
 
 func TestGenerateRequestConfirmationEvent(t *testing.T) {
 	confirmingFunctionCall := &genai.FunctionCall{

--- a/internal/llminternal/functions_test.go
+++ b/internal/llminternal/functions_test.go
@@ -55,7 +55,6 @@ func (m *mockInvocationContext) Branch() string {
 	return m.branch
 }
 
-func (m *mockInvocationContext) TriggeredBy() string             { return "" }
 func (m *mockInvocationContext) ResumedInput(string) (any, bool) { return nil, false }
 
 func TestGenerateRequestConfirmationEvent(t *testing.T) {

--- a/internal/telemetry/functionaltest/agent_telemetry_schema_test.go
+++ b/internal/telemetry/functionaltest/agent_telemetry_schema_test.go
@@ -1,0 +1,150 @@
+// Copyright 2026 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package functionaltest_test
+
+import (
+	"testing"
+
+	"github.com/google/go-cmp/cmp"
+	sdklog "go.opentelemetry.io/otel/sdk/log"
+	sdktrace "go.opentelemetry.io/otel/sdk/trace"
+	"go.opentelemetry.io/otel/sdk/trace/tracetest"
+	"google.golang.org/genai"
+
+	"google.golang.org/adk/agent"
+	"google.golang.org/adk/agent/llmagent"
+	"google.golang.org/adk/internal/telemetry"
+	"google.golang.org/adk/internal/telemetry/telemetrytest"
+	"google.golang.org/adk/internal/telemetry/telemetrytestcase"
+	"google.golang.org/adk/internal/testutil"
+	"google.golang.org/adk/tool"
+	"google.golang.org/adk/tool/functiontool"
+)
+
+// captureMessageContentEnvVar is the OpenTelemetry-spec env var
+// that controls whether ADK emits full message content in log
+// records or elides it for privacy.
+const captureMessageContentEnvVar = "OTEL_INSTRUMENTATION_GENAI_CAPTURE_MESSAGE_CONTENT"
+
+// TestTelemetrySchema_AgentWithTool runs the canonical
+// "llmagent with one FunctionTool" scenario end-to-end and asserts
+// the emitted span+log tree matches the expected shape exactly.
+// Parametrized over the
+// OTEL_INSTRUMENTATION_GENAI_CAPTURE_MESSAGE_CONTENT env var:
+// the "elided" subtest expects the production default (no message
+// content in log bodies); the "capture_content" subtest expects
+// the full decoded JSON content. Hermetic: no network calls, no
+// GCP, no live model.
+//
+// Mirrors test_telemetry_schema in
+// adk-python/tests/unittests/telemetry/test_functional.py.
+func TestTelemetrySchema_AgentWithTool(t *testing.T) {
+	tests := []struct {
+		name           string
+		captureContent bool
+		want           *telemetrytest.SpanDigest
+	}{
+		{
+			name:           "elided",
+			captureContent: false,
+			want:           telemetrytestcase.AgentWithToolCase,
+		},
+		{
+			name:           "capture_content",
+			captureContent: true,
+			want:           telemetrytestcase.AgentWithToolCaptureContentCase,
+		},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			if tc.captureContent {
+				t.Setenv(captureMessageContentEnvVar, "true")
+			} else {
+				t.Setenv(captureMessageContentEnvVar, "")
+			}
+
+			// Install in-memory tracer + logger so the test sees
+			// every span/log without depending on global OTel state.
+			spanExp := tracetest.NewInMemoryExporter()
+			telemetry.OverrideTracerForTesting(t, sdktrace.NewTracerProvider(sdktrace.WithSyncer(spanExp)))
+
+			logExp := telemetrytest.NewInMemoryLogExporter()
+			telemetry.OverrideLoggerForTesting(t, sdklog.NewLoggerProvider(
+				sdklog.WithProcessor(sdklog.NewSimpleProcessor(logExp)),
+			))
+
+			rootAgent := newAgentWithToolScenario(t)
+			telemetrytest.RunScenario(t, rootAgent, "hello")
+
+			got := telemetrytest.BuildDigests(t, spanExp.GetSpans(), logExp.Records())
+			if diff := cmp.Diff(tc.want, got); diff != "" {
+				t.Errorf("telemetry mismatch (-want +got):\n%s", diff)
+			}
+		})
+	}
+}
+
+// newAgentWithToolScenario constructs the canonical llmagent +
+// 1 FunctionTool + 2 LLM turns scenario. The first turn returns a
+// function call to the tool; the second turn returns the final
+// text response. The expected telemetry shape for this scenario
+// is declared in telemetrytestcase.AgentWithToolCase (and its
+// capture-content variant).
+func newAgentWithToolScenario(t *testing.T) agent.Agent {
+	t.Helper()
+	mockModel := &testutil.MockModel{
+		Responses: []*genai.Content{
+			{
+				Role: "model",
+				Parts: []*genai.Part{{
+					FunctionCall: &genai.FunctionCall{
+						Name: "some_tool",
+						Args: map[string]any{"arg1": "val1"},
+					},
+				}},
+			},
+			{
+				Role:  "model",
+				Parts: []*genai.Part{{Text: "text response"}},
+			},
+		},
+	}
+
+	type Args struct {
+		Arg1 string `json:"arg1"`
+	}
+	sampleTool, err := functiontool.New(functiontool.Config{
+		Name:        "some_tool",
+		Description: "A sample tool.",
+	}, func(_ tool.Context, in Args) (string, error) {
+		return "processed " + in.Arg1, nil
+	})
+	if err != nil {
+		t.Fatalf("functiontool.New: %v", err)
+	}
+
+	rootAgent, err := llmagent.New(llmagent.Config{
+		Name:        "some_root_agent",
+		Description: "A sample root agent.",
+		Model:       mockModel,
+		Instruction: "you are helpful",
+		Tools:       []tool.Tool{sampleTool},
+	})
+	if err != nil {
+		t.Fatalf("llmagent.New: %v", err)
+	}
+	return rootAgent
+}

--- a/internal/telemetry/functionaltest/doc.go
+++ b/internal/telemetry/functionaltest/doc.go
@@ -1,0 +1,38 @@
+// Copyright 2026 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+// Package functionaltest contains hermetic functional tests for ADK
+// telemetry: each Test* function builds a real ADK agent
+// (llmagent, workflowagent, ...) backed by a hermetic
+// [google.golang.org/adk/internal/testutil.MockModel], drives it
+// through a real Runner, and asserts the emitted span tree + log
+// records against the expected shape declared in the
+// telemetrytestcase package.
+//
+// Layout:
+//
+//   - The expected shapes (SpanDigest + LogDigest literals) live in
+//     internal/telemetry/telemetrytestcase, one file per scenario.
+//   - The helpers used to build the digests, install the
+//     in-memory tracer/logger, and stand in for the LLM live in
+//     internal/telemetry/telemetrytest.
+//   - This package only holds the runners: scenario setup +
+//     comparison code, so failures in this package always indicate
+//     either a regression in the production code or a stale
+//     expectation in telemetrytestcase.
+//
+// The package lives outside internal/telemetry to avoid import
+// cycles (the runners pull in agent/llmagent, agent/workflowagent,
+// runner, etc., which transitively import internal/telemetry).
+package functionaltest

--- a/internal/telemetry/functionaltest/workflow_telemetry_schema_test.go
+++ b/internal/telemetry/functionaltest/workflow_telemetry_schema_test.go
@@ -1,0 +1,81 @@
+// Copyright 2026 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package functionaltest_test
+
+import (
+	"strings"
+	"testing"
+
+	"github.com/google/go-cmp/cmp"
+	sdklog "go.opentelemetry.io/otel/sdk/log"
+	sdktrace "go.opentelemetry.io/otel/sdk/trace"
+	"go.opentelemetry.io/otel/sdk/trace/tracetest"
+
+	"google.golang.org/adk/agent"
+	"google.golang.org/adk/agent/workflowagent"
+	"google.golang.org/adk/internal/telemetry"
+	"google.golang.org/adk/internal/telemetry/telemetrytest"
+	"google.golang.org/adk/internal/telemetry/telemetrytestcase"
+	"google.golang.org/adk/workflow"
+)
+
+// TestTelemetrySchema_WorkflowChain runs the
+// [telemetrytestcase.WorkflowChainCase] scenario end-to-end and
+// asserts the emitted span tree matches the expected shape. No LLM
+// is involved so no log records are emitted; the test still
+// installs an in-memory log exporter so a regression that suddenly
+// starts emitting events would be caught by the cmp.Diff against
+// the empty-Logs expectation.
+//
+// Hermetic: no network calls, no LLMs, no GCP.
+//
+// Mirrors test_telemetry_schema in
+// adk-python/tests/unittests/telemetry/test_node_functional.py.
+func TestTelemetrySchema_WorkflowChain(t *testing.T) {
+	spanExp := tracetest.NewInMemoryExporter()
+	telemetry.OverrideTracerForTesting(t, sdktrace.NewTracerProvider(sdktrace.WithSyncer(spanExp)))
+
+	logExp := telemetrytest.NewInMemoryLogExporter()
+	telemetry.OverrideLoggerForTesting(t, sdklog.NewLoggerProvider(
+		sdklog.WithProcessor(sdklog.NewSimpleProcessor(logExp)),
+	))
+
+	upperFn := func(_ agent.InvocationContext, in string) (string, error) {
+		return strings.ToUpper(in), nil
+	}
+	suffixFn := func(_ agent.InvocationContext, in string) (string, error) {
+		return in + " IS AWESOME!", nil
+	}
+
+	nodeCfg := workflow.NodeConfig{RetryConfig: workflow.DefaultRetryConfig()}
+	upperNode := workflow.NewFunctionNode("upper_node", upperFn, nodeCfg)
+	suffixNode := workflow.NewFunctionNode("suffix_node", suffixFn, nodeCfg)
+
+	wfAgent, err := workflowagent.New(workflowagent.Config{
+		Name:        "my_workflow",
+		Description: "uppercases input then appends a suffix",
+		Edges:       workflow.Chain(workflow.Start, upperNode, suffixNode),
+	})
+	if err != nil {
+		t.Fatalf("workflowagent.New: %v", err)
+	}
+
+	telemetrytest.RunScenario(t, wfAgent, "hello")
+
+	got := telemetrytest.BuildDigests(t, spanExp.GetSpans(), logExp.Records())
+	if diff := cmp.Diff(telemetrytestcase.WorkflowChainCase, got); diff != "" {
+		t.Errorf("telemetry mismatch (-want +got):\n%s", diff)
+	}
+}

--- a/internal/telemetry/logger.go
+++ b/internal/telemetry/logger.go
@@ -17,8 +17,8 @@ package telemetry
 import (
 	"context"
 	"encoding/json"
+	"os"
 	"strings"
-	"sync/atomic"
 
 	"go.opentelemetry.io/otel/log"
 	"go.opentelemetry.io/otel/log/global"
@@ -29,17 +29,17 @@ import (
 	"google.golang.org/adk/model"
 )
 
-// genAICaptureMessageContent is true if message content should be elided. False by default.
-var genAICaptureMessageContent atomic.Bool
+// captureMessageContentEnvVar is the OpenTelemetry-spec env var
+// that controls whether ADK emits full message content in log
+// records (true) or elides it for privacy (anything else,
+// including unset). Defined by
+// https://opentelemetry.io/docs/specs/semconv/registry/attributes/gen-ai/.
+const captureMessageContentEnvVar = "OTEL_INSTRUMENTATION_GENAI_CAPTURE_MESSAGE_CONTENT"
 
-// SetGenAICaptureMessageContent sets whether message content should be elided.
-func SetGenAICaptureMessageContent(capture bool) {
-	genAICaptureMessageContent.Store(capture)
-}
-
-// getGenAICaptureMessageContent returns whether message content should be elided.
+// getGenAICaptureMessageContent reports whether message content
+// should be captured in log records.
 func getGenAICaptureMessageContent() bool {
-	return genAICaptureMessageContent.Load()
+	return strings.TrimSpace(os.Getenv(captureMessageContentEnvVar)) == "true"
 }
 
 const elidedContent = "<elided>"
@@ -49,6 +49,19 @@ var otelLogger = global.GetLoggerProvider().Logger(
 	log.WithSchemaURL(semconv.SchemaURL),
 	log.WithInstrumentationVersion(version.Version),
 )
+
+// OverrideLoggerForTesting replaces the package-level otelLogger
+// with one derived from lp for the duration of the calling test.
+// The original logger is restored via t.Cleanup.
+func OverrideLoggerForTesting(t interface{ Cleanup(func()) }, lp log.LoggerProvider) {
+	original := otelLogger
+	otelLogger = lp.Logger(
+		systemName,
+		log.WithSchemaURL(semconv.SchemaURL),
+		log.WithInstrumentationVersion(version.Version),
+	)
+	t.Cleanup(func() { otelLogger = original })
+}
 
 // LogRequest logs the request to the model - the system message and user messages.
 // It iterates over the request contents and logs each as a separate event.

--- a/internal/telemetry/logger_test.go
+++ b/internal/telemetry/logger_test.go
@@ -576,7 +576,7 @@ func TestSpanIDPropagation(t *testing.T) {
 	}
 }
 
-func setup(t *testing.T, elided bool) *inMemoryExporter {
+func setup(t *testing.T, capture bool) *inMemoryExporter {
 	exporter := &inMemoryExporter{}
 	provider := sdklog.NewLoggerProvider(
 		sdklog.WithProcessor(sdklog.NewSimpleProcessor(exporter)),
@@ -587,11 +587,11 @@ func setup(t *testing.T, elided bool) *inMemoryExporter {
 		otelLogger = originalLogger
 	})
 
-	original := getGenAICaptureMessageContent()
-	SetGenAICaptureMessageContent(elided)
-	t.Cleanup(func() {
-		SetGenAICaptureMessageContent(original)
-	})
+	if capture {
+		t.Setenv(captureMessageContentEnvVar, "true")
+	} else {
+		t.Setenv(captureMessageContentEnvVar, "")
+	}
 	return exporter
 }
 

--- a/internal/telemetry/node_tracing.go
+++ b/internal/telemetry/node_tracing.go
@@ -1,0 +1,148 @@
+// Copyright 2026 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package telemetry
+
+import (
+	"context"
+	"fmt"
+
+	"go.opentelemetry.io/otel/attribute"
+	semconv "go.opentelemetry.io/otel/semconv/v1.36.0"
+	"go.opentelemetry.io/otel/trace"
+	"go.opentelemetry.io/otel/trace/noop"
+
+	agentinternal "google.golang.org/adk/internal/agent"
+	"google.golang.org/adk/session"
+)
+
+// gen_ai.operation.name attribute values for the agent / workflow /
+// node spans. These mirror the values set by adk-python's
+// node_tracing module.
+const (
+	invokeWorkflowOperationName = "invoke_workflow"
+	invokeNodeOperationName     = "invoke_node"
+)
+
+// Attribute keys not yet in the Go semconv package; the string
+// literals match the keys used by adk-python.
+var (
+	genAIWorkflowName = attribute.Key("gen_ai.workflow.name")
+	genAINodeName     = attribute.Key("gen_ai.node.name")
+)
+
+// Operation is the internal sum-type which describes what can be used to start a span.
+type Operation interface {
+	isOperation()
+}
+
+// AgentLike is the minimal contract telemetry needs to describe a BaseAgent.
+type AgentLike interface {
+	Name() string
+	Description() string
+}
+
+// WorkflowNodeLike is the minimal contract telemetry needs to describe a workflow BaseNode.
+type WorkflowNodeLike interface {
+	Name() string
+}
+
+// OperationAgent is the [Operation] variant for an agent invocation.
+// concrete span name (invoke_agent vs invoke_workflow) is decided
+// inside [StartNodeSpan] by peeking at the agent's internal
+// State.AgentType.
+type OperationAgent struct {
+	Agent AgentLike
+}
+
+func (OperationAgent) isOperation() {}
+
+// OperationNode is the [Operation] variant for a workflow BaseNode activation.
+type OperationNode struct {
+	Node WorkflowNodeLike
+}
+
+func (OperationNode) isOperation() {}
+
+// InvocationContext is the minimal copy of agent.InvocationContext necessary for telemetry.
+type InvocationContext interface {
+	Session() session.Session
+	InvocationID() string
+}
+
+// StartNodeSpan emits an OpenTelemetry span and returns a derived context with the new Span.
+// Emits:
+// - invoke_workflow <workflow_name> if provided with [OperationNode] or workflow agent.
+// - invoke_agent <agent_name> if provided with non-workflow agent.
+// - invoke_node <node_name> if provided with a generic node.
+// - otherwise doesn't start any new span and returns the input context unchanged.
+func StartNodeSpan(ctx context.Context, ictx InvocationContext, op Operation) (context.Context, trace.Span) {
+	switch o := op.(type) {
+	case OperationAgent:
+		if isWorkflowAgent(o.Agent) {
+			return startInvokeWorkflowSpan(ctx, ictx, o.Agent)
+		}
+		return startInvokeAgentSpan(ctx, ictx, o.Agent)
+	case OperationNode:
+		return startInvokeNodeSpan(ctx, ictx, o.Node)
+	default:
+		return ctx, noop.Span{}
+	}
+}
+
+func isWorkflowAgent(a AgentLike) bool {
+	internal, ok := a.(agentinternal.Agent)
+	if !ok {
+		return false
+	}
+	return agentinternal.Reveal(internal).AgentType == agentinternal.TypeWorkflowAgent
+}
+
+// sessionID returns ictx.Session().ID() or "" if the
+// InvocationContext has no session attached. Tolerates nil
+// sessions because workflow tests construct mock invocation
+// contexts without one.
+func sessionID(ictx InvocationContext) string {
+	s := ictx.Session()
+	if s == nil {
+		return ""
+	}
+	return s.ID()
+}
+
+func startInvokeAgentSpan(ctx context.Context, ictx InvocationContext, a AgentLike) (context.Context, trace.Span) {
+	return tracer.Start(ctx, fmt.Sprintf("invoke_agent %s", a.Name()), trace.WithAttributes(
+		gcpVertexAgentInvocationID.String(ictx.InvocationID()), // used by adk-web
+		semconv.GenAIOperationNameInvokeAgent,
+		semconv.GenAIAgentDescription(a.Description()),
+		semconv.GenAIAgentName(a.Name()),
+		semconv.GenAIConversationID(sessionID(ictx)),
+	))
+}
+
+func startInvokeWorkflowSpan(ctx context.Context, ictx InvocationContext, w AgentLike) (context.Context, trace.Span) {
+	return tracer.Start(ctx, fmt.Sprintf("invoke_workflow %s", w.Name()), trace.WithAttributes(
+		semconv.GenAIOperationNameKey.String(invokeWorkflowOperationName),
+		genAIWorkflowName.String(w.Name()),
+		semconv.GenAIConversationID(sessionID(ictx)),
+	))
+}
+
+func startInvokeNodeSpan(ctx context.Context, ictx InvocationContext, n WorkflowNodeLike) (context.Context, trace.Span) {
+	return tracer.Start(ctx, fmt.Sprintf("invoke_node %s", n.Name()), trace.WithAttributes(
+		semconv.GenAIOperationNameKey.String(invokeNodeOperationName),
+		genAINodeName.String(n.Name()),
+		semconv.GenAIConversationID(sessionID(ictx)),
+	))
+}

--- a/internal/telemetry/telemetry.go
+++ b/internal/telemetry/telemetry.go
@@ -70,26 +70,6 @@ func OverrideTracerForTesting(t interface{ Cleanup(func()) }, tp trace.TracerPro
 	t.Cleanup(func() { tracer = original })
 }
 
-type agent interface {
-	Name() string
-	Description() string
-}
-
-// StartInvokeAgentSpan starts a new semconv invoke_agent span.
-// It returns a new context with the span and the span itself.
-func StartInvokeAgentSpan(ctx context.Context, agent agent, sessionID, invocationID string) (context.Context, trace.Span) {
-	agentName := agent.Name()
-	spanCtx, span := tracer.Start(ctx, fmt.Sprintf("invoke_agent %s", agentName), trace.WithAttributes(
-		gcpVertexAgentInvocationID.String(invocationID), // used by adk-web
-		semconv.GenAIOperationNameInvokeAgent,
-		semconv.GenAIAgentDescription(agent.Description()),
-		semconv.GenAIAgentName(agentName),
-		semconv.GenAIConversationID(sessionID),
-	))
-
-	return spanCtx, span
-}
-
 type TraceAgentResultParams struct {
 	ResponseEvent *session.Event
 	Error         error

--- a/internal/telemetry/telemetry.go
+++ b/internal/telemetry/telemetry.go
@@ -57,6 +57,19 @@ var tracer trace.Tracer = otel.GetTracerProvider().Tracer(
 	trace.WithSchemaURL(semconv.SchemaURL),
 )
 
+// OverrideTracerForTesting replaces the package-level tracer with one
+// derived from tp for the duration of the calling test. The original
+// tracer is restored via t.Cleanup.
+func OverrideTracerForTesting(t interface{ Cleanup(func()) }, tp trace.TracerProvider) {
+	original := tracer
+	tracer = tp.Tracer(
+		systemName,
+		trace.WithInstrumentationVersion(version.Version),
+		trace.WithSchemaURL(semconv.SchemaURL),
+	)
+	t.Cleanup(func() { tracer = original })
+}
+
 type agent interface {
 	Name() string
 	Description() string

--- a/internal/telemetry/telemetry_test.go
+++ b/internal/telemetry/telemetry_test.go
@@ -29,6 +29,7 @@ import (
 	"go.opentelemetry.io/otel/trace/noop"
 	"google.golang.org/genai"
 
+	agentinternal "google.golang.org/adk/internal/agent"
 	"google.golang.org/adk/model"
 	"google.golang.org/adk/session"
 )
@@ -105,20 +106,57 @@ func TestWrapYield_MultipleCalls(t *testing.T) {
 
 var errTest = errors.New("test error")
 
-type mockAgent struct{}
-
-func (a *mockAgent) Name() string {
-	return "test-agent"
+// fakeAgent satisfies both [AgentLike] and [agentinternal.Agent]
+// by embedding [agentinternal.State] (which provides the unexported
+// internal() method required by the Agent interface). Used by
+// node-tracing tests to drive [StartNodeSpan] without spinning up
+// a real agent.
+type fakeAgent struct {
+	agentinternal.State
+	name        string
+	description string
 }
 
-func (a *mockAgent) Description() string {
-	return "test-agent-description"
+func (f *fakeAgent) Name() string        { return f.name }
+func (f *fakeAgent) Description() string { return f.description }
+
+// fakeInvocationContext satisfies [InvocationContext]. The session
+// is built lazily from the in-memory service so the conversation
+// ID attribute matches sessionID exactly.
+type fakeInvocationContext struct {
+	t            *testing.T
+	sessionID    string
+	invocationID string
+	sess         session.Session
 }
+
+func (f *fakeInvocationContext) Session() session.Session {
+	if f.sess == nil {
+		svc := session.InMemoryService()
+		resp, err := svc.Create(context.Background(), &session.CreateRequest{
+			AppName:   "test_app",
+			UserID:    "test_user",
+			SessionID: f.sessionID,
+		})
+		if err != nil {
+			f.t.Fatalf("session create: %v", err)
+		}
+		f.sess = resp.Session
+	}
+	return f.sess
+}
+
+func (f *fakeInvocationContext) InvocationID() string { return f.invocationID }
 
 func TestInvokeAgent(t *testing.T) {
 	sessionID := "test-session"
 	invocationID := "test-invocation-id"
-	agent := &mockAgent{}
+	a := &fakeAgent{
+		State:       agentinternal.State{AgentType: agentinternal.TypeLLMAgent},
+		name:        "test-agent",
+		description: "test-agent-description",
+	}
+	ictx := &fakeInvocationContext{t: t, sessionID: sessionID, invocationID: invocationID}
 	tests := []struct {
 		name         string
 		resultParams TraceAgentResultParams
@@ -163,7 +201,7 @@ func TestInvokeAgent(t *testing.T) {
 			exporter := setupTestTracer(t)
 			ctx := t.Context()
 
-			_, span := StartInvokeAgentSpan(ctx, agent, sessionID, invocationID)
+			_, span := StartNodeSpan(ctx, ictx, OperationAgent{Agent: a})
 			TraceAgentResult(span, tc.resultParams)
 			span.End()
 

--- a/internal/telemetry/telemetrytest/doc.go
+++ b/internal/telemetry/telemetrytest/doc.go
@@ -1,0 +1,35 @@
+// Copyright 2026 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+// Package telemetrytest provides reusable helpers for hermetic
+// telemetry tests in ADK.
+//
+// Helpers in this package:
+//
+//   - [SpanDigest] / [BuildDigests] / [PRESENT] — capture and
+//     normalise the emitted OTel span tree so tests can compare
+//     against a literal expected shape. Log records nest inside
+//     the SpanDigest of the span they were emitted under via
+//     [SpanDigest.Logs], yielding a single causal tree.
+//   - [LogDigest] / [InMemoryLogExporter] — log-record snapshot
+//     type and the in-memory sink to install via
+//     telemetry.OverrideLoggerForTesting.
+//
+// The expected shapes for each scenario live in the sibling
+// telemetrytestcase package; the runners that drive the agent and
+// compare actual vs expected live in the telemetry/functionaltest
+// test package. Functional tests use the shared
+// [google.golang.org/adk/internal/testutil.MockModel] as the
+// deterministic LLM stand-in.
+package telemetrytest

--- a/internal/telemetry/telemetrytest/log_digest.go
+++ b/internal/telemetry/telemetrytest/log_digest.go
@@ -1,0 +1,138 @@
+// Copyright 2026 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package telemetrytest
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+	"sync"
+
+	"go.opentelemetry.io/otel/log"
+	sdklog "go.opentelemetry.io/otel/sdk/log"
+)
+
+// LogDigest is a deterministic snapshot of one OTel log record:
+// the event name, attributes, and the body decoded to a Go value.
+type LogDigest struct {
+	EventName  string
+	Attributes map[string]any
+	Body       any // JSON-normalized: int64 values are returned as float64
+}
+
+func buildLogDigest(r *sdklog.Record) *LogDigest {
+	attrs := map[string]any{}
+	r.WalkAttributes(func(kv log.KeyValue) bool {
+		attrs[kv.Key] = logValueToAny(kv.Value)
+		return true
+	})
+	return &LogDigest{
+		EventName:  r.EventName(),
+		Attributes: attrs,
+		Body:       jsonRoundTrip(logValueToAny(r.Body())),
+	}
+}
+
+// jsonRoundTrip marshals v to JSON and unmarshals the result back
+// into a fresh any. This normalises:
+//   - numeric types (int64, float64 → float64),
+//   - string-valued bodies (returned as plain Go strings),
+//   - structured bodies (returned as map[string]any / []any).
+//
+// On marshal/unmarshal failure the input value is returned
+// unchanged; cmp.Diff will then surface the unconverted shape and
+// the test author can fix the body rendering.
+func jsonRoundTrip(v any) any {
+	b, err := json.Marshal(v)
+	if err != nil {
+		return v
+	}
+	var out any
+	if err := json.Unmarshal(b, &out); err != nil {
+		return v
+	}
+	return out
+}
+
+// InMemoryLogExporter is a minimal in-memory log record sink for tests.
+type InMemoryLogExporter struct {
+	mu      sync.Mutex
+	records []sdklog.Record
+}
+
+// NewInMemoryLogExporter returns an empty exporter ready for use with sdklog.NewSimpleProcessor.
+func NewInMemoryLogExporter() *InMemoryLogExporter { return &InMemoryLogExporter{} }
+
+// Export implements sdklog.Exporter.
+func (e *InMemoryLogExporter) Export(_ context.Context, records []sdklog.Record) error {
+	e.mu.Lock()
+	defer e.mu.Unlock()
+	for _, r := range records {
+		// Records are pooled by some processors; clone so the
+		// stored copy is stable.
+		e.records = append(e.records, r.Clone())
+	}
+	return nil
+}
+
+// Shutdown implements sdklog.Exporter.
+func (e *InMemoryLogExporter) Shutdown(_ context.Context) error { return nil }
+
+// ForceFlush implements sdklog.Exporter.
+func (e *InMemoryLogExporter) ForceFlush(_ context.Context) error { return nil }
+
+// Records returns a snapshot of the records collected so far, in emit order.
+func (e *InMemoryLogExporter) Records() []sdklog.Record {
+	e.mu.Lock()
+	defer e.mu.Unlock()
+	out := make([]sdklog.Record, len(e.records))
+	copy(out, e.records)
+	return out
+}
+
+// logValueToAny converts an OTel log.Value to a plain Go value
+// (string, int64, float64, bool, []any, map[string]any).
+func logValueToAny(v log.Value) any {
+	switch v.Kind() {
+	case log.KindBool:
+		return v.AsBool()
+	case log.KindFloat64:
+		return v.AsFloat64()
+	case log.KindInt64:
+		return v.AsInt64()
+	case log.KindString:
+		return v.AsString()
+	case log.KindBytes:
+		return v.AsBytes()
+	case log.KindSlice:
+		s := v.AsSlice()
+		out := make([]any, len(s))
+		for i, e := range s {
+			out[i] = logValueToAny(e)
+		}
+		return out
+	case log.KindMap:
+		m := v.AsMap()
+		out := make(map[string]any, len(m))
+		for _, kv := range m {
+			out[kv.Key] = logValueToAny(kv.Value)
+		}
+		return out
+	case log.KindEmpty:
+		return nil
+	default:
+		return fmt.Sprintf("<unknown log.Kind %v>", v.Kind())
+	}
+}

--- a/internal/telemetry/telemetrytest/scenario.go
+++ b/internal/telemetry/telemetrytest/scenario.go
@@ -1,0 +1,62 @@
+// Copyright 2026 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package telemetrytest
+
+import (
+	"context"
+	"testing"
+
+	"google.golang.org/genai"
+
+	"google.golang.org/adk/agent"
+	"google.golang.org/adk/runner"
+	"google.golang.org/adk/session"
+)
+
+// RunScenario drives rootAgent through a single user turn via a
+// real Runner backed by an in-memory session service. Used by
+// every functional telemetry test; kept here rather than in a
+// _test.go file so callers in any external test package can reuse
+// the same scenario harness.
+//
+// Mirrors functional_test_helpers.run_agent_scenario in adk-python.
+func RunScenario(t *testing.T, rootAgent agent.Agent, prompt string) {
+	t.Helper()
+	ctx := context.Background()
+
+	sessSvc := session.InMemoryService()
+	r, err := runner.New(runner.Config{
+		AppName:        "test_app",
+		Agent:          rootAgent,
+		SessionService: sessSvc,
+	})
+	if err != nil {
+		t.Fatalf("runner.New: %v", err)
+	}
+	sess, err := sessSvc.Create(ctx, &session.CreateRequest{
+		AppName: "test_app",
+		UserID:  "test_user",
+	})
+	if err != nil {
+		t.Fatalf("session create: %v", err)
+	}
+
+	msg := genai.NewContentFromText(prompt, genai.RoleUser)
+	for _, err := range r.Run(ctx, "test_user", sess.Session.ID(), msg, agent.RunConfig{}) {
+		if err != nil {
+			t.Fatalf("runner.Run yielded error: %v", err)
+		}
+	}
+}

--- a/internal/telemetry/telemetrytest/span_digest.go
+++ b/internal/telemetry/telemetrytest/span_digest.go
@@ -1,0 +1,170 @@
+// Copyright 2026 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package telemetrytest
+
+import (
+	"sort"
+	"testing"
+
+	"go.opentelemetry.io/otel/attribute"
+	sdklog "go.opentelemetry.io/otel/sdk/log"
+	"go.opentelemetry.io/otel/sdk/trace/tracetest"
+	"go.opentelemetry.io/otel/trace"
+)
+
+// PRESENT is the sentinel used to mark attributes whose value is
+// non-deterministic across runs but whose presence must still be
+// asserted (e.g. invocation_id, session_id).
+const PRESENT = "<PRESENT>"
+
+// nonDeterministicSpanAttributes are span attributes whose VALUE
+// varies run-to-run. [BuildDigests] replaces these with [PRESENT]
+// so the comparison shape is stable while still asserting the key
+// is set.
+var nonDeterministicSpanAttributes = map[string]bool{
+	"gcp.vertex.agent.event_id":       true,
+	"gen_ai.tool.call.id":             true,
+	"gen_ai.conversation.id":          true,
+	"gcp.vertex.agent.invocation_id":  true,
+	"gcp.vertex.agent.session_id":     true,
+	"gcp.vertex.agent.tool_call_args": true, // contains generated arg ids
+	"gcp.vertex.agent.tool_response":  true, // contains generated event ids
+}
+
+// SpanDigest is a deterministic snapshot of a span: name, normalised
+// attributes, child spans, and the log records emitted while the
+// span was active.
+type SpanDigest struct {
+	Name       string
+	Attributes map[string]any
+	Children   []*SpanDigest
+	Logs       []*LogDigest
+}
+
+type spanWithMeta struct {
+	digest    *SpanDigest
+	spanID    trace.SpanID
+	parentID  trace.SpanID
+	startTime int64
+}
+
+// BuildDigests collects the spans and log records into a single
+// tree, attaching each log to the SpanDigest of the span
+// it was emitted under. The scenario MUST produce exactly one root span.
+func BuildDigests(t *testing.T, spans tracetest.SpanStubs, logs []sdklog.Record) *SpanDigest {
+	t.Helper()
+	digests := make([]*spanWithMeta, 0, len(spans))
+	for _, s := range spans {
+		digests = append(digests, buildSpanDigest(s))
+	}
+	digests = attachLogs(digests, logs)
+	roots := linkAndSort(digests)
+	if len(roots) != 1 {
+		t.Fatalf("expected exactly 1 root span, got %d", len(roots))
+	}
+	return roots[0]
+}
+
+func buildSpanDigest(s tracetest.SpanStub) *spanWithMeta {
+	return &spanWithMeta{
+		digest: &SpanDigest{
+			Name:       s.Name,
+			Attributes: normaliseSpanAttributes(s.Attributes),
+		},
+		spanID:    s.SpanContext.SpanID(),
+		parentID:  s.Parent.SpanID(),
+		startTime: s.StartTime.UnixNano(),
+	}
+}
+
+// attachLogs populates the Logs slice of each digest whose SpanID
+// matches a log record's SpanID. Log iteration order is emit
+// order, so the resulting per-span Logs slices end up
+// chronological. Logs not associated with any collected span
+// (e.g. emitted at module init) are dropped silently.
+func attachLogs(digests []*spanWithMeta, logs []sdklog.Record) []*spanWithMeta {
+	bySpanID := make(map[trace.SpanID]*SpanDigest, len(digests))
+	for _, d := range digests {
+		bySpanID[d.spanID] = d.digest
+	}
+	for _, r := range logs {
+		if d, ok := bySpanID[r.SpanID()]; ok {
+			d.Logs = append(d.Logs, buildLogDigest(&r))
+		}
+	}
+	return digests
+}
+
+// linkAndSort assembles the parent→children adjacency, recursively
+// sorts each level by start time (name as tiebreaker), assigns the
+// sorted children to the SpanDigest.Children slices, and returns
+// the roots (spans whose parent was not collected).
+func linkAndSort(digests []*spanWithMeta) []*SpanDigest {
+	bySpanID := make(map[trace.SpanID]*spanWithMeta, len(digests))
+	for _, sw := range digests {
+		bySpanID[sw.spanID] = sw
+	}
+	childrenOf := map[*spanWithMeta][]*spanWithMeta{}
+	var roots []*spanWithMeta
+	for _, sw := range digests {
+		if parent, ok := bySpanID[sw.parentID]; ok {
+			childrenOf[parent] = append(childrenOf[parent], sw)
+		} else {
+			roots = append(roots, sw)
+		}
+	}
+	less := func(a, b *spanWithMeta) bool {
+		if a.startTime != b.startTime {
+			return a.startTime < b.startTime
+		}
+		return a.digest.Name < b.digest.Name
+	}
+	var assignSorted func(sw *spanWithMeta)
+	assignSorted = func(sw *spanWithMeta) {
+		children := childrenOf[sw]
+		if len(children) == 0 {
+			return
+		}
+		sort.SliceStable(children, func(i, j int) bool { return less(children[i], children[j]) })
+		sw.digest.Children = make([]*SpanDigest, len(children))
+		for i, c := range children {
+			sw.digest.Children[i] = c.digest
+			assignSorted(c)
+		}
+	}
+	sort.SliceStable(roots, func(i, j int) bool { return less(roots[i], roots[j]) })
+	out := make([]*SpanDigest, len(roots))
+	for i, r := range roots {
+		assignSorted(r)
+		out[i] = r.digest
+	}
+	return out
+}
+
+// normaliseSpanAttributes converts the OTel attribute slice into a
+// map[string]any with non-deterministic values collapsed to
+// [PRESENT].
+func normaliseSpanAttributes(attrs []attribute.KeyValue) map[string]any {
+	out := make(map[string]any, len(attrs))
+	for _, kv := range attrs {
+		key := string(kv.Key)
+		if nonDeterministicSpanAttributes[key] {
+			out[key] = PRESENT
+			continue
+		}
+		out[key] = kv.Value.AsInterface()
+	}
+	return out
+}

--- a/internal/telemetry/telemetrytestcase/agent_with_tool.go
+++ b/internal/telemetry/telemetrytestcase/agent_with_tool.go
@@ -1,0 +1,116 @@
+// Copyright 2026 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package telemetrytestcase
+
+import (
+	"google.golang.org/adk/internal/telemetry/telemetrytest"
+)
+
+// AgentWithToolCase is the expected root span emitted by the
+// canonical "llmagent with one FunctionTool" scenario.
+var AgentWithToolCase = &telemetrytest.SpanDigest{
+	Name: "invoke_agent some_root_agent",
+	Attributes: map[string]any{
+		"gen_ai.operation.name":          "invoke_agent",
+		"gen_ai.agent.name":              "some_root_agent",
+		"gen_ai.agent.description":       "A sample root agent.",
+		"gen_ai.conversation.id":         telemetrytest.PRESENT,
+		"gcp.vertex.agent.invocation_id": telemetrytest.PRESENT,
+	},
+	Children: []*telemetrytest.SpanDigest{
+		{
+			Name: "generate_content mock",
+			Attributes: map[string]any{
+				"gen_ai.operation.name":          "generate_content",
+				"gen_ai.request.model":           "mock",
+				"gcp.vertex.agent.event_id":      telemetrytest.PRESENT,
+				"gcp.vertex.agent.invocation_id": telemetrytest.PRESENT,
+				// MockModel returns no UsageMetadata, so no token
+				// attrs are set. The mock response carries no
+				// FinishReason; the existing telemetry emits the
+				// empty FinishReason as a single-element string
+				// slice.
+				"gen_ai.response.finish_reasons": []string{""},
+			},
+			Logs: []*telemetrytest.LogDigest{
+				// Content elision is on by default.
+				{
+					EventName:  "gen_ai.system.message",
+					Attributes: map[string]any{},
+					Body:       map[string]any{"content": "<elided>"},
+				},
+				{
+					EventName:  "gen_ai.user.message",
+					Attributes: map[string]any{},
+					Body:       map[string]any{"content": "<elided>"},
+				},
+				{
+					EventName:  "gen_ai.choice",
+					Attributes: map[string]any{},
+					Body:       map[string]any{"content": "<elided>", "index": float64(0)},
+				},
+			},
+		},
+		{
+			Name: "execute_tool some_tool",
+			Attributes: map[string]any{
+				"gen_ai.operation.name":           "execute_tool",
+				"gen_ai.tool.name":                "some_tool",
+				"gen_ai.tool.description":         "A sample tool.",
+				"gen_ai.tool.call.id":             telemetrytest.PRESENT,
+				"gcp.vertex.agent.event_id":       telemetrytest.PRESENT,
+				"gcp.vertex.agent.tool_call_args": telemetrytest.PRESENT,
+				"gcp.vertex.agent.tool_response":  telemetrytest.PRESENT,
+			},
+		},
+		{
+			Name: "generate_content mock",
+			Attributes: map[string]any{
+				"gen_ai.operation.name":          "generate_content",
+				"gen_ai.request.model":           "mock",
+				"gcp.vertex.agent.event_id":      telemetrytest.PRESENT,
+				"gcp.vertex.agent.invocation_id": telemetrytest.PRESENT,
+				"gen_ai.response.finish_reasons": []string{""},
+			},
+			Logs: []*telemetrytest.LogDigest{
+				{
+					EventName:  "gen_ai.system.message",
+					Attributes: map[string]any{},
+					Body:       map[string]any{"content": "<elided>"},
+				},
+				{
+					EventName:  "gen_ai.user.message",
+					Attributes: map[string]any{},
+					Body:       map[string]any{"content": "<elided>"},
+				},
+				{
+					EventName:  "gen_ai.user.message",
+					Attributes: map[string]any{},
+					Body:       map[string]any{"content": "<elided>"},
+				},
+				{
+					EventName:  "gen_ai.user.message",
+					Attributes: map[string]any{},
+					Body:       map[string]any{"content": "<elided>"},
+				},
+				{
+					EventName:  "gen_ai.choice",
+					Attributes: map[string]any{},
+					Body:       map[string]any{"content": "<elided>", "index": float64(0)},
+				},
+			},
+		},
+	},
+}

--- a/internal/telemetry/telemetrytestcase/agent_with_tool_capture_content.go
+++ b/internal/telemetry/telemetrytestcase/agent_with_tool_capture_content.go
@@ -1,0 +1,167 @@
+// Copyright 2026 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package telemetrytestcase
+
+import (
+	"google.golang.org/adk/internal/telemetry/telemetrytest"
+)
+
+// AgentWithToolCaptureContentCase is the expected root span for
+// the same scenario as [AgentWithToolCase] but with content capture
+// enabled, via OTEL_INSTRUMENTATION_GENAI_CAPTURE_MESSAGE_CONTENT env var.
+var AgentWithToolCaptureContentCase = &telemetrytest.SpanDigest{
+	Name: "invoke_agent some_root_agent",
+	Attributes: map[string]any{
+		"gen_ai.operation.name":          "invoke_agent",
+		"gen_ai.agent.name":              "some_root_agent",
+		"gen_ai.agent.description":       "A sample root agent.",
+		"gen_ai.conversation.id":         telemetrytest.PRESENT,
+		"gcp.vertex.agent.invocation_id": telemetrytest.PRESENT,
+	},
+	Children: []*telemetrytest.SpanDigest{
+		{
+			Name: "generate_content mock",
+			Attributes: map[string]any{
+				"gen_ai.operation.name":          "generate_content",
+				"gen_ai.request.model":           "mock",
+				"gcp.vertex.agent.event_id":      telemetrytest.PRESENT,
+				"gcp.vertex.agent.invocation_id": telemetrytest.PRESENT,
+				"gen_ai.response.finish_reasons": []string{""},
+			},
+			Logs: []*telemetrytest.LogDigest{
+				{
+					EventName:  "gen_ai.system.message",
+					Attributes: map[string]any{},
+					Body: map[string]any{
+						"content": "you are helpful\n\nYou are an agent. Your internal name is \"some_root_agent\". The description about you is \"A sample root agent.\".",
+					},
+				},
+				{
+					EventName:  "gen_ai.user.message",
+					Attributes: map[string]any{},
+					Body: map[string]any{
+						"content": map[string]any{
+							"role":  "user",
+							"parts": []any{map[string]any{"text": "hello"}},
+						},
+					},
+				},
+				{
+					EventName:  "gen_ai.choice",
+					Attributes: map[string]any{},
+					// Turn 1: model emits a function call.
+					Body: map[string]any{
+						"index": float64(0),
+						"content": map[string]any{
+							"role": "model",
+							"parts": []any{map[string]any{
+								"functionCall": map[string]any{
+									"name": "some_tool",
+									"args": map[string]any{"arg1": "val1"},
+								},
+							}},
+						},
+					},
+				},
+			},
+		},
+		{
+			Name: "execute_tool some_tool",
+			Attributes: map[string]any{
+				"gen_ai.operation.name":           "execute_tool",
+				"gen_ai.tool.name":                "some_tool",
+				"gen_ai.tool.description":         "A sample tool.",
+				"gen_ai.tool.call.id":             telemetrytest.PRESENT,
+				"gcp.vertex.agent.event_id":       telemetrytest.PRESENT,
+				"gcp.vertex.agent.tool_call_args": telemetrytest.PRESENT,
+				"gcp.vertex.agent.tool_response":  telemetrytest.PRESENT,
+			},
+		},
+		{
+			Name: "generate_content mock",
+			Attributes: map[string]any{
+				"gen_ai.operation.name":          "generate_content",
+				"gen_ai.request.model":           "mock",
+				"gcp.vertex.agent.event_id":      telemetrytest.PRESENT,
+				"gcp.vertex.agent.invocation_id": telemetrytest.PRESENT,
+				"gen_ai.response.finish_reasons": []string{""},
+			},
+			Logs: []*telemetrytest.LogDigest{
+				{
+					EventName:  "gen_ai.system.message",
+					Attributes: map[string]any{},
+					Body: map[string]any{
+						"content": "you are helpful\n\nYou are an agent. Your internal name is \"some_root_agent\". The description about you is \"A sample root agent.\".",
+					},
+				},
+				{
+					EventName:  "gen_ai.user.message",
+					Attributes: map[string]any{},
+					Body: map[string]any{
+						"content": map[string]any{
+							"role":  "user",
+							"parts": []any{map[string]any{"text": "hello"}},
+						},
+					},
+				},
+				{
+					EventName:  "gen_ai.user.message",
+					Attributes: map[string]any{},
+					// Turn 2 carries the model's previous turn
+					// (the function call) as a content entry.
+					Body: map[string]any{
+						"content": map[string]any{
+							"role": "model",
+							"parts": []any{map[string]any{
+								"functionCall": map[string]any{
+									"name": "some_tool",
+									"args": map[string]any{"arg1": "val1"},
+								},
+							}},
+						},
+					},
+				},
+				{
+					EventName:  "gen_ai.user.message",
+					Attributes: map[string]any{},
+					// Turn 2 carries the function-response turn.
+					Body: map[string]any{
+						"content": map[string]any{
+							"role": "user",
+							"parts": []any{map[string]any{
+								"functionResponse": map[string]any{
+									"name":     "some_tool",
+									"response": map[string]any{"result": "processed val1"},
+								},
+							}},
+						},
+					},
+				},
+				{
+					EventName:  "gen_ai.choice",
+					Attributes: map[string]any{},
+					// Turn 2: final text response.
+					Body: map[string]any{
+						"index": float64(0),
+						"content": map[string]any{
+							"role":  "model",
+							"parts": []any{map[string]any{"text": "text response"}},
+						},
+					},
+				},
+			},
+		},
+	},
+}

--- a/internal/telemetry/telemetrytestcase/doc.go
+++ b/internal/telemetry/telemetrytestcase/doc.go
@@ -1,0 +1,29 @@
+// Copyright 2026 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+// Package telemetrytestcase declares the expected telemetry shape
+// (spans + log records nested inside their owning span) emitted by
+// each canonical end-to-end ADK scenario.
+//
+// Each test case lives in its own file and exports exactly one
+// symbol — a *[telemetrytest.SpanDigest] holding the expected root
+// span and its full subtree — so the literal SpanDigest /
+// LogDigest expectations are visible at a glance, undivided by
+// helpers, and the package's exported surface is a 1:1 inventory
+// of the scenarios under test.
+//
+// The actual runners that build the agent, drive a Runner, and
+// compare against the expected digest live in the
+// telemetry/functionaltest test package.
+package telemetrytestcase

--- a/internal/telemetry/telemetrytestcase/workflow_chain.go
+++ b/internal/telemetry/telemetrytestcase/workflow_chain.go
@@ -1,0 +1,48 @@
+// Copyright 2026 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package telemetrytestcase
+
+import (
+	"google.golang.org/adk/internal/telemetry/telemetrytest"
+)
+
+// WorkflowChainCase is the expected root span for the canonical
+// "workflowagent chaining two FunctionNodes" scenario.
+var WorkflowChainCase = &telemetrytest.SpanDigest{
+	Name: "invoke_workflow my_workflow",
+	Attributes: map[string]any{
+		"gen_ai.operation.name":  "invoke_workflow",
+		"gen_ai.workflow.name":   "my_workflow",
+		"gen_ai.conversation.id": telemetrytest.PRESENT,
+	},
+	Children: []*telemetrytest.SpanDigest{
+		{
+			Name: "invoke_node upper_node",
+			Attributes: map[string]any{
+				"gen_ai.operation.name":  "invoke_node",
+				"gen_ai.node.name":       "upper_node",
+				"gen_ai.conversation.id": telemetrytest.PRESENT,
+			},
+		},
+		{
+			Name: "invoke_node suffix_node",
+			Attributes: map[string]any{
+				"gen_ai.operation.name":  "invoke_node",
+				"gen_ai.node.name":       "suffix_node",
+				"gen_ai.conversation.id": telemetrytest.PRESENT,
+			},
+		},
+	},
+}

--- a/internal/workflowinternal/finish_task_tool.go
+++ b/internal/workflowinternal/finish_task_tool.go
@@ -1,11 +1,186 @@
+// Copyright 2026 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//	http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
 package workflowinternal
 
 import (
+	"fmt"
+	"strings"
+
 	"google.golang.org/adk/agent"
+	"google.golang.org/adk/internal/llminternal"
+	"google.golang.org/adk/internal/toolinternal/toolutils"
+	"google.golang.org/adk/internal/utils"
+	"google.golang.org/adk/model"
 	"google.golang.org/adk/tool"
+	"google.golang.org/genai"
 )
 
-func NewFinishTaskTool(llmAgent agent.Agent) (tool.Tool, error) {
-	// TODO: implement
-	return nil, nil
+const (
+	FinishTaskToolName      = "finish_task"
+	FinishTaskSuccessResult = "Task completed."
+)
+
+// NewFinishTaskTool allows the model to signal that the agent has completed its
+// task. On success it sets `tool_context.actions.finish_task` with a
+// serialized `TaskResult` dict.
+//
+// Args:
+//
+//	taskAgent: The task agent this tool belongs to. The agent's
+//	  `output_schema` is used for validation. If None, the default
+//	  schema (a single `result` string) is used.
+func NewFinishTaskTool(taskAgent agent.Agent) (tool.Tool, error) {
+	llmAgentInternal, ok := taskAgent.(llminternal.Agent)
+	if !ok {
+		return nil, fmt.Errorf("NewFinishTaskTool: %q is not an LLMAgent", taskAgent.Name())
+	}
+
+	llmAgentState := llminternal.Reveal(llmAgentInternal)
+
+	newTool := &FinishTaskTool{
+		taskAgentName: taskAgent.Name(),
+	}
+
+	if llmAgentState.OutputSchema != nil {
+		newTool.userSchema = llmAgentState.OutputSchema
+	} else {
+		newTool.userSchema = &genai.Schema{
+			Type: genai.TypeObject,
+			Properties: map[string]*genai.Schema{
+				defaultWrapperKey: {
+					Type:        genai.TypeString,
+					Description: "A brief summary of what the agent accomplished.",
+				},
+			},
+			Required: []string{defaultWrapperKey},
+		}
+	}
+
+	// Function declaration parameters must be an OBJECT schema.
+	if isObjectSchema(newTool.userSchema) {
+		newTool.wrappedSchema = newTool.userSchema
+	} else {
+		newTool.wrapperKey = defaultWrapperKey
+		newTool.wrappedSchema = &genai.Schema{
+			Type: genai.TypeObject,
+			Properties: map[string]*genai.Schema{
+				newTool.wrapperKey: newTool.userSchema,
+			},
+			Required: []string{newTool.wrapperKey},
+		}
+	}
+
+	newTool.description = "Signal that this agent has completed its delegated task. Call this when you have finished your delegated task."
+	if llmAgentState.OutputSchema != nil {
+		newTool.description += " Pass the required output data in the parameters."
+	}
+
+	return newTool, nil
+}
+
+type FinishTaskTool struct {
+	taskAgentName string
+	description   string
+	// userSchema it's either LLMAgent.OutputSchema or the default schema if not set by the user.
+	userSchema *genai.Schema
+	// if userSchema is not an object, we wrap it into object using wrapperKey
+	// As function call parameters must be an OBJECT schema, so non-object output schemas are
+	// wrapped inside `{type: OBJECT, properties: {result: <schema>}, required:
+	// [result]}` and the model-provided value is unwrapped before validation.
+	wrappedSchema *genai.Schema
+	wrapperKey    string
+}
+
+const defaultWrapperKey = "result"
+
+func isObjectSchema(s *genai.Schema) bool {
+	if s == nil {
+		return false
+	}
+	return genai.Type(strings.ToUpper(string(s.Type))) == genai.TypeObject
+}
+
+func (t *FinishTaskTool) Name() string {
+	return FinishTaskToolName
+}
+
+func (t *FinishTaskTool) Description() string {
+	return t.description
+}
+
+func (t *FinishTaskTool) IsLongRunning() bool {
+	return false
+}
+
+func (t *FinishTaskTool) WrapperKey() string {
+	return t.wrapperKey
+}
+
+func (t *FinishTaskTool) Declaration() *genai.FunctionDeclaration {
+	return &genai.FunctionDeclaration{
+		Name:        t.Name(),
+		Description: t.Description(),
+		Parameters:  t.wrappedSchema,
+	}
+}
+
+func (t *FinishTaskTool) ProcessRequest(ctx tool.Context, req *model.LLMRequest) error {
+	instructions := `
+Do NOT call 'finish_task' prematurely. Use your available tools to
+fully complete every aspect of the delegated task first. If the
+task is unclear, ask the user for clarification before proceeding.
+Once the task is fully complete, call 'finish_task' by itself with
+no accompanying text output.
+`
+
+	utils.AppendInstructions(req, instructions)
+
+	return toolutils.PackTool(req, t)
+}
+
+func (t *FinishTaskTool) Run(ctx tool.Context, args any) (map[string]any, error) {
+	if args == nil {
+		return nil, fmt.Errorf("missing argument")
+	}
+
+	m, ok := args.(map[string]any)
+	if !ok {
+		return nil, fmt.Errorf("unexpected args type: %T, expected map[string]any", args)
+	}
+
+	if err := t.validateArgs(m); err != nil {
+		return map[string]any{
+			"error": fmt.Sprintf(
+				"Invoking `%s()` failed due to validation errors:\n%s\n"+
+					"You could retry calling this tool, but it is IMPORTANT for you"+
+					" to provide all the mandatory parameters with correct types.",
+				t.Name(), err,
+			),
+		}, nil
+	}
+
+	return map[string]any{"result": FinishTaskSuccessResult}, nil
+}
+
+func (t *FinishTaskTool) validateArgs(args map[string]any) error {
+	if t.wrapperKey == "" {
+		return utils.ValidateMapOnSchema(args, t.userSchema, false)
+	}
+
+	return utils.ValidateMapOnSchema(
+		args,
+		t.wrappedSchema,
+		false,
+	)
 }

--- a/internal/workflowinternal/finish_task_tool.go
+++ b/internal/workflowinternal/finish_task_tool.go
@@ -4,13 +4,14 @@
 // you may not use this file except in compliance with the License.
 // You may obtain a copy of the License at
 //
-//	http://www.apache.org/licenses/LICENSE-2.0
+//     http://www.apache.org/licenses/LICENSE-2.0
 //
 // Unless required by applicable law or agreed to in writing, software
 // distributed under the License is distributed on an "AS IS" BASIS,
 // WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 // See the License for the specific language governing permissions and
 // limitations under the License.
+
 package workflowinternal
 
 import (

--- a/internal/workflowinternal/finish_task_tool.go
+++ b/internal/workflowinternal/finish_task_tool.go
@@ -1,0 +1,11 @@
+package workflowinternal
+
+import (
+	"google.golang.org/adk/agent"
+	"google.golang.org/adk/tool"
+)
+
+func NewFinishTaskTool(llmAgent agent.Agent) (tool.Tool, error) {
+	// TODO: implement
+	return nil, nil
+}

--- a/internal/workflowinternal/finish_task_tool_test.go
+++ b/internal/workflowinternal/finish_task_tool_test.go
@@ -1,0 +1,458 @@
+// Copyright 2026 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package workflowinternal_test
+
+import (
+	"slices"
+	"strings"
+	"testing"
+
+	"github.com/google/go-cmp/cmp"
+	"google.golang.org/genai"
+
+	"google.golang.org/adk/agent"
+	"google.golang.org/adk/agent/llmagent"
+	"google.golang.org/adk/internal/utils"
+	"google.golang.org/adk/internal/workflowinternal"
+	"google.golang.org/adk/model"
+)
+
+var sampleOutputSchema = &genai.Schema{
+	Type: genai.TypeObject,
+	Properties: map[string]*genai.Schema{
+		"result": {Type: genai.TypeString},
+		"count":  {Type: genai.TypeInteger},
+	},
+	Required: []string{"result", "count"},
+}
+
+func makeTaskAgent(t *testing.T, outputSchema *genai.Schema) agent.Agent {
+	t.Helper()
+	a, err := llmagent.New(llmagent.Config{
+		Name:         "test_agent",
+		OutputSchema: outputSchema,
+	})
+	if err != nil {
+		t.Fatalf("llmagent.New failed: %v", err)
+	}
+	return a
+}
+
+func newFinishTaskTool(t *testing.T, outputSchema *genai.Schema) *workflowinternal.FinishTaskTool {
+	t.Helper()
+	tt, err := workflowinternal.NewFinishTaskTool(makeTaskAgent(t, outputSchema))
+	if err != nil {
+		t.Fatalf("NewFinishTaskTool failed: %v", err)
+	}
+	ft, ok := tt.(*workflowinternal.FinishTaskTool)
+	if !ok {
+		t.Fatalf("NewFinishTaskTool returned %T, want *finishTaskTool", tt)
+	}
+	return ft
+}
+
+func TestNewFinishTaskTool(t *testing.T) {
+	tests := []struct {
+		name             string
+		outputSchema     *genai.Schema
+		wantHasOutputDoc bool
+	}{
+		{
+			name:             "without output schema",
+			outputSchema:     nil,
+			wantHasOutputDoc: false,
+		},
+		{
+			name:             "with output schema",
+			outputSchema:     sampleOutputSchema,
+			wantHasOutputDoc: true,
+		},
+	}
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			ft := newFinishTaskTool(t, tc.outputSchema)
+			if got, want := ft.Name(), workflowinternal.FinishTaskToolName; got != want {
+				t.Errorf("Name() = %q, want %q", got, want)
+			}
+			if !strings.Contains(ft.Description(), "Signal that this agent has completed") {
+				t.Errorf("Description() = %q, want substring %q",
+					ft.Description(), "Signal that this agent has completed")
+			}
+			if got, want := strings.Contains(ft.Description(), "output data"), tc.wantHasOutputDoc; got != want {
+				t.Errorf("Description() contains %q = %v, want %v",
+					"output data", got, want)
+			}
+		})
+	}
+}
+
+func TestFinishTaskTool_Declaration(t *testing.T) {
+	tests := []struct {
+		name           string
+		outputSchema   *genai.Schema
+		wantProperties []string
+	}{
+		{
+			name:           "without output schema",
+			outputSchema:   nil,
+			wantProperties: []string{"result"},
+		},
+		{
+			name:           "with object output schema",
+			outputSchema:   sampleOutputSchema,
+			wantProperties: []string{"result", "count"},
+		},
+		{
+			name:           "wrapped string output schema",
+			outputSchema:   &genai.Schema{Type: genai.TypeString},
+			wantProperties: []string{"result"},
+		},
+		{
+			name:           "wrapped integer output schema",
+			outputSchema:   &genai.Schema{Type: genai.TypeInteger},
+			wantProperties: []string{"result"},
+		},
+		{
+			name:           "wrapped boolean output schema",
+			outputSchema:   &genai.Schema{Type: genai.TypeBoolean},
+			wantProperties: []string{"result"},
+		},
+		{
+			name:           "wrapped number output schema",
+			outputSchema:   &genai.Schema{Type: genai.TypeNumber},
+			wantProperties: []string{"result"},
+		},
+		{
+			name: "wrapped array of strings output schema",
+			outputSchema: &genai.Schema{
+				Type:  genai.TypeArray,
+				Items: &genai.Schema{Type: genai.TypeString},
+			},
+			wantProperties: []string{"result"},
+		},
+		{
+			name: "wrapped array of integers output schema",
+			outputSchema: &genai.Schema{
+				Type:  genai.TypeArray,
+				Items: &genai.Schema{Type: genai.TypeInteger},
+			},
+			wantProperties: []string{"result"},
+		},
+		{
+			name: "wrapped array of objects output schema",
+			outputSchema: &genai.Schema{
+				Type:  genai.TypeArray,
+				Items: sampleOutputSchema,
+			},
+			wantProperties: []string{"result"},
+		},
+	}
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			ft := newFinishTaskTool(t, tc.outputSchema)
+			decl := ft.Declaration()
+			if decl == nil {
+				t.Fatal("Declaration() = nil, want non-nil")
+			}
+			if got, want := decl.Name, workflowinternal.FinishTaskToolName; got != want {
+				t.Errorf("Declaration().Name = %q, want %q", got, want)
+			}
+			if decl.Parameters == nil {
+				t.Fatal("Declaration().Parameters = nil, want non-nil")
+			}
+			if got, want := decl.Parameters.Type, genai.TypeObject; got != want {
+				t.Errorf("Declaration().Parameters.Type = %q, want %q", got, want)
+			}
+			for _, p := range tc.wantProperties {
+				if _, ok := decl.Parameters.Properties[p]; !ok {
+					t.Errorf("Declaration().Parameters.Properties is missing %q, got keys %v",
+						p, propertyKeys(decl.Parameters.Properties))
+				}
+			}
+		})
+	}
+}
+
+func TestFinishTaskTool_WrapperKey(t *testing.T) {
+	tests := []struct {
+		name           string
+		outputSchema   *genai.Schema
+		wantWrapperKey string
+	}{
+		{
+			name:           "default (no user schema)",
+			outputSchema:   nil,
+			wantWrapperKey: "",
+		},
+		{
+			name:           "object",
+			outputSchema:   sampleOutputSchema,
+			wantWrapperKey: "",
+		},
+		{
+			name:           "string",
+			outputSchema:   &genai.Schema{Type: genai.TypeString},
+			wantWrapperKey: "result",
+		},
+		{
+			name:           "integer",
+			outputSchema:   &genai.Schema{Type: genai.TypeInteger},
+			wantWrapperKey: "result",
+		},
+		{
+			name:           "boolean",
+			outputSchema:   &genai.Schema{Type: genai.TypeBoolean},
+			wantWrapperKey: "result",
+		},
+		{
+			name:           "number",
+			outputSchema:   &genai.Schema{Type: genai.TypeNumber},
+			wantWrapperKey: "result",
+		},
+		{
+			name: "array of strings",
+			outputSchema: &genai.Schema{
+				Type:  genai.TypeArray,
+				Items: &genai.Schema{Type: genai.TypeString},
+			},
+			wantWrapperKey: "result",
+		},
+		{
+			name: "array of integers",
+			outputSchema: &genai.Schema{
+				Type:  genai.TypeArray,
+				Items: &genai.Schema{Type: genai.TypeInteger},
+			},
+			wantWrapperKey: "result",
+		},
+		{
+			name: "array of objects",
+			outputSchema: &genai.Schema{
+				Type:  genai.TypeArray,
+				Items: sampleOutputSchema,
+			},
+			wantWrapperKey: "result",
+		},
+	}
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			ft := newFinishTaskTool(t, tc.outputSchema)
+			if got, want := ft.WrapperKey(), tc.wantWrapperKey; got != want {
+				t.Errorf("wrapperKey = %q, want %q", got, want)
+			}
+		})
+	}
+}
+
+func TestFinishTaskTool_Run(t *testing.T) {
+	wantSuccess := map[string]any{"result": workflowinternal.FinishTaskSuccessResult}
+
+	tests := []struct {
+		name         string
+		outputSchema *genai.Schema
+		args         any
+		want         map[string]any
+		wantErr      bool
+		// wantErrSubstr, when non-empty, asserts the returned tool result has
+		// an `error` key containing the substring. wantErr must be false.
+		wantErrSubstr []string
+	}{
+		{
+			name:         "default schema, valid args",
+			outputSchema: nil,
+			args:         map[string]any{"result": "done"},
+			want:         wantSuccess,
+		},
+		{
+			name:         "object schema, valid args",
+			outputSchema: sampleOutputSchema,
+			args:         map[string]any{"result": "success", "count": 42.0},
+			want:         wantSuccess,
+		},
+		{
+			name:         "string wrapper, valid args",
+			outputSchema: &genai.Schema{Type: genai.TypeString},
+			args:         map[string]any{"result": "hello"},
+			want:         wantSuccess,
+		},
+		{
+			name:         "integer wrapper, valid args",
+			outputSchema: &genai.Schema{Type: genai.TypeInteger},
+			args:         map[string]any{"result": 42.0},
+			want:         wantSuccess,
+		},
+		{
+			name:         "boolean wrapper, valid args",
+			outputSchema: &genai.Schema{Type: genai.TypeBoolean},
+			args:         map[string]any{"result": true},
+			want:         wantSuccess,
+		},
+		{
+			name:         "number wrapper, valid args",
+			outputSchema: &genai.Schema{Type: genai.TypeNumber},
+			args:         map[string]any{"result": 3.14},
+			want:         wantSuccess,
+		},
+		{
+			name: "array of strings wrapper, valid args",
+			outputSchema: &genai.Schema{
+				Type:  genai.TypeArray,
+				Items: &genai.Schema{Type: genai.TypeString},
+			},
+			args: map[string]any{"result": []any{"a", "b", "c"}},
+			want: wantSuccess,
+		},
+		{
+			name: "array of integers wrapper, valid args",
+			outputSchema: &genai.Schema{
+				Type:  genai.TypeArray,
+				Items: &genai.Schema{Type: genai.TypeInteger},
+			},
+			args: map[string]any{"result": []any{1.0, 2.0, 3.0}},
+			want: wantSuccess,
+		},
+		{
+			name: "array of strings wrapper, empty args",
+			outputSchema: &genai.Schema{
+				Type:  genai.TypeArray,
+				Items: &genai.Schema{Type: genai.TypeString},
+			},
+			args: map[string]any{"result": []any{}},
+			want: wantSuccess,
+		},
+		{
+			name:          "validation error: missing required field",
+			outputSchema:  sampleOutputSchema,
+			args:          map[string]any{"result": "success"},
+			wantErrSubstr: []string{"finish_task", "validation errors", "count"},
+		},
+		{
+			name:          "validation error: wrong type",
+			outputSchema:  sampleOutputSchema,
+			args:          map[string]any{"result": "success", "count": "not_an_int"},
+			wantErrSubstr: []string{"finish_task", "validation errors"},
+		},
+		{
+			name:    "nil args",
+			args:    nil,
+			wantErr: true,
+		},
+		{
+			name:    "non-map args",
+			args:    "not a map",
+			wantErr: true,
+		},
+	}
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			ft := newFinishTaskTool(t, tc.outputSchema)
+			got, err := ft.Run(nil, tc.args)
+			if tc.wantErr {
+				if err == nil {
+					t.Fatalf("Run() error = nil, want non-nil; result = %v", got)
+				}
+				return
+			}
+			if err != nil {
+				t.Fatalf("Run() unexpected error: %v", err)
+			}
+
+			if len(tc.wantErrSubstr) > 0 {
+				gotErr, ok := got["error"].(string)
+				if !ok {
+					t.Fatalf("Run() result missing %q key or wrong type, got %v",
+						"error", got)
+				}
+				for _, sub := range tc.wantErrSubstr {
+					if !strings.Contains(gotErr, sub) {
+						t.Errorf("Run() error %q does not contain substring %q",
+							gotErr, sub)
+					}
+				}
+				return
+			}
+
+			if diff := cmp.Diff(tc.want, got); diff != "" {
+				t.Errorf("Run() result mismatch (-want +got):\n%s", diff)
+			}
+		})
+	}
+}
+
+func TestFinishTaskTool_ProcessRequest(t *testing.T) {
+	ft := newFinishTaskTool(t, nil)
+	req := &model.LLMRequest{}
+
+	if err := ft.ProcessRequest(nil, req); err != nil {
+		t.Fatalf("ProcessRequest() failed: %v", err)
+	}
+
+	// The tool should be registered on the request.
+	if _, ok := req.Tools[workflowinternal.FinishTaskToolName]; !ok {
+		t.Errorf("req.Tools does not include %q; got keys %v",
+			workflowinternal.FinishTaskToolName, toolKeys(req.Tools))
+	}
+
+	// The function declaration should also be present.
+	decls := utils.FunctionDecls(req.Config)
+	if !slices.ContainsFunc(decls, func(d *genai.FunctionDeclaration) bool {
+		return d.Name == workflowinternal.FinishTaskToolName
+	}) {
+		t.Errorf("req.Config function declarations do not include %q; got %v",
+			workflowinternal.FinishTaskToolName, decls)
+	}
+
+	// The finish_task instruction should have been appended to the system
+	// instruction. Mirrors `test_instruction_content` from Python.
+	instructions := utils.TextParts(req.Config.SystemInstruction)
+	if !slices.ContainsFunc(instructions, func(s string) bool {
+		return strings.Contains(s, "finish_task") &&
+			strings.Contains(s, "Do NOT call") &&
+			strings.Contains(s, "by itself with")
+	}) {
+		t.Errorf("system instruction does not contain finish_task guidance; got %v",
+			instructions)
+	}
+}
+
+func TestFinishTaskToolConstants(t *testing.T) {
+	if got, want := workflowinternal.FinishTaskToolName, "finish_task"; got != want {
+		t.Errorf("FinishTaskToolName = %q, want %q", got, want)
+	}
+	if got, want := workflowinternal.FinishTaskSuccessResult, "Task completed."; got != want {
+		t.Errorf("FinishTaskSuccessResult = %q, want %q", got, want)
+	}
+}
+
+// propertyKeys returns the sorted keys of a schema properties map, for
+// stable error messages.
+func propertyKeys(m map[string]*genai.Schema) []string {
+	keys := make([]string, 0, len(m))
+	for k := range m {
+		keys = append(keys, k)
+	}
+	slices.Sort(keys)
+	return keys
+}
+
+// toolKeys returns the sorted keys of req.Tools for stable error messages.
+func toolKeys(m map[string]any) []string {
+	keys := make([]string, 0, len(m))
+	for k := range m {
+		keys = append(keys, k)
+	}
+	slices.Sort(keys)
+	return keys
+}

--- a/internal/workflowinternal/single_turn_tool.go
+++ b/internal/workflowinternal/single_turn_tool.go
@@ -9,3 +9,9 @@ func NewSingleTurnTool(a agent.Agent) (tool.Tool, error) {
 	// TODO: implement
 	return nil, nil
 }
+
+//func (t *singleTurnTool) Run(ctx tool.Context, args any) (map[string]any, error) {
+// nc, ok := workflow.NodeContextFromGoContext(ctx)
+// node, err := workflow.NewAgentNode(t.agent, workflow.NodeConfig{})
+// out, err := workflow.RunNode[any](nc, node, nodeInput)
+//}

--- a/internal/workflowinternal/single_turn_tool.go
+++ b/internal/workflowinternal/single_turn_tool.go
@@ -1,17 +1,137 @@
+// Copyright 2026 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
 package workflowinternal
 
 import (
+	"fmt"
+
 	"google.golang.org/adk/agent"
+	"google.golang.org/adk/internal/llminternal"
+	"google.golang.org/adk/internal/toolinternal/toolutils"
+	"google.golang.org/adk/internal/utils"
+	"google.golang.org/adk/model"
 	"google.golang.org/adk/tool"
+	"google.golang.org/adk/workflow"
+	"google.golang.org/genai"
 )
 
-func NewSingleTurnTool(a agent.Agent) (tool.Tool, error) {
-	// TODO: implement
-	return nil, nil
+type SingleTurnTool struct {
+	agent           agent.Agent
+	funcDeclaration *genai.FunctionDeclaration
 }
 
-//func (t *singleTurnTool) Run(ctx tool.Context, args any) (map[string]any, error) {
-// nc, ok := workflow.NodeContextFromGoContext(ctx)
-// node, err := workflow.NewAgentNode(t.agent, workflow.NodeConfig{})
-// out, err := workflow.RunNode[any](nc, node, nodeInput)
-//}
+func NewSingleTurnTool(a agent.Agent) (tool.Tool, error) {
+	s := &SingleTurnTool{
+		agent:           a,
+		funcDeclaration: MakeFunctionDeclaration(a),
+	}
+
+	return s, nil
+}
+
+func (t *SingleTurnTool) Name() string {
+	return t.agent.Name()
+}
+
+func (t *SingleTurnTool) Description() string {
+	return t.agent.Description()
+}
+
+func (t *SingleTurnTool) IsLongRunning() bool {
+	return false
+}
+
+func (t *SingleTurnTool) Run(toolCtx tool.Context, args any) (map[string]any, error) {
+	margs, ok := args.(map[string]any)
+	if !ok {
+		return nil, fmt.Errorf("single turn tool expects map[string]any arguments, got %T", args)
+	}
+
+	var nodeInput any
+
+	if t.funcDeclaration.Parameters != nil {
+		if err := utils.ValidateMapOnSchema(margs, t.funcDeclaration.Parameters, true); err != nil {
+			return nil, fmt.Errorf("argument validation failed for agent %s: %w", t.agent.Name(), err)
+		}
+		nodeInput = margs
+	} else {
+		nodeInput = margs["request"]
+	}
+
+	nc, ok := workflow.NodeContextFromGoContext(toolCtx)
+	if !ok {
+		return nil, fmt.Errorf("failed to infer node context")
+	}
+
+	node, err := workflow.NewAgentNode(t.agent, workflow.NodeConfig{})
+	if err != nil {
+		return nil, fmt.Errorf("failed to create agent node: %w", err)
+	}
+
+	result, err := workflow.RunNode[any](nc, node, nodeInput, workflow.WithUseSubBranch())
+	if err != nil {
+		return nil, fmt.Errorf("failed to run agent node: %w", err)
+	}
+
+	return map[string]any{"result": result}, nil
+}
+
+// Declaration returns the function declaration for the wrapped agent.
+// It generates a function declaration based on the agent's input schema.
+// If the agent does not have an input schema, a default schema with a
+// "request" string parameter is used.
+func (t *SingleTurnTool) Declaration() *genai.FunctionDeclaration {
+	return t.funcDeclaration
+}
+
+func (t *SingleTurnTool) ProcessRequest(ctx tool.Context, req *model.LLMRequest) error {
+	return toolutils.PackTool(req, t)
+}
+
+func getInputSchema(cur agent.Agent) *genai.Schema {
+	llmAgent, ok := cur.(llminternal.Agent)
+	if ok && llmAgent != nil {
+		return llminternal.Reveal(llmAgent).InputSchema
+	}
+
+	if len(cur.SubAgents()) > 0 {
+		return getInputSchema(cur.SubAgents()[0])
+	}
+
+	return nil
+}
+
+// MakeFunctionDeclaration creates a function declaration for a given agent.
+func MakeFunctionDeclaration(curAgent agent.Agent) *genai.FunctionDeclaration {
+	decl := &genai.FunctionDeclaration{
+		Name:        curAgent.Name(),
+		Description: curAgent.Description(),
+	}
+
+	agentInputSchema := getInputSchema(curAgent)
+
+	if agentInputSchema != nil {
+		decl.Parameters = agentInputSchema
+	} else {
+		decl.Parameters = &genai.Schema{
+			Type: "OBJECT",
+			Properties: map[string]*genai.Schema{
+				"request": {Type: "STRING"},
+			},
+			Required: []string{"request"},
+		}
+	}
+	return decl
+}

--- a/internal/workflowinternal/single_turn_tool.go
+++ b/internal/workflowinternal/single_turn_tool.go
@@ -1,0 +1,11 @@
+package workflowinternal
+
+import (
+	"google.golang.org/adk/agent"
+	"google.golang.org/adk/tool"
+)
+
+func NewSingleTurnTool(a agent.Agent) (tool.Tool, error) {
+	// TODO: implement
+	return nil, nil
+}

--- a/internal/workflowinternal/single_turn_tool.go
+++ b/internal/workflowinternal/single_turn_tool.go
@@ -113,6 +113,19 @@ func getInputSchema(cur agent.Agent) *genai.Schema {
 	return nil
 }
 
+func getOutputSchema(cur agent.Agent) *genai.Schema {
+	llmAgent, ok := cur.(llminternal.Agent)
+	if ok && llmAgent != nil {
+		return llminternal.Reveal(llmAgent).OutputSchema
+	}
+
+	if len(cur.SubAgents()) > 0 {
+		return getOutputSchema(cur.SubAgents()[len(cur.SubAgents())-1])
+	}
+
+	return nil
+}
+
 // MakeFunctionDeclaration creates a function declaration for a given agent.
 func MakeFunctionDeclaration(curAgent agent.Agent) *genai.FunctionDeclaration {
 	decl := &genai.FunctionDeclaration{

--- a/internal/workflowinternal/single_turn_tool_test.go
+++ b/internal/workflowinternal/single_turn_tool_test.go
@@ -1,0 +1,340 @@
+// Copyright 2026 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package workflowinternal_test
+
+import (
+	"context"
+	"errors"
+	"iter"
+	"slices"
+	"strings"
+	"testing"
+
+	"github.com/google/go-cmp/cmp"
+	"google.golang.org/genai"
+
+	"google.golang.org/adk/agent"
+	"google.golang.org/adk/agent/llmagent"
+	"google.golang.org/adk/internal/toolinternal"
+	"google.golang.org/adk/internal/utils"
+	"google.golang.org/adk/internal/workflowinternal"
+	"google.golang.org/adk/model"
+	"google.golang.org/adk/session"
+	"google.golang.org/adk/workflow"
+)
+
+const (
+	agentName = "math_agent"
+	agentDesc = "Solves math problems."
+)
+
+var sampleInputSchema = &genai.Schema{
+	Type: "OBJECT",
+	Properties: map[string]*genai.Schema{
+		"is_magic": {Type: "BOOLEAN"},
+		"name":     {Type: "STRING"},
+	},
+	Required: []string{"is_magic", "name"},
+}
+
+var defaultDecl = &genai.FunctionDeclaration{
+	Name:        agentName,
+	Description: agentDesc,
+	Parameters: &genai.Schema{
+		Type: "OBJECT",
+		Properties: map[string]*genai.Schema{
+			"request": {Type: "STRING"},
+		},
+		Required: []string{"request"},
+	},
+}
+
+func TestSingleTurnTool_Metadata(t *testing.T) {
+	a := newLLMAgent(t, agentName, agentDesc, nil)
+	st := newSingleTurnTool(t, a)
+
+	if got, want := st.Name(), agentName; got != want {
+		t.Errorf("Name() = %q, want %q", got, want)
+	}
+	if got, want := st.Description(), agentDesc; got != want {
+		t.Errorf("Description() = %q, want %q", got, want)
+	}
+	if st.IsLongRunning() {
+		t.Errorf("IsLongRunning() = true, want false")
+	}
+}
+
+func TestSingleTurnTool_Declaration(t *testing.T) {
+	tests := []struct {
+		name  string
+		agent agent.Agent
+		want  *genai.FunctionDeclaration
+	}{
+		{
+			name:  "no input schema falls back to {request: STRING}",
+			agent: newLLMAgent(t, agentName, agentDesc, nil),
+			want:  defaultDecl,
+		},
+		{
+			name:  "uses wrapped agent's input schema as is",
+			agent: newLLMAgent(t, agentName, agentDesc, sampleInputSchema),
+			want: &genai.FunctionDeclaration{
+				Name:        agentName,
+				Description: agentDesc,
+				Parameters:  sampleInputSchema,
+			},
+		},
+		{
+			name: "composite agent recurses into first sub-agent's schema",
+			agent: newCompositeAgent(t, "parent_no_schema", "Outer composite.",
+				newLLMAgent(t, "child_with_schema", "Inner agent.", sampleInputSchema)),
+			want: &genai.FunctionDeclaration{
+				Name:        "parent_no_schema",
+				Description: "Outer composite.",
+				Parameters:  sampleInputSchema,
+			},
+		},
+	}
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			got := newSingleTurnTool(t, tc.agent).Declaration()
+			if diff := cmp.Diff(tc.want, got); diff != "" {
+				t.Errorf("Declaration() diff (-want +got):\n%s", diff)
+			}
+		})
+	}
+}
+
+func TestSingleTurnTool_Run_Failures(t *testing.T) {
+	tests := []struct {
+		name        string
+		inputSchema *genai.Schema
+		args        any
+		wantSubstr  []string
+	}{
+		{
+			name:       "args is not a map",
+			args:       "not a map",
+			wantSubstr: []string{"map[string]any"},
+		},
+		{
+			name:        "schema: extra field rejected",
+			inputSchema: sampleInputSchema,
+			args:        map[string]any{"is_magic": true, "name": "x", "name_invalid": "y"},
+			wantSubstr:  []string{"argument validation failed", agentName, "name_invalid"},
+		},
+		{
+			name:        "schema: missing required field",
+			inputSchema: sampleInputSchema,
+			args:        map[string]any{"is_magic": true},
+			wantSubstr:  []string{"argument validation failed", agentName, "name"},
+		},
+		{
+			name:        "schema: wrong type for boolean field",
+			inputSchema: sampleInputSchema,
+			args:        map[string]any{"is_magic": "not a bool", "name": "x"},
+			wantSubstr:  []string{"argument validation failed", agentName, "is_magic"},
+		},
+		{
+			name:        "schema: wrong type for string field",
+			inputSchema: sampleInputSchema,
+			args:        map[string]any{"is_magic": true, "name": 42.0},
+			wantSubstr:  []string{"argument validation failed", agentName, "name"},
+		},
+		{
+			name:       "default schema: empty args missing required \"request\"",
+			args:       map[string]any{},
+			wantSubstr: []string{"argument validation failed", "request"},
+		},
+	}
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			a := newLLMAgent(t, agentName, agentDesc, tc.inputSchema)
+			st := newSingleTurnTool(t, a)
+
+			got, err := st.Run(nil, tc.args)
+			if err == nil {
+				t.Fatalf("Run(%v) err = nil, want non-nil", tc.args)
+			}
+			if got != nil {
+				t.Errorf("Run(%v) result = %v, want nil", tc.args, got)
+			}
+			for _, sub := range tc.wantSubstr {
+				if !strings.Contains(err.Error(), sub) {
+					t.Errorf("Run(%v) err = %q, want substring %q", tc.args, err.Error(), sub)
+				}
+			}
+		})
+	}
+}
+
+func TestSingleTurnTool_ProcessRequest_RegistersTool(t *testing.T) {
+	st := newSingleTurnTool(t, newLLMAgent(t, agentName, agentDesc, nil))
+
+	req := &model.LLMRequest{}
+	if err := st.ProcessRequest(nil, req); err != nil {
+		t.Fatalf("ProcessRequest() err = %v", err)
+	}
+
+	if _, ok := req.Tools[agentName]; !ok {
+		t.Errorf("req.Tools missing %q; got keys %v", agentName, sortedKeys(req.Tools))
+	}
+	decls := utils.FunctionDecls(req.Config)
+	if !slices.ContainsFunc(decls, func(d *genai.FunctionDeclaration) bool { return d.Name == agentName }) {
+		var names []string
+		for _, d := range decls {
+			if d != nil {
+				names = append(names, d.Name)
+			}
+		}
+		t.Errorf("req.Config function declarations missing %q; got %v", agentName, names)
+	}
+}
+
+func TestSingleTurnTool_Run_HappyPath(t *testing.T) {
+	const wantOutput = "world"
+
+	a, err := agent.New(agent.Config{
+		Name:        "echo_agent",
+		Description: "Yields a single fixed-output event.",
+		Run: func(_ agent.InvocationContext) iter.Seq2[*session.Event, error] {
+			return func(yield func(*session.Event, error) bool) {
+				yield(&session.Event{Output: wantOutput}, nil)
+			}
+		},
+	})
+	if err != nil {
+		t.Fatalf("agent.New: %v", err)
+	}
+	st := newSingleTurnTool(t, a)
+
+	var (
+		gotResult map[string]any
+		gotErr    error
+	)
+	orchestrator := workflow.NewDynamicNode("orchestrator",
+		func(ctx workflow.NodeContext, _ string, _ func(*session.Event) error) (any, error) {
+			ic := ctx.WithContext(workflow.WithNodeContext(ctx, ctx))
+			toolCtx := toolinternal.NewToolContext(ic, "fc-id", &session.EventActions{}, nil)
+			gotResult, gotErr = st.Run(toolCtx, map[string]any{"request": "hello"})
+			return nil, gotErr
+		},
+		workflow.NodeConfig{},
+	)
+
+	w, err := workflow.New("root", workflow.Chain(workflow.Start, orchestrator))
+	if err != nil {
+		t.Fatalf("workflow.New: %v", err)
+	}
+
+	sessResp, err := session.InMemoryService().Create(t.Context(), &session.CreateRequest{
+		AppName:   "test_app",
+		UserID:    "test_user",
+		SessionID: "test_session",
+	})
+	if err != nil {
+		t.Fatalf("session.Create: %v", err)
+	}
+
+	ic := &fakeInvocationContext{Context: t.Context(), sess: sessResp.Session}
+	for _, err := range w.Run(ic) {
+		if err != nil {
+			t.Fatalf("workflow.Run error: %v", err)
+		}
+	}
+
+	if gotErr != nil {
+		t.Fatalf("SingleTurnTool.Run err = %v, want nil", gotErr)
+	}
+	want := map[string]any{"result": wantOutput}
+	if diff := cmp.Diff(want, gotResult); diff != "" {
+		t.Errorf("SingleTurnTool.Run result diff (-want +got):\n%s", diff)
+	}
+}
+
+func newSingleTurnTool(t *testing.T, a agent.Agent) *workflowinternal.SingleTurnTool {
+	t.Helper()
+	tt, err := workflowinternal.NewSingleTurnTool(a)
+	if err != nil {
+		t.Fatalf("NewSingleTurnTool: %v", err)
+	}
+	st, ok := tt.(*workflowinternal.SingleTurnTool)
+	if !ok {
+		t.Fatalf("NewSingleTurnTool returned %T, want *workflowinternal.SingleTurnTool", tt)
+	}
+	return st
+}
+
+func newLLMAgent(t *testing.T, name, description string, inputSchema *genai.Schema) agent.Agent {
+	t.Helper()
+	a, err := llmagent.New(llmagent.Config{
+		Name:        name,
+		Description: description,
+		InputSchema: inputSchema,
+	})
+	if err != nil {
+		t.Fatalf("llmagent.New(%q): %v", name, err)
+	}
+	return a
+}
+
+func newCompositeAgent(t *testing.T, name, description string, subAgents ...agent.Agent) agent.Agent {
+	t.Helper()
+	a, err := agent.New(agent.Config{
+		Name:        name,
+		Description: description,
+		SubAgents:   subAgents,
+		Run: func(_ agent.InvocationContext) iter.Seq2[*session.Event, error] {
+			return func(yield func(*session.Event, error) bool) {
+				yield(nil, errors.New("custom agent Run should not be invoked in unit tests"))
+			}
+		},
+	})
+	if err != nil {
+		t.Fatalf("agent.New(%q): %v", name, err)
+	}
+	return a
+}
+
+func sortedKeys(m map[string]any) []string {
+	keys := make([]string, 0, len(m))
+	for k := range m {
+		keys = append(keys, k)
+	}
+	slices.Sort(keys)
+	return keys
+}
+
+type fakeInvocationContext struct {
+	context.Context
+	sess session.Session
+}
+
+func (c *fakeInvocationContext) Agent() agent.Agent              { return nil }
+func (c *fakeInvocationContext) Artifacts() agent.Artifacts      { return nil }
+func (c *fakeInvocationContext) Memory() agent.Memory            { return nil }
+func (c *fakeInvocationContext) Session() session.Session        { return c.sess }
+func (c *fakeInvocationContext) InvocationID() string            { return "test-invocation-id" }
+func (c *fakeInvocationContext) Branch() string                  { return "" }
+func (c *fakeInvocationContext) UserContent() *genai.Content     { return nil }
+func (c *fakeInvocationContext) RunConfig() *agent.RunConfig     { return nil }
+func (c *fakeInvocationContext) EndInvocation()                  {}
+func (c *fakeInvocationContext) Ended() bool                     { return false }
+func (c *fakeInvocationContext) ResumedInput(string) (any, bool) { return nil, false }
+func (c *fakeInvocationContext) WithContext(ctx context.Context) agent.InvocationContext {
+	cp := *c
+	cp.Context = ctx
+	return &cp
+}

--- a/internal/workflowinternal/task.go
+++ b/internal/workflowinternal/task.go
@@ -1,3 +1,17 @@
+// Copyright 2026 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
 package workflowinternal
 
 type TaskRequest struct {

--- a/internal/workflowinternal/task.go
+++ b/internal/workflowinternal/task.go
@@ -1,0 +1,15 @@
+package workflowinternal
+
+type TaskRequest struct {
+	AgentName string
+	Input     map[string]any
+}
+
+type TaskResult struct {
+	Output any
+}
+
+type DefaultTaskInput struct {
+	Goal       string
+	Background string
+}

--- a/internal/workflowinternal/task_agent_tool.go
+++ b/internal/workflowinternal/task_agent_tool.go
@@ -15,11 +15,97 @@
 package workflowinternal
 
 import (
+	"fmt"
+	"strings"
+
 	"google.golang.org/adk/agent"
+	"google.golang.org/adk/internal/llminternal"
+	"google.golang.org/adk/internal/llminternal/googlellm"
+	"google.golang.org/adk/internal/toolinternal/toolutils"
+	"google.golang.org/adk/model"
 	"google.golang.org/adk/tool"
+	"google.golang.org/genai"
 )
 
-func NewTaskAgentTool(a agent.Agent) (tool.Tool, error) {
-	// TODO: implement
+type TaskAgentTool struct {
+	agent           agent.Agent
+	funcDeclaration *genai.FunctionDeclaration
+}
+
+func NewTaskAgentTool(curAgent agent.Agent) (tool.Tool, error) {
+	if curAgent == nil {
+		return nil, fmt.Errorf("NewTaskAgentTool: agent is nil")
+	}
+
+	return &TaskAgentTool{
+		agent:           curAgent,
+		funcDeclaration: createTaskAgentFuncDeclaration(curAgent),
+	}, nil
+}
+
+func (t *TaskAgentTool) Declaration() *genai.FunctionDeclaration {
+	return t.funcDeclaration
+}
+
+func (t *TaskAgentTool) Run(toolCtx tool.Context, args any) (map[string]any, error) {
+	// Framework handles task delegation dispatch directly via the wrapper.
+	// TODO: add _defer_response logic.
 	return nil, nil
+}
+
+func (t *TaskAgentTool) Name() string {
+	return t.agent.Name()
+}
+
+func (t *TaskAgentTool) Description() string {
+	return t.agent.Description()
+}
+
+func (t *TaskAgentTool) IsLongRunning() bool {
+	return false
+}
+
+func (t *TaskAgentTool) ProcessRequest(ctx tool.Context, req *model.LLMRequest) error {
+	return toolutils.PackTool(req, t)
+}
+
+func createTaskAgentFuncDeclaration(curAgent agent.Agent) *genai.FunctionDeclaration {
+	decl := &genai.FunctionDeclaration{
+		Name: curAgent.Name(),
+		Description: strings.TrimSpace(
+			fmt.Sprintf(
+				"%s\nIMPORTANT: This tool delegates execution to a specialized agent. Do NOT call this tool in parallel with any other tools.",
+				curAgent.Description())),
+	}
+
+	agentInputSchema := getInputSchema(curAgent)
+	if agentInputSchema != nil {
+		decl.Parameters = agentInputSchema
+	} else {
+		decl.Parameters = &genai.Schema{
+			Type: "OBJECT",
+			Properties: map[string]*genai.Schema{
+				"request": {
+					Type:        "STRING",
+					Description: "Detailed instructions or context for the task sub-agent.",
+				},
+			},
+			Required: []string{"request"},
+		}
+	}
+
+	if llmAgent, ok := curAgent.(llminternal.Agent); ok && llmAgent != nil {
+		agentState := llminternal.Reveal(llmAgent)
+
+		if !googlellm.IsGeminiAPIVariant(agentState.Model) {
+			outputSchema := getOutputSchema(curAgent)
+			if outputSchema != nil {
+				decl.ResponseJsonSchema = &genai.Schema{Type: "OBJECT"}
+			} else {
+				decl.ResponseJsonSchema = &genai.Schema{Type: "STRING"}
+			}
+		}
+	}
+
+	return decl
 }

--- a/internal/workflowinternal/task_agent_tool.go
+++ b/internal/workflowinternal/task_agent_tool.go
@@ -1,0 +1,25 @@
+// Copyright 2026 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package workflowinternal
+
+import (
+	"google.golang.org/adk/agent"
+	"google.golang.org/adk/tool"
+)
+
+func NewTaskAgentTool(a agent.Agent) (tool.Tool, error) {
+	// TODO: implement
+	return nil, nil
+}

--- a/internal/workflowinternal/task_agent_tool_test.go
+++ b/internal/workflowinternal/task_agent_tool_test.go
@@ -1,0 +1,210 @@
+// Copyright 2026 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package workflowinternal_test
+
+import (
+	"context"
+	"iter"
+	"testing"
+
+	"github.com/google/go-cmp/cmp"
+	"google.golang.org/genai"
+
+	"google.golang.org/adk/agent"
+	"google.golang.org/adk/agent/llmagent"
+	"google.golang.org/adk/internal/workflowinternal"
+	"google.golang.org/adk/model"
+)
+
+const (
+	taskAgentName = "task_agent"
+	taskAgentDesc = "Solves a delegated task."
+	taskSuffix    = "IMPORTANT: This tool delegates execution to a specialized agent. Do NOT call this tool in parallel with any other tools."
+)
+
+var taskAgentOutputSchema = &genai.Schema{
+	Type: "OBJECT",
+	Properties: map[string]*genai.Schema{
+		"answer": {Type: "STRING"},
+	},
+	Required: []string{"answer"},
+}
+
+var defaultTaskRequestParams = &genai.Schema{
+	Type: "OBJECT",
+	Properties: map[string]*genai.Schema{
+		"request": {
+			Type:        "STRING",
+			Description: "Detailed instructions or context for the task sub-agent.",
+		},
+	},
+	Required: []string{"request"},
+}
+
+func TestTaskAgentTool_Metadata(t *testing.T) {
+	a := newLLMAgent(t, taskAgentName, taskAgentDesc, nil)
+	tt := newTaskAgentTool(t, a)
+
+	if got, want := tt.Name(), taskAgentName; got != want {
+		t.Errorf("Name() = %q, want %q", got, want)
+	}
+	if got, want := tt.Description(), taskAgentDesc; got != want {
+		t.Errorf("Description() = %q, want %q", got, want)
+	}
+	if tt.IsLongRunning() {
+		t.Errorf("IsLongRunning() = true, want false")
+	}
+}
+
+func TestTaskAgentTool_Declaration(t *testing.T) {
+	tests := []struct {
+		name  string
+		agent agent.Agent
+		want  *genai.FunctionDeclaration
+	}{
+		{
+			name:  "no input schema falls back to default {request: STRING}",
+			agent: newLLMAgent(t, taskAgentName, taskAgentDesc, nil),
+			want: &genai.FunctionDeclaration{
+				Name:        taskAgentName,
+				Description: taskAgentDesc + "\n" + taskSuffix,
+				Parameters:  defaultTaskRequestParams,
+				// Model is nil → IsGeminiAPIVariant returns false →
+				// Vertex branch fires; no output schema → STRING.
+				ResponseJsonSchema: &genai.Schema{Type: "STRING"},
+			},
+		},
+		{
+			name:  "uses wrapped agent's input schema as is",
+			agent: newLLMAgent(t, taskAgentName, taskAgentDesc, sampleInputSchema),
+			want: &genai.FunctionDeclaration{
+				Name:               taskAgentName,
+				Description:        taskAgentDesc + "\n" + taskSuffix,
+				Parameters:         sampleInputSchema,
+				ResponseJsonSchema: &genai.Schema{Type: "STRING"},
+			},
+		},
+		{
+			name: "composite agent recurses into first sub-agent for input schema",
+			agent: newCompositeAgent(t, "parent_no_schema", "Outer composite.",
+				newLLMAgent(t, "child_with_schema", "Inner agent.", sampleInputSchema)),
+			want: &genai.FunctionDeclaration{
+				Name:        "parent_no_schema",
+				Description: "Outer composite." + "\n" + taskSuffix,
+				Parameters:  sampleInputSchema,
+			},
+		},
+		{
+			name:  "empty wrapped-agent description is trimmed (no leading newline)",
+			agent: newLLMAgent(t, taskAgentName, "", nil),
+			want: &genai.FunctionDeclaration{
+				Name:               taskAgentName,
+				Description:        taskSuffix,
+				Parameters:         defaultTaskRequestParams,
+				ResponseJsonSchema: &genai.Schema{Type: "STRING"},
+			},
+		},
+		{
+			name:  "wrapped-agent description with trailing whitespace is trimmed",
+			agent: newLLMAgent(t, taskAgentName, "Solves problems.  ", nil),
+			want: &genai.FunctionDeclaration{
+				Name:               taskAgentName,
+				Description:        "Solves problems.  \n" + taskSuffix,
+				Parameters:         defaultTaskRequestParams,
+				ResponseJsonSchema: &genai.Schema{Type: "STRING"},
+			},
+		},
+		{
+			name:  "Gemini API variant suppresses ResponseJsonSchema",
+			agent: newLLMAgentWithModel(t, taskAgentName, taskAgentDesc, nil, nil, &fakeLLM{backend: genai.BackendGeminiAPI}),
+			want: &genai.FunctionDeclaration{
+				Name:               taskAgentName,
+				Description:        taskAgentDesc + "\n" + taskSuffix,
+				Parameters:         defaultTaskRequestParams,
+				ResponseJsonSchema: nil,
+			},
+		},
+		{
+			name:  "Vertex AI variant sets ResponseJsonSchema to STRING when no output schema",
+			agent: newLLMAgentWithModel(t, taskAgentName, taskAgentDesc, nil, nil, &fakeLLM{backend: genai.BackendVertexAI}),
+			want: &genai.FunctionDeclaration{
+				Name:               taskAgentName,
+				Description:        taskAgentDesc + "\n" + taskSuffix,
+				Parameters:         defaultTaskRequestParams,
+				ResponseJsonSchema: &genai.Schema{Type: "STRING"},
+			},
+		},
+		{
+			name:  "Vertex AI variant sets ResponseJsonSchema to OBJECT when output schema is present",
+			agent: newLLMAgentWithModel(t, taskAgentName, taskAgentDesc, nil, taskAgentOutputSchema, &fakeLLM{backend: genai.BackendVertexAI}),
+			want: &genai.FunctionDeclaration{
+				Name:               taskAgentName,
+				Description:        taskAgentDesc + "\n" + taskSuffix,
+				Parameters:         defaultTaskRequestParams,
+				ResponseJsonSchema: &genai.Schema{Type: "OBJECT"},
+			},
+		},
+	}
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			got := newTaskAgentTool(t, tc.agent).Declaration()
+			if diff := cmp.Diff(tc.want, got); diff != "" {
+				t.Errorf("Declaration() diff (-want +got):\n%s", diff)
+			}
+		})
+	}
+}
+
+func newTaskAgentTool(t *testing.T, a agent.Agent) *workflowinternal.TaskAgentTool {
+	t.Helper()
+	tt, err := workflowinternal.NewTaskAgentTool(a)
+	if err != nil {
+		t.Fatalf("NewTaskAgentTool: %v", err)
+	}
+	st, ok := tt.(*workflowinternal.TaskAgentTool)
+	if !ok {
+		t.Fatalf("NewTaskAgentTool returned %T, want *workflowinternal.TaskAgentTool", tt)
+	}
+	return st
+}
+
+func newLLMAgentWithModel(t *testing.T, name, description string, inputSchema, outputSchema *genai.Schema, llm model.LLM) agent.Agent {
+	t.Helper()
+	a, err := llmagent.New(llmagent.Config{
+		Name:         name,
+		Description:  description,
+		InputSchema:  inputSchema,
+		OutputSchema: outputSchema,
+		Model:        llm,
+	})
+	if err != nil {
+		t.Fatalf("llmagent.New(%q): %v", name, err)
+	}
+	return a
+}
+
+type fakeLLM struct {
+	backend genai.Backend
+}
+
+func (f *fakeLLM) Name() string { return "fake-model" }
+
+func (f *fakeLLM) GenerateContent(context.Context, *model.LLMRequest, bool) iter.Seq2[*model.LLMResponse, error] {
+	return func(yield func(*model.LLMResponse, error) bool) {}
+}
+
+func (f *fakeLLM) GetGoogleLLMVariant() genai.Backend { return f.backend }
+
+var _ model.LLM = (*fakeLLM)(nil)

--- a/plugin/functioncallmodifier/plugin_test.go
+++ b/plugin/functioncallmodifier/plugin_test.go
@@ -346,6 +346,7 @@ type mockAgent struct {
 func (m *mockAgent) Name() string               { return m.name }
 func (m *mockAgent) Description() string        { return m.description }
 func (m *mockAgent) InputSchema() *genai.Schema { return m.inputSchema }
+func (m *mockAgent) SubAgents() []agent.Agent   { return nil }
 
 func createAgentTool(t *testing.T, name, desc string, schema *genai.Schema) tool.Tool {
 	t.Helper()

--- a/server/adkrest/internal/models/event.go
+++ b/server/adkrest/internal/models/event.go
@@ -53,6 +53,7 @@ type Event struct {
 	InputTranscription  *genai.Transcription                        `json:"inputTranscription,omitempty"`
 	OutputTranscription *genai.Transcription                        `json:"outputTranscription,omitempty"`
 	Actions             EventActions                                `json:"actions"`
+	Output              any                                         `json:"output,omitempty"`
 }
 
 // ToSessionEvent maps Event data struct to session.Event
@@ -63,6 +64,7 @@ func ToSessionEvent(event Event) *session.Event {
 		Branch:             event.Branch,
 		Author:             event.Author,
 		LongRunningToolIDs: event.LongRunningToolIDs,
+		Output:             event.Output,
 		LLMResponse: model.LLMResponse{
 			AvgLogprobs:         event.AvgLogprobs,
 			Content:             event.Content,
@@ -97,6 +99,7 @@ func FromSessionEvent(event session.Event) Event {
 		Author:              event.Author,
 		Partial:             event.Partial,
 		LongRunningToolIDs:  event.LongRunningToolIDs,
+		Output:              event.Output,
 		AvgLogprobs:         event.LLMResponse.AvgLogprobs,
 		Content:             event.LLMResponse.Content,
 		GroundingMetadata:   event.LLMResponse.GroundingMetadata,

--- a/session/database/storage_session.go
+++ b/session/database/storage_session.go
@@ -79,6 +79,7 @@ type storageEvent struct {
 	// equivalent. Unpickling would require a custom library or service.
 	Actions                []byte
 	LongRunningToolIDsJSON dynamicJSON
+	RoutesJSON              dynamicJSON
 	Branch                 *string
 	Timestamp              time.Time `gorm:"precision:6"`
 
@@ -133,6 +134,14 @@ func createStorageEvent(session session.Session, event *session.Event) (*storage
 			return nil, fmt.Errorf("failed to marshal long running tool IDs: %w", err)
 		}
 		storageEv.LongRunningToolIDsJSON = toolIDsJSON
+	}
+
+	if len(event.Routes) > 0 {
+		routesJSON, err := json.Marshal(event.Routes)
+		if err != nil {
+			return nil, fmt.Errorf("failed to marshal event route: %w", err)
+		}
+		storageEv.RoutesJSON = routesJSON
 	}
 
 	// Handle optional fields by taking the address of the value.
@@ -250,6 +259,13 @@ func createEventFromStorageEvent(se *storageEvent) (*session.Event, error) {
 		}
 	}
 
+	var routes []string
+	if se.RoutesJSON != nil {
+		if err := json.Unmarshal([]byte(se.RoutesJSON), &routes); err != nil {
+			return nil, fmt.Errorf("failed to unmarshal event route: %w", err)
+		}
+	}
+
 	// --- Handle simple pointer fields (dereference or use zero value) ---
 	// Use the helper to safely get the value or its zero-value default
 	branch := derefOrZero(se.Branch)
@@ -267,6 +283,7 @@ func createEventFromStorageEvent(se *storageEvent) (*session.Event, error) {
 		Timestamp:          se.Timestamp,
 		Actions:            actions,
 		LongRunningToolIDs: toolIDs,
+		Routes:             routes,
 		Branch:             branch,
 		LLMResponse: model.LLMResponse{
 			Content:           content,

--- a/session/database/storage_session.go
+++ b/session/database/storage_session.go
@@ -79,7 +79,7 @@ type storageEvent struct {
 	// equivalent. Unpickling would require a custom library or service.
 	Actions                []byte
 	LongRunningToolIDsJSON dynamicJSON
-	RoutesJSON              dynamicJSON
+	RoutesJSON             dynamicJSON
 	Branch                 *string
 	Timestamp              time.Time `gorm:"precision:6"`
 

--- a/session/database/storage_session.go
+++ b/session/database/storage_session.go
@@ -80,6 +80,7 @@ type storageEvent struct {
 	Actions                []byte
 	LongRunningToolIDsJSON dynamicJSON
 	RoutesJSON             dynamicJSON
+	OutputJSON             dynamicJSON
 	Branch                 *string
 	Timestamp              time.Time `gorm:"precision:6"`
 
@@ -142,6 +143,14 @@ func createStorageEvent(session session.Session, event *session.Event) (*storage
 			return nil, fmt.Errorf("failed to marshal event route: %w", err)
 		}
 		storageEv.RoutesJSON = routesJSON
+	}
+
+	if event.Output != nil {
+		outputJSON, err := json.Marshal(event.Output)
+		if err != nil {
+			return nil, fmt.Errorf("failed to marshal output: %w", err)
+		}
+		storageEv.OutputJSON = outputJSON
 	}
 
 	// Handle optional fields by taking the address of the value.
@@ -266,6 +275,13 @@ func createEventFromStorageEvent(se *storageEvent) (*session.Event, error) {
 		}
 	}
 
+	var output any
+	if se.OutputJSON != nil {
+		if err := json.Unmarshal([]byte(se.OutputJSON), &output); err != nil {
+			return nil, fmt.Errorf("failed to unmarshal output: %w", err)
+		}
+	}
+
 	// --- Handle simple pointer fields (dereference or use zero value) ---
 	// Use the helper to safely get the value or its zero-value default
 	branch := derefOrZero(se.Branch)
@@ -285,6 +301,7 @@ func createEventFromStorageEvent(se *storageEvent) (*session.Event, error) {
 		LongRunningToolIDs: toolIDs,
 		Routes:             routes,
 		Branch:             branch,
+		Output:             output,
 		LLMResponse: model.LLMResponse{
 			Content:           content,
 			GroundingMetadata: groundingMetadata,

--- a/session/inmemory.go
+++ b/session/inmemory.go
@@ -239,6 +239,7 @@ func (s *inMemoryService) AppendEvent(ctx context.Context, curSession Session, e
 		},
 		LongRunningToolIDs: slices.Clone(event.LongRunningToolIDs),
 		LLMResponse:        event.LLMResponse,
+		Output:             event.Output,
 	}
 
 	// update the in-memory session service

--- a/session/session.go
+++ b/session/session.go
@@ -115,6 +115,8 @@ type Event struct {
 	// Agent client will know from this field about which function call is long running.
 	// Only valid for function call event.
 	LongRunningToolIDs []string
+	// Routing information for workflow execution
+	Routes []string
 }
 
 // IsFinalResponse returns whether the event is the final response of an agent.

--- a/session/session.go
+++ b/session/session.go
@@ -19,6 +19,7 @@ import (
 	"iter"
 	"time"
 
+	"github.com/google/jsonschema-go/jsonschema"
 	"github.com/google/uuid"
 
 	"google.golang.org/adk/model"
@@ -117,6 +118,41 @@ type Event struct {
 	LongRunningToolIDs []string
 	// Routing information for workflow execution
 	Routes []string
+	// RequestedInput, when non-nil, signals that the workflow node
+	// emitting this event is asking for human input and is about to
+	// pause. The workflow scheduler observes this field at event
+	// dispatch time and transitions the corresponding node to
+	// NodeWaiting on the activation's completion. UI surfaces read
+	// the same field to render the prompt.
+	//
+	// At most one event per node activation may carry this field.
+	RequestedInput *RequestInput
+}
+
+// RequestInput describes a single human-in-the-loop prompt emitted
+// by a workflow node. It travels on Event.RequestedInput from the
+// node, through the scheduler, out to the UI surface; the matching
+// response is routed back by InterruptID.
+type RequestInput struct {
+	// InterruptID is the stable correlation key for this request.
+	// It identifies the intent of the prompt (e.g. "manager_approval",
+	// "human_review"). If empty when the node yields the event, the
+	// engine fills in a UUID so the downstream contract is always a
+	// non-empty string.
+	InterruptID string
+
+	// Message is the human-readable description of what is being
+	// asked. Surfaced in UI as the prompt text. Optional.
+	Message string
+
+	// ResponseSchema, when non-nil, is the JSON schema the user's
+	// response payload must conform to.
+	ResponseSchema *jsonschema.Schema
+
+	// Payload is optional context the UI may render alongside the
+	// prompt (e.g. the document to approve, the proposed parameters).
+	// Carried through opaquely; the engine does not interpret it.
+	Payload any
 }
 
 // IsFinalResponse returns whether the event is the final response of an agent.

--- a/session/session.go
+++ b/session/session.go
@@ -133,26 +133,31 @@ type Event struct {
 // by a workflow node. It travels on Event.RequestedInput from the
 // node, through the scheduler, out to the UI surface; the matching
 // response is routed back by InterruptID.
+//
+// JSON-marshallable: persisted in session.State across pause/resume
+// turns. Payload is typed any and must be JSON-encodable; for
+// binary data, stash the bytes via agent.Artifacts and put a URI
+// string in Payload.
 type RequestInput struct {
 	// InterruptID is the stable correlation key for this request.
 	// It identifies the intent of the prompt (e.g. "manager_approval",
 	// "human_review"). If empty when the node yields the event, the
 	// engine fills in a UUID so the downstream contract is always a
 	// non-empty string.
-	InterruptID string
+	InterruptID string `json:"interruptId"`
 
 	// Message is the human-readable description of what is being
 	// asked. Surfaced in UI as the prompt text. Optional.
-	Message string
+	Message string `json:"message,omitempty"`
 
 	// ResponseSchema, when non-nil, is the JSON schema the user's
 	// response payload must conform to.
-	ResponseSchema *jsonschema.Schema
+	ResponseSchema *jsonschema.Schema `json:"responseSchema,omitempty"`
 
 	// Payload is optional context the UI may render alongside the
 	// prompt (e.g. the document to approve, the proposed parameters).
 	// Carried through opaquely; the engine does not interpret it.
-	Payload any
+	Payload any `json:"payload,omitempty"`
 }
 
 // IsFinalResponse returns whether the event is the final response of an agent.

--- a/session/session.go
+++ b/session/session.go
@@ -127,6 +127,9 @@ type Event struct {
 	//
 	// At most one event per node activation may carry this field.
 	RequestedInput *RequestInput
+
+	// Output is the generic data output from a workflow node.
+	Output any
 }
 
 // RequestInput describes a single human-in-the-loop prompt emitted

--- a/session/session.go
+++ b/session/session.go
@@ -130,6 +130,26 @@ type Event struct {
 
 	// Output is the generic data output from a workflow node.
 	Output any
+
+	// NodeInfo carries workflow-node metadata for events emitted
+	// inside a workflow. Nil for non-workflow events.
+	NodeInfo *NodeInfo `json:"nodeInfo,omitempty"`
+}
+
+// NodeInfo carries the per-event metadata identifying which node in
+// a workflow activation emitted it.
+//
+// TODO(wolo): adk-python's NodeInfo also has OutputFor []string
+// (fan-in re-attribution) and MessageAsOutput bool (content-as-output
+// shorthand). Add as the corresponding features land in adk-go.
+type NodeInfo struct {
+	// Path is the composite path of the emitting node within its
+	// workflow activation. Empty for top-level static nodes;
+	// "<parent_path>/<child_name>@<run_id>" for dynamic children.
+	// The scheduler uses it to scope per-activation Output/Routes
+	// invariants to the emitter, allowing dynamic nodes to forward
+	// children's terminal events alongside their own.
+	Path string `json:"path,omitempty"`
 }
 
 // RequestInput describes a single human-in-the-loop prompt emitted

--- a/telemetry/config.go
+++ b/telemetry/config.go
@@ -26,10 +26,6 @@ type config struct {
 	// Enables/disables telemetry export to GCP.
 	oTelToCloud bool
 
-	// genAICaptureMessageContent enables/disables logging of message content. The default value is taken from OTEL_INSTRUMENTATION_GENAI_CAPTURE_MESSAGE_CONTENT env variable.
-	// If set to true, the message content will be logged in message body. Otherwise it will be elided.
-	genAICaptureMessageContent bool
-
 	// gcpResourceProject is used as the gcp.project.id resource attribute.
 	// If it's empty, the project will be read from ADC or GOOGLE_CLOUD_PROJECT env variable.
 	gcpResourceProject string
@@ -136,14 +132,6 @@ func WithTracerProvider(tp *sdktrace.TracerProvider) Option {
 func WithLoggerProvider(lp *sdklog.LoggerProvider) Option {
 	return optionFunc(func(cfg *config) error {
 		cfg.loggerProvider = lp
-		return nil
-	})
-}
-
-// WithGenAICaptureMessageContent overrides the default [config.genAICaptureMessageContent].
-func WithGenAICaptureMessageContent(capture bool) Option {
-	return optionFunc(func(cfg *config) error {
-		cfg.genAICaptureMessageContent = capture
 		return nil
 	})
 }

--- a/telemetry/setup_otel.go
+++ b/telemetry/setup_otel.go
@@ -72,9 +72,7 @@ func configure(ctx context.Context, opts ...Option) (*config, error) {
 }
 
 func configFromOpts(opts ...Option) (*config, error) {
-	cfg := &config{
-		genAICaptureMessageContent: strings.TrimSpace(os.Getenv("OTEL_INSTRUMENTATION_GENAI_CAPTURE_MESSAGE_CONTENT")) == "true",
-	}
+	cfg := &config{}
 
 	for _, opt := range opts {
 		if err := opt.apply(cfg); err != nil {
@@ -91,9 +89,8 @@ func newInternal(cfg *config) (*Providers, error) {
 	// TODO(#479) init meter provider
 
 	return &Providers{
-		TracerProvider:             tp,
-		genAICaptureMessageContent: cfg.genAICaptureMessageContent,
-		LoggerProvider:             lp,
+		TracerProvider: tp,
+		LoggerProvider: lp,
 	}, nil
 }
 

--- a/telemetry/telemetry.go
+++ b/telemetry/telemetry.go
@@ -19,8 +19,6 @@ import (
 	"context"
 	"errors"
 
-	internal "google.golang.org/adk/internal/telemetry"
-
 	"go.opentelemetry.io/otel"
 	logglobal "go.opentelemetry.io/otel/log/global"
 	sdklog "go.opentelemetry.io/otel/sdk/log"
@@ -29,7 +27,6 @@ import (
 
 // Providers wraps all telemetry providers and provides [Shutdown] function.
 type Providers struct {
-	genAICaptureMessageContent bool
 	// TracerProvider is the configured TracerProvider or nil.
 	TracerProvider *sdktrace.TracerProvider
 	// LoggerProvider is the configured LoggerProvider or nil.
@@ -54,7 +51,6 @@ func (t *Providers) Shutdown(ctx context.Context) error {
 
 // SetGlobalOtelProviders registers the configured providers as the global OTel providers.
 func (t *Providers) SetGlobalOtelProviders() {
-	internal.SetGenAICaptureMessageContent(t.genAICaptureMessageContent)
 	if t.TracerProvider != nil {
 		otel.SetTracerProvider(t.TracerProvider)
 	}

--- a/tool/agenttool/agent_tool.go
+++ b/tool/agenttool/agent_tool.go
@@ -29,6 +29,7 @@ import (
 	"google.golang.org/adk/internal/llminternal"
 	"google.golang.org/adk/internal/toolinternal/toolutils"
 	"google.golang.org/adk/internal/utils"
+	"google.golang.org/adk/internal/workflowinternal"
 	"google.golang.org/adk/memory"
 	"google.golang.org/adk/model"
 	"google.golang.org/adk/runner"
@@ -84,35 +85,7 @@ func (t *agentTool) IsLongRunning() bool {
 // If the agent does not have an input schema, a default schema with a
 // "request" string parameter is used.
 func (t *agentTool) Declaration() *genai.FunctionDeclaration {
-	decl := &genai.FunctionDeclaration{
-		Name:        t.Name(),
-		Description: t.Description(),
-	}
-
-	var agentInputSchema *genai.Schema
-	llmAgent, ok := t.agent.(llminternal.Agent)
-	if ok && llmAgent != nil {
-		// TODO - understand what build_function_declaration does in python and apply if needed.
-		internalLlmAgent, ok := t.agent.(llminternal.Agent)
-		if !ok {
-			return nil
-		}
-		agentInputSchema = llminternal.Reveal(internalLlmAgent).InputSchema
-	}
-
-	if agentInputSchema != nil {
-		decl.Parameters = agentInputSchema
-	} else {
-		decl.Parameters = &genai.Schema{
-			Type: "OBJECT",
-			Properties: map[string]*genai.Schema{
-				"request": {Type: "STRING"},
-			},
-			Required: []string{"request"},
-		}
-	}
-	// TODO - understand how _api_variant affects response type.
-	return decl
+	return workflowinternal.MakeFunctionDeclaration(t.agent)
 }
 
 // Run executes the wrapped agent with the provided arguments.

--- a/workflow/agent_node.go
+++ b/workflow/agent_node.go
@@ -27,7 +27,8 @@ import (
 	"google.golang.org/adk/session"
 )
 
-// AgentNode wraps a standard agent.Agent.
+// AgentNode wraps a standard agent.Agent. Wrapped agents should emit their final output via
+// Event.Output to be propagated to successor nodes
 type AgentNode struct {
 	BaseNode
 	agent        agent.Agent
@@ -103,9 +104,9 @@ func (n *AgentNode) Run(ctx agent.InvocationContext, input any) iter.Seq2[*sessi
 
 		// Use existing agent context instead of implementing a new one
 		params := internalcontext.InvocationContextParams{
-			Artifacts:     ctx.Artifacts(),
-			Memory:        ctx.Memory(),
-			Session:       ctx.Session(),
+			Artifacts: ctx.Artifacts(),
+			Memory:    ctx.Memory(),
+			Session:   ctx.Session(),
 			// TODO: branch isolation in a separate PR
 			Branch:        ctx.Branch(),
 			Agent:         n.agent,

--- a/workflow/agent_node.go
+++ b/workflow/agent_node.go
@@ -32,8 +32,6 @@ import (
 type AgentNode struct {
 	BaseNode
 	agent        agent.Agent
-	inputSchema  *jsonschema.Resolved
-	outputSchema *jsonschema.Resolved
 }
 
 // newAgentNodeWithSchemasTyped creates a new node wrapping an agent with explicitly provided schemas.
@@ -52,10 +50,8 @@ func newAgentNodeWithSchemasTyped[Input, Output any](a agent.Agent, inputSchema,
 	}
 
 	return &AgentNode{
-		BaseNode:     NewBaseNode(a.Name(), a.Description(), cfg),
+		BaseNode:     NewBaseNodeWithSchemas(a.Name(), a.Description(), cfg, ischema, oschema),
 		agent:        a,
-		inputSchema:  ischema,
-		outputSchema: oschema,
 	}, nil
 }
 
@@ -80,10 +76,15 @@ func NewAgentNode(a agent.Agent, cfg NodeConfig) (*AgentNode, error) {
 // Run implements the Node interface.
 func (n *AgentNode) Run(ctx agent.InvocationContext, input any) iter.Seq2[*session.Event, error] {
 	return func(yield func(*session.Event, error) bool) {
-		// TODO: add input validation
+		validatedInput, err := n.ValidateInput(input)
+		if err != nil {
+			yield(nil, err)
+			return
+		}
+
 		var userContent *genai.Content
-		if input != nil {
-			switch v := input.(type) {
+		if validatedInput != nil {
+			switch v := validatedInput.(type) {
 			case string:
 				userContent = &genai.Content{
 					Parts: []*genai.Part{{Text: v}},

--- a/workflow/agent_node.go
+++ b/workflow/agent_node.go
@@ -102,12 +102,15 @@ func (n *AgentNode) Run(ctx agent.InvocationContext, input any) iter.Seq2[*sessi
 			}
 		}
 
-		// Use existing agent context instead of implementing a new one
+		// Use existing agent context instead of implementing a new one.
+		// Branch is inherited from ctx so the agent runs under the
+		// activation's branch; the scheduler assigns sub-branches at
+		// fan-out, and the LLM flow's history filter scopes events
+		// by branch prefix.
 		params := internalcontext.InvocationContextParams{
-			Artifacts: ctx.Artifacts(),
-			Memory:    ctx.Memory(),
-			Session:   ctx.Session(),
-			// TODO: branch isolation in a separate PR
+			Artifacts:     ctx.Artifacts(),
+			Memory:        ctx.Memory(),
+			Session:       ctx.Session(),
 			Branch:        ctx.Branch(),
 			Agent:         n.agent,
 			UserContent:   userContent,

--- a/workflow/agent_node.go
+++ b/workflow/agent_node.go
@@ -1,0 +1,131 @@
+// Copyright 2026 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package workflow
+
+import (
+	"encoding/json"
+	"fmt"
+	"iter"
+
+	"github.com/google/jsonschema-go/jsonschema"
+	"google.golang.org/genai"
+
+	"google.golang.org/adk/agent"
+	internalcontext "google.golang.org/adk/internal/context"
+	"google.golang.org/adk/session"
+)
+
+// AgentNode wraps a standard agent.Agent.
+type AgentNode struct {
+	BaseNode
+	agent        agent.Agent
+	inputSchema  *jsonschema.Resolved
+	outputSchema *jsonschema.Resolved
+}
+
+// newAgentNodeWithSchemasTyped creates a new node wrapping an agent with explicitly provided schemas.
+// If a schema is nil, it will be inferred from the corresponding generic type Input or Output.
+func newAgentNodeWithSchemasTyped[Input, Output any](a agent.Agent, inputSchema, outputSchema *jsonschema.Schema, cfg NodeConfig) (*AgentNode, error) {
+	if a == nil {
+		return nil, fmt.Errorf("agent cannot be nil")
+	}
+	ischema, err := resolvedSchema[Input](inputSchema)
+	if err != nil {
+		return nil, fmt.Errorf("resolving input schema for agent %q: %w", a.Name(), err)
+	}
+	oschema, err := resolvedSchema[Output](outputSchema)
+	if err != nil {
+		return nil, fmt.Errorf("resolving output schema for agent %q: %w", a.Name(), err)
+	}
+
+	return &AgentNode{
+		BaseNode:     NewBaseNode(a.Name(), a.Description(), cfg),
+		agent:        a,
+		inputSchema:  ischema,
+		outputSchema: oschema,
+	}, nil
+}
+
+// NewAgentNodeWithSchemas is a convenience wrapper for NewAgentNodeWithSchemasTyped[any, any].
+// It uses explicitly provided schemas for both input and output.
+func NewAgentNodeWithSchemas(a agent.Agent, inputSchema, outputSchema *jsonschema.Schema, cfg NodeConfig) (*AgentNode, error) {
+	return newAgentNodeWithSchemasTyped[any, any](a, inputSchema, outputSchema, cfg)
+}
+
+// NewAgentNodeTyped creates a new node wrapping an agent using generics to
+// automatically infer input and output schemas from the provided types.
+func NewAgentNodeTyped[Input, Output any](a agent.Agent, cfg NodeConfig) (*AgentNode, error) {
+	return newAgentNodeWithSchemasTyped[Input, Output](a, nil, nil, cfg)
+}
+
+// NewAgentNode creates a new node wrapping an agent. Input and output schemas
+// are inferred as `any`.
+func NewAgentNode(a agent.Agent, cfg NodeConfig) (*AgentNode, error) {
+	return NewAgentNodeTyped[any, any](a, cfg)
+}
+
+// Run implements the Node interface.
+func (n *AgentNode) Run(ctx agent.InvocationContext, input any) iter.Seq2[*session.Event, error] {
+	return func(yield func(*session.Event, error) bool) {
+		// TODO: add input validation
+		var userContent *genai.Content
+		if input != nil {
+			switch v := input.(type) {
+			case string:
+				userContent = &genai.Content{
+					Parts: []*genai.Part{{Text: v}},
+				}
+			case *genai.Content:
+				userContent = v
+			default:
+				b, err := json.Marshal(v)
+				if err != nil {
+					yield(nil, fmt.Errorf("marshaling input for agent %q to JSON: %w", n.agent.Name(), err))
+					return
+				}
+				userContent = &genai.Content{
+					Parts: []*genai.Part{{Text: string(b)}},
+				}
+			}
+		}
+
+		// Use existing agent context instead of implementing a new one
+		params := internalcontext.InvocationContextParams{
+			Artifacts:     ctx.Artifacts(),
+			Memory:        ctx.Memory(),
+			Session:       ctx.Session(),
+			// TODO: branch isolation in a separate PR
+			Branch:        ctx.Branch(),
+			Agent:         n.agent,
+			UserContent:   userContent,
+			RunConfig:     ctx.RunConfig(),
+			EndInvocation: ctx.Ended(),
+			InvocationID:  ctx.InvocationID(),
+		}
+		agentCtx := internalcontext.NewInvocationContext(ctx, params)
+
+		for event, err := range n.agent.Run(agentCtx) {
+			if err != nil {
+				yield(nil, err)
+				return
+			}
+
+			// TODO: add output validation
+			if !yield(event, nil) {
+				return
+			}
+		}
+	}
+}

--- a/workflow/agent_node_test.go
+++ b/workflow/agent_node_test.go
@@ -54,9 +54,7 @@ func TestAgentNode_New(t *testing.T) {
 		Run: func(ctx agent.InvocationContext) iter.Seq2[*session.Event, error] {
 			return func(yield func(*session.Event, error) bool) {
 				event := session.NewEvent(ctx.InvocationID())
-				event.Actions.StateDelta = map[string]any{
-					"output": map[string]any{"result": "success"},
-				}
+				event.Output = map[string]any{"result": "success"}
 				yield(event, nil)
 			}
 		},
@@ -162,9 +160,7 @@ func TestAgentNode_Run(t *testing.T) {
 								val = uc.Parts[0].Text
 							}
 							event := session.NewEvent(ctx.InvocationID())
-							event.Actions.StateDelta = map[string]any{
-								"output": map[string]any{"result": val},
-							}
+							event.Output = map[string]any{"result": val}
 							yield(event, nil)
 						}
 					},
@@ -200,9 +196,7 @@ func TestAgentNode_Run(t *testing.T) {
 								val = uc.Parts[0].Text
 							}
 							event := session.NewEvent(ctx.InvocationID())
-							event.Actions.StateDelta = map[string]any{
-								"output": val,
-							}
+							event.Output = val
 							yield(event, nil)
 						}
 					},
@@ -271,12 +265,7 @@ func TestAgentNode_Run(t *testing.T) {
 				}
 				count++
 
-				output, ok := ev.Actions.StateDelta["output"]
-				if !ok {
-					t.Fatal("expected output in state delta")
-				}
-
-				got = tc.extract(t, output)
+				got = tc.extract(t, ev.Output)
 			}
 
 			if tc.wantErr != "" {
@@ -340,9 +329,7 @@ func TestAgentNode_WorkflowIntegration(t *testing.T) {
 						}
 
 						event := session.NewEvent(ctx.InvocationID())
-						event.Actions.StateDelta = map[string]any{
-							"output": map[string]any{"result": val * 2},
-						}
+						event.Output = map[string]any{"result": val * 2}
 						yield(event, nil)
 					}
 				},
@@ -382,10 +369,8 @@ func TestAgentNode_WorkflowIntegration(t *testing.T) {
 					if err != nil {
 						t.Fatalf("workflow failed: %v", err)
 					}
-					if ev.Actions.StateDelta != nil {
-						if out, ok := ev.Actions.StateDelta["output"]; ok {
-							outB = out
-						}
+					if ev.Output != nil {
+						outB = ev.Output
 					}
 				}
 

--- a/workflow/agent_node_test.go
+++ b/workflow/agent_node_test.go
@@ -1,0 +1,398 @@
+// Copyright 2026 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package workflow
+
+import (
+	"encoding/json"
+	"errors"
+	"iter"
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/google/go-cmp/cmp"
+	"github.com/google/jsonschema-go/jsonschema"
+
+	"google.golang.org/adk/agent"
+	"google.golang.org/adk/session"
+)
+
+type mockSession struct {
+	id string
+}
+
+func (m *mockSession) ID() string                { return m.id }
+func (m *mockSession) AppName() string           { return "test-app" }
+func (m *mockSession) UserID() string            { return "test-user" }
+func (m *mockSession) State() session.State      { return nil }
+func (m *mockSession) Events() session.Events    { return nil }
+func (m *mockSession) LastUpdateTime() time.Time { return time.Now() }
+
+func TestAgentNode_New(t *testing.T) {
+	type Input struct {
+		Value string `json:"value"`
+	}
+	type Output struct {
+		Result string `json:"result"`
+	}
+
+	myAgent, err := agent.New(agent.Config{
+		Name:        "test_agent",
+		Description: "a test agent",
+		Run: func(ctx agent.InvocationContext) iter.Seq2[*session.Event, error] {
+			return func(yield func(*session.Event, error) bool) {
+				event := session.NewEvent(ctx.InvocationID())
+				event.Actions.StateDelta = map[string]any{
+					"output": map[string]any{"result": "success"},
+				}
+				yield(event, nil)
+			}
+		},
+	})
+	if err != nil {
+		t.Fatalf("failed to create agent: %v", err)
+	}
+
+	ischema, err := jsonschema.For[Input](nil)
+	if err != nil {
+		t.Fatalf("jsonschema.For[Input] failed: %v", err)
+	}
+	oschema, err := jsonschema.For[Output](nil)
+	if err != nil {
+		t.Fatalf("jsonschema.For[Output] failed: %v", err)
+	}
+
+	tests := []struct {
+		name    string
+		creator func() (Node, error)
+		want    string
+	}{
+		{
+			name: "NewAgentNodeTyped",
+			creator: func() (Node, error) {
+				return NewAgentNodeTyped[Input, Output](myAgent, defaultNodeConfig)
+			},
+		},
+		{
+			name: "NewAgentNodeWithSchemas",
+			creator: func() (Node, error) {
+				return NewAgentNodeWithSchemas(myAgent, ischema, oschema, defaultNodeConfig)
+			},
+		},
+		{
+			name: "NewAgentNode",
+			creator: func() (Node, error) {
+				return NewAgentNode(myAgent, defaultNodeConfig)
+			},
+		},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			node, err := tc.creator()
+			if err != nil {
+				t.Fatalf("creation failed: %v", err)
+			}
+
+			if got, want := node.Name(), "test_agent"; got != want {
+				t.Errorf("node.Name() = %q, want %q", got, want)
+			}
+			if got, want := node.Description(), "a test agent"; got != want {
+				t.Errorf("node.Description() = %q, want %q", got, want)
+			}
+
+			// Basic internal check via reflection-like cast.
+			var inputResolved, outputResolved *jsonschema.Resolved
+			switch tn := node.(type) {
+			case *AgentNode:
+				inputResolved, outputResolved = tn.inputSchema, tn.outputSchema
+			default:
+				t.Errorf("unknown node type: %T", tn)
+			}
+
+			if inputResolved == nil || outputResolved == nil {
+				t.Error("expected schemas to be resolved")
+			}
+		})
+	}
+}
+
+func TestAgentNode_Run(t *testing.T) {
+	type Input struct {
+		Val string `json:"val"`
+	}
+	type Output struct {
+		Result string `json:"result"`
+	}
+	type ErrorOutput struct {
+		Result int `json:"result"`
+	}
+
+	tests := []struct {
+		name      string
+		agent     func() (agent.Agent, error)
+		nodeInput any
+		node      func(agent.Agent) (Node, error)
+		extract   func(t *testing.T, out any) string
+		want      string
+		wantErr   string
+	}{
+		{
+			name: "struct_input_output",
+			agent: func() (agent.Agent, error) {
+				return agent.New(agent.Config{
+					Name: "test_agent",
+					Run: func(ctx agent.InvocationContext) iter.Seq2[*session.Event, error] {
+						return func(yield func(*session.Event, error) bool) {
+							uc := ctx.UserContent()
+							val := "Unknown"
+							if uc != nil && len(uc.Parts) > 0 {
+								val = uc.Parts[0].Text
+							}
+							event := session.NewEvent(ctx.InvocationID())
+							event.Actions.StateDelta = map[string]any{
+								"output": map[string]any{"result": val},
+							}
+							yield(event, nil)
+						}
+					},
+				})
+			},
+			nodeInput: Input{Val: "A"},
+			node: func(a agent.Agent) (Node, error) {
+				return NewAgentNodeTyped[Input, Output](a, defaultNodeConfig)
+			},
+			extract: func(t *testing.T, out any) string {
+				bytes, err := json.Marshal(out)
+				if err != nil {
+					t.Fatalf("json marshal output: %v", err)
+				}
+				var output Output
+				if err := json.Unmarshal(bytes, &output); err != nil {
+					t.Fatalf("json unmarshal output: %v", err)
+				}
+				return output.Result
+			},
+			want: `{"val":"A"}`,
+		},
+		{
+			name: "string_output",
+			agent: func() (agent.Agent, error) {
+				return agent.New(agent.Config{
+					Name: "test_agent",
+					Run: func(ctx agent.InvocationContext) iter.Seq2[*session.Event, error] {
+						return func(yield func(*session.Event, error) bool) {
+							uc := ctx.UserContent()
+							val := "Unknown"
+							if uc != nil && len(uc.Parts) > 0 {
+								val = uc.Parts[0].Text
+							}
+							event := session.NewEvent(ctx.InvocationID())
+							event.Actions.StateDelta = map[string]any{
+								"output": val,
+							}
+							yield(event, nil)
+						}
+					},
+				})
+			},
+			nodeInput: Input{Val: "B"},
+			node: func(a agent.Agent) (Node, error) {
+				return NewAgentNodeTyped[Input, string](a, defaultNodeConfig)
+			},
+			extract: func(t *testing.T, out any) string {
+				return out.(string)
+			},
+			want: `{"val":"B"}`,
+		},
+		{
+			name: "agent_execution_error",
+			agent: func() (agent.Agent, error) {
+				return agent.New(agent.Config{
+					Name: "test_agent",
+					Run: func(ctx agent.InvocationContext) iter.Seq2[*session.Event, error] {
+						return func(yield func(*session.Event, error) bool) {
+							yield(nil, errors.New("something went wrong"))
+						}
+					},
+				})
+			},
+			nodeInput: Input{Val: "C"},
+			node: func(a agent.Agent) (Node, error) {
+				return NewAgentNodeTyped[Input, Output](a, defaultNodeConfig)
+			},
+			wantErr: "something went wrong",
+		},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			myAgent, err := tc.agent()
+			if err != nil {
+				t.Fatalf("failed to create agent: %v", err)
+			}
+
+			node, err := tc.node(myAgent)
+			if err != nil {
+				t.Fatalf("node creation failed: %v", err)
+			}
+
+			mockCtx := newMockCtx(t)
+			mockCtx.sess = &mockSession{id: "test-session-id"} // Fix nil panic
+			events := node.Run(mockCtx, tc.nodeInput)
+
+			var got string
+			count := 0
+			for ev, err := range events {
+				if tc.wantErr != "" {
+					if err == nil {
+						t.Fatal("expected error, got nil")
+					}
+					if !strings.Contains(err.Error(), tc.wantErr) {
+						t.Errorf("expected error containing %q, got: %v", tc.wantErr, err)
+					}
+					return
+				}
+
+				if err != nil {
+					t.Fatalf("unexpected error: %v", err)
+				}
+				count++
+
+				output, ok := ev.Actions.StateDelta["output"]
+				if !ok {
+					t.Fatal("expected output in state delta")
+				}
+
+				got = tc.extract(t, output)
+			}
+
+			if tc.wantErr != "" {
+				t.Error("expected at least one event/error from Run")
+				return
+			}
+
+			if count != 1 {
+				t.Errorf("expected 1 event, got %d", count)
+			}
+			if diff := cmp.Diff(tc.want, got); diff != "" {
+				t.Errorf("output mismatch (-want +got):\n%s", diff)
+			}
+		})
+	}
+}
+
+func TestAgentNode_WorkflowIntegration(t *testing.T) {
+	type Input struct {
+		Val int `json:"val"`
+	}
+	type Output struct {
+		Result int `json:"result"`
+	}
+
+	tests := []struct {
+		name  string
+		input int
+		want  int
+	}{
+		{
+			name:  "chain_agent_and_function",
+			input: 5,
+			want:  11,
+		},
+		{
+			name:  "chain_agent_and_function_zero",
+			input: 0,
+			want:  1,
+		},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			integrationAgent, err := agent.New(agent.Config{
+				Name: "integration_agent",
+				Run: func(ctx agent.InvocationContext) iter.Seq2[*session.Event, error] {
+					return func(yield func(*session.Event, error) bool) {
+						uc := ctx.UserContent()
+						valStr := "0"
+						if uc != nil && len(uc.Parts) > 0 {
+							valStr = uc.Parts[0].Text
+						}
+						// valStr will be something like `{"val":5}`
+						var val int
+						var parsed struct {
+							Val int `json:"val"`
+						}
+						if err := json.Unmarshal([]byte(valStr), &parsed); err == nil {
+							val = parsed.Val
+						}
+
+						event := session.NewEvent(ctx.InvocationID())
+						event.Actions.StateDelta = map[string]any{
+							"output": map[string]any{"result": val * 2},
+						}
+						yield(event, nil)
+					}
+				},
+			})
+			if err != nil {
+				t.Fatalf("failed to create agent: %v", err)
+			}
+
+			agentNode, err := NewAgentNodeTyped[Input, Output](integrationAgent, defaultNodeConfig)
+			if err != nil {
+				t.Fatalf("NewAgentNodeTyped failed: %v", err)
+			}
+
+			// Connect to a function node.
+			functionNode := NewFunctionNode[Output, int]("plus_one", func(ctx agent.InvocationContext, in Output) (int, error) {
+				return in.Result + 1, nil
+			}, NodeConfig{})
+
+			mockCtx := newMockCtx(t)
+			mockCtx.sess = &mockSession{id: "test-session-id"} // Ensure session is set
+
+			t.Run("WorkflowExecution", func(t *testing.T) {
+				// Use a seed node to pass the struct input to agentNode
+				seedNode := NewFunctionNode("seed", func(ctx agent.InvocationContext, input any) (*Input, error) {
+					return &Input{Val: tc.input}, nil
+				}, NodeConfig{})
+
+				edges := Chain(Start, seedNode, agentNode, functionNode)
+				w, err := New("test_workflow", edges)
+				if err != nil {
+					t.Fatalf("unexpected error: %v", err)
+				}
+				events := w.Run(mockCtx)
+
+				var outB any
+				for ev, err := range events {
+					if err != nil {
+						t.Fatalf("workflow failed: %v", err)
+					}
+					if ev.Actions.StateDelta != nil {
+						if out, ok := ev.Actions.StateDelta["output"]; ok {
+							outB = out
+						}
+					}
+				}
+
+				if diff := cmp.Diff(tc.want, outB); diff != "" {
+					t.Errorf("output mismatch (-want +got):\n%s", diff)
+				}
+			})
+		})
+	}
+}

--- a/workflow/base_node.go
+++ b/workflow/base_node.go
@@ -1,0 +1,49 @@
+// Copyright 2026 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package workflow
+
+// BaseNode provides identity and a default Config implementation for
+// types that satisfy the Node interface. Custom node types embed
+// BaseNode by value and supply only Run.
+type BaseNode struct {
+	name   string
+	desc   string
+	config NodeConfig
+}
+
+// NewBaseNode returns a BaseNode with the given identity and
+// configuration. Embedders typically call it from their own
+// constructor:
+//
+//	type CustomNode struct {
+//	    BaseNode
+//	    // ...
+//	}
+//
+//	func NewCustomNode(name string, cfg NodeConfig) *CustomNode {
+//	    return &CustomNode{BaseNode: NewBaseNode(name, "", cfg)}
+//	}
+func NewBaseNode(name, description string, cfg NodeConfig) BaseNode {
+	return BaseNode{name: name, desc: description, config: cfg}
+}
+
+// Name returns the node's name.
+func (b BaseNode) Name() string { return b.name }
+
+// Description returns the node's human-readable description.
+func (b BaseNode) Description() string { return b.desc }
+
+// Config returns the node's configuration.
+func (b BaseNode) Config() NodeConfig { return b.config }

--- a/workflow/base_node.go
+++ b/workflow/base_node.go
@@ -15,8 +15,14 @@
 package workflow
 
 import (
+	"encoding/json"
+	"strings"
+
 	"github.com/google/jsonschema-go/jsonschema"
+	"google.golang.org/genai"
+
 	"google.golang.org/adk/internal/typeutil"
+	"google.golang.org/adk/session"
 )
 
 // BaseNode provides identity and a default Config implementation for
@@ -89,16 +95,92 @@ func defaultValidateInput(in any, schema *jsonschema.Resolved) (any, error) {
 }
 
 // ValidateOutput validates the output against the node's output schema.
+// See defaultValidateOutput for the validation strategy.
 func (b BaseNode) ValidateOutput(out any) (any, error) {
 	return defaultValidateOutput(out, b.outputSchema)
 }
 
+// defaultValidateOutput is the shared output-validation helper used
+// by BaseNode.ValidateOutput. It applies the following strategy:
+//
+//  1. When schema is nil, the output is returned unchanged.
+//  2. Framework control values (*session.Event, *session.RequestInput)
+//     are returned unchanged: they are routed through Event.Output by
+//     some nodes but they are not user-defined output payloads and
+//     should never be schema-validated.
+//  3. The output is validated against schema. On success, it is
+//     returned unchanged.
+//  4. On validation failure, when the output is a *genai.Content, the
+//     helper falls back to extracting the concatenated text from the
+//     content's parts and:
+//     - returns the text directly when the schema's root type is
+//     "string",
+//     - otherwise parses the text as JSON and re-validates the parsed
+//     value, returning the parsed value on success.
+//  5. When neither the standard nor the fallback path succeeds, the
+//     original validation error is returned.
+//
+// The Content fallback mirrors ADK Python's _validate_output_data and
+// is intended for nodes (notably LlmAgent) that yield raw model output
+// as *genai.Content without first projecting it onto the node's
+// declared output schema.
 func defaultValidateOutput(out any, schema *jsonschema.Resolved) (any, error) {
 	if schema == nil {
 		return out, nil
 	}
-	if err := schema.Validate(out); err != nil {
-		return nil, err
+	switch out.(type) {
+	case *session.Event, *session.RequestInput:
+		return out, nil
 	}
-	return out, nil
+	err := schema.Validate(out)
+	if err == nil {
+		return out, nil
+	}
+	// Try the Content fallback before giving up.
+	if content, ok := out.(*genai.Content); ok {
+		if v, ok := validateContentFallback(content, schema); ok {
+			return v, nil
+		}
+	}
+	return nil, err
+}
+
+// validateContentFallback implements the *genai.Content path of
+// defaultValidateOutput: extract concatenated text, return it as a
+// string when the schema expects a string, otherwise JSON-parse and
+// re-validate. Returns ok=false when the fallback cannot produce a
+// valid value, leaving error reporting to the caller.
+func validateContentFallback(content *genai.Content, schema *jsonschema.Resolved) (any, bool) {
+	var text strings.Builder
+	for _, part := range content.Parts {
+		if part != nil && part.Text != "" {
+			text.WriteString(part.Text)
+		}
+	}
+	s := text.String()
+	if rootSchemaIsString(schema) {
+		return s, true
+	}
+	if strings.TrimSpace(s) == "" {
+		return nil, false
+	}
+	var parsed any
+	if err := json.Unmarshal([]byte(s), &parsed); err != nil {
+		return nil, false
+	}
+	if err := schema.Validate(parsed); err != nil {
+		return nil, false
+	}
+	return parsed, true
+}
+
+// rootSchemaIsString reports whether schema's root type is "string".
+// Used by the Content fallback to short-circuit JSON parsing for
+// string-typed schemas.
+func rootSchemaIsString(schema *jsonschema.Resolved) bool {
+	root := schema.Schema()
+	if root == nil {
+		return false
+	}
+	return root.Type == "string"
 }

--- a/workflow/base_node.go
+++ b/workflow/base_node.go
@@ -14,15 +14,35 @@
 
 package workflow
 
-import "github.com/google/jsonschema-go/jsonschema"
+import (
+	"github.com/google/jsonschema-go/jsonschema"
+	"google.golang.org/adk/internal/typeutil"
+)
 
 // BaseNode provides identity and a default Config implementation for
 // types that satisfy the Node interface. Custom node types embed
 // BaseNode by value and supply only Run.
 type BaseNode struct {
-	name   string
-	desc   string
-	config NodeConfig
+	name         string
+	desc         string
+	config       NodeConfig
+	inputSchema  *jsonschema.Resolved
+	outputSchema *jsonschema.Resolved
+}
+
+// NewBaseNodeWithSchemas returns a BaseNode with the given identity, configuration, and schemas.
+func NewBaseNodeWithSchemas(
+	name, description string,
+	cfg NodeConfig,
+	inputSchema, outputSchema *jsonschema.Resolved,
+) BaseNode {
+	return BaseNode{
+		name:         name,
+		desc:         description,
+		config:       cfg,
+		inputSchema:  inputSchema,
+		outputSchema: outputSchema,
+	}
 }
 
 // NewBaseNode returns a BaseNode with the given identity and
@@ -38,7 +58,7 @@ type BaseNode struct {
 //	    return &CustomNode{BaseNode: NewBaseNode(name, "", cfg)}
 //	}
 func NewBaseNode(name, description string, cfg NodeConfig) BaseNode {
-	return BaseNode{name: name, desc: description, config: cfg}
+	return NewBaseNodeWithSchemas(name, description, cfg, nil, nil)
 }
 
 // Name returns the node's name.
@@ -50,11 +70,20 @@ func (b BaseNode) Description() string { return b.desc }
 // Config returns the node's configuration.
 func (b BaseNode) Config() NodeConfig { return b.config }
 
-// InputSchema returns nil to indicate no input validation schema by default.
-func (b BaseNode) InputSchema() *jsonschema.Resolved { return nil }
+// InputSchema returns the node's input validation schema.
+func (b BaseNode) InputSchema() *jsonschema.Resolved { return b.inputSchema }
 
-// OutputSchema returns nil to indicate no output validation schema by default.
-func (b BaseNode) OutputSchema() *jsonschema.Resolved { return nil }
+// OutputSchema returns the node's output validation schema.
+func (b BaseNode) OutputSchema() *jsonschema.Resolved { return b.outputSchema }
 
-// ValidateInput returns the input unchanged as a default passthrough implementation.
-func (b BaseNode) ValidateInput(input any) (any, error) { return input, nil }
+// ValidateInput validates and coerces the input using the node's input schema.
+func (b BaseNode) ValidateInput(in any) (any, error) {
+	return defaultValidateInput(in, b.inputSchema)
+}
+
+func defaultValidateInput(in any, schema *jsonschema.Resolved) (any, error) {
+	if schema == nil {
+		return in, nil
+	}
+	return typeutil.ConvertToWithJSONSchema[any, any](in, schema)
+}

--- a/workflow/base_node.go
+++ b/workflow/base_node.go
@@ -14,6 +14,8 @@
 
 package workflow
 
+import "github.com/google/jsonschema-go/jsonschema"
+
 // BaseNode provides identity and a default Config implementation for
 // types that satisfy the Node interface. Custom node types embed
 // BaseNode by value and supply only Run.
@@ -47,3 +49,12 @@ func (b BaseNode) Description() string { return b.desc }
 
 // Config returns the node's configuration.
 func (b BaseNode) Config() NodeConfig { return b.config }
+
+// InputSchema returns nil to indicate no input validation schema by default.
+func (b BaseNode) InputSchema() *jsonschema.Resolved { return nil }
+
+// OutputSchema returns nil to indicate no output validation schema by default.
+func (b BaseNode) OutputSchema() *jsonschema.Resolved { return nil }
+
+// ValidateInput returns the input unchanged as a default passthrough implementation.
+func (b BaseNode) ValidateInput(input any) (any, error) { return input, nil }

--- a/workflow/base_node.go
+++ b/workflow/base_node.go
@@ -87,3 +87,18 @@ func defaultValidateInput(in any, schema *jsonschema.Resolved) (any, error) {
 	}
 	return typeutil.ConvertToWithJSONSchema[any, any](in, schema)
 }
+
+// ValidateOutput validates the output against the node's output schema.
+func (b BaseNode) ValidateOutput(out any) (any, error) {
+	return defaultValidateOutput(out, b.outputSchema)
+}
+
+func defaultValidateOutput(out any, schema *jsonschema.Resolved) (any, error) {
+	if schema == nil {
+		return out, nil
+	}
+	if err := schema.Validate(out); err != nil {
+		return nil, err
+	}
+	return out, nil
+}

--- a/workflow/base_node_test.go
+++ b/workflow/base_node_test.go
@@ -1,0 +1,108 @@
+// Copyright 2026 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package workflow
+
+import (
+	"testing"
+	"time"
+
+	"github.com/google/go-cmp/cmp"
+)
+
+// Compile-time assertions: every built-in workflow node must satisfy
+// the Node interface.
+var (
+	_ Node = (*startNode)(nil)
+	_ Node = (*FunctionNode)(nil)
+)
+
+func TestNewBaseNode_RoundTrip(t *testing.T) {
+	tTrue := true
+	tFalse := false
+	tests := []struct {
+		name       string
+		nameArg    string
+		descArg    string
+		cfg        NodeConfig
+		wantConfig NodeConfig
+	}{
+		{
+			name:    "zero config",
+			nameArg: "n",
+			descArg: "desc",
+		},
+		{
+			name:       "WaitForOutput=true (JoinNode shape)",
+			nameArg:    "join",
+			descArg:    "fan-in",
+			cfg:        NodeConfig{WaitForOutput: &tTrue},
+			wantConfig: NodeConfig{WaitForOutput: &tTrue},
+		},
+		{
+			name:       "ParallelWorker=true",
+			nameArg:    "mapper",
+			descArg:    "data parallel",
+			cfg:        NodeConfig{ParallelWorker: true},
+			wantConfig: NodeConfig{ParallelWorker: true},
+		},
+		{
+			name:       "empty name and description",
+			cfg:        NodeConfig{},
+			wantConfig: NodeConfig{},
+		},
+		{
+			name:    "fully populated configuration",
+			nameArg: "full_node",
+			descArg: "Node with all config fields set",
+			cfg: NodeConfig{
+				ParallelWorker: true,
+				RerunOnResume:  &tFalse,
+				WaitForOutput:  &tTrue,
+				RetryConfig: &RetryConfig{
+					MaxAttempts: 3,
+				},
+				Timeout: 10 * time.Second,
+			},
+			wantConfig: NodeConfig{
+				ParallelWorker: true,
+				RerunOnResume:  &tFalse,
+				WaitForOutput:  &tTrue,
+				RetryConfig: &RetryConfig{
+					MaxAttempts: 3,
+				},
+				Timeout: 10 * time.Second,
+			},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			b := NewBaseNode(tt.nameArg, tt.descArg, tt.cfg)
+			if got := b.Name(); got != tt.nameArg {
+				t.Errorf("Name() = %q, want %q", got, tt.nameArg)
+			}
+			if got := b.Description(); got != tt.descArg {
+				t.Errorf("Description() = %q, want %q", got, tt.descArg)
+			}
+			want := tt.wantConfig
+			if (tt.cfg.WaitForOutput == nil) && (tt.cfg.ParallelWorker == false) {
+				want = NodeConfig{}
+			}
+			if diff := cmp.Diff(want, b.Config()); diff != "" {
+				t.Errorf("Config() mismatch (-want +got):\n%s", diff)
+			}
+		})
+	}
+}

--- a/workflow/base_node_test.go
+++ b/workflow/base_node_test.go
@@ -27,6 +27,11 @@ import (
 var (
 	_ Node = (*startNode)(nil)
 	_ Node = (*FunctionNode)(nil)
+	_ Node = (*AgentNode)(nil)
+	_ Node = (*ToolNode)(nil)
+	_ Node = (*JoinNode)(nil)
+	_ Node = (*ParallelWorker)(nil)
+	_ Node = (*WorkflowNode)(nil)
 )
 
 func TestNewBaseNode_RoundTrip(t *testing.T) {
@@ -130,6 +135,16 @@ func TestBaseNode_NilSchemas(t *testing.T) {
 	if diff := cmp.Diff(input, got); diff != "" {
 		t.Errorf("ValidateInput mismatch (-want +got):\n%s", diff)
 	}
+
+	// ValidateOutput with nil schema is a passthrough.
+	output := map[string]any{"value": "world"}
+	gotOut, err := b.ValidateOutput(output)
+	if err != nil {
+		t.Fatalf("ValidateOutput failed: %v", err)
+	}
+	if diff := cmp.Diff(output, gotOut); diff != "" {
+		t.Errorf("ValidateOutput mismatch (-want +got):\n%s", diff)
+	}
 }
 
 func TestBaseNode_WithSchemas(t *testing.T) {
@@ -171,5 +186,22 @@ func TestBaseNode_WithSchemas(t *testing.T) {
 	_, err = b.ValidateInput(invalidInput)
 	if err == nil {
 		t.Error("expected ValidateInput to fail on invalid input type, but succeeded")
+	}
+
+	// Valid output is returned unchanged.
+	output := map[string]any{"value": "world"}
+	gotOut, err := b.ValidateOutput(output)
+	if err != nil {
+		t.Fatalf("ValidateOutput failed on valid output: %v", err)
+	}
+	if diff := cmp.Diff(output, gotOut); diff != "" {
+		t.Errorf("ValidateOutput mismatch (-want +got):\n%s", diff)
+	}
+
+	// Invalid output fails validation.
+	invalidOutput := map[string]any{"value": 123}
+	_, err = b.ValidateOutput(invalidOutput)
+	if err == nil {
+		t.Error("expected ValidateOutput to fail on invalid output type, but succeeded")
 	}
 }

--- a/workflow/base_node_test.go
+++ b/workflow/base_node_test.go
@@ -19,6 +19,7 @@ import (
 	"time"
 
 	"github.com/google/go-cmp/cmp"
+	"github.com/google/jsonschema-go/jsonschema"
 )
 
 // Compile-time assertions: every built-in workflow node must satisfy
@@ -104,5 +105,71 @@ func TestNewBaseNode_RoundTrip(t *testing.T) {
 				t.Errorf("Config() mismatch (-want +got):\n%s", diff)
 			}
 		})
+	}
+}
+
+type testSchemaInput struct {
+	Value string `json:"value"`
+}
+
+func TestBaseNode_NilSchemas(t *testing.T) {
+	b := NewBaseNode("nil_schema_node", "no validation node", NodeConfig{})
+	if b.InputSchema() != nil {
+		t.Errorf("InputSchema() = %v, want nil", b.InputSchema())
+	}
+	if b.OutputSchema() != nil {
+		t.Errorf("OutputSchema() = %v, want nil", b.OutputSchema())
+	}
+
+	// ValidateInput with nil schema is a passthrough.
+	input := map[string]any{"value": "hello"}
+	got, err := b.ValidateInput(input)
+	if err != nil {
+		t.Fatalf("ValidateInput failed: %v", err)
+	}
+	if diff := cmp.Diff(input, got); diff != "" {
+		t.Errorf("ValidateInput mismatch (-want +got):\n%s", diff)
+	}
+}
+
+func TestBaseNode_WithSchemas(t *testing.T) {
+	s, err := jsonschema.For[testSchemaInput](nil)
+	if err != nil {
+		t.Fatalf("jsonschema.For failed: %v", err)
+	}
+	resolvedInputSchema, err := s.Resolve(nil)
+	if err != nil {
+		t.Fatalf("Resolve failed: %v", err)
+	}
+
+	b := NewBaseNodeWithSchemas("schema_node", "validation node", NodeConfig{}, resolvedInputSchema, resolvedInputSchema)
+	if b.InputSchema() != resolvedInputSchema {
+		t.Errorf("InputSchema() = %v, want %v", b.InputSchema(), resolvedInputSchema)
+	}
+	if b.OutputSchema() != resolvedInputSchema {
+		t.Errorf("OutputSchema() = %v, want %v", b.OutputSchema(), resolvedInputSchema)
+	}
+
+	// Valid input is coerced/returned.
+	input := map[string]any{"value": "hello"}
+	got, err := b.ValidateInput(input)
+	if err != nil {
+		t.Fatalf("ValidateInput failed on valid input: %v", err)
+	}
+	// ValidateInput returns a coerced type (which is map[string]any because we coerce using ConvertToWithJSONSchema[any, any])
+	// Let's verify it contains the expected value.
+	gotMap, ok := got.(map[string]any)
+	if !ok {
+		t.Fatalf("expected got to be map[string]any, got %T", got)
+	}
+	if gotMap["value"] != "hello" {
+		t.Errorf("expected value %q, got %v", "hello", gotMap["value"])
+	}
+
+	// Invalid input fails validation.
+	invalidInput := map[string]any{"value": 123}
+	_, err = b.ValidateInput(invalidInput)
+	if err == nil {
+		t.Error("expected ValidateInput to fail on invalid input type, but succeeded")
 	}
 }

--- a/workflow/base_node_test.go
+++ b/workflow/base_node_test.go
@@ -20,6 +20,9 @@ import (
 
 	"github.com/google/go-cmp/cmp"
 	"github.com/google/jsonschema-go/jsonschema"
+	"google.golang.org/genai"
+
+	"google.golang.org/adk/session"
 )
 
 // Compile-time assertions: every built-in workflow node must satisfy
@@ -204,4 +207,114 @@ func TestBaseNode_WithSchemas(t *testing.T) {
 	if err == nil {
 		t.Error("expected ValidateOutput to fail on invalid output type, but succeeded")
 	}
+}
+
+// resolveTestSchema generates a *jsonschema.Resolved from a Go type
+// for use in tests.
+func resolveTestSchema[T any](t *testing.T) *jsonschema.Resolved {
+	t.Helper()
+	s, err := jsonschema.For[T](nil)
+	if err != nil {
+		t.Fatalf("jsonschema.For failed: %v", err)
+	}
+	resolved, err := s.Resolve(nil)
+	if err != nil {
+		t.Fatalf("Resolve failed: %v", err)
+	}
+	return resolved
+}
+
+// TestDefaultValidateOutput_PassthroughTypes verifies that framework
+// control values (*session.Event, *session.RequestInput) are returned
+// unchanged by defaultValidateOutput even when a strict schema is
+// configured: they are routed through Event.Output by some nodes but
+// are not user output payloads.
+func TestDefaultValidateOutput_PassthroughTypes(t *testing.T) {
+	schema := resolveTestSchema[testSchemaInput](t)
+
+	tests := []struct {
+		name string
+		in   any
+	}{
+		{
+			name: "*session.Event",
+			in:   &session.Event{Author: "node"},
+		},
+		{
+			name: "*session.RequestInput",
+			in:   &session.RequestInput{InterruptID: "approval"},
+		},
+	}
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			got, err := defaultValidateOutput(tc.in, schema)
+			if err != nil {
+				t.Fatalf("expected passthrough, got error: %v", err)
+			}
+			if got != tc.in {
+				t.Errorf("expected identity passthrough, got different value")
+			}
+		})
+	}
+}
+
+// TestDefaultValidateOutput_ContentFallback exercises the
+// *genai.Content fallback path: extract text from parts, return it
+// directly when the schema's root type is "string", otherwise
+// JSON-parse and re-validate. When the fallback cannot produce a
+// valid value the original validation error is surfaced.
+func TestDefaultValidateOutput_ContentFallback(t *testing.T) {
+	t.Run("string_schema_returns_text", func(t *testing.T) {
+		schema := resolveTestSchema[string](t)
+		content := &genai.Content{
+			Parts: []*genai.Part{{Text: "hello "}, {Text: "world"}},
+		}
+		got, err := defaultValidateOutput(content, schema)
+		if err != nil {
+			t.Fatalf("defaultValidateOutput failed: %v", err)
+		}
+		if got != "hello world" {
+			t.Errorf("got %q, want %q", got, "hello world")
+		}
+	})
+
+	t.Run("object_schema_parses_json", func(t *testing.T) {
+		schema := resolveTestSchema[testSchemaInput](t)
+		content := &genai.Content{
+			Parts: []*genai.Part{{Text: `{"value":"hello"}`}},
+		}
+		got, err := defaultValidateOutput(content, schema)
+		if err != nil {
+			t.Fatalf("defaultValidateOutput failed: %v", err)
+		}
+		gotMap, ok := got.(map[string]any)
+		if !ok {
+			t.Fatalf("expected map[string]any, got %T", got)
+		}
+		if gotMap["value"] != "hello" {
+			t.Errorf("got %v, want value=hello", gotMap)
+		}
+	})
+
+	t.Run("invalid_json_returns_original_error", func(t *testing.T) {
+		schema := resolveTestSchema[testSchemaInput](t)
+		content := &genai.Content{
+			Parts: []*genai.Part{{Text: "not valid json"}},
+		}
+		_, err := defaultValidateOutput(content, schema)
+		if err == nil {
+			t.Fatal("expected validation error, got nil")
+		}
+	})
+
+	t.Run("empty_text_returns_original_error", func(t *testing.T) {
+		schema := resolveTestSchema[testSchemaInput](t)
+		content := &genai.Content{
+			Parts: []*genai.Part{{Text: "   "}},
+		}
+		_, err := defaultValidateOutput(content, schema)
+		if err == nil {
+			t.Fatal("expected validation error, got nil")
+		}
+	})
 }

--- a/workflow/branch.go
+++ b/workflow/branch.go
@@ -1,0 +1,149 @@
+// Copyright 2026 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package workflow
+
+import (
+	"context"
+	"strings"
+
+	"google.golang.org/adk/agent"
+)
+
+// Branch composition helpers for the static, parallel, and dynamic
+// schedulers. Branches are dot-separated strings identifying the
+// position of an in-flight node within an invocation's parallel
+// execution tree. The LLM flow processor's history filter uses
+// prefix matching with explicit dot delimiter to scope events: an
+// agent on branch "a.b" sees events on branches "" (root), "a"
+// (ancestor), and "a.b" (self) but not "a.c" (sibling).
+
+// deriveSubBranch appends segment to parent with the dot delimiter.
+// An empty parent yields the bare segment (root + segment), keeping
+// the resulting string non-dot-prefixed; an empty segment is a
+// no-op returning parent unchanged.
+//
+// segment is expected to be a stable identifier (callers commonly
+// use "<node_name>@<run_id>") but this helper does not impose a
+// shape. Callers that need uniqueness across replays must supply a
+// stable run id (auto-counter or WithRunID for dynamic; index+1 for
+// ParallelWorker; "<successor>@1" for static fan-out).
+func deriveSubBranch(parent, segment string) string {
+	if segment == "" {
+		return parent
+	}
+	if parent == "" {
+		return segment
+	}
+	return parent + "." + segment
+}
+
+// withBranch returns ctx wrapped with branch as its Branch().
+// Implemented as a small adapter that overrides only Branch() and
+// delegates the rest of the interface to the embedded ctx.
+func withBranch(ctx agent.InvocationContext, branch string) agent.InvocationContext {
+	if ctx.Branch() == branch {
+		return ctx
+	}
+	return &branchOverride{InvocationContext: ctx, branch: branch}
+}
+
+// branchOverride wraps an InvocationContext and overrides Branch().
+// All other interface methods delegate to the embedded value.
+//
+// WithContext is overridden so the branch survives a subsequent
+// context-cancellation wrap. Without this, a caller that does
+// ctx.WithContext(cancelCtx) would get an InvocationContext whose
+// Branch() returns the inner ctx's branch (empty), silently
+// losing the override.
+type branchOverride struct {
+	agent.InvocationContext
+	branch string
+}
+
+func (b *branchOverride) Branch() string { return b.branch }
+
+// WithContext returns a branchOverride wrapping the inner
+// InvocationContext's WithContext result so the branch override is
+// preserved through context-cancellation wrapping.
+func (b *branchOverride) WithContext(ctx context.Context) agent.InvocationContext {
+	return &branchOverride{
+		InvocationContext: b.InvocationContext.WithContext(ctx),
+		branch:            b.branch,
+	}
+}
+
+// deriveChildBranch composes the branch for a dynamically-scheduled
+// child given the parent's branch and the RunNode options.
+//
+// Algorithm:
+//   - base = overrideBranch if non-empty, else parentBranch
+//   - useSubBranch=true → base.<name>@<runID> (or bare <name>@<runID>
+//     when base is empty)
+//   - useSubBranch=false → base unchanged
+//
+// Note: overrideBranch="" is treated as "no override"; see
+// WithOverrideBranch godoc.
+func deriveChildBranch(parentBranch, name, runID string, useSubBranch bool, overrideBranch string) string {
+	base := parentBranch
+	if overrideBranch != "" {
+		base = overrideBranch
+	}
+	if useSubBranch {
+		return deriveSubBranch(base, name+"@"+runID)
+	}
+	return base
+}
+
+// commonBranchPrefix returns the longest dot-delimited prefix shared
+// by all input branches. Used by JoinNode to derive its own branch
+// from the branches of its predecessors so the join "returns up the
+// tree" to the deepest common ancestor.
+//
+// Behavior:
+//   - Empty input → "" (root).
+//   - Any input branch == "" → "" (root contains everything).
+//   - All inputs identical → that exact value.
+//   - Otherwise the longest shared dot-segment prefix.
+//
+// Note that segment-aware comparison is intentional: branches "a"
+// and "ab" share no prefix (zero common segments), not "a"-as-string.
+func commonBranchPrefix(branches []string) string {
+	if len(branches) == 0 {
+		return ""
+	}
+	splits := make([][]string, len(branches))
+	minLen := -1
+	for i, b := range branches {
+		if b == "" {
+			return ""
+		}
+		segs := strings.Split(b, ".")
+		splits[i] = segs
+		if minLen < 0 || len(segs) < minLen {
+			minLen = len(segs)
+		}
+	}
+	commonCount := 0
+	for i := 0; i < minLen; i++ {
+		seg := splits[0][i]
+		for _, s := range splits[1:] {
+			if s[i] != seg {
+				return strings.Join(splits[0][:commonCount], ".")
+			}
+		}
+		commonCount++
+	}
+	return strings.Join(splits[0][:commonCount], ".")
+}

--- a/workflow/branch_isolation_test.go
+++ b/workflow/branch_isolation_test.go
@@ -1,0 +1,131 @@
+// Copyright 2026 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package workflow
+
+import (
+	"fmt"
+	"slices"
+	"sort"
+	"testing"
+
+	"google.golang.org/adk/agent"
+	"google.golang.org/adk/session"
+)
+
+// TestRunNode_SequentialFanOut_BranchesFromOptions drives a
+// dynamic orchestrator that sequentially calls RunNode three times
+// on the same child and verifies the per-call Branch() observed by
+// the child as a function of the RunNode options passed.
+//
+// Why sequential (not errgroup): per req §5.1 D-Emit-Sequential,
+// emit / RunNode are single-goroutine only. Running fan-out via
+// errgroup violates the iter.Seq2 contract (concurrent yield calls
+// from multiple goroutines) and races on the event-collection slice
+// inside drainDynamicWithErr.
+func TestRunNode_SequentialFanOut_BranchesFromOptions(t *testing.T) {
+	const childName = "peeker"
+
+	tests := []struct {
+		name string
+		// extraOpts are appended after the per-call WithRunID; nil
+		// or empty means "inherit parent branch" (no opt-in).
+		extraOpts []RunNodeOption
+		// wantBranches is the sorted list of Branch() values the
+		// child should observe across the three sequential calls.
+		wantBranches []string
+	}{
+		{
+			// Opt-in: each child sees a distinct sub-branch of the
+			// form "<childName>@<customRunID>" off the
+			// orchestrator's root branch.
+			name:      "WithUseSubBranch_DistinctBranches",
+			extraOpts: []RunNodeOption{WithUseSubBranch()},
+			wantBranches: []string{
+				childName + "@custom-1",
+				childName + "@custom-2",
+				childName + "@custom-3",
+			},
+		},
+		{
+			// Default behaviour: without the opt-in, children
+			// inherit the orchestrator's branch verbatim
+			// (backward-compat contract for callers relying on
+			// inherited branches).
+			name:         "NoOption_StillSharesBranch",
+			extraOpts:    nil,
+			wantBranches: []string{"", "", ""},
+		},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			seenBranches := runSequentialFanOut(t, childName, tc.extraOpts)
+			sort.Strings(seenBranches)
+			if !slices.Equal(seenBranches, tc.wantBranches) {
+				t.Errorf("seenBranches = %q, want %q",
+					seenBranches, tc.wantBranches)
+			}
+		})
+	}
+}
+
+// runSequentialFanOut drives a dynamic orchestrator that sequentially
+// invokes a peeker child three times (items "a"/"b"/"c"), passing
+// WithRunID("custom-N") plus the caller-supplied extraOpts on each
+// call, and returns the Branch() values the child observed in call
+// order. Fails the test if the orchestrator errors or invokes the
+// child a wrong number of times.
+func runSequentialFanOut(t *testing.T, childName string, extraOpts []RunNodeOption) []string {
+	t.Helper()
+	const nItems = 3
+
+	var seenBranches []string
+	peekerNode := NewFunctionNode(
+		childName,
+		func(ctx agent.InvocationContext, input string) (string, error) {
+			seenBranches = append(seenBranches, ctx.Branch())
+			return input, nil
+		},
+		NodeConfig{},
+	)
+
+	orch := NewDynamicNode[any, []string](
+		"orch",
+		func(ctx NodeContext, _ any, _ func(*session.Event) error) ([]string, error) {
+			items := []string{"a", "b", "c"}
+			results := make([]string, len(items))
+			for i, item := range items {
+				opts := append([]RunNodeOption{
+					WithRunID(fmt.Sprintf("custom-%d", i+1)),
+				}, extraOpts...)
+				out, err := RunNode[string](ctx, peekerNode, item, opts...)
+				if err != nil {
+					return nil, err
+				}
+				results[i] = out
+			}
+			return results, nil
+		},
+		NodeConfig{},
+	)
+
+	if _, err := drainDynamicWithErr(t, orch, nil); err != nil {
+		t.Fatalf("orchestrator: %v", err)
+	}
+	if got, want := len(seenBranches), nItems; got != want {
+		t.Fatalf("got %d peeker invocations, want %d", got, want)
+	}
+	return seenBranches
+}

--- a/workflow/branch_test.go
+++ b/workflow/branch_test.go
@@ -1,0 +1,89 @@
+// Copyright 2026 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package workflow
+
+import "testing"
+
+func TestDeriveSubBranch(t *testing.T) {
+	tests := []struct {
+		name, parent, segment, want string
+	}{
+		{"root_and_segment", "", "child@1", "child@1"},
+		{"parent_and_segment", "wf", "child@1", "wf.child@1"},
+		{"nested_parent", "wf.outer@1", "child@2", "wf.outer@1.child@2"},
+		{"empty_segment_noop", "wf", "", "wf"},
+		{"empty_both", "", "", ""},
+	}
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			got := deriveSubBranch(tc.parent, tc.segment)
+			if got != tc.want {
+				t.Errorf("deriveSubBranch(%q, %q) = %q, want %q",
+					tc.parent, tc.segment, got, tc.want)
+			}
+		})
+	}
+}
+
+func TestCommonBranchPrefix(t *testing.T) {
+	tests := []struct {
+		name     string
+		branches []string
+		want     string
+	}{
+		{"empty_input", nil, ""},
+		{"single_branch", []string{"a.b.c"}, "a.b.c"},
+		{"single_empty_branch", []string{""}, ""},
+		{"any_empty_short_circuits_to_root", []string{"a.b", "", "a.b.c"}, ""},
+		{"identical_branches", []string{"a.b", "a.b", "a.b"}, "a.b"},
+		{"shared_prefix_one_segment", []string{"a.b", "a.c"}, "a"},
+		{"shared_prefix_two_segments", []string{"a.b.c", "a.b.d"}, "a.b"},
+		{"no_common_prefix", []string{"a", "b"}, ""},
+		{
+			// segment-aware comparison: "a" and "ab" share NO segments
+			// (not "a" as string prefix).
+			name:     "string_prefix_but_no_segment_prefix",
+			branches: []string{"a", "ab"},
+			want:     "",
+		},
+		{
+			// Mixed depth: deeper branches still share the shallower prefix.
+			name:     "mixed_depth",
+			branches: []string{"a.b", "a.b.c.d"},
+			want:     "a.b",
+		},
+		{
+			// Three branches, deepest common is two segments.
+			name:     "three_branches_two_common",
+			branches: []string{"a.b.x", "a.b.y", "a.b.z.w"},
+			want:     "a.b",
+		},
+		{
+			// First segment differs → root.
+			name:     "first_segment_differs",
+			branches: []string{"a.b.c", "x.b.c"},
+			want:     "",
+		},
+	}
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			got := commonBranchPrefix(tc.branches)
+			if got != tc.want {
+				t.Errorf("commonBranchPrefix(%v) = %q, want %q",
+					tc.branches, got, tc.want)
+			}
+		})
+	}
+}

--- a/workflow/config.go
+++ b/workflow/config.go
@@ -44,22 +44,20 @@ func DefaultRetryConfig() *RetryConfig {
 // NodeConfig defines the configuration for a node.
 //
 // All fields are optional. The pointer-typed fields (RerunOnResume,
-// WaitForOutput) are tri-state: nil means "use the engine default for
-// this node kind", which mirrors Python's per-node-type defaults
-// (e.g. AgentNode in task mode defaults WaitForOutput to true while
-// other nodes default to false). Use the *Or accessor helpers to
-// read these values with an explicit per-call-site default.
+// WaitForOutput) are tri-state so node implementations can
+// distinguish "user explicitly opted out" (&false) from "user did
+// not configure" (nil).
 type NodeConfig struct {
 	// ParallelWorker, when true, runs the node concurrently for each
 	// item of a list-typed input. The engine collects per-item
 	// outputs and emits a single aggregate output event.
 	ParallelWorker bool
 
-	// RerunOnResume controls human-in-the-loop resume behaviour. When
-	// true, an interrupted node re-runs from scratch on resume; when
-	// false, the resume payload is treated as the node's output.
-	// nil means "use the engine default", which is true for AgentNode
-	// and false elsewhere.
+	// RerunOnResume controls human-in-the-loop resume behaviour:
+	// &true re-runs the interrupted node from scratch on resume
+	// (re-entry mode), &false routes the resume payload to the
+	// node's successor as input (handoff mode), and nil defers to
+	// the engine. The engine currently treats nil as handoff.
 	RerunOnResume *bool
 
 	// WaitForOutput, when true, keeps the node in NodeWaiting

--- a/workflow/config.go
+++ b/workflow/config.go
@@ -28,26 +28,61 @@ var defaultRetryConfig = RetryConfig{
 	},
 }
 
+// DefaultRetryConfig returns a copy of the default retry policy
+// (5 attempts, 1s initial delay, 60s cap, 2x backoff, full jitter,
+// retry every error). Override fields on the returned value to
+// customise:
+//
+//	rc := workflow.DefaultRetryConfig()
+//	rc.MaxAttempts = 10
+//	cfg := workflow.NodeConfig{RetryConfig: rc}
 func DefaultRetryConfig() *RetryConfig {
 	cfg := defaultRetryConfig
 	return &cfg
 }
 
 // NodeConfig defines the configuration for a node.
+//
+// All fields are optional. The pointer-typed fields (RerunOnResume,
+// WaitForOutput) are tri-state: nil means "use the engine default for
+// this node kind", which mirrors Python's per-node-type defaults
+// (e.g. AgentNode in task mode defaults WaitForOutput to true while
+// other nodes default to false). Use the *Or accessor helpers to
+// read these values with an explicit per-call-site default.
 type NodeConfig struct {
-	// Enables data parallelism (runs node concurrently for each item in input collection)
+	// ParallelWorker, when true, runs the node concurrently for each
+	// item of a list-typed input. The engine collects per-item
+	// outputs and emits a single aggregate output event.
 	ParallelWorker bool
-	// Re-runs node on resume. Defaults to true for AgentNode
+
+	// RerunOnResume controls human-in-the-loop resume behaviour. When
+	// true, an interrupted node re-runs from scratch on resume; when
+	// false, the resume payload is treated as the node's output.
+	// nil means "use the engine default", which is true for AgentNode
+	// and false elsewhere.
 	RerunOnResume *bool
-	// Wait for output before triggering edges. Defaults to true for Task agents
+
+	// WaitForOutput, when true, keeps the node in NodeWaiting
+	// (re-triggerable) until it actually yields an event carrying an
+	// "output" key in Actions.StateDelta, instead of moving it to
+	// NodeCompleted on first return. JoinNode and any custom fan-in
+	// node sets this. nil means "use the engine default" — false for
+	// most node kinds.
 	WaitForOutput *bool
-	// Retry configuration on failure
+
+	// RetryConfig, when non-nil, makes the scheduler retry this node
+	// on failure per the policy. nil means "no retries".
 	RetryConfig *RetryConfig
-	// Max duration for node to complete. Optional for global defaults
-	Timeout *time.Duration
+
+	// Timeout, when > 0, bounds a single activation of the node via
+	// context.WithTimeout on the per-node context. Zero (the default)
+	// means the node is bounded only by the parent invocation
+	// context's deadline, if any.
+	Timeout time.Duration
 }
 
 // RetryConfig defines the parameters for retrying a failed node.
+//
 // Recommended construction is via DefaultRetryConfig and override
 // the fields you want to customize:
 //
@@ -59,17 +94,30 @@ type NodeConfig struct {
 // but discouraged: any unset field defaults to its zero value, not
 // to DefaultRetryConfig's value. The zero RetryConfig is a valid
 // "no retry, no backoff, no jitter" policy.
+//
+// The struct shape is deliberately a flat set of plain values: no
+// dependency on cenkalti/backoff/v5.
 type RetryConfig struct {
 	// Maximum number of attempts, including the original request. If 0 or 1, it means no retries. If not specified, default to 5.
 	MaxAttempts int
+
 	// Initial delay before the first retry, in fractions of a second. If not specified, default to 1 second.
 	InitialDelay time.Duration
+
 	// Maximum delay between retries, in fractions of a second. If not specified, default to 60 seconds.
 	MaxDelay time.Duration
-	// Multiplier by which the delay increases after each attempt. If not specified, default to 2.0.
+
+	// BackoffFactor is the per-attempt multiplier applied to the
+	// delay. A factor of 1.0 means a constant InitialDelay between
+	// retries; 2.0 means classic exponential backoff. Values < 1.0
+	// shrink the delay each attempt (rare but permitted).
 	BackoffFactor float64
-	// Randomness factor for the delay. Use 0.0 to remove randomness. If not specified, default to 1.0.
+
+	// Jitter is a randomness factor in [0.0, 1.0]. The actual delay
+	// is sampled from delay * (1 ± Jitter). Zero means deterministic
+	// delays.
 	Jitter float64
+
 	// Predicate that defines when to retry (true means retry). If not specified, default to true.
 	ShouldRetry func(error) bool
 }

--- a/workflow/config.go
+++ b/workflow/config.go
@@ -1,0 +1,75 @@
+// Copyright 2026 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package workflow
+
+import "time"
+
+// defaultRetryConfig is the default retry configuration for a node.
+var defaultRetryConfig = RetryConfig{
+	MaxAttempts:   5,
+	InitialDelay:  time.Second,
+	MaxDelay:      60 * time.Second,
+	BackoffFactor: 2.0,
+	Jitter:        1.0,
+	ShouldRetry: func(error) bool {
+		return true
+	},
+}
+
+func DefaultRetryConfig() *RetryConfig {
+	cfg := defaultRetryConfig
+	return &cfg
+}
+
+// NodeConfig defines the configuration for a node.
+type NodeConfig struct {
+	// Enables data parallelism (runs node concurrently for each item in input collection)
+	ParallelWorker bool
+	// Re-runs node on resume. Defaults to true for AgentNode
+	RerunOnResume *bool
+	// Wait for output before triggering edges. Defaults to true for Task agents
+	WaitForOutput *bool
+	// Retry configuration on failure
+	RetryConfig *RetryConfig
+	// Max duration for node to complete. Optional for global defaults
+	Timeout *time.Duration
+}
+
+// RetryConfig defines the parameters for retrying a failed node.
+// Recommended construction is via DefaultRetryConfig and override
+// the fields you want to customize:
+//
+//	rc := workflow.DefaultRetryConfig()
+//	rc.MaxAttempts = 10
+//	cfg := workflow.NodeConfig{RetryConfig: rc}
+//
+// Constructing via struct literal (RetryConfig{...}) is permitted
+// but discouraged: any unset field defaults to its zero value, not
+// to DefaultRetryConfig's value. The zero RetryConfig is a valid
+// "no retry, no backoff, no jitter" policy.
+type RetryConfig struct {
+	// Maximum number of attempts, including the original request. If 0 or 1, it means no retries. If not specified, default to 5.
+	MaxAttempts int
+	// Initial delay before the first retry, in fractions of a second. If not specified, default to 1 second.
+	InitialDelay time.Duration
+	// Maximum delay between retries, in fractions of a second. If not specified, default to 60 seconds.
+	MaxDelay time.Duration
+	// Multiplier by which the delay increases after each attempt. If not specified, default to 2.0.
+	BackoffFactor float64
+	// Randomness factor for the delay. Use 0.0 to remove randomness. If not specified, default to 1.0.
+	Jitter float64
+	// Predicate that defines when to retry (true means retry). If not specified, default to true.
+	ShouldRetry func(error) bool
+}

--- a/workflow/config_test.go
+++ b/workflow/config_test.go
@@ -1,0 +1,42 @@
+// Copyright 2026 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package workflow
+
+import (
+	"testing"
+	"time"
+
+	"github.com/google/go-cmp/cmp"
+	"github.com/google/go-cmp/cmp/cmpopts"
+)
+
+func TestDefaultRetryConfig(t *testing.T) {
+	want := &RetryConfig{
+		MaxAttempts:   5,
+		InitialDelay:  time.Second,
+		MaxDelay:      60 * time.Second,
+		BackoffFactor: 2.0,
+		Jitter:        1.0,
+	}
+	got := DefaultRetryConfig()
+
+	if diff := cmp.Diff(want, got, cmpopts.IgnoreFields(RetryConfig{}, "ShouldRetry")); diff != "" {
+		t.Errorf("DefaultRetryConfig() mismatch (-want +got):\n%s", diff)
+	}
+
+	if got.ShouldRetry == nil || !got.ShouldRetry(nil) {
+		t.Errorf("ShouldRetry is nil or returns false")
+	}
+}

--- a/workflow/config_test.go
+++ b/workflow/config_test.go
@@ -22,6 +22,9 @@ import (
 	"github.com/google/go-cmp/cmp/cmpopts"
 )
 
+// TestDefaultRetryConfig verifies the values returned by
+// DefaultRetryConfig (5 attempts, 1s initial delay, 60s cap, 2x
+// backoff, full jitter, retry-every-error predicate).
 func TestDefaultRetryConfig(t *testing.T) {
 	want := &RetryConfig{
 		MaxAttempts:   5,

--- a/workflow/dynamic_node.go
+++ b/workflow/dynamic_node.go
@@ -80,7 +80,7 @@ func newDynamicNodeWithResolvedSchemas[IN, OUT any](
 	cfg NodeConfig,
 ) *dynamicNode[IN, OUT] {
 	return &dynamicNode[IN, OUT]{
-		BaseNode:     NewBaseNode(name, "", cfg),
+		BaseNode:     NewBaseNodeWithSchemas(name, "", cfg, inputSchema, outputSchema),
 		fn:           fn,
 		inputSchema:  inputSchema,
 		outputSchema: outputSchema,

--- a/workflow/dynamic_node.go
+++ b/workflow/dynamic_node.go
@@ -1,0 +1,183 @@
+// Copyright 2026 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package workflow
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"iter"
+
+	"github.com/google/jsonschema-go/jsonschema"
+	"google.golang.org/adk/agent"
+	"google.golang.org/adk/internal/typeutil"
+	"google.golang.org/adk/session"
+)
+
+// DynamicFn is the orchestrator body of a dynamic node. emit publishes
+// mid-body events (state updates, HITL requests, progress); the return
+// value becomes the node's terminal Event.Output.
+type DynamicFn[IN, OUT any] = func(ctx NodeContext, in IN, emit func(*session.Event) error) (OUT, error)
+
+type dynamicNode[IN, OUT any] struct {
+	BaseNode
+	fn           DynamicFn[IN, OUT]
+	inputSchema  *jsonschema.Resolved
+	outputSchema *jsonschema.Resolved
+}
+
+// NewDynamicNode wraps fn as a workflow Node whose execution order is
+// expressed as Go code calling RunNode for each child. cfg.RerunOnResume
+// defaults to &true when nil (needed so resume can re-enter the
+// orchestrator and deliver cached child results); explicit &false is
+// respected.
+func NewDynamicNode[IN, OUT any](name string, fn DynamicFn[IN, OUT], cfg NodeConfig) Node {
+	return newDynamicNodeWithResolvedSchemas[IN, OUT](name, fn, nil, nil, applyDynamicDefaults(cfg))
+}
+
+// NewDynamicNodeWithSchema is the explicit-schema variant.
+func NewDynamicNodeWithSchema[IN, OUT any](
+	name string,
+	fn DynamicFn[IN, OUT],
+	inputSchema, outputSchema *jsonschema.Schema,
+	cfg NodeConfig,
+) (Node, error) {
+	var ischema *jsonschema.Resolved
+	if inputSchema != nil {
+		r, err := inputSchema.Resolve(nil)
+		if err != nil {
+			return nil, fmt.Errorf("resolving input schema: %w", err)
+		}
+		ischema = r
+	}
+	var oschema *jsonschema.Resolved
+	if outputSchema != nil {
+		r, err := outputSchema.Resolve(nil)
+		if err != nil {
+			return nil, fmt.Errorf("resolving output schema: %w", err)
+		}
+		oschema = r
+	}
+	return newDynamicNodeWithResolvedSchemas[IN, OUT](name, fn, ischema, oschema, applyDynamicDefaults(cfg)), nil
+}
+
+func newDynamicNodeWithResolvedSchemas[IN, OUT any](
+	name string,
+	fn DynamicFn[IN, OUT],
+	inputSchema, outputSchema *jsonschema.Resolved,
+	cfg NodeConfig,
+) *dynamicNode[IN, OUT] {
+	return &dynamicNode[IN, OUT]{
+		BaseNode:     NewBaseNode(name, "", cfg),
+		fn:           fn,
+		inputSchema:  inputSchema,
+		outputSchema: outputSchema,
+	}
+}
+
+func applyDynamicDefaults(cfg NodeConfig) NodeConfig {
+	if cfg.RerunOnResume == nil {
+		t := true
+		cfg.RerunOnResume = &t
+	}
+	return cfg
+}
+
+func (n *dynamicNode[IN, OUT]) Run(ctx agent.InvocationContext, input any) iter.Seq2[*session.Event, error] {
+	return func(yield func(*session.Event, error) bool) {
+		parentNC, ok := ctx.(NodeContext)
+		if !ok {
+			yield(nil, fmt.Errorf("dynamic node %q: scheduler did not supply a NodeContext", n.Name()))
+			return
+		}
+
+		typedInput, err := n.coerceInput(input)
+		if err != nil {
+			yield(nil, err)
+			return
+		}
+
+		emit := makeEmit(yield, parentNC)
+		sub := newDynamicSubScheduler(parentNC, n.composePath(parentNC), emit)
+		orchestratorCtx := newDynamicNodeContext(parentNC, sub.parentPath, "", sub)
+
+		out, err := n.fn(orchestratorCtx, typedInput, emit)
+		if err != nil {
+			// HITL: the RequestedInput was already forwarded upstream;
+			// swallow the sentinel so the engine sees only the pause event.
+			if errors.Is(err, ErrNodeInterrupted) {
+				return
+			}
+			yield(nil, err)
+			return
+		}
+
+		ev := session.NewEvent(parentNC.InvocationID())
+		ev.Output = out
+		ev.NodeInfo = &session.NodeInfo{Path: sub.parentPath}
+		// TODO(wolo): validate out against n.outputSchema before yielding,
+		// mirroring function_node.go:87-92.
+		yield(ev, nil)
+	}
+}
+
+// coerceInput converts the raw input to IN, using a typeutil JSON
+// roundtrip as a fallback (mirrors FunctionNode for tool-node →
+// dynamic-node edges where the upstream emits map[string]any).
+func (n *dynamicNode[IN, OUT]) coerceInput(input any) (IN, error) {
+	var zero IN
+	if input == nil {
+		return zero, nil
+	}
+	if v, ok := input.(IN); ok {
+		return v, nil
+	}
+	typed, err := typeutil.ConvertToWithJSONSchema[any, IN](input, n.inputSchema)
+	if err != nil {
+		return zero, fmt.Errorf("dynamic node %q: invalid input type, expected %T: %w", n.Name(), zero, err)
+	}
+	return typed, nil
+}
+
+// composePath returns this dynamic node's own composite path. Top-level
+// activations get the bare Name(); nested dynamic nodes append.
+func (n *dynamicNode[IN, OUT]) composePath(parent NodeContext) string {
+	if p := parent.Path(); p != "" {
+		return p + "/" + n.Name()
+	}
+	return n.Name()
+}
+
+// makeEmit wraps yield as an emit callback. Contract: nil return =
+// delivered, non-nil = orchestrator must stop (calling yield after
+// it returned false is a runtime error per the iter spec).
+//
+// When yield returns false without ctx cancellation (no current
+// consumer triggers this, but the contract must not depend on it),
+// return context.Canceled as a stand-in.
+func makeEmit(yield func(*session.Event, error) bool, parentCtx NodeContext) func(*session.Event) error {
+	return func(ev *session.Event) error {
+		if err := parentCtx.Err(); err != nil {
+			return err
+		}
+		if !yield(ev, nil) {
+			if err := parentCtx.Err(); err != nil {
+				return err
+			}
+			return context.Canceled
+		}
+		return nil
+	}
+}

--- a/workflow/dynamic_node_test.go
+++ b/workflow/dynamic_node_test.go
@@ -1,0 +1,292 @@
+// Copyright 2026 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package workflow
+
+import (
+	"errors"
+	"iter"
+	"testing"
+
+	"google.golang.org/adk/agent"
+	"google.golang.org/adk/session"
+)
+
+func TestNewDynamicNode_DefaultsRerunOnResume(t *testing.T) {
+	fn := func(NodeContext, string, func(*session.Event) error) (string, error) {
+		return "", nil
+	}
+	n := NewDynamicNode[string, string]("d", fn, NodeConfig{})
+	rr := n.Config().RerunOnResume
+	if rr == nil || !*rr {
+		t.Errorf("RerunOnResume = %v, want &true (default)", rr)
+	}
+}
+
+func TestNewDynamicNode_RespectsExplicitFalse(t *testing.T) {
+	f := false
+	fn := func(NodeContext, string, func(*session.Event) error) (string, error) {
+		return "", nil
+	}
+	n := NewDynamicNode[string, string]("d", fn, NodeConfig{RerunOnResume: &f})
+	if rr := n.Config().RerunOnResume; rr == nil || *rr {
+		t.Errorf("RerunOnResume = %v, want &false (explicit override)", rr)
+	}
+}
+
+func TestDynamicNode_Sequential_RunNodeChain(t *testing.T) {
+	stepA := newStubNode("stepA", "from A")
+	stepB := newStubNode("stepB", "from B")
+
+	orchestrator := NewDynamicNode[string, string]("orch",
+		func(ctx NodeContext, _ string, _ func(*session.Event) error) (string, error) {
+			outA, err := RunNode[string](ctx, stepA, "ignored")
+			if err != nil {
+				return "", err
+			}
+			outB, err := RunNode[string](ctx, stepB, outA)
+			if err != nil {
+				return "", err
+			}
+			return outA + " | " + outB, nil
+		},
+		NodeConfig{},
+	)
+
+	events := drainDynamic(t, orchestrator, "input")
+	last := events[len(events)-1]
+	if last.Output != "from A | from B" {
+		t.Errorf("terminal Output = %v, want %q", last.Output, "from A | from B")
+	}
+}
+
+func TestDynamicNode_TypedInput(t *testing.T) {
+	type Req struct{ Name string }
+
+	var observed Req
+	orchestrator := NewDynamicNode[Req, string]("orch",
+		func(_ NodeContext, in Req, _ func(*session.Event) error) (string, error) {
+			observed = in
+			return "ok", nil
+		},
+		NodeConfig{},
+	)
+
+	drainDynamic(t, orchestrator, Req{Name: "alice"})
+	if observed.Name != "alice" {
+		t.Errorf("observed Req.Name = %q, want %q", observed.Name, "alice")
+	}
+}
+
+func TestDynamicNode_TypedInput_JSONFallback(t *testing.T) {
+	// Upstream produces map[string]any (e.g. a tool node). Constructor
+	// coerces to the typed struct via typeutil JSON roundtrip.
+	type Req struct {
+		Name string `json:"name"`
+		N    int    `json:"n"`
+	}
+
+	var observed Req
+	orchestrator := NewDynamicNode[Req, string]("orch",
+		func(_ NodeContext, in Req, _ func(*session.Event) error) (string, error) {
+			observed = in
+			return "ok", nil
+		},
+		NodeConfig{},
+	)
+
+	drainDynamic(t, orchestrator, map[string]any{"name": "bob", "n": 7})
+	if observed.Name != "bob" || observed.N != 7 {
+		t.Errorf("observed = %+v, want {Name:bob N:7}", observed)
+	}
+}
+
+func TestDynamicNode_EmitMidBody(t *testing.T) {
+	orchestrator := NewDynamicNode[string, string]("orch",
+		func(_ NodeContext, _ string, emit func(*session.Event) error) (string, error) {
+			if err := emit(&session.Event{Actions: session.EventActions{
+				StateDelta: map[string]any{"progress": "halfway"},
+			}}); err != nil {
+				return "", err
+			}
+			return "done", nil
+		},
+		NodeConfig{},
+	)
+
+	events := drainDynamic(t, orchestrator, "")
+	if len(events) < 2 {
+		t.Fatalf("got %d events, want >= 2 (mid-body emit + terminal)", len(events))
+	}
+	if got, want := events[0].Actions.StateDelta["progress"], "halfway"; got != want {
+		t.Errorf("first event StateDelta progress = %v, want %q", got, want)
+	}
+	if events[len(events)-1].Output != "done" {
+		t.Errorf("terminal Output = %v, want \"done\"", events[len(events)-1].Output)
+	}
+}
+
+func TestDynamicNode_HITL_SwallowsInterrupt(t *testing.T) {
+	// Pause already reached the engine via the forwarded
+	// RequestedInput event; Run must not also yield the sentinel.
+	asker := newRequestInputNode("asker", "approve?")
+	orchestrator := NewDynamicNode[string, string]("orch",
+		func(ctx NodeContext, _ string, _ func(*session.Event) error) (string, error) {
+			_, err := RunNode[string](ctx, asker, nil)
+			return "", err
+		},
+		NodeConfig{},
+	)
+
+	events, runErr := drainDynamicWithErr(t, orchestrator, "")
+	if runErr != nil {
+		t.Errorf("Run yielded error %v; want nil (HITL swallowed)", runErr)
+	}
+	if !hasRequestedInput(events) {
+		t.Errorf("expected RequestedInput event in stream, got %+v", events)
+	}
+}
+
+func TestDynamicNode_ChildFailure_PropagatesError(t *testing.T) {
+	failer := newFailingNode("failer", errors.New("boom"))
+	orchestrator := NewDynamicNode[string, string]("orch",
+		func(ctx NodeContext, _ string, _ func(*session.Event) error) (string, error) {
+			_, err := RunNode[string](ctx, failer, nil)
+			return "", err
+		},
+		NodeConfig{},
+	)
+
+	_, runErr := drainDynamicWithErr(t, orchestrator, "")
+	if !errors.Is(runErr, ErrNodeFailed) {
+		t.Errorf("Run error = %v, want errors.Is ErrNodeFailed", runErr)
+	}
+}
+
+func TestDynamicNode_TerminalOutputEvent(t *testing.T) {
+	orchestrator := NewDynamicNode[string, int]("orch",
+		func(NodeContext, string, func(*session.Event) error) (int, error) {
+			return 42, nil
+		},
+		NodeConfig{},
+	)
+	events := drainDynamic(t, orchestrator, "")
+	last := events[len(events)-1]
+	if last.Output != 42 {
+		t.Errorf("Output = %v, want 42", last.Output)
+	}
+}
+
+// TestDynamicNode_Integration_ChildAndParentOutputs verifies that
+// when a dynamic orchestrator calls a child via RunNode, both the
+// child's terminal output event and the parent's own terminal output
+// reach the workflow stream without the top-level scheduler rejecting
+// the pair as "multiple outputs per activation".
+func TestDynamicNode_Integration_ChildAndParentOutputs(t *testing.T) {
+	helloNode := NewFunctionNode("hello_node",
+		func(_ agent.InvocationContext, _ string) (string, error) {
+			return "Hello World", nil
+		},
+		NodeConfig{},
+	)
+	orch := NewDynamicNode[string, string]("my_workflow",
+		func(ctx NodeContext, _ string, _ func(*session.Event) error) (string, error) {
+			return RunNode[string](ctx, helloNode, "hello")
+		},
+		NodeConfig{},
+	)
+
+	w, err := New("root", Chain(Start, orch))
+	if err != nil {
+		t.Fatalf("workflow.New: %v", err)
+	}
+
+	var outputs []any
+	for ev, err := range w.Run(newMockCtx(t)) {
+		if err != nil {
+			t.Fatalf("workflow.Run error: %v", err)
+		}
+		if ev != nil && ev.Output != nil {
+			outputs = append(outputs, ev.Output)
+		}
+	}
+	if len(outputs) != 2 {
+		t.Fatalf("got %d output events, want 2 (child + parent terminal); outputs=%v", len(outputs), outputs)
+	}
+	for _, out := range outputs {
+		if out != "Hello World" {
+			t.Errorf("output = %v, want %q", out, "Hello World")
+		}
+	}
+}
+
+func TestNewDynamicNodeWithSchema_NilSchemasOK(t *testing.T) {
+	fn := func(NodeContext, string, func(*session.Event) error) (string, error) { return "", nil }
+	if _, err := NewDynamicNodeWithSchema[string, string]("d", fn, nil, nil, NodeConfig{}); err != nil {
+		t.Errorf("nil schemas should construct cleanly, got %v", err)
+	}
+}
+
+// --- test helpers ---
+
+func drainDynamic(t *testing.T, n Node, input any) []*session.Event {
+	t.Helper()
+	events, err := drainDynamicWithErr(t, n, input)
+	if err != nil {
+		t.Fatalf("Run error: %v", err)
+	}
+	return events
+}
+
+func drainDynamicWithErr(t *testing.T, n Node, input any) ([]*session.Event, error) {
+	t.Helper()
+	parent := newNodeContext(newMockCtx(t), nil)
+	var events []*session.Event
+	for ev, err := range n.Run(parent, input) {
+		if err != nil {
+			return events, err
+		}
+		if ev != nil {
+			events = append(events, ev)
+		}
+	}
+	return events, nil
+}
+
+func hasRequestedInput(events []*session.Event) bool {
+	for _, ev := range events {
+		if ev.RequestedInput != nil {
+			return true
+		}
+	}
+	return false
+}
+
+type failingNode struct {
+	BaseNode
+	err error
+}
+
+func newFailingNode(name string, err error) *failingNode {
+	return &failingNode{
+		BaseNode: NewBaseNode(name, "", NodeConfig{}),
+		err:      err,
+	}
+}
+
+func (n *failingNode) Run(agent.InvocationContext, any) iter.Seq2[*session.Event, error] {
+	return func(yield func(*session.Event, error) bool) {
+		yield(nil, n.err)
+	}
+}

--- a/workflow/dynamic_scheduler.go
+++ b/workflow/dynamic_scheduler.go
@@ -49,20 +49,25 @@ func newDynamicSubScheduler(parent NodeContext, parentPath string, emitUp func(*
 // runNode executes child once, forwards its events upstream, and
 // classifies the outcome. HITL surfaces as ErrNodeInterrupted; runtime
 // failure as ErrNodeFailed; a child that fails after requesting input
-// surfaces as ErrNodeFailed (matches adk-python precedence).
+// surfaces as ErrNodeFailed.
 //
 // Session, invocation metadata, and cancellation come from s.parentCtx
-// captured at sub-scheduler construction. customRunID is empty to use
-// the auto-counter, or a user-supplied stable id (validated against
-// the rules in validateCustomRunID).
-func (s *dynamicSubScheduler) runNode(child Node, input any, customRunID string) (any, error) {
+// captured at sub-scheduler construction. opts carries the resolved
+// per-call configuration assembled from RunNode's variadic
+// RunNodeOption arguments: opts.customRunID is empty to use the
+// auto-counter or a user-supplied stable id (validated against the
+// rules in validateCustomRunID); opts.useSubBranch and
+// opts.overrideBranch derive the child's Branch() via
+// deriveChildBranch.
+func (s *dynamicSubScheduler) runNode(child Node, input any, opts runNodeOptions) (any, error) {
 	name := child.Name()
-	runID, err := s.resolveRunID(name, customRunID)
+	runID, err := s.resolveRunID(name, opts.customRunID)
 	if err != nil {
 		return nil, &NodeRunError{ChildName: name, Cause: err}
 	}
 	childPath := s.parentPath + "/" + name + "@" + runID
-	childCtx := newDynamicNodeContext(s.parentCtx, childPath, runID, s)
+	childBranch := deriveChildBranch(s.parentCtx.Branch(), name, runID, opts.useSubBranch, opts.overrideBranch)
+	childCtx := newDynamicNodeContext(s.parentCtx.WithBranch(childBranch), childPath, runID, s)
 
 	// EXPERIMENTAL: stash childCtx (a *nodeContext with non-nil
 	// subScheduler) in the embedded context.Context so tools running

--- a/workflow/dynamic_scheduler.go
+++ b/workflow/dynamic_scheduler.go
@@ -64,6 +64,16 @@ func (s *dynamicSubScheduler) runNode(child Node, input any, customRunID string)
 	childPath := s.parentPath + "/" + name + "@" + runID
 	childCtx := newDynamicNodeContext(s.parentCtx, childPath, runID, s)
 
+	// EXPERIMENTAL: stash childCtx (a *nodeContext with non-nil
+	// subScheduler) in the embedded context.Context so tools running
+	// inside an LlmAgent that is itself running as this dynamic
+	// child can recover the NodeContext via
+	// workflow.NodeContextFromGoContext. See
+	// scheduleResumedNode for the static-node equivalent.
+	childCtx.InvocationContext = childCtx.InvocationContext.WithContext(
+		WithNodeContext(childCtx.InvocationContext, childCtx),
+	)
+
 	var (
 		out         any
 		interrupted bool

--- a/workflow/dynamic_scheduler.go
+++ b/workflow/dynamic_scheduler.go
@@ -1,0 +1,148 @@
+// Copyright 2026 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package workflow
+
+import (
+	"fmt"
+	"strconv"
+	"strings"
+	"sync"
+
+	"google.golang.org/adk/session"
+)
+
+// dynamicSubScheduler runs the children of one dynamic-node activation.
+type dynamicSubScheduler struct {
+	parentPath string
+	parentCtx  NodeContext
+	emitUp     func(*session.Event) error
+
+	// mu protects runCountByChild.
+	mu sync.Mutex
+	// runCountByChild seeds the auto-counter for each child name —
+	// the n-th invocation of any given name gets runID
+	// strconv.Itoa(n).
+	runCountByChild map[string]int
+}
+
+func newDynamicSubScheduler(parent NodeContext, parentPath string, emitUp func(*session.Event) error) *dynamicSubScheduler {
+	return &dynamicSubScheduler{
+		parentPath:      parentPath,
+		parentCtx:       parent,
+		emitUp:          emitUp,
+		runCountByChild: map[string]int{},
+	}
+}
+
+// runNode executes child once, forwards its events upstream, and
+// classifies the outcome. HITL surfaces as ErrNodeInterrupted; runtime
+// failure as ErrNodeFailed; a child that fails after requesting input
+// surfaces as ErrNodeFailed (matches adk-python precedence).
+//
+// Session, invocation metadata, and cancellation come from s.parentCtx
+// captured at sub-scheduler construction. customRunID is empty to use
+// the auto-counter, or a user-supplied stable id (validated against
+// the rules in validateCustomRunID).
+//
+// Fresh execution only; resume support lands in a follow-up PR.
+func (s *dynamicSubScheduler) runNode(child Node, input any, customRunID string) (any, error) {
+	name := child.Name()
+	runID, err := s.resolveRunID(name, customRunID)
+	if err != nil {
+		return nil, &NodeRunError{ChildName: name, Cause: err}
+	}
+	childPath := s.parentPath + "/" + name + "@" + runID
+	childCtx := newDynamicNodeContext(s.parentCtx, childPath, runID, s)
+
+	var (
+		out         any
+		interrupted bool
+	)
+	for ev, evErr := range child.Run(childCtx, input) {
+		if evErr != nil {
+			// Child error wins over any prior interrupt.
+			return nil, &NodeRunError{
+				ChildName: name, ChildPath: childPath, RunID: runID,
+				Cause: fmt.Errorf("%w: %v", ErrNodeFailed, evErr),
+			}
+		}
+		if ev == nil {
+			continue
+		}
+		if ev.RequestedInput != nil {
+			interrupted = true
+		}
+		if ev.Output != nil {
+			out = ev.Output
+		}
+		if err := s.emitUp(ev); err != nil {
+			return nil, &NodeRunError{
+				ChildName: name, ChildPath: childPath, RunID: runID,
+				Cause: fmt.Errorf("%w: emitUp: %v", ErrNodeFailed, err),
+			}
+		}
+	}
+
+	if interrupted {
+		return nil, &NodeRunError{
+			ChildName: name, ChildPath: childPath, RunID: runID,
+			Cause: ErrNodeInterrupted,
+		}
+	}
+	return out, nil
+}
+
+// resolveRunID validates a user-supplied id, or returns the next
+// per-child-name counter value under lock.
+func (s *dynamicSubScheduler) resolveRunID(childName, custom string) (string, error) {
+	if custom != "" {
+		if err := validateCustomRunID(custom); err != nil {
+			return "", err
+		}
+		return custom, nil
+	}
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	s.runCountByChild[childName]++
+	return strconv.Itoa(s.runCountByChild[childName]), nil
+}
+
+// validateCustomRunID rejects empty ids, purely-numeric ids (collide
+// with the auto-counter), and ids containing the composite-path
+// separators / and @.
+func validateCustomRunID(id string) error {
+	if id == "" {
+		return fmt.Errorf("%w: empty", ErrInvalidRunID)
+	}
+	if isAllDigits(id) {
+		return fmt.Errorf("%w: %q is purely numeric (reserved for auto-counter)", ErrInvalidRunID, id)
+	}
+	if strings.ContainsAny(id, "/@") {
+		return fmt.Errorf("%w: %q contains reserved separator (/ or @)", ErrInvalidRunID, id)
+	}
+	return nil
+}
+
+// isAllDigits checks ASCII digits only by design: the auto-counter
+// emits ASCII digits, so collision is only possible with ASCII numeric
+// ids.
+func isAllDigits(s string) bool {
+	for _, r := range s {
+		if r < '0' || r > '9' {
+			return false
+		}
+	}
+	return true
+}

--- a/workflow/dynamic_scheduler.go
+++ b/workflow/dynamic_scheduler.go
@@ -55,8 +55,6 @@ func newDynamicSubScheduler(parent NodeContext, parentPath string, emitUp func(*
 // captured at sub-scheduler construction. customRunID is empty to use
 // the auto-counter, or a user-supplied stable id (validated against
 // the rules in validateCustomRunID).
-//
-// Fresh execution only; resume support lands in a follow-up PR.
 func (s *dynamicSubScheduler) runNode(child Node, input any, customRunID string) (any, error) {
 	name := child.Name()
 	runID, err := s.resolveRunID(name, customRunID)
@@ -80,6 +78,15 @@ func (s *dynamicSubScheduler) runNode(child Node, input any, customRunID string)
 		}
 		if ev == nil {
 			continue
+		}
+		// Stamp NodeInfo.Path so the top scheduler scopes the
+		// child's Output/Routes to the child (not the parent's
+		// accumulator). RequestedInput is promoted to the parent —
+		// see scheduler.handleEvent. Skip if the child already
+		// stamped NodeInfo (nested dynamic node yielding its own
+		// terminal event, dynamic_node.go).
+		if ev.NodeInfo == nil {
+			ev.NodeInfo = &session.NodeInfo{Path: childPath}
 		}
 		if ev.RequestedInput != nil {
 			interrupted = true

--- a/workflow/dynamic_scheduler_test.go
+++ b/workflow/dynamic_scheduler_test.go
@@ -1,0 +1,259 @@
+// Copyright 2026 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package workflow
+
+import (
+	"errors"
+	"iter"
+	"strconv"
+	"sync"
+	"testing"
+
+	"google.golang.org/adk/agent"
+	"google.golang.org/adk/session"
+)
+
+func TestValidateCustomRunID(t *testing.T) {
+	tests := []struct {
+		id      string
+		wantErr bool
+	}{
+		{"", true},    // empty
+		{"123", true}, // purely numeric
+		{"0", true},   // purely numeric
+		{"a/b", true}, // contains /
+		{"a@b", true}, // contains @
+		{"order-7", false},
+		{"abc", false},
+		{"v2-attempt-3", false},
+		{"7a", false}, // mixed
+	}
+	for _, tc := range tests {
+		t.Run(tc.id, func(t *testing.T) {
+			err := validateCustomRunID(tc.id)
+			if (err != nil) != tc.wantErr {
+				t.Errorf("validateCustomRunID(%q) err = %v, wantErr = %v", tc.id, err, tc.wantErr)
+			}
+			if err != nil && !errors.Is(err, ErrInvalidRunID) {
+				t.Errorf("validateCustomRunID(%q) err = %v, want errors.Is ErrInvalidRunID", tc.id, err)
+			}
+		})
+	}
+}
+
+func TestSubScheduler_Counter_AutoIncrementsPerChildName(t *testing.T) {
+	sub := newDynamicSubScheduler(newTopLevelCtx(t), "parent", noopEmit)
+
+	for i := 1; i <= 3; i++ {
+		got, err := sub.resolveRunID("childA", "")
+		if err != nil {
+			t.Fatalf("resolveRunID childA #%d: %v", i, err)
+		}
+		if got != strconv.Itoa(i) {
+			t.Errorf("childA #%d got %q, want %q", i, got, strconv.Itoa(i))
+		}
+	}
+	// Independent counter per child name.
+	got, _ := sub.resolveRunID("childB", "")
+	if got != "1" {
+		t.Errorf("childB first invocation got %q, want \"1\"", got)
+	}
+}
+
+func TestSubScheduler_Counter_ConcurrentSafe(t *testing.T) {
+	sub := newDynamicSubScheduler(newTopLevelCtx(t), "parent", noopEmit)
+	const goroutines = 64
+
+	var wg sync.WaitGroup
+	wg.Add(goroutines)
+	seen := sync.Map{}
+	for i := 0; i < goroutines; i++ {
+		go func() {
+			defer wg.Done()
+			id, err := sub.resolveRunID("worker", "")
+			if err != nil {
+				t.Errorf("resolveRunID: %v", err)
+				return
+			}
+			if _, dup := seen.LoadOrStore(id, struct{}{}); dup {
+				t.Errorf("duplicate run id %q", id)
+			}
+		}()
+	}
+	wg.Wait()
+}
+
+func TestSubScheduler_Counter_CustomIDDoesNotIncrement(t *testing.T) {
+	sub := newDynamicSubScheduler(newTopLevelCtx(t), "parent", noopEmit)
+
+	if _, err := sub.resolveRunID("c", "order-1"); err != nil {
+		t.Fatalf("custom id: %v", err)
+	}
+	got, _ := sub.resolveRunID("c", "")
+	if got != "1" {
+		t.Errorf("auto id after custom got %q, want \"1\" (custom must not bump counter)", got)
+	}
+}
+
+func TestSubScheduler_RunNode_FreshExecution(t *testing.T) {
+	child := newStubNode("greeter", "hello")
+	var forwarded []*session.Event
+	sub := newDynamicSubScheduler(newTopLevelCtx(t), "wf", func(ev *session.Event) error {
+		forwarded = append(forwarded, ev)
+		return nil
+	})
+
+	out, err := sub.runNode(child, "world", "")
+	if err != nil {
+		t.Fatalf("runNode: %v", err)
+	}
+	if out != "hello" {
+		t.Errorf("output = %v, want \"hello\"", out)
+	}
+	if len(forwarded) != 1 {
+		t.Fatalf("forwarded events = %d, want 1", len(forwarded))
+	}
+	if forwarded[0].Output != "hello" {
+		t.Errorf("forwarded event Output = %v, want \"hello\"", forwarded[0].Output)
+	}
+}
+
+func TestSubScheduler_RunNode_CustomIDInPath(t *testing.T) {
+	child := newStubNode("processor", nil)
+	sub := newDynamicSubScheduler(newTopLevelCtx(t), "wf", noopEmit)
+
+	if _, err := sub.runNode(child, nil, "order-42"); err != nil {
+		t.Fatalf("runNode: %v", err)
+	}
+	// The child must have observed its NodeContext populated with the
+	// composite path; verify via the stub's captured context.
+	if got, want := child.lastPath, "wf/processor@order-42"; got != want {
+		t.Errorf("child Path() = %q, want %q", got, want)
+	}
+}
+
+func TestSubScheduler_RunNode_HITLReturnsInterrupted(t *testing.T) {
+	child := newRequestInputNode("asker", "approve?")
+	var forwarded []*session.Event
+	sub := newDynamicSubScheduler(newTopLevelCtx(t), "wf", func(ev *session.Event) error {
+		forwarded = append(forwarded, ev)
+		return nil
+	})
+
+	_, err := sub.runNode(child, nil, "")
+	if !errors.Is(err, ErrNodeInterrupted) {
+		t.Fatalf("err = %v, want ErrNodeInterrupted", err)
+	}
+	var nre *NodeRunError
+	if !errors.As(err, &nre) {
+		t.Fatalf("err is not *NodeRunError: %v", err)
+	}
+	if nre.ChildPath != "wf/asker@1" {
+		t.Errorf("ChildPath = %q, want %q", nre.ChildPath, "wf/asker@1")
+	}
+	if len(forwarded) != 1 || forwarded[0].RequestedInput == nil {
+		t.Errorf("forwarded events = %+v, want 1 RequestedInput event", forwarded)
+	}
+}
+
+func TestSubScheduler_RunNode_ErrorWinsOverInterrupt(t *testing.T) {
+	child := newInterruptThenFailNode("flaky")
+	sub := newDynamicSubScheduler(newTopLevelCtx(t), "wf", noopEmit)
+
+	_, err := sub.runNode(child, nil, "")
+	if !errors.Is(err, ErrNodeFailed) {
+		t.Errorf("err = %v, want ErrNodeFailed", err)
+	}
+	if errors.Is(err, ErrNodeInterrupted) {
+		t.Errorf("err = %v; ErrNodeInterrupted must not leak when child fails after RequestInput", err)
+	}
+}
+
+// =============================================================================
+// Test fixtures and helpers
+// =============================================================================
+
+func noopEmit(*session.Event) error { return nil }
+
+func newTopLevelCtx(t *testing.T) *nodeContext {
+	t.Helper()
+	return newNodeContext(newMockCtx(t), nil)
+}
+
+// stubNode emits one Event{Output: out} and exits.
+type stubNode struct {
+	BaseNode
+	out      any
+	lastPath string
+}
+
+func newStubNode(name string, out any) *stubNode {
+	return &stubNode{
+		BaseNode: NewBaseNode(name, "", NodeConfig{}),
+		out:      out,
+	}
+}
+
+func (n *stubNode) Run(ctx agent.InvocationContext, _ any) iter.Seq2[*session.Event, error] {
+	if nc, ok := ctx.(NodeContext); ok {
+		n.lastPath = nc.Path()
+	}
+	out := n.out
+	return func(yield func(*session.Event, error) bool) {
+		yield(&session.Event{Output: out}, nil)
+	}
+}
+
+// requestInputNode emits one RequestedInput event and exits cleanly.
+type requestInputNode struct {
+	BaseNode
+	message string
+}
+
+func newRequestInputNode(name, msg string) *requestInputNode {
+	return &requestInputNode{
+		BaseNode: NewBaseNode(name, "", NodeConfig{}),
+		message:  msg,
+	}
+}
+
+func (n *requestInputNode) Run(agent.InvocationContext, any) iter.Seq2[*session.Event, error] {
+	return func(yield func(*session.Event, error) bool) {
+		yield(&session.Event{
+			RequestedInput: &session.RequestInput{
+				InterruptID: "iid-1",
+				Message:     n.message,
+			},
+		}, nil)
+	}
+}
+
+// interruptThenFailNode yields RequestedInput, then yields an error.
+type interruptThenFailNode struct{ BaseNode }
+
+func newInterruptThenFailNode(name string) *interruptThenFailNode {
+	return &interruptThenFailNode{BaseNode: NewBaseNode(name, "", NodeConfig{})}
+}
+
+func (n *interruptThenFailNode) Run(agent.InvocationContext, any) iter.Seq2[*session.Event, error] {
+	return func(yield func(*session.Event, error) bool) {
+		if !yield(&session.Event{
+			RequestedInput: &session.RequestInput{InterruptID: "iid", Message: "ask"},
+		}, nil) {
+			return
+		}
+		yield(nil, errors.New("boom"))
+	}
+}

--- a/workflow/dynamic_scheduler_test.go
+++ b/workflow/dynamic_scheduler_test.go
@@ -115,7 +115,7 @@ func TestSubScheduler_RunNode_FreshExecution(t *testing.T) {
 		return nil
 	})
 
-	out, err := sub.runNode(child, "world", "")
+	out, err := sub.runNode(child, "world", runNodeOptions{})
 	if err != nil {
 		t.Fatalf("runNode: %v", err)
 	}
@@ -134,7 +134,7 @@ func TestSubScheduler_RunNode_CustomIDInPath(t *testing.T) {
 	child := newStubNode("processor", nil)
 	sub := newDynamicSubScheduler(newTopLevelCtx(t), "wf", noopEmit)
 
-	if _, err := sub.runNode(child, nil, "order-42"); err != nil {
+	if _, err := sub.runNode(child, nil, runNodeOptions{customRunID: "order-42"}); err != nil {
 		t.Fatalf("runNode: %v", err)
 	}
 	// The child must have observed its NodeContext populated with the
@@ -152,7 +152,7 @@ func TestSubScheduler_RunNode_HITLReturnsInterrupted(t *testing.T) {
 		return nil
 	})
 
-	_, err := sub.runNode(child, nil, "")
+	_, err := sub.runNode(child, nil, runNodeOptions{})
 	if !errors.Is(err, ErrNodeInterrupted) {
 		t.Fatalf("err = %v, want ErrNodeInterrupted", err)
 	}
@@ -172,7 +172,7 @@ func TestSubScheduler_RunNode_ErrorWinsOverInterrupt(t *testing.T) {
 	child := newInterruptThenFailNode("flaky")
 	sub := newDynamicSubScheduler(newTopLevelCtx(t), "wf", noopEmit)
 
-	_, err := sub.runNode(child, nil, "")
+	_, err := sub.runNode(child, nil, runNodeOptions{})
 	if !errors.Is(err, ErrNodeFailed) {
 		t.Errorf("err = %v, want ErrNodeFailed", err)
 	}
@@ -195,8 +195,9 @@ func newTopLevelCtx(t *testing.T) *nodeContext {
 // stubNode emits one Event{Output: out} and exits.
 type stubNode struct {
 	BaseNode
-	out      any
-	lastPath string
+	out        any
+	lastPath   string
+	lastBranch string
 }
 
 func newStubNode(name string, out any) *stubNode {
@@ -210,6 +211,7 @@ func (n *stubNode) Run(ctx agent.InvocationContext, _ any) iter.Seq2[*session.Ev
 	if nc, ok := ctx.(NodeContext); ok {
 		n.lastPath = nc.Path()
 	}
+	n.lastBranch = ctx.Branch()
 	out := n.out
 	return func(yield func(*session.Event, error) bool) {
 		yield(&session.Event{Output: out}, nil)

--- a/workflow/edgebuilder.go
+++ b/workflow/edgebuilder.go
@@ -1,0 +1,94 @@
+// Copyright 2026 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package workflow
+
+// EdgeBuilder provides a fluent API for building a list of Edges.
+type EdgeBuilder struct {
+	edges []Edge
+}
+
+// NewEdgeBuilder creates a new EdgeBuilder.
+func NewEdgeBuilder() *EdgeBuilder {
+	return &EdgeBuilder{}
+}
+
+// Add adds a new edge between two nodes.
+func (b *EdgeBuilder) Add(from, to Node) *EdgeBuilder {
+	b.edges = append(b.edges, Edge{From: from, To: to})
+	return b
+}
+
+// AddRoute adds a new edge with a route condition between two nodes.
+// The route condition is of type any and is converted to a Route interface.
+// Supported routes are StringRoute, IntRoute, BoolRoute and MultiRoute.
+func (b *EdgeBuilder) AddRoute(from, to Node, route Route) *EdgeBuilder {
+	b.edges = append(b.edges, Edge{From: from, To: to, Route: route})
+	return b
+}
+
+// AddFanOut adds multiple edges from a single source node to multiple target nodes.
+func (b *EdgeBuilder) AddFanOut(from Node, to ...Node) *EdgeBuilder {
+	for _, t := range to {
+		b.Add(from, t)
+	}
+	return b
+}
+
+// AddFanIn adds multiple edges from multiple source nodes to a single target node.
+func (b *EdgeBuilder) AddFanIn(to Node, from ...Node) *EdgeBuilder {
+	for _, f := range from {
+		b.Add(f, to)
+	}
+	return b
+}
+
+// AddRoutes adds multiple edges from a single source node to multiple target nodes with different route conditions.
+func (b *EdgeBuilder) AddRoutes(from Node, routes map[string]Node) *EdgeBuilder {
+	for route, to := range routes {
+		b.AddRoute(from, to, StringRoute(route))
+	}
+	return b
+}
+
+// Build returns the list of edges.
+func (b *EdgeBuilder) Build() []Edge {
+	return b.edges
+}
+
+// Chain generates a slice of Edges to form a chain of nodes.
+func Chain(nodes ...Node) []Edge {
+	if len(nodes) < 2 {
+		return nil
+	}
+	edges := make([]Edge, len(nodes)-1)
+	for i := 0; i < len(nodes)-1; i++ {
+		edges[i] = Edge{From: nodes[i], To: nodes[i+1]}
+	}
+	return edges
+}
+
+// Concat combines Edges and []Edge slices into a single slice of edges.
+func Concat(items ...any) []Edge {
+	var edges []Edge
+	for _, item := range items {
+		switch v := item.(type) {
+		case Edge:
+			edges = append(edges, v)
+		case []Edge:
+			edges = append(edges, v...)
+		}
+	}
+	return edges
+}

--- a/workflow/edgebuilder_test.go
+++ b/workflow/edgebuilder_test.go
@@ -1,0 +1,125 @@
+// Copyright 2026 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package workflow
+
+import (
+	"iter"
+	"reflect"
+	"testing"
+
+	"google.golang.org/adk/agent"
+	"google.golang.org/adk/session"
+)
+
+func TestEdgeBuilder(t *testing.T) {
+	nodeA := &dummyNode{name: "A"}
+	nodeB := &dummyNode{name: "B"}
+	nodeC := &dummyNode{name: "C"}
+
+	tests := []struct {
+		name     string
+		build    func(*EdgeBuilder) *EdgeBuilder
+		expected []Edge
+	}{
+		{
+			name: "Add",
+			build: func(b *EdgeBuilder) *EdgeBuilder {
+				return b.Add(nodeA, nodeB)
+			},
+			expected: []Edge{{From: nodeA, To: nodeB}},
+		},
+		{
+			name: "AddRoute",
+			build: func(b *EdgeBuilder) *EdgeBuilder {
+				return b.AddRoute(nodeA, nodeB, StringRoute("test-route"))
+			},
+			expected: []Edge{{From: nodeA, To: nodeB, Route: StringRoute("test-route")}},
+		},
+		{
+			name: "AddRoute MultiRoute",
+			build: func(b *EdgeBuilder) *EdgeBuilder {
+				return b.AddRoute(nodeA, nodeB, MultiRoute[int]{1, 2, 3})
+			},
+			expected: []Edge{{From: nodeA, To: nodeB, Route: MultiRoute[int]{1, 2, 3}}},
+		},
+		{
+			name: "AddFanOut",
+			build: func(b *EdgeBuilder) *EdgeBuilder {
+				return b.AddFanOut(nodeA, nodeB, nodeC)
+			},
+			expected: []Edge{
+				{From: nodeA, To: nodeB},
+				{From: nodeA, To: nodeC},
+			},
+		},
+		{
+			name: "AddFanIn",
+			build: func(b *EdgeBuilder) *EdgeBuilder {
+				return b.AddFanIn(nodeA, nodeB, nodeC)
+			},
+			expected: []Edge{
+				{From: nodeB, To: nodeA},
+				{From: nodeC, To: nodeA},
+			},
+		},
+		{
+			name: "AddRoutes",
+			build: func(b *EdgeBuilder) *EdgeBuilder {
+				return b.AddRoutes(nodeA, map[string]Node{
+					"42":         nodeB,
+					"workflow_C": nodeC,
+				})
+			},
+			expected: []Edge{
+				{From: nodeA, To: nodeB, Route: StringRoute("42")},
+				{From: nodeA, To: nodeC, Route: StringRoute("workflow_C")},
+			},
+		},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			edges := tc.build(NewEdgeBuilder()).Build()
+
+			if len(edges) != len(tc.expected) {
+				t.Fatalf("expected %d edges, got %d", len(tc.expected), len(edges))
+			}
+
+			for _, exp := range tc.expected {
+				found := false
+				for _, actual := range edges {
+					if actual.From == exp.From && actual.To == exp.To && reflect.DeepEqual(actual.Route, exp.Route) {
+						found = true
+						break
+					}
+				}
+				if !found {
+					t.Errorf("expected edge not found: From %s, To %s, Route %v", exp.From.Name(), exp.To.Name(), exp.Route)
+				}
+			}
+		})
+	}
+}
+
+// dummyNode is a minimal implementation of Node for testing purposes.
+type dummyNode struct {
+	name string
+}
+
+func (n *dummyNode) Name() string        { return n.name }
+func (n *dummyNode) Description() string { return "" }
+func (n *dummyNode) Run(ctx agent.InvocationContext, input any) iter.Seq2[*session.Event, error] {
+	return func(yield func(*session.Event, error) bool) {}
+}

--- a/workflow/edgebuilder_test.go
+++ b/workflow/edgebuilder_test.go
@@ -120,7 +120,7 @@ type dummyNode struct {
 
 func (n *dummyNode) Name() string        { return n.name }
 func (n *dummyNode) Description() string { return "" }
-func (n *dummyNode) Config() NodeConfig     { return NodeConfig{} }
+func (n *dummyNode) Config() NodeConfig  { return NodeConfig{} }
 func (n *dummyNode) Run(ctx agent.InvocationContext, input any) iter.Seq2[*session.Event, error] {
 	return func(yield func(*session.Event, error) bool) {}
 }

--- a/workflow/edgebuilder_test.go
+++ b/workflow/edgebuilder_test.go
@@ -120,6 +120,7 @@ type dummyNode struct {
 
 func (n *dummyNode) Name() string        { return n.name }
 func (n *dummyNode) Description() string { return "" }
+func (n *dummyNode) Config() NodeConfig     { return NodeConfig{} }
 func (n *dummyNode) Run(ctx agent.InvocationContext, input any) iter.Seq2[*session.Event, error] {
 	return func(yield func(*session.Event, error) bool) {}
 }

--- a/workflow/edgebuilder_test.go
+++ b/workflow/edgebuilder_test.go
@@ -127,6 +127,9 @@ func (n *dummyNode) OutputSchema() *jsonschema.Resolved { return nil }
 func (n *dummyNode) ValidateInput(input any) (any, error) {
 	return input, nil
 }
+func (n *dummyNode) ValidateOutput(output any) (any, error) {
+	return output, nil
+}
 func (n *dummyNode) Run(ctx agent.InvocationContext, input any) iter.Seq2[*session.Event, error] {
 	return func(yield func(*session.Event, error) bool) {}
 }

--- a/workflow/edgebuilder_test.go
+++ b/workflow/edgebuilder_test.go
@@ -19,6 +19,7 @@ import (
 	"reflect"
 	"testing"
 
+	"github.com/google/jsonschema-go/jsonschema"
 	"google.golang.org/adk/agent"
 	"google.golang.org/adk/session"
 )
@@ -118,9 +119,14 @@ type dummyNode struct {
 	name string
 }
 
-func (n *dummyNode) Name() string        { return n.name }
-func (n *dummyNode) Description() string { return "" }
-func (n *dummyNode) Config() NodeConfig  { return NodeConfig{} }
+func (n *dummyNode) Name() string                       { return n.name }
+func (n *dummyNode) Description() string                { return "" }
+func (n *dummyNode) Config() NodeConfig                 { return NodeConfig{} }
+func (n *dummyNode) InputSchema() *jsonschema.Resolved  { return nil }
+func (n *dummyNode) OutputSchema() *jsonschema.Resolved { return nil }
+func (n *dummyNode) ValidateInput(input any) (any, error) {
+	return input, nil
+}
 func (n *dummyNode) Run(ctx agent.InvocationContext, input any) iter.Seq2[*session.Event, error] {
 	return func(yield func(*session.Event, error) bool) {}
 }

--- a/workflow/errors.go
+++ b/workflow/errors.go
@@ -1,0 +1,76 @@
+// Copyright 2026 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package workflow
+
+import (
+	"errors"
+	"fmt"
+)
+
+var (
+	// ErrNodeFailed wraps a child node's runtime failure after retries.
+	ErrNodeFailed = errors.New("workflow: dynamic child failed")
+
+	// ErrNodeInterrupted wraps a child node's HITL pause request.
+	ErrNodeInterrupted = errors.New("workflow: dynamic child interrupted")
+
+	// ErrInvalidRunNodeContext is returned by RunNode when ctx is not
+	// the NodeContext of a currently-executing dynamic node.
+	ErrInvalidRunNodeContext = errors.New("workflow: RunNode called outside a dynamic node")
+
+	// ErrInvalidRunID rejects a custom run id that would collide
+	// with the auto-counter: purely numeric ids are reserved.
+	ErrInvalidRunID = errors.New("workflow: invalid run id")
+
+	// ErrParallelHITLUnsupported rejects two children of one
+	// activation interrupting concurrently — at most one pending HITL
+	// per activation.
+	ErrParallelHITLUnsupported = errors.New("workflow: parallel HITL is not supported")
+)
+
+// NodeRunError wraps a sentinel with the failing child's identity.
+// Use errors.As to recover the fields.
+type NodeRunError struct {
+	// ChildName is the child's Node.Name(), e.g. "fixer_agent".
+	ChildName string
+	// ChildPath is the composite path, e.g. "code_workflow/fixer_agent@2".
+	ChildPath string
+	// RunID is the per-invocation identifier, auto-counter or
+	// user-supplied via WithRunID.
+	RunID string
+	Cause error
+}
+
+// Error formats as "workflow: dynamic child <path>: <cause>".
+func (e *NodeRunError) Error() string {
+	if e == nil {
+		return "<nil>"
+	}
+	path := e.ChildPath
+	if path == "" {
+		path = e.ChildName
+	}
+	if e.Cause == nil {
+		return fmt.Sprintf("workflow: dynamic child %s: <nil cause>", path)
+	}
+	return fmt.Sprintf("workflow: dynamic child %s: %v", path, e.Cause)
+}
+
+func (e *NodeRunError) Unwrap() error {
+	if e == nil {
+		return nil
+	}
+	return e.Cause
+}

--- a/workflow/errors_test.go
+++ b/workflow/errors_test.go
@@ -1,0 +1,86 @@
+// Copyright 2026 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package workflow
+
+import (
+	"strings"
+	"testing"
+)
+
+func TestSentinels_HaveWorkflowPrefix(t *testing.T) {
+	sentinels := map[string]error{
+		"ErrNodeFailed":              ErrNodeFailed,
+		"ErrNodeInterrupted":         ErrNodeInterrupted,
+		"ErrInvalidRunNodeContext":   ErrInvalidRunNodeContext,
+		"ErrInvalidRunID":            ErrInvalidRunID,
+		"ErrParallelHITLUnsupported": ErrParallelHITLUnsupported,
+	}
+	for name, err := range sentinels {
+		t.Run(name, func(t *testing.T) {
+			if !strings.HasPrefix(err.Error(), "workflow:") {
+				t.Errorf("%s.Error() = %q; want prefix \"workflow:\"", name, err.Error())
+			}
+		})
+	}
+}
+
+func TestNodeRunError_Unwrap(t *testing.T) {
+	t.Run("returns Cause", func(t *testing.T) {
+		nre := &NodeRunError{Cause: ErrNodeFailed}
+		if got := nre.Unwrap(); got != ErrNodeFailed {
+			t.Errorf("Unwrap() = %v, want %v", got, ErrNodeFailed)
+		}
+	})
+	t.Run("nil receiver returns nil", func(t *testing.T) {
+		var nre *NodeRunError
+		if got := nre.Unwrap(); got != nil {
+			t.Errorf("(*NodeRunError)(nil).Unwrap() = %v, want nil", got)
+		}
+	})
+}
+
+func TestNodeRunError_Error(t *testing.T) {
+	t.Run("includes ChildPath and cause", func(t *testing.T) {
+		nre := &NodeRunError{ChildPath: "code_workflow/fixer@2", Cause: ErrNodeFailed}
+		s := nre.Error()
+		if !strings.Contains(s, "code_workflow/fixer@2") {
+			t.Errorf("Error() = %q, want to contain ChildPath", s)
+		}
+		if !strings.Contains(s, ErrNodeFailed.Error()) {
+			t.Errorf("Error() = %q, want to contain cause message", s)
+		}
+	})
+
+	t.Run("falls back to ChildName when ChildPath empty", func(t *testing.T) {
+		nre := &NodeRunError{ChildName: "fixer", Cause: ErrNodeInterrupted}
+		s := nre.Error()
+		if !strings.Contains(s, "fixer") {
+			t.Errorf("Error() = %q, want to contain ChildName when ChildPath unset", s)
+		}
+	})
+
+	t.Run("nil cause does not panic", func(t *testing.T) {
+		nre := &NodeRunError{ChildPath: "x/y@1"}
+		_ = nre.Error()
+	})
+
+	t.Run("nil receiver does not panic", func(t *testing.T) {
+		var nre *NodeRunError
+		_ = nre.Error()
+	})
+}
+
+// Compile-time: *NodeRunError implements error.
+var _ error = (*NodeRunError)(nil)

--- a/workflow/function_node.go
+++ b/workflow/function_node.go
@@ -1,0 +1,121 @@
+// Copyright 2026 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package workflow
+
+import (
+	"fmt"
+	"iter"
+
+	"github.com/google/jsonschema-go/jsonschema"
+	"google.golang.org/genai"
+
+	"google.golang.org/adk/agent"
+	"google.golang.org/adk/internal/typeutil"
+	"google.golang.org/adk/session"
+)
+
+// FunctionNode wraps a custom function.
+type FunctionNode struct {
+	BaseNode
+	fn func(ctx agent.InvocationContext, input any) (any, error)
+}
+
+// NewFunctionNode creates a new node wrapping a custom function using generics to automatically infer input and output types.
+func NewFunctionNode[IN, OUT any](name string, fn func(ctx agent.InvocationContext, input IN) (OUT, error), cfg NodeConfig) *FunctionNode {
+	return newFunctionNodeWithResolvedSchemas[IN, OUT](name, fn, nil, nil, cfg)
+}
+
+// NewFunctionNodeWithSchema creates a new node wrapping a custom function using generics to automatically infer input and output types.
+func NewFunctionNodeWithSchema[IN, OUT any](name string, fn func(ctx agent.InvocationContext, input IN) (OUT, error), inputSchema, outputSchema *jsonschema.Schema, cfg NodeConfig) (*FunctionNode, error) {
+	var ischema *jsonschema.Resolved
+	var err error
+	if inputSchema != nil {
+		ischema, err = inputSchema.Resolve(nil)
+		if err != nil {
+			return nil, fmt.Errorf("resolving input schema: %w", err)
+		}
+	}
+
+	var oschema *jsonschema.Resolved
+	if outputSchema != nil {
+		oschema, err = outputSchema.Resolve(nil)
+		if err != nil {
+			return nil, fmt.Errorf("resolving output schema: %w", err)
+		}
+	}
+
+	return newFunctionNodeWithResolvedSchemas[IN, OUT](name, fn, ischema, oschema, cfg), nil
+}
+
+// newFunctionNodeWithResolvedSchemas is an internal constructor that consumes already resolved schemas.
+func newFunctionNodeWithResolvedSchemas[IN, OUT any](name string, fn func(ctx agent.InvocationContext, input IN) (OUT, error), inputSchema, outputSchema *jsonschema.Resolved, cfg NodeConfig) *FunctionNode {
+	wrappedFn := func(ctx agent.InvocationContext, input any) (any, error) {
+		var output OUT
+		var err error
+		if input == nil {
+			var zero IN
+			output, err = fn(ctx, zero)
+		} else {
+			typedInput, ok := input.(IN)
+			if !ok {
+				// Fallback to the json-like input types that cannot be converted by the standard type assertion.
+				// E.g. tool nodes return map[string]any as input and user may define a struct as the target type.
+				typedInput, err = typeutil.ConvertToWithJSONSchema[any, IN](input, inputSchema)
+				if err != nil {
+					return nil, fmt.Errorf("new function node: invalid input type, expected %T: %w", new(IN), err)
+				}
+			}
+			output, err = fn(ctx, typedInput)
+		}
+
+		if err != nil {
+			return output, err
+		}
+
+		if outputSchema != nil {
+			validateErr := outputSchema.Validate(output)
+			if validateErr != nil {
+				return nil, fmt.Errorf("function node %s: validation failed for output %T: %w", name, new(OUT), validateErr)
+			}
+		}
+
+		return output, nil
+	}
+
+	return &FunctionNode{
+		BaseNode: BaseNode{name: name, config: cfg},
+		fn:       wrappedFn,
+	}
+}
+
+// Run executes the function node with the given input and returns an iterator over events.
+func (n *FunctionNode) Run(ctx agent.InvocationContext, input any) iter.Seq2[*session.Event, error] {
+	return func(yield func(*session.Event, error) bool) {
+		output, err := n.fn(ctx, input)
+		if err != nil {
+			yield(nil, err)
+			return
+		}
+
+		event := session.NewEvent(ctx.InvocationID())
+		event.Actions.StateDelta["output"] = output
+		if s, ok := output.(string); ok {
+			event.Content = &genai.Content{
+				Parts: []*genai.Part{{Text: s}},
+			}
+		}
+		yield(event, nil)
+	}
+}

--- a/workflow/function_node.go
+++ b/workflow/function_node.go
@@ -29,7 +29,7 @@ import (
 // FunctionNode wraps a custom function.
 type FunctionNode struct {
 	BaseNode
-	fn func(ctx agent.InvocationContext, input any) (any, error)
+	fn           func(ctx agent.InvocationContext, input any) (any, error)
 }
 
 // NewFunctionNode creates a new node wrapping a custom function using generics to automatically infer input and output types.
@@ -95,8 +95,8 @@ func newFunctionNodeWithResolvedSchemas[IN, OUT any](name string, fn func(ctx ag
 	}
 
 	return &FunctionNode{
-		BaseNode: BaseNode{name: name, config: cfg},
-		fn:       wrappedFn,
+		BaseNode:     BaseNode{name: name, config: cfg},
+		fn:           wrappedFn,
 	}
 }
 

--- a/workflow/function_node.go
+++ b/workflow/function_node.go
@@ -95,7 +95,7 @@ func newFunctionNodeWithResolvedSchemas[IN, OUT any](name string, fn func(ctx ag
 	}
 
 	return &FunctionNode{
-		BaseNode:     BaseNode{name: name, config: cfg},
+		BaseNode:     NewBaseNodeWithSchemas(name, "", cfg, inputSchema, outputSchema),
 		fn:           wrappedFn,
 	}
 }

--- a/workflow/function_node.go
+++ b/workflow/function_node.go
@@ -111,7 +111,6 @@ func (n *FunctionNode) Run(ctx agent.InvocationContext, input any) iter.Seq2[*se
 
 		event := session.NewEvent(ctx.InvocationID())
 		event.Output = output
-		event.Actions.StateDelta["output"] = output
 		if s, ok := output.(string); ok {
 			event.Content = &genai.Content{
 				Parts: []*genai.Part{{Text: s}},

--- a/workflow/function_node.go
+++ b/workflow/function_node.go
@@ -110,6 +110,7 @@ func (n *FunctionNode) Run(ctx agent.InvocationContext, input any) iter.Seq2[*se
 		}
 
 		event := session.NewEvent(ctx.InvocationID())
+		event.Output = output
 		event.Actions.StateDelta["output"] = output
 		if s, ok := output.(string); ok {
 			event.Content = &genai.Content{

--- a/workflow/function_node_test.go
+++ b/workflow/function_node_test.go
@@ -1,0 +1,140 @@
+// Copyright 2026 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package workflow
+
+import (
+	"strings"
+	"testing"
+
+	"github.com/google/go-cmp/cmp"
+	"github.com/google/jsonschema-go/jsonschema"
+
+	"google.golang.org/adk/agent"
+)
+
+func TestNewFunctionNodeWithSchema(t *testing.T) {
+	type Input struct {
+		Value string `json:"value"`
+	}
+	type Output struct {
+		Result string `json:"result"`
+	}
+	type TargetOutput struct {
+		Result int `json:"result"`
+	}
+
+	tests := []struct {
+		name         string
+		nodeName     string
+		fn           func(ctx agent.InvocationContext, input Input) (map[string]any, error)
+		inputSchema  *jsonschema.Schema
+		outputSchema *jsonschema.Schema
+		input        any
+		wantOutput   map[string]any
+		wantErr      bool
+		errSubstr    string
+	}{
+		{
+			name:     "Success",
+			nodeName: "upper",
+			fn: func(ctx agent.InvocationContext, input Input) (map[string]any, error) {
+				return map[string]any{"result": strings.ToUpper(input.Value)}, nil
+			},
+			inputSchema:  mustSchema[Input](t),
+			outputSchema: mustSchema[Output](t),
+			input:        Input{Value: "hello"},
+			wantOutput:   map[string]any{"result": "HELLO"},
+			wantErr:      false,
+		},
+		{
+			name:     "NilInput",
+			nodeName: "nil_test",
+			fn: func(ctx agent.InvocationContext, input Input) (map[string]any, error) {
+				if input.Value == "" {
+					return map[string]any{"result": "zero"}, nil
+				}
+				return map[string]any{"result": "not-zero"}, nil
+			},
+			inputSchema:  mustSchema[Input](t),
+			outputSchema: mustSchema[Output](t),
+			input:        nil,
+			wantOutput:   map[string]any{"result": "zero"},
+			wantErr:      false,
+		},
+		{
+			name:     "ValidationError",
+			nodeName: "test",
+			fn: func(ctx agent.InvocationContext, input Input) (map[string]any, error) {
+				return map[string]any{"result": "not-an-int"}, nil
+			},
+			inputSchema:  mustSchema[Input](t),
+			outputSchema: mustSchema[TargetOutput](t),
+			input:        Input{Value: "hello"},
+			wantErr:      true,
+			errSubstr:    "validation failed for output",
+		},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			node, err := NewFunctionNodeWithSchema[Input, map[string]any](tc.nodeName, tc.fn, tc.inputSchema, tc.outputSchema, defaultNodeConfig)
+			if err != nil {
+				t.Fatalf("NewFunctionNodeWithSchema failed: %v", err)
+			}
+
+			mockCtx := &MockInvocationContext{sess: nil}
+			events := node.Run(mockCtx, tc.input)
+
+			count := 0
+			for ev, err := range events {
+				if err != nil {
+					if !tc.wantErr {
+						t.Fatalf("unexpected error: %v", err)
+					}
+					if tc.errSubstr != "" && !strings.Contains(err.Error(), tc.errSubstr) {
+						t.Errorf("expected error containing %q, got %v", tc.errSubstr, err)
+					}
+					return // Expected error handled
+				}
+				count++
+				if tc.wantErr {
+					t.Fatal("expected error, got nil")
+				}
+
+				output, ok := ev.Actions.StateDelta["output"]
+				if !ok {
+					t.Fatal("expected output in state delta")
+				}
+
+				if diff := cmp.Diff(tc.wantOutput, output); diff != "" {
+					t.Errorf("output mismatch (-want +got):\n%s", diff)
+				}
+			}
+
+			if !tc.wantErr && count != 1 {
+				t.Errorf("expected 1 event, got %d", count)
+			}
+		})
+	}
+}
+
+func mustSchema[T any](t *testing.T) *jsonschema.Schema {
+	t.Helper()
+	s, err := jsonschema.For[T](nil)
+	if err != nil {
+		t.Fatalf("jsonschema.For failed: %v", err)
+	}
+	return s
+}

--- a/workflow/function_node_test.go
+++ b/workflow/function_node_test.go
@@ -113,16 +113,7 @@ func TestNewFunctionNodeWithSchema(t *testing.T) {
 					t.Fatal("expected error, got nil")
 				}
 
-				output, ok := ev.Actions.StateDelta["output"]
-				if !ok {
-					t.Fatal("expected output in state delta")
-				}
-
-				if diff := cmp.Diff(output, ev.Output); diff != "" {
-					t.Errorf("ev.Output mismatch (-stateDelta +Output):\n%s", diff)
-				}
-
-				if diff := cmp.Diff(tc.wantOutput, output); diff != "" {
+				if diff := cmp.Diff(tc.wantOutput, ev.Output); diff != "" {
 					t.Errorf("output mismatch (-want +got):\n%s", diff)
 				}
 			}

--- a/workflow/function_node_test.go
+++ b/workflow/function_node_test.go
@@ -118,6 +118,10 @@ func TestNewFunctionNodeWithSchema(t *testing.T) {
 					t.Fatal("expected output in state delta")
 				}
 
+				if diff := cmp.Diff(output, ev.Output); diff != "" {
+					t.Errorf("ev.Output mismatch (-stateDelta +Output):\n%s", diff)
+				}
+
 				if diff := cmp.Diff(tc.wantOutput, output); diff != "" {
 					t.Errorf("output mismatch (-want +got):\n%s", diff)
 				}

--- a/workflow/graph.go
+++ b/workflow/graph.go
@@ -1,0 +1,43 @@
+// Copyright 2026 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package workflow
+
+// graph is the precomputed structural view of a workflow's edges.
+// Built once at workflow construction; queried by the engine at
+// dispatch time.
+type graph struct {
+	successors map[Node][]Edge
+}
+
+// newGraph indexes edges by source node so successor lookups are
+// O(1) at dispatch time. The returned graph references the input
+// edges by value; mutating the input edge slice afterwards does not
+// affect the graph.
+func newGraph(edges []Edge) *graph {
+	succ := make(map[Node][]Edge)
+	for _, edge := range edges {
+		succ[edge.From] = append(succ[edge.From], edge)
+	}
+	return &graph{successors: succ}
+}
+
+// successorsOf returns the outgoing edges for a node.
+// Returns nil if n has no outgoing edges
+// (including the case where n is not in the graph at all). The
+// returned slice is owned by the graph and must not be mutated by
+// callers.
+func (g *graph) successorsOf(n Node) []Edge {
+	return g.successors[n]
+}

--- a/workflow/graph.go
+++ b/workflow/graph.go
@@ -18,19 +18,22 @@ package workflow
 // Built once at workflow construction; queried by the engine at
 // dispatch time.
 type graph struct {
-	successors map[Node][]Edge
+	successors   map[Node][]Edge
+	predecessors map[Node][]Edge
 }
 
-// newGraph indexes edges by source node so successor lookups are
-// O(1) at dispatch time. The returned graph references the input
-// edges by value; mutating the input edge slice afterwards does not
-// affect the graph.
+// newGraph indexes edges by source and target node so successor
+// and predecessor lookups are both O(1) at dispatch time. The
+// returned graph references the input edges by value; mutating the
+// input edge slice afterwards does not affect the graph.
 func newGraph(edges []Edge) *graph {
 	succ := make(map[Node][]Edge)
+	pred := make(map[Node][]Edge)
 	for _, edge := range edges {
 		succ[edge.From] = append(succ[edge.From], edge)
+		pred[edge.To] = append(pred[edge.To], edge)
 	}
-	return &graph{successors: succ}
+	return &graph{successors: succ, predecessors: pred}
 }
 
 // successorsOf returns the outgoing edges for a node.
@@ -40,4 +43,12 @@ func newGraph(edges []Edge) *graph {
 // callers.
 func (g *graph) successorsOf(n Node) []Edge {
 	return g.successors[n]
+}
+
+// predecessorsOf returns the incoming edges for a node. Returns
+// nil if n has no incoming edges (including the case where n is
+// not in the graph at all). The returned slice is owned by the
+// graph and must not be mutated by callers.
+func (g *graph) predecessorsOf(n Node) []Edge {
+	return g.predecessors[n]
 }

--- a/workflow/graph_test.go
+++ b/workflow/graph_test.go
@@ -1,0 +1,181 @@
+// Copyright 2026 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package workflow
+
+import (
+	"iter"
+	"testing"
+
+	"github.com/google/go-cmp/cmp"
+	"google.golang.org/adk/agent"
+	"google.golang.org/adk/session"
+)
+
+// edgeIDs renders edges as "From→To" strings using node names.
+func edgeIDs(es []Edge) []string {
+	if len(es) == 0 {
+		return nil
+	}
+	out := make([]string, len(es))
+	for i, e := range es {
+		out[i] = e.From.Name() + "→" + e.To.Name()
+	}
+	return out
+}
+
+func TestNewGraph_SuccessorsOf(t *testing.T) {
+	a := newTestNode("A")
+	b := newTestNode("B")
+	c := newTestNode("C")
+
+	tests := []struct {
+		name  string
+		edges []Edge
+		// want maps a node name to the expected outgoing-edge IDs
+		// ("From→To" strings). Nodes absent from want are expected
+		// to have no successors.
+		want map[string][]string
+	}{
+		{
+			name:  "empty graph",
+			edges: nil,
+			want:  map[string][]string{},
+		},
+		{
+			name:  "single edge",
+			edges: []Edge{{From: Start, To: a}},
+			want: map[string][]string{
+				"START": {"START→A"},
+			},
+		},
+		{
+			name: "linear chain",
+			edges: []Edge{
+				{From: Start, To: a},
+				{From: a, To: b},
+				{From: b, To: c},
+			},
+			want: map[string][]string{
+				"START": {"START→A"},
+				"A":     {"A→B"},
+				"B":     {"B→C"},
+			},
+		},
+		{
+			name: "fan-out from Start to three nodes",
+			edges: []Edge{
+				{From: Start, To: a},
+				{From: Start, To: b},
+				{From: Start, To: c},
+			},
+			want: map[string][]string{
+				"START": {"START→A", "START→B", "START→C"},
+			},
+		},
+		{
+			name: "fan-in: two upstreams converge on c",
+			edges: []Edge{
+				{From: Start, To: a},
+				{From: Start, To: b},
+				{From: a, To: c},
+				{From: b, To: c},
+			},
+			want: map[string][]string{
+				"START": {"START→A", "START→B"},
+				"A":     {"A→C"},
+				"B":     {"B→C"},
+			},
+		},
+		{
+			name: "cycle a → b → a",
+			edges: []Edge{
+				{From: a, To: b},
+				{From: b, To: a},
+			},
+			want: map[string][]string{
+				"A": {"A→B"},
+				"B": {"B→A"},
+			},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			g := newGraph(tt.edges)
+			for _, n := range []Node{Start, a, b, c} {
+				want := tt.want[n.Name()]
+				got := edgeIDs(g.successorsOf(n))
+				if diff := cmp.Diff(want, got); diff != "" {
+					t.Errorf("successorsOf(%q) mismatch (-want +got):\n%s", n.Name(), diff)
+				}
+			}
+		})
+	}
+}
+
+func TestNewGraph_SuccessorsOf_NodeNotInGraph(t *testing.T) {
+	a := newTestNode("A")
+	b := newTestNode("B")
+	stranger := newTestNode("stranger")
+
+	g := newGraph([]Edge{{From: a, To: b}})
+
+	if got := g.successorsOf(stranger); got != nil {
+		t.Errorf("successorsOf(stranger) = %v, want nil", got)
+	}
+	// Terminal-detection callsite pattern: a node with no outgoing
+	// edges (here: b) should also report nil/empty so the engine can
+	// stop dispatching successors.
+	if got := g.successorsOf(b); len(got) != 0 {
+		t.Errorf("successorsOf(b) = %v, want empty (b is terminal)", got)
+	}
+}
+
+func TestNewGraph_PreservesEdgeOrder(t *testing.T) {
+	// Within a single From node, successorsOf returns edges in input
+	// order.
+	a := newTestNode("A")
+	b := newTestNode("B")
+	c := newTestNode("C")
+	d := newTestNode("D")
+
+	edges := []Edge{
+		{From: a, To: c},
+		{From: a, To: d},
+		{From: a, To: b},
+	}
+	g := newGraph(edges)
+
+	got := edgeIDs(g.successorsOf(a))
+	want := []string{"A→C", "A→D", "A→B"}
+	if diff := cmp.Diff(want, got); diff != "" {
+		t.Errorf("successorsOf(a) mismatch (-want +got):\n%s", diff)
+	}
+}
+
+// newTestNode returns a minimal Node implementation suitable for
+// graph-structure tests. Run is a no-op; only Name matters for
+// diagnostic output.
+func newTestNode(name string) Node {
+	return &testNode{BaseNode: NewBaseNode(name, "", NodeConfig{})}
+}
+
+type testNode struct {
+	BaseNode
+}
+
+func (n *testNode) Run(_ agent.InvocationContext, _ any) iter.Seq2[*session.Event, error] {
+	return func(yield func(*session.Event, error) bool) {}
+}

--- a/workflow/graph_test.go
+++ b/workflow/graph_test.go
@@ -19,6 +19,7 @@ import (
 	"testing"
 
 	"github.com/google/go-cmp/cmp"
+
 	"google.golang.org/adk/agent"
 	"google.golang.org/adk/session"
 )

--- a/workflow/graph_test.go
+++ b/workflow/graph_test.go
@@ -19,7 +19,6 @@ import (
 	"testing"
 
 	"github.com/google/go-cmp/cmp"
-
 	"google.golang.org/adk/agent"
 	"google.golang.org/adk/session"
 )

--- a/workflow/hitl_test.go
+++ b/workflow/hitl_test.go
@@ -1,0 +1,247 @@
+// Copyright 2026 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package workflow
+
+import (
+	"errors"
+	"iter"
+	"sync/atomic"
+	"testing"
+
+	"google.golang.org/adk/agent"
+	"google.golang.org/adk/session"
+)
+
+// hitlNode is a small custom Node used by the HITL pause tests. The
+// Run callback is supplied per test so each scenario can shape its
+// own emission pattern (single request, multiple requests, request
+// then error, etc.).
+type hitlNode struct {
+	BaseNode
+	run func(ctx agent.InvocationContext, input any, yield func(*session.Event, error) bool)
+}
+
+func newHitlNode(name string, run func(ctx agent.InvocationContext, input any, yield func(*session.Event, error) bool)) *hitlNode {
+	return &hitlNode{
+		BaseNode: NewBaseNode(name, "", defaultNodeConfig),
+		run:      run,
+	}
+}
+
+func (n *hitlNode) Run(ctx agent.InvocationContext, input any) iter.Seq2[*session.Event, error] {
+	return func(yield func(*session.Event, error) bool) {
+		n.run(ctx, input, yield)
+	}
+}
+
+// findRequestedInputEvent returns the first yielded event whose
+// RequestedInput field is non-nil, plus how many such events were
+// observed in total. Useful for asserting that the engine forwarded
+// the HITL prompt to the caller.
+func findRequestedInputEvent(events []*session.Event) (req *session.Event, count int) {
+	for _, ev := range events {
+		if ev != nil && ev.RequestedInput != nil {
+			if req == nil {
+				req = ev
+			}
+			count++
+		}
+	}
+	return req, count
+}
+
+// TestScheduler_HitlNode_PausesAndForwardsRequest verifies the
+// happy-path single-waiting-node scenario: a node yields one
+// RequestInput event and exits; the engine forwards the event
+// downstream, does not schedule the successor, and the workflow
+// terminates cleanly with the asker parked.
+func TestScheduler_HitlNode_PausesAndForwardsRequest(t *testing.T) {
+	mockCtx := newSeededMockCtx(t)
+
+	var downstreamRan atomic.Bool
+	asker := newHitlNode("asker", func(ctx agent.InvocationContext, _ any, yield func(*session.Event, error) bool) {
+		yield(NewRequestInputEvent(ctx, session.RequestInput{
+			InterruptID: "human_review",
+			Message:     "Please approve",
+			Payload:     "the draft",
+		}), nil)
+	})
+	downstream := newHitlNode("downstream", func(ctx agent.InvocationContext, _ any, yield func(*session.Event, error) bool) {
+		downstreamRan.Store(true)
+	})
+
+	w := mustNew(t, []Edge{
+		{From: Start, To: asker},
+		{From: asker, To: downstream},
+	})
+
+	events := drain(t, w.Run(mockCtx))
+
+	if downstreamRan.Load() {
+		t.Error("downstream node ran; HITL pause must suppress successor scheduling")
+	}
+
+	req, count := findRequestedInputEvent(events)
+	if count != 1 {
+		t.Fatalf("expected exactly 1 event with RequestedInput, got %d (events=%d total)", count, len(events))
+	}
+	if got, want := req.RequestedInput.InterruptID, "human_review"; got != want {
+		t.Errorf("InterruptID = %q, want %q", got, want)
+	}
+	if got, want := req.RequestedInput.Message, "Please approve"; got != want {
+		t.Errorf("Message = %q, want %q", got, want)
+	}
+	if got, want := req.RequestedInput.Payload, "the draft"; got != want {
+		t.Errorf("Payload = %v, want %q", got, want)
+	}
+}
+
+// TestScheduler_HitlNode_AutoGeneratesInterruptID verifies the
+// scheduler-side contract that an empty InterruptID supplied by the
+// node author becomes a non-empty UUID by the time the request
+// reaches the consumer.
+func TestScheduler_HitlNode_AutoGeneratesInterruptID(t *testing.T) {
+	mockCtx := newSeededMockCtx(t)
+
+	asker := newHitlNode("asker", func(ctx agent.InvocationContext, _ any, yield func(*session.Event, error) bool) {
+		// InterruptID intentionally left empty.
+		yield(NewRequestInputEvent(ctx, session.RequestInput{
+			Message: "approve?",
+		}), nil)
+	})
+	w := mustNew(t, []Edge{{From: Start, To: asker}})
+
+	events := drain(t, w.Run(mockCtx))
+	req, count := findRequestedInputEvent(events)
+	if count != 1 {
+		t.Fatalf("expected exactly 1 RequestedInput event, got %d", count)
+	}
+	if req.RequestedInput.InterruptID == "" {
+		t.Error("InterruptID is empty; engine must auto-generate when caller omits it")
+	}
+}
+
+// TestScheduler_HitlNode_PreservesExplicitInterruptID verifies
+// that an explicit InterruptID supplied by the node author flows
+// through to the consumer unchanged.
+func TestScheduler_HitlNode_PreservesExplicitInterruptID(t *testing.T) {
+	mockCtx := newSeededMockCtx(t)
+
+	asker := newHitlNode("asker", func(ctx agent.InvocationContext, _ any, yield func(*session.Event, error) bool) {
+		yield(NewRequestInputEvent(ctx, session.RequestInput{
+			InterruptID: "stable-id-42",
+			Message:     "approve?",
+		}), nil)
+	})
+	w := mustNew(t, []Edge{{From: Start, To: asker}})
+
+	events := drain(t, w.Run(mockCtx))
+	req, _ := findRequestedInputEvent(events)
+	if req == nil {
+		t.Fatal("no RequestedInput event found")
+	}
+	if got, want := req.RequestedInput.InterruptID, "stable-id-42"; got != want {
+		t.Errorf("InterruptID = %q, want %q (engine must preserve caller-supplied IDs)", got, want)
+	}
+}
+
+// TestScheduler_HitlNode_MultipleRequestsFails verifies the
+// single-request-per-activation invariant: a node yielding two
+// RequestedInput events surfaces ErrMultipleInputRequests at
+// completion and is treated as failed, so it does not silently
+// park in NodeWaiting.
+func TestScheduler_HitlNode_MultipleRequestsFails(t *testing.T) {
+	mockCtx := newSeededMockCtx(t)
+
+	asker := newHitlNode("asker", func(ctx agent.InvocationContext, _ any, yield func(*session.Event, error) bool) {
+		yield(NewRequestInputEvent(ctx, session.RequestInput{InterruptID: "first"}), nil)
+		yield(NewRequestInputEvent(ctx, session.RequestInput{InterruptID: "second"}), nil)
+	})
+
+	w := mustNew(t, []Edge{{From: Start, To: asker}})
+
+	gotErr := drainErr(t, w.Run(mockCtx))
+	if !errors.Is(gotErr, ErrMultipleInputRequests) {
+		t.Errorf("Run error = %v, want ErrMultipleInputRequests (node must fail, not park)", gotErr)
+	}
+}
+
+// TestScheduler_HitlNode_ErrorAfterRequestFails verifies the
+// precedence ordering inside handleCompletion: a node that
+// recorded a request and then returned an error surfaces as
+// failed, not as waiting. The waiting branch runs only on a
+// clean activation.
+func TestScheduler_HitlNode_ErrorAfterRequestFails(t *testing.T) {
+	mockCtx := newSeededMockCtx(t)
+
+	wantErr := errors.New("downstream of request")
+	asker := newHitlNode("asker", func(ctx agent.InvocationContext, _ any, yield func(*session.Event, error) bool) {
+		yield(NewRequestInputEvent(ctx, session.RequestInput{InterruptID: "ignored"}), nil)
+		yield(nil, wantErr)
+	})
+	w := mustNew(t, []Edge{{From: Start, To: asker}})
+
+	gotErr := drainErr(t, w.Run(mockCtx))
+	if !errors.Is(gotErr, wantErr) {
+		t.Errorf("Run error = %v, want %v (failure must take precedence over the recorded request)", gotErr, wantErr)
+	}
+}
+
+// TestScheduler_HitlNode_ConcurrentBranches_PausesOnlyWhenAllNonRunning
+// verifies that a workflow with two parallel branches — one that
+// requests input, one that completes normally — pauses cleanly:
+// the non-HITL branch's downstream still runs, the HITL branch's
+// downstream does not. Termination happens once the last live node
+// has either completed or moved into NodeWaiting.
+func TestScheduler_HitlNode_ConcurrentBranches_PausesOnlyWhenAllNonRunning(t *testing.T) {
+	mockCtx := newSeededMockCtx(t)
+
+	var hitlDownstreamRan atomic.Bool
+	var plainDownstreamRan atomic.Bool
+
+	hitlAsker := newHitlNode("hitl_asker", func(ctx agent.InvocationContext, _ any, yield func(*session.Event, error) bool) {
+		yield(NewRequestInputEvent(ctx, session.RequestInput{InterruptID: "ask"}), nil)
+	})
+	hitlDownstream := newHitlNode("hitl_downstream", func(ctx agent.InvocationContext, _ any, yield func(*session.Event, error) bool) {
+		hitlDownstreamRan.Store(true)
+	})
+	plainNode := newHitlNode("plain", func(ctx agent.InvocationContext, _ any, yield func(*session.Event, error) bool) {
+		ev := session.NewEvent(ctx.InvocationID())
+		ev.Actions.StateDelta["output"] = "done"
+		yield(ev, nil)
+	})
+	plainDownstream := newHitlNode("plain_downstream", func(ctx agent.InvocationContext, _ any, yield func(*session.Event, error) bool) {
+		plainDownstreamRan.Store(true)
+	})
+
+	w := mustNew(t, []Edge{
+		{From: Start, To: hitlAsker},
+		{From: Start, To: plainNode},
+		{From: hitlAsker, To: hitlDownstream},
+		{From: plainNode, To: plainDownstream},
+	})
+
+	events := drain(t, w.Run(mockCtx))
+
+	if hitlDownstreamRan.Load() {
+		t.Error("hitl_downstream ran; HITL branch must not schedule successors before resume")
+	}
+	if !plainDownstreamRan.Load() {
+		t.Error("plain_downstream did not run; non-HITL branch must complete normally even while a sibling pauses")
+	}
+	if _, count := findRequestedInputEvent(events); count != 1 {
+		t.Errorf("expected exactly 1 RequestedInput event in the stream, got %d", count)
+	}
+}

--- a/workflow/hitl_test.go
+++ b/workflow/hitl_test.go
@@ -219,7 +219,7 @@ func TestScheduler_HitlNode_ConcurrentBranches_PausesOnlyWhenAllNonRunning(t *te
 	})
 	plainNode := newHitlNode("plain", func(ctx agent.InvocationContext, _ any, yield func(*session.Event, error) bool) {
 		ev := session.NewEvent(ctx.InvocationID())
-		ev.Actions.StateDelta["output"] = "done"
+		ev.Output = "done"
 		yield(ev, nil)
 	})
 	plainDownstream := newHitlNode("plain_downstream", func(ctx agent.InvocationContext, _ any, yield func(*session.Event, error) bool) {

--- a/workflow/join_node.go
+++ b/workflow/join_node.go
@@ -1,0 +1,51 @@
+// Copyright 2026 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package workflow
+
+import (
+	"iter"
+
+	"google.golang.org/adk/agent"
+	"google.golang.org/adk/session"
+)
+
+// JoinNode is a fan-in barrier. It is activated exactly once,
+// after every predecessor declared by the graph edges has
+// completed, and receives those predecessors' outputs as a single
+// map[string]any keyed by predecessor name. Its own output is
+// that map, emitted verbatim.
+//
+// All incoming edges feed the barrier; conditional routing into a
+// JoinNode is a configuration error, because the barrier waits
+// for every declared predecessor and a route-skipped predecessor
+// never fires.
+type JoinNode struct {
+	BaseNode
+}
+
+// NewJoinNode returns a JoinNode with the given name.
+func NewJoinNode(name string) *JoinNode {
+	return &JoinNode{BaseNode: NewBaseNode(name, "", NodeConfig{})}
+}
+
+// Run satisfies the Node interface. See JoinNode for the
+// aggregation contract.
+func (n *JoinNode) Run(ctx agent.InvocationContext, input any) iter.Seq2[*session.Event, error] {
+	return func(yield func(*session.Event, error) bool) {
+		event := session.NewEvent(ctx.InvocationID())
+		event.Actions.StateDelta["output"] = input
+		yield(event, nil)
+	}
+}

--- a/workflow/join_node.go
+++ b/workflow/join_node.go
@@ -45,7 +45,7 @@ func NewJoinNode(name string) *JoinNode {
 func (n *JoinNode) Run(ctx agent.InvocationContext, input any) iter.Seq2[*session.Event, error] {
 	return func(yield func(*session.Event, error) bool) {
 		event := session.NewEvent(ctx.InvocationID())
-		event.Actions.StateDelta["output"] = input
+		event.Output = input
 		yield(event, nil)
 	}
 }

--- a/workflow/join_node_test.go
+++ b/workflow/join_node_test.go
@@ -1,0 +1,234 @@
+// Copyright 2026 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package workflow
+
+import (
+	"reflect"
+	"sort"
+	"testing"
+
+	"google.golang.org/adk/agent"
+)
+
+// TestJoinNode_E2E_FanInTwoBranches verifies that with two
+// parallel predecessors the JoinNode is activated once with the
+// aggregated map; the downstream consumer observes it verbatim.
+func TestJoinNode_E2E_FanInTwoBranches(t *testing.T) {
+	mockCtx := newSeededMockCtx(t)
+
+	branchA := constNode("branchA", "A-result")
+	branchB := constNode("branchB", "B-result")
+	join := NewJoinNode("join")
+	var seen any
+	handler := inputRecorder("handler", &seen)
+
+	w := mustNew(t, []Edge{
+		{From: Start, To: branchA},
+		{From: Start, To: branchB},
+		{From: branchA, To: join},
+		{From: branchB, To: join},
+		{From: join, To: handler},
+	})
+
+	drain(t, w.Run(mockCtx))
+
+	gotMap, ok := seen.(map[string]any)
+	if !ok {
+		t.Fatalf("handler input = %T %#v, want map[string]any", seen, seen)
+	}
+	wantMap := map[string]any{
+		"branchA": "A-result",
+		"branchB": "B-result",
+	}
+	if !reflect.DeepEqual(gotMap, wantMap) {
+		t.Errorf("handler input = %#v, want %#v", gotMap, wantMap)
+	}
+}
+
+// TestJoinNode_E2E_FanInThreeBranches scales the canonical case
+// to three predecessors to verify the dispatch list does not
+// special-case the two-predecessor count.
+func TestJoinNode_E2E_FanInThreeBranches(t *testing.T) {
+	mockCtx := newSeededMockCtx(t)
+
+	a := constNode("a", "va")
+	b := constNode("b", "vb")
+	c := constNode("c", "vc")
+	join := NewJoinNode("join")
+	var seen any
+	handler := inputRecorder("handler", &seen)
+
+	w := mustNew(t, []Edge{
+		{From: Start, To: a},
+		{From: Start, To: b},
+		{From: Start, To: c},
+		{From: a, To: join},
+		{From: b, To: join},
+		{From: c, To: join},
+		{From: join, To: handler},
+	})
+
+	drain(t, w.Run(mockCtx))
+
+	m, _ := seen.(map[string]any)
+	var seenKeys []string
+	for k := range m {
+		seenKeys = append(seenKeys, k)
+	}
+	sort.Strings(seenKeys)
+	if want := []string{"a", "b", "c"}; !reflect.DeepEqual(seenKeys, want) {
+		t.Errorf("handler input keys = %v, want %v", seenKeys, want)
+	}
+}
+
+// TestJoinNode_BarrierSkipsUntilAllPredecessorsComplete pins the
+// barrier semantics directly. With branchA fast and branchB slow
+// (a fresh-channel block lifted by a separate goroutine), the
+// handler must not see partial aggregation: the join is not
+// triggered when only A has completed.
+func TestJoinNode_BarrierSkipsUntilAllPredecessorsComplete(t *testing.T) {
+	mockCtx := newSeededMockCtx(t)
+
+	bBlocker := make(chan struct{})
+	branchA := NewFunctionNode("branchA",
+		func(ctx agent.InvocationContext, _ any) (string, error) {
+			// Release B once A's function body returns. The
+			// barrier must hold until B also completes, so the
+			// handler runs exactly once with both outputs.
+			close(bBlocker)
+			return "a", nil
+		}, defaultNodeConfig)
+	branchB := NewFunctionNode("branchB",
+		func(ctx agent.InvocationContext, _ any) (string, error) {
+			<-bBlocker
+			return "b", nil
+		}, defaultNodeConfig)
+	join := NewJoinNode("join")
+
+	handlerCalls := 0
+	var handlerInput any
+	handler := NewFunctionNode("handler",
+		func(ctx agent.InvocationContext, input any) (string, error) {
+			handlerCalls++
+			handlerInput = input
+			return "ok", nil
+		}, defaultNodeConfig)
+
+	w := mustNew(t, []Edge{
+		{From: Start, To: branchA},
+		{From: Start, To: branchB},
+		{From: branchA, To: join},
+		{From: branchB, To: join},
+		{From: join, To: handler},
+	})
+
+	drain(t, w.Run(mockCtx))
+
+	if handlerCalls != 1 {
+		t.Fatalf("handler ran %d times, want exactly 1", handlerCalls)
+	}
+	got, _ := handlerInput.(map[string]any)
+	want := map[string]any{"branchA": "a", "branchB": "b"}
+	if !reflect.DeepEqual(got, want) {
+		t.Errorf("handler input = %#v, want %#v", got, want)
+	}
+}
+
+// TestJoinNode_RunIsPassthrough pins the JoinNode contract
+// independently of the engine: given an aggregated input map,
+// the node emits exactly one event whose StateDelta["output"]
+// equals the input. This is the property the orchestrator relies
+// on when treating JoinNode as a no-op aggregator.
+func TestJoinNode_RunIsPassthrough(t *testing.T) {
+	mockCtx := newSeededMockCtx(t)
+	n := NewJoinNode("join")
+
+	input := map[string]any{"a": "x", "b": 42}
+	events := drain(t, n.Run(mockCtx, input))
+
+	if len(events) != 1 {
+		t.Fatalf("expected 1 event, got %d", len(events))
+	}
+	got, ok := events[0].Actions.StateDelta["output"]
+	if !ok {
+		t.Fatalf("event has no StateDelta[output]; got %#v", events[0].Actions.StateDelta)
+	}
+	if !reflect.DeepEqual(got, input) {
+		t.Errorf("StateDelta[output] = %#v, want %#v (verbatim)", got, input)
+	}
+}
+
+// TestJoinNode_PredecessorWithNilOutput pins the aggregation
+// contract for a predecessor whose recorded Output is nil: the
+// aggregated map carries the predecessor's name with a nil value,
+// and the join activates normally — the barrier counts
+// completions, not outputs.
+func TestJoinNode_PredecessorWithNilOutput(t *testing.T) {
+	mockCtx := newSeededMockCtx(t)
+
+	branchA := constNode("branchA", "A-result")
+	branchNil := NewFunctionNode("branchNil",
+		func(ctx agent.InvocationContext, _ any) (any, error) {
+			return nil, nil
+		}, defaultNodeConfig)
+	join := NewJoinNode("join")
+	var seen any
+	handler := inputRecorder("handler", &seen)
+
+	w := mustNew(t, []Edge{
+		{From: Start, To: branchA},
+		{From: Start, To: branchNil},
+		{From: branchA, To: join},
+		{From: branchNil, To: join},
+		{From: join, To: handler},
+	})
+
+	drain(t, w.Run(mockCtx))
+
+	gotMap, ok := seen.(map[string]any)
+	if !ok {
+		t.Fatalf("handler input = %T %#v, want map[string]any", seen, seen)
+	}
+	wantMap := map[string]any{
+		"branchA":   "A-result",
+		"branchNil": nil,
+	}
+	if !reflect.DeepEqual(gotMap, wantMap) {
+		t.Errorf("handler input = %#v, want %#v", gotMap, wantMap)
+	}
+}
+
+// =============================================================================
+// Test fixtures and helpers
+// =============================================================================
+
+// constNode returns a FunctionNode that ignores its input and
+// yields the given string value.
+func constNode(name, value string) *FunctionNode {
+	return NewFunctionNode(name,
+		func(agent.InvocationContext, any) (string, error) { return value, nil },
+		defaultNodeConfig)
+}
+
+// inputRecorder returns a FunctionNode that stores its input in
+// *seen and yields "done". Use it for the terminal consumer of a
+// graph when the assertion only inspects the input it observed.
+func inputRecorder(name string, seen *any) *FunctionNode {
+	return NewFunctionNode(name,
+		func(_ agent.InvocationContext, input any) (string, error) {
+			*seen = input
+			return "done", nil
+		}, defaultNodeConfig)
+}

--- a/workflow/join_node_test.go
+++ b/workflow/join_node_test.go
@@ -148,7 +148,7 @@ func TestJoinNode_BarrierSkipsUntilAllPredecessorsComplete(t *testing.T) {
 
 // TestJoinNode_RunIsPassthrough pins the JoinNode contract
 // independently of the engine: given an aggregated input map,
-// the node emits exactly one event whose StateDelta["output"]
+// the node emits exactly one event whose Output
 // equals the input. This is the property the orchestrator relies
 // on when treating JoinNode as a no-op aggregator.
 func TestJoinNode_RunIsPassthrough(t *testing.T) {
@@ -161,12 +161,9 @@ func TestJoinNode_RunIsPassthrough(t *testing.T) {
 	if len(events) != 1 {
 		t.Fatalf("expected 1 event, got %d", len(events))
 	}
-	got, ok := events[0].Actions.StateDelta["output"]
-	if !ok {
-		t.Fatalf("event has no StateDelta[output]; got %#v", events[0].Actions.StateDelta)
-	}
+	got := events[0].Output
 	if !reflect.DeepEqual(got, input) {
-		t.Errorf("StateDelta[output] = %#v, want %#v (verbatim)", got, input)
+		t.Errorf("Output = %#v, want %#v (verbatim)", got, input)
 	}
 }
 

--- a/workflow/max_concurrency_test.go
+++ b/workflow/max_concurrency_test.go
@@ -1,0 +1,188 @@
+// Copyright 2026 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package workflow
+
+import (
+	"errors"
+	"fmt"
+	"sync/atomic"
+	"testing"
+	"time"
+
+	"google.golang.org/adk/agent"
+)
+
+// bumpPeak increments inFlight, updates peak if the new value is
+// higher, and returns a closure that decrements inFlight when
+// called. Used by tests that observe peak concurrency.
+func bumpPeak(inFlight, peak *atomic.Int32) func() {
+	now := inFlight.Add(1)
+	for {
+		p := peak.Load()
+		if now <= p || peak.CompareAndSwap(p, now) {
+			break
+		}
+	}
+	return func() { inFlight.Add(-1) }
+}
+
+// fanOutFromStart builds N Edge{Start, nodes[i]} edges.
+func fanOutFromStart(nodes []Node) []Edge {
+	edges := make([]Edge, 0, len(nodes))
+	for _, n := range nodes {
+		edges = append(edges, Edge{From: Start, To: n})
+	}
+	return edges
+}
+
+// TestMaxConcurrency_Caps verifies that a fan-out wider than the
+// configured cap never exceeds the cap in the number of nodes
+// running simultaneously.
+func TestMaxConcurrency_Caps(t *testing.T) {
+	const fanOut = 6
+	const cap = 2
+
+	mockCtx := newSeededMockCtx(t)
+	var inFlight, peak atomic.Int32
+
+	releases := make([]chan struct{}, fanOut)
+	nodes := make([]Node, fanOut)
+	for i := range fanOut {
+		i := i
+		releases[i] = make(chan struct{})
+		nodes[i] = newBlockingNode(fmt.Sprintf("N%d", i), func() {
+			defer bumpPeak(&inFlight, &peak)()
+			<-releases[i]
+		})
+	}
+
+	w, err := New("", fanOutFromStart(nodes), WithMaxConcurrency(cap))
+	if err != nil {
+		t.Fatalf("New: %v", err)
+	}
+
+	done := make(chan struct{})
+	go func() {
+		defer close(done)
+		drain(t, w.Run(mockCtx))
+	}()
+
+	// Wait until cap nodes are admitted, then release them
+	// one by one so the scheduler dispatches queued nodes
+	// into their slots without ever exceeding the cap.
+	deadline := time.Now().Add(2 * time.Second)
+	for time.Now().Before(deadline) && inFlight.Load() != cap {
+		time.Sleep(time.Millisecond)
+	}
+	if got := inFlight.Load(); got != cap {
+		t.Fatalf("after warmup: inFlight = %d, want %d (cap not enforced)", got, cap)
+	}
+	for i := range fanOut {
+		close(releases[i])
+	}
+	<-done
+
+	if got := peak.Load(); got > cap {
+		t.Errorf("peak in-flight = %d, want <= %d (cap violated)", got, cap)
+	}
+}
+
+// TestMaxConcurrency_PendingDispatchedFIFO verifies that queued
+// activations are dispatched in arrival order: a fan-out with
+// cap=1 must run in strict sequence.
+func TestMaxConcurrency_PendingDispatchedFIFO(t *testing.T) {
+	const fanOut = 4
+	mockCtx := newSeededMockCtx(t)
+
+	var order atomic.Int32
+	starts := make([]int32, fanOut)
+	nodes := make([]Node, fanOut)
+	for i := range fanOut {
+		i := i
+		nodes[i] = NewFunctionNode(
+			fmt.Sprintf("N%d", i),
+			func(ctx agent.InvocationContext, input any) (string, error) {
+				starts[i] = order.Add(1)
+				return "ok", nil
+			},
+			defaultNodeConfig,
+		)
+	}
+	w, err := New("", fanOutFromStart(nodes), WithMaxConcurrency(1))
+	if err != nil {
+		t.Fatalf("New: %v", err)
+	}
+
+	drain(t, w.Run(mockCtx))
+
+	for i := range fanOut {
+		if want := int32(i + 1); starts[i] != want {
+			t.Errorf("N%d start order = %d, want %d (FIFO violated)", i, starts[i], want)
+		}
+	}
+}
+
+// TestMaxConcurrency_RetryRespectsLimit verifies that a node
+// scheduled via the retry path also goes through the
+// concurrency-cap gate. Without the gate, a retry could squeeze
+// in while a sibling is still in-flight under cap=1.
+func TestMaxConcurrency_RetryRespectsLimit(t *testing.T) {
+	mockCtx := newSeededMockCtx(t)
+	var inFlight, peak atomic.Int32
+
+	var flakyCalls atomic.Int32
+	flaky := NewFunctionNode("flaky",
+		func(ctx agent.InvocationContext, input any) (string, error) {
+			defer bumpPeak(&inFlight, &peak)()
+			// Hold long enough that, if the cap were broken, a
+			// sibling could sneak in.
+			time.Sleep(20 * time.Millisecond)
+			if flakyCalls.Add(1) == 1 {
+				return "", errors.New("retryable")
+			}
+			return "ok", nil
+		},
+		NodeConfig{
+			RetryConfig: &RetryConfig{
+				MaxAttempts:   3,
+				InitialDelay:  10 * time.Millisecond,
+				MaxDelay:      10 * time.Millisecond,
+				BackoffFactor: 1.0,
+				ShouldRetry:   func(error) bool { return true },
+			},
+		},
+	)
+	stable := NewFunctionNode("stable",
+		func(ctx agent.InvocationContext, input any) (string, error) {
+			defer bumpPeak(&inFlight, &peak)()
+			time.Sleep(20 * time.Millisecond)
+			return "ok", nil
+		},
+		defaultNodeConfig,
+	)
+
+	w, err := New("", fanOutFromStart([]Node{flaky, stable}), WithMaxConcurrency(1))
+	if err != nil {
+		t.Fatalf("New: %v", err)
+	}
+	drain(t, w.Run(mockCtx))
+
+	if got := peak.Load(); got > 1 {
+		t.Errorf("peak in-flight = %d, want <= 1 (retry bypassed cap)", got)
+	}
+	if got := flakyCalls.Load(); got < 2 {
+		t.Errorf("flaky calls = %d, want >= 2 (retry never happened)", got)
+	}
+}

--- a/workflow/node_context.go
+++ b/workflow/node_context.go
@@ -17,9 +17,8 @@ package workflow
 import "google.golang.org/adk/agent"
 
 // nodeContext is the per-node InvocationContext seen inside Node.Run.
-// It wraps the workflow's incoming agent.InvocationContext and adds
-// engine-supplied metadata: the upstream node name (TriggeredBy)
-// and any human-input responses the scheduler injected for a
+// It wraps the workflow's incoming agent.InvocationContext and
+// surfaces the human-input responses the scheduler injected for a
 // re-entry resume activation (ResumedInput).
 //
 // TODO(wolo): replace once context-unification work lands. The
@@ -27,7 +26,6 @@ import "google.golang.org/adk/agent"
 // that the base interface does not have.
 type nodeContext struct {
 	agent.InvocationContext
-	triggeredBy string
 
 	// resumeInputs carries the user-supplied response payloads for
 	// a re-entry resume activation, keyed by InterruptID. Nil on
@@ -37,22 +35,14 @@ type nodeContext struct {
 	resumeInputs map[string]any
 }
 
-// newNodeContext returns a nodeContext wrapping parent with the given
-// upstream-node name. triggeredBy is empty for the initial START
-// activation. resumeInputs is nil for non-resume activations.
-func newNodeContext(parent agent.InvocationContext, triggeredBy string, resumeInputs map[string]any) *nodeContext {
+// newNodeContext returns a nodeContext wrapping parent. resumeInputs
+// is nil for non-resume activations.
+func newNodeContext(parent agent.InvocationContext, resumeInputs map[string]any) *nodeContext {
 	return &nodeContext{
 		InvocationContext: parent,
-		triggeredBy:       triggeredBy,
 		resumeInputs:      resumeInputs,
 	}
 }
-
-// TriggeredBy returns the name of the upstream node whose output
-// scheduled this node activation. Empty for the initial START
-// trigger and for non-workflow invocations (where the wrapper is not
-// used).
-func (c *nodeContext) TriggeredBy() string { return c.triggeredBy }
 
 // ResumedInput returns the response payload associated with the
 // given InterruptID for a re-entry resume activation. Returns

--- a/workflow/node_context.go
+++ b/workflow/node_context.go
@@ -1,0 +1,41 @@
+// Copyright 2026 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package workflow
+
+import "google.golang.org/adk/agent"
+
+// nodeContext is the per-node InvocationContext seen inside Node.Run.
+// It wraps the workflow's incoming agent.InvocationContext and adds
+// engine-supplied metadata — currently only the upstream node name
+// (TriggeredBy).
+//
+// TODO(wolo): replace once context-unification work lands.
+type nodeContext struct {
+	agent.InvocationContext
+	triggeredBy string
+}
+
+// newNodeContext returns a nodeContext wrapping parent with the given
+// upstream-node name. triggeredBy is empty for the initial START
+// activation.
+func newNodeContext(parent agent.InvocationContext, triggeredBy string) *nodeContext {
+	return &nodeContext{InvocationContext: parent, triggeredBy: triggeredBy}
+}
+
+// TriggeredBy returns the name of the upstream node whose output
+// scheduled this node activation. Empty for the initial START
+// trigger and for non-workflow invocations (where the wrapper is not
+// used).
+func (c *nodeContext) TriggeredBy() string { return c.triggeredBy }

--- a/workflow/node_context.go
+++ b/workflow/node_context.go
@@ -18,20 +18,34 @@ import "google.golang.org/adk/agent"
 
 // nodeContext is the per-node InvocationContext seen inside Node.Run.
 // It wraps the workflow's incoming agent.InvocationContext and adds
-// engine-supplied metadata — currently only the upstream node name
-// (TriggeredBy).
+// engine-supplied metadata: the upstream node name (TriggeredBy)
+// and any human-input responses the scheduler injected for a
+// re-entry resume activation (ResumedInput).
 //
-// TODO(wolo): replace once context-unification work lands.
+// TODO(wolo): replace once context-unification work lands. The
+// wrapper exists today only to surface workflow-specific accessors
+// that the base interface does not have.
 type nodeContext struct {
 	agent.InvocationContext
 	triggeredBy string
+
+	// resumeInputs carries the user-supplied response payloads for
+	// a re-entry resume activation, keyed by InterruptID. Nil on
+	// fresh activations and on handoff resume (where the response
+	// flows to the successor as its input rather than back to the
+	// asker via this map).
+	resumeInputs map[string]any
 }
 
 // newNodeContext returns a nodeContext wrapping parent with the given
 // upstream-node name. triggeredBy is empty for the initial START
-// activation.
-func newNodeContext(parent agent.InvocationContext, triggeredBy string) *nodeContext {
-	return &nodeContext{InvocationContext: parent, triggeredBy: triggeredBy}
+// activation. resumeInputs is nil for non-resume activations.
+func newNodeContext(parent agent.InvocationContext, triggeredBy string, resumeInputs map[string]any) *nodeContext {
+	return &nodeContext{
+		InvocationContext: parent,
+		triggeredBy:       triggeredBy,
+		resumeInputs:      resumeInputs,
+	}
 }
 
 // TriggeredBy returns the name of the upstream node whose output
@@ -39,3 +53,16 @@ func newNodeContext(parent agent.InvocationContext, triggeredBy string) *nodeCon
 // trigger and for non-workflow invocations (where the wrapper is not
 // used).
 func (c *nodeContext) TriggeredBy() string { return c.triggeredBy }
+
+// ResumedInput returns the response payload associated with the
+// given InterruptID for a re-entry resume activation. Returns
+// (nil, false) on fresh activations, on handoff resume, and when
+// the InterruptID does not match any payload supplied by the
+// resuming caller.
+func (c *nodeContext) ResumedInput(interruptID string) (any, bool) {
+	if c.resumeInputs == nil {
+		return nil, false
+	}
+	v, ok := c.resumeInputs[interruptID]
+	return v, ok
+}

--- a/workflow/node_context.go
+++ b/workflow/node_context.go
@@ -40,6 +40,11 @@ type NodeContext interface {
 	// static nodes; auto-counter or user-supplied via WithRunID for
 	// dynamic children.
 	RunID() string
+
+	// WithBranch returns a NodeContext whose Branch() returns the
+	// given value; all other fields (path, runID, subScheduler,
+	// resumeInputs, embedded InvocationContext) are preserved.
+	WithBranch(branch string) NodeContext
 }
 
 // nodeContext is the unexported NodeContext implementation.
@@ -102,3 +107,16 @@ func (c *nodeContext) ResumedInput(interruptID string) (any, bool) {
 
 func (c *nodeContext) Path() string  { return c.path }
 func (c *nodeContext) RunID() string { return c.runID }
+
+func (c *nodeContext) WithBranch(branch string) NodeContext {
+	// Reuse the package-level withBranch helper to swap Branch on
+	// the underlying InvocationContext; preserve the NodeContext
+	// envelope (path, runID, resumeInputs, subScheduler) unchanged.
+	return &nodeContext{
+		InvocationContext: withBranch(c.InvocationContext, branch),
+		resumeInputs:      c.resumeInputs,
+		path:              c.path,
+		runID:             c.runID,
+		subScheduler:      c.subScheduler,
+	}
+}

--- a/workflow/node_context.go
+++ b/workflow/node_context.go
@@ -14,29 +14,56 @@
 
 package workflow
 
-import "google.golang.org/adk/agent"
+import (
+	"google.golang.org/adk/agent"
+)
 
-// nodeContext is the per-node InvocationContext seen inside Node.Run.
-// It wraps the workflow's incoming agent.InvocationContext and
-// surfaces the human-input responses the scheduler injected for a
-// re-entry resume activation (ResumedInput).
+// NodeContext is the per-node context seen inside Node.Run and inside
+// dynamic-node orchestrator bodies. It extends agent.InvocationContext
+// with workflow-specific accessors.
 //
-// TODO(wolo): replace once context-unification work lands. The
-// wrapper exists today only to surface workflow-specific accessors
-// that the base interface does not have.
+// TODO(wolo): unify with the in-flight context-unification work
+// (CallbackContext / ToolContext series).
+type NodeContext interface {
+	agent.InvocationContext
+
+	// ResumedInput returns the response payload for a re-entry resume
+	// activation keyed by InterruptID, or (nil, false) otherwise.
+	ResumedInput(interruptID string) (any, bool)
+
+	// Path returns the composite path of the currently-executing node.
+	// Empty for top-level static nodes; "<parent_path>/<child_name>@<run_id>"
+	// for dynamic children.
+	Path() string
+
+	// RunID returns the per-invocation identifier. Empty for top-level
+	// static nodes; auto-counter or user-supplied via WithRunID for
+	// dynamic children.
+	RunID() string
+}
+
+// nodeContext is the unexported NodeContext implementation.
 type nodeContext struct {
 	agent.InvocationContext
 
-	// resumeInputs carries the user-supplied response payloads for
-	// a re-entry resume activation, keyed by InterruptID. Nil on
-	// fresh activations and on handoff resume (where the response
-	// flows to the successor as its input rather than back to the
-	// asker via this map).
+	// resumeInputs are keyed by InterruptID. Nil on fresh activations
+	// and on handoff resume.
 	resumeInputs map[string]any
+
+	// path and runID are populated for dynamic children, empty for
+	// top-level static activations.
+	path  string
+	runID string
+
+	// subScheduler is non-nil only when this context belongs to a
+	// dynamic-node activation; RunNode uses it to schedule children.
+	subScheduler *dynamicSubScheduler
 }
 
-// newNodeContext returns a nodeContext wrapping parent. resumeInputs
-// is nil for non-resume activations.
+// Compile-time: *nodeContext implements NodeContext.
+var _ NodeContext = (*nodeContext)(nil)
+
+// newNodeContext wraps parent for a top-level (static) activation.
 func newNodeContext(parent agent.InvocationContext, resumeInputs map[string]any) *nodeContext {
 	return &nodeContext{
 		InvocationContext: parent,
@@ -44,11 +71,27 @@ func newNodeContext(parent agent.InvocationContext, resumeInputs map[string]any)
 	}
 }
 
-// ResumedInput returns the response payload associated with the
-// given InterruptID for a re-entry resume activation. Returns
-// (nil, false) on fresh activations, on handoff resume, and when
-// the InterruptID does not match any payload supplied by the
-// resuming caller.
+// newDynamicNodeContext wraps parent for either a dynamic-node
+// activation or one of its children, attaching path, runID, and the
+// sub-scheduler RunNode reaches from the orchestrator body. Children
+// pass the sub-scheduler's counter (or WithRunID) value as runID; a
+// dynamic node's own activation passes runID="" — it is not itself a
+// sub-scheduler child. Child inherits resumeInputs so HITL responses
+// reach dynamic children.
+func newDynamicNodeContext(parent NodeContext, path, runID string, sub *dynamicSubScheduler) *nodeContext {
+	var inherited map[string]any
+	if p, ok := parent.(*nodeContext); ok {
+		inherited = p.resumeInputs
+	}
+	return &nodeContext{
+		InvocationContext: parent,
+		resumeInputs:      inherited,
+		path:              path,
+		runID:             runID,
+		subScheduler:      sub,
+	}
+}
+
 func (c *nodeContext) ResumedInput(interruptID string) (any, bool) {
 	if c.resumeInputs == nil {
 		return nil, false
@@ -56,3 +99,6 @@ func (c *nodeContext) ResumedInput(interruptID string) (any, bool) {
 	v, ok := c.resumeInputs[interruptID]
 	return v, ok
 }
+
+func (c *nodeContext) Path() string  { return c.path }
+func (c *nodeContext) RunID() string { return c.runID }

--- a/workflow/node_context.go
+++ b/workflow/node_context.go
@@ -15,6 +15,8 @@
 package workflow
 
 import (
+	"context"
+
 	"google.golang.org/adk/agent"
 )
 
@@ -118,5 +120,21 @@ func (c *nodeContext) WithBranch(branch string) NodeContext {
 		path:              c.path,
 		runID:             c.runID,
 		subScheduler:      c.subScheduler,
+	}
+}
+
+// WithContext preserves the nodeContext wrapper when callers derive
+// a new context from this one (e.g. when the scheduler attaches an
+// OpenTelemetry span context). Without this override, the base
+// invocationContext.WithContext would return a *invocationContext
+// and silently drop the resumeInputs map, breaking re-entry resume
+// activations and any other workflow-specific accessors.
+func (c *nodeContext) WithContext(ctx context.Context) agent.InvocationContext {
+	return &nodeContext{
+		c.InvocationContext.WithContext(ctx),
+		c.resumeInputs,
+		c.path,
+		c.runID,
+		c.subScheduler,
 	}
 }

--- a/workflow/node_context_bridge.go
+++ b/workflow/node_context_bridge.go
@@ -1,0 +1,45 @@
+// Copyright 2026 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package workflow
+
+import "context"
+
+// EXPERIMENTAL: temporary bridge that lets runnable tools recover
+// the surrounding NodeContext from a tool.Context value chain
+// without modifying the tool.Context interface. Will be removed
+// once the CallbackContext / ToolContext unification (see TODO in
+// node_context.go) lands.
+type nodeContextKey struct{}
+
+// WithNodeContext returns a derived Go context that carries nc under
+// an opaque key, recoverable via NodeContextFromGoContext from any
+// descendant context.Context. The scheduler calls this on every
+// per-node activation.
+func WithNodeContext(parent context.Context, nc NodeContext) context.Context {
+	if parent == nil || nc == nil {
+		return parent
+	}
+	return context.WithValue(parent, nodeContextKey{}, nc)
+}
+
+// NodeContextFromGoContext returns the NodeContext stashed by
+// WithNodeContext, or (nil, false) if none is present on ctx.
+func NodeContextFromGoContext(ctx context.Context) (NodeContext, bool) {
+	if ctx == nil {
+		return nil, false
+	}
+	nc, ok := ctx.Value(nodeContextKey{}).(NodeContext)
+	return nc, ok
+}

--- a/workflow/node_context_bridge_test.go
+++ b/workflow/node_context_bridge_test.go
@@ -1,0 +1,55 @@
+// Copyright 2026 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package workflow
+
+import (
+	"context"
+	"testing"
+)
+
+// TestWithNodeContext_SurvivesDerivedContext pins the core property
+// the bridge exists for: a NodeContext stashed via WithNodeContext
+// must survive arbitrary downstream context.Context derivations
+// (context.WithCancel, context.WithValue, ...) because the
+// scheduler -> AgentNode -> LlmAgent -> Flow -> tool.Context chain
+// produces exactly those derivations along the way (per-node
+// WithCancel in scheduleResumedNode; telemetry span ctx wrap in
+// Flow.handleFunctionCalls; the embedded context.Context in every
+// InvocationContext built along the path).
+//
+// If this test regresses, NodeContextFromGoContext(toolCtx)
+// lookups in runnable tools will silently return (nil, false) at
+// runtime and the tools will fall back to their no-NodeContext
+// path.
+func TestWithNodeContext_SurvivesDerivedContext(t *testing.T) {
+	sentinel := &nodeContext{}
+	parent := WithNodeContext(context.Background(), sentinel)
+
+	// Simulate a WithCancel (NewInvocationContext does effectively
+	// this when called with the per-node nodeCtx).
+	derived, cancel := context.WithCancel(parent)
+	defer cancel()
+
+	// And a WithValue layer on top (telemetry span ctx does this).
+	derived = context.WithValue(derived, struct{ k string }{"span"}, "stub")
+
+	got, ok := NodeContextFromGoContext(derived)
+	if !ok {
+		t.Fatal("NodeContext lost across WithCancel + WithValue derivations")
+	}
+	if got != NodeContext(sentinel) {
+		t.Errorf("Derived context returned wrong NodeContext: got %p, want %p", got, sentinel)
+	}
+}

--- a/workflow/node_context_propagation_test.go
+++ b/workflow/node_context_propagation_test.go
@@ -1,0 +1,114 @@
+// Copyright 2026 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package workflow
+
+import (
+	"context"
+	"errors"
+	"iter"
+	"testing"
+
+	"google.golang.org/adk/agent"
+	"google.golang.org/adk/session"
+)
+
+var errFnNodeNeedsNodeContext = errors.New("fnNode: ctx is not a NodeContext")
+
+// End-to-end check that a child of a dynamic-node activation can
+// recover its own NodeContext via NodeContextFromGoContext — the
+// path runnable tools rely on to reach the sub-scheduler from
+// tool.Context.
+func TestNodeContextPropagation_DynamicChildEmbedsItself(t *testing.T) {
+	var captured NodeContext
+
+	inner := newFnNode("inner", func(ctx NodeContext) (any, error) {
+		nc, ok := NodeContextFromGoContext(ctx)
+		if !ok {
+			t.Errorf("inner: NodeContext not recovered from go context value")
+			return nil, nil
+		}
+		captured = nc
+		return "ok", nil
+	})
+
+	orchestrator := NewDynamicNode[string, string]("orch",
+		func(ctx NodeContext, _ string, _ func(*session.Event) error) (string, error) {
+			return RunNode[string](ctx, inner, nil)
+		},
+		NodeConfig{},
+	)
+
+	if _, err := drainDynamicWithErr(t, orchestrator, ""); err != nil {
+		t.Fatalf("orchestrator error: %v", err)
+	}
+	if captured == nil {
+		t.Fatal("inner did not recover any NodeContext")
+	}
+}
+
+// Top-level (static) activations stash a NodeContext too, even
+// though their RunNode would be rejected for lack of a
+// sub-scheduler — consumers can still detect "inside a workflow
+// node" and react accordingly.
+func TestNodeContextPropagation_StaticActivationStashed(t *testing.T) {
+	// Mini-replication of scheduler.scheduleResumedNode's stash
+	// sequence; avoids the full scheduler loop.
+	parent := newMockCtx(t)
+	perNodeCtx := newNodeContext(parent.WithContext(context.Background()), nil)
+	perNodeCtx.InvocationContext = perNodeCtx.InvocationContext.WithContext(
+		WithNodeContext(perNodeCtx.InvocationContext, perNodeCtx),
+	)
+
+	nc, ok := NodeContextFromGoContext(perNodeCtx)
+	if !ok {
+		t.Fatal("static activation did not stash NodeContext on its own embedded context")
+	}
+	if nc != NodeContext(perNodeCtx) {
+		t.Errorf("recovered NodeContext != perNodeCtx (%p vs %p)", nc, perNodeCtx)
+	}
+}
+
+// --- test helpers ---
+
+// fnNode adapts a func(NodeContext) callback into a Node that emits
+// a single Output event on success.
+type fnNode struct {
+	BaseNode
+	fn func(NodeContext) (any, error)
+}
+
+func newFnNode(name string, fn func(NodeContext) (any, error)) *fnNode {
+	return &fnNode{
+		BaseNode: NewBaseNode(name, "", NodeConfig{}),
+		fn:       fn,
+	}
+}
+
+func (n *fnNode) Run(ctx agent.InvocationContext, input any) iter.Seq2[*session.Event, error] {
+	return func(yield func(*session.Event, error) bool) {
+		// dynamic_scheduler passes *nodeContext as agent.InvocationContext.
+		nc, ok := ctx.(NodeContext)
+		if !ok {
+			yield(nil, errFnNodeNeedsNodeContext)
+			return
+		}
+		out, err := n.fn(nc)
+		if err != nil {
+			yield(nil, err)
+			return
+		}
+		yield(&session.Event{Output: out}, nil)
+	}
+}

--- a/workflow/node_context_test.go
+++ b/workflow/node_context_test.go
@@ -20,7 +20,7 @@ import (
 	"google.golang.org/adk/agent"
 )
 
-func TestNewNodeContext_TriggeredByRoundTrip(t *testing.T) {
+func TestNodeContext_TriggeredByPreservesValue(t *testing.T) {
 	tests := []struct {
 		name        string
 		triggeredBy string
@@ -33,12 +33,34 @@ func TestNewNodeContext_TriggeredByRoundTrip(t *testing.T) {
 	parent := newMockCtx(t)
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			c := newNodeContext(parent, tt.triggeredBy)
+			c := newNodeContext(parent, tt.triggeredBy, nil)
 			if got := c.TriggeredBy(); got != tt.triggeredBy {
 				t.Errorf("TriggeredBy() = %q, want %q", got, tt.triggeredBy)
 			}
 		})
 	}
+}
+
+func TestNodeContext_ResumedInput(t *testing.T) {
+	parent := newMockCtx(t)
+
+	t.Run("nil resumeInputs returns (nil, false)", func(t *testing.T) {
+		c := newNodeContext(parent, "", nil)
+		v, ok := c.ResumedInput("any_id")
+		if v != nil || ok {
+			t.Errorf("ResumedInput() = (%v, %v), want (nil, false)", v, ok)
+		}
+	})
+
+	t.Run("populated resumeInputs returns matched payload", func(t *testing.T) {
+		c := newNodeContext(parent, "", map[string]any{
+			"approval": "yes",
+			"comment":  "looks good",
+		})
+		if v, ok := c.ResumedInput("approval"); !ok || v != "yes" {
+			t.Errorf("ResumedInput(\"approval\") = (%v, %v), want (\"yes\", true)", v, ok)
+		}
+	})
 }
 
 // Compile-time assertion: *nodeContext satisfies agent.InvocationContext.

--- a/workflow/node_context_test.go
+++ b/workflow/node_context_test.go
@@ -20,32 +20,11 @@ import (
 	"google.golang.org/adk/agent"
 )
 
-func TestNodeContext_TriggeredByPreservesValue(t *testing.T) {
-	tests := []struct {
-		name        string
-		triggeredBy string
-	}{
-		{name: "empty (initial START activation)", triggeredBy: ""},
-		{name: "named upstream node", triggeredBy: "upstream"},
-		{name: "node name with dots (branch path)", triggeredBy: "agent_1.agent_2"},
-	}
-
-	parent := newMockCtx(t)
-	for _, tt := range tests {
-		t.Run(tt.name, func(t *testing.T) {
-			c := newNodeContext(parent, tt.triggeredBy, nil)
-			if got := c.TriggeredBy(); got != tt.triggeredBy {
-				t.Errorf("TriggeredBy() = %q, want %q", got, tt.triggeredBy)
-			}
-		})
-	}
-}
-
 func TestNodeContext_ResumedInput(t *testing.T) {
 	parent := newMockCtx(t)
 
 	t.Run("nil resumeInputs returns (nil, false)", func(t *testing.T) {
-		c := newNodeContext(parent, "", nil)
+		c := newNodeContext(parent, nil)
 		v, ok := c.ResumedInput("any_id")
 		if v != nil || ok {
 			t.Errorf("ResumedInput() = (%v, %v), want (nil, false)", v, ok)
@@ -53,7 +32,7 @@ func TestNodeContext_ResumedInput(t *testing.T) {
 	})
 
 	t.Run("populated resumeInputs returns matched payload", func(t *testing.T) {
-		c := newNodeContext(parent, "", map[string]any{
+		c := newNodeContext(parent, map[string]any{
 			"approval": "yes",
 			"comment":  "looks good",
 		})

--- a/workflow/node_context_test.go
+++ b/workflow/node_context_test.go
@@ -1,0 +1,45 @@
+// Copyright 2026 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package workflow
+
+import (
+	"testing"
+
+	"google.golang.org/adk/agent"
+)
+
+func TestNewNodeContext_TriggeredByRoundTrip(t *testing.T) {
+	tests := []struct {
+		name        string
+		triggeredBy string
+	}{
+		{name: "empty (initial START activation)", triggeredBy: ""},
+		{name: "named upstream node", triggeredBy: "upstream"},
+		{name: "node name with dots (branch path)", triggeredBy: "agent_1.agent_2"},
+	}
+
+	parent := newMockCtx(t)
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			c := newNodeContext(parent, tt.triggeredBy)
+			if got := c.TriggeredBy(); got != tt.triggeredBy {
+				t.Errorf("TriggeredBy() = %q, want %q", got, tt.triggeredBy)
+			}
+		})
+	}
+}
+
+// Compile-time assertion: *nodeContext satisfies agent.InvocationContext.
+var _ agent.InvocationContext = (*nodeContext)(nil)

--- a/workflow/node_context_test.go
+++ b/workflow/node_context_test.go
@@ -16,8 +16,6 @@ package workflow
 
 import (
 	"testing"
-
-	"google.golang.org/adk/agent"
 )
 
 func TestNodeContext_ResumedInput(t *testing.T) {
@@ -40,7 +38,70 @@ func TestNodeContext_ResumedInput(t *testing.T) {
 			t.Errorf("ResumedInput(\"approval\") = (%v, %v), want (\"yes\", true)", v, ok)
 		}
 	})
+
+	t.Run("unmatched InterruptID returns (nil, false)", func(t *testing.T) {
+		c := newNodeContext(parent, map[string]any{"approval": "yes"})
+		if v, ok := c.ResumedInput("missing"); v != nil || ok {
+			t.Errorf("ResumedInput(\"missing\") = (%v, %v), want (nil, false)", v, ok)
+		}
+	})
 }
 
-// Compile-time assertion: *nodeContext satisfies agent.InvocationContext.
-var _ agent.InvocationContext = (*nodeContext)(nil)
+func TestNodeContext_PathAndRunID(t *testing.T) {
+	t.Run("top-level static returns empty", func(t *testing.T) {
+		c := newNodeContext(newMockCtx(t), nil)
+		if got := c.Path(); got != "" {
+			t.Errorf("Path() = %q, want empty", got)
+		}
+		if got := c.RunID(); got != "" {
+			t.Errorf("RunID() = %q, want empty", got)
+		}
+	})
+
+	t.Run("child populated from constructor", func(t *testing.T) {
+		parent := newNodeContext(newMockCtx(t), nil)
+		child := newDynamicNodeContext(parent, "wf/fixer@2", "2", nil)
+		if got, want := child.Path(), "wf/fixer@2"; got != want {
+			t.Errorf("Path() = %q, want %q", got, want)
+		}
+		if got, want := child.RunID(), "2"; got != want {
+			t.Errorf("RunID() = %q, want %q", got, want)
+		}
+	})
+
+	t.Run("activation populated with empty runID", func(t *testing.T) {
+		parent := newNodeContext(newMockCtx(t), nil)
+		act := newDynamicNodeContext(parent, "city_workflow", "", nil)
+		if got, want := act.Path(), "city_workflow"; got != want {
+			t.Errorf("Path() = %q, want %q", got, want)
+		}
+		if got := act.RunID(); got != "" {
+			t.Errorf("RunID() = %q, want empty for dynamic-node activation", got)
+		}
+	})
+}
+
+func TestNodeContext_DynamicInheritsResumeInputs(t *testing.T) {
+	parent := newNodeContext(newMockCtx(t), map[string]any{"approval": "yes"})
+	sub := &dynamicSubScheduler{}
+
+	t.Run("child", func(t *testing.T) {
+		child := newDynamicNodeContext(parent, "wf/asker@1", "1", sub)
+		if v, ok := child.ResumedInput("approval"); !ok || v != "yes" {
+			t.Errorf("child.ResumedInput(\"approval\") = (%v, %v), want (\"yes\", true)", v, ok)
+		}
+		if child.subScheduler != sub {
+			t.Errorf("subScheduler pointer differs from supplied")
+		}
+	})
+
+	t.Run("activation", func(t *testing.T) {
+		act := newDynamicNodeContext(parent, "city_workflow", "", sub)
+		if v, ok := act.ResumedInput("approval"); !ok || v != "yes" {
+			t.Errorf("act.ResumedInput(\"approval\") = (%v, %v), want (\"yes\", true)", v, ok)
+		}
+		if act.subScheduler != sub {
+			t.Errorf("subScheduler pointer differs from supplied")
+		}
+	})
+}

--- a/workflow/parallel_worker.go
+++ b/workflow/parallel_worker.go
@@ -1,0 +1,232 @@
+// Copyright 2026 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package workflow
+
+import (
+	"context"
+	"fmt"
+	"iter"
+	"reflect"
+	"sync"
+	"time"
+
+	"google.golang.org/adk/agent"
+	"google.golang.org/adk/session"
+)
+
+// ParallelWorker runs a wrapped node in parallel for each item in the input list.
+type ParallelWorker struct {
+	BaseNode
+	wrapped        Node
+	maxConcurrency int
+	retryCfg       *RetryConfig
+}
+
+// NewParallelWorker creates a new ParallelWorker node.
+// maxConcurrency <= 0 means no limit on concurrency.
+func NewParallelWorker(name string, wrapped Node, maxConcurrency int, cfg NodeConfig) (*ParallelWorker, error) {
+	if wrapped.Config().RetryConfig != nil {
+		return nil, fmt.Errorf("ParallelWorker %s: wrapped node %s cannot have RetryConfig", name, wrapped.Name())
+	}
+	retryCfg := cfg.RetryConfig
+	cfg.RetryConfig = nil // Hide from scheduler, so it does not try to retry the node itself.
+
+	return &ParallelWorker{
+		BaseNode:       BaseNode{name: name, config: cfg},
+		wrapped:        wrapped,
+		maxConcurrency: maxConcurrency,
+		retryCfg:       retryCfg,
+	}, nil
+}
+
+// Run executes the wrapped node in parallel for each item in the input list.
+// It aggregates the "output" from each wrapped node execution into a list and
+// yields a single final event with the aggregated list as output.
+//
+// RetryConfig in the wrapped nodes are not allowed, only the parent node (ParallelWorker)
+// will be respected. Each failed input will be retried based on the RetryConfig independently from other inputs.
+// Which means for the input: []any{"a", "b", "c"}, if "b" always fails, and MaxAttempt is 3
+// the ParallelWorker will perform 1 ("a") + 3 ("b" retried) + 1 ("c") = 5 calls in total.
+//
+// If any of the wrapped node executions returns a non-retryable error, the workflow
+// will fail fast, cancel other in-flight workers, and return this first encountered error.
+//
+// In case the wrapped node produces more then one output event, they will be
+// aggregated into a list, and the final result will be a multi dimensional list.
+//
+// Intermediate non-output events emitted by the wrapped node are suppressed.
+func (n *ParallelWorker) Run(ctx agent.InvocationContext, input any) iter.Seq2[*session.Event, error] {
+	return func(yield func(*session.Event, error) bool) {
+		cancelCtx, cancelFunc := context.WithCancel(ctx)
+		defer cancelFunc()
+		workerCtx := ctx.WithContext(cancelCtx)
+
+		v := reflect.ValueOf(input)
+		if v.Kind() != reflect.Slice {
+			yield(nil, fmt.Errorf("parallel worker %s expects a slice input, got %T", n.Name(), input))
+			return
+		}
+
+		nItems := v.Len()
+		if nItems == 0 {
+			// Yield an empty list as output
+			event := session.NewEvent(ctx.InvocationID())
+			event.Output = []any{}
+			yield(event, nil)
+			return
+		}
+
+		outputs := make([]any, nItems)
+		var wg sync.WaitGroup
+		wg.Add(nItems)
+
+		var sem chan struct{}
+		if n.maxConcurrency > 0 {
+			sem = make(chan struct{}, n.maxConcurrency)
+		}
+
+		resCh := make(chan workerResult, nItems)
+
+		for i := 0; i < nItems; i++ {
+			item := v.Index(i).Interface()
+
+			if sem != nil {
+				select {
+				case sem <- struct{}{}:
+				case <-ctx.Done():
+					wg.Done()
+					continue
+				}
+			}
+
+			go n.runWorker(workerCtx, i, item, sem, resCh, &wg)
+		}
+
+		// Goroutine to close channel when all workers are done
+		go func() {
+			wg.Wait()
+			close(resCh)
+		}()
+
+		var firstErr error
+
+		for res := range resCh {
+			if res.err != nil {
+				if firstErr == nil {
+					firstErr = res.err
+					cancelFunc() // Cancel all other workers!
+				}
+				continue
+			}
+
+			if res.ev != nil {
+				if out, ok := extractOutput(res.ev); ok {
+					outputs[res.index] = out
+				}
+			}
+		}
+
+		if firstErr != nil {
+			yield(nil, firstErr)
+			return
+		}
+
+		// Yield the aggregated output
+		event := session.NewEvent(ctx.InvocationID())
+		event.Output = outputs
+		yield(event, nil)
+	}
+}
+
+type workerResult struct {
+	index int
+	ev    *session.Event
+	err   error
+}
+
+func (n *ParallelWorker) runWorker(ctx agent.InvocationContext, idx int, item any, sem chan struct{}, resCh chan<- workerResult, wg *sync.WaitGroup) {
+	defer wg.Done()
+	defer func() {
+		if sem != nil {
+			<-sem
+		}
+	}()
+
+	retryCfg := n.retryCfg
+	failedAttempts := 0
+
+	for {
+		var workerOutputs []any
+		var runErr error
+
+		for ev, err := range n.wrapped.Run(ctx, item) {
+			if err != nil {
+				runErr = err
+				break
+			}
+
+			if out, ok := extractOutput(ev); ok {
+				workerOutputs = append(workerOutputs, out)
+			}
+		}
+
+		if runErr == nil {
+			// On success populate the output event.
+			resCh <- workerResult{index: idx, ev: makeWorkerOutputEvent(workerOutputs)}
+			return
+		}
+
+		// Failure, check if the retry config is configured.
+		// If so, follow the retry logic and repeat the execution of the wrapped node on failed input.
+		failedAttempts++
+		if ShouldRetry(retryCfg, runErr, failedAttempts) {
+			delay := CalculateDelay(retryCfg, failedAttempts)
+			select {
+			case <-time.After(delay):
+				continue
+			case <-ctx.Done():
+				resCh <- workerResult{index: idx, err: ctx.Err()}
+				return
+			}
+		}
+
+		// Cannot retry or exhausted attempts
+		resCh <- workerResult{index: idx, err: runErr}
+		return
+	}
+}
+
+func makeWorkerOutputEvent(outputs []any) *session.Event {
+	if len(outputs) == 0 {
+		return nil
+	}
+	var output any
+	if len(outputs) == 1 {
+		output = outputs[0]
+	} else {
+		output = outputs
+	}
+	return &session.Event{Output: output}
+}
+
+func extractOutput(ev *session.Event) (any, bool) {
+	if ev == nil {
+		return nil, false
+	}
+	if ev.Output != nil {
+		return ev.Output, true
+	}
+	return nil, false
+}

--- a/workflow/parallel_worker.go
+++ b/workflow/parallel_worker.go
@@ -19,6 +19,7 @@ import (
 	"fmt"
 	"iter"
 	"reflect"
+	"strconv"
 	"sync"
 	"time"
 
@@ -99,6 +100,13 @@ func (n *ParallelWorker) Run(ctx agent.InvocationContext, input any) iter.Seq2[*
 
 		resCh := make(chan workerResult, nItems)
 
+		// Branch isolation: derive a per-item sub-branch so each
+		// worker's wrapped node sees an isolated event history (the
+		// LLM flow's history filter scopes by branch prefix). Items
+		// 0..N-1 receive sub-branches name@1..name@N.
+		parentBranch := workerCtx.Branch()
+		wrappedName := n.wrapped.Name()
+
 		for i := 0; i < nItems; i++ {
 			item := v.Index(i).Interface()
 
@@ -111,7 +119,9 @@ func (n *ParallelWorker) Run(ctx agent.InvocationContext, input any) iter.Seq2[*
 				}
 			}
 
-			go n.runWorker(workerCtx, i, item, sem, resCh, &wg)
+			itemBranch := deriveSubBranch(parentBranch, wrappedName+"@"+strconv.Itoa(i+1))
+			itemCtx := withBranch(workerCtx, itemBranch)
+			go n.runWorker(itemCtx, i, item, sem, resCh, &wg)
 		}
 
 		// Goroutine to close channel when all workers are done

--- a/workflow/parallel_worker_branch_test.go
+++ b/workflow/parallel_worker_branch_test.go
@@ -1,0 +1,179 @@
+// Copyright 2026 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package workflow
+
+import (
+	"errors"
+	"sort"
+	"sync"
+	"testing"
+
+	"google.golang.org/adk/agent"
+)
+
+// TestParallelWorker_PerItemSubBranch verifies that ParallelWorker
+// gives each of its N concurrent workers a distinct sub-branch of
+// the form "<wrapped>@<i+1>", so a downstream LlmAgent reading the
+// session event log under the LLM flow's branch-prefix filter no
+// longer sees sibling-worker events in its prompt history.
+func TestParallelWorker_PerItemSubBranch(t *testing.T) {
+	const wrappedName = "summarize"
+
+	var (
+		mu           sync.Mutex
+		seenBranches []string
+	)
+	wrapped := NewFunctionNode(wrappedName,
+		func(ctx agent.InvocationContext, input string) (string, error) {
+			mu.Lock()
+			seenBranches = append(seenBranches, ctx.Branch())
+			mu.Unlock()
+			return input + "-done", nil
+		}, defaultNodeConfig)
+
+	pw, err := NewParallelWorker("pw", wrapped, 0, defaultNodeConfig)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	mockCtx := newMockCtx(t)
+	events := pw.Run(mockCtx, []any{"a", "b", "c"})
+	for _, err := range events {
+		if err != nil {
+			t.Fatalf("Run error: %v", err)
+		}
+	}
+
+	if got, want := len(seenBranches), 3; got != want {
+		t.Fatalf("seenBranches len = %d, want %d", got, want)
+	}
+
+	// Parent (mockCtx) is on root branch "" — each worker's
+	// sub-branch is the bare "<wrappedName>@<i+1>".
+	sort.Strings(seenBranches)
+	wantBranches := []string{
+		wrappedName + "@1",
+		wrappedName + "@2",
+		wrappedName + "@3",
+	}
+	for i, want := range wantBranches {
+		if seenBranches[i] != want {
+			t.Errorf("seenBranches[%d] = %q, want %q",
+				i, seenBranches[i], want)
+		}
+	}
+}
+
+// TestParallelWorker_SubBranchUnderNonRootParent verifies that
+// ParallelWorker correctly appends the per-item segment to a non-
+// empty parent branch (e.g. when ParallelWorker itself sits inside
+// another fan-out and runs under a sub-branch).
+func TestParallelWorker_SubBranchUnderNonRootParent(t *testing.T) {
+	const wrappedName = "worker"
+
+	var (
+		mu           sync.Mutex
+		seenBranches []string
+	)
+	wrapped := NewFunctionNode(wrappedName,
+		func(ctx agent.InvocationContext, input string) (string, error) {
+			mu.Lock()
+			seenBranches = append(seenBranches, ctx.Branch())
+			mu.Unlock()
+			return input, nil
+		}, defaultNodeConfig)
+
+	pw, err := NewParallelWorker("pw", wrapped, 0, defaultNodeConfig)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	// Simulate ParallelWorker running under a parent branch
+	// "outer@1" (e.g. one branch of a static fan-out).
+	parentCtx := withBranch(newMockCtx(t), "outer@1")
+
+	events := pw.Run(parentCtx, []any{"x", "y"})
+	for _, err := range events {
+		if err != nil {
+			t.Fatalf("Run error: %v", err)
+		}
+	}
+
+	if got, want := len(seenBranches), 2; got != want {
+		t.Fatalf("seenBranches len = %d, want %d", got, want)
+	}
+	sort.Strings(seenBranches)
+	wantBranches := []string{
+		"outer@1." + wrappedName + "@1",
+		"outer@1." + wrappedName + "@2",
+	}
+	for i, want := range wantBranches {
+		if seenBranches[i] != want {
+			t.Errorf("seenBranches[%d] = %q, want %q",
+				i, seenBranches[i], want)
+		}
+	}
+}
+
+// TestParallelWorker_RetryKeepsSameBranch verifies that a retried
+// item runs under the same sub-branch as the original attempt — the
+// branch is captured into the per-item context once before the
+// retry loop in runWorker.
+func TestParallelWorker_RetryKeepsSameBranch(t *testing.T) {
+	const wrappedName = "flaky"
+
+	errAlwaysFail := errors.New("force retry")
+	var (
+		mu               sync.Mutex
+		attemptsByBranch = map[string]int{}
+	)
+	wrapped := NewFunctionNode(wrappedName,
+		func(ctx agent.InvocationContext, input string) (string, error) {
+			mu.Lock()
+			attemptsByBranch[ctx.Branch()]++
+			mu.Unlock()
+			return "", errAlwaysFail
+		}, defaultNodeConfig)
+
+	cfg := NodeConfig{RetryConfig: &RetryConfig{MaxAttempts: 3}}
+	pw, err := NewParallelWorker("pw", wrapped, 0, cfg)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	mockCtx := newMockCtx(t)
+	var gotErr error
+	for _, runErr := range pw.Run(mockCtx, []any{"a"}) {
+		if runErr != nil {
+			gotErr = runErr
+		}
+	}
+	if gotErr == nil {
+		t.Fatal("expected wrapped node to ultimately fail after retries, got nil error")
+	}
+
+	if got := len(attemptsByBranch); got != 1 {
+		t.Fatalf("attemptsByBranch keys = %d, want 1 "+
+			"(retries must share one branch); got %+v", got, attemptsByBranch)
+	}
+	for branch, count := range attemptsByBranch {
+		if branch != wrappedName+"@1" {
+			t.Errorf("retry branch = %q, want %q", branch, wrappedName+"@1")
+		}
+		if count < 2 {
+			t.Errorf("retry attempts under %q = %d, want ≥2", branch, count)
+		}
+	}
+}

--- a/workflow/parallel_worker_test.go
+++ b/workflow/parallel_worker_test.go
@@ -1,0 +1,636 @@
+// Copyright 2026 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package workflow
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"iter"
+	"strings"
+	"sync"
+	"sync/atomic"
+	"testing"
+	"time"
+
+	"github.com/google/go-cmp/cmp"
+	"google.golang.org/genai"
+
+	"google.golang.org/adk/agent"
+	"google.golang.org/adk/session"
+)
+
+var upperNode = NewFunctionNode("upper", func(ctx agent.InvocationContext, input string) (string, error) {
+	return strings.ToUpper(input), nil
+}, defaultNodeConfig)
+
+func TestParallelWorker_Run(t *testing.T) {
+	tests := []struct {
+		name           string
+		maxConcurrency int
+		input          any
+		wrapped        Node
+		wantOutput     []any
+		wantErr        bool
+		errSubstr      string
+	}{
+		{
+			name:           "Success",
+			maxConcurrency: 0,
+			input:          []any{"a", "b", "c"},
+			wrapped:        upperNode,
+			wantOutput:     []any{"A", "B", "C"},
+			wantErr:        false,
+		},
+		{
+			name:           "EmptyList",
+			maxConcurrency: 0,
+			input:          []any{},
+			wrapped:        upperNode,
+			wantOutput:     []any{},
+			wantErr:        false,
+		},
+		{
+			name:           "InvalidInput_NotSlice",
+			maxConcurrency: 0,
+			input:          "not a slice",
+			wrapped:        upperNode,
+			wantErr:        true,
+			errSubstr:      "expects a slice input",
+		},
+		{
+			name:           "WorkerError",
+			maxConcurrency: 0,
+			input:          []any{"a", "b", "c"},
+			wrapped: NewFunctionNode("error_node", func(ctx agent.InvocationContext, input string) (string, error) {
+				if input == "b" {
+					return "", errors.New("failed on b")
+				}
+				return input, nil
+			}, defaultNodeConfig),
+			wantErr:   true,
+			errSubstr: "failed on b",
+		},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			pw, err := NewParallelWorker("parallel", tc.wrapped, tc.maxConcurrency, defaultNodeConfig)
+			if err != nil {
+				t.Fatal(err)
+			}
+
+			mockCtx := newMockCtx(t)
+			events := pw.Run(mockCtx, tc.input)
+
+			var gotOutput []any
+			var gotErr error
+
+			for ev, err := range events {
+				if err != nil {
+					gotErr = err
+					break
+				}
+				if out, ok := extractOutput(ev); ok {
+					gotOutput = out.([]any)
+				}
+			}
+
+			if tc.wantErr {
+				if gotErr == nil {
+					t.Fatal("expected error, got nil")
+				}
+				if tc.errSubstr != "" && !strings.Contains(gotErr.Error(), tc.errSubstr) {
+					t.Errorf("expected error containing %q, got %v", tc.errSubstr, gotErr)
+				}
+			} else {
+				if gotErr != nil {
+					t.Fatalf("unexpected error: %v", gotErr)
+				}
+				if diff := cmp.Diff(tc.wantOutput, gotOutput); diff != "" {
+					t.Errorf("output mismatch (-want +got):\n%s", diff)
+				}
+			}
+		})
+	}
+}
+
+func TestParallelWorker_Concurrency(t *testing.T) {
+	var counter int32
+	blockCh := make(chan struct{})
+
+	startedCh := make(chan struct{}, 4)
+	wrapped := NewFunctionNode("blocking", func(ctx agent.InvocationContext, input int) (int, error) {
+		atomic.AddInt32(&counter, 1)
+		startedCh <- struct{}{}
+		<-blockCh
+		return input, nil
+	}, defaultNodeConfig)
+
+	pw, err := NewParallelWorker("parallel", wrapped, 2, defaultNodeConfig)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	mockCtx := newMockCtx(t)
+	input := []any{1, 2, 3, 4}
+
+	done := make(chan struct{})
+	go func() {
+		for range pw.Run(mockCtx, input) {
+		}
+		close(done)
+	}()
+
+	// Wait for 2 workers to start.
+	// We expect at most 2 workers to start because maxConcurrency is 2.
+	<-startedCh
+	<-startedCh
+
+	c := atomic.LoadInt32(&counter)
+	if c != 2 {
+		t.Errorf("expected counter to be 2, got %d", c)
+	}
+
+	// Verify no 3rd worker started
+	select {
+	case <-startedCh:
+		t.Error("expected only 2 workers to start, but more did")
+	default:
+	}
+
+	// Unblock workers
+	close(blockCh)
+
+	// Wait for completion
+	select {
+	case <-done:
+	case <-time.After(2 * time.Second):
+		t.Fatal("timeout waiting for execution to complete")
+	}
+
+	// After unblocking, all workers should have run
+	c = atomic.LoadInt32(&counter)
+	if c != 4 {
+		t.Errorf("expected final counter to be 4, got %d", c)
+	}
+}
+
+func TestParallelWorker_SuppressIntermediateEvents(t *testing.T) {
+	wrapped := NewFunctionNode("wrapped", func(ctx agent.InvocationContext, input any) (any, error) { return input, nil }, defaultNodeConfig)
+
+	pw, err := NewParallelWorker("parallel", wrapped, 0, defaultNodeConfig)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	mockCtx := newMockCtx(t)
+	input := []any{1, 2}
+
+	events := pw.Run(mockCtx, input)
+
+	nonOutputCount := 0
+	hasAggregatedOutput := false
+
+	for ev, err := range events {
+		if err != nil {
+			t.Fatalf("unexpected error: %v", err)
+		}
+		if out, ok := extractOutput(ev); ok {
+			hasAggregatedOutput = true
+			wantOutput := []any{1, 2}
+			if diff := cmp.Diff(wantOutput, out); diff != "" {
+				t.Errorf("output mismatch (-want +got):\n%s", diff)
+			}
+		} else if ev.Content != nil && len(ev.Content.Parts) > 0 && ev.Content.Parts[0].Text == "progress" {
+			nonOutputCount++
+		}
+	}
+
+	if nonOutputCount != 0 {
+		t.Errorf("expected 0 progress events, got %d", nonOutputCount)
+	}
+	if !hasAggregatedOutput {
+		t.Error("expected final aggregated output event")
+	}
+}
+
+func TestParallelWorker_WorkflowIntegration(t *testing.T) {
+	splitFn := func(ctx agent.InvocationContext, input string) ([]any, error) {
+		parts := strings.Split(input, ",")
+		var res []any
+		for _, p := range parts {
+			res = append(res, p)
+		}
+		return res, nil
+	}
+	splitNode := NewFunctionNode("split", splitFn, defaultNodeConfig)
+
+	pw, err := NewParallelWorker("parallel", upperNode, 0, defaultNodeConfig)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	joinFn := func(ctx agent.InvocationContext, input []any) (string, error) {
+		var strs []string
+		for _, v := range input {
+			strs = append(strs, v.(string))
+		}
+		return strings.Join(strs, ":"), nil
+	}
+	joinNode := NewFunctionNode("join", joinFn, defaultNodeConfig)
+
+	edges := []Edge{
+		{From: Start, To: splitNode},
+		{From: splitNode, To: pw},
+		{From: pw, To: joinNode},
+	}
+
+	w := mustNew(t, edges)
+
+	mockCtx := newMockCtx(t)
+	mockCtx.userContent = &genai.Content{
+		Parts: []*genai.Part{{Text: "a,b,c"}},
+	}
+
+	events := w.Run(mockCtx)
+
+	var lastOutput any
+	for ev, err := range events {
+		if err != nil {
+			t.Fatalf("unexpected error: %v", err)
+		}
+		if out, ok := extractOutput(ev); ok {
+			lastOutput = out
+		}
+	}
+
+	wantOutput := "A:B:C"
+	if lastOutput != wantOutput {
+		t.Errorf("expected output %q, got %v", wantOutput, lastOutput)
+	}
+}
+
+func TestNewParallelWorker_ErrorOnWrappedRetryConfig(t *testing.T) {
+	wrapped := NewFunctionNode("wrapped", func(ctx agent.InvocationContext, input any) (any, error) { return input, nil }, NodeConfig{RetryConfig: DefaultRetryConfig()})
+
+	_, err := NewParallelWorker("parallel", wrapped, 0, defaultNodeConfig)
+	if err == nil {
+		t.Fatal("expected error when wrapped node has RetryConfig, got nil")
+	}
+	if !strings.Contains(err.Error(), "cannot have RetryConfig") {
+		t.Errorf("expected error containing 'cannot have RetryConfig', got %v", err)
+	}
+}
+
+func TestParallelWorker_Retry(t *testing.T) {
+	var mu sync.Mutex
+	attempts := make(map[string]int)
+
+	wrapped := NewFunctionNode("retry_node", func(ctx agent.InvocationContext, input string) (string, error) {
+		mu.Lock()
+		attempts[input]++
+		count := attempts[input]
+		mu.Unlock()
+
+		if input == "b" && count <= 2 {
+			return "", errors.New("temporary failure")
+		}
+		return input, nil
+	}, defaultNodeConfig)
+
+	rc := DefaultRetryConfig()
+	rc.MaxAttempts = 3
+	rc.InitialDelay = 0
+	rc.MaxDelay = 0
+	rc.Jitter = 0
+	rc.ShouldRetry = func(err error) bool { return true }
+
+	pw, err := NewParallelWorker("parallel", wrapped, 0, NodeConfig{RetryConfig: rc})
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	mockCtx := newMockCtx(t)
+	input := []any{"a", "b"}
+
+	events := pw.Run(mockCtx, input)
+
+	var gotOutput []any
+	var gotErr error
+
+	for ev, err := range events {
+		if err != nil {
+			gotErr = err
+			break
+		}
+		if out, ok := extractOutput(ev); ok {
+			gotOutput = out.([]any)
+		}
+	}
+
+	if gotErr != nil {
+		t.Fatalf("unexpected error: %v", gotErr)
+	}
+
+	wantOutput := []any{"a", "b"}
+	if diff := cmp.Diff(wantOutput, gotOutput); diff != "" {
+		t.Errorf("output mismatch (-want +got):\n%s", diff)
+	}
+
+	mu.Lock()
+	countA := attempts["a"]
+	countB := attempts["b"]
+	mu.Unlock()
+
+	if countA != 1 {
+		t.Errorf("expected 1 attempt for 'a', got %d", countA)
+	}
+	if countB != 3 {
+		t.Errorf("expected 3 attempts for 'b', got %d", countB)
+	}
+}
+
+func TestParallelWorker_FailFast(t *testing.T) {
+	var workerCCancelled int32
+	cancelledCh := make(chan struct{})
+
+	wrapped := NewFunctionNode("fail_fast_node", func(ctx agent.InvocationContext, input string) (string, error) {
+		if input == "b" {
+			return "", errors.New("error b")
+		}
+		if input == "c" {
+			// Block until cancelled
+			select {
+			case <-ctx.Done():
+				atomic.StoreInt32(&workerCCancelled, 1)
+				close(cancelledCh)
+				return "", ctx.Err()
+			}
+		}
+		return input, nil
+	}, defaultNodeConfig)
+
+	pw, err := NewParallelWorker("parallel", wrapped, 0, defaultNodeConfig)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	mockCtx := newMockCtx(t)
+	input := []any{"a", "b", "c"}
+
+	events := pw.Run(mockCtx, input)
+
+	var gotErr error
+	for _, err := range events {
+		if err != nil {
+			gotErr = err
+			break
+		}
+	}
+
+	if gotErr == nil {
+		t.Fatal("expected error, got nil")
+	}
+
+	if gotErr.Error() != "error b" {
+		t.Errorf("expected error 'error b', got %v", gotErr)
+	}
+
+	// Wait for worker C to observe cancellation
+	select {
+	case <-cancelledCh:
+		// Good
+	case <-time.After(2 * time.Second):
+		t.Fatal("timeout waiting for worker C to be cancelled")
+	}
+
+	if atomic.LoadInt32(&workerCCancelled) != 1 {
+		t.Error("expected worker c to be cancelled")
+	}
+}
+
+func TestParallelWorker_CancelDuringExecution(t *testing.T) {
+	blockCh := make(chan struct{})
+	startedCh := make(chan struct{}, 2)
+	wrapped := NewFunctionNode("blocking", func(ctx agent.InvocationContext, input any) (any, error) {
+		startedCh <- struct{}{}
+		select {
+		case <-ctx.Done():
+			return nil, ctx.Err()
+		case <-blockCh:
+			return input, nil
+		}
+	}, defaultNodeConfig)
+
+	pw, err := NewParallelWorker("parallel", wrapped, 0, defaultNodeConfig)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	ctx, cancel := context.WithCancel(t.Context())
+	mockCtx := &MockInvocationContext{Context: ctx}
+	input := []any{1, 2}
+
+	done := make(chan struct{})
+	var gotErr error
+	var hasFinalResult bool
+
+	go func() {
+		for ev, err := range pw.Run(mockCtx, input) {
+			if err != nil {
+				gotErr = err
+			}
+			if _, ok := extractOutput(ev); ok {
+				hasFinalResult = true
+			}
+		}
+		close(done)
+	}()
+
+	// Wait for workers to start before cancelling
+	<-startedCh
+	<-startedCh
+	cancel()
+
+	select {
+	case <-done:
+	case <-time.After(2 * time.Second):
+		t.Fatal("timeout waiting for cancellation to complete")
+	}
+
+	if gotErr == nil {
+		t.Error("expected error on cancellation, got nil")
+	}
+	if !errors.Is(gotErr, context.Canceled) {
+		t.Errorf("expected context.Canceled, got %v", gotErr)
+	}
+	if hasFinalResult {
+		t.Error("expected no final result to be yielded")
+	}
+
+	close(blockCh)
+}
+
+func TestParallelWorker_ConcurrentMultiOutputOrder(t *testing.T) {
+	releaseA := make(chan struct{})
+	releaseB := make(chan struct{})
+	releaseC := make(chan struct{})
+	startedCh := make(chan struct{}, 3)
+
+	wrapped := &delayedMultiOutputTestNode{
+		releaseChans: map[string]chan struct{}{
+			"a": releaseA,
+			"b": releaseB,
+			"c": releaseC,
+		},
+		startedCh: startedCh,
+	}
+
+	pw, err := NewParallelWorker("parallel", wrapped, 0, defaultNodeConfig)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	mockCtx := newMockCtx(t)
+	input := []any{"a", "b", "c"}
+
+	done := make(chan struct{})
+	var gotOutput []any
+	go func() {
+		events := pw.Run(mockCtx, input)
+		for ev, err := range events {
+			if err != nil {
+				t.Errorf("unexpected error: %v", err)
+				return
+			}
+			if out, ok := extractOutput(ev); ok {
+				gotOutput = out.([]any)
+			}
+		}
+		close(done)
+	}()
+
+	// Wait for all workers to start
+	<-startedCh
+	<-startedCh
+	<-startedCh
+
+	// Release in reverse order to simulate out-of-order completion
+	close(releaseC)
+	close(releaseB)
+	close(releaseA)
+
+	<-done
+
+	wantOutput := []any{
+		[]any{"a", "a_2"},
+		[]any{"b", "b_2"},
+		[]any{"c", "c_2"},
+	}
+
+	if diff := cmp.Diff(wantOutput, gotOutput); diff != "" {
+		t.Errorf("output mismatch (-want +got):\n%s", diff)
+	}
+}
+
+type delayedMultiOutputTestNode struct {
+	BaseNode
+	releaseChans map[string]chan struct{}
+	startedCh    chan struct{}
+}
+
+func (n *delayedMultiOutputTestNode) Run(ctx agent.InvocationContext, input any) iter.Seq2[*session.Event, error] {
+	return func(yield func(*session.Event, error) bool) {
+		s := input.(string)
+
+		if n.startedCh != nil {
+			n.startedCh <- struct{}{}
+		}
+		if ch, ok := n.releaseChans[s]; ok {
+			<-ch
+		}
+
+		ev1 := session.NewEvent(ctx.InvocationID())
+		ev1.Output = s
+		if !yield(ev1, nil) {
+			return
+		}
+
+		ev2 := session.NewEvent(ctx.InvocationID())
+		ev2.Output = fmt.Sprintf("%v_2", s)
+		yield(ev2, nil)
+	}
+}
+
+func (n *delayedMultiOutputTestNode) Name() string        { return "delayed_multi_output" }
+func (n *delayedMultiOutputTestNode) Description() string { return "" }
+func (n *delayedMultiOutputTestNode) Config() NodeConfig  { return defaultNodeConfig }
+
+func TestParallelWorker_SchedulerDoesNotRetryOnFailure(t *testing.T) {
+	var wrappedAttempts int32
+
+	wrapped := NewFunctionNode("worker", func(ctx agent.InvocationContext, input string) (string, error) {
+		atomic.AddInt32(&wrappedAttempts, 1)
+		return "", errors.New("persistent failure")
+	}, defaultNodeConfig)
+
+	rc := DefaultRetryConfig()
+	rc.MaxAttempts = 2
+	rc.InitialDelay = 0
+	rc.MaxDelay = 0
+	rc.Jitter = 0
+
+	pw, err := NewParallelWorker("parallel", wrapped, 0, NodeConfig{RetryConfig: rc})
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	splitFn := func(ctx agent.InvocationContext, input string) ([]any, error) {
+		return []any{input}, nil
+	}
+	splitNode := NewFunctionNode("split", splitFn, defaultNodeConfig)
+
+	edges := []Edge{
+		{From: Start, To: splitNode},
+		{From: splitNode, To: pw},
+	}
+
+	w := mustNew(t, edges)
+
+	mockCtx := newMockCtx(t)
+	mockCtx.userContent = &genai.Content{
+		Parts: []*genai.Part{{Text: "a"}},
+	}
+
+	events := w.Run(mockCtx)
+
+	var gotErr error
+	for _, err := range events {
+		if err != nil {
+			gotErr = err
+			break
+		}
+	}
+
+	if gotErr == nil {
+		t.Fatal("expected error, got nil")
+	}
+
+	if atomic.LoadInt32(&wrappedAttempts) != 2 {
+		t.Errorf("expected 2 attempts for wrapped node, got %d (scheduler likely retried the node)", atomic.LoadInt32(&wrappedAttempts))
+	}
+}
+

--- a/workflow/persistence.go
+++ b/workflow/persistence.go
@@ -1,0 +1,101 @@
+// Copyright 2026 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package workflow
+
+import (
+	"encoding/json"
+	"errors"
+	"fmt"
+
+	"google.golang.org/adk/session"
+)
+
+// runStateSessionKeyPrefix is the prefix used by RunStateSessionKey
+// for namespacing workflow RunStates inside session.State.
+const runStateSessionKeyPrefix = "adk.workflow.runstate."
+
+// RunStateSessionKey returns the session.State key under which a
+// workflow's RunState is persisted between invocations. Namespaced
+// by workflow name so multiple workflows in the same session do
+// not collide.
+func RunStateSessionKey(workflowName string) string {
+	return runStateSessionKeyPrefix + workflowName
+}
+
+// LoadRunState reads and decodes the workflow's persisted RunState
+// from the given session. Returns (nil, nil) when no state has
+// been stored yet, so callers can distinguish "nothing to resume"
+// from "load failed". An empty workflowName disables persistence
+// and always returns (nil, nil).
+func LoadRunState(sess session.Session, workflowName string) (*RunState, error) {
+	if sess == nil || workflowName == "" {
+		return nil, nil
+	}
+	state := sess.State()
+	if state == nil {
+		return nil, nil
+	}
+	raw, err := state.Get(RunStateSessionKey(workflowName))
+	if err != nil {
+		if errors.Is(err, session.ErrStateKeyNotExist) {
+			return nil, nil
+		}
+		return nil, err
+	}
+
+	// raw is JSON-encoded []byte (or its base64-string form when
+	// the session backend round-trips StateDelta through JSON).
+	decode := func(b []byte) (*RunState, error) {
+		var state RunState
+		if err := json.Unmarshal(b, &state); err != nil {
+			return nil, fmt.Errorf("workflow: decode run state: %w", err)
+		}
+		return &state, nil
+	}
+	switch v := raw.(type) {
+	case []byte:
+		return decode(v)
+	case string:
+		return decode([]byte(v))
+	default:
+		return nil, fmt.Errorf("workflow: run state has unexpected type %T (want []byte or string)", raw)
+	}
+}
+
+// NewRunStateEvent builds a session.Event whose Actions.StateDelta
+// carries the workflow's serialised RunState. Workflow.Run and
+// Workflow.Resume yield this event before returning so the
+// surrounding event-append pipeline can persist the state
+// alongside every other delta-based update.
+//
+// Persistence backends apply state mutations only when they
+// observe them on Event.Actions.StateDelta during the append
+// path; a direct session.State().Set updates the per-invocation
+// copy but is not propagated to storage. Returning nil for an
+// empty workflowName lets callers use NewRunStateEvent
+// unconditionally and skip the yield when persistence is not
+// desired.
+func NewRunStateEvent(invocationID, workflowName string, state *RunState) (*session.Event, error) {
+	if workflowName == "" || state == nil {
+		return nil, nil
+	}
+	bytes, err := json.Marshal(state)
+	if err != nil {
+		return nil, fmt.Errorf("workflow: encode run state: %w", err)
+	}
+	ev := session.NewEvent(invocationID)
+	ev.Actions.StateDelta[RunStateSessionKey(workflowName)] = bytes
+	return ev, nil
+}

--- a/workflow/request_input.go
+++ b/workflow/request_input.go
@@ -1,0 +1,54 @@
+// Copyright 2026 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package workflow
+
+import (
+	"github.com/google/uuid"
+
+	"google.golang.org/adk/agent"
+	"google.golang.org/adk/session"
+)
+
+// NewRequestInputEvent constructs a session.Event that asks the
+// surrounding workflow to pause and surface a human-input prompt.
+// A node yields the returned event and then exits its iter.Seq2;
+// the scheduler observes Event.RequestedInput and transitions the
+// node to NodeWaiting.
+//
+// If req.InterruptID is empty, a UUID is generated so the
+// downstream contract (a non-empty correlation key on
+// NodeState.PendingRequest) is always satisfied. Pass an explicit
+// InterruptID when the prompt has a stable, author-defined intent
+// that the UI or a multi-prompt node needs to recognise.
+//
+// Example:
+//
+//	func (n *MyNode) Run(ctx agent.InvocationContext, in any) iter.Seq2[*session.Event, error] {
+//	    return func(yield func(*session.Event, error) bool) {
+//	        yield(workflow.NewRequestInputEvent(ctx, session.RequestInput{
+//	            InterruptID: "human_review",
+//	            Message:     "Please review this draft.",
+//	            Payload:     draft,
+//	        }), nil)
+//	    }
+//	}
+func NewRequestInputEvent(ctx agent.InvocationContext, req session.RequestInput) *session.Event {
+	if req.InterruptID == "" {
+		req.InterruptID = uuid.NewString()
+	}
+	ev := session.NewEvent(ctx.InvocationID())
+	ev.RequestedInput = &req
+	return ev
+}

--- a/workflow/request_input.go
+++ b/workflow/request_input.go
@@ -16,16 +16,33 @@ package workflow
 
 import (
 	"github.com/google/uuid"
+	"google.golang.org/genai"
 
 	"google.golang.org/adk/agent"
+	"google.golang.org/adk/model"
 	"google.golang.org/adk/session"
 )
+
+// WorkflowInputFunctionCallName is the FunctionCall name carried on
+// a request event so the agent runtime's generic FunctionResponse-
+// by-ID dispatch can route the user's follow-up reply back to the
+// workflow agent that issued the request. Mirrors
+// toolconfirmation.FunctionCallName.
+const WorkflowInputFunctionCallName = "adk_request_workflow_input"
 
 // NewRequestInputEvent constructs a session.Event that asks the
 // surrounding workflow to pause and surface a human-input prompt.
 // A node yields the returned event and then exits its iter.Seq2;
 // the scheduler observes Event.RequestedInput and transitions the
 // node to NodeWaiting.
+//
+// The event also carries a synthesised FunctionCall part with name
+// WorkflowInputFunctionCallName and ID equal to req.InterruptID,
+// plus req.InterruptID in LongRunningToolIDs. This shape makes
+// Event.IsFinalResponse() return true so the surrounding agent
+// loop terminates after the request is yielded, and lets the
+// generic FunctionResponse-by-ID dispatch route the human's reply
+// back to the workflow agent that issued the request.
 //
 // If req.InterruptID is empty, a UUID is generated so the
 // downstream contract (a non-empty correlation key on
@@ -48,7 +65,42 @@ func NewRequestInputEvent(ctx agent.InvocationContext, req session.RequestInput)
 	if req.InterruptID == "" {
 		req.InterruptID = uuid.NewString()
 	}
+
 	ev := session.NewEvent(ctx.InvocationID())
 	ev.RequestedInput = &req
+
+	// Synthesise the FunctionCall part so generic
+	// FunctionResponse-by-ID dispatch can route the human's reply
+	// back to this agent on the follow-up turn. Args mirror the
+	// RequestInput fields so a client that does not parse the
+	// dedicated RequestedInput field can still display the prompt
+	// from the args alone.
+	args := map[string]any{
+		"interruptId": req.InterruptID,
+		"message":     req.Message,
+		"payload":     req.Payload,
+	}
+	if req.ResponseSchema != nil {
+		args["responseSchema"] = req.ResponseSchema
+	}
+	ev.LLMResponse = model.LLMResponse{
+		Content: &genai.Content{
+			Role: genai.RoleModel,
+			Parts: []*genai.Part{{
+				FunctionCall: &genai.FunctionCall{
+					ID:   req.InterruptID,
+					Name: WorkflowInputFunctionCallName,
+					Args: args,
+				},
+			}},
+		},
+	}
+	ev.LongRunningToolIDs = []string{req.InterruptID}
+
+	if a := ctx.Agent(); a != nil {
+		ev.Author = a.Name()
+	}
+	ev.Branch = ctx.Branch()
+
 	return ev
 }

--- a/workflow/request_input.go
+++ b/workflow/request_input.go
@@ -28,7 +28,12 @@ import (
 // by-ID dispatch can route the user's follow-up reply back to the
 // workflow agent that issued the request. Mirrors
 // toolconfirmation.FunctionCallName.
-const WorkflowInputFunctionCallName = "adk_request_workflow_input"
+//
+// This is a wire-format identifier shared with other ADK runtimes
+// and must not be changed without coordinated updates across them;
+// a session recorded by one runtime must round-trip through any
+// other runtime's resume dispatch.
+const WorkflowInputFunctionCallName = "adk_request_input"
 
 // NewRequestInputEvent constructs a session.Event that asks the
 // surrounding workflow to pause and surface a human-input prompt.

--- a/workflow/resume.go
+++ b/workflow/resume.go
@@ -111,21 +111,38 @@ func (w *Workflow) Resume(
 				continue
 			}
 
+			// Snapshot InterruptID before consuming PendingRequest;
+			// re-entry mode passes it through resumeInputs.
+			interruptID := ns.PendingRequest.InterruptID
+
 			// Consume PendingRequest before scheduling. A duplicate
 			// Resume with the same InterruptID will skip this node
 			// because PendingRequest is now nil.
 			ns.PendingRequest = nil
 			ns.Status = NodePending
 
-			// Handoff mode: schedule each successor with the
-			// response as its input, exactly as if the asker had
-			// emitted it as output. Reuses findSuccessors so
-			// routing, fan-out and fan-in invariants apply
-			// uniformly. (No routing event is supplied, so a
-			// router-style handoff target falls back to its
-			// Default route or dead-ends.)
-			for _, succ := range findSuccessors(s.graph, node, resp, nil) {
-				s.scheduleNode(succ.node, succ.input, succ.triggeredBy)
+			if r := node.Config().RerunOnResume; r != nil && *r {
+				// Re-entry mode: re-activate the asker with its
+				// original input; the response is delivered via
+				// ctx.ResumedInput(InterruptID), not via the
+				// input parameter. Successors fire only when the
+				// re-entry activation produces an output.
+				resumeInputs := map[string]any{interruptID: resp}
+				s.scheduleResumedNode(node, ns.Input, ns.TriggeredBy, resumeInputs)
+			} else {
+				// Handoff mode: schedule each successor with the
+				// response as its input, exactly as if the asker
+				// had emitted it as output. Reuses findSuccessors
+				// so routing, fan-out and fan-in invariants apply
+				// uniformly. findSuccessors is called with
+				// event=nil, so successors reached only via a
+				// concrete Route (StringRoute etc.) do not fire —
+				// the response is opaque to the routing layer.
+				// Successors reached via an unconditional edge or
+				// via the Default route fire as usual.
+				for _, succ := range findSuccessors(s.graph, node, resp, nil) {
+					s.scheduleNode(succ.node, succ.input, succ.triggeredBy)
+				}
 			}
 			scheduled++
 		}

--- a/workflow/resume.go
+++ b/workflow/resume.go
@@ -1,0 +1,165 @@
+// Copyright 2026 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package workflow
+
+import (
+	"errors"
+	"fmt"
+	"iter"
+
+	"github.com/google/jsonschema-go/jsonschema"
+
+	"google.golang.org/adk/agent"
+	"google.golang.org/adk/internal/typeutil"
+	"google.golang.org/adk/session"
+)
+
+// ErrInvalidResumeResponse is returned by Workflow.Resume when a
+// response payload does not match its corresponding
+// RequestInput.ResponseSchema. The waiting node is left in
+// NodeWaiting with PendingRequest intact so the caller can retry
+// with a corrected payload.
+var ErrInvalidResumeResponse = errors.New("workflow: resume response does not match request schema")
+
+// ErrNothingToResume is returned by Workflow.Resume when the
+// caller supplied a non-empty responses map but no waiting node
+// matched any of the InterruptIDs in it. Lets the caller
+// distinguish "successful resume" from "submitted response had no
+// effect" — typically a sign that the response targets a stale or
+// already-consumed request, or that the workflow graph has
+// evolved out of the node that was waiting.
+var ErrNothingToResume = errors.New("workflow: no waiting node matched the supplied responses")
+
+// Resume continues a previously paused workflow run. state is the
+// RunState loaded from session storage; responses maps
+// RequestInput.InterruptID to the user-supplied response payload.
+//
+// For each waiting node whose InterruptID has a matching entry in
+// responses, Resume:
+//
+//  1. Validates the payload against PendingRequest.ResponseSchema,
+//     if non-nil. A mismatch surfaces as ErrInvalidResumeResponse
+//     via the iterator and leaves the node in NodeWaiting with
+//     PendingRequest intact.
+//
+//  2. Consumes the pending request (clears PendingRequest, sets
+//     Status = NodePending) before re-scheduling, so a duplicate
+//     Resume call with the same InterruptID becomes a no-op.
+//
+//  3. Routes the response to the asker's successors as if the
+//     asker had emitted it as its output (handoff mode). The
+//     asker itself does NOT re-execute.
+//
+// Waiting nodes whose InterruptID is absent from responses remain
+// in NodeWaiting unchanged.
+//
+// If responses is non-empty but no waiting node matches any
+// InterruptID in it, Resume yields ErrNothingToResume so the
+// caller can distinguish a successful resume from a stale or
+// mistargeted submission. An empty responses map (or nil state)
+// is treated as a clean no-op with no error.
+func (w *Workflow) Resume(
+	ctx agent.InvocationContext,
+	state *RunState,
+	responses map[string]any,
+) iter.Seq2[*session.Event, error] {
+	return func(yield func(*session.Event, error) bool) {
+		if state == nil || len(responses) == 0 {
+			return
+		}
+
+		s := newScheduler(ctx, w.graph)
+		s.state = state
+
+		scheduled := 0
+		for name, ns := range state.Nodes {
+			if ns.Status != NodeWaiting || ns.PendingRequest == nil {
+				continue
+			}
+			resp, ok := responses[ns.PendingRequest.InterruptID]
+			if !ok {
+				continue
+			}
+
+			// Schema validation: surface a typed error and leave
+			// the node parked so the caller can retry.
+			if ns.PendingRequest.ResponseSchema != nil {
+				validated, err := validateResumeResponse(resp, ns.PendingRequest.ResponseSchema)
+				if err != nil {
+					if !yield(nil, fmt.Errorf("%w: node %q: %w", ErrInvalidResumeResponse, name, err)) {
+						return
+					}
+					continue
+				}
+				resp = validated
+			}
+
+			node := s.nodesByName[name]
+			if node == nil {
+				continue
+			}
+
+			// Consume PendingRequest before scheduling. A duplicate
+			// Resume with the same InterruptID will skip this node
+			// because PendingRequest is now nil.
+			ns.PendingRequest = nil
+			ns.Status = NodePending
+
+			// Handoff mode: schedule each successor with the
+			// response as its input, exactly as if the asker had
+			// emitted it as output. Reuses findSuccessors so
+			// routing, fan-out and fan-in invariants apply
+			// uniformly. (No routing event is supplied, so a
+			// router-style handoff target falls back to its
+			// Default route or dead-ends.)
+			for _, succ := range findSuccessors(s.graph, node, resp, nil) {
+				s.scheduleNode(succ.node, succ.input, succ.triggeredBy)
+			}
+			scheduled++
+		}
+
+		if scheduled == 0 {
+			yield(nil, ErrNothingToResume)
+			return
+		}
+
+		s.run(yield)
+		s.wg.Wait()
+
+		// Persist the post-resume state via a session.Event with
+		// StateDelta. If new nodes paused during this Resume the
+		// next turn will see them; if the run completed the state
+		// reflects that too.
+		yieldRunStateEvent(ctx, w.name, s.state, yield)
+	}
+}
+
+// validateResumeResponse coerces resp into the type described by
+// schema, returning the validated value or an error. When schema
+// is nil, resp passes through unchanged.
+//
+// The schema is resolved on each call rather than cached: persisted
+// RunState round-trips schemas through JSON, which does not
+// preserve any pre-resolved form.
+func validateResumeResponse(resp any, schema *jsonschema.Schema) (any, error) {
+	if schema == nil {
+		return resp, nil
+	}
+	resolved, err := schema.Resolve(nil)
+	if err != nil {
+		return nil, fmt.Errorf("resolve schema: %w", err)
+	}
+	return typeutil.ConvertToWithJSONSchema[any, any](resp, resolved)
+}

--- a/workflow/resume.go
+++ b/workflow/resume.go
@@ -127,8 +127,17 @@ func (w *Workflow) Resume(
 				// ctx.ResumedInput(InterruptID), not via the
 				// input parameter. Successors fire only when the
 				// re-entry activation produces an output.
-				resumeInputs := map[string]any{interruptID: resp}
-				s.scheduleResumedNode(node, ns.Input, ns.TriggeredBy, resumeInputs)
+				//
+				// Accumulate into ns.ResumedInputs so a node that
+				// yields multiple RequestInputs across resume
+				// cycles sees every prior response, not just the
+				// most recent one. The map is cleared when the
+				// node transitions to NodeCompleted.
+				if ns.ResumedInputs == nil {
+					ns.ResumedInputs = map[string]any{}
+				}
+				ns.ResumedInputs[interruptID] = resp
+				s.scheduleResumedNode(node, ns.Input, ns.TriggeredBy, ns.ResumedInputs)
 			} else {
 				// Handoff mode: schedule each successor with the
 				// response as its input, exactly as if the asker

--- a/workflow/resume.go
+++ b/workflow/resume.go
@@ -83,6 +83,19 @@ func (w *Workflow) Resume(
 		s := newScheduler(ctx, w.graph)
 		s.state = state
 
+		// Resume runs in two passes so that when one call
+		// satisfies several askers feeding a JoinNode, the
+		// barrier sees every predecessor as NodeCompleted
+		// before it is evaluated. Re-entry-mode askers are
+		// unaffected — they re-run rather than complete here.
+		type deferredHandoff struct {
+			node Node
+			resp any
+		}
+		var deferredHandoffs []deferredHandoff
+
+		// Pass 1: dispatch every waiting asker matched by
+		// responses (handoff → defer; re-entry → reschedule now).
 		scheduled := 0
 		for name, ns := range state.Nodes {
 			if ns.Status != NodeWaiting || ns.PendingRequest == nil {
@@ -139,21 +152,32 @@ func (w *Workflow) Resume(
 				ns.ResumedInputs[interruptID] = resp
 				s.scheduleResumedNode(node, ns.Input, ns.TriggeredBy, ns.ResumedInputs)
 			} else {
-				// Handoff mode: schedule each successor with the
-				// response as its input, exactly as if the asker
-				// had emitted it as output. Reuses findSuccessors
-				// so routing, fan-out and fan-in invariants apply
-				// uniformly. findSuccessors is called with
-				// event=nil, so successors reached only via a
-				// concrete Route (StringRoute etc.) do not fire —
-				// the response is opaque to the routing layer.
-				// Successors reached via an unconditional edge or
-				// via the Default route fire as usual.
-				for _, succ := range findSuccessors(s.graph, node, resp, nil) {
-					s.scheduleNode(succ.node, succ.input, succ.triggeredBy)
-				}
+				// Handoff mode: promote the asker as if it had
+				// emitted resp as its output. Recording Output
+				// lets the join barrier read it back without a
+				// special case for "completed via resume".
+				ns.Status = NodeCompleted
+				ns.Output = resp
+				deferredHandoffs = append(deferredHandoffs, deferredHandoff{
+					node: node, resp: resp,
+				})
 			}
 			scheduled++
+		}
+
+		// Pass 2: walk successors of the deferred handoffs.
+		// All matched askers are now NodeCompleted, so any
+		// downstream JoinNode sees a settled predecessor set.
+		for _, h := range deferredHandoffs {
+			// findSuccessors is called with event=nil, so
+			// successors reached only via a concrete Route
+			// (StringRoute etc.) do not fire — the response is
+			// opaque to the routing layer. Successors reached via
+			// an unconditional edge or via the Default route fire
+			// as usual.
+			for _, succ := range findSuccessors(s.graph, s.state, h.node, h.resp, nil) {
+				s.scheduleNode(succ.node, succ.input, succ.triggeredBy)
+			}
 		}
 
 		if scheduled == 0 {

--- a/workflow/resume.go
+++ b/workflow/resume.go
@@ -80,7 +80,7 @@ func (w *Workflow) Resume(
 			return
 		}
 
-		s := newScheduler(ctx, w.graph)
+		s := newScheduler(ctx, w.graph, w.maxConcurrency)
 		s.state = state
 
 		// Resume runs in two passes so that when one call

--- a/workflow/resume.go
+++ b/workflow/resume.go
@@ -150,7 +150,7 @@ func (w *Workflow) Resume(
 					ns.ResumedInputs = map[string]any{}
 				}
 				ns.ResumedInputs[interruptID] = resp
-				s.scheduleResumedNode(node, ns.Input, ns.TriggeredBy, ns.ResumedInputs)
+				s.scheduleResumedNode(node, ns.Input, ns.TriggeredBy, ns.Branch, ns.ResumedInputs)
 			} else {
 				// Handoff mode: promote the asker as if it had
 				// emitted resp as its output. Recording Output
@@ -175,8 +175,15 @@ func (w *Workflow) Resume(
 			// opaque to the routing layer. Successors reached via
 			// an unconditional edge or via the Default route fire
 			// as usual.
-			for _, succ := range findSuccessors(s.graph, s.state, h.node, h.resp, nil) {
-				s.scheduleNode(succ.node, succ.input, succ.triggeredBy)
+			// Handoff successors inherit the asker's branch so the
+			// downstream LLM history filter still scopes correctly
+			// when a parallel branch resumes via handoff.
+			parentBranch := ""
+			if ns := s.state.Nodes[h.node.Name()]; ns != nil {
+				parentBranch = ns.Branch
+			}
+			for _, succ := range findSuccessors(s.graph, s.state, h.node, h.resp, nil, parentBranch) {
+				s.scheduleNode(succ.node, succ.input, succ.triggeredBy, succ.branch)
 			}
 		}
 

--- a/workflow/retry.go
+++ b/workflow/retry.go
@@ -1,0 +1,67 @@
+// Copyright 2026 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package workflow
+
+import (
+	"math/rand"
+	"time"
+)
+
+// CalculateDelay calculates the delay before the next retry attempt.
+// failedAttempts is the number of times the node has already failed.
+func CalculateDelay(cfg *RetryConfig, failedAttempts int) time.Duration {
+	if cfg == nil || failedAttempts <= 0 {
+		return 0
+	}
+
+	delay := float64(cfg.InitialDelay)
+	for i := 1; i < failedAttempts; i++ {
+		delay *= cfg.BackoffFactor
+	}
+
+	maxDelay := float64(cfg.MaxDelay)
+	if maxDelay > 0 && delay > maxDelay {
+		delay = maxDelay
+	}
+
+	if cfg.Jitter > 0 {
+		randVal := rand.Float64()
+		randomOffset := (randVal*2.0 - 1.0) * cfg.Jitter * delay
+		delay += randomOffset
+		if delay < 0 {
+			delay = 0
+		}
+	}
+
+	return time.Duration(delay)
+}
+
+// ShouldRetry decides whether a node should be retried after a failure.
+// failedAttempts is the number of times the node has already failed.
+func ShouldRetry(cfg *RetryConfig, err error, failedAttempts int) bool {
+	if cfg == nil {
+		return false
+	}
+	if cfg.MaxAttempts <= 1 {
+		return false
+	}
+	if failedAttempts >= cfg.MaxAttempts {
+		return false
+	}
+	if cfg.ShouldRetry != nil {
+		return cfg.ShouldRetry(err)
+	}
+	return true // Default to true if not specified
+}

--- a/workflow/retry_loop_test.go
+++ b/workflow/retry_loop_test.go
@@ -40,7 +40,7 @@ func (n *retryLoopTestNode) Run(ctx agent.InvocationContext, input any) iter.Seq
 		calls := n.calls.Add(1)
 
 		// Make 2 failing calls and one successful call in each execution of the node.
-		if calls % 3 != 0 {
+		if calls%3 != 0 {
 			yield(nil, fmt.Errorf("fail attempt %d", calls))
 			return
 		}
@@ -52,7 +52,7 @@ func (n *retryLoopTestNode) Run(ctx agent.InvocationContext, input any) iter.Seq
 		} else {
 			ev.Routes = []string{"loop"}
 		}
-		ev.Actions.StateDelta["output"] = fmt.Sprintf("%v:%s", input, n.Name())
+		ev.Output = fmt.Sprintf("%v:%s", input, n.Name())
 		yield(ev, nil)
 	}
 }
@@ -97,7 +97,7 @@ func TestScheduler_RetryLoop(t *testing.T) {
 
 	wantOutputs := []string{"seed:A", "seed:A:A", "seed:A:A:Finish"}
 	gotOutputs := outputsOf(events)
-	
+
 	if diff := cmp.Diff(wantOutputs, gotOutputs); diff != "" {
 		t.Errorf("outputs mismatch (-want +got):\n%s", diff)
 	}

--- a/workflow/retry_loop_test.go
+++ b/workflow/retry_loop_test.go
@@ -1,0 +1,108 @@
+// Copyright 2026 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package workflow
+
+import (
+	"fmt"
+	"iter"
+	"sync/atomic"
+	"testing"
+
+	"github.com/google/go-cmp/cmp"
+	"google.golang.org/adk/agent"
+	"google.golang.org/adk/session"
+)
+
+// retryLoopTestNode simulates a node that fails twice in each execution
+// and succeeds on the third attempt.
+type retryLoopTestNode struct {
+	BaseNode
+	calls atomic.Int32
+	cfg   NodeConfig
+}
+
+func (n *retryLoopTestNode) Config() NodeConfig { return n.cfg }
+
+func (n *retryLoopTestNode) Run(ctx agent.InvocationContext, input any) iter.Seq2[*session.Event, error] {
+	return func(yield func(*session.Event, error) bool) {
+		calls := n.calls.Add(1)
+
+		// Make 2 failing calls and one successful call in each execution of the node.
+		if calls % 3 != 0 {
+			yield(nil, fmt.Errorf("fail attempt %d", calls))
+			return
+		}
+
+		ev := session.NewEvent(ctx.InvocationID())
+		// Finish after 2 loop executions.
+		if calls >= 6 {
+			ev.Routes = []string{"finish"}
+		} else {
+			ev.Routes = []string{"loop"}
+		}
+		ev.Actions.StateDelta["output"] = fmt.Sprintf("%v:%s", input, n.Name())
+		yield(ev, nil)
+	}
+}
+
+func TestScheduler_RetryLoop(t *testing.T) {
+	mockCtx := newSeededMockCtx(t)
+	retryConfig := DefaultRetryConfig()
+	retryConfig.MaxAttempts = 3
+	retryConfig.InitialDelay = 0
+	retryConfig.Jitter = 0.0
+
+	cfg := NodeConfig{
+		RetryConfig: retryConfig,
+	}
+
+	nodeA := &retryLoopTestNode{
+		BaseNode: NewBaseNode("A", "", cfg),
+		cfg:      cfg,
+	}
+
+	nodeFinish := newRecordingNode("Finish")
+	nodeFinish.release()
+
+	edges := []Edge{
+		{From: Start, To: nodeA},
+		{From: nodeA, To: nodeA, Route: StringRoute("loop")},
+		{From: nodeA, To: nodeFinish, Route: StringRoute("finish")},
+	}
+
+	w := mustNew(t, edges)
+
+	// Verify that ns.Attempt is reset on success, allowing full retries
+	// in subsequent executions in a loop.
+
+	var events []*session.Event
+	for ev, err := range w.Run(mockCtx) {
+		if err != nil {
+			t.Fatalf("unexpected error: %v", err)
+		}
+		events = append(events, ev)
+	}
+
+	wantOutputs := []string{"seed:A", "seed:A:A", "seed:A:A:Finish"}
+	gotOutputs := outputsOf(events)
+	
+	if diff := cmp.Diff(wantOutputs, gotOutputs); diff != "" {
+		t.Errorf("outputs mismatch (-want +got):\n%s", diff)
+	}
+
+	if got := nodeA.calls.Load(); got != 6 {
+		t.Errorf("node A calls = %d, want 6", got)
+	}
+}

--- a/workflow/retry_test.go
+++ b/workflow/retry_test.go
@@ -1,0 +1,152 @@
+// Copyright 2026 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package workflow
+
+import (
+	"errors"
+	"testing"
+	"time"
+)
+
+func TestCalculateDelay(t *testing.T) {
+	cfg := &RetryConfig{
+		InitialDelay:  time.Second,
+		BackoffFactor: 2.0,
+		MaxDelay:      10 * time.Second,
+		Jitter:        0.0, // Deterministic for base testing
+	}
+
+	tests := []struct {
+		failedAttempts int
+		want           time.Duration
+	}{
+		{failedAttempts: 0, want: 0},
+		{failedAttempts: 1, want: time.Second},
+		{failedAttempts: 2, want: 2 * time.Second},
+		{failedAttempts: 3, want: 4 * time.Second},
+		{failedAttempts: 4, want: 8 * time.Second},
+		{failedAttempts: 5, want: 10 * time.Second}, // Capped at MaxDelay
+		{failedAttempts: 6, want: 10 * time.Second},
+	}
+
+	for _, tt := range tests {
+		got := CalculateDelay(cfg, tt.failedAttempts)
+		if got != tt.want {
+			t.Errorf("CalculateDelay(..., %d) = %v, want %v", tt.failedAttempts, got, tt.want)
+		}
+	}
+}
+
+func TestCalculateDelayWithJitter(t *testing.T) {
+	cfg := &RetryConfig{
+		InitialDelay:  time.Second,
+		BackoffFactor: 2.0,
+		MaxDelay:      10 * time.Second,
+		Jitter:        0.5,
+	}
+
+	// With jitter 0.5, delay for 1st failed attempt (base 1s) should be in [0.5s, 1.5s]
+	got := CalculateDelay(cfg, 1)
+	if got < 500*time.Millisecond || got > 1500*time.Millisecond {
+		t.Errorf("CalculateDelay with jitter returned %v, expected in range [0.5s, 1.5s]", got)
+	}
+}
+
+func TestShouldRetry(t *testing.T) {
+	errTest := errors.New("test error")
+
+	tests := []struct {
+		name           string
+		cfg            *RetryConfig
+		err            error
+		failedAttempts int
+		want           bool
+	}{
+		{
+			name:           "Nil config",
+			cfg:            nil,
+			err:            errTest,
+			failedAttempts: 1,
+			want:           false,
+		},
+		{
+			name: "Under max attempts",
+			cfg: &RetryConfig{
+				MaxAttempts: 3,
+				ShouldRetry: func(e error) bool { return true },
+			},
+			err:            errTest,
+			failedAttempts: 1,
+			want:           true,
+		},
+		{
+			name:           "Default to true when ShouldRetry is nil",
+			cfg:            &RetryConfig{MaxAttempts: 3},
+			err:            errTest,
+			failedAttempts: 1,
+			want:           true,
+		},
+		{
+			name:           "At max attempts",
+			cfg:            &RetryConfig{MaxAttempts: 3},
+			err:            errTest,
+			failedAttempts: 3,
+			want:           false,
+		},
+		{
+			name:           "Above max attempts",
+			cfg:            &RetryConfig{MaxAttempts: 3},
+			err:            errTest,
+			failedAttempts: 4,
+			want:           false,
+		},
+		{
+			name:           "Zero max attempts (no retry)",
+			cfg:            &RetryConfig{MaxAttempts: 0},
+			err:            errTest,
+			failedAttempts: 1,
+			want:           false,
+		},
+		{
+			name: "Predicate allows",
+			cfg: &RetryConfig{
+				MaxAttempts: 3,
+				ShouldRetry: func(e error) bool { return true },
+			},
+			err:            errTest,
+			failedAttempts: 1,
+			want:           true,
+		},
+		{
+			name: "Predicate denies",
+			cfg: &RetryConfig{
+				MaxAttempts: 3,
+				ShouldRetry: func(e error) bool { return false },
+			},
+			err:            errTest,
+			failedAttempts: 1,
+			want:           false,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got := ShouldRetry(tt.cfg, tt.err, tt.failedAttempts)
+			if got != tt.want {
+				t.Errorf("ShouldRetry() = %v, want %v", got, tt.want)
+			}
+		})
+	}
+}

--- a/workflow/run_node.go
+++ b/workflow/run_node.go
@@ -16,14 +16,13 @@ package workflow
 
 import "fmt"
 
-// RunNodeOption configures a single RunNode call. Today only WithRunID
-// exists; the option set will grow to mirror adk-python's ctx.run_node
-// kwargs (use_as_output for output delegation, override_isolation_scope,
-// per-call timeout/retry overrides, etc.) as those features land.
+// RunNodeOption configures a single RunNode call.
 type RunNodeOption func(*runNodeOptions)
 
 type runNodeOptions struct {
-	customRunID string
+	customRunID    string
+	useSubBranch   bool
+	overrideBranch string
 }
 
 // WithRunID overrides the auto-generated counter with a stable
@@ -37,6 +36,37 @@ type runNodeOptions struct {
 // (https://adk.dev/graphs/dynamic/#custom-execution-ids).
 func WithRunID(id string) RunNodeOption {
 	return func(o *runNodeOptions) { o.customRunID = id }
+}
+
+// WithUseSubBranch derives a per-child sub-branch of the form
+// "<parentBranch>.<childName>@<runID>" (or just "<childName>@<runID>"
+// at root) for the child activation.
+//
+// Use this when the caller runs multiple concurrent or independent
+// children that should not see each other's events in their LLM
+// prompt history. Without it, every RunNode child inherits the
+// orchestrator's branch and an LlmAgent child would see sibling
+// events through the LLM flow's history filter.
+//
+// Combinable with WithOverrideBranch: the override sets the base,
+// and the sub-branch segment is appended to it.
+func WithUseSubBranch() RunNodeOption {
+	return func(o *runNodeOptions) { o.useSubBranch = true }
+}
+
+// WithOverrideBranch replaces the inherited branch verbatim,
+// regardless of WithUseSubBranch. Useful for nested dispatch
+// patterns (e.g. chat coordinator → task agent) where the parent
+// assigns a specific branch label by convention.
+//
+// Combinable with WithUseSubBranch: the override sets the base,
+// and the sub-branch segment "<childName>@<runID>" is appended.
+//
+// Empty branch is treated as "no override". To force root, pass
+// WithUseSubBranch() alone, which derives a fresh sub-branch off
+// root.
+func WithOverrideBranch(branch string) RunNodeOption {
+	return func(o *runNodeOptions) { o.overrideBranch = branch }
 }
 
 // RunNode schedules child as a sub-node of the currently-executing
@@ -62,7 +92,7 @@ func RunNode[OUT any](ctx NodeContext, child Node, input any, opts ...RunNodeOpt
 		opt(&o)
 	}
 
-	rawOut, err := nc.subScheduler.runNode(child, input, o.customRunID)
+	rawOut, err := nc.subScheduler.runNode(child, input, o)
 	if err != nil {
 		return zero, err
 	}

--- a/workflow/run_node.go
+++ b/workflow/run_node.go
@@ -1,0 +1,78 @@
+// Copyright 2026 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package workflow
+
+import "fmt"
+
+// RunNodeOption configures a single RunNode call. Today only WithRunID
+// exists; the option set will grow to mirror adk-python's ctx.run_node
+// kwargs (use_as_output for output delegation, override_isolation_scope,
+// per-call timeout/retry overrides, etc.) as those features land.
+type RunNodeOption func(*runNodeOptions)
+
+type runNodeOptions struct {
+	customRunID string
+}
+
+// WithRunID overrides the auto-generated counter with a stable
+// user-supplied identifier — useful for reorderable lists keyed by
+// e.g. an order id. id must be non-empty, contain at least one
+// non-digit character (purely numeric ids collide with the
+// auto-counter), and exclude the composite-path separators '/' and
+// '@'. Violations surface as ErrInvalidRunID from RunNode.
+//
+// Mirrors adk-python's run_id kwarg
+// (https://adk.dev/graphs/dynamic/#custom-execution-ids).
+func WithRunID(id string) RunNodeOption {
+	return func(o *runNodeOptions) { o.customRunID = id }
+}
+
+// RunNode schedules child as a sub-node of the currently-executing
+// dynamic node and returns its typed output. ctx must be the
+// NodeContext passed into the enclosing dynamic node's body.
+//
+// On failure:
+//   - errors.Is(err, ErrNodeInterrupted): child paused for HITL.
+//   - errors.Is(err, ErrNodeFailed): child errored after retries;
+//     errors.As recovers *NodeRunError with diagnostics.
+//   - ErrInvalidRunNodeContext, ErrInvalidRunID: misuse.
+//   - ctx.Err(): parent cancellation.
+func RunNode[OUT any](ctx NodeContext, child Node, input any, opts ...RunNodeOption) (OUT, error) {
+	var zero OUT
+
+	nc, ok := ctx.(*nodeContext)
+	if !ok || nc.subScheduler == nil {
+		return zero, ErrInvalidRunNodeContext
+	}
+
+	var o runNodeOptions
+	for _, opt := range opts {
+		opt(&o)
+	}
+
+	rawOut, err := nc.subScheduler.runNode(child, input, o.customRunID)
+	if err != nil {
+		return zero, err
+	}
+	if rawOut == nil {
+		return zero, nil
+	}
+	typed, ok := rawOut.(OUT)
+	if !ok {
+		return zero, fmt.Errorf("workflow.RunNode: child %q output type %T does not satisfy expected %T",
+			child.Name(), rawOut, zero)
+	}
+	return typed, nil
+}

--- a/workflow/run_node_test.go
+++ b/workflow/run_node_test.go
@@ -1,0 +1,140 @@
+// Copyright 2026 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package workflow
+
+import (
+	"errors"
+	"strings"
+	"testing"
+
+	"google.golang.org/adk/session"
+)
+
+func TestRunNode_ErrInvalidRunNodeContext_OnStaticContext(t *testing.T) {
+	ctx := newNodeContext(newMockCtx(t), nil) // no subScheduler attached
+	_, err := RunNode[string](ctx, newStubNode("c", "x"), nil)
+	if !errors.Is(err, ErrInvalidRunNodeContext) {
+		t.Errorf("err = %v, want ErrInvalidRunNodeContext", err)
+	}
+}
+
+func TestRunNode_ReturnsTypedOutput(t *testing.T) {
+	child := newStubNode("c", "hello")
+	got := runInOrchestrator[string](t, func(ctx NodeContext) (string, error) {
+		return RunNode[string](ctx, child, nil)
+	})
+	if got != "hello" {
+		t.Errorf("RunNode output = %q, want %q", got, "hello")
+	}
+}
+
+func TestRunNode_OutputTypeMismatch(t *testing.T) {
+	child := newStubNode("c", 42) // emits int
+	_, err := runInOrchestratorWithErr[string](t, func(ctx NodeContext) (string, error) {
+		return RunNode[string](ctx, child, nil) // expects string
+	})
+	if err == nil {
+		t.Fatal("expected error for type mismatch, got nil")
+	}
+	if !strings.Contains(err.Error(), "does not satisfy expected") {
+		t.Errorf("err = %v, want type-mismatch message", err)
+	}
+}
+
+func TestRunNode_PropagatesErrNodeInterrupted(t *testing.T) {
+	asker := newRequestInputNode("asker", "approve?")
+	_, err := runInOrchestratorWithErr[string](t, func(ctx NodeContext) (string, error) {
+		return RunNode[string](ctx, asker, nil)
+	})
+	if !errors.Is(err, ErrNodeInterrupted) {
+		t.Errorf("err = %v, want errors.Is ErrNodeInterrupted", err)
+	}
+}
+
+func TestRunNode_PropagatesErrNodeFailed(t *testing.T) {
+	failer := newFailingNode("failer", errors.New("boom"))
+	_, err := runInOrchestratorWithErr[string](t, func(ctx NodeContext) (string, error) {
+		return RunNode[string](ctx, failer, nil)
+	})
+	if !errors.Is(err, ErrNodeFailed) {
+		t.Errorf("err = %v, want errors.Is ErrNodeFailed", err)
+	}
+}
+
+func TestRunNode_WithRunID_AppearsInChildPath(t *testing.T) {
+	child := newStubNode("processor", "")
+	runInOrchestrator[string](t, func(ctx NodeContext) (string, error) {
+		return RunNode[string](ctx, child, nil, WithRunID("order-42"))
+	})
+	if got, want := child.lastPath, "orch/processor@order-42"; got != want {
+		t.Errorf("child Path() = %q, want %q", got, want)
+	}
+}
+
+func TestRunNode_WithRunID_InvalidRejected(t *testing.T) {
+	child := newStubNode("c", "")
+	_, err := runInOrchestratorWithErr[string](t, func(ctx NodeContext) (string, error) {
+		return RunNode[string](ctx, child, nil, WithRunID("123")) // purely numeric
+	})
+	if !errors.Is(err, ErrInvalidRunID) {
+		t.Errorf("err = %v, want errors.Is ErrInvalidRunID", err)
+	}
+}
+
+func TestRunNode_NilChildOutput_ReturnsZero(t *testing.T) {
+	child := newStubNode("c", nil)
+	got := runInOrchestrator[string](t, func(ctx NodeContext) (string, error) {
+		return RunNode[string](ctx, child, nil)
+	})
+	if got != "" {
+		t.Errorf("nil child output → OUT = %q, want \"\" (zero)", got)
+	}
+}
+
+// --- test helpers ---
+
+// runInOrchestrator drives orchestratorFn inside a dynamic node so that
+// the RunNode calls inside have a valid NodeContext + sub-scheduler.
+func runInOrchestrator[OUT any](t *testing.T, orchestratorFn func(NodeContext) (OUT, error)) OUT {
+	t.Helper()
+	got, err := runInOrchestratorWithErr[OUT](t, orchestratorFn)
+	if err != nil {
+		t.Fatalf("orchestrator error: %v", err)
+	}
+	return got
+}
+
+func runInOrchestratorWithErr[OUT any](t *testing.T, orchestratorFn func(NodeContext) (OUT, error)) (OUT, error) {
+	t.Helper()
+	var (
+		got    OUT
+		gotErr error
+	)
+	n := NewDynamicNode[string, OUT]("orch",
+		func(ctx NodeContext, _ string, _ func(*session.Event) error) (OUT, error) {
+			got, gotErr = orchestratorFn(ctx)
+			if gotErr != nil {
+				return got, gotErr
+			}
+			return got, nil
+		},
+		NodeConfig{},
+	)
+	_, runErr := drainDynamicWithErr(t, n, "")
+	if runErr != nil {
+		return got, runErr
+	}
+	return got, gotErr
+}

--- a/workflow/run_node_test.go
+++ b/workflow/run_node_test.go
@@ -103,6 +103,106 @@ func TestRunNode_NilChildOutput_ReturnsZero(t *testing.T) {
 	}
 }
 
+func TestRunNode_DefaultInheritsParentBranch(t *testing.T) {
+	child := newStubNode("c", "x")
+	runInOrchestrator[string](t, func(ctx NodeContext) (string, error) {
+		return RunNode[string](ctx, child, nil)
+	})
+	// MockInvocationContext yields Branch() == "", and the
+	// orchestrator inherits it, so the child must also see "".
+	if got := child.lastBranch; got != "" {
+		t.Errorf("child Branch() = %q, want \"\" (inherits parent at root)", got)
+	}
+}
+
+func TestRunNode_WithUseSubBranch_AppendsSegment(t *testing.T) {
+	child := newStubNode("c", "x")
+	runInOrchestrator[string](t, func(ctx NodeContext) (string, error) {
+		return RunNode[string](ctx, child, nil, WithUseSubBranch())
+	})
+	// Parent branch is "" (root); sub-branch is bare "<name>@<runID>".
+	// Auto-counter assigns runID "1" for the first call.
+	if got, want := child.lastBranch, "c@1"; got != want {
+		t.Errorf("child Branch() = %q, want %q (use_sub_branch at root)", got, want)
+	}
+}
+
+func TestRunNode_WithUseSubBranch_PlusCustomRunID(t *testing.T) {
+	child := newStubNode("c", "x")
+	runInOrchestrator[string](t, func(ctx NodeContext) (string, error) {
+		return RunNode[string](ctx, child, nil, WithUseSubBranch(), WithRunID("order-42"))
+	})
+	if got, want := child.lastBranch, "c@order-42"; got != want {
+		t.Errorf("child Branch() = %q, want %q", got, want)
+	}
+}
+
+func TestRunNode_WithOverrideBranch_ReplacesBase(t *testing.T) {
+	child := newStubNode("c", "x")
+	runInOrchestrator[string](t, func(ctx NodeContext) (string, error) {
+		return RunNode[string](ctx, child, nil, WithOverrideBranch("custom_branch"))
+	})
+	if got, want := child.lastBranch, "custom_branch"; got != want {
+		t.Errorf("child Branch() = %q, want %q", got, want)
+	}
+}
+
+func TestRunNode_WithOverrideBranch_PlusUseSubBranch_AppendsToOverride(t *testing.T) {
+	child := newStubNode("c", "x")
+	runInOrchestrator[string](t, func(ctx NodeContext) (string, error) {
+		return RunNode[string](ctx, child, nil,
+			WithOverrideBranch("base"),
+			WithUseSubBranch())
+	})
+	if got, want := child.lastBranch, "base.c@1"; got != want {
+		t.Errorf("child Branch() = %q, want %q (override is base, use_sub_branch appends)", got, want)
+	}
+}
+
+func TestRunNode_WithOverrideBranch_Empty_TreatedAsNoOverride(t *testing.T) {
+	// Empty WithOverrideBranch is a no-op (per WithOverrideBranch
+	// godoc): even combined with WithUseSubBranch the sub-branch
+	// derives off the inherited parent branch.
+	child := newStubNode("c", "x")
+	runInOrchestrator[string](t, func(ctx NodeContext) (string, error) {
+		return RunNode[string](ctx, child, nil,
+			WithOverrideBranch(""),
+			WithUseSubBranch())
+	})
+	if got, want := child.lastBranch, "c@1"; got != want {
+		t.Errorf("child Branch() = %q, want %q (empty override is a no-op)", got, want)
+	}
+}
+
+func TestRunNode_SequentialFanOut_PerSibling_DistinctBranches(t *testing.T) {
+	// Two children scheduled sequentially with WithUseSubBranch get
+	// distinct sub-branches via the auto-counter — child name + "@1",
+	// child name + "@2", etc. (counter is per child name, not global).
+	c1 := newStubNode("c", "first")
+	// re-use the same node twice to exercise the per-name counter.
+	var got []string
+	runInOrchestrator[string](t, func(ctx NodeContext) (string, error) {
+		if _, err := RunNode[string](ctx, c1, nil, WithUseSubBranch()); err != nil {
+			return "", err
+		}
+		got = append(got, c1.lastBranch)
+		if _, err := RunNode[string](ctx, c1, nil, WithUseSubBranch()); err != nil {
+			return "", err
+		}
+		got = append(got, c1.lastBranch)
+		return "", nil
+	})
+	if len(got) != 2 {
+		t.Fatalf("got %d branches, want 2 (orchestrator may have errored mid-loop)", len(got))
+	}
+	want := []string{"c@1", "c@2"}
+	if got[0] != want[0] || got[1] != want[1] {
+		t.Errorf("observed branches = %v, want %v "+
+			"(per-(name) auto-counter must produce distinct sub-branches)",
+			got, want)
+	}
+}
+
 // --- test helpers ---
 
 // runInOrchestrator drives orchestratorFn inside a dynamic node so that

--- a/workflow/scheduler.go
+++ b/workflow/scheduler.go
@@ -238,7 +238,7 @@ func (s *scheduler) scheduleResumedNode(n Node, input any, triggeredBy string, r
 	} else {
 		nodeCtx, cancel = context.WithCancel(s.parentCtx)
 	}
-	perNodeCtx := newNodeContext(s.parentCtx.WithContext(nodeCtx), triggeredBy, resumeInputs)
+	perNodeCtx := newNodeContext(s.parentCtx.WithContext(nodeCtx), resumeInputs)
 
 	ns := s.state.EnsureNode(name)
 	ns.Status = NodeRunning
@@ -478,8 +478,9 @@ func (s *scheduler) handleCompletion(it completionItem, scheduleSuccessors bool)
 }
 
 // successor is the per-target dispatch tuple produced by
-// findSuccessors. The triggeredBy field carries the upstream node's
-// name for downstream visibility via ctx.TriggeredBy().
+// findSuccessors. The triggeredBy field carries the upstream
+// node's name for persistence on NodeState (used by Resume to
+// reconstruct the activation chain across pause/resume turns).
 type successor struct {
 	node        Node
 	input       any

--- a/workflow/scheduler.go
+++ b/workflow/scheduler.go
@@ -1,0 +1,474 @@
+// Copyright 2026 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package workflow
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"sync"
+
+	"google.golang.org/adk/agent"
+	"google.golang.org/adk/session"
+)
+
+// defaultEventQueueCapacity bounds the buffered channel between
+// node-runner goroutines and the consumer. A small fixed capacity
+// keeps backpressure tight without serialising producers.
+const defaultEventQueueCapacity = 16
+
+var (
+	// ErrMultipleOutputs is returned when a node yields more than
+	// one event whose Actions.StateDelta carries an "output" key.
+	// A node activation may emit at most one output value.
+	ErrMultipleOutputs = errors.New("workflow: node produced multiple events with output values; only one event per execution can carry output")
+
+	// ErrMultipleRoutingEvents is returned when a node yields more
+	// than one event whose Routes field is set. A node activation
+	// may emit at most one routing decision.
+	ErrMultipleRoutingEvents = errors.New("workflow: node produced multiple events with route tags; only one event per execution can specify routes")
+)
+
+// scheduler drives a single Workflow.Run invocation. It owns the
+// per-node task table, the event channel, lifecycle counters, and
+// the parent invocation context — none of which survive across
+// processes. The persistable view of the same run (node statuses,
+// inputs, triggers) lives on the embedded *RunState.
+//
+// Concurrency model: producer-consumer over eventQueue.
+//
+//   - Producers are the per-node goroutines started by scheduleNode.
+//     They only send to eventQueue (events and a final completion);
+//     they never read from it and never touch any other scheduler
+//     field.
+//   - The consumer is the single goroutine running scheduler.run
+//     (the caller of Workflow.Run). It is the only reader of
+//     eventQueue and the only mutator of runsByName, runCancels,
+//     state.Nodes, and per-node accumulators.
+//
+// Because producers and the consumer share only eventQueue (a
+// channel — already safe for concurrent use), the consumer-only
+// fields below need no mutex.
+type scheduler struct {
+	state       *RunState       // persisted lifecycle state
+	graph       *graph          // adjacency, terminal lookup
+	nodesByName map[string]Node // built once at construction; lets handleCompletion resolve a completion's name back to its Node in O(1)
+
+	// Per-node accumulators, created when a node is scheduled and
+	// deleted on its completion. Owned by the consumer goroutine.
+	runsByName map[string]*nodeRun
+
+	// Per-node cancel funcs. Owned by the consumer goroutine.
+	runCancels map[string]context.CancelFunc
+
+	// eventQueue carries events and completions from producer
+	// goroutines to the consumer.
+	eventQueue chan queueItem
+	wg         sync.WaitGroup
+
+	parentCtx agent.InvocationContext
+}
+
+// nodeRun is the per-node consumer-side accumulator. It buffers the
+// node's routing event (if any) and its single output between the
+// time those events arrive and the time the node's completion
+// arrives, at which point successors are scheduled.
+//
+// The single-output and single-routing-event constraints are
+// enforced here: a second event carrying either kind sets err
+// without overwriting the first value, and the consumer surfaces
+// the error at completion.
+type nodeRun struct {
+	routingEvent *session.Event // at most one; multiple is an error
+	output       any            // single StateDelta["output"]; nil if hasOutput is false
+	hasOutput    bool           // distinguishes "no output yet" from "output was nil"
+	err          error          // set on duplicate output or duplicate routing event
+}
+
+// recordErr stores err as the accumulator's first error. Subsequent
+// calls are no-ops, preserving the first failure for handleCompletion
+// to surface.
+func (nr *nodeRun) recordErr(err error) {
+	if nr.err == nil {
+		nr.err = err
+	}
+}
+
+// setRoutingEvent stores ev as the node's single routing event. A
+// second call records ErrMultipleRoutingEvents instead of overwriting.
+func (nr *nodeRun) setRoutingEvent(ev *session.Event, nodeName string) {
+	if nr.routingEvent != nil {
+		nr.recordErr(fmt.Errorf("%w: node %q", ErrMultipleRoutingEvents, nodeName))
+		return
+	}
+	nr.routingEvent = ev
+}
+
+// setOutput stores out as the node's single output value. A second
+// call records ErrMultipleOutputs instead of overwriting.
+func (nr *nodeRun) setOutput(out any, nodeName string) {
+	if nr.hasOutput {
+		nr.recordErr(fmt.Errorf("%w: node %q", ErrMultipleOutputs, nodeName))
+		return
+	}
+	nr.output = out
+	nr.hasOutput = true
+}
+
+// queueItem is sealed: only types in this package can satisfy it.
+// The unexported sentinel method enforces the seal at compile time.
+type queueItem interface{ isQueueItem() }
+
+// eventItem carries one event from a node-runner goroutine to the
+// consumer. nodeName is required so the consumer can correlate the
+// event with the right nodeRun without relying on channel-FIFO-
+// per-task semantics (which Go channels do not provide).
+type eventItem struct {
+	nodeName string
+	ev       *session.Event
+}
+
+func (eventItem) isQueueItem() {}
+
+// completionItem signals that a node-runner goroutine has finished.
+// err is nil on success; non-nil errors are classified by the
+// consumer via errors.Is (currently: context.Canceled,
+// context.DeadlineExceeded, anything else → NodeFailed).
+type completionItem struct {
+	nodeName string
+	err      error
+}
+
+func (completionItem) isQueueItem() {}
+
+// newScheduler returns an initialised scheduler ready for the
+// consumer to drive. The caller is responsible for seeding the
+// initial trigger (typically Start with the user input).
+func newScheduler(parent agent.InvocationContext, g *graph) *scheduler {
+	return &scheduler{
+		state:       NewRunState(),
+		graph:       g,
+		nodesByName: buildNodesByName(g),
+		runsByName:  map[string]*nodeRun{},
+		runCancels:  map[string]context.CancelFunc{},
+		eventQueue:  make(chan queueItem, defaultEventQueueCapacity),
+		parentCtx:   parent,
+	}
+}
+
+// buildNodesByName walks the graph's edges and returns the name→Node
+// lookup. Lets handleCompletion resolve a completion's node name to
+// its instance in O(1) instead of scanning the full table.
+func buildNodesByName(g *graph) map[string]Node {
+	nodesByName := map[string]Node{}
+	for n, edges := range g.successors {
+		nodesByName[n.Name()] = n
+		for _, e := range edges {
+			nodesByName[e.To.Name()] = e.To
+		}
+	}
+	return nodesByName
+}
+
+// scheduleNode launches a per-node goroutine for n with the given
+// input. The node's lifecycle status transitions to NodeRunning, and
+// the node is registered in runsByName and runCancels. The goroutine
+// wrapper is responsible for pushing exactly one completionItem when
+// it returns (success, error, panic, or cancellation).
+//
+// scheduleNode runs only on the consumer goroutine.
+func (s *scheduler) scheduleNode(n Node, input any, triggeredBy string) {
+	name := n.Name()
+
+	// Per-node context: WithTimeout when Config().Timeout > 0,
+	// WithCancel otherwise. Either way it inherits from parentCtx,
+	// so an ambient deadline on the workflow invocation still
+	// applies.
+	cfg := n.Config()
+	var (
+		nodeCtx context.Context
+		cancel  context.CancelFunc
+	)
+	if cfg.Timeout > 0 {
+		nodeCtx, cancel = context.WithTimeout(s.parentCtx, cfg.Timeout)
+	} else {
+		nodeCtx, cancel = context.WithCancel(s.parentCtx)
+	}
+	perNodeCtx := newNodeContext(s.parentCtx.WithContext(nodeCtx), triggeredBy)
+
+	ns := s.state.EnsureNode(name)
+	ns.Status = NodeRunning
+	ns.Input = input
+	ns.TriggeredBy = triggeredBy
+	s.runsByName[name] = &nodeRun{}
+
+	s.runCancels[name] = cancel
+	s.wg.Add(1)
+
+	go runNode(s.eventQueue, &s.wg, name, n, perNodeCtx, input)
+}
+
+// runNode is the per-node goroutine wrapper. It drives the node's
+// iter.Seq2, pushes events into the queue, and ends with exactly
+// one completionItem. A panic in the node body is recovered and
+// reported as a completion error so the consumer never deadlocks
+// waiting for a vanished goroutine.
+//
+// Event sends select on ctx.Done(): if the scheduler has cancelled
+// this node, an in-progress send to a full eventQueue does not
+// deadlock — the goroutine drops the pending event and proceeds to
+// completion. The completion send is unconditional because the
+// consumer's runsByName bookkeeping relies on it.
+func runNode(
+	out chan<- queueItem,
+	wg *sync.WaitGroup,
+	name string,
+	n Node,
+	ctx agent.InvocationContext,
+	input any,
+) {
+	defer wg.Done()
+
+	// completion holds the final completionItem. It is sent in the
+	// outer defer so panic recovery, normal exit, and cancellation
+	// all funnel through the same send path.
+	completion := completionItem{nodeName: name}
+	defer func() {
+		if r := recover(); r != nil {
+			completion.err = fmt.Errorf("node %q panicked: %v", name, r)
+		}
+		out <- completion
+	}()
+
+	for ev, err := range n.Run(ctx, input) {
+		if err != nil {
+			completion.err = err
+			return
+		}
+		select {
+		case out <- eventItem{nodeName: name, ev: ev}:
+		case <-ctx.Done():
+			completion.err = ctx.Err()
+			return
+		}
+	}
+	// If the node's iter returned cleanly but the context was
+	// cancelled or its deadline elapsed, surface that as the
+	// completion error: the node likely returned because it observed
+	// ctx.Done(), and the consumer needs to classify it.
+	if ctxErr := ctx.Err(); ctxErr != nil {
+		completion.err = ctxErr
+	}
+}
+
+// cancelAll cancels every running task. Idempotent: cancelled
+// goroutines may still push events that already left the producer
+// before observing ctx.Done(); the consumer continues draining
+// until runsByName is empty.
+//
+// cancelAll runs only on the consumer goroutine.
+func (s *scheduler) cancelAll() {
+	for _, cancel := range s.runCancels {
+		cancel()
+	}
+}
+
+// run is the single-consumer loop. It drains the eventQueue, applies
+// state-side effects, yields events to the caller, and schedules
+// successor nodes when a node completes. Returns when all running
+// tasks have signalled completion.
+//
+// On non-nil yield-return-false (caller broke from the range loop)
+// or on a non-retryable node error, run cancels all in-flight
+// tasks and continues draining until runsByName is empty, then
+// surfaces the original error (if any) via yield.
+//
+// run runs on the caller's goroutine (the goroutine that called
+// Workflow.Run); it is the only mutator of state.Nodes and the
+// node-side accumulators.
+func (s *scheduler) run(yield func(*session.Event, error) bool) {
+	var pendingErr error // first non-nil node error; surfaced after drain
+	draining := false    // true once cancelAll has run; remaining queue items are drained without yielding or scheduling new successors
+
+	for len(s.runsByName) > 0 {
+		item := <-s.eventQueue
+		switch it := item.(type) {
+		case eventItem:
+			s.handleEvent(it)
+			if !draining {
+				if !yield(it.ev, nil) {
+					draining = true
+					s.cancelAll()
+				}
+			}
+		case completionItem:
+			err := s.handleCompletion(it, !draining)
+			if err != nil && pendingErr == nil {
+				pendingErr = err
+				if !draining {
+					draining = true
+					s.cancelAll()
+				}
+			}
+		}
+	}
+
+	// All goroutines have returned and pushed their final events.
+	// Surface the first error to the caller, unless we're already
+	// draining.
+	if pendingErr != nil {
+		yield(nil, pendingErr)
+	}
+}
+
+// handleEvent updates the per-node accumulator and is called once
+// per event. The event itself has already been read from the queue
+// and will be yielded to the caller by the consumer loop.
+func (s *scheduler) handleEvent(it eventItem) {
+	nr := s.runsByName[it.nodeName]
+	if nr == nil {
+		// Defensive: completion already processed for this node;
+		// shouldn't happen if producer goroutines preserve send order.
+		return
+	}
+	if it.ev == nil {
+		return
+	}
+	if it.ev.Routes != nil {
+		nr.setRoutingEvent(it.ev, it.nodeName)
+	}
+	if it.ev.Actions.StateDelta != nil {
+		if out, ok := it.ev.Actions.StateDelta["output"]; ok {
+			nr.setOutput(out, it.nodeName)
+		}
+	}
+}
+
+// handleCompletion finalises a node's run: transitions its lifecycle
+// status, removes the live task, and (if scheduleSuccessors is true)
+// schedules its successors. When the consumer is draining (caller
+// stopped or a node failed), pass scheduleSuccessors=false so the
+// workflow does not keep dispatching new nodes after cancellation.
+//
+// The returned error is the node's own error (NodeFailed); nil on
+// clean success or sibling cancellation.
+func (s *scheduler) handleCompletion(it completionItem, scheduleSuccessors bool) error {
+	ns := s.state.EnsureNode(it.nodeName)
+	nr := s.runsByName[it.nodeName]
+	delete(s.runsByName, it.nodeName)
+	delete(s.runCancels, it.nodeName)
+
+	switch {
+	case it.err == nil:
+		ns.Status = NodeCompleted
+	case errors.Is(it.err, context.Canceled):
+		ns.Status = NodeCancelled
+		return nil // sibling cancellation; not the original error
+	default:
+		ns.Status = NodeFailed
+		return it.err
+	}
+
+	if nr != nil && nr.err != nil {
+		ns.Status = NodeFailed
+		return nr.err
+	}
+
+	if !scheduleSuccessors {
+		return nil
+	}
+
+	// Schedule successors. Find them via the routing-aware helper,
+	// which reads any routing event off this completion's accumulator.
+	currentNode := s.nodesByName[it.nodeName]
+	if currentNode == nil {
+		return nil
+	}
+	var input any
+	var routingEv *session.Event
+	if nr != nil {
+		input = nr.output
+		routingEv = nr.routingEvent
+	}
+	// START's own output is empty by definition; for START we
+	// propagate the workflow's seed input (carried as the START
+	// node's NodeState.Input).
+	if currentNode == Start {
+		input = ns.Input
+	}
+
+	for _, succ := range findSuccessors(s.graph, currentNode, input, routingEv) {
+		s.scheduleNode(succ.node, succ.input, succ.triggeredBy)
+	}
+	return nil
+}
+
+// successor is the per-target dispatch tuple produced by
+// findSuccessors. The triggeredBy field carries the upstream node's
+// name for downstream visibility via ctx.TriggeredBy().
+type successor struct {
+	node        Node
+	input       any
+	triggeredBy string
+}
+
+// findSuccessors evaluates the outgoing edges of currentNode against
+// the optional routing event and returns the dispatch list:
+//
+//   - Edges with no Route always fire (and do not suppress Default).
+//   - Edges with a concrete Route fire only if Route.Matches(event) is true.
+//   - Duplicate To targets are deduplicated (same target node may not
+//     be queued twice for one parent activation).
+//   - The Default edge fires when no concrete Route matched. An
+//     unconditional edge does not count as a "match" for this
+//     purpose, so a graph with one unconditional edge and one
+//     Default edge fans out to both targets.
+//   - If every outgoing edge has a concrete Route and none matched,
+//     and no Default is present, the workflow silently dead-ends at
+//     this node — by design, mirroring adk-python's routing semantics.
+func findSuccessors(g *graph, currentNode Node, input any, event *session.Event) []successor {
+	succs := g.successorsOf(currentNode)
+	if len(succs) == 0 {
+		return nil
+	}
+	from := currentNode.Name()
+	concreteMatched := false // any concrete Route fired (controls Default)
+	out := []successor{}
+	added := map[Node]struct{}{}
+	var defaultRouteNode Node
+	for _, edge := range succs {
+		if _, ok := added[edge.To]; ok {
+			continue
+		}
+		if edge.Route == nil {
+			out = append(out, successor{node: edge.To, input: input, triggeredBy: from})
+			added[edge.To] = struct{}{}
+			continue
+		}
+		if edge.Route == Default {
+			defaultRouteNode = edge.To
+			continue
+		}
+		if event != nil && edge.Route.Matches(event) {
+			out = append(out, successor{node: edge.To, input: input, triggeredBy: from})
+			added[edge.To] = struct{}{}
+			concreteMatched = true
+		}
+	}
+	if !concreteMatched && defaultRouteNode != nil {
+		out = append(out, successor{node: defaultRouteNode, input: input, triggeredBy: from})
+	}
+	return out
+}

--- a/workflow/scheduler.go
+++ b/workflow/scheduler.go
@@ -210,6 +210,18 @@ func buildNodesByName(g *graph) map[string]Node {
 //
 // scheduleNode runs only on the consumer goroutine.
 func (s *scheduler) scheduleNode(n Node, input any, triggeredBy string) {
+	s.scheduleResumedNode(n, input, triggeredBy, nil)
+}
+
+// scheduleResumedNode is like scheduleNode but additionally
+// injects resumeInputs into the per-node context, so re-entry
+// nodes can read the user-supplied response payload via
+// ctx.ResumedInput(interruptID). resumeInputs is keyed by
+// InterruptID; nil disables re-entry semantics and yields the same
+// behaviour as scheduleNode.
+//
+// scheduleResumedNode runs only on the consumer goroutine.
+func (s *scheduler) scheduleResumedNode(n Node, input any, triggeredBy string, resumeInputs map[string]any) {
 	name := n.Name()
 
 	// Per-node context: WithTimeout when Config().Timeout > 0,
@@ -226,7 +238,7 @@ func (s *scheduler) scheduleNode(n Node, input any, triggeredBy string) {
 	} else {
 		nodeCtx, cancel = context.WithCancel(s.parentCtx)
 	}
-	perNodeCtx := newNodeContext(s.parentCtx.WithContext(nodeCtx), triggeredBy)
+	perNodeCtx := newNodeContext(s.parentCtx.WithContext(nodeCtx), triggeredBy, resumeInputs)
 
 	ns := s.state.EnsureNode(name)
 	ns.Status = NodeRunning

--- a/workflow/scheduler.go
+++ b/workflow/scheduler.go
@@ -447,6 +447,10 @@ func (s *scheduler) handleCompletion(it completionItem, scheduleSuccessors bool)
 	}
 
 	ns.Status = NodeCompleted
+	// Release the accumulated re-entry response history; the node
+	// has finished and a future activation (if any, e.g. via
+	// loop-back routing) starts a fresh lifecycle.
+	ns.ResumedInputs = nil
 
 	if !scheduleSuccessors {
 		return nil

--- a/workflow/scheduler.go
+++ b/workflow/scheduler.go
@@ -39,6 +39,11 @@ var (
 	// than one event whose Routes field is set. A node activation
 	// may emit at most one routing decision.
 	ErrMultipleRoutingEvents = errors.New("workflow: node produced multiple events with route tags; only one event per execution can specify routes")
+
+	// ErrMultipleInputRequests is returned when a node yields more
+	// than one event whose RequestedInput field is set. A node
+	// activation may issue at most one human-input request.
+	ErrMultipleInputRequests = errors.New("workflow: node produced multiple events with RequestedInput; only one human-input request per execution is allowed")
 )
 
 // scheduler drives a single Workflow.Run invocation. It owns the
@@ -91,10 +96,11 @@ type scheduler struct {
 // without overwriting the first value, and the consumer surfaces
 // the error at completion.
 type nodeRun struct {
-	routingEvent *session.Event // at most one; multiple is an error
-	output       any            // single StateDelta["output"]; nil if hasOutput is false
-	hasOutput    bool           // distinguishes "no output yet" from "output was nil"
-	err          error          // set on duplicate output or duplicate routing event
+	routingEvent *session.Event        // at most one; multiple is an error
+	output       any                   // single StateDelta["output"]; nil if hasOutput is false
+	hasOutput    bool                  // distinguishes "no output yet" from "output was nil"
+	inputRequest *session.RequestInput // at most one human-input request; multiple is an error
+	err          error                 // set on duplicate output, duplicate routing event, or duplicate input request
 }
 
 // recordErr stores err as the accumulator's first error. Subsequent
@@ -114,6 +120,20 @@ func (nr *nodeRun) setRoutingEvent(ev *session.Event, nodeName string) {
 		return
 	}
 	nr.routingEvent = ev
+}
+
+// setInputRequest stores req as the node's single in-flight
+// human-input request. A second call records
+// ErrMultipleInputRequests instead of overwriting; the consumer
+// surfaces the error at completion and the node ends up
+// NodeFailed (the waiting branch is gated on nr.err == nil so a
+// node that requested twice does not silently park).
+func (nr *nodeRun) setInputRequest(req *session.RequestInput, nodeName string) {
+	if nr.inputRequest != nil {
+		nr.recordErr(fmt.Errorf("%w: node %q", ErrMultipleInputRequests, nodeName))
+		return
+	}
+	nr.inputRequest = req
 }
 
 // setOutput stores out as the node's single output value. A second
@@ -349,6 +369,9 @@ func (s *scheduler) handleEvent(it eventItem) {
 	if it.ev.Routes != nil {
 		nr.setRoutingEvent(it.ev, it.nodeName)
 	}
+	if it.ev.RequestedInput != nil {
+		nr.setInputRequest(it.ev.RequestedInput, it.nodeName)
+	}
 	if it.ev.Actions.StateDelta != nil {
 		if out, ok := it.ev.Actions.StateDelta["output"]; ok {
 			nr.setOutput(out, it.nodeName)
@@ -364,27 +387,54 @@ func (s *scheduler) handleEvent(it eventItem) {
 //
 // The returned error is the node's own error (NodeFailed); nil on
 // clean success or sibling cancellation.
+//
+// # Human-input waiting branch
+//
+// When an activation completes cleanly and recorded a non-nil
+// inputRequest (via setInputRequest from handleEvent), the node
+// transitions to NodeWaiting instead of NodeCompleted, the request
+// is persisted on NodeState.PendingRequest, and successors are not
+// scheduled. The scheduler's main loop terminates naturally when
+// every live node has either completed or moved into NodeWaiting,
+// at which point Workflow.Run's iterator exhausts and the caller
+// observes the pause by inspecting RunState.
+//
+// The waiting branch is checked after the error/cancel branches,
+// so a node that fails for any reason (returned error, panic,
+// context cancel, multiple-output, multiple-routing-event,
+// multiple-input-request) does not silently park in NodeWaiting:
+// failures take precedence and surface as NodeFailed.
 func (s *scheduler) handleCompletion(it completionItem, scheduleSuccessors bool) error {
 	ns := s.state.EnsureNode(it.nodeName)
 	nr := s.runsByName[it.nodeName]
 	delete(s.runsByName, it.nodeName)
 	delete(s.runCancels, it.nodeName)
 
-	switch {
-	case it.err == nil:
-		ns.Status = NodeCompleted
-	case errors.Is(it.err, context.Canceled):
+	if errors.Is(it.err, context.Canceled) {
 		ns.Status = NodeCancelled
 		return nil // sibling cancellation; not the original error
-	default:
+	}
+	if it.err != nil {
 		ns.Status = NodeFailed
 		return it.err
 	}
-
 	if nr != nil && nr.err != nil {
 		ns.Status = NodeFailed
 		return nr.err
 	}
+
+	// Happy path: decide between NodeWaiting (a recorded human-
+	// input request) or NodeCompleted. The waiting branch fires
+	// regardless of the scheduleSuccessors flag — a request that
+	// survived the run must be observable in RunState even when
+	// the consumer is draining, so the caller can persist it.
+	if nr != nil && nr.inputRequest != nil {
+		ns.Status = NodeWaiting
+		ns.PendingRequest = nr.inputRequest
+		return nil
+	}
+
+	ns.Status = NodeCompleted
 
 	if !scheduleSuccessors {
 		return nil

--- a/workflow/scheduler.go
+++ b/workflow/scheduler.go
@@ -596,8 +596,33 @@ func (s *scheduler) handleEvent(it eventItem) {
 		nr.setRoutingEvent(it.ev, it.nodeName)
 	}
 	if it.ev.Output != nil {
-		nr.setOutput(it.ev.Output, it.nodeName)
+		validated, err := s.validateNodeOutput(it.nodeName, it.ev.Output)
+		if err != nil {
+			nr.recordErr(err)
+			return
+		}
+		it.ev.Output = validated
+		nr.setOutput(validated, it.nodeName)
 	}
+}
+
+// validateNodeOutput invokes ValidateOutput on the node identified by
+// nodeName for the given output value. On validation failure the
+// returned error is wrapped with the node name to aid debugging; the
+// caller is responsible for recording it on the node-run accumulator
+// so handleCompletion surfaces it as a NodeFailed transition.
+func (s *scheduler) validateNodeOutput(nodeName string, out any) (any, error) {
+	n := s.nodesByName[nodeName]
+	if n == nil {
+		// Defensive: should never happen because handleEvent is only
+		// invoked for nodes registered in the graph.
+		return out, nil
+	}
+	validated, err := n.ValidateOutput(out)
+	if err != nil {
+		return nil, fmt.Errorf("output validation failed for node %q: %w", nodeName, err)
+	}
+	return validated, nil
 }
 
 // handleCompletion finalises a node's run: transitions its lifecycle

--- a/workflow/scheduler.go
+++ b/workflow/scheduler.go
@@ -101,7 +101,7 @@ type scheduler struct {
 // the error at completion.
 type nodeRun struct {
 	routingEvent *session.Event        // at most one; multiple is an error
-	output       any                   // single StateDelta["output"]; nil if hasOutput is false
+	output       any                   // single Event.Output; nil if hasOutput is false
 	hasOutput    bool                  // distinguishes "no output yet" from "output was nil"
 	inputRequest *session.RequestInput // at most one human-input request; multiple is an error
 	err          error                 // set on duplicate output, duplicate routing event, or duplicate input request
@@ -432,10 +432,8 @@ func (s *scheduler) handleEvent(it eventItem) {
 	if it.ev.RequestedInput != nil {
 		nr.setInputRequest(it.ev.RequestedInput, it.nodeName)
 	}
-	if it.ev.Actions.StateDelta != nil {
-		if out, ok := it.ev.Actions.StateDelta["output"]; ok {
-			nr.setOutput(out, it.nodeName)
-		}
+	if it.ev.Output != nil {
+		nr.setOutput(it.ev.Output, it.nodeName)
 	}
 }
 

--- a/workflow/scheduler.go
+++ b/workflow/scheduler.go
@@ -19,6 +19,7 @@ import (
 	"errors"
 	"fmt"
 	"sync"
+	"time"
 
 	"google.golang.org/adk/agent"
 	"google.golang.org/adk/session"
@@ -77,6 +78,9 @@ type scheduler struct {
 
 	// Per-node cancel funcs. Owned by the consumer goroutine.
 	runCancels map[string]context.CancelFunc
+
+	// Timers for scheduled retries. Owned by the consumer goroutine.
+	retryTimers map[string]*time.Timer
 
 	// eventQueue carries events and completions from producer
 	// goroutines to the consumer.
@@ -173,6 +177,15 @@ type completionItem struct {
 
 func (completionItem) isQueueItem() {}
 
+// retryItem signals that a node should be retried after a delay.
+type retryItem struct {
+	node        Node
+	input       any
+	triggeredBy string
+}
+
+func (retryItem) isQueueItem() {}
+
 // newScheduler returns an initialised scheduler ready for the
 // consumer to drive. The caller is responsible for seeding the
 // initial trigger (typically Start with the user input).
@@ -183,6 +196,7 @@ func newScheduler(parent agent.InvocationContext, g *graph) *scheduler {
 		nodesByName: buildNodesByName(g),
 		runsByName:  map[string]*nodeRun{},
 		runCancels:  map[string]context.CancelFunc{},
+		retryTimers: map[string]*time.Timer{},
 		eventQueue:  make(chan queueItem, defaultEventQueueCapacity),
 		parentCtx:   parent,
 	}
@@ -252,6 +266,19 @@ func (s *scheduler) scheduleResumedNode(n Node, input any, triggeredBy string, r
 	go runNode(s.eventQueue, &s.wg, name, n, perNodeCtx, input)
 }
 
+// scheduleRetry schedules a retry for node n after the given delay.
+func (s *scheduler) scheduleRetry(n Node, input any, triggeredBy string, delay time.Duration) {
+	timer := time.AfterFunc(delay, func() {
+		go func() {
+			select {
+			case s.eventQueue <- retryItem{node: n, input: input, triggeredBy: triggeredBy}:
+			case <-s.parentCtx.Done():
+			}
+		}()
+	})
+	s.retryTimers[n.Name()] = timer
+}
+
 // runNode is the per-node goroutine wrapper. It drives the node's
 // iter.Seq2, pushes events into the queue, and ends with exactly
 // one completionItem. A panic in the node body is recovered and
@@ -315,6 +342,10 @@ func (s *scheduler) cancelAll() {
 	for _, cancel := range s.runCancels {
 		cancel()
 	}
+	for _, t := range s.retryTimers {
+		t.Stop()
+	}
+	s.retryTimers = nil
 }
 
 // run is the single-consumer loop. It drains the eventQueue, applies
@@ -334,8 +365,20 @@ func (s *scheduler) run(yield func(*session.Event, error) bool) {
 	var pendingErr error // first non-nil node error; surfaced after drain
 	draining := false    // true once cancelAll has run; remaining queue items are drained without yielding or scheduling new successors
 
-	for len(s.runsByName) > 0 {
-		item := <-s.eventQueue
+	doneChan := s.parentCtx.Done()
+
+	for len(s.runsByName) > 0 || len(s.retryTimers) > 0 {
+		var item queueItem
+		select {
+		case item = <-s.eventQueue:
+		case <-doneChan:
+			if !draining {
+				draining = true
+				s.cancelAll()
+			}
+			doneChan = nil // Disable this case so we don't busy loop
+		}
+
 		switch it := item.(type) {
 		case eventItem:
 			s.handleEvent(it)
@@ -353,6 +396,11 @@ func (s *scheduler) run(yield func(*session.Event, error) bool) {
 					draining = true
 					s.cancelAll()
 				}
+			}
+		case retryItem:
+			delete(s.retryTimers, it.node.Name())
+			if !draining {
+				s.scheduleNode(it.node, it.input, it.triggeredBy)
 			}
 		}
 	}
@@ -419,6 +467,9 @@ func (s *scheduler) handleEvent(it eventItem) {
 func (s *scheduler) handleCompletion(it completionItem, scheduleSuccessors bool) error {
 	ns := s.state.EnsureNode(it.nodeName)
 	nr := s.runsByName[it.nodeName]
+	// For retryable nodes still delete them from run variables. If the node is retried,
+	// it will get a fresh accumulator in scheduleNode to avoid ErrMultipleOutputs
+	// from partial results of this failed run.
 	delete(s.runsByName, it.nodeName)
 	delete(s.runCancels, it.nodeName)
 
@@ -427,6 +478,23 @@ func (s *scheduler) handleCompletion(it completionItem, scheduleSuccessors bool)
 		return nil // sibling cancellation; not the original error
 	}
 	if it.err != nil {
+		currentNode := s.nodesByName[it.nodeName]
+		if currentNode != nil {
+			cfg := currentNode.Config()
+			if cfg.RetryConfig != nil {
+				ns.Attempt = ns.Attempt + 1
+
+				if ShouldRetry(cfg.RetryConfig, it.err, ns.Attempt) {
+					delay := CalculateDelay(cfg.RetryConfig, ns.Attempt)
+					ns.Status = NodePending
+					s.scheduleRetry(currentNode, ns.Input, ns.TriggeredBy, delay)
+					// Return nil to continue the scheduler loop. Successors will
+					// be scheduled only when a retry attempt eventually succeeds
+					// and reaches the bottom of this function.
+					return nil // Don't fail the workflow
+				}
+			}
+		}
 		ns.Status = NodeFailed
 		return it.err
 	}
@@ -447,6 +515,7 @@ func (s *scheduler) handleCompletion(it completionItem, scheduleSuccessors bool)
 	}
 
 	ns.Status = NodeCompleted
+	ns.Attempt = 0
 	// Release the accumulated re-entry response history; the node
 	// has finished and a future activation (if any, e.g. via
 	// loop-back routing) starts a fresh lifecycle.

--- a/workflow/scheduler.go
+++ b/workflow/scheduler.go
@@ -254,6 +254,21 @@ func (s *scheduler) scheduleResumedNode(n Node, input any, triggeredBy string, r
 	}
 	perNodeCtx := newNodeContext(s.parentCtx.WithContext(nodeCtx), resumeInputs)
 
+	// EXPERIMENTAL: stash perNodeCtx in the embedded context.Context
+	// so tools running inside an LlmAgent that is itself running as
+	// this node can recover the NodeContext via
+	// workflow.NodeContextFromGoContext. The value rides through
+	// every downstream NewInvocationContext / WithContext call by
+	// virtue of context.Context value-chain propagation.
+	//
+	// See WithNodeContext / NodeContextFromGoContext in
+	// node_context_bridge.go. Top-level static activations have
+	// subScheduler == nil, so RunNode will still reject them; the
+	// stash is harmless in that case.
+	perNodeCtx.InvocationContext = perNodeCtx.InvocationContext.WithContext(
+		WithNodeContext(perNodeCtx.InvocationContext, perNodeCtx),
+	)
+
 	ns := s.state.EnsureNode(name)
 	ns.Status = NodeRunning
 	ns.Input = input

--- a/workflow/scheduler.go
+++ b/workflow/scheduler.go
@@ -516,6 +516,9 @@ func (s *scheduler) handleCompletion(it completionItem, scheduleSuccessors bool)
 
 	ns.Status = NodeCompleted
 	ns.Attempt = 0
+	if nr != nil && nr.hasOutput {
+		ns.Output = nr.output
+	}
 	// Release the accumulated re-entry response history; the node
 	// has finished and a future activation (if any, e.g. via
 	// loop-back routing) starts a fresh lifecycle.
@@ -544,7 +547,7 @@ func (s *scheduler) handleCompletion(it completionItem, scheduleSuccessors bool)
 		input = ns.Input
 	}
 
-	for _, succ := range findSuccessors(s.graph, currentNode, input, routingEv) {
+	for _, succ := range findSuccessors(s.graph, s.state, currentNode, input, routingEv) {
 		s.scheduleNode(succ.node, succ.input, succ.triggeredBy)
 	}
 	return nil
@@ -573,8 +576,11 @@ type successor struct {
 //     Default edge fans out to both targets.
 //   - If every outgoing edge has a concrete Route and none matched,
 //     and no Default is present, the workflow silently dead-ends at
-//     this node — by design, mirroring adk-python's routing semantics.
-func findSuccessors(g *graph, currentNode Node, input any, event *session.Event) []successor {
+//     this node. The absence of a matching route is treated as a
+//     deliberate decision not to continue, not an error.
+//
+// JoinNode successors are gated by appendSuccessor; see its docs.
+func findSuccessors(g *graph, state *RunState, currentNode Node, input any, event *session.Event) []successor {
 	succs := g.successorsOf(currentNode)
 	if len(succs) == 0 {
 		return nil
@@ -589,7 +595,7 @@ func findSuccessors(g *graph, currentNode Node, input any, event *session.Event)
 			continue
 		}
 		if edge.Route == nil {
-			out = append(out, successor{node: edge.To, input: input, triggeredBy: from})
+			out = appendSuccessor(out, g, state, edge.To, input, from)
 			added[edge.To] = struct{}{}
 			continue
 		}
@@ -598,13 +604,49 @@ func findSuccessors(g *graph, currentNode Node, input any, event *session.Event)
 			continue
 		}
 		if event != nil && edge.Route.Matches(event) {
-			out = append(out, successor{node: edge.To, input: input, triggeredBy: from})
+			out = appendSuccessor(out, g, state, edge.To, input, from)
 			added[edge.To] = struct{}{}
 			concreteMatched = true
 		}
 	}
 	if !concreteMatched && defaultRouteNode != nil {
-		out = append(out, successor{node: defaultRouteNode, input: input, triggeredBy: from})
+		out = appendSuccessor(out, g, state, defaultRouteNode, input, from)
 	}
 	return out
+}
+
+// appendSuccessor records a routing match in the dispatch list.
+// Non-JoinNode targets are recorded as-is. A *JoinNode target is
+// recorded only when every declared predecessor has completed;
+// its input is replaced with the aggregated predecessor outputs.
+// A barrier-blocked JoinNode is silently skipped — a later
+// predecessor completion re-evaluates the barrier.
+func appendSuccessor(out []successor, g *graph, state *RunState, target Node, input any, triggeredBy string) []successor {
+	if _, isJoin := target.(*JoinNode); !isJoin {
+		return append(out, successor{node: target, input: input, triggeredBy: triggeredBy})
+	}
+	aggregated, ok := aggregatePredecessorOutputs(g, state, target)
+	if !ok {
+		return out
+	}
+	return append(out, successor{node: target, input: aggregated, triggeredBy: triggeredBy})
+}
+
+// aggregatePredecessorOutputs returns a map of predecessor name to
+// recorded Output for every predecessor of target. Returns
+// (nil, false) if any predecessor is not yet NodeCompleted; a
+// predecessor that completed without an output contributes a nil
+// value (same as the absence the predecessor itself emitted).
+func aggregatePredecessorOutputs(g *graph, state *RunState, target Node) (map[string]any, bool) {
+	predEdges := g.predecessorsOf(target)
+	aggregated := make(map[string]any, len(predEdges))
+	for _, edge := range predEdges {
+		name := edge.From.Name()
+		ns := state.Nodes[name]
+		if ns == nil || ns.Status != NodeCompleted {
+			return nil, false
+		}
+		aggregated[name] = ns.Output
+	}
+	return aggregated, true
 }

--- a/workflow/scheduler.go
+++ b/workflow/scheduler.go
@@ -32,8 +32,8 @@ const defaultEventQueueCapacity = 16
 
 var (
 	// ErrMultipleOutputs is returned when a node yields more than
-	// one event whose Actions.StateDelta carries an "output" key.
-	// A node activation may emit at most one output value.
+	// one event with Event.Output set. A node activation may emit
+	// at most one output value.
 	ErrMultipleOutputs = errors.New("workflow: node produced multiple events with output values; only one event per execution can carry output")
 
 	// ErrMultipleRoutingEvents is returned when a node yields more
@@ -413,9 +413,18 @@ func (s *scheduler) run(yield func(*session.Event, error) bool) {
 	}
 }
 
-// handleEvent updates the per-node accumulator and is called once
-// per event. The event itself has already been read from the queue
-// and will be yielded to the caller by the consumer loop.
+// handleEvent updates the per-node accumulator. The event has
+// already been read from the queue and will be yielded to the
+// caller by the consumer loop.
+//
+// Descendant events (NodeInfo.Path != it.nodeName) are dynamic-node
+// children forwarded by the sub-scheduler. Their Output/Routes
+// belong to the child, not the parent — skip the parent accumulator.
+//
+// RequestedInput is the exception: the child's pause unwinds the
+// orchestrator (dynamic_scheduler.go runNode), and Workflow.Resume
+// matches InterruptID against the parent's NodeState.PendingRequest,
+// so the parent must transition to NodeWaiting on a descendant pause.
 func (s *scheduler) handleEvent(it eventItem) {
 	nr := s.runsByName[it.nodeName]
 	if nr == nil {
@@ -426,11 +435,19 @@ func (s *scheduler) handleEvent(it eventItem) {
 	if it.ev == nil {
 		return
 	}
-	if it.ev.Routes != nil {
-		nr.setRoutingEvent(it.ev, it.nodeName)
+	var path string
+	if it.ev.NodeInfo != nil {
+		path = it.ev.NodeInfo.Path
 	}
+	isDescendant := path != "" && path != it.nodeName
 	if it.ev.RequestedInput != nil {
 		nr.setInputRequest(it.ev.RequestedInput, it.nodeName)
+	}
+	if isDescendant {
+		return
+	}
+	if it.ev.Routes != nil {
+		nr.setRoutingEvent(it.ev, it.nodeName)
 	}
 	if it.ev.Output != nil {
 		nr.setOutput(it.ev.Output, it.nodeName)

--- a/workflow/scheduler.go
+++ b/workflow/scheduler.go
@@ -105,6 +105,7 @@ type nodeRun struct {
 	hasOutput    bool                  // distinguishes "no output yet" from "output was nil"
 	inputRequest *session.RequestInput // at most one human-input request; multiple is an error
 	err          error                 // set on duplicate output, duplicate routing event, or duplicate input request
+	branch       string                // composite branch assigned at scheduling; used to stamp Event.Branch when the node leaves it empty
 }
 
 // recordErr stores err as the accumulator's first error. Subsequent
@@ -182,6 +183,7 @@ type retryItem struct {
 	node        Node
 	input       any
 	triggeredBy string
+	branch      string
 }
 
 func (retryItem) isQueueItem() {}
@@ -222,9 +224,15 @@ func buildNodesByName(g *graph) map[string]Node {
 // wrapper is responsible for pushing exactly one completionItem when
 // it returns (success, error, panic, or cancellation).
 //
+// branch is the composite branch string this activation runs under;
+// empty means inherit the workflow's root branch. Branch scopes
+// LLM history visibility (via the flow processor's branch-prefix
+// filter) and gets stamped onto every emitted event when the node
+// leaves Event.Branch empty.
+//
 // scheduleNode runs only on the consumer goroutine.
-func (s *scheduler) scheduleNode(n Node, input any, triggeredBy string) {
-	s.scheduleResumedNode(n, input, triggeredBy, nil)
+func (s *scheduler) scheduleNode(n Node, input any, triggeredBy, branch string) {
+	s.scheduleResumedNode(n, input, triggeredBy, branch, nil)
 }
 
 // scheduleResumedNode is like scheduleNode but additionally
@@ -235,7 +243,7 @@ func (s *scheduler) scheduleNode(n Node, input any, triggeredBy string) {
 // behaviour as scheduleNode.
 //
 // scheduleResumedNode runs only on the consumer goroutine.
-func (s *scheduler) scheduleResumedNode(n Node, input any, triggeredBy string, resumeInputs map[string]any) {
+func (s *scheduler) scheduleResumedNode(n Node, input any, triggeredBy, branch string, resumeInputs map[string]any) {
 	name := n.Name()
 
 	// Per-node context: WithTimeout when Config().Timeout > 0,
@@ -252,7 +260,12 @@ func (s *scheduler) scheduleResumedNode(n Node, input any, triggeredBy string, r
 	} else {
 		nodeCtx, cancel = context.WithCancel(s.parentCtx)
 	}
-	perNodeCtx := newNodeContext(s.parentCtx.WithContext(nodeCtx), resumeInputs)
+	// Order matters: WithContext sets up per-node cancellation on
+	// the underlying InvocationContext; withBranch then wraps the
+	// result in branchOverride. Reversing would either lose the
+	// cancellation context or strip the branch override.
+	wrapped := withBranch(s.parentCtx.WithContext(nodeCtx), branch)
+	perNodeCtx := newNodeContext(wrapped, resumeInputs)
 
 	// EXPERIMENTAL: stash perNodeCtx in the embedded context.Context
 	// so tools running inside an LlmAgent that is itself running as
@@ -273,7 +286,8 @@ func (s *scheduler) scheduleResumedNode(n Node, input any, triggeredBy string, r
 	ns.Status = NodeRunning
 	ns.Input = input
 	ns.TriggeredBy = triggeredBy
-	s.runsByName[name] = &nodeRun{}
+	ns.Branch = branch
+	s.runsByName[name] = &nodeRun{branch: branch}
 
 	s.runCancels[name] = cancel
 	s.wg.Add(1)
@@ -282,11 +296,13 @@ func (s *scheduler) scheduleResumedNode(n Node, input any, triggeredBy string, r
 }
 
 // scheduleRetry schedules a retry for node n after the given delay.
-func (s *scheduler) scheduleRetry(n Node, input any, triggeredBy string, delay time.Duration) {
+// branch is preserved across attempts so retries do not silently
+// move the node to a different branch.
+func (s *scheduler) scheduleRetry(n Node, input any, triggeredBy, branch string, delay time.Duration) {
 	timer := time.AfterFunc(delay, func() {
 		go func() {
 			select {
-			case s.eventQueue <- retryItem{node: n, input: input, triggeredBy: triggeredBy}:
+			case s.eventQueue <- retryItem{node: n, input: input, triggeredBy: triggeredBy, branch: branch}:
 			case <-s.parentCtx.Done():
 			}
 		}()
@@ -415,7 +431,7 @@ func (s *scheduler) run(yield func(*session.Event, error) bool) {
 		case retryItem:
 			delete(s.retryTimers, it.node.Name())
 			if !draining {
-				s.scheduleNode(it.node, it.input, it.triggeredBy)
+				s.scheduleNode(it.node, it.input, it.triggeredBy, it.branch)
 			}
 		}
 	}
@@ -449,6 +465,12 @@ func (s *scheduler) handleEvent(it eventItem) {
 	}
 	if it.ev == nil {
 		return
+	}
+	// Stamp the activation's branch onto events that left
+	// Event.Branch empty; nodes that set a non-empty Event.Branch
+	// keep it.
+	if it.ev.Branch == "" && nr.branch != "" {
+		it.ev.Branch = nr.branch
 	}
 	var path string
 	if it.ev.NodeInfo != nil {
@@ -517,7 +539,7 @@ func (s *scheduler) handleCompletion(it completionItem, scheduleSuccessors bool)
 				if ShouldRetry(cfg.RetryConfig, it.err, ns.Attempt) {
 					delay := CalculateDelay(cfg.RetryConfig, ns.Attempt)
 					ns.Status = NodePending
-					s.scheduleRetry(currentNode, ns.Input, ns.TriggeredBy, delay)
+					s.scheduleRetry(currentNode, ns.Input, ns.TriggeredBy, ns.Branch, delay)
 					// Return nil to continue the scheduler loop. Successors will
 					// be scheduled only when a retry attempt eventually succeeds
 					// and reaches the bottom of this function.
@@ -577,8 +599,8 @@ func (s *scheduler) handleCompletion(it completionItem, scheduleSuccessors bool)
 		input = ns.Input
 	}
 
-	for _, succ := range findSuccessors(s.graph, s.state, currentNode, input, routingEv) {
-		s.scheduleNode(succ.node, succ.input, succ.triggeredBy)
+	for _, succ := range findSuccessors(s.graph, s.state, currentNode, input, routingEv, ns.Branch) {
+		s.scheduleNode(succ.node, succ.input, succ.triggeredBy, succ.branch)
 	}
 	return nil
 }
@@ -587,10 +609,15 @@ func (s *scheduler) handleCompletion(it completionItem, scheduleSuccessors bool)
 // findSuccessors. The triggeredBy field carries the upstream
 // node's name for persistence on NodeState (used by Resume to
 // reconstruct the activation chain across pause/resume turns).
+// The branch field carries the composite branch string the
+// successor should run under — empty for chains that inherit the
+// parent's branch, populated when fan-out derives a sub-branch or
+// when JoinNode resolves its common predecessor prefix.
 type successor struct {
 	node        Node
 	input       any
 	triggeredBy string
+	branch      string
 }
 
 // findSuccessors evaluates the outgoing edges of currentNode against
@@ -610,7 +637,21 @@ type successor struct {
 //     deliberate decision not to continue, not an error.
 //
 // JoinNode successors are gated by appendSuccessor; see its docs.
-func findSuccessors(g *graph, state *RunState, currentNode Node, input any, event *session.Event) []successor {
+//
+// Branch derivation:
+//
+//   - When this activation fans out to >1 successor, each non-Join
+//     successor is given a sub-branch
+//     "<parentBranch>.<successorName>@1" (run_id "1" because the
+//     static scheduler does not auto-counter activations of the
+//     same name within one fan-out; loop-back routing re-enters the
+//     same node and the sub-branch stays stable).
+//   - When this activation has a single successor, the successor
+//     inherits parentBranch unchanged.
+//   - JoinNode successors compute their own branch in
+//     appendSuccessor as the common dot-prefix of the branches of
+//     all completed predecessors — see aggregatePredecessorBranches.
+func findSuccessors(g *graph, state *RunState, currentNode Node, input any, event *session.Event, parentBranch string) []successor {
 	succs := g.successorsOf(currentNode)
 	if len(succs) == 0 {
 		return nil
@@ -625,7 +666,7 @@ func findSuccessors(g *graph, state *RunState, currentNode Node, input any, even
 			continue
 		}
 		if edge.Route == nil {
-			out = appendSuccessor(out, g, state, edge.To, input, from)
+			out = appendSuccessor(out, g, state, edge.To, input, from, parentBranch)
 			added[edge.To] = struct{}{}
 			continue
 		}
@@ -634,32 +675,64 @@ func findSuccessors(g *graph, state *RunState, currentNode Node, input any, even
 			continue
 		}
 		if event != nil && edge.Route.Matches(event) {
-			out = appendSuccessor(out, g, state, edge.To, input, from)
+			out = appendSuccessor(out, g, state, edge.To, input, from, parentBranch)
 			added[edge.To] = struct{}{}
 			concreteMatched = true
 		}
 	}
 	if !concreteMatched && defaultRouteNode != nil {
-		out = appendSuccessor(out, g, state, defaultRouteNode, input, from)
+		out = appendSuccessor(out, g, state, defaultRouteNode, input, from, parentBranch)
+	}
+	// Second pass: if we fanned out to more than one successor,
+	// stamp a sub-branch onto each non-Join entry whose branch is
+	// still the inherited parentBranch. JoinNode entries already
+	// carry their common-prefix branch from appendSuccessor and
+	// must not be re-derived.
+	if len(out) > 1 {
+		for i, s := range out {
+			if _, isJoin := s.node.(*JoinNode); isJoin {
+				continue
+			}
+			if s.branch != parentBranch {
+				continue
+			}
+			out[i].branch = deriveSubBranch(parentBranch, s.node.Name()+"@1")
+		}
 	}
 	return out
 }
 
 // appendSuccessor records a routing match in the dispatch list.
-// Non-JoinNode targets are recorded as-is. A *JoinNode target is
-// recorded only when every declared predecessor has completed;
-// its input is replaced with the aggregated predecessor outputs.
-// A barrier-blocked JoinNode is silently skipped — a later
-// predecessor completion re-evaluates the barrier.
-func appendSuccessor(out []successor, g *graph, state *RunState, target Node, input any, triggeredBy string) []successor {
+// Non-JoinNode targets are recorded with parentBranch as their
+// initial branch; findSuccessors may upgrade to a sub-branch in a
+// second pass if this activation fanned out.
+//
+// A *JoinNode target is recorded only when every declared
+// predecessor has completed; its input is replaced with the
+// aggregated predecessor outputs, and its branch is the common
+// dot-prefix of all predecessor branches. A barrier-blocked
+// JoinNode is silently skipped — a later predecessor completion
+// re-evaluates the barrier.
+func appendSuccessor(out []successor, g *graph, state *RunState, target Node, input any, triggeredBy, parentBranch string) []successor {
 	if _, isJoin := target.(*JoinNode); !isJoin {
-		return append(out, successor{node: target, input: input, triggeredBy: triggeredBy})
+		return append(out, successor{
+			node:        target,
+			input:       input,
+			triggeredBy: triggeredBy,
+			branch:      parentBranch,
+		})
 	}
 	aggregated, ok := aggregatePredecessorOutputs(g, state, target)
 	if !ok {
 		return out
 	}
-	return append(out, successor{node: target, input: aggregated, triggeredBy: triggeredBy})
+	joinBranch := commonBranchPrefix(aggregatePredecessorBranches(g, state, target))
+	return append(out, successor{
+		node:        target,
+		input:       aggregated,
+		triggeredBy: triggeredBy,
+		branch:      joinBranch,
+	})
 }
 
 // aggregatePredecessorOutputs returns a map of predecessor name to
@@ -679,4 +752,28 @@ func aggregatePredecessorOutputs(g *graph, state *RunState, target Node) (map[st
 		aggregated[name] = ns.Output
 	}
 	return aggregated, true
+}
+
+// aggregatePredecessorBranches returns the branch strings recorded
+// for every predecessor of target. Order is the graph's
+// predecessor-edge order, which is deterministic per construction.
+// Callers feed the result into commonBranchPrefix to compute the
+// join's own branch.
+//
+// Assumes appendSuccessor's caller has already verified all
+// predecessors are NodeCompleted (via aggregatePredecessorOutputs
+// returning ok); a missing entry contributes "" which conservatively
+// short-circuits the common-prefix to root.
+func aggregatePredecessorBranches(g *graph, state *RunState, target Node) []string {
+	predEdges := g.predecessorsOf(target)
+	branches := make([]string, 0, len(predEdges))
+	for _, edge := range predEdges {
+		name := edge.From.Name()
+		var br string
+		if ns := state.Nodes[name]; ns != nil {
+			br = ns.Branch
+		}
+		branches = append(branches, br)
+	}
+	return branches
 }

--- a/workflow/scheduler.go
+++ b/workflow/scheduler.go
@@ -93,6 +93,30 @@ type scheduler struct {
 	wg         sync.WaitGroup
 
 	parentCtx agent.InvocationContext
+
+	// maxConcurrency caps len(runsByName); 0 disables the cap.
+	// When at the cap, scheduleResumedNode enqueues into
+	// pendingQueue (status NodePending) and the consumer drains
+	// pendingQueue via tryDispatchPending on each completion.
+	// Set once at construction; immutable thereafter.
+	maxConcurrency int
+
+	// pendingQueue holds activations queued while the
+	// concurrency cap is saturated. FIFO; nodes are dispatched
+	// in arrival order as in-flight nodes complete. Owned by the
+	// consumer goroutine.
+	pendingQueue []pendingActivation
+}
+
+// pendingActivation is a deferred scheduleResumedNode call kept on
+// the consumer-owned pendingQueue while the concurrency cap is
+// saturated. Drained by tryDispatchPending on each completion.
+type pendingActivation struct {
+	node         Node
+	input        any
+	triggeredBy  string
+	branch       string
+	resumeInputs map[string]any // nil for non-resume schedules
 }
 
 // nodeRun is the per-node consumer-side accumulator. It buffers the
@@ -196,16 +220,23 @@ func (retryItem) isQueueItem() {}
 // newScheduler returns an initialised scheduler ready for the
 // consumer to drive. The caller is responsible for seeding the
 // initial trigger (typically Start with the user input).
-func newScheduler(parent agent.InvocationContext, g *graph) *scheduler {
+//
+// maxConcurrency caps len(runsByName) at any point in time:
+// scheduleResumedNode enqueues into pendingQueue when the cap is
+// reached, and the consumer drains the queue via
+// tryDispatchPending as in-flight nodes complete. 0 disables the
+// cap (unlimited).
+func newScheduler(parent agent.InvocationContext, g *graph, maxConcurrency int) *scheduler {
 	return &scheduler{
-		state:       NewRunState(),
-		graph:       g,
-		nodesByName: buildNodesByName(g),
-		runsByName:  map[string]*nodeRun{},
-		runCancels:  map[string]context.CancelFunc{},
-		retryTimers: map[string]*time.Timer{},
-		eventQueue:  make(chan queueItem, defaultEventQueueCapacity),
-		parentCtx:   parent,
+		state:          NewRunState(),
+		graph:          g,
+		nodesByName:    buildNodesByName(g),
+		runsByName:     map[string]*nodeRun{},
+		runCancels:     map[string]context.CancelFunc{},
+		retryTimers:    map[string]*time.Timer{},
+		eventQueue:     make(chan queueItem, defaultEventQueueCapacity),
+		parentCtx:      parent,
+		maxConcurrency: maxConcurrency,
 	}
 }
 
@@ -235,9 +266,34 @@ func buildNodesByName(g *graph) map[string]Node {
 // filter) and gets stamped onto every emitted event when the node
 // leaves Event.Branch empty.
 //
+// When the engine's max-concurrency cap is reached, the activation
+// is enqueued instead of started; the node enters NodePending and
+// the scheduler dispatches it as in-flight nodes complete.
+//
 // scheduleNode runs only on the consumer goroutine.
 func (s *scheduler) scheduleNode(n Node, input any, triggeredBy, branch string) {
 	s.scheduleResumedNode(n, input, triggeredBy, branch, nil)
+}
+
+// atConcurrencyLimit reports whether the number of in-flight
+// activations has reached the configured cap. Always false when
+// maxConcurrency is 0 (unlimited).
+func (s *scheduler) atConcurrencyLimit() bool {
+	return s.maxConcurrency > 0 && len(s.runsByName) >= s.maxConcurrency
+}
+
+// tryDispatchPending starts as many queued activations as the
+// current concurrency budget allows. FIFO over pendingQueue;
+// stops when the queue is empty or the cap is reached again.
+//
+// Called after every completion (and after retry-timer expiry)
+// to make room-becoming-available immediately observable.
+func (s *scheduler) tryDispatchPending() {
+	for len(s.pendingQueue) > 0 && !s.atConcurrencyLimit() {
+		next := s.pendingQueue[0]
+		s.pendingQueue = s.pendingQueue[1:]
+		s.startNode(next.node, next.input, next.triggeredBy, next.branch, next.resumeInputs)
+	}
 }
 
 // scheduleResumedNode is like scheduleNode but additionally
@@ -247,8 +303,38 @@ func (s *scheduler) scheduleNode(n Node, input any, triggeredBy, branch string) 
 // InterruptID; nil disables re-entry semantics and yields the same
 // behaviour as scheduleNode.
 //
+// When the engine's max-concurrency cap is reached, the
+// activation is enqueued onto pendingQueue and the node enters
+// NodePending instead of starting immediately. tryDispatchPending
+// drains the queue as in-flight nodes complete.
+//
 // scheduleResumedNode runs only on the consumer goroutine.
 func (s *scheduler) scheduleResumedNode(n Node, input any, triggeredBy, branch string, resumeInputs map[string]any) {
+	if s.atConcurrencyLimit() {
+		name := n.Name()
+		ns := s.state.EnsureNode(name)
+		ns.Status = NodePending
+		ns.Input = input
+		ns.TriggeredBy = triggeredBy
+		ns.Branch = branch
+		s.pendingQueue = append(s.pendingQueue, pendingActivation{
+			node:         n,
+			input:        input,
+			triggeredBy:  triggeredBy,
+			branch:       branch,
+			resumeInputs: resumeInputs,
+		})
+		return
+	}
+	s.startNode(n, input, triggeredBy, branch, resumeInputs)
+}
+
+// startNode is the unguarded core of scheduleResumedNode: it
+// creates the per-node context, registers bookkeeping, and
+// launches the runner goroutine. Always honours the call; the
+// concurrency-cap check is done by scheduleResumedNode (the
+// public entry point) before reaching here.
+func (s *scheduler) startNode(n Node, input any, triggeredBy, branch string, resumeInputs map[string]any) {
 	name := n.Name()
 
 	// Per-node context: WithTimeout when Config().Timeout > 0,
@@ -380,6 +466,11 @@ func runNode(
 // before observing ctx.Done(); the consumer continues draining
 // until runsByName is empty.
 //
+// Also drops the pendingQueue so queued (NodePending) activations
+// do not start after cancellation. Their NodeState is left as
+// NodePending — the surrounding RunState snapshot preserves the
+// fact that they were ready-but-not-yet-started.
+//
 // cancelAll runs only on the consumer goroutine.
 func (s *scheduler) cancelAll() {
 	for _, cancel := range s.runCancels {
@@ -389,6 +480,7 @@ func (s *scheduler) cancelAll() {
 		t.Stop()
 	}
 	s.retryTimers = nil
+	s.pendingQueue = nil
 }
 
 // run is the single-consumer loop. It drains the eventQueue, applies
@@ -439,6 +531,11 @@ func (s *scheduler) run(yield func(*session.Event, error) bool) {
 					draining = true
 					s.cancelAll()
 				}
+			}
+			// A slot just freed up; promote any queued
+			// activations to running.
+			if !draining {
+				s.tryDispatchPending()
 			}
 		case retryItem:
 			delete(s.retryTimers, it.node.Name())

--- a/workflow/scheduler.go
+++ b/workflow/scheduler.go
@@ -21,7 +21,12 @@ import (
 	"sync"
 	"time"
 
+	"go.opentelemetry.io/otel/codes"
+	"go.opentelemetry.io/otel/trace"
+	"go.opentelemetry.io/otel/trace/noop"
+
 	"google.golang.org/adk/agent"
+	"google.golang.org/adk/internal/telemetry"
 	"google.golang.org/adk/session"
 )
 
@@ -331,6 +336,9 @@ func runNode(
 ) {
 	defer wg.Done()
 
+	span, ctx := startNodeSpan(ctx, n)
+	defer span.End()
+
 	// completion holds the final completionItem. It is sent in the
 	// outer defer so panic recovery, normal exit, and cancellation
 	// all funnel through the same send path.
@@ -338,6 +346,10 @@ func runNode(
 	defer func() {
 		if r := recover(); r != nil {
 			completion.err = fmt.Errorf("node %q panicked: %v", name, r)
+		}
+		if completion.err != nil && !errors.Is(completion.err, context.Canceled) {
+			span.RecordError(completion.err)
+			span.SetStatus(codes.Error, completion.err.Error())
 		}
 		out <- completion
 	}()
@@ -776,4 +788,13 @@ func aggregatePredecessorBranches(g *graph, state *RunState, target Node) []stri
 		branches = append(branches, br)
 	}
 	return branches
+}
+
+func startNodeSpan(ctx agent.InvocationContext, n Node) (trace.Span, agent.InvocationContext) {
+	if n == Start {
+		// Don't create span for the Start node.
+		return noop.Span{}, ctx
+	}
+	spanCtx, span := telemetry.StartNodeSpan(ctx, ctx, telemetry.OperationNode{Node: n})
+	return span, ctx.WithContext(spanCtx)
 }

--- a/workflow/scheduler_branch_test.go
+++ b/workflow/scheduler_branch_test.go
@@ -1,0 +1,256 @@
+// Copyright 2026 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package workflow
+
+import (
+	"sync"
+	"testing"
+
+	"google.golang.org/adk/agent"
+)
+
+// branchRecorder returns a FunctionNode that captures the
+// ctx.Branch() string into *seen at execution time, keyed by node
+// name.
+func branchRecorder(name string, mu *sync.Mutex, seen *map[string]string) *FunctionNode {
+	return NewFunctionNode(name,
+		func(ctx agent.InvocationContext, input any) (string, error) {
+			mu.Lock()
+			(*seen)[name] = ctx.Branch()
+			mu.Unlock()
+			return name + "-done", nil
+		}, defaultNodeConfig)
+}
+
+// TestScheduler_SingleSuccessorChain_InheritsRootBranch verifies
+// that a linear chain (one successor per node) keeps every
+// activation on the root branch — sub-branches are only derived at
+// fan-out, not on every edge.
+func TestScheduler_SingleSuccessorChain_InheritsRootBranch(t *testing.T) {
+	mockCtx := newSeededMockCtx(t)
+	var mu sync.Mutex
+	seen := map[string]string{}
+
+	a := branchRecorder("a", &mu, &seen)
+	b := branchRecorder("b", &mu, &seen)
+	c := branchRecorder("c", &mu, &seen)
+
+	w := mustNew(t, []Edge{
+		{From: Start, To: a},
+		{From: a, To: b},
+		{From: b, To: c},
+	})
+
+	drain(t, w.Run(mockCtx))
+
+	for _, name := range []string{"a", "b", "c"} {
+		if got := seen[name]; got != "" {
+			t.Errorf("seen[%q] = %q, want \"\" (chain inherits root)", name, got)
+		}
+	}
+}
+
+// TestScheduler_MultipleSuccessors_AssignsSubBranches verifies that
+// fan-out from one node to N successors derives sub-branches of the
+// form "<successor>@1" for each branch.
+func TestScheduler_MultipleSuccessors_AssignsSubBranches(t *testing.T) {
+	mockCtx := newSeededMockCtx(t)
+	var mu sync.Mutex
+	seen := map[string]string{}
+
+	a := branchRecorder("a", &mu, &seen)
+	b := branchRecorder("b", &mu, &seen)
+	c := branchRecorder("c", &mu, &seen)
+
+	// START fans out to a + b + c.
+	w := mustNew(t, []Edge{
+		{From: Start, To: a},
+		{From: Start, To: b},
+		{From: Start, To: c},
+	})
+
+	drain(t, w.Run(mockCtx))
+
+	want := map[string]string{
+		"a": "a@1",
+		"b": "b@1",
+		"c": "c@1",
+	}
+	for name, wantBranch := range want {
+		if got := seen[name]; got != wantBranch {
+			t.Errorf("seen[%q] = %q, want %q (fan-out should derive sub-branch)",
+				name, got, wantBranch)
+		}
+	}
+}
+
+// TestScheduler_FanOutChainedDeeperBranches verifies that after a
+// fan-out, successors of each branch continue to extend their
+// branch when they themselves fan out further.
+func TestScheduler_FanOutChainedDeeperBranches(t *testing.T) {
+	mockCtx := newSeededMockCtx(t)
+	var mu sync.Mutex
+	seen := map[string]string{}
+
+	a := branchRecorder("a", &mu, &seen)
+	// a fans out to b1+b2 within its sub-branch.
+	b1 := branchRecorder("b1", &mu, &seen)
+	b2 := branchRecorder("b2", &mu, &seen)
+
+	w := mustNew(t, []Edge{
+		{From: Start, To: a}, // a stays on root (single successor)
+		{From: a, To: b1},    // a fans out: b1 and b2 get sub-branches
+		{From: a, To: b2},
+	})
+
+	drain(t, w.Run(mockCtx))
+
+	if got, want := seen["a"], ""; got != want {
+		t.Errorf("seen[a] = %q, want %q (root, since START's only successor is a)", got, want)
+	}
+	if got, want := seen["b1"], "b1@1"; got != want {
+		t.Errorf("seen[b1] = %q, want %q", got, want)
+	}
+	if got, want := seen["b2"], "b2@1"; got != want {
+		t.Errorf("seen[b2] = %q, want %q", got, want)
+	}
+}
+
+// TestScheduler_JoinNode_UsesCommonPrefix verifies that when a
+// JoinNode fires after a fan-out of its predecessors, the join
+// activation runs on the common branch prefix of its predecessors
+// (which in the simple case is the parent of the fan-out).
+func TestScheduler_JoinNode_UsesCommonPrefix(t *testing.T) {
+	mockCtx := newSeededMockCtx(t)
+	var mu sync.Mutex
+	seen := map[string]string{}
+
+	branchA := branchRecorder("branchA", &mu, &seen)
+	branchB := branchRecorder("branchB", &mu, &seen)
+	join := NewJoinNode("join")
+	handler := branchRecorder("handler", &mu, &seen)
+
+	w := mustNew(t, []Edge{
+		{From: Start, To: branchA}, // fan-out: branchA and branchB get sub-branches
+		{From: Start, To: branchB},
+		{From: branchA, To: join},
+		{From: branchB, To: join},
+		{From: join, To: handler}, // single successor; handler inherits join's branch
+	})
+
+	drain(t, w.Run(mockCtx))
+
+	// Predecessors are on their own sub-branches.
+	if got, want := seen["branchA"], "branchA@1"; got != want {
+		t.Errorf("seen[branchA] = %q, want %q", got, want)
+	}
+	if got, want := seen["branchB"], "branchB@1"; got != want {
+		t.Errorf("seen[branchB] = %q, want %q", got, want)
+	}
+	// Join's branch is the common prefix of "branchA@1" and "branchB@1",
+	// which share no dot-separated segments → root.
+	// The handler inherits the join's branch (single successor).
+	if got, want := seen["handler"], ""; got != want {
+		t.Errorf("seen[handler] = %q, want %q (common prefix of branchA@1/branchB@1 is root)", got, want)
+	}
+}
+
+// TestScheduler_JoinNode_NestedFanOut verifies the common-prefix
+// behaviour when predecessors share a deeper ancestor branch. After
+// fan-out, predecessors that themselves shared an outer branch
+// produce a join on that outer branch (not all the way back to
+// root).
+func TestScheduler_JoinNode_NestedFanOut(t *testing.T) {
+	mockCtx := newSeededMockCtx(t)
+	var mu sync.Mutex
+	seen := map[string]string{}
+
+	// outer is a single successor of START → stays on root.
+	outer := branchRecorder("outer", &mu, &seen)
+	// outer fans out to leaf1 + leaf2 → each gets sub-branch.
+	leaf1 := branchRecorder("leaf1", &mu, &seen)
+	leaf2 := branchRecorder("leaf2", &mu, &seen)
+	join := NewJoinNode("join")
+	handler := branchRecorder("handler", &mu, &seen)
+
+	w := mustNew(t, []Edge{
+		{From: Start, To: outer},
+		{From: outer, To: leaf1},
+		{From: outer, To: leaf2},
+		{From: leaf1, To: join},
+		{From: leaf2, To: join},
+		{From: join, To: handler},
+	})
+
+	drain(t, w.Run(mockCtx))
+
+	if got, want := seen["outer"], ""; got != want {
+		t.Errorf("seen[outer] = %q, want %q", got, want)
+	}
+	if got, want := seen["leaf1"], "leaf1@1"; got != want {
+		t.Errorf("seen[leaf1] = %q, want %q", got, want)
+	}
+	if got, want := seen["leaf2"], "leaf2@1"; got != want {
+		t.Errorf("seen[leaf2] = %q, want %q", got, want)
+	}
+	// Common prefix of "leaf1@1" and "leaf2@1" is "" (no shared
+	// segments) — because outer is on the *root* branch, its
+	// successors' sub-branches share no parent segment, so the join
+	// returns to root (deepest common ancestor).
+	if got, want := seen["handler"], ""; got != want {
+		t.Errorf("seen[handler] = %q, want %q", got, want)
+	}
+}
+
+// TestScheduler_EventsAreBranchStamped verifies that the scheduler
+// stamps Event.Branch on every emitted event using the activation's
+// branch when the node itself leaves Event.Branch empty.
+func TestScheduler_EventsAreBranchStamped(t *testing.T) {
+	mockCtx := newSeededMockCtx(t)
+	var mu sync.Mutex
+	seen := map[string]string{}
+
+	a := branchRecorder("a", &mu, &seen)
+	b := branchRecorder("b", &mu, &seen)
+
+	w := mustNew(t, []Edge{
+		{From: Start, To: a},
+		{From: Start, To: b},
+	})
+
+	events := drain(t, w.Run(mockCtx))
+
+	gotByAuthor := map[string][]string{}
+	for _, ev := range events {
+		if ev.Author == "" {
+			continue
+		}
+		gotByAuthor[ev.Author] = append(gotByAuthor[ev.Author], ev.Branch)
+	}
+
+	for _, author := range []string{"a", "b"} {
+		branches, ok := gotByAuthor[author]
+		if !ok {
+			continue // node may have emitted no events with author set
+		}
+		wantBranch := author + "@1"
+		for _, got := range branches {
+			if got != wantBranch {
+				t.Errorf("event from %q has Branch = %q, want %q",
+					author, got, wantBranch)
+			}
+		}
+	}
+}

--- a/workflow/scheduler_test.go
+++ b/workflow/scheduler_test.go
@@ -1,0 +1,460 @@
+// Copyright 2026 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package workflow
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"iter"
+	"sort"
+	"sync/atomic"
+	"testing"
+	"time"
+
+	"github.com/google/go-cmp/cmp"
+
+	"google.golang.org/adk/agent"
+	"google.golang.org/adk/session"
+)
+
+// TestScheduler_LinearChain verifies that a linear graph
+// Start → A → B → C runs to completion in the expected order and
+// that each node's lifecycle ends at NodeCompleted.
+func TestScheduler_LinearChain(t *testing.T) {
+	mockCtx := newSeededMockCtx(t)
+
+	a := newRecordingNode("A")
+	b := newRecordingNode("B")
+	c := newRecordingNode("C")
+	a.release()
+	b.release()
+	c.release()
+
+	w := mustNew(t, Chain(Start, a, b, c))
+
+	gotEvents := drain(t, w.Run(mockCtx))
+
+	// Each recording node yields exactly one event with output =
+	// "<input>:<name>". The chain accumulates: A sees "seed", B sees
+	// "seed:A", C sees "seed:A:B".
+	wantOutputs := []string{"seed:A", "seed:A:B", "seed:A:B:C"}
+	gotOutputs := outputsOf(gotEvents)
+	if diff := cmp.Diff(wantOutputs, gotOutputs); diff != "" {
+		t.Errorf("outputs mismatch (-want +got):\n%s", diff)
+	}
+}
+
+// TestScheduler_FanOutConcurrency verifies that three nodes
+// downstream of START are mid-Run simultaneously, not serialised by
+// the legacy BFS. Each node blocks on its release channel until the
+// test signals.
+func TestScheduler_FanOutConcurrency(t *testing.T) {
+	const fanOut = 3
+
+	mockCtx := newSeededMockCtx(t)
+
+	var concurrent atomic.Int32
+	var peakConcurrent atomic.Int32
+
+	// Make N nodes that each bump a "currently running" counter on
+	// entry and decrement on exit. Track the peak. They block on a
+	// shared barrier so they can all be observed mid-flight together.
+	barrier := make(chan struct{})
+	nodes := make([]Node, fanOut)
+	for i := range fanOut {
+		name := fmt.Sprintf("N%d", i)
+		nodes[i] = newBlockingNode(name, func() {
+			nowConcurrent := concurrent.Add(1)
+			for {
+				peak := peakConcurrent.Load()
+				if nowConcurrent <= peak || peakConcurrent.CompareAndSwap(peak, nowConcurrent) {
+					break
+				}
+			}
+			<-barrier
+			concurrent.Add(-1)
+		})
+	}
+
+	edges := make([]Edge, 0, fanOut)
+	for _, n := range nodes {
+		edges = append(edges, Edge{From: Start, To: n})
+	}
+	w := mustNew(t, edges)
+
+	// Release the barrier once we observe peak == fanOut, or fail
+	// after a generous timeout.
+	done := make(chan struct{})
+	go func() {
+		defer close(done)
+		drain(t, w.Run(mockCtx))
+	}()
+
+	deadline := time.Now().Add(2 * time.Second)
+	for time.Now().Before(deadline) {
+		if peakConcurrent.Load() == fanOut {
+			break
+		}
+		time.Sleep(time.Millisecond)
+	}
+
+	close(barrier)
+	<-done
+
+	if got := peakConcurrent.Load(); got != fanOut {
+		t.Errorf("peak concurrent nodes = %d, want %d (fan-out children should run in parallel)", got, fanOut)
+	}
+}
+
+// TestScheduler_FailedSiblingsCancelled verifies that when one
+// node returns an error, the consumer cancels every sibling, the
+// final yielded error is the failing node's own error, and the
+// lifecycle map ends up with the right mix of statuses.
+func TestScheduler_FailedSiblingsCancelled(t *testing.T) {
+	mockCtx := newSeededMockCtx(t)
+
+	failErr := errors.New("B failed intentionally")
+
+	// A and C block until their context is cancelled. B errors
+	// immediately. After B's failure, A and C should observe ctx.Done.
+	a := newCancelObservingNode("A")
+	b := newErroringNode("B", failErr)
+	c := newCancelObservingNode("C")
+
+	edges := []Edge{
+		{From: Start, To: a},
+		{From: Start, To: b},
+		{From: Start, To: c},
+	}
+	w := mustNew(t, edges)
+
+	gotErr := drainErr(t, w.Run(mockCtx))
+	if !errors.Is(gotErr, failErr) {
+		t.Errorf("Run error = %v, want it to wrap %v", gotErr, failErr)
+	}
+	if got := a.cancelObserved.Load(); !got {
+		t.Errorf("node A: ctx.Done() not observed (sibling cancellation broken)")
+	}
+	if got := c.cancelObserved.Load(); !got {
+		t.Errorf("node C: ctx.Done() not observed (sibling cancellation broken)")
+	}
+}
+
+// TestScheduler_CallerBreakStopsScheduling verifies that when the
+// caller breaks out of the event range loop, the scheduler stops
+// dispatching new successor nodes — not just stops yielding events.
+// Without this guarantee, an early caller break would leave the rest
+// of the workflow running silently in the background.
+func TestScheduler_CallerBreakStopsScheduling(t *testing.T) {
+	mockCtx := newSeededMockCtx(t)
+
+	var bRan, cRan atomic.Bool
+
+	a := NewFunctionNode("A", func(ctx agent.InvocationContext, input any) (string, error) {
+		return "a-out", nil
+	}, defaultNodeConfig)
+	b := NewFunctionNode("B", func(ctx agent.InvocationContext, input any) (string, error) {
+		bRan.Store(true)
+		return "b-out", nil
+	}, defaultNodeConfig)
+	c := NewFunctionNode("C", func(ctx agent.InvocationContext, input any) (string, error) {
+		cRan.Store(true)
+		return "c-out", nil
+	}, defaultNodeConfig)
+
+	w := mustNew(t, []Edge{
+		{From: Start, To: a},
+		{From: a, To: b},
+		{From: b, To: c},
+	})
+
+	// Caller breaks immediately after the first event.
+	for range w.Run(mockCtx) {
+		break
+	}
+
+	if bRan.Load() {
+		t.Error("node B ran after caller break; draining should stop further scheduling")
+	}
+	if cRan.Load() {
+		t.Error("node C ran after caller break; draining should stop further scheduling")
+	}
+}
+
+// TestScheduler_NodeTimeout verifies that a node with
+// Config().Timeout set is killed after the timeout and the resulting
+// completion is treated as a failure (deadline exceeded). Sibling
+// nodes without a timeout are not affected.
+func TestScheduler_NodeTimeout(t *testing.T) {
+	mockCtx := newSeededMockCtx(t)
+
+	slow := newCancelObservingNode("slow")
+	slow.cfg = NodeConfig{Timeout: 50 * time.Millisecond}
+
+	w := mustNew(t, []Edge{{From: Start, To: slow}})
+
+	gotErr := drainErr(t, w.Run(mockCtx))
+	if !errors.Is(gotErr, context.DeadlineExceeded) {
+		t.Errorf("Run error = %v, want context.DeadlineExceeded", gotErr)
+	}
+	if !slow.cancelObserved.Load() {
+		t.Error("slow node: ctx.Done() not observed (timeout cancellation broken)")
+	}
+}
+
+// TestScheduler_MultipleOutputsFailNode verifies that a node which
+// yields more than one event carrying StateDelta["output"] fails
+// the workflow with ErrMultipleOutputs (matching adk-python's
+// "single output per node" contract). The first output value is
+// preserved; subsequent ones trip the accumulator error.
+func TestScheduler_MultipleOutputsFailNode(t *testing.T) {
+	mockCtx := newSeededMockCtx(t)
+
+	bad := newMultiOutputNode("bad", []string{"first", "second"})
+	w := mustNew(t, []Edge{{From: Start, To: bad}})
+
+	gotErr := drainErr(t, w.Run(mockCtx))
+	if !errors.Is(gotErr, ErrMultipleOutputs) {
+		t.Errorf("Run error = %v, want it to wrap ErrMultipleOutputs", gotErr)
+	}
+}
+
+// TestScheduler_ProgressEventsThenSingleOutputSucceed verifies
+// that events with no StateDelta["output"] (progress / status
+// events) do not consume the single-output budget. A node may
+// yield many such events followed by exactly one output event
+// without violating the contract.
+func TestScheduler_ProgressEventsThenSingleOutputSucceed(t *testing.T) {
+	mockCtx := newSeededMockCtx(t)
+
+	n := newProgressThenOutputNode("n", 3 /*progress events*/, "final")
+	w := mustNew(t, []Edge{{From: Start, To: n}})
+
+	events := drain(t, w.Run(mockCtx))
+
+	// Expect 3 progress events + 1 output event = 4 events total,
+	// and the last one carries the output value.
+	if got, want := len(events), 4; got != want {
+		t.Fatalf("event count = %d, want %d", got, want)
+	}
+	last := events[len(events)-1]
+	if last.Actions.StateDelta == nil {
+		t.Fatal("last event has nil StateDelta")
+	}
+	if got, want := fmt.Sprint(last.Actions.StateDelta["output"]), "final"; got != want {
+		t.Errorf("last event output = %q, want %q", got, want)
+	}
+}
+
+// --- test fixtures: helper nodes and drain helpers below this line ---
+
+// drain consumes all events from an iter.Seq2 and returns the
+// successful events. The first error fails the test.
+func drain(t *testing.T, seq iter.Seq2[*session.Event, error]) []*session.Event {
+	t.Helper()
+	var out []*session.Event
+	for ev, err := range seq {
+		if err != nil {
+			t.Fatalf("unexpected error: %v", err)
+		}
+		out = append(out, ev)
+	}
+	return out
+}
+
+// drainErr consumes all events and returns the first error. Fails
+// the test if no error was produced.
+func drainErr(t *testing.T, seq iter.Seq2[*session.Event, error]) error {
+	t.Helper()
+	var firstErr error
+	for _, err := range seq {
+		if err != nil && firstErr == nil {
+			firstErr = err
+		}
+	}
+	if firstErr == nil {
+		t.Fatal("expected an error from Run, got none")
+	}
+	return firstErr
+}
+
+// outputsOf extracts the StateDelta["output"] string from each event,
+// sorted to make assertions order-independent across concurrent runs.
+func outputsOf(events []*session.Event) []string {
+	out := make([]string, 0, len(events))
+	for _, ev := range events {
+		if ev == nil || ev.Actions.StateDelta == nil {
+			continue
+		}
+		if v, ok := ev.Actions.StateDelta["output"]; ok {
+			out = append(out, fmt.Sprint(v))
+		}
+	}
+	sort.Strings(out)
+	return out
+}
+
+// recordingNode emits one event with output = "<input>:<name>".
+// Used in chains to verify per-step input propagation.
+type recordingNode struct {
+	BaseNode
+	released chan struct{}
+}
+
+func newRecordingNode(name string) *recordingNode {
+	return &recordingNode{
+		BaseNode: NewBaseNode(name, "", NodeConfig{}),
+		released: make(chan struct{}),
+	}
+}
+
+func (n *recordingNode) release() { close(n.released) }
+
+func (n *recordingNode) Run(ctx agent.InvocationContext, input any) iter.Seq2[*session.Event, error] {
+	return func(yield func(*session.Event, error) bool) {
+		<-n.released
+		ev := session.NewEvent(ctx.InvocationID())
+		out := fmt.Sprintf("%v:%s", input, n.Name())
+		ev.Actions.StateDelta["output"] = out
+		yield(ev, nil)
+	}
+}
+
+// blockingNode runs the supplied work function (which typically
+// touches an external counter and waits on a barrier). Yields one
+// empty event after the work returns so the scheduler can record
+// completion.
+type blockingNode struct {
+	BaseNode
+	work func()
+}
+
+func newBlockingNode(name string, work func()) *blockingNode {
+	return &blockingNode{
+		BaseNode: NewBaseNode(name, "", NodeConfig{}),
+		work:     work,
+	}
+}
+
+func (n *blockingNode) Run(ctx agent.InvocationContext, _ any) iter.Seq2[*session.Event, error] {
+	return func(yield func(*session.Event, error) bool) {
+		n.work()
+		ev := session.NewEvent(ctx.InvocationID())
+		ev.Actions.StateDelta["output"] = n.Name()
+		yield(ev, nil)
+	}
+}
+
+// erroringNode returns the supplied error immediately.
+type erroringNode struct {
+	BaseNode
+	err error
+}
+
+func newErroringNode(name string, err error) *erroringNode {
+	return &erroringNode{
+		BaseNode: NewBaseNode(name, "", NodeConfig{}),
+		err:      err,
+	}
+}
+
+func (n *erroringNode) Run(_ agent.InvocationContext, _ any) iter.Seq2[*session.Event, error] {
+	return func(yield func(*session.Event, error) bool) {
+		yield(nil, n.err)
+	}
+}
+
+// cancelObservingNode blocks until its context is cancelled, then
+// records that fact via cancelObserved. Used to verify sibling
+// cancellation and timeout behaviour.
+type cancelObservingNode struct {
+	BaseNode
+	cfg            NodeConfig
+	cancelObserved atomic.Bool
+}
+
+func newCancelObservingNode(name string) *cancelObservingNode {
+	return &cancelObservingNode{BaseNode: NewBaseNode(name, "", NodeConfig{})}
+}
+
+// Config returns n.cfg, which tests may mutate after construction.
+func (n *cancelObservingNode) Config() NodeConfig { return n.cfg }
+
+func (n *cancelObservingNode) Run(ctx agent.InvocationContext, _ any) iter.Seq2[*session.Event, error] {
+	return func(yield func(*session.Event, error) bool) {
+		<-ctx.Done()
+		n.cancelObserved.Store(true)
+	}
+}
+
+// multiOutputNode yields one event per supplied output value, each
+// carrying StateDelta["output"]. Used to exercise the
+// single-output-per-node constraint.
+type multiOutputNode struct {
+	BaseNode
+	outputs []string
+}
+
+func newMultiOutputNode(name string, outputs []string) *multiOutputNode {
+	return &multiOutputNode{
+		BaseNode: NewBaseNode(name, "", NodeConfig{}),
+		outputs:  outputs,
+	}
+}
+
+func (n *multiOutputNode) Run(ctx agent.InvocationContext, _ any) iter.Seq2[*session.Event, error] {
+	return func(yield func(*session.Event, error) bool) {
+		for _, out := range n.outputs {
+			ev := session.NewEvent(ctx.InvocationID())
+			ev.Actions.StateDelta["output"] = out
+			if !yield(ev, nil) {
+				return
+			}
+		}
+	}
+}
+
+// progressThenOutputNode yields N events with no output (progress
+// events) followed by exactly one output event. Used to verify
+// that progress events do not consume the single-output budget.
+type progressThenOutputNode struct {
+	BaseNode
+	progressCount int
+	finalOutput   string
+}
+
+func newProgressThenOutputNode(name string, progressCount int, finalOutput string) *progressThenOutputNode {
+	return &progressThenOutputNode{
+		BaseNode:      NewBaseNode(name, "", NodeConfig{}),
+		progressCount: progressCount,
+		finalOutput:   finalOutput,
+	}
+}
+
+func (n *progressThenOutputNode) Run(ctx agent.InvocationContext, _ any) iter.Seq2[*session.Event, error] {
+	return func(yield func(*session.Event, error) bool) {
+		for range n.progressCount {
+			ev := session.NewEvent(ctx.InvocationID())
+			// progress event: no StateDelta["output"]
+			if !yield(ev, nil) {
+				return
+			}
+		}
+		final := session.NewEvent(ctx.InvocationID())
+		final.Actions.StateDelta["output"] = n.finalOutput
+		yield(final, nil)
+	}
+}

--- a/workflow/scheduler_test.go
+++ b/workflow/scheduler_test.go
@@ -216,7 +216,7 @@ func TestScheduler_NodeTimeout(t *testing.T) {
 }
 
 // TestScheduler_MultipleOutputsFailNode verifies that a node which
-// yields more than one event carrying StateDelta["output"] fails
+// yields more than one event carrying Output fails
 // the workflow with ErrMultipleOutputs (matching adk-python's
 // "single output per node" contract). The first output value is
 // preserved; subsequent ones trip the accumulator error.
@@ -233,7 +233,7 @@ func TestScheduler_MultipleOutputsFailNode(t *testing.T) {
 }
 
 // TestScheduler_ProgressEventsThenSingleOutputSucceed verifies
-// that events with no StateDelta["output"] (progress / status
+// that events with no Output (progress / status
 // events) do not consume the single-output budget. A node may
 // yield many such events followed by exactly one output event
 // without violating the contract.
@@ -251,11 +251,8 @@ func TestScheduler_ProgressEventsThenSingleOutputSucceed(t *testing.T) {
 		t.Fatalf("event count = %d, want %d", got, want)
 	}
 	last := events[len(events)-1]
-	if last.Actions.StateDelta == nil {
-		t.Fatal("last event has nil StateDelta")
-	}
-	if got, want := fmt.Sprint(last.Actions.StateDelta["output"]), "final"; got != want {
-		t.Errorf("last event output = %q, want %q", got, want)
+	if got, want := fmt.Sprint(last.Output), "final"; got != want {
+		t.Errorf("last event Output = %q, want %q", got, want)
 	}
 }
 
@@ -291,17 +288,15 @@ func drainErr(t *testing.T, seq iter.Seq2[*session.Event, error]) error {
 	return firstErr
 }
 
-// outputsOf extracts the StateDelta["output"] string from each event,
+// outputsOf extracts the Output string from each event,
 // sorted to make assertions order-independent across concurrent runs.
 func outputsOf(events []*session.Event) []string {
 	out := make([]string, 0, len(events))
 	for _, ev := range events {
-		if ev == nil || ev.Actions.StateDelta == nil {
+		if ev == nil || ev.Output == nil {
 			continue
 		}
-		if v, ok := ev.Actions.StateDelta["output"]; ok {
-			out = append(out, fmt.Sprint(v))
-		}
+		out = append(out, fmt.Sprint(ev.Output))
 	}
 	sort.Strings(out)
 	return out
@@ -328,7 +323,7 @@ func (n *recordingNode) Run(ctx agent.InvocationContext, input any) iter.Seq2[*s
 		<-n.released
 		ev := session.NewEvent(ctx.InvocationID())
 		out := fmt.Sprintf("%v:%s", input, n.Name())
-		ev.Actions.StateDelta["output"] = out
+		ev.Output = out
 		yield(ev, nil)
 	}
 }
@@ -353,7 +348,7 @@ func (n *blockingNode) Run(ctx agent.InvocationContext, _ any) iter.Seq2[*sessio
 	return func(yield func(*session.Event, error) bool) {
 		n.work()
 		ev := session.NewEvent(ctx.InvocationID())
-		ev.Actions.StateDelta["output"] = n.Name()
+		ev.Output = n.Name()
 		yield(ev, nil)
 	}
 }
@@ -401,7 +396,7 @@ func (n *cancelObservingNode) Run(ctx agent.InvocationContext, _ any) iter.Seq2[
 }
 
 // multiOutputNode yields one event per supplied output value, each
-// carrying StateDelta["output"]. Used to exercise the
+// carrying Output. Used to exercise the
 // single-output-per-node constraint.
 type multiOutputNode struct {
 	BaseNode
@@ -419,7 +414,7 @@ func (n *multiOutputNode) Run(ctx agent.InvocationContext, _ any) iter.Seq2[*ses
 	return func(yield func(*session.Event, error) bool) {
 		for _, out := range n.outputs {
 			ev := session.NewEvent(ctx.InvocationID())
-			ev.Actions.StateDelta["output"] = out
+			ev.Output = out
 			if !yield(ev, nil) {
 				return
 			}
@@ -448,13 +443,12 @@ func (n *progressThenOutputNode) Run(ctx agent.InvocationContext, _ any) iter.Se
 	return func(yield func(*session.Event, error) bool) {
 		for range n.progressCount {
 			ev := session.NewEvent(ctx.InvocationID())
-			// progress event: no StateDelta["output"]
 			if !yield(ev, nil) {
 				return
 			}
 		}
 		final := session.NewEvent(ctx.InvocationID())
-		final.Actions.StateDelta["output"] = n.finalOutput
+		final.Output = n.finalOutput
 		yield(final, nil)
 	}
 }
@@ -487,7 +481,7 @@ func TestScheduler_RetryNode(t *testing.T) {
 		t.Fatalf("expected 1 event, got %d", len(events))
 	}
 
-	out := fmt.Sprint(events[0].Actions.StateDelta["output"])
+	out := fmt.Sprint(events[0].Output)
 	if out != "seed:retryNode" {
 		t.Errorf("output = %q, want %q", out, "seed:retryNode")
 	}
@@ -549,7 +543,7 @@ func (n *retryTestNode) Run(ctx agent.InvocationContext, input any) iter.Seq2[*s
 		}
 		ev := session.NewEvent(ctx.InvocationID())
 		out := fmt.Sprintf("%v:%s", input, n.Name())
-		ev.Actions.StateDelta["output"] = out
+		ev.Output = out
 		yield(ev, nil)
 	}
 }

--- a/workflow/scheduler_test.go
+++ b/workflow/scheduler_test.go
@@ -20,11 +20,13 @@ import (
 	"fmt"
 	"iter"
 	"sort"
+	"strings"
 	"sync/atomic"
 	"testing"
 	"time"
 
 	"github.com/google/go-cmp/cmp"
+	"github.com/google/jsonschema-go/jsonschema"
 
 	"google.golang.org/adk/agent"
 	"google.golang.org/adk/session"
@@ -253,6 +255,82 @@ func TestScheduler_ProgressEventsThenSingleOutputSucceed(t *testing.T) {
 	last := events[len(events)-1]
 	if got, want := fmt.Sprint(last.Output), "final"; got != want {
 		t.Errorf("last event Output = %q, want %q", got, want)
+	}
+}
+
+// TestScheduler_ValidateOutput_ValidPasses verifies that a node
+// with an output_schema whose yielded output conforms to the schema
+// is forwarded unchanged to the consumer.
+func TestScheduler_ValidateOutput_ValidPasses(t *testing.T) {
+	mockCtx := newSeededMockCtx(t)
+	schema := resolveTestSchema[testSchemaInput](t)
+	n := newSchemaValidatedNode("n", schema, map[string]any{"value": "hello"})
+
+	w := mustNew(t, []Edge{{From: Start, To: n}})
+
+	events := drain(t, w.Run(mockCtx))
+	if got, want := len(events), 1; got != want {
+		t.Fatalf("event count = %d, want %d", got, want)
+	}
+	gotMap, ok := events[0].Output.(map[string]any)
+	if !ok {
+		t.Fatalf("Output type = %T, want map[string]any", events[0].Output)
+	}
+	if gotMap["value"] != "hello" {
+		t.Errorf("Output[value] = %v, want %q", gotMap["value"], "hello")
+	}
+}
+
+// TestScheduler_ValidateOutput_InvalidEndsActivation verifies that
+// when a node yields output that fails its output_schema, the
+// scheduler surfaces a validation error and the activation does not
+// transition to NodeCompleted.
+func TestScheduler_ValidateOutput_InvalidEndsActivation(t *testing.T) {
+	mockCtx := newSeededMockCtx(t)
+	schema := resolveTestSchema[testSchemaInput](t)
+	// "value" must be a string; an integer must trip validation.
+	n := newSchemaValidatedNode("n", schema, map[string]any{"value": 123})
+
+	w := mustNew(t, []Edge{{From: Start, To: n}})
+
+	gotErr := drainErr(t, w.Run(mockCtx))
+	if gotErr == nil {
+		t.Fatal("expected validation error, got nil")
+	}
+	wantSubstr := `output validation failed for node "n"`
+	if !strings.Contains(gotErr.Error(), wantSubstr) {
+		t.Errorf("error = %q, want substring %q", gotErr.Error(), wantSubstr)
+	}
+}
+
+// TestScheduler_ValidateOutput_NoOutputSkipsValidation verifies that
+// events without Output (progress / status events) are forwarded
+// without invoking ValidateOutput, even when the node carries an
+// output_schema that would reject nil.
+func TestScheduler_ValidateOutput_NoOutputSkipsValidation(t *testing.T) {
+	mockCtx := newSeededMockCtx(t)
+	schema := resolveTestSchema[testSchemaInput](t)
+	// 3 progress events (Output == nil) + 1 valid output event.
+	n := &progressThenSchemaOutputNode{
+		BaseNode: NewBaseNodeWithSchemas("n", "", NodeConfig{}, nil, schema),
+		progress: 3,
+		output:   map[string]any{"value": "hello"},
+	}
+
+	w := mustNew(t, []Edge{{From: Start, To: n}})
+
+	events := drain(t, w.Run(mockCtx))
+	if got, want := len(events), 4; got != want {
+		t.Fatalf("event count = %d, want %d", got, want)
+	}
+	// Last event carries the (validated) output; first 3 are passthrough.
+	for i := 0; i < 3; i++ {
+		if events[i].Output != nil {
+			t.Errorf("event %d Output = %v, want nil (progress)", i, events[i].Output)
+		}
+	}
+	if got := events[3].Output; got == nil {
+		t.Errorf("last event Output = nil, want validated map")
 	}
 }
 
@@ -641,5 +719,51 @@ func TestScheduler_RetryCancelled(t *testing.T) {
 
 	if got := n.calls.Load(); got != 1 {
 		t.Errorf("node calls = %d, want 1 (retry should not have triggered)", got)
+	}
+}
+
+// schemaValidatedNode yields exactly one event whose Output is the
+// supplied value. The BaseNode carries the supplied output schema so
+// the scheduler invokes ValidateOutput on the yielded value.
+type schemaValidatedNode struct {
+	BaseNode
+	output any
+}
+
+func newSchemaValidatedNode(name string, schema *jsonschema.Resolved, output any) *schemaValidatedNode {
+	return &schemaValidatedNode{
+		BaseNode: NewBaseNodeWithSchemas(name, "", NodeConfig{}, nil, schema),
+		output:   output,
+	}
+}
+
+func (n *schemaValidatedNode) Run(ctx agent.InvocationContext, _ any) iter.Seq2[*session.Event, error] {
+	return func(yield func(*session.Event, error) bool) {
+		ev := session.NewEvent(ctx.InvocationID())
+		ev.Output = n.output
+		yield(ev, nil)
+	}
+}
+
+// progressThenSchemaOutputNode yields `progress` events without Output
+// followed by one event carrying `output`. Used to verify that the
+// scheduler does not invoke ValidateOutput on output-less events.
+type progressThenSchemaOutputNode struct {
+	BaseNode
+	progress int
+	output   any
+}
+
+func (n *progressThenSchemaOutputNode) Run(ctx agent.InvocationContext, _ any) iter.Seq2[*session.Event, error] {
+	return func(yield func(*session.Event, error) bool) {
+		for i := 0; i < n.progress; i++ {
+			ev := session.NewEvent(ctx.InvocationID())
+			if !yield(ev, nil) {
+				return
+			}
+		}
+		ev := session.NewEvent(ctx.InvocationID())
+		ev.Output = n.output
+		yield(ev, nil)
 	}
 }

--- a/workflow/scheduler_test.go
+++ b/workflow/scheduler_test.go
@@ -458,3 +458,194 @@ func (n *progressThenOutputNode) Run(ctx agent.InvocationContext, _ any) iter.Se
 		yield(final, nil)
 	}
 }
+
+// TestScheduler_RetryNode verifies that a node with RetryConfig
+// is retried on failure and eventually succeeds if the failure is transient.
+func TestScheduler_RetryNode(t *testing.T) {
+	mockCtx := newSeededMockCtx(t)
+
+	cfg := NodeConfig{
+		RetryConfig: &RetryConfig{
+			MaxAttempts:   3,
+			InitialDelay:  1 * time.Millisecond,
+			BackoffFactor: 1.0,
+			Jitter:        0.0,
+			ShouldRetry:   func(err error) bool { return true },
+		},
+	}
+
+	n := newRetryTestNode("retryNode", 2, cfg)
+	w := mustNew(t, []Edge{{From: Start, To: n}})
+
+	events := drain(t, w.Run(mockCtx))
+
+	if got := n.calls.Load(); got != 3 {
+		t.Errorf("node calls = %d, want 3", got)
+	}
+
+	if len(events) != 1 {
+		t.Fatalf("expected 1 event, got %d", len(events))
+	}
+
+	out := fmt.Sprint(events[0].Actions.StateDelta["output"])
+	if out != "seed:retryNode" {
+		t.Errorf("output = %q, want %q", out, "seed:retryNode")
+	}
+}
+
+// TestScheduler_RetryNodeExhausted verifies that a node with RetryConfig
+// eventually fails the workflow after MaxAttempts are exhausted.
+func TestScheduler_RetryNodeExhausted(t *testing.T) {
+	mockCtx := newSeededMockCtx(t)
+
+	cfg := NodeConfig{
+		RetryConfig: &RetryConfig{
+			MaxAttempts:   3,
+			InitialDelay:  1 * time.Millisecond,
+			BackoffFactor: 1.0,
+			Jitter:        0.0,
+			ShouldRetry:   func(err error) bool { return true },
+		},
+	}
+
+	n := newRetryTestNode("retryNode", 10, cfg)
+	w := mustNew(t, []Edge{{From: Start, To: n}})
+
+	gotErr := drainErr(t, w.Run(mockCtx))
+
+	if got := n.calls.Load(); got != 3 {
+		t.Errorf("node calls = %d, want 3", got)
+	}
+
+	if gotErr == nil {
+		t.Fatal("expected error, got nil")
+	}
+}
+
+// retryTestNode fails failCount times and then succeeds.
+type retryTestNode struct {
+	BaseNode
+	failCount int
+	calls     atomic.Int32
+	cfg       NodeConfig
+}
+
+func newRetryTestNode(name string, failCount int, cfg NodeConfig) *retryTestNode {
+	return &retryTestNode{
+		BaseNode:  NewBaseNode(name, "", cfg),
+		failCount: failCount,
+		cfg:       cfg,
+	}
+}
+
+func (n *retryTestNode) Config() NodeConfig { return n.cfg }
+
+func (n *retryTestNode) Run(ctx agent.InvocationContext, input any) iter.Seq2[*session.Event, error] {
+	return func(yield func(*session.Event, error) bool) {
+		calls := n.calls.Add(1)
+		if int(calls) <= n.failCount {
+			yield(nil, fmt.Errorf("fail attempt %d", calls))
+			return
+		}
+		ev := session.NewEvent(ctx.InvocationID())
+		out := fmt.Sprintf("%v:%s", input, n.Name())
+		ev.Actions.StateDelta["output"] = out
+		yield(ev, nil)
+	}
+}
+
+// TestScheduler_RetryInChain verifies that a node in a chain can retry
+// and successfully propagate data to downstream nodes.
+func TestScheduler_RetryInChain(t *testing.T) {
+	mockCtx := newSeededMockCtx(t)
+
+	a := newRecordingNode("A")
+	a.release()
+
+	cfg := NodeConfig{
+		RetryConfig: &RetryConfig{
+			MaxAttempts:   3,
+			InitialDelay:  1 * time.Millisecond,
+			BackoffFactor: 1.0,
+			Jitter:        0.0,
+			ShouldRetry:   func(err error) bool { return true },
+		},
+	}
+	b := newRetryTestNode("B", 2, cfg) // Fails twice
+
+	c := newRecordingNode("C")
+	c.release()
+
+	w := mustNew(t, Chain(Start, a, b, c))
+
+	gotEvents := drain(t, w.Run(mockCtx))
+
+	wantOutputs := []string{"seed:A", "seed:A:B", "seed:A:B:C"}
+	gotOutputs := outputsOf(gotEvents)
+	if diff := cmp.Diff(wantOutputs, gotOutputs); diff != "" {
+		t.Errorf("outputs mismatch (-want +got):\n%s", diff)
+	}
+
+	if got := b.calls.Load(); got != 3 {
+		t.Errorf("node B calls = %d, want 3", got)
+	}
+}
+
+// TestScheduler_RetryCancelled verifies that a node waiting for retry
+// does not run if the workflow is cancelled.
+func TestScheduler_RetryCancelled(t *testing.T) {
+	mockCtx := newSeededMockCtx(t)
+	ctx, cancel := context.WithCancel(mockCtx.Context)
+	mockCtx = mockCtx.WithContext(ctx).(*MockInvocationContext)
+
+	cfg := NodeConfig{
+		RetryConfig: &RetryConfig{
+			MaxAttempts:   3,
+			InitialDelay:  100 * time.Millisecond,
+			BackoffFactor: 1.0,
+			Jitter:        0.0,
+			ShouldRetry:   func(err error) bool { return true },
+		},
+	}
+
+	n := newRetryTestNode("retryNode", 2, cfg)
+	w := mustNew(t, []Edge{{From: Start, To: n}})
+
+	errCh := make(chan error, 1)
+	go func() {
+		var firstErr error
+		for _, err := range w.Run(mockCtx) {
+			if err != nil && firstErr == nil {
+				firstErr = err
+			}
+		}
+		errCh <- firstErr
+	}()
+
+	deadline := time.Now().Add(1 * time.Second)
+	for time.Now().Before(deadline) {
+		if n.calls.Load() == 1 {
+			break
+		}
+		time.Sleep(1 * time.Millisecond)
+	}
+
+	if n.calls.Load() != 1 {
+		t.Fatalf("node calls = %d, want 1 before cancellation", n.calls.Load())
+	}
+
+	cancel()
+
+	select {
+	case err := <-errCh:
+		if err != nil && !errors.Is(err, context.Canceled) {
+			t.Errorf("unexpected error: %v", err)
+		}
+	case <-time.After(500 * time.Millisecond):
+		t.Fatal("timeout waiting for workflow to finish")
+	}
+
+	if got := n.calls.Load(); got != 1 {
+		t.Errorf("node calls = %d, want 1 (retry should not have triggered)", got)
+	}
+}

--- a/workflow/state.go
+++ b/workflow/state.go
@@ -73,33 +73,40 @@ const (
 
 // NodeState is the per-node lifecycle record. A RunState holds one
 // of these for every node the engine has touched.
+//
+// JSON-marshallable: NodeState is persisted across pause/resume
+// turns via session.State (see persistence.go). The Input and
+// PendingRequest.Payload fields are typed any and must therefore
+// be JSON-encodable for the persisted state to round-trip. Nodes
+// that need to carry binary data across a pause should store the
+// bytes via agent.Artifacts and stash a URI string in place of
+// the bytes, mirroring how the Live API surfaces audio.
 type NodeState struct {
 	// Status is the current lifecycle position. See NodeStatus.
-	Status NodeStatus
+	Status NodeStatus `json:"status"`
 
 	// Input is the value most recently handed to the node's Run
 	// method. It is set when the node is scheduled.
-	Input any
+	Input any `json:"input,omitempty"`
 
 	// TriggeredBy is the name of the upstream node that produced
 	// the current Input. Empty for the initial START activation.
-	TriggeredBy string
+	TriggeredBy string `json:"triggeredBy,omitempty"`
 
 	// PendingRequest, when non-nil, carries the human-input request
 	// the node emitted before pausing. Non-nil iff Status ==
 	// NodeWaiting and the wait was caused by a human-input request
 	// (as opposed to a fan-in barrier).
-	PendingRequest *session.RequestInput
+	PendingRequest *session.RequestInput `json:"pendingRequest,omitempty"`
 }
 
 // RunState is the per-invocation lifecycle state for a workflow
-// run. It is intended to be embedded in (or referenced from) the
-// agent's session-persisted state so HITL pauses and crash
-// recovery can pick up where a previous invocation left off.
+// run. It rides in session.State across pause and resume turns so
+// the workflow can pick up where a previous invocation left off.
 type RunState struct {
 	// Nodes is the per-node lifecycle map. Absent entries are
 	// inactive.
-	Nodes map[string]*NodeState
+	Nodes map[string]*NodeState `json:"nodes,omitempty"`
 }
 
 // NewRunState returns an empty state with the Nodes map

--- a/workflow/state.go
+++ b/workflow/state.go
@@ -98,6 +98,19 @@ type NodeState struct {
 	// NodeWaiting and the wait was caused by a human-input request
 	// (as opposed to a fan-in barrier).
 	PendingRequest *session.RequestInput `json:"pendingRequest,omitempty"`
+
+	// ResumedInputs accumulates response payloads for re-entry-mode
+	// nodes that yield RequestInput more than once during a single
+	// activation lifecycle. Each Resume call adds the new response
+	// keyed by its InterruptID. The map is exposed to the node via
+	// ctx.ResumedInput on every re-entry activation, so the node
+	// can observe responses to all prior requests, not only the
+	// most recent one.
+	//
+	// Cleared when the node transitions to NodeCompleted; absent
+	// for handoff-mode nodes (where successors receive the response
+	// as input and the asker never re-runs).
+	ResumedInputs map[string]any `json:"resumedInputs,omitempty"`
 }
 
 // RunState is the per-invocation lifecycle state for a workflow

--- a/workflow/state.go
+++ b/workflow/state.go
@@ -1,0 +1,116 @@
+// Copyright 2026 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package workflow
+
+// NodeStatus is the lifecycle status of a node in the workflow graph.
+//
+// The status is the engine's single source of truth for what a node
+// is doing. It mediates between the trigger buffer (what wants to
+// run), the in-process task table (what is currently running), and
+// the persisted node history (what has run).
+type NodeStatus uint8
+
+const (
+	// NodeInactive means the node has not been touched yet. This is
+	// the zero value.
+	NodeInactive NodeStatus = iota
+
+	// NodePending means the node is ready to run. It may be queued
+	// because its input has arrived (consumed from the trigger
+	// buffer) or because it is being retried after a failure. The
+	// scheduler may keep a NodePending node from starting if the
+	// engine's max-concurrency cap is reached.
+	NodePending
+
+	// NodeRunning means the engine has started a task for this node.
+	// The task is in flight in the current process. A NodeRunning
+	// entry that has no live task in the run state (e.g. after a
+	// process restart) must be re-scheduled.
+	NodeRunning
+
+	// NodeCompleted means the node finished and produced its output.
+	// This is a terminal status for normal execution, but a node in
+	// NodeCompleted may still be re-triggered by a fresh entry in
+	// the trigger buffer (this is what enables loops as graph
+	// cycles).
+	NodeCompleted
+
+	// NodeWaiting means the node is paused. Two cases share this
+	// status:
+	//
+	//   1. Human-in-the-loop: the node yielded a RequestInput and
+	//      is blocked until a function-response payload resumes it.
+	//   2. Fan-in (WaitForOutput=true, e.g. JoinNode): the node ran
+	//      but did not yet produce its final output because not all
+	//      predecessors have triggered it.
+	//
+	// While any node is NodeWaiting the workflow does not finalize.
+	NodeWaiting
+
+	// NodeFailed means the node returned an error and the retry
+	// policy (if any) has been exhausted. Terminal.
+	NodeFailed
+
+	// NodeCancelled means the node was cancelled, typically because
+	// a sibling node failed and the engine cancelled all running
+	// tasks. Terminal.
+	NodeCancelled
+)
+
+// NodeState is the per-node lifecycle record. A RunState holds one
+// of these for every node the engine has touched.
+type NodeState struct {
+	// Status is the current lifecycle position. See NodeStatus.
+	Status NodeStatus
+
+	// Input is the value most recently handed to the node's Run
+	// method. It is set when the node is scheduled.
+	Input any
+
+	// TriggeredBy is the name of the upstream node that produced
+	// the current Input. Empty for the initial START activation.
+	TriggeredBy string
+}
+
+// RunState is the per-invocation lifecycle state for a workflow
+// run. It is intended to be embedded in (or referenced from) the
+// agent's session-persisted state so HITL pauses and crash
+// recovery can pick up where a previous invocation left off.
+type RunState struct {
+	// Nodes is the per-node lifecycle map. Absent entries are
+	// inactive.
+	Nodes map[string]*NodeState
+}
+
+// NewRunState returns an empty state with the Nodes map
+// initialised so callers can write to it without a nil check.
+func NewRunState() *RunState {
+	return &RunState{Nodes: map[string]*NodeState{}}
+}
+
+// EnsureNode returns the NodeState for the given node name,
+// creating an inactive entry if none exists. The returned pointer
+// is owned by the state and may be mutated in place.
+func (s *RunState) EnsureNode(name string) *NodeState {
+	if s.Nodes == nil {
+		s.Nodes = map[string]*NodeState{}
+	}
+	ns, ok := s.Nodes[name]
+	if !ok {
+		ns = &NodeState{Status: NodeInactive}
+		s.Nodes[name] = ns
+	}
+	return ns
+}

--- a/workflow/state.go
+++ b/workflow/state.go
@@ -14,6 +14,8 @@
 
 package workflow
 
+import "google.golang.org/adk/session"
+
 // NodeStatus is the lifecycle status of a node in the workflow graph.
 //
 // The status is the engine's single source of truth for what a node
@@ -82,6 +84,12 @@ type NodeState struct {
 	// TriggeredBy is the name of the upstream node that produced
 	// the current Input. Empty for the initial START activation.
 	TriggeredBy string
+
+	// PendingRequest, when non-nil, carries the human-input request
+	// the node emitted before pausing. Non-nil iff Status ==
+	// NodeWaiting and the wait was caused by a human-input request
+	// (as opposed to a fan-in barrier).
+	PendingRequest *session.RequestInput
 }
 
 // RunState is the per-invocation lifecycle state for a workflow

--- a/workflow/state.go
+++ b/workflow/state.go
@@ -98,6 +98,17 @@ type NodeState struct {
 	// the current Input. Empty for the initial START activation.
 	TriggeredBy string `json:"triggeredBy,omitempty"`
 
+	// Branch is the composite branch string assigned to this
+	// activation at scheduling time. Empty for nodes that inherit
+	// the root branch (single-successor chains); populated for
+	// nodes scheduled after a fan-out and for JoinNodes resolving
+	// the common branch prefix of their predecessors.
+	//
+	// Persisted so resume can reconstruct the same branch tree on
+	// re-entry, which is required for JoinNode's common-prefix
+	// derivation to remain stable across pause/resume turns.
+	Branch string `json:"branch,omitempty"`
+
 	// PendingRequest, when non-nil, carries the human-input request
 	// the node emitted before pausing. Non-nil iff Status ==
 	// NodeWaiting and the wait was caused by a human-input request

--- a/workflow/state.go
+++ b/workflow/state.go
@@ -99,6 +99,9 @@ type NodeState struct {
 	// (as opposed to a fan-in barrier).
 	PendingRequest *session.RequestInput `json:"pendingRequest,omitempty"`
 
+	// Attempt is the number of times this node has been failed.
+	Attempt int `json:"attempt,omitempty"`	
+
 	// ResumedInputs accumulates response payloads for re-entry-mode
 	// nodes that yield RequestInput more than once during a single
 	// activation lifecycle. Each Resume call adds the new response

--- a/workflow/state.go
+++ b/workflow/state.go
@@ -75,12 +75,12 @@ const (
 // of these for every node the engine has touched.
 //
 // JSON-marshallable: NodeState is persisted across pause/resume
-// turns via session.State (see persistence.go). The Input and
-// PendingRequest.Payload fields are typed any and must therefore
-// be JSON-encodable for the persisted state to round-trip. Nodes
-// that need to carry binary data across a pause should store the
-// bytes via agent.Artifacts and stash a URI string in place of
-// the bytes, mirroring how the Live API surfaces audio.
+// turns via session.State (see persistence.go). The Input, Output,
+// and PendingRequest.Payload fields are typed any and must
+// therefore be JSON-encodable for the persisted state to
+// round-trip. Nodes that need to carry binary data across a pause
+// should store the bytes via agent.Artifacts and stash a URI
+// string in place of the bytes.
 type NodeState struct {
 	// Status is the current lifecycle position. See NodeStatus.
 	Status NodeStatus `json:"status"`
@@ -88,6 +88,11 @@ type NodeState struct {
 	// Input is the value most recently handed to the node's Run
 	// method. It is set when the node is scheduled.
 	Input any `json:"input,omitempty"`
+
+	// Output is the value the node emitted via
+	// Actions.StateDelta["output"]. Set when Status transitions
+	// to NodeCompleted.
+	Output any `json:"output,omitempty"`
 
 	// TriggeredBy is the name of the upstream node that produced
 	// the current Input. Empty for the initial START activation.

--- a/workflow/state.go
+++ b/workflow/state.go
@@ -90,7 +90,7 @@ type NodeState struct {
 	Input any `json:"input,omitempty"`
 
 	// Output is the value the node emitted via
-	// Actions.StateDelta["output"]. Set when Status transitions
+	// Event.Output. Set when Status transitions
 	// to NodeCompleted.
 	Output any `json:"output,omitempty"`
 
@@ -105,7 +105,7 @@ type NodeState struct {
 	PendingRequest *session.RequestInput `json:"pendingRequest,omitempty"`
 
 	// Attempt is the number of times this node has been failed.
-	Attempt int `json:"attempt,omitempty"`	
+	Attempt int `json:"attempt,omitempty"`
 
 	// ResumedInputs accumulates response payloads for re-entry-mode
 	// nodes that yield RequestInput more than once during a single

--- a/workflow/state_test.go
+++ b/workflow/state_test.go
@@ -1,0 +1,56 @@
+// Copyright 2026 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package workflow
+
+import (
+	"testing"
+)
+
+func TestRunState_EnsureNode(t *testing.T) {
+	t.Run("creates inactive node when absent", func(t *testing.T) {
+		s := NewRunState()
+		ns := s.EnsureNode("A")
+		if ns.Status != NodeInactive {
+			t.Errorf("new node Status = %v, want NodeInactive", ns.Status)
+		}
+		if s.Nodes["A"] != ns {
+			t.Error("EnsureNode should return the same pointer stored in Nodes map")
+		}
+	})
+
+	t.Run("returns existing node without resetting it", func(t *testing.T) {
+		s := NewRunState()
+		first := s.EnsureNode("A")
+		first.Status = NodeRunning
+		first.Input = "in"
+		first.TriggeredBy = "X"
+
+		second := s.EnsureNode("A")
+		if first != second {
+			t.Error("EnsureNode should return the same pointer on repeat call")
+		}
+		if second.Status != NodeRunning || second.Input != "in" || second.TriggeredBy != "X" {
+			t.Errorf("EnsureNode should not reset existing node, got %+v", *second)
+		}
+	})
+
+	t.Run("allocates Nodes map on demand", func(t *testing.T) {
+		s := &RunState{} // Nodes nil
+		s.EnsureNode("A")
+		if s.Nodes == nil {
+			t.Error("EnsureNode should allocate Nodes map")
+		}
+	})
+}

--- a/workflow/tool_node.go
+++ b/workflow/tool_node.go
@@ -31,7 +31,7 @@ import (
 
 // toolNode wraps a tool from the tool package.
 type toolNode struct {
-	baseNode
+	BaseNode
 	tool         tool.Tool
 	inputSchema  *jsonschema.Resolved
 	outputSchema *jsonschema.Resolved
@@ -67,7 +67,7 @@ func newToolNodeWithSchemasTyped[Input, Output any](t tool.Tool, inputSchema, ou
 	}
 
 	return &toolNode{
-		baseNode:     baseNode{name: t.Name(), description: t.Description(), config: cfg},
+		BaseNode:     NewBaseNode(t.Name(), t.Description(), cfg),
 		tool:         t,
 		inputSchema:  ischema,
 		outputSchema: oschema,

--- a/workflow/tool_node.go
+++ b/workflow/tool_node.go
@@ -1,0 +1,161 @@
+// Copyright 2026 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package workflow
+
+import (
+	"fmt"
+	"iter"
+
+	"github.com/google/jsonschema-go/jsonschema"
+	"github.com/google/uuid"
+	"google.golang.org/genai"
+
+	"google.golang.org/adk/agent"
+	"google.golang.org/adk/internal/toolinternal"
+	"google.golang.org/adk/internal/typeutil"
+	"google.golang.org/adk/session"
+	"google.golang.org/adk/tool"
+)
+
+// toolNode wraps a tool from the tool package.
+type toolNode struct {
+	baseNode
+	tool         tool.Tool
+	inputSchema  *jsonschema.Resolved
+	outputSchema *jsonschema.Resolved
+}
+
+type runnableTool interface {
+	Run(ctx tool.Context, args any) (map[string]any, error)
+}
+
+// newToolNodeWithSchemasTyped creates a new node wrapping a tool with explicitly provided schemas.
+// If a schema is nil, it will be inferred from the corresponding generic type Input or Output.
+func newToolNodeWithSchemasTyped[Input, Output any](t tool.Tool, inputSchema, outputSchema *jsonschema.Schema) (Node, error) {
+	if t == nil {
+		return nil, fmt.Errorf("tool cannot be nil")
+	}
+	ischema, err := resolvedSchema[Input](inputSchema)
+	if err != nil {
+		return nil, fmt.Errorf("resolving input schema for tool %q: %w", t.Name(), err)
+	}
+	if ischema == nil {
+		return nil, fmt.Errorf("resolved input schema for tool %q is nil", t.Name())
+	}
+	oschema, err := resolvedSchema[Output](outputSchema)
+	if err != nil {
+		return nil, fmt.Errorf("resolving output schema for tool %q: %w", t.Name(), err)
+	}
+	if oschema == nil {
+		return nil, fmt.Errorf("resolved output schema for tool %q is nil", t.Name())
+	}
+
+	if _, ok := t.(runnableTool); !ok {
+		return nil, fmt.Errorf("tool %q (type %T) is not directly runnable in workflow node", t.Name(), t)
+	}
+
+	return &toolNode{
+		baseNode:     baseNode{name: t.Name(), description: t.Description()},
+		tool:         t,
+		inputSchema:  ischema,
+		outputSchema: oschema,
+	}, nil
+}
+
+// NewToolNodeWithSchemas is a convenience wrapper for NewToolNodeWithSchemasTyped[any, any].
+// It uses explicitly provided schemas for both input and output.
+func NewToolNodeWithSchemas(t tool.Tool, inputSchema, outputSchema *jsonschema.Schema) (Node, error) {
+	return newToolNodeWithSchemasTyped[any, any](t, inputSchema, outputSchema)
+}
+
+// NewToolNodeTyped creates a new node wrapping a tool using generics to
+// automatically infer input and output schemas from the provided types.
+func NewToolNodeTyped[Input, Output any](t tool.Tool) (Node, error) {
+	return newToolNodeWithSchemasTyped[Input, Output](t, nil, nil)
+}
+
+// NewToolNode creates a new node wrapping a tool. Input and output schemas
+// are inferred as 'any'.
+func NewToolNode(t tool.Tool) (Node, error) {
+	return NewToolNodeTyped[any, any](t)
+}
+
+func (n *toolNode) runTool(toolCtx tool.Context, input any) (any, error) {
+	runnable := n.tool.(runnableTool)
+	toolInput, err := typeutil.ConvertToWithJSONSchema[any, any](input, n.inputSchema)
+	if err != nil {
+		return nil, fmt.Errorf("converting input for tool %q: %w", n.tool.Name(), err)
+	}
+
+	output, err := runnable.Run(toolCtx, toolInput)
+	if err != nil {
+		return nil, fmt.Errorf("tool %q execution failed: %w", n.tool.Name(), err)
+	}
+
+	var toolOutput any = output
+
+	// Validate
+	if err := n.outputSchema.Validate(output); err != nil {
+		if val, ok := output["result"]; ok {
+			if err := n.outputSchema.Validate(val); err != nil {
+				return nil, fmt.Errorf("converting tool %q output: validation failed for result key: %w", n.tool.Name(), err)
+			}
+			toolOutput = val
+		} else {
+			return nil, fmt.Errorf("converting tool %q output: validation failed: %w", n.tool.Name(), err)
+		}
+	}
+
+	return toolOutput, nil
+}
+
+// Run implements the Node interface and executes the tool.
+func (n *toolNode) Run(ctx agent.InvocationContext, input any) iter.Seq2[*session.Event, error] {
+	return func(yield func(*session.Event, error) bool) {
+		eventActions := &session.EventActions{StateDelta: make(map[string]any), ArtifactDelta: make(map[string]int64)}
+		toolCtx := toolinternal.NewToolContext(ctx, uuid.NewString(), eventActions, nil)
+
+		toolOutput, err := n.runTool(toolCtx, input)
+		if err != nil {
+			yield(nil, err)
+			return
+		}
+
+		event := session.NewEvent(ctx.InvocationID())
+		event.Actions = *eventActions
+		event.Actions.StateDelta["output"] = toolOutput
+
+		// If output is a string, set it as content for convenience (similar to FunctionNode).
+		if s, ok := toolOutput.(string); ok {
+			event.Content = &genai.Content{
+				Parts: []*genai.Part{{Text: s}},
+			}
+		}
+
+		yield(event, nil)
+	}
+}
+
+// resolvedSchema is a helper to infer schema from type T.
+func resolvedSchema[T any](override *jsonschema.Schema) (*jsonschema.Resolved, error) {
+	if override != nil {
+		return override.Resolve(nil)
+	}
+	schema, err := jsonschema.For[T](nil)
+	if err != nil {
+		return nil, err
+	}
+	return schema.Resolve(nil)
+}

--- a/workflow/tool_node.go
+++ b/workflow/tool_node.go
@@ -43,7 +43,7 @@ type runnableTool interface {
 
 // newToolNodeWithSchemasTyped creates a new node wrapping a tool with explicitly provided schemas.
 // If a schema is nil, it will be inferred from the corresponding generic type Input or Output.
-func newToolNodeWithSchemasTyped[Input, Output any](t tool.Tool, inputSchema, outputSchema *jsonschema.Schema) (Node, error) {
+func newToolNodeWithSchemasTyped[Input, Output any](t tool.Tool, inputSchema, outputSchema *jsonschema.Schema, cfg NodeConfig) (Node, error) {
 	if t == nil {
 		return nil, fmt.Errorf("tool cannot be nil")
 	}
@@ -67,7 +67,7 @@ func newToolNodeWithSchemasTyped[Input, Output any](t tool.Tool, inputSchema, ou
 	}
 
 	return &toolNode{
-		baseNode:     baseNode{name: t.Name(), description: t.Description()},
+		baseNode:     baseNode{name: t.Name(), description: t.Description(), config: cfg},
 		tool:         t,
 		inputSchema:  ischema,
 		outputSchema: oschema,
@@ -76,20 +76,20 @@ func newToolNodeWithSchemasTyped[Input, Output any](t tool.Tool, inputSchema, ou
 
 // NewToolNodeWithSchemas is a convenience wrapper for NewToolNodeWithSchemasTyped[any, any].
 // It uses explicitly provided schemas for both input and output.
-func NewToolNodeWithSchemas(t tool.Tool, inputSchema, outputSchema *jsonschema.Schema) (Node, error) {
-	return newToolNodeWithSchemasTyped[any, any](t, inputSchema, outputSchema)
+func NewToolNodeWithSchemas(t tool.Tool, inputSchema, outputSchema *jsonschema.Schema, cfg NodeConfig) (Node, error) {
+	return newToolNodeWithSchemasTyped[any, any](t, inputSchema, outputSchema, cfg)
 }
 
 // NewToolNodeTyped creates a new node wrapping a tool using generics to
 // automatically infer input and output schemas from the provided types.
-func NewToolNodeTyped[Input, Output any](t tool.Tool) (Node, error) {
-	return newToolNodeWithSchemasTyped[Input, Output](t, nil, nil)
+func NewToolNodeTyped[Input, Output any](t tool.Tool, cfg NodeConfig) (Node, error) {
+	return newToolNodeWithSchemasTyped[Input, Output](t, nil, nil, cfg)
 }
 
 // NewToolNode creates a new node wrapping a tool. Input and output schemas
 // are inferred as 'any'.
-func NewToolNode(t tool.Tool) (Node, error) {
-	return NewToolNodeTyped[any, any](t)
+func NewToolNode(t tool.Tool, cfg NodeConfig) (Node, error) {
+	return NewToolNodeTyped[any, any](t, cfg)
 }
 
 func (n *toolNode) runTool(toolCtx tool.Context, input any) (any, error) {

--- a/workflow/tool_node.go
+++ b/workflow/tool_node.go
@@ -24,7 +24,6 @@ import (
 
 	"google.golang.org/adk/agent"
 	"google.golang.org/adk/internal/toolinternal"
-	"google.golang.org/adk/internal/typeutil"
 	"google.golang.org/adk/session"
 	"google.golang.org/adk/tool"
 )
@@ -33,8 +32,6 @@ import (
 type ToolNode struct {
 	BaseNode
 	tool         tool.Tool
-	inputSchema  *jsonschema.Resolved
-	outputSchema *jsonschema.Resolved
 }
 
 type runnableTool interface {
@@ -67,10 +64,8 @@ func newToolNodeWithSchemasTyped[Input, Output any](t tool.Tool, inputSchema, ou
 	}
 
 	return &ToolNode{
-		BaseNode:     NewBaseNode(t.Name(), t.Description(), cfg),
+		BaseNode:     NewBaseNodeWithSchemas(t.Name(), t.Description(), cfg, ischema, oschema),
 		tool:         t,
-		inputSchema:  ischema,
-		outputSchema: oschema,
 	}, nil
 }
 
@@ -94,7 +89,7 @@ func NewToolNode(t tool.Tool, cfg NodeConfig) (*ToolNode, error) {
 
 func (n *ToolNode) runTool(toolCtx tool.Context, input any) (any, error) {
 	runnable := n.tool.(runnableTool)
-	toolInput, err := typeutil.ConvertToWithJSONSchema[any, any](input, n.inputSchema)
+	toolInput, err := n.ValidateInput(input)
 	if err != nil {
 		return nil, fmt.Errorf("converting input for tool %q: %w", n.tool.Name(), err)
 	}
@@ -107,14 +102,16 @@ func (n *ToolNode) runTool(toolCtx tool.Context, input any) (any, error) {
 	var toolOutput any = output
 
 	// Validate
-	if err := n.outputSchema.Validate(output); err != nil {
-		if val, ok := output["result"]; ok {
-			if err := n.outputSchema.Validate(val); err != nil {
-				return nil, fmt.Errorf("converting tool %q output: validation failed for result key: %w", n.tool.Name(), err)
+	if schema := n.OutputSchema(); schema != nil {
+		if err := schema.Validate(output); err != nil {
+			if val, ok := output["result"]; ok {
+				if err := schema.Validate(val); err != nil {
+					return nil, fmt.Errorf("converting tool %q output: validation failed for result key: %w", n.tool.Name(), err)
+				}
+				toolOutput = val
+			} else {
+				return nil, fmt.Errorf("converting tool %q output: validation failed: %w", n.tool.Name(), err)
 			}
-			toolOutput = val
-		} else {
-			return nil, fmt.Errorf("converting tool %q output: validation failed: %w", n.tool.Name(), err)
 		}
 	}
 

--- a/workflow/tool_node.go
+++ b/workflow/tool_node.go
@@ -135,6 +135,7 @@ func (n *toolNode) Run(ctx agent.InvocationContext, input any) iter.Seq2[*sessio
 
 		event := session.NewEvent(ctx.InvocationID())
 		event.Actions = *eventActions
+		event.Output = toolOutput
 		event.Actions.StateDelta["output"] = toolOutput
 
 		// If output is a string, set it as content for convenience (similar to FunctionNode).

--- a/workflow/tool_node.go
+++ b/workflow/tool_node.go
@@ -136,7 +136,6 @@ func (n *toolNode) Run(ctx agent.InvocationContext, input any) iter.Seq2[*sessio
 		event := session.NewEvent(ctx.InvocationID())
 		event.Actions = *eventActions
 		event.Output = toolOutput
-		event.Actions.StateDelta["output"] = toolOutput
 
 		// If output is a string, set it as content for convenience (similar to FunctionNode).
 		if s, ok := toolOutput.(string); ok {

--- a/workflow/tool_node.go
+++ b/workflow/tool_node.go
@@ -29,8 +29,8 @@ import (
 	"google.golang.org/adk/tool"
 )
 
-// toolNode wraps a tool from the tool package.
-type toolNode struct {
+// ToolNode wraps a tool from the tool package.
+type ToolNode struct {
 	BaseNode
 	tool         tool.Tool
 	inputSchema  *jsonschema.Resolved
@@ -43,7 +43,7 @@ type runnableTool interface {
 
 // newToolNodeWithSchemasTyped creates a new node wrapping a tool with explicitly provided schemas.
 // If a schema is nil, it will be inferred from the corresponding generic type Input or Output.
-func newToolNodeWithSchemasTyped[Input, Output any](t tool.Tool, inputSchema, outputSchema *jsonschema.Schema, cfg NodeConfig) (Node, error) {
+func newToolNodeWithSchemasTyped[Input, Output any](t tool.Tool, inputSchema, outputSchema *jsonschema.Schema, cfg NodeConfig) (*ToolNode, error) {
 	if t == nil {
 		return nil, fmt.Errorf("tool cannot be nil")
 	}
@@ -66,7 +66,7 @@ func newToolNodeWithSchemasTyped[Input, Output any](t tool.Tool, inputSchema, ou
 		return nil, fmt.Errorf("tool %q (type %T) is not directly runnable in workflow node", t.Name(), t)
 	}
 
-	return &toolNode{
+	return &ToolNode{
 		BaseNode:     NewBaseNode(t.Name(), t.Description(), cfg),
 		tool:         t,
 		inputSchema:  ischema,
@@ -76,23 +76,23 @@ func newToolNodeWithSchemasTyped[Input, Output any](t tool.Tool, inputSchema, ou
 
 // NewToolNodeWithSchemas is a convenience wrapper for NewToolNodeWithSchemasTyped[any, any].
 // It uses explicitly provided schemas for both input and output.
-func NewToolNodeWithSchemas(t tool.Tool, inputSchema, outputSchema *jsonschema.Schema, cfg NodeConfig) (Node, error) {
+func NewToolNodeWithSchemas(t tool.Tool, inputSchema, outputSchema *jsonschema.Schema, cfg NodeConfig) (*ToolNode, error) {
 	return newToolNodeWithSchemasTyped[any, any](t, inputSchema, outputSchema, cfg)
 }
 
 // NewToolNodeTyped creates a new node wrapping a tool using generics to
 // automatically infer input and output schemas from the provided types.
-func NewToolNodeTyped[Input, Output any](t tool.Tool, cfg NodeConfig) (Node, error) {
+func NewToolNodeTyped[Input, Output any](t tool.Tool, cfg NodeConfig) (*ToolNode, error) {
 	return newToolNodeWithSchemasTyped[Input, Output](t, nil, nil, cfg)
 }
 
 // NewToolNode creates a new node wrapping a tool. Input and output schemas
 // are inferred as 'any'.
-func NewToolNode(t tool.Tool, cfg NodeConfig) (Node, error) {
+func NewToolNode(t tool.Tool, cfg NodeConfig) (*ToolNode, error) {
 	return NewToolNodeTyped[any, any](t, cfg)
 }
 
-func (n *toolNode) runTool(toolCtx tool.Context, input any) (any, error) {
+func (n *ToolNode) runTool(toolCtx tool.Context, input any) (any, error) {
 	runnable := n.tool.(runnableTool)
 	toolInput, err := typeutil.ConvertToWithJSONSchema[any, any](input, n.inputSchema)
 	if err != nil {
@@ -122,7 +122,7 @@ func (n *toolNode) runTool(toolCtx tool.Context, input any) (any, error) {
 }
 
 // Run implements the Node interface and executes the tool.
-func (n *toolNode) Run(ctx agent.InvocationContext, input any) iter.Seq2[*session.Event, error] {
+func (n *ToolNode) Run(ctx agent.InvocationContext, input any) iter.Seq2[*session.Event, error] {
 	return func(yield func(*session.Event, error) bool) {
 		eventActions := &session.EventActions{StateDelta: make(map[string]any), ArtifactDelta: make(map[string]int64)}
 		toolCtx := toolinternal.NewToolContext(ctx, uuid.NewString(), eventActions, nil)

--- a/workflow/tool_node_test.go
+++ b/workflow/tool_node_test.go
@@ -63,19 +63,19 @@ func TestToolNode_New(t *testing.T) {
 		{
 			name: "NewToolNodeTyped",
 			creator: func() (Node, error) {
-				return NewToolNodeTyped[Input, Output](myTool)
+				return NewToolNodeTyped[Input, Output](myTool, defaultNodeConfig)
 			},
 		},
 		{
 			name: "NewToolNodeWithSchemas",
 			creator: func() (Node, error) {
-				return NewToolNodeWithSchemas(myTool, ischema, oschema)
+				return NewToolNodeWithSchemas(myTool, ischema, oschema, defaultNodeConfig)
 			},
 		},
 		{
 			name: "NewToolNode",
 			creator: func() (Node, error) {
-				return NewToolNode(myTool)
+				return NewToolNode(myTool, defaultNodeConfig)
 			},
 		},
 	}
@@ -142,7 +142,7 @@ func TestToolNode_Run(t *testing.T) {
 			},
 			nodeInput: Input{Name: "World"},
 			node: func(t tool.Tool) (Node, error) {
-				return NewToolNodeTyped[Input, Output](t)
+				return NewToolNodeTyped[Input, Output](t, defaultNodeConfig)
 			},
 			extract: func(t *testing.T, out any) string {
 				bytes, err := json.Marshal(out)
@@ -168,7 +168,7 @@ func TestToolNode_Run(t *testing.T) {
 			},
 			nodeInput: Input{Name: "world"},
 			node: func(t tool.Tool) (Node, error) {
-				return NewToolNodeTyped[Input, string](t)
+				return NewToolNodeTyped[Input, string](t, defaultNodeConfig)
 			},
 			extract: func(t *testing.T, out any) string {
 				return out.(string)
@@ -186,7 +186,7 @@ func TestToolNode_Run(t *testing.T) {
 			},
 			nodeInput: map[string]any{},
 			node: func(t tool.Tool) (Node, error) {
-				return NewToolNodeTyped[map[string]any, ErrorOutput](t)
+				return NewToolNodeTyped[map[string]any, ErrorOutput](t, defaultNodeConfig)
 			},
 			wantErr: "converting tool \"test_tool\" output",
 		},
@@ -201,7 +201,7 @@ func TestToolNode_Run(t *testing.T) {
 			},
 			nodeInput: Input{Name: "World"},
 			node: func(t tool.Tool) (Node, error) {
-				return NewToolNodeTyped[Input, Output](t)
+				return NewToolNodeTyped[Input, Output](t, defaultNodeConfig)
 			},
 			wantErr: "tool \"fail_tool\" execution failed: something went wrong",
 		},
@@ -299,7 +299,7 @@ func TestToolNode_WorkflowIntegration(t *testing.T) {
 				t.Fatalf("failed to create tool: %v", err)
 			}
 
-			toolNode, err := NewToolNodeTyped[*Input, *Output](doubleTool)
+			toolNode, err := NewToolNodeTyped[*Input, *Output](doubleTool, defaultNodeConfig)
 			if err != nil {
 				t.Fatalf("NewToolNodeTyped failed: %v", err)
 			}
@@ -307,7 +307,7 @@ func TestToolNode_WorkflowIntegration(t *testing.T) {
 			// Connect to a function node.
 			functionNode := NewFunctionNode[Output, int]("plus_one", func(ctx agent.InvocationContext, in Output) (int, error) {
 				return in.Result + 1, nil
-			})
+			}, defaultNodeConfig)
 
 			mockCtx := &MockInvocationContext{sess: nil}
 
@@ -316,7 +316,7 @@ func TestToolNode_WorkflowIntegration(t *testing.T) {
 				// since Workflow.Run currently only passes strings from UserContent.
 				seedNode := NewFunctionNode("seed", func(ctx agent.InvocationContext, input any) (*Input, error) {
 					return &Input{Val: tc.input}, nil
-				})
+				}, defaultNodeConfig)
 
 				edges := Chain(Start, seedNode, toolNode, functionNode)
 				w := New(edges)

--- a/workflow/tool_node_test.go
+++ b/workflow/tool_node_test.go
@@ -319,8 +319,10 @@ func TestToolNode_WorkflowIntegration(t *testing.T) {
 				}, defaultNodeConfig)
 
 				edges := Chain(Start, seedNode, toolNode, functionNode)
-				w := New(edges)
-
+				w, err := New(edges)
+				if err != nil {
+					t.Fatalf("unexpexted error: %v", err)
+				}
 				events := w.Run(mockCtx)
 
 				var outB any

--- a/workflow/tool_node_test.go
+++ b/workflow/tool_node_test.go
@@ -219,7 +219,7 @@ func TestToolNode_Run(t *testing.T) {
 				t.Fatalf("node creation failed: %v", err)
 			}
 
-			mockCtx := &MockInvocationContext{sess: nil}
+			mockCtx := newMockCtx(t)
 			events := node.Run(mockCtx, tc.nodeInput)
 
 			var got string
@@ -309,7 +309,7 @@ func TestToolNode_WorkflowIntegration(t *testing.T) {
 				return in.Result + 1, nil
 			}, defaultNodeConfig)
 
-			mockCtx := &MockInvocationContext{sess: nil}
+			mockCtx := newMockCtx(t)
 
 			t.Run("WorkflowExecution", func(t *testing.T) {
 				// Use a seed node to pass the struct input to toolNode,
@@ -319,10 +319,7 @@ func TestToolNode_WorkflowIntegration(t *testing.T) {
 				}, defaultNodeConfig)
 
 				edges := Chain(Start, seedNode, toolNode, functionNode)
-				w, err := New(edges)
-				if err != nil {
-					t.Fatalf("unexpexted error: %v", err)
-				}
+				w := mustNew(t, edges)
 				events := w.Run(mockCtx)
 
 				var outB any

--- a/workflow/tool_node_test.go
+++ b/workflow/tool_node_test.go
@@ -1,0 +1,344 @@
+// Copyright 2026 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package workflow
+
+import (
+	"encoding/json"
+	"errors"
+	"strings"
+	"testing"
+
+	"github.com/google/go-cmp/cmp"
+	"github.com/google/jsonschema-go/jsonschema"
+
+	"google.golang.org/adk/agent"
+	"google.golang.org/adk/tool"
+	"google.golang.org/adk/tool/functiontool"
+)
+
+func TestToolNode_New(t *testing.T) {
+	type Input struct {
+		Value string `json:"value"`
+	}
+	type Output struct {
+		Result string `json:"result"`
+	}
+
+	myTool, err := functiontool.New(functiontool.Config{
+		Name:        "test_tool",
+		Description: "a test tool",
+	}, func(ctx tool.Context, in Input) (Output, error) {
+		return Output{Result: strings.ToUpper(in.Value)}, nil
+	})
+	if err != nil {
+		t.Fatalf("failed to create tool: %v", err)
+	}
+
+	ischema, err := jsonschema.For[Input](nil)
+	if err != nil {
+		t.Fatalf("jsonschema.For[Input] failed: %v", err)
+	}
+	oschema, err := jsonschema.For[Output](nil)
+	if err != nil {
+		t.Fatalf("jsonschema.For[Output] failed: %v", err)
+	}
+
+	tests := []struct {
+		name    string
+		creator func() (Node, error)
+		want    string
+	}{
+		{
+			name: "NewToolNodeTyped",
+			creator: func() (Node, error) {
+				return NewToolNodeTyped[Input, Output](myTool)
+			},
+		},
+		{
+			name: "NewToolNodeWithSchemas",
+			creator: func() (Node, error) {
+				return NewToolNodeWithSchemas(myTool, ischema, oschema)
+			},
+		},
+		{
+			name: "NewToolNode",
+			creator: func() (Node, error) {
+				return NewToolNode(myTool)
+			},
+		},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			node, err := tc.creator()
+			if err != nil {
+				t.Fatalf("creation failed: %v", err)
+			}
+
+			if got, want := node.Name(), "test_tool"; got != want {
+				t.Errorf("node.Name() = %q, want %q", got, want)
+			}
+			if got, want := node.Description(), "a test tool"; got != want {
+				t.Errorf("node.Description() = %q, want %q", got, want)
+			}
+
+			// Basic internal check via reflection-like cast.
+			// We use any, any for constructors that don't preserve types in the struct.
+			var inputResolved, outputResolved *jsonschema.Resolved
+			switch tn := node.(type) {
+			case *toolNode:
+				inputResolved, outputResolved = tn.inputSchema, tn.outputSchema
+			default:
+				t.Errorf("unknown node type: %T", tn)
+			}
+
+			if inputResolved == nil || outputResolved == nil {
+				t.Error("expected schemas to be resolved")
+			}
+		})
+	}
+}
+
+func TestToolNode_Run(t *testing.T) {
+	type Input struct {
+		Name string `json:"name"`
+	}
+	type Output struct {
+		Greeting string `json:"greeting"`
+	}
+	type ErrorOutput struct {
+		Result int `json:"result"`
+	}
+
+	tests := []struct {
+		name      string
+		tool      func() (tool.Tool, error)
+		nodeInput any
+		node      func(tool.Tool) (Node, error)
+		extract   func(t *testing.T, out any) string
+		want      string
+		wantErr   string
+	}{
+		{
+			name: "struct_input_output",
+			tool: func() (tool.Tool, error) {
+				return functiontool.New(functiontool.Config{
+					Name: "greet",
+				}, func(ctx tool.Context, in Input) (Output, error) {
+					return Output{Greeting: "Hello " + in.Name}, nil
+				})
+			},
+			nodeInput: Input{Name: "World"},
+			node: func(t tool.Tool) (Node, error) {
+				return NewToolNodeTyped[Input, Output](t)
+			},
+			extract: func(t *testing.T, out any) string {
+				bytes, err := json.Marshal(out)
+				if err != nil {
+					t.Fatalf("json marshal output: %v", err)
+				}
+				var output Output
+				if err := json.Unmarshal(bytes, &output); err != nil {
+					t.Fatalf("json unmarsal output: %v", err)
+				}
+				return output.Greeting
+			},
+			want: "Hello World",
+		},
+		{
+			name: "string_output",
+			tool: func() (tool.Tool, error) {
+				return functiontool.New(functiontool.Config{
+					Name: "greet",
+				}, func(ctx tool.Context, in Input) (string, error) {
+					return "HELLO " + strings.ToUpper(in.Name), nil
+				})
+			},
+			nodeInput: Input{Name: "world"},
+			node: func(t tool.Tool) (Node, error) {
+				return NewToolNodeTyped[Input, string](t)
+			},
+			extract: func(t *testing.T, out any) string {
+				return out.(string)
+			},
+			want: "HELLO WORLD",
+		},
+		{
+			name: "schema_validation_error",
+			tool: func() (tool.Tool, error) {
+				return functiontool.New(functiontool.Config{
+					Name: "test_tool",
+				}, func(ctx tool.Context, in map[string]any) (map[string]any, error) {
+					return map[string]any{"result": "not-an-int"}, nil
+				})
+			},
+			nodeInput: map[string]any{},
+			node: func(t tool.Tool) (Node, error) {
+				return NewToolNodeTyped[map[string]any, ErrorOutput](t)
+			},
+			wantErr: "converting tool \"test_tool\" output",
+		},
+		{
+			name: "tool_execution_error",
+			tool: func() (tool.Tool, error) {
+				return functiontool.New(functiontool.Config{
+					Name: "fail_tool",
+				}, func(ctx tool.Context, in Input) (*Output, error) {
+					return nil, errors.New("something went wrong")
+				})
+			},
+			nodeInput: Input{Name: "World"},
+			node: func(t tool.Tool) (Node, error) {
+				return NewToolNodeTyped[Input, Output](t)
+			},
+			wantErr: "tool \"fail_tool\" execution failed: something went wrong",
+		},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			myTool, err := tc.tool()
+			if err != nil {
+				t.Fatalf("failed to create tool: %v", err)
+			}
+
+			node, err := tc.node(myTool)
+			if err != nil {
+				t.Fatalf("node creation failed: %v", err)
+			}
+
+			mockCtx := &MockInvocationContext{sess: nil}
+			events := node.Run(mockCtx, tc.nodeInput)
+
+			var got string
+			count := 0
+			for ev, err := range events {
+				if tc.wantErr != "" {
+					if err == nil {
+						t.Fatal("expected error, got nil")
+					}
+					if !strings.Contains(err.Error(), tc.wantErr) {
+						t.Errorf("expected error containing %q, got: %v", tc.wantErr, err)
+					}
+					return
+				}
+
+				if err != nil {
+					t.Fatalf("unexpected error: %v", err)
+				}
+				count++
+
+				output, ok := ev.Actions.StateDelta["output"]
+				if !ok {
+					t.Fatal("expected output in state delta")
+				}
+
+				got = tc.extract(t, output)
+			}
+
+			if tc.wantErr != "" {
+				t.Error("expected at least one event/error from Run")
+				return
+			}
+
+			if count != 1 {
+				t.Errorf("expected 1 event, got %d", count)
+			}
+			if diff := cmp.Diff(tc.want, got); diff != "" {
+				t.Errorf("output mismatch (-want +got):\n%s", diff)
+			}
+		})
+	}
+}
+
+func TestToolNode_WorkflowIntegration(t *testing.T) {
+	type Input struct {
+		Val int `json:"val"`
+	}
+	type Output struct {
+		Result int `json:"result"`
+	}
+
+	tests := []struct {
+		name  string
+		input int
+		want  int
+	}{
+		{
+			name:  "chain_tool_and_function",
+			input: 5,
+			want:  11,
+		},
+		{
+			name:  "chain_tool_and_function_zero",
+			input: 0,
+			want:  1,
+		},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			doubleTool, err := functiontool.New(functiontool.Config{
+				Name: "double",
+			}, func(ctx tool.Context, in *Input) (Output, error) {
+				return Output{Result: in.Val * 2}, nil
+			})
+			if err != nil {
+				t.Fatalf("failed to create tool: %v", err)
+			}
+
+			toolNode, err := NewToolNodeTyped[*Input, *Output](doubleTool)
+			if err != nil {
+				t.Fatalf("NewToolNodeTyped failed: %v", err)
+			}
+
+			// Connect to a function node.
+			functionNode := NewFunctionNode[Output, int]("plus_one", func(ctx agent.InvocationContext, in Output) (int, error) {
+				return in.Result + 1, nil
+			})
+
+			mockCtx := &MockInvocationContext{sess: nil}
+
+			t.Run("WorkflowExecution", func(t *testing.T) {
+				// Use a seed node to pass the struct input to toolNode,
+				// since Workflow.Run currently only passes strings from UserContent.
+				seedNode := NewFunctionNode("seed", func(ctx agent.InvocationContext, input any) (*Input, error) {
+					return &Input{Val: tc.input}, nil
+				})
+
+				edges := Chain(Start, seedNode, toolNode, functionNode)
+				w := New(edges)
+
+				events := w.Run(mockCtx)
+
+				var outB any
+				for ev, err := range events {
+					if err != nil {
+						t.Fatalf("workflow failed: %v", err)
+					}
+					if ev.Actions.StateDelta != nil {
+						if out, ok := ev.Actions.StateDelta["output"]; ok {
+							outB = out
+						}
+					}
+				}
+
+				if diff := cmp.Diff(tc.want, outB); diff != "" {
+					t.Errorf("output mismatch (-want +got):\n%s", diff)
+				}
+			})
+		})
+	}
+}

--- a/workflow/tool_node_test.go
+++ b/workflow/tool_node_test.go
@@ -197,6 +197,27 @@ func TestToolNode_Run(t *testing.T) {
 			},
 			wantErr: "tool \"fail_tool\" execution failed: something went wrong",
 		},
+		{
+			name: "nil_output_schema_no_panic",
+			tool: func() (tool.Tool, error) {
+				return functiontool.New(functiontool.Config{
+					Name: "greet",
+				}, func(ctx tool.Context, in Input) (Output, error) {
+					return Output{Greeting: "Hello " + in.Name}, nil
+				})
+			},
+			nodeInput: map[string]any{"name": "World"},
+			node: func(t tool.Tool) (Node, error) {
+				return &ToolNode{
+					BaseNode: NewBaseNode(t.Name(), t.Description(), defaultNodeConfig),
+					tool:     t,
+				}, nil
+			},
+			extract: func(t *testing.T, out any) string {
+				return out.(map[string]any)["greeting"].(string)
+			},
+			want: "Hello World",
+		},
 	}
 
 	for _, tc := range tests {

--- a/workflow/tool_node_test.go
+++ b/workflow/tool_node_test.go
@@ -240,16 +240,7 @@ func TestToolNode_Run(t *testing.T) {
 				}
 				count++
 
-				output, ok := ev.Actions.StateDelta["output"]
-				if !ok {
-					t.Fatal("expected output in state delta")
-				}
-
-				if diff := cmp.Diff(output, ev.Output); diff != "" {
-					t.Errorf("ev.Output mismatch (-stateDelta +Output):\n%s", diff)
-				}
-
-				got = tc.extract(t, output)
+				got = tc.extract(t, ev.Output)
 			}
 
 			if tc.wantErr != "" {
@@ -331,10 +322,8 @@ func TestToolNode_WorkflowIntegration(t *testing.T) {
 					if err != nil {
 						t.Fatalf("workflow failed: %v", err)
 					}
-					if ev.Actions.StateDelta != nil {
-						if out, ok := ev.Actions.StateDelta["output"]; ok {
-							outB = out
-						}
+					if ev.Output != nil {
+						outB = ev.Output
 					}
 				}
 

--- a/workflow/tool_node_test.go
+++ b/workflow/tool_node_test.go
@@ -245,6 +245,10 @@ func TestToolNode_Run(t *testing.T) {
 					t.Fatal("expected output in state delta")
 				}
 
+				if diff := cmp.Diff(output, ev.Output); diff != "" {
+					t.Errorf("ev.Output mismatch (-stateDelta +Output):\n%s", diff)
+				}
+
 				got = tc.extract(t, output)
 			}
 

--- a/workflow/tool_node_test.go
+++ b/workflow/tool_node_test.go
@@ -57,24 +57,24 @@ func TestToolNode_New(t *testing.T) {
 
 	tests := []struct {
 		name    string
-		creator func() (Node, error)
+		creator func() (*ToolNode, error)
 		want    string
 	}{
 		{
 			name: "NewToolNodeTyped",
-			creator: func() (Node, error) {
+			creator: func() (*ToolNode, error) {
 				return NewToolNodeTyped[Input, Output](myTool, defaultNodeConfig)
 			},
 		},
 		{
 			name: "NewToolNodeWithSchemas",
-			creator: func() (Node, error) {
+			creator: func() (*ToolNode, error) {
 				return NewToolNodeWithSchemas(myTool, ischema, oschema, defaultNodeConfig)
 			},
 		},
 		{
 			name: "NewToolNode",
-			creator: func() (Node, error) {
+			creator: func() (*ToolNode, error) {
 				return NewToolNode(myTool, defaultNodeConfig)
 			},
 		},
@@ -94,15 +94,7 @@ func TestToolNode_New(t *testing.T) {
 				t.Errorf("node.Description() = %q, want %q", got, want)
 			}
 
-			// Basic internal check via reflection-like cast.
-			// We use any, any for constructors that don't preserve types in the struct.
-			var inputResolved, outputResolved *jsonschema.Resolved
-			switch tn := node.(type) {
-			case *toolNode:
-				inputResolved, outputResolved = tn.inputSchema, tn.outputSchema
-			default:
-				t.Errorf("unknown node type: %T", tn)
-			}
+			inputResolved, outputResolved := node.inputSchema, node.outputSchema
 
 			if inputResolved == nil || outputResolved == nil {
 				t.Error("expected schemas to be resolved")

--- a/workflow/validation.go
+++ b/workflow/validation.go
@@ -17,6 +17,8 @@ package workflow
 import (
 	"errors"
 	"fmt"
+	"slices"
+	"strings"
 )
 
 // ErrDuplicateNodeName is returned when an edge set contains two
@@ -36,6 +38,9 @@ var ErrDuplicateEdge = errors.New("duplicate edge")
 
 // ErrMultipleDefaultRoutes is returned when a node has more than one default route.
 var ErrMultipleDefaultRoutes = errors.New("node has more than one default route")
+
+// ErrNodesNotReachable is returned when some nodes are not reachable from the start node.
+var ErrNodesNotReachable = errors.New("nodes not reachable from start node")
 
 // ErrUnconditionalCycle is returned when a cycle is detected that does not
 // contain any conditional edges.
@@ -109,6 +114,9 @@ func validateWorkflow(workflow *graph) error {
 	if err := validateDefaultRoute(workflow); err != nil {
 		return err
 	}
+	if err := validateConnectivity(workflow); err != nil {
+		return err
+	}
 	if err := validateCycles(workflow); err != nil {
 		return err
 	}
@@ -143,6 +151,48 @@ func validateDefaultRoute(workflow *graph) error {
 			}
 		}
 	}
+	return nil
+}
+
+// validateConnectivity checks that all nodes in the edge set are reachable from the start node.
+func validateConnectivity(workflow *graph) error {
+	if len(workflow.successors) == 0 {
+		return nil
+	}
+
+	visited := make(map[Node]bool)
+	var traverse func(n Node)
+	traverse = func(n Node) {
+		visited[n] = true
+		for _, neighbor := range workflow.successors[n] {
+			if !visited[neighbor.To] {
+				traverse(neighbor.To)
+			}
+		}
+	}
+
+	traverse(Start)
+
+	allNodes := make(map[Node]bool)
+	for node, edges := range workflow.successors {
+		allNodes[node] = true
+		for _, edge := range edges {
+			allNodes[edge.To] = true
+		}
+	}
+
+	var unreachable []string
+	for node := range allNodes {
+		if !visited[node] {
+			unreachable = append(unreachable, node.Name())
+		}
+	}
+	slices.Sort(unreachable)
+
+	if len(unreachable) > 0 {
+		return fmt.Errorf("%w: %q", ErrNodesNotReachable, strings.Join(unreachable, ", "))
+	}
+
 	return nil
 }
 

--- a/workflow/validation.go
+++ b/workflow/validation.go
@@ -29,6 +29,9 @@ var ErrNoStartNode = errors.New("no start node found")
 // ErrNodePointsToStart is returned when a node points to the start node.
 var ErrNodePointsToStart = errors.New("node points to start node")
 
+// ErrMultipleDefaultRoutes is returned when a node has more than one default route.
+var ErrMultipleDefaultRoutes = errors.New("node has more than one default route")
+
 // validateNodes executes a set of edges validation checks.
 func validateNodes(edges []Edge) error {
 	if err := validateUniqueNames(edges); err != nil {
@@ -84,6 +87,29 @@ func validateStartNodeNoIncoming(edges []Edge) error {
 	for _, edge := range edges {
 		if edge.To == Start {
 			return fmt.Errorf("%w: %s", ErrNodePointsToStart, edge.From.Name())
+		}
+	}
+	return nil
+}
+
+// validateWorkflow executes a set of workflow validation checks.
+func validateWorkflow(workflow *Workflow) error {
+	if err := validateDefaultRoute(workflow); err != nil {
+		return err
+	}
+	return nil
+}
+
+// validateDefaultRoute checks that there are no multiple default routes for one node.
+func validateDefaultRoute(workflow *Workflow) error {
+	for node, edges := range workflow.graph.successors {
+		hasDefault := false
+		for _, edge := range edges {
+			if edge.Route == Default && !hasDefault {
+				hasDefault = true
+			} else if edge.Route == Default && hasDefault {
+				return fmt.Errorf("%w: %q", ErrMultipleDefaultRoutes, node.Name())
+			}
 		}
 	}
 	return nil

--- a/workflow/validation.go
+++ b/workflow/validation.go
@@ -29,6 +29,11 @@ var ErrNoStartNode = errors.New("no start node found")
 // ErrNodePointsToStart is returned when a node points to the start node.
 var ErrNodePointsToStart = errors.New("node points to start node")
 
+// ErrDuplicateEdge is returned when an edge set contains two identical edges.
+// Two edges with the same (From, To) are rejected regardless of Route; use
+// MultiRoute to express alternatives to the same target.
+var ErrDuplicateEdge = errors.New("duplicate edge")
+
 // ErrMultipleDefaultRoutes is returned when a node has more than one default route.
 var ErrMultipleDefaultRoutes = errors.New("node has more than one default route")
 
@@ -97,7 +102,10 @@ func validateStartNodeNoIncoming(edges []Edge) error {
 }
 
 // validateWorkflow executes a set of workflow validation checks.
-func validateWorkflow(workflow *Workflow) error {
+func validateWorkflow(workflow *graph) error {
+	if err := validateUniqueEdges(workflow); err != nil {
+		return err
+	}
 	if err := validateDefaultRoute(workflow); err != nil {
 		return err
 	}
@@ -107,9 +115,25 @@ func validateWorkflow(workflow *Workflow) error {
 	return nil
 }
 
+// validateUniqueEdges checks that there are no duplicate edges in the workflow.
+// Two edges with the same (From, To) are rejected regardless of Route; use
+// MultiRoute to express alternatives to the same target.
+func validateUniqueEdges(workflow *graph) error {
+	for node, edges := range workflow.successors {
+		uniqueEdges := make(map[Node]struct{})
+		for _, edge := range edges {
+			if _, ok := uniqueEdges[edge.To]; ok {
+				return fmt.Errorf("%w: from %q to %q", ErrDuplicateEdge, node.Name(), edge.To.Name())
+			}
+			uniqueEdges[edge.To] = struct{}{}
+		}
+	}
+	return nil
+}
+
 // validateDefaultRoute checks that there are no multiple default routes for one node.
-func validateDefaultRoute(workflow *Workflow) error {
-	for node, edges := range workflow.graph.successors {
+func validateDefaultRoute(workflow *graph) error {
+	for node, edges := range workflow.successors {
 		hasDefault := false
 		for _, edge := range edges {
 			if edge.Route == Default && !hasDefault {
@@ -127,7 +151,7 @@ func validateDefaultRoute(workflow *Workflow) error {
 // for cycles where all edges in the cycle have nil routes.
 // Default routes (where Route == Default) are treated as conditional edges
 // and are ignored during unconditional cycle detection.
-func validateCycles(workflow *Workflow) error {
+func validateCycles(workflow *graph) error {
 	visited := make(map[Node]struct{})
 
 	var traverse func(n Node, inStack map[Node]struct{}) error
@@ -143,7 +167,7 @@ func validateCycles(workflow *Workflow) error {
 		inStack[n] = struct{}{}
 		visited[n] = struct{}{}
 
-		for _, edge := range workflow.graph.successors[n] {
+		for _, edge := range workflow.successors[n] {
 			if edge.Route == nil {
 				if err := traverse(edge.To, inStack); err != nil {
 					return err
@@ -155,7 +179,7 @@ func validateCycles(workflow *Workflow) error {
 		return nil
 	}
 
-	for node := range workflow.graph.successors {
+	for node := range workflow.successors {
 		if _, ok := visited[node]; !ok {
 			inStack := make(map[Node]struct{})
 			if err := traverse(node, inStack); err != nil {

--- a/workflow/validation.go
+++ b/workflow/validation.go
@@ -1,0 +1,50 @@
+// Copyright 2026 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package workflow
+
+import (
+	"errors"
+	"fmt"
+)
+
+// ErrDuplicateNodeName is returned when an edge set contains two
+// distinct Node instances that share the same Name.
+var ErrDuplicateNodeName = errors.New("duplicate node name")
+
+// validateUniqueNames checks that all nodes in the edge set have unique names.
+// If duplicate node names are found, it returns an error. The equality between
+// nodes is checked by comparing the nodes directly.
+func validateUniqueNames(edges []Edge) error {
+	names := make(map[string]Node)
+	checkNode := func(node Node) error {
+		if storedNode, ok := names[node.Name()]; ok {
+			if storedNode != node {
+				return fmt.Errorf("%w: %s", ErrDuplicateNodeName, node.Name())
+			}
+		} else {
+			names[node.Name()] = node
+		}
+		return nil
+	}
+	for _, edge := range edges {
+		if err := checkNode(edge.From); err != nil {
+			return err
+		}
+		if err := checkNode(edge.To); err != nil {
+			return err
+		}
+	}
+	return nil
+}

--- a/workflow/validation.go
+++ b/workflow/validation.go
@@ -23,6 +23,26 @@ import (
 // distinct Node instances that share the same Name.
 var ErrDuplicateNodeName = errors.New("duplicate node name")
 
+// ErrNoStartNode is returned when no start node is found in the edge set.
+var ErrNoStartNode = errors.New("no start node found")
+
+// ErrNodePointsToStart is returned when a node points to the start node.
+var ErrNodePointsToStart = errors.New("node points to start node")
+
+// validateNodes executes a set of edges validation checks.
+func validateNodes(edges []Edge) error {
+	if err := validateUniqueNames(edges); err != nil {
+		return err
+	}
+	if err := validateStartNodePresent(edges); err != nil {
+		return err
+	}
+	if err := validateStartNodeNoIncoming(edges); err != nil {
+		return err
+	}
+	return nil
+}
+
 // validateUniqueNames checks that all nodes in the edge set have unique names.
 // If duplicate node names are found, it returns an error. The equality between
 // nodes is checked by comparing the nodes directly.
@@ -44,6 +64,26 @@ func validateUniqueNames(edges []Edge) error {
 		}
 		if err := checkNode(edge.To); err != nil {
 			return err
+		}
+	}
+	return nil
+}
+
+// validateStartNodePresent checks that there is at least one edge starting from the start node.
+func validateStartNodePresent(edges []Edge) error {
+	for _, edge := range edges {
+		if edge.From == Start {
+			return nil
+		}
+	}
+	return ErrNoStartNode
+}
+
+// validateStartNodeNoIncoming checks that no node points to the start node.
+func validateStartNodeNoIncoming(edges []Edge) error {
+	for _, edge := range edges {
+		if edge.To == Start {
+			return fmt.Errorf("%w: %s", ErrNodePointsToStart, edge.From.Name())
 		}
 	}
 	return nil

--- a/workflow/validation.go
+++ b/workflow/validation.go
@@ -32,6 +32,10 @@ var ErrNodePointsToStart = errors.New("node points to start node")
 // ErrMultipleDefaultRoutes is returned when a node has more than one default route.
 var ErrMultipleDefaultRoutes = errors.New("node has more than one default route")
 
+// ErrUnconditionalCycle is returned when a cycle is detected that does not
+// contain any conditional edges.
+var ErrUnconditionalCycle = errors.New("unconditional cycle detected")
+
 // validateNodes executes a set of edges validation checks.
 func validateNodes(edges []Edge) error {
 	if err := validateUniqueNames(edges); err != nil {
@@ -97,6 +101,9 @@ func validateWorkflow(workflow *Workflow) error {
 	if err := validateDefaultRoute(workflow); err != nil {
 		return err
 	}
+	if err := validateCycles(workflow); err != nil {
+		return err
+	}
 	return nil
 }
 
@@ -112,5 +119,50 @@ func validateDefaultRoute(workflow *Workflow) error {
 			}
 		}
 	}
+	return nil
+}
+
+// validateCycles checks that there are no unconditional cycles in the workflow.
+// It performs a depth first search for every node in the workflow and checks
+// for cycles where all edges in the cycle have nil routes.
+// Default routes (where Route == Default) are treated as conditional edges
+// and are ignored during unconditional cycle detection.
+func validateCycles(workflow *Workflow) error {
+	visited := make(map[Node]struct{})
+
+	var traverse func(n Node, inStack map[Node]struct{}) error
+	traverse = func(n Node, inStack map[Node]struct{}) error {
+		if _, ok := inStack[n]; ok {
+			return fmt.Errorf("%w: %q", ErrUnconditionalCycle, n.Name())
+		}
+
+		if _, ok := visited[n]; ok {
+			return nil
+		}
+
+		inStack[n] = struct{}{}
+		visited[n] = struct{}{}
+
+		for _, edge := range workflow.graph.successors[n] {
+			if edge.Route == nil {
+				if err := traverse(edge.To, inStack); err != nil {
+					return err
+				}
+			}
+		}
+
+		delete(inStack, n)
+		return nil
+	}
+
+	for node := range workflow.graph.successors {
+		if _, ok := visited[node]; !ok {
+			inStack := make(map[Node]struct{})
+			if err := traverse(node, inStack); err != nil {
+				return err
+			}
+		}
+	}
+
 	return nil
 }

--- a/workflow/validation.go
+++ b/workflow/validation.go
@@ -46,6 +46,9 @@ var ErrNodesNotReachable = errors.New("nodes not reachable from start node")
 // contain any conditional edges.
 var ErrUnconditionalCycle = errors.New("unconditional cycle detected")
 
+// ErrSubWorkflowNameCollision is returned when a sub-workflow has the same name as the parent workflow.
+var ErrSubWorkflowNameCollision = errors.New("sub-workflow name collision")
+
 // validateNodes executes a set of edges validation checks.
 func validateNodes(edges []Edge) error {
 	if err := validateUniqueNames(edges); err != nil {
@@ -56,6 +59,29 @@ func validateNodes(edges []Edge) error {
 	}
 	if err := validateStartNodeNoIncoming(edges); err != nil {
 		return err
+	}
+	return nil
+}
+
+// validateSubWorkflowNames checks that no sub-workflow has the same name as the parent workflow.
+func validateSubWorkflowNames(workflowName string, edges []Edge) error {
+	for _, edge := range edges {
+		if err := checkSubWorkflowName(edge.From, workflowName); err != nil {
+			return err
+		}
+		if err := checkSubWorkflowName(edge.To, workflowName); err != nil {
+			return err
+		}
+	}
+	return nil
+}
+
+// checkSubWorkflowName checks if the node is a WorkflowNode and if its sub-workflow has the same name as the parent workflow.
+func checkSubWorkflowName(node Node, workflowName string) error {
+	if wfNode, ok := node.(*WorkflowNode); ok {
+		if wfNode.subWorkflow.Name() == workflowName {
+			return fmt.Errorf("%w: %q", ErrSubWorkflowNameCollision, workflowName)
+		}
 	}
 	return nil
 }

--- a/workflow/validation_test.go
+++ b/workflow/validation_test.go
@@ -155,6 +155,50 @@ func TestStartNodeNoIncomingEdges(t *testing.T) {
 	}
 }
 
+func TestDuplicateEdges(t *testing.T) {
+	nodeA := &dummyNode{name: "A"}
+	nodeB := &dummyNode{name: "B"}
+	tests := []struct {
+		name      string
+		edges     []Edge
+		expectErr bool
+	}{
+		{
+			name:  "no duplicate edges",
+			edges: []Edge{{From: nodeA, To: nodeB}},
+		},
+		{
+			name:      "duplicate edges",
+			edges:     []Edge{{From: nodeA, To: nodeB}, {From: nodeA, To: nodeB}},
+			expectErr: true,
+		},
+		{
+			name:      "duplicate edges with different routes",
+			edges:     []Edge{{From: nodeA, To: nodeB, Route: StringRoute("test1")}, {From: nodeA, To: nodeB, Route: StringRoute("test2")}},
+			expectErr: true,
+		},
+		{
+			name:      "duplicate edges one without route",
+			edges:     []Edge{{From: nodeA, To: nodeB, Route: StringRoute("test1")}, {From: nodeA, To: nodeB}},
+			expectErr: true,
+		},
+		{
+			name:  "empty edges",
+			edges: []Edge{},
+		},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			if err := validateUniqueEdges(newGraph(tc.edges)); err != nil && !tc.expectErr {
+				t.Errorf("got an error %v, expected none", err)
+			} else if err == nil && tc.expectErr {
+				t.Errorf("expected an error, got none")
+			}
+		})
+	}
+}
+
 func TestDefaultRoute(t *testing.T) {
 	nodeA := &dummyNode{name: "A"}
 	nodeB := &dummyNode{name: "B"}
@@ -177,7 +221,7 @@ func TestDefaultRoute(t *testing.T) {
 
 	for _, tc := range tests {
 		t.Run(tc.name, func(t *testing.T) {
-			if err := validateDefaultRoute(&Workflow{graph: newGraph(tc.edges)}); !errors.Is(err, tc.expectErr) {
+			if err := validateDefaultRoute(newGraph(tc.edges)); !errors.Is(err, tc.expectErr) {
 				t.Errorf("got %v, expected %v", err, tc.expectErr)
 			}
 		})
@@ -272,9 +316,7 @@ func TestValidateCycles(t *testing.T) {
 
 	for _, tc := range tests {
 		t.Run(tc.name, func(t *testing.T) {
-			w := &Workflow{graph: newGraph(tc.edges())}
-
-			err := validateCycles(w)
+			err := validateCycles(newGraph(tc.edges()))
 			if tc.expectErr && err == nil {
 				t.Errorf("expected error, got none")
 			} else if !tc.expectErr && err != nil {

--- a/workflow/validation_test.go
+++ b/workflow/validation_test.go
@@ -64,3 +64,92 @@ func TestUniqueNames(t *testing.T) {
 		})
 	}
 }
+
+func TestStartNodePresent(t *testing.T) {
+	tests := []struct {
+		name           string
+		edges          []Edge
+		expectErrorMsg string
+	}{
+		{
+			name: "with start node",
+			edges: func() []Edge {
+				nodeA := &dummyNode{name: "A"}
+				nodeB := &dummyNode{name: "B"}
+				return []Edge{
+					{From: Start, To: nodeA},
+					{From: nodeA, To: nodeB},
+				}
+			}(),
+		},
+		{
+			name: "no start node",
+			edges: func() []Edge {
+				nodeA := &dummyNode{name: "A"}
+				nodeB := &dummyNode{name: "B"}
+				return []Edge{
+					{From: nodeA, To: nodeB},
+				}
+			}(),
+			expectErrorMsg: "no start node found",
+		},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			err := validateStartNodePresent(tc.edges)
+			if tc.expectErrorMsg != "" {
+				if err == nil {
+					t.Errorf("expected error matching %q, got none", tc.expectErrorMsg)
+				} else if !strings.Contains(err.Error(), tc.expectErrorMsg) {
+					t.Errorf("expected error containing %q, got %v", tc.expectErrorMsg, err)
+				}
+			}
+		})
+	}
+}
+
+func TestStartNodeNoIncomingEdges(t *testing.T) {
+	tests := []struct {
+		name           string
+		edges          []Edge
+		expectErrorMsg string
+	}{
+		{
+			name: "start node with no incoming edges",
+			edges: func() []Edge {
+				nodeA := &dummyNode{name: "A"}
+				nodeB := &dummyNode{name: "B"}
+				return []Edge{
+					{From: Start, To: nodeA},
+					{From: nodeA, To: nodeB},
+				}
+			}(),
+		},
+		{
+			name: "start node has incoming edges",
+			edges: func() []Edge {
+				nodeA := &dummyNode{name: "A"}
+				nodeB := &dummyNode{name: "B"}
+				return []Edge{
+					{From: nodeA, To: Start},
+					{From: Start, To: nodeB},
+				}
+			}(),
+			expectErrorMsg: "node points to start node: A",
+		},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			err := validateStartNodeNoIncoming(tc.edges)
+			if tc.expectErrorMsg != "" {
+				if err == nil {
+					t.Errorf("expected error matching %q, got none", tc.expectErrorMsg)
+				} else if !strings.Contains(err.Error(), tc.expectErrorMsg) {
+					t.Errorf("expected error containing %q, got %v", tc.expectErrorMsg, err)
+				}
+			}
+		})
+	}
+}

--- a/workflow/validation_test.go
+++ b/workflow/validation_test.go
@@ -15,6 +15,7 @@
 package workflow
 
 import (
+	"errors"
 	"strings"
 	"testing"
 )
@@ -149,6 +150,35 @@ func TestStartNodeNoIncomingEdges(t *testing.T) {
 				} else if !strings.Contains(err.Error(), tc.expectErrorMsg) {
 					t.Errorf("expected error containing %q, got %v", tc.expectErrorMsg, err)
 				}
+			}
+		})
+	}
+}
+
+func TestDefaultRoute(t *testing.T) {
+	nodeA := &dummyNode{name: "A"}
+	nodeB := &dummyNode{name: "B"}
+	nodeC := &dummyNode{name: "C"}
+	tests := []struct {
+		name      string
+		edges     []Edge
+		expectErr error
+	}{
+		{
+			name:  "single default route",
+			edges: []Edge{{From: nodeA, To: nodeB, Route: Default}},
+		},
+		{
+			name:      "multiple default routes",
+			edges:     []Edge{{From: nodeA, To: nodeB, Route: Default}, {From: nodeA, To: nodeC, Route: Default}},
+			expectErr: ErrMultipleDefaultRoutes,
+		},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			if err := validateDefaultRoute(&Workflow{graph: newGraph(tc.edges)}); !errors.Is(err, tc.expectErr) {
+				t.Errorf("got %v, expected %v", err, tc.expectErr)
 			}
 		})
 	}

--- a/workflow/validation_test.go
+++ b/workflow/validation_test.go
@@ -228,6 +228,46 @@ func TestDefaultRoute(t *testing.T) {
 	}
 }
 
+func TestConnectivity(t *testing.T) {
+	nodeA := &dummyNode{name: "A"}
+	nodeB := &dummyNode{name: "B"}
+	nodeC := &dummyNode{name: "C"}
+	tests := []struct {
+		name           string
+		edges          []Edge
+		expectErrorMsg string
+	}{
+		{
+			name: "all nodes connected",
+			edges: []Edge{{From: Start, To: nodeA},
+				{From: nodeA, To: nodeB},
+				{From: nodeB, To: nodeC},
+			},
+		},
+		{
+			name: "disconnected nodes",
+			edges: []Edge{{From: Start, To: nodeA},
+				{From: nodeB, To: nodeC},
+			},
+			expectErrorMsg: "nodes not reachable from start node: \"B, C\"",
+		},
+	}
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			err := validateConnectivity(newGraph(tc.edges))
+			if tc.expectErrorMsg != "" {
+				if err == nil {
+					t.Errorf("expected error matching %q, got none", tc.expectErrorMsg)
+				} else if !strings.Contains(err.Error(), tc.expectErrorMsg) {
+					t.Errorf("expected error containing %q, got %v", tc.expectErrorMsg, err)
+				}
+			} else if err != nil {
+				t.Errorf("expected no error, got %v", err)
+			}
+		})
+	}
+}
+
 func TestValidateCycles(t *testing.T) {
 	tests := []struct {
 		name      string

--- a/workflow/validation_test.go
+++ b/workflow/validation_test.go
@@ -1,0 +1,66 @@
+// Copyright 2026 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package workflow
+
+import (
+	"strings"
+	"testing"
+)
+
+func TestUniqueNames(t *testing.T) {
+	type nodeSetup struct{ aName, bName, cName string }
+	tests := []struct {
+		name           string
+		setup          nodeSetup
+		expectErrorMsg string
+	}{
+		{
+			name:  "unique names",
+			setup: nodeSetup{"A", "B", "C"},
+		},
+		{
+			name:           "duplicate node names in From",
+			setup:          nodeSetup{"A", "A", "C"},
+			expectErrorMsg: "duplicate node name: A",
+		},
+		{
+			name:           "duplicate node names in To",
+			setup:          nodeSetup{"A", "B", "A"},
+			expectErrorMsg: "duplicate node name: A",
+		},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			nodeA := &dummyNode{name: tc.setup.aName}
+			nodeB := &dummyNode{name: tc.setup.bName}
+			nodeC := &dummyNode{name: tc.setup.cName}
+			edges := []Edge{
+				{From: nodeA, To: nodeB},
+				{From: nodeB, To: nodeC},
+			}
+			err := validateUniqueNames(edges)
+			if tc.expectErrorMsg != "" {
+				if err == nil {
+					t.Errorf("expected error matching %q, got none", tc.expectErrorMsg)
+				} else if !strings.Contains(err.Error(), tc.expectErrorMsg) {
+					t.Errorf("expected error containing %q, got %v", tc.expectErrorMsg, err)
+				}
+			} else if err != nil {
+				t.Errorf("expected no error, got %v", err)
+			}
+		})
+	}
+}

--- a/workflow/validation_test.go
+++ b/workflow/validation_test.go
@@ -183,3 +183,103 @@ func TestDefaultRoute(t *testing.T) {
 		})
 	}
 }
+
+func TestValidateCycles(t *testing.T) {
+	tests := []struct {
+		name      string
+		edges     func() []Edge
+		expectErr bool
+	}{
+		{
+			name: "no cycles",
+			edges: func() []Edge {
+				nodeA := &dummyNode{name: "A"}
+				nodeB := &dummyNode{name: "B"}
+				return []Edge{
+					{From: Start, To: nodeA},
+					{From: nodeA, To: nodeB},
+				}
+			},
+			expectErr: false,
+		},
+		{
+			name: "no cycles diamond graph",
+			edges: func() []Edge {
+				nodeA := &dummyNode{name: "A"}
+				nodeB := &dummyNode{name: "B"}
+				nodeC := &dummyNode{name: "C"}
+				nodeD := &dummyNode{name: "D"}
+				return []Edge{
+					{From: Start, To: nodeA},
+					{From: nodeA, To: nodeB},
+					{From: nodeA, To: nodeC},
+					{From: nodeB, To: nodeD},
+					{From: nodeC, To: nodeD},
+				}
+			},
+			expectErr: false,
+		},
+		{
+			name: "only conditional cycle",
+			edges: func() []Edge {
+				nodeA := &dummyNode{name: "A"}
+				nodeB := &dummyNode{name: "B"}
+				return []Edge{
+					{From: Start, To: nodeA},
+					{From: nodeA, To: nodeB},
+					{From: nodeB, To: nodeA, Route: StringRoute("back")},
+				}
+			},
+			expectErr: false,
+		},
+		{
+			name: "both conditional and unconditional cycles",
+			edges: func() []Edge {
+				nodeA := &dummyNode{name: "A"}
+				nodeB := &dummyNode{name: "B"}
+				nodeC := &dummyNode{name: "C"}
+				nodeD := &dummyNode{name: "D"}
+				return []Edge{
+					{From: Start, To: nodeA},
+					{From: nodeA, To: nodeB},
+					{From: nodeB, To: nodeA, Route: StringRoute("back")},
+					{From: Start, To: nodeC},
+					{From: nodeC, To: nodeD},
+					{From: nodeD, To: nodeC}, // Unconditional
+				}
+			},
+			expectErr: true,
+		},
+		{
+			name: "cycle with default route",
+			edges: func() []Edge {
+				nodeA := &dummyNode{name: "A"}
+				nodeB := &dummyNode{name: "B"}
+				return []Edge{
+					{From: Start, To: nodeA},
+					{From: nodeA, To: nodeB},
+					{From: nodeB, To: nodeA, Route: Default},
+				}
+			},
+			expectErr: false,
+		},
+		{
+			name:      "empty graph",
+			edges:     func() []Edge { return []Edge{} },
+			expectErr: false,
+		},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			w := &Workflow{graph: newGraph(tc.edges())}
+
+			err := validateCycles(w)
+			if tc.expectErr && err == nil {
+				t.Errorf("expected error, got none")
+			} else if !tc.expectErr && err != nil {
+				t.Errorf("expected no error, got %v", err)
+			}
+		})
+	}
+}

--- a/workflow/validation_test.go
+++ b/workflow/validation_test.go
@@ -239,14 +239,16 @@ func TestConnectivity(t *testing.T) {
 	}{
 		{
 			name: "all nodes connected",
-			edges: []Edge{{From: Start, To: nodeA},
+			edges: []Edge{
+				{From: Start, To: nodeA},
 				{From: nodeA, To: nodeB},
 				{From: nodeB, To: nodeC},
 			},
 		},
 		{
 			name: "disconnected nodes",
-			edges: []Edge{{From: Start, To: nodeA},
+			edges: []Edge{
+				{From: Start, To: nodeA},
 				{From: nodeB, To: nodeC},
 			},
 			expectErrorMsg: "nodes not reachable from start node: \"B, C\"",

--- a/workflow/validation_test.go
+++ b/workflow/validation_test.go
@@ -367,3 +367,50 @@ func TestValidateCycles(t *testing.T) {
 		})
 	}
 }
+
+func TestValidateSubWorkflowNames(t *testing.T) {
+	// Create a valid sub-workflow
+	subWf, err := New("inner_wf", []Edge{{From: Start, To: &dummyNode{name: "A"}}})
+	if err != nil {
+		t.Fatalf("failed to create sub-workflow: %v", err)
+	}
+
+	wfNode := &WorkflowNode{
+		BaseNode:    NewBaseNode("nested_node", "", NodeConfig{}),
+		subWorkflow: subWf,
+	}
+
+	tests := []struct {
+		name           string
+		parentName     string
+		edges          []Edge
+		expectErrorMsg string
+	}{
+		{
+			name:       "no collision",
+			parentName: "outer_wf",
+			edges:      []Edge{{From: Start, To: wfNode}},
+		},
+		{
+			name:           "collision with sub-workflow name",
+			parentName:     "inner_wf",
+			edges:          []Edge{{From: Start, To: wfNode}},
+			expectErrorMsg: `sub-workflow name collision: "inner_wf"`,
+		},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			err := validateSubWorkflowNames(tc.parentName, tc.edges)
+			if tc.expectErrorMsg != "" {
+				if err == nil {
+					t.Errorf("expected error matching %q, got none", tc.expectErrorMsg)
+				} else if !strings.Contains(err.Error(), tc.expectErrorMsg) {
+					t.Errorf("expected error containing %q, got %v", tc.expectErrorMsg, err)
+				}
+			} else if err != nil {
+				t.Errorf("expected no error, got %v", err)
+			}
+		})
+	}
+}

--- a/workflow/workflow.go
+++ b/workflow/workflow.go
@@ -120,7 +120,11 @@ func New(edges []Edge) (*Workflow, error) {
 	if err := validateNodes(edges); err != nil {
 		return nil, err
 	}
-	return &Workflow{graph: newGraph(edges)}, nil
+	graph := newGraph(edges)
+	if err := validateWorkflow(graph); err != nil {
+		return nil, err
+	}
+	return &Workflow{graph: graph}, nil
 }
 
 // Run drives the workflow to completion (or to a graceful pause in

--- a/workflow/workflow.go
+++ b/workflow/workflow.go
@@ -22,6 +22,7 @@ import (
 	"google.golang.org/genai"
 
 	"google.golang.org/adk/agent"
+	"google.golang.org/adk/internal/typeutil"
 	"google.golang.org/adk/session"
 )
 
@@ -92,7 +93,7 @@ type FunctionNode struct {
 }
 
 // NewFunctionNode creates a new node wrapping a custom function using generics to automatically infer input and output types.
-func NewFunctionNode[IN any, OUT any](name string, fn func(ctx agent.InvocationContext, input IN) (OUT, error)) *FunctionNode {
+func NewFunctionNode[IN, OUT any](name string, fn func(ctx agent.InvocationContext, input IN) (OUT, error)) *FunctionNode {
 	wrappedFn := func(ctx agent.InvocationContext, input any) (any, error) {
 		if input == nil {
 			var zero IN
@@ -100,7 +101,13 @@ func NewFunctionNode[IN any, OUT any](name string, fn func(ctx agent.InvocationC
 		}
 		typedInput, ok := input.(IN)
 		if !ok {
-			return nil, fmt.Errorf("invalid input type, expected %T", new(IN))
+			// Fallback to the json-like input types that cannot be converted by the standard type assertion.
+			// E.g. tool nodes return map[string]any as input and user may define a struct as the target type.
+			var err error
+			typedInput, err = typeutil.ConvertToWithJSONSchema[any, IN](input, nil)
+			if err != nil {
+				return nil, fmt.Errorf("new function node: invalid input type, expected %T: %v", new(IN), err)
+			}
 		}
 		return fn(ctx, typedInput)
 	}

--- a/workflow/workflow.go
+++ b/workflow/workflow.go
@@ -1,0 +1,215 @@
+// Copyright 2026 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package workflow
+
+import (
+	"fmt"
+	"iter"
+	"strings"
+
+	"google.golang.org/genai"
+
+	"google.golang.org/adk/agent"
+	"google.golang.org/adk/session"
+)
+
+// Node is the interface for all nodes in a workflow.
+type Node interface {
+	Name() string
+	Description() string
+	Run(ctx agent.InvocationContext, input any) iter.Seq2[*session.Event, error]
+}
+
+// Route defines the interface for matching execution results to edges.
+type Route interface {
+	Matches(output any) bool
+}
+
+// StringRoute matches an exact string value.
+type StringRoute struct {
+	Value string
+}
+
+func (r StringRoute) Matches(output any) bool {
+	s, ok := output.(string)
+	return ok && s == r.Value
+}
+
+// BaseNode provides common fields for all nodes.
+type BaseNode struct {
+	name        string
+	description string
+}
+
+func (b *BaseNode) Name() string        { return b.name }
+func (b *BaseNode) Description() string { return b.description }
+
+// FunctionNode wraps a custom function.
+type FunctionNode struct {
+	BaseNode
+	fn func(ctx agent.InvocationContext, input any) (any, error)
+}
+
+// NewFunctionNode creates a new node wrapping a custom function using generics to automatically infer input and output types.
+func NewFunctionNode[IN any, OUT any](name string, fn func(ctx agent.InvocationContext, input IN) (OUT, error)) *FunctionNode {
+	wrappedFn := func(ctx agent.InvocationContext, input any) (any, error) {
+		if input == nil {
+			var zero IN
+			return fn(ctx, zero)
+		}
+		typedInput, ok := input.(IN)
+		if !ok {
+			return nil, fmt.Errorf("invalid input type, expected %T", new(IN))
+		}
+		return fn(ctx, typedInput)
+	}
+	return &FunctionNode{
+		BaseNode: BaseNode{name: name},
+		fn:        wrappedFn,
+	}
+}
+
+func (n *FunctionNode) Run(ctx agent.InvocationContext, input any) iter.Seq2[*session.Event, error] {
+	return func(yield func(*session.Event, error) bool) {
+		output, err := n.fn(ctx, input)
+		if err != nil {
+			yield(nil, err)
+			return
+		}
+		
+		event := session.NewEvent(ctx.InvocationID())
+		event.Actions.StateDelta["output"] = output
+		if s, ok := output.(string); ok {
+			event.Content = &genai.Content{
+				Parts: []*genai.Part{{Text: s}},
+			}
+		}
+		yield(event, nil)
+	}
+}
+
+// Edge defines a directed connection between nodes in the workflow graph.
+type Edge struct {
+	From  Node  // The source node
+	To    Node  // The target node
+	Route Route // Routing condition
+}
+
+// Chain generates a slice of Edges to form a chain of nodes.
+func Chain(nodes ...Node) []Edge {
+	if len(nodes) < 2 {
+		return nil
+	}
+	edges := make([]Edge, len(nodes)-1)
+	for i := 0; i < len(nodes)-1; i++ {
+		edges[i] = Edge{From: nodes[i], To: nodes[i+1]}
+	}
+	return edges
+}
+
+// Concat combines Edges and []Edge slices into a single slice of edges.
+func Concat(items ...any) []Edge {
+	var edges []Edge
+	for _, item := range items {
+		switch v := item.(type) {
+		case Edge:
+			edges = append(edges, v)
+		case []Edge:
+			edges = append(edges, v...)
+		}
+	}
+	return edges
+}
+
+// START is a sentinel node used to indicate the entry point of the workflow.
+var START Node = &startNode{}
+
+type startNode struct{}
+
+func (s *startNode) Name() string        { return "START" }
+func (s *startNode) Description() string { return "Start node" }
+func (s *startNode) Run(ctx agent.InvocationContext, input any) iter.Seq2[*session.Event, error] {
+	return func(yield func(*session.Event, error) bool) {}
+}
+
+const DEFAULT_ROUTE = "__DEFAULT__"
+
+// Workflow manages the workflow graph execution.
+type Workflow struct {
+	edges []Edge
+}
+
+// New creates a new Workflow engine with the given edges.
+func New(edges []Edge) *Workflow {
+	return &Workflow{edges: edges}
+}
+
+func (w *Workflow) Run(ctx agent.InvocationContext) iter.Seq2[*session.Event, error] {
+	return func(yield func(*session.Event, error) bool) {
+		var currentNode Node
+		for _, edge := range w.edges {
+			if edge.From == START {
+				currentNode = edge.To
+				break
+			}
+		}
+
+		if currentNode == nil {
+			yield(nil, fmt.Errorf("no start node found"))
+			return
+		}
+
+		var input any
+		userContent := ctx.UserContent()
+		if userContent != nil {
+			var sb strings.Builder
+			for _, part := range userContent.Parts {
+				if part.Text != "" {
+					sb.WriteString(part.Text)
+				}
+			}
+			input = sb.String()
+		}
+
+		for currentNode != nil {
+			for ev, err := range currentNode.Run(ctx, input) {
+				if err != nil {
+					yield(nil, err)
+					return
+				}
+				if !yield(ev, nil) {
+					return
+				}
+
+				// Extract output for next node
+				if ev.Actions.StateDelta != nil {
+					if out, ok := ev.Actions.StateDelta["output"]; ok {
+						input = out
+					}
+				}
+			}
+
+			// Find next node (assuming linear chain for now)
+			var nextNode Node
+			for _, edge := range w.edges {
+				if edge.From == currentNode {
+					nextNode = edge.To
+					break
+				}
+			}
+			currentNode = nextNode
+		}
+	}
+}

--- a/workflow/workflow.go
+++ b/workflow/workflow.go
@@ -64,6 +64,18 @@ func (r BoolRoute) Matches(event *session.Event) bool {
 	return matchRoute(fmt.Sprint(r), event)
 }
 
+// MultiRoute matches any value within a specified list of allowed routes.
+type MultiRoute[T comparable] []T
+
+func (r MultiRoute[T]) Matches(event *session.Event) bool {
+	for _, route := range r {
+		if matchRoute(fmt.Sprint(route), event) {
+			return true
+		}
+	}
+	return false
+}
+
 // baseNode provides common fields for all nodes.
 type baseNode struct {
 	name        string
@@ -182,6 +194,15 @@ type nodeInput struct {
 	input any
 }
 
+// findNextNodes determines the set of nodes to execute next based on the outgoing edges of the currentNode.
+// It evaluates routes attached to edges against the provided session.Event.
+// 
+// Behavior:
+// - Edges with no route condition always match.
+// - Edges with a route condition match only if the route matches the event.
+// - Duplicate target nodes are excluded to avoid queuing the same node multiple times.
+// - If there are outgoing edges but none of them match (neither by route nor by being unrouted),
+//   it falls back to the default route (TODO: hanorik - add default route support).
 func (w *Workflow) findNextNodes(currentNode Node, input any, event *session.Event) ([]nodeInput, error) {
 	if len(w.edges[currentNode]) == 0 {
 		return nil, nil

--- a/workflow/workflow.go
+++ b/workflow/workflow.go
@@ -47,18 +47,18 @@ func (r StringRoute) Matches(output any) bool {
 	return ok && s == r.Value
 }
 
-// BaseNode provides common fields for all nodes.
-type BaseNode struct {
+// baseNode provides common fields for all nodes.
+type baseNode struct {
 	name        string
 	description string
 }
 
-func (b *BaseNode) Name() string        { return b.name }
-func (b *BaseNode) Description() string { return b.description }
+func (b *baseNode) Name() string        { return b.name }
+func (b *baseNode) Description() string { return b.description }
 
 // FunctionNode wraps a custom function.
 type FunctionNode struct {
-	BaseNode
+	baseNode
 	fn func(ctx agent.InvocationContext, input any) (any, error)
 }
 
@@ -76,7 +76,7 @@ func NewFunctionNode[IN any, OUT any](name string, fn func(ctx agent.InvocationC
 		return fn(ctx, typedInput)
 	}
 	return &FunctionNode{
-		BaseNode: BaseNode{name: name},
+		baseNode: baseNode{name: name},
 		fn:        wrappedFn,
 	}
 }
@@ -133,8 +133,8 @@ func Concat(items ...any) []Edge {
 	return edges
 }
 
-// START is a sentinel node used to indicate the entry point of the workflow.
-var START Node = &startNode{}
+// Start is a sentinel node used to indicate the entry point of the workflow.
+var Start Node = &startNode{}
 
 type startNode struct{}
 
@@ -160,7 +160,7 @@ func (w *Workflow) Run(ctx agent.InvocationContext) iter.Seq2[*session.Event, er
 	return func(yield func(*session.Event, error) bool) {
 		var currentNode Node
 		for _, edge := range w.edges {
-			if edge.From == START {
+			if edge.From == Start {
 				currentNode = edge.To
 				break
 			}

--- a/workflow/workflow.go
+++ b/workflow/workflow.go
@@ -77,6 +77,15 @@ func (r MultiRoute[T]) Matches(event *session.Event) bool {
 	return false
 }
 
+// DefaultRoute is a special route that matches when no other concrete routes match.
+var Default = &defaultRoute{}
+
+type defaultRoute struct{}
+
+func (r *defaultRoute) Matches(event *session.Event) bool {
+	return false
+}
+
 // baseNode provides common fields for all nodes.
 type baseNode struct {
 	name        string
@@ -180,8 +189,6 @@ func (s *startNode) Run(ctx agent.InvocationContext, input any) iter.Seq2[*sessi
 	return func(yield func(*session.Event, error) bool) {}
 }
 
-const DEFAULT_ROUTE = "__DEFAULT__"
-
 // Workflow manages the workflow graph execution.
 type Workflow struct {
 	edges map[Node][]Edge
@@ -203,20 +210,21 @@ type nodeInput struct {
 
 // findNextNodes determines the set of nodes to execute next based on the outgoing edges of the currentNode.
 // It evaluates routes attached to edges against the provided session.Event.
-// 
+//
 // Behavior:
-// - Edges with no route condition always match.
-// - Edges with a route condition match only if the route matches the event.
-// - Duplicate target nodes are excluded to avoid queuing the same node multiple times.
-// - If there are outgoing edges but none of them match (neither by route nor by being unrouted),
-//   it falls back to the default route (TODO: hanorik - add default route support).
-func (w *Workflow) findNextNodes(currentNode Node, input any, event *session.Event) ([]nodeInput, error) {
+//   - Edges with no route condition always match.
+//   - Edges with a route condition match only if the route matches the event.
+//   - Duplicate target nodes are excluded to avoid queuing the same node multiple times.
+//   - If there are outgoing edges but none of them match (neither by route nor by being unrouted),
+//     it falls back to the default route (TODO: hanorik - add default route support).
+func (w *Workflow) findNextNodes(currentNode Node, input any, event *session.Event) []nodeInput {
 	if len(w.edges[currentNode]) == 0 {
-		return nil, nil
+		return nil
 	}
 	matched := false
 	queue := []nodeInput{}
 	added := make(map[Node]struct{})
+	var defaultRouteNode Node
 	for _, edge := range w.edges[currentNode] {
 		if _, ok := added[edge.To]; ok {
 			continue
@@ -224,20 +232,23 @@ func (w *Workflow) findNextNodes(currentNode Node, input any, event *session.Eve
 		if edge.Route == nil {
 			queue = append(queue, nodeInput{node: edge.To, input: input})
 			added[edge.To] = struct{}{}
-			matched = true
 			continue
 		}
-
+		if edge.Route == Default {
+			defaultRouteNode = edge.To
+			continue
+		}
 		if edge.Route.Matches(event) {
 			queue = append(queue, nodeInput{node: edge.To, input: input})
 			added[edge.To] = struct{}{}
 			matched = true
 		}
 	}
-	if !matched {
-		return nil, fmt.Errorf("no outgoing edge matches the event with routes %v emitted by node %s", event.Routes, currentNode.Name())
+	if !matched && defaultRouteNode != nil {
+		queue = append(queue, nodeInput{node: defaultRouteNode, input: input})
 	}
-	return queue, nil
+
+	return queue
 }
 
 func (w *Workflow) Run(ctx agent.InvocationContext) iter.Seq2[*session.Event, error] {
@@ -295,11 +306,7 @@ func (w *Workflow) Run(ctx agent.InvocationContext) iter.Seq2[*session.Event, er
 			if currentNode != Start {
 				input = outputData
 			}
-			nextNodes, err := w.findNextNodes(currentNode, input, event)
-			if err != nil {
-				yield(nil, err)
-				return
-			}
+			nextNodes := w.findNextNodes(currentNode, input, event)
 			queue = append(queue, nextNodes...)
 		}
 	}

--- a/workflow/workflow.go
+++ b/workflow/workflow.go
@@ -177,12 +177,15 @@ type Workflow struct {
 }
 
 // New creates a new Workflow engine with the given edges.
-func New(edges []Edge) *Workflow {
+func New(edges []Edge) (*Workflow, error) {
+	if err := validateUniqueNames(edges); err != nil {
+		return nil, err
+	}
 	adj := make(map[Node][]Edge)
 	for _, edge := range edges {
 		adj[edge.From] = append(adj[edge.From], edge)
 	}
-	return &Workflow{edges: adj}
+	return &Workflow{edges: adj}, nil
 }
 
 type nodeInput struct {

--- a/workflow/workflow.go
+++ b/workflow/workflow.go
@@ -27,11 +27,15 @@ import (
 )
 
 // Node is the interface for all nodes in a workflow.
+//
+// Custom nodes typically embed BaseNode (constructed via NewBaseNode)
+// to inherit Name, Description, and Config implementations, and
+// supply only Run.
 type Node interface {
 	Name() string
 	Description() string
-	Run(ctx agent.InvocationContext, input any) iter.Seq2[*session.Event, error]
 	Config() NodeConfig
+	Run(ctx agent.InvocationContext, input any) iter.Seq2[*session.Event, error]
 }
 
 // Route defines the interface for matching execution results to edges.
@@ -90,25 +94,21 @@ func (r *defaultRoute) Matches(event *session.Event) bool {
 	return false
 }
 
-// baseNode provides common fields for all nodes.
-type baseNode struct {
-	name        string
-	description string
-	config      NodeConfig
-}
-
-func (b *baseNode) Name() string        { return b.name }
-func (b *baseNode) Description() string { return b.description }
-func (b *baseNode) Config() NodeConfig  { return b.config }
-
 // FunctionNode wraps a custom function.
 type FunctionNode struct {
-	baseNode
+	BaseNode
 	fn func(ctx agent.InvocationContext, input any) (any, error)
 }
 
-// NewFunctionNode creates a new node wrapping a custom function using generics to automatically infer input and output types.
-func NewFunctionNode[IN, OUT any](name string, fn func(ctx agent.InvocationContext, input IN) (OUT, error), cfg NodeConfig) *FunctionNode {
+// NewFunctionNode creates a new node wrapping a custom function. The
+// IN and OUT type parameters are inferred from the function signature
+// by the compiler. The cfg argument carries per-node knobs (retry,
+// timeout, fan-in barrier); pass NodeConfig{} for defaults.
+func NewFunctionNode[IN any, OUT any](
+	name string,
+	fn func(ctx agent.InvocationContext, input IN) (OUT, error),
+	cfg NodeConfig,
+) *FunctionNode {
 	wrappedFn := func(ctx agent.InvocationContext, input any) (any, error) {
 		if input == nil {
 			var zero IN
@@ -128,7 +128,7 @@ func NewFunctionNode[IN, OUT any](name string, fn func(ctx agent.InvocationConte
 	}
 
 	return &FunctionNode{
-		baseNode: baseNode{name: name, config: cfg},
+		BaseNode: NewBaseNode(name, "", cfg),
 		fn:       wrappedFn,
 	}
 }
@@ -166,14 +166,14 @@ type startNode struct{}
 
 func (s *startNode) Name() string        { return "START" }
 func (s *startNode) Description() string { return "Start node" }
+func (s *startNode) Config() NodeConfig  { return NodeConfig{} }
 func (s *startNode) Run(ctx agent.InvocationContext, input any) iter.Seq2[*session.Event, error] {
 	return func(yield func(*session.Event, error) bool) {}
 }
-func (s *startNode) Config() NodeConfig { return NodeConfig{} }
 
 // Workflow manages the workflow graph execution.
 type Workflow struct {
-	edges map[Node][]Edge
+	graph *graph
 }
 
 // New creates a new Workflow engine with the given edges.
@@ -181,119 +181,51 @@ func New(edges []Edge) (*Workflow, error) {
 	if err := validateNodes(edges); err != nil {
 		return nil, err
 	}
-	adj := make(map[Node][]Edge)
-	for _, edge := range edges {
-		adj[edge.From] = append(adj[edge.From], edge)
-	}
-	return &Workflow{edges: adj}, nil
+	return &Workflow{graph: newGraph(edges)}, nil
 }
 
-type nodeInput struct {
-	node  Node
-	input any
-}
-
-// findNextNodes determines the set of nodes to execute next based on the outgoing edges of the currentNode.
-// It evaluates routes attached to edges against the provided session.Event.
+// Run drives the workflow to completion (or to a graceful pause in
+// later milestones). It returns an iter.Seq2 that yields events
+// from per-node goroutines in arrival order; the caller may break
+// from the range loop at any point and the engine will cancel all
+// in-flight nodes before returning.
 //
-// Behavior:
-//   - Edges with no route condition always match.
-//   - Edges with a route condition match only if the route matches the event.
-//   - Duplicate target nodes are excluded to avoid queuing the same node multiple times.
-//   - If there are outgoing edges but none of them match (neither by route nor by being unrouted),
-//     it falls back to the default route (TODO: hanorik - add default route support).
-func (w *Workflow) findNextNodes(currentNode Node, input any, event *session.Event) []nodeInput {
-	if len(w.edges[currentNode]) == 0 {
-		return nil
-	}
-	matched := false
-	queue := []nodeInput{}
-	added := make(map[Node]struct{})
-	var defaultRouteNode Node
-	for _, edge := range w.edges[currentNode] {
-		if _, ok := added[edge.To]; ok {
-			continue
-		}
-		if edge.Route == nil {
-			queue = append(queue, nodeInput{node: edge.To, input: input})
-			added[edge.To] = struct{}{}
-			continue
-		}
-		if edge.Route == Default {
-			defaultRouteNode = edge.To
-			continue
-		}
-		if edge.Route.Matches(event) {
-			queue = append(queue, nodeInput{node: edge.To, input: input})
-			added[edge.To] = struct{}{}
-			matched = true
-		}
-	}
-	if !matched && defaultRouteNode != nil {
-		queue = append(queue, nodeInput{node: defaultRouteNode, input: input})
-	}
-
-	return queue
-}
-
-// Run executes the workflow.
+// The engine model: each scheduled node runs in its own goroutine
+// pushing events into a buffered channel. A single consumer
+// goroutine (this one) drains the channel, applies state-side
+// effects, yields events to the caller, and schedules successors
+// when nodes complete. The consumer is the only mutator of the
+// per-node lifecycle map and of session state.
 func (w *Workflow) Run(ctx agent.InvocationContext) iter.Seq2[*session.Event, error] {
 	return func(yield func(*session.Event, error) bool) {
-		var input any
-		userContent := ctx.UserContent()
-		if userContent != nil {
-			var sb strings.Builder
-			for _, part := range userContent.Parts {
-				if part.Text != "" {
-					sb.WriteString(part.Text)
-				}
-			}
-			input = sb.String()
-		}
+		input := userInput(ctx)
 
-		queue := []nodeInput{{Start, input}}
+		s := newScheduler(ctx, w.graph)
+		// Seed: schedule START with the user-supplied input.
+		startState := s.state.EnsureNode(Start.Name())
+		startState.Input = input
+		s.scheduleNode(Start, input, "")
 
-		for len(queue) > 0 {
-			currentNode := queue[0].node
-			input = queue[0].input
-			queue = queue[1:]
+		s.run(yield)
 
-			var eventsWithRoutes []*session.Event
-			var outputData any
-			for ev, err := range currentNode.Run(ctx, input) {
-				if err != nil {
-					yield(nil, err)
-					return
-				}
-				if !yield(ev, nil) {
-					return
-				}
+		// All goroutines have returned; ensure no leak.
+		s.wg.Wait()
+	}
+}
 
-				if ev.Routes != nil {
-					eventsWithRoutes = append(eventsWithRoutes, ev)
-				}
-
-				// Extract output for next node
-				if ev.Actions.StateDelta != nil {
-					if out, ok := ev.Actions.StateDelta["output"]; ok {
-						outputData = out
-					}
-				}
-			}
-
-			if len(eventsWithRoutes) > 1 {
-				yield(nil, fmt.Errorf("node %s produced multiple events with route tags. Only one event per execution can specify routes", currentNode.Name()))
-				return
-			}
-			var event *session.Event
-			if len(eventsWithRoutes) == 1 {
-				event = eventsWithRoutes[0]
-			}
-			if currentNode != Start {
-				input = outputData
-			}
-			nextNodes := w.findNextNodes(currentNode, input, event)
-			queue = append(queue, nextNodes...)
+// userInput extracts the workflow's seed input from the
+// InvocationContext's UserContent. Concatenates all text parts;
+// returns nil for an empty UserContent.
+func userInput(ctx agent.InvocationContext) any {
+	uc := ctx.UserContent()
+	if uc == nil {
+		return nil
+	}
+	var sb strings.Builder
+	for _, part := range uc.Parts {
+		if part.Text != "" {
+			sb.WriteString(part.Text)
 		}
 	}
+	return sb.String()
 }

--- a/workflow/workflow.go
+++ b/workflow/workflow.go
@@ -31,6 +31,7 @@ type Node interface {
 	Name() string
 	Description() string
 	Run(ctx agent.InvocationContext, input any) iter.Seq2[*session.Event, error]
+	Config() NodeConfig
 }
 
 // Route defines the interface for matching execution results to edges.
@@ -47,18 +48,21 @@ func matchRoute(routeValue string, event *session.Event) bool {
 	return false
 }
 
+// StringRoute is a route defined by a string value.
 type StringRoute string
 
 func (r StringRoute) Matches(event *session.Event) bool {
 	return matchRoute(string(r), event)
 }
 
+// IntRoute is a route defined by an integer value.
 type IntRoute int
 
 func (r IntRoute) Matches(event *session.Event) bool {
 	return matchRoute(fmt.Sprint(r), event)
 }
 
+// BoolRoute is a route defined by a boolean value.
 type BoolRoute bool
 
 func (r BoolRoute) Matches(event *session.Event) bool {
@@ -90,10 +94,12 @@ func (r *defaultRoute) Matches(event *session.Event) bool {
 type baseNode struct {
 	name        string
 	description string
+	config      NodeConfig
 }
 
 func (b *baseNode) Name() string        { return b.name }
 func (b *baseNode) Description() string { return b.description }
+func (b *baseNode) Config() NodeConfig  { return b.config }
 
 // FunctionNode wraps a custom function.
 type FunctionNode struct {
@@ -102,7 +108,7 @@ type FunctionNode struct {
 }
 
 // NewFunctionNode creates a new node wrapping a custom function using generics to automatically infer input and output types.
-func NewFunctionNode[IN, OUT any](name string, fn func(ctx agent.InvocationContext, input IN) (OUT, error)) *FunctionNode {
+func NewFunctionNode[IN, OUT any](name string, fn func(ctx agent.InvocationContext, input IN) (OUT, error), cfg NodeConfig) *FunctionNode {
 	wrappedFn := func(ctx agent.InvocationContext, input any) (any, error) {
 		if input == nil {
 			var zero IN
@@ -120,8 +126,9 @@ func NewFunctionNode[IN, OUT any](name string, fn func(ctx agent.InvocationConte
 		}
 		return fn(ctx, typedInput)
 	}
+
 	return &FunctionNode{
-		baseNode: baseNode{name: name},
+		baseNode: baseNode{name: name, config: cfg},
 		fn:       wrappedFn,
 	}
 }
@@ -162,6 +169,7 @@ func (s *startNode) Description() string { return "Start node" }
 func (s *startNode) Run(ctx agent.InvocationContext, input any) iter.Seq2[*session.Event, error] {
 	return func(yield func(*session.Event, error) bool) {}
 }
+func (s *startNode) Config() NodeConfig { return NodeConfig{} }
 
 // Workflow manages the workflow graph execution.
 type Workflow struct {
@@ -225,6 +233,7 @@ func (w *Workflow) findNextNodes(currentNode Node, input any, event *session.Eve
 	return queue
 }
 
+// Run executes the workflow.
 func (w *Workflow) Run(ctx agent.InvocationContext) iter.Seq2[*session.Event, error] {
 	return func(yield func(*session.Event, error) bool) {
 		var input any
@@ -270,7 +279,7 @@ func (w *Workflow) Run(ctx agent.InvocationContext) iter.Seq2[*session.Event, er
 			}
 
 			if len(eventsWithRoutes) > 1 {
-				yield(nil, fmt.Errorf("node %s produced multiple events with route tags. Only one event per execution can specify routes.", currentNode.Name()))
+				yield(nil, fmt.Errorf("node %s produced multiple events with route tags. Only one event per execution can specify routes", currentNode.Name()))
 				return
 			}
 			var event *session.Event

--- a/workflow/workflow.go
+++ b/workflow/workflow.go
@@ -152,32 +152,6 @@ type Edge struct {
 	Route Route // Routing condition
 }
 
-// Chain generates a slice of Edges to form a chain of nodes.
-func Chain(nodes ...Node) []Edge {
-	if len(nodes) < 2 {
-		return nil
-	}
-	edges := make([]Edge, len(nodes)-1)
-	for i := 0; i < len(nodes)-1; i++ {
-		edges[i] = Edge{From: nodes[i], To: nodes[i+1]}
-	}
-	return edges
-}
-
-// Concat combines Edges and []Edge slices into a single slice of edges.
-func Concat(items ...any) []Edge {
-	var edges []Edge
-	for _, item := range items {
-		switch v := item.(type) {
-		case Edge:
-			edges = append(edges, v)
-		case []Edge:
-			edges = append(edges, v...)
-		}
-	}
-	return edges
-}
-
 // Start is a sentinel node used to indicate the entry point of the workflow.
 var Start Node = &startNode{}
 

--- a/workflow/workflow.go
+++ b/workflow/workflow.go
@@ -113,25 +113,56 @@ func (s *startNode) Run(ctx agent.InvocationContext, input any) iter.Seq2[*sessi
 // Workflow manages the workflow graph execution.
 type Workflow struct {
 	graph *graph
+
+	// name is the per-session-unique identifier under which this
+	// workflow's RunState is persisted in session.State. Empty
+	// disables persistence. Set at construction by New.
+	name string
 }
 
-// New creates a new Workflow engine with the given edges.
-func New(edges []Edge) (*Workflow, error) {
+// New creates a new Workflow engine with the given name and edges.
+//
+// The name forms part of the session.State key under which this
+// workflow's RunState is persisted (see RunStateSessionKey for
+// the exact key shape). It must be unique within any session that
+// runs more than one workflow: two workflows sharing a name and a
+// session will silently overwrite each other's RunState, leading
+// to corrupted resume behaviour. The same workflow may safely
+// share a name across different sessions.
+//
+// An empty name disables persistence: the workflow runs normally
+// but its RunState is neither saved nor loaded, so Resume on a
+// follow-up turn will find nothing to resume from.
+func New(name string, edges []Edge) (*Workflow, error) {
 	if err := validateNodes(edges); err != nil {
 		return nil, err
 	}
+	// TODO(wolo): sanity-check name (reject whitespace-only,
+	// reject characters that break the session.State key shape).
+	// TODO(wolo): record a graph fingerprint (e.g. sorted node
+	// names hash) on the Workflow and verify it against any
+	// loaded RunState in Resume; today a name collision or a
+	// graph evolution between deploys silently corrupts the
+	// resume path.
 	graph := newGraph(edges)
 	if err := validateWorkflow(graph); err != nil {
 		return nil, err
 	}
-	return &Workflow{graph: graph}, nil
+	return &Workflow{graph: graph, name: name}, nil
 }
 
-// Run drives the workflow to completion (or to a graceful pause in
-// later milestones). It returns an iter.Seq2 that yields events
-// from per-node goroutines in arrival order; the caller may break
-// from the range loop at any point and the engine will cancel all
-// in-flight nodes before returning.
+// Name returns the workflow's persistence-namespacing name as set
+// by New. Empty when the workflow is anonymous (does not persist
+// its RunState).
+func (w *Workflow) Name() string {
+	return w.name
+}
+
+// Run drives the workflow to completion or to a graceful pause
+// when any node enters NodeWaiting. It returns an iter.Seq2 that
+// yields events from per-node goroutines in arrival order; the
+// caller may break from the range loop at any point and the
+// engine will cancel all in-flight nodes before returning.
 //
 // The engine model: each scheduled node runs in its own goroutine
 // pushing events into a buffered channel. A single consumer
@@ -153,7 +184,38 @@ func (w *Workflow) Run(ctx agent.InvocationContext) iter.Seq2[*session.Event, er
 
 		// All goroutines have returned; ensure no leak.
 		s.wg.Wait()
+
+		// Persist the run state so a follow-up turn can call
+		// Workflow.Resume with the recovered NodeWaiting set.
+		// Emitted as a session.Event with StateDelta so the
+		// surrounding event-append pipeline can propagate it to
+		// storage; see NewRunStateEvent for why a direct
+		// State.Set is not sufficient.
+		yieldRunStateEvent(ctx, w.name, s.state, yield)
 	}
+}
+
+// yieldRunStateEvent emits a session.Event carrying the workflow's
+// serialised RunState in Actions.StateDelta. No-op when the
+// workflow is anonymous (no name → no persistence) or when the
+// caller has stopped consuming the iterator. See NewRunStateEvent
+// for why the state must be delivered as an event rather than via
+// a direct State.Set call.
+func yieldRunStateEvent(
+	ctx agent.InvocationContext,
+	workflowName string,
+	state *RunState,
+	yield func(*session.Event, error) bool,
+) {
+	ev, err := NewRunStateEvent(ctx.InvocationID(), workflowName, state)
+	if err != nil {
+		yield(nil, err)
+		return
+	}
+	if ev == nil {
+		return
+	}
+	yield(ev, nil)
 }
 
 // userInput extracts the workflow's seed input from the

--- a/workflow/workflow.go
+++ b/workflow/workflow.go
@@ -178,7 +178,7 @@ type Workflow struct {
 
 // New creates a new Workflow engine with the given edges.
 func New(edges []Edge) (*Workflow, error) {
-	if err := validateUniqueNames(edges); err != nil {
+	if err := validateNodes(edges); err != nil {
 		return nil, err
 	}
 	adj := make(map[Node][]Edge)

--- a/workflow/workflow.go
+++ b/workflow/workflow.go
@@ -19,10 +19,7 @@ import (
 	"iter"
 	"strings"
 
-	"google.golang.org/genai"
-
 	"google.golang.org/adk/agent"
-	"google.golang.org/adk/internal/typeutil"
 	"google.golang.org/adk/session"
 )
 
@@ -92,64 +89,6 @@ type defaultRoute struct{}
 
 func (r *defaultRoute) Matches(event *session.Event) bool {
 	return false
-}
-
-// FunctionNode wraps a custom function.
-type FunctionNode struct {
-	BaseNode
-	fn func(ctx agent.InvocationContext, input any) (any, error)
-}
-
-// NewFunctionNode creates a new node wrapping a custom function. The
-// IN and OUT type parameters are inferred from the function signature
-// by the compiler. The cfg argument carries per-node knobs (retry,
-// timeout, fan-in barrier); pass NodeConfig{} for defaults.
-func NewFunctionNode[IN any, OUT any](
-	name string,
-	fn func(ctx agent.InvocationContext, input IN) (OUT, error),
-	cfg NodeConfig,
-) *FunctionNode {
-	wrappedFn := func(ctx agent.InvocationContext, input any) (any, error) {
-		if input == nil {
-			var zero IN
-			return fn(ctx, zero)
-		}
-		typedInput, ok := input.(IN)
-		if !ok {
-			// Fallback to the json-like input types that cannot be converted by the standard type assertion.
-			// E.g. tool nodes return map[string]any as input and user may define a struct as the target type.
-			var err error
-			typedInput, err = typeutil.ConvertToWithJSONSchema[any, IN](input, nil)
-			if err != nil {
-				return nil, fmt.Errorf("new function node: invalid input type, expected %T: %v", new(IN), err)
-			}
-		}
-		return fn(ctx, typedInput)
-	}
-
-	return &FunctionNode{
-		BaseNode: NewBaseNode(name, "", cfg),
-		fn:       wrappedFn,
-	}
-}
-
-func (n *FunctionNode) Run(ctx agent.InvocationContext, input any) iter.Seq2[*session.Event, error] {
-	return func(yield func(*session.Event, error) bool) {
-		output, err := n.fn(ctx, input)
-		if err != nil {
-			yield(nil, err)
-			return
-		}
-
-		event := session.NewEvent(ctx.InvocationID())
-		event.Actions.StateDelta["output"] = output
-		if s, ok := output.(string); ok {
-			event.Content = &genai.Content{
-				Parts: []*genai.Part{{Text: s}},
-			}
-		}
-		yield(event, nil)
-	}
 }
 
 // Edge defines a directed connection between nodes in the workflow graph.

--- a/workflow/workflow.go
+++ b/workflow/workflow.go
@@ -34,17 +34,34 @@ type Node interface {
 
 // Route defines the interface for matching execution results to edges.
 type Route interface {
-	Matches(output any) bool
+	Matches(event *session.Event) bool
 }
 
-// StringRoute matches an exact string value.
-type StringRoute struct {
-	Value string
+func matchRoute(routeValue string, event *session.Event) bool {
+	for _, v := range event.Routes {
+		if v == routeValue {
+			return true
+		}
+	}
+	return false
 }
 
-func (r StringRoute) Matches(output any) bool {
-	s, ok := output.(string)
-	return ok && s == r.Value
+type StringRoute string
+
+func (r StringRoute) Matches(event *session.Event) bool {
+	return matchRoute(string(r), event)
+}
+
+type IntRoute int
+
+func (r IntRoute) Matches(event *session.Event) bool {
+	return matchRoute(fmt.Sprint(r), event)
+}
+
+type BoolRoute bool
+
+func (r BoolRoute) Matches(event *session.Event) bool {
+	return matchRoute(fmt.Sprint(r), event)
 }
 
 // baseNode provides common fields for all nodes.
@@ -77,7 +94,7 @@ func NewFunctionNode[IN any, OUT any](name string, fn func(ctx agent.InvocationC
 	}
 	return &FunctionNode{
 		baseNode: baseNode{name: name},
-		fn:        wrappedFn,
+		fn:       wrappedFn,
 	}
 }
 
@@ -88,7 +105,7 @@ func (n *FunctionNode) Run(ctx agent.InvocationContext, input any) iter.Seq2[*se
 			yield(nil, err)
 			return
 		}
-		
+
 		event := session.NewEvent(ctx.InvocationID())
 		event.Actions.StateDelta["output"] = output
 		if s, ok := output.(string); ok {
@@ -148,29 +165,55 @@ const DEFAULT_ROUTE = "__DEFAULT__"
 
 // Workflow manages the workflow graph execution.
 type Workflow struct {
-	edges []Edge
+	edges map[Node][]Edge
 }
 
 // New creates a new Workflow engine with the given edges.
 func New(edges []Edge) *Workflow {
-	return &Workflow{edges: edges}
+	adj := make(map[Node][]Edge)
+	for _, edge := range edges {
+		adj[edge.From] = append(adj[edge.From], edge)
+	}
+	return &Workflow{edges: adj}
+}
+
+type nodeInput struct {
+	node  Node
+	input any
+}
+
+func (w *Workflow) findNextNodes(currentNode Node, input any, event *session.Event) ([]nodeInput, error) {
+	if len(w.edges[currentNode]) == 0 {
+		return nil, nil
+	}
+	matched := false
+	queue := []nodeInput{}
+	added := make(map[Node]struct{})
+	for _, edge := range w.edges[currentNode] {
+		if _, ok := added[edge.To]; ok {
+			continue
+		}
+		if edge.Route == nil {
+			queue = append(queue, nodeInput{node: edge.To, input: input})
+			added[edge.To] = struct{}{}
+			matched = true
+			continue
+		}
+
+		if edge.Route.Matches(event) {
+			queue = append(queue, nodeInput{node: edge.To, input: input})
+			added[edge.To] = struct{}{}
+			matched = true
+		}
+	}
+	if !matched {
+		return nil, fmt.Errorf("no outgoing edge matches the event with routes %v emitted by node %s", event.Routes, currentNode.Name())
+	}
+	return queue, nil
 }
 
 func (w *Workflow) Run(ctx agent.InvocationContext) iter.Seq2[*session.Event, error] {
 	return func(yield func(*session.Event, error) bool) {
-		var currentNode Node
-		for _, edge := range w.edges {
-			if edge.From == Start {
-				currentNode = edge.To
-				break
-			}
-		}
-
-		if currentNode == nil {
-			yield(nil, fmt.Errorf("no start node found"))
-			return
-		}
-
 		var input any
 		userContent := ctx.UserContent()
 		if userContent != nil {
@@ -183,7 +226,15 @@ func (w *Workflow) Run(ctx agent.InvocationContext) iter.Seq2[*session.Event, er
 			input = sb.String()
 		}
 
-		for currentNode != nil {
+		queue := []nodeInput{{Start, input}}
+
+		for len(queue) > 0 {
+			currentNode := queue[0].node
+			input = queue[0].input
+			queue = queue[1:]
+
+			var eventsWithRoutes []*session.Event
+			var outputData any
 			for ev, err := range currentNode.Run(ctx, input) {
 				if err != nil {
 					yield(nil, err)
@@ -193,23 +244,35 @@ func (w *Workflow) Run(ctx agent.InvocationContext) iter.Seq2[*session.Event, er
 					return
 				}
 
+				if ev.Routes != nil {
+					eventsWithRoutes = append(eventsWithRoutes, ev)
+				}
+
 				// Extract output for next node
 				if ev.Actions.StateDelta != nil {
 					if out, ok := ev.Actions.StateDelta["output"]; ok {
-						input = out
+						outputData = out
 					}
 				}
 			}
 
-			// Find next node (assuming linear chain for now)
-			var nextNode Node
-			for _, edge := range w.edges {
-				if edge.From == currentNode {
-					nextNode = edge.To
-					break
-				}
+			if len(eventsWithRoutes) > 1 {
+				yield(nil, fmt.Errorf("node %s produced multiple events with route tags. Only one event per execution can specify routes.", currentNode.Name()))
+				return
 			}
-			currentNode = nextNode
+			var event *session.Event
+			if len(eventsWithRoutes) == 1 {
+				event = eventsWithRoutes[0]
+			}
+			if currentNode != Start {
+				input = outputData
+			}
+			nextNodes, err := w.findNextNodes(currentNode, input, event)
+			if err != nil {
+				yield(nil, err)
+				return
+			}
+			queue = append(queue, nextNodes...)
 		}
 	}
 }

--- a/workflow/workflow.go
+++ b/workflow/workflow.go
@@ -191,10 +191,13 @@ func (w *Workflow) Run(ctx agent.InvocationContext) iter.Seq2[*session.Event, er
 		input := userInput(ctx)
 
 		s := newScheduler(ctx, w.graph)
-		// Seed: schedule START with the user-supplied input.
+		// Seed: schedule START with the user-supplied input. START
+		// itself runs at the workflow's root branch (inherits
+		// ctx.Branch()); its successors derive sub-branches when
+		// the START fan-out has more than one edge.
 		startState := s.state.EnsureNode(Start.Name())
 		startState.Input = input
-		s.scheduleNode(Start, input, "")
+		s.scheduleNode(Start, input, "", ctx.Branch())
 
 		s.run(yield)
 

--- a/workflow/workflow.go
+++ b/workflow/workflow.go
@@ -136,6 +136,38 @@ type Workflow struct {
 	// workflow's RunState is persisted in session.State. Empty
 	// disables persistence. Set at construction by New.
 	name string
+
+	// maxConcurrency caps the number of graph-scheduled nodes that
+	// may run concurrently within a single Run invocation. 0
+	// (the default) means unlimited. Set via WithMaxConcurrency.
+	maxConcurrency int
+}
+
+// Option configures a Workflow at construction time. Pass options
+// as trailing variadic arguments to New.
+type Option func(*workflowOptions)
+
+// workflowOptions holds the resolved settings derived from the
+// caller's Option list. Zero values mean "no override / use
+// engine defaults".
+type workflowOptions struct {
+	maxConcurrency int
+}
+
+// WithMaxConcurrency caps how many graph-scheduled nodes may run
+// concurrently in a single Workflow invocation; nodes beyond the
+// cap queue as NodePending. n <= 0 disables the cap (unlimited).
+//
+// Does NOT apply to dynamic sub-nodes invoked via workflow.RunNode
+// from inside a DynamicNode body — they are awaited inline by the
+// parent and gating them would deadlock.
+func WithMaxConcurrency(n int) Option {
+	return func(o *workflowOptions) {
+		if n < 0 {
+			n = 0
+		}
+		o.maxConcurrency = n
+	}
 }
 
 // New creates a new Workflow engine with the given name and edges.
@@ -151,7 +183,10 @@ type Workflow struct {
 // An empty name disables persistence: the workflow runs normally
 // but its RunState is neither saved nor loaded, so Resume on a
 // follow-up turn will find nothing to resume from.
-func New(name string, edges []Edge) (*Workflow, error) {
+//
+// Optional Option values configure engine behaviour
+// (concurrency cap, etc.); see WithMaxConcurrency.
+func New(name string, edges []Edge, opts ...Option) (*Workflow, error) {
 	if err := validateNodes(edges); err != nil {
 		return nil, err
 	}
@@ -169,7 +204,15 @@ func New(name string, edges []Edge) (*Workflow, error) {
 	if err := validateWorkflow(graph); err != nil {
 		return nil, err
 	}
-	return &Workflow{graph: graph, name: name}, nil
+	var o workflowOptions
+	for _, opt := range opts {
+		opt(&o)
+	}
+	return &Workflow{
+		graph:          graph,
+		name:           name,
+		maxConcurrency: o.maxConcurrency,
+	}, nil
 }
 
 // Name returns the workflow's persistence-namespacing name as set
@@ -199,7 +242,7 @@ func (w *Workflow) Run(ctx agent.InvocationContext) iter.Seq2[*session.Event, er
 // This is used by WorkflowNode to run nested workflows.
 func (w *Workflow) RunNode(ctx agent.InvocationContext, input any) iter.Seq2[*session.Event, error] {
 	return func(yield func(*session.Event, error) bool) {
-		s := newScheduler(ctx, w.graph)
+		s := newScheduler(ctx, w.graph, w.maxConcurrency)
 		// Seed: schedule START with the supplied input.
 		startState := s.state.EnsureNode(Start.Name())
 		startState.Input = input

--- a/workflow/workflow.go
+++ b/workflow/workflow.go
@@ -19,6 +19,7 @@ import (
 	"iter"
 	"strings"
 
+	"github.com/google/jsonschema-go/jsonschema"
 	"google.golang.org/adk/agent"
 	"google.golang.org/adk/session"
 )
@@ -32,6 +33,16 @@ type Node interface {
 	Name() string
 	Description() string
 	Config() NodeConfig
+	// InputSchema returns the JSON schema for the node's input.
+	// If it returns nil, it indicates there is no schema and no input validation is performed.
+	InputSchema() *jsonschema.Resolved
+	// OutputSchema returns the JSON schema for the node's output.
+	// If it returns nil, it indicates there is no schema and no output validation is performed.
+	OutputSchema() *jsonschema.Resolved
+	// ValidateInput validates and optionally coerces/transforms the input before the node runs.
+	// It returns the validated input (which might be coerced/parsed/transformed) or an error.
+	// It will be called by the scheduler before Run on every activation.
+	ValidateInput(input any) (any, error)
 	Run(ctx agent.InvocationContext, input any) iter.Seq2[*session.Event, error]
 }
 
@@ -103,9 +114,14 @@ var Start Node = &startNode{}
 
 type startNode struct{}
 
-func (s *startNode) Name() string        { return "START" }
-func (s *startNode) Description() string { return "Start node" }
-func (s *startNode) Config() NodeConfig  { return NodeConfig{} }
+func (s *startNode) Name() string                       { return "START" }
+func (s *startNode) Description() string                { return "Start node" }
+func (s *startNode) Config() NodeConfig                 { return NodeConfig{} }
+func (s *startNode) InputSchema() *jsonschema.Resolved  { return nil }
+func (s *startNode) OutputSchema() *jsonschema.Resolved { return nil }
+func (s *startNode) ValidateInput(input any) (any, error) {
+	return input, nil
+}
 func (s *startNode) Run(ctx agent.InvocationContext, input any) iter.Seq2[*session.Event, error] {
 	return func(yield func(*session.Event, error) bool) {}
 }

--- a/workflow/workflow.go
+++ b/workflow/workflow.go
@@ -20,6 +20,7 @@ import (
 	"strings"
 
 	"github.com/google/jsonschema-go/jsonschema"
+
 	"google.golang.org/adk/agent"
 	"google.golang.org/adk/session"
 )
@@ -122,6 +123,7 @@ func (s *startNode) OutputSchema() *jsonschema.Resolved { return nil }
 func (s *startNode) ValidateInput(input any) (any, error) {
 	return input, nil
 }
+
 func (s *startNode) Run(ctx agent.InvocationContext, input any) iter.Seq2[*session.Event, error] {
 	return func(yield func(*session.Event, error) bool) {}
 }
@@ -151,6 +153,9 @@ type Workflow struct {
 // follow-up turn will find nothing to resume from.
 func New(name string, edges []Edge) (*Workflow, error) {
 	if err := validateNodes(edges); err != nil {
+		return nil, err
+	}
+	if err := validateSubWorkflowNames(name, edges); err != nil {
 		return nil, err
 	}
 	// TODO(wolo): sanity-check name (reject whitespace-only,
@@ -187,14 +192,15 @@ func (w *Workflow) Name() string {
 // when nodes complete. The consumer is the only mutator of the
 // per-node lifecycle map and of session state.
 func (w *Workflow) Run(ctx agent.InvocationContext) iter.Seq2[*session.Event, error] {
-	return func(yield func(*session.Event, error) bool) {
-		input := userInput(ctx)
+	return w.RunNode(ctx, userInput(ctx))
+}
 
+// RunNode drives the workflow with the given input.
+// This is used by WorkflowNode to run nested workflows.
+func (w *Workflow) RunNode(ctx agent.InvocationContext, input any) iter.Seq2[*session.Event, error] {
+	return func(yield func(*session.Event, error) bool) {
 		s := newScheduler(ctx, w.graph)
-		// Seed: schedule START with the user-supplied input. START
-		// itself runs at the workflow's root branch (inherits
-		// ctx.Branch()); its successors derive sub-branches when
-		// the START fan-out has more than one edge.
+		// Seed: schedule START with the supplied input.
 		startState := s.state.EnsureNode(Start.Name())
 		startState.Input = input
 		s.scheduleNode(Start, input, "", ctx.Branch())

--- a/workflow/workflow.go
+++ b/workflow/workflow.go
@@ -44,6 +44,10 @@ type Node interface {
 	// It returns the validated input (which might be coerced/parsed/transformed) or an error.
 	// It will be called by the scheduler before Run on every activation.
 	ValidateInput(input any) (any, error)
+	// ValidateOutput validates and optionally coerces/transforms an output emitted by the node.
+	// It returns the validated output (which might be coerced/parsed/transformed) or an error.
+	// The scheduler invokes it on every yielded event with a non-nil output, before forwarding it to the consumer.
+	ValidateOutput(output any) (any, error)
 	Run(ctx agent.InvocationContext, input any) iter.Seq2[*session.Event, error]
 }
 
@@ -122,6 +126,9 @@ func (s *startNode) InputSchema() *jsonschema.Resolved  { return nil }
 func (s *startNode) OutputSchema() *jsonschema.Resolved { return nil }
 func (s *startNode) ValidateInput(input any) (any, error) {
 	return input, nil
+}
+func (s *startNode) ValidateOutput(output any) (any, error) {
+	return output, nil
 }
 
 func (s *startNode) Run(ctx agent.InvocationContext, input any) iter.Seq2[*session.Event, error] {

--- a/workflow/workflow_node.go
+++ b/workflow/workflow_node.go
@@ -1,0 +1,101 @@
+// Copyright 2026 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package workflow
+
+import (
+	"context"
+	"iter"
+
+	"google.golang.org/adk/agent"
+	"google.golang.org/adk/session"
+)
+
+// WorkflowNode wraps a Workflow to be used as a Node.
+type WorkflowNode struct {
+	BaseNode
+	subWorkflow *Workflow
+}
+
+// NewWorkflowNode creates a new node that runs a nested workflow.
+// It uses the same arguments as New to construct the inner workflow.
+func NewWorkflowNode(name string, edges []Edge) (*WorkflowNode, error) {
+	wf, err := New(name, edges)
+	if err != nil {
+		return nil, err
+	}
+	return &WorkflowNode{
+		BaseNode:    NewBaseNode(name, "", NodeConfig{}),
+		subWorkflow: wf,
+	}, nil
+}
+
+// Run executes the sub-workflow with the given input.
+// It intercepts events from the sub-workflow to ensure that only the final
+// output is yielded to the parent scheduler, preventing ErrMultipleOutputs
+// if intermediate steps also produced outputs.
+func (n *WorkflowNode) Run(ctx agent.InvocationContext, input any) iter.Seq2[*session.Event, error] {
+	return func(yield func(*session.Event, error) bool) {
+		var lastOutput any
+		var pendingErr error
+
+		// Create a cancellable context to signal the sub-workflow to stop on error or break.
+		subCtx, cancel := context.WithCancel(ctx)
+		defer cancel()
+
+		for ev, err := range n.subWorkflow.RunNode(ctx.WithContext(subCtx), input) {
+			if err != nil {
+				pendingErr = err
+				// Signal the sub-workflow to stop execution. We use 'continue' instead of 'break'
+				// to allow the for-range loop to run to completion. This ensures the sub-workflow's scheduler
+				// can finish draining its event queue (avoiding goroutine leaks) without triggering
+				// Go 1.23's panic ("runtime error: range function continued iteration after function for loop body returned false").
+				cancel()
+				continue
+			}
+
+			if ev.Output != nil {
+				lastOutput = ev.Output
+				// Create a shallow copy and clear Output so the parent
+				// scheduler doesn't fail on multiple outputs for this node.
+				evCopy := *ev
+				evCopy.Output = nil
+				if !yield(&evCopy, nil) {
+					// Same as above: cancel and drain to avoid leaks and panics.
+					cancel()
+					continue
+				}
+			} else {
+				if !yield(ev, nil) {
+					// Same as above: cancel and drain to avoid leaks and panics.
+					cancel()
+					continue
+				}
+			}
+		}
+
+		// Yield the error at the very end if one occurred.
+		if pendingErr != nil {
+			yield(nil, pendingErr)
+			return
+		}
+
+		// Yield the final output at the end if we captured any.
+		if lastOutput != nil {
+			event := session.NewEvent(ctx.InvocationID())
+			event.Output = lastOutput
+			yield(event, nil)
+		}
+	}
+}

--- a/workflow/workflow_node_test.go
+++ b/workflow/workflow_node_test.go
@@ -1,0 +1,298 @@
+// Copyright 2026 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package workflow
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"iter"
+	"strings"
+	"sync"
+	"testing"
+	"time"
+
+	"google.golang.org/genai"
+
+	"google.golang.org/adk/agent"
+	"google.golang.org/adk/session"
+)
+
+type mockWorkflowState struct {
+	data map[string]any
+}
+
+func (m *mockWorkflowState) Get(k string) (any, error) {
+	v, ok := m.data[k]
+	if !ok {
+		return nil, session.ErrStateKeyNotExist
+	}
+	return v, nil
+}
+
+func (m *mockWorkflowState) Set(k string, v any) error {
+	if m.data == nil {
+		m.data = make(map[string]any)
+	}
+	m.data[k] = v
+	return nil
+}
+
+func (m *mockWorkflowState) All() iter.Seq2[string, any] { return nil }
+
+type mockWorkflowSession struct {
+	state session.State
+}
+
+func (m *mockWorkflowSession) ID() string                { return "test-session" }
+func (m *mockWorkflowSession) AppName() string           { return "test-app" }
+func (m *mockWorkflowSession) UserID() string            { return "test-user" }
+func (m *mockWorkflowSession) State() session.State      { return m.state }
+func (m *mockWorkflowSession) Events() session.Events    { return nil }
+func (m *mockWorkflowSession) LastUpdateTime() time.Time { return time.Now() }
+
+func TestNestedWorkflow(t *testing.T) {
+	// Create inner workflow edges
+	innerFn := func(ctx agent.InvocationContext, input string) (string, error) {
+		return input + "-inner", nil
+	}
+	innerNode := NewFunctionNode("inner_node", innerFn, defaultNodeConfig)
+	innerEdges := Chain(Start, innerNode)
+
+	// Create outer workflow with WorkflowNode
+	wfNode, err := NewWorkflowNode("nested_step", innerEdges)
+	if err != nil {
+		t.Fatalf("failed to create workflow node: %v", err)
+	}
+
+	outerFn := func(ctx agent.InvocationContext, input string) (string, error) {
+		return input + "-outer", nil
+	}
+	outerNode := NewFunctionNode("outer_node", outerFn, defaultNodeConfig)
+
+	outerEdges := Chain(Start, wfNode, outerNode)
+	outerWf := mustNew(t, outerEdges)
+
+	// Run outer workflow
+	mockCtx := newMockCtx(t)
+	mockCtx.userContent = &genai.Content{
+		Parts: []*genai.Part{{Text: "input"}},
+	}
+
+	events := outerWf.Run(mockCtx)
+
+	var lastOutput any
+	for ev, err := range events {
+		if err != nil {
+			t.Fatalf("unexpected error: %v", err)
+		}
+		if ev.Output != nil {
+			lastOutput = ev.Output
+		}
+	}
+
+	if lastOutput != "input-inner-outer" {
+		t.Errorf("expected last output 'input-inner-outer', got %v", lastOutput)
+	}
+}
+
+func TestNestedWorkflow_MultipleOutputs(t *testing.T) {
+	// Create inner workflow edges with two nodes producing outputs
+	innerFn1 := func(ctx agent.InvocationContext, input string) (string, error) {
+		return input + "-inner1", nil
+	}
+	innerFn2 := func(ctx agent.InvocationContext, input string) (string, error) {
+		return input + "-inner2", nil
+	}
+	innerNode1 := NewFunctionNode("inner_node1", innerFn1, defaultNodeConfig)
+	innerNode2 := NewFunctionNode("inner_node2", innerFn2, defaultNodeConfig)
+	innerEdges := Chain(Start, innerNode1, innerNode2)
+
+	// Create outer workflow with WorkflowNode
+	wfNode, err := NewWorkflowNode("nested_step", innerEdges)
+	if err != nil {
+		t.Fatalf("failed to create workflow node: %v", err)
+	}
+
+	outerEdges := Chain(Start, wfNode)
+	outerWf := mustNew(t, outerEdges)
+
+	// Run outer workflow
+	mockCtx := newMockCtx(t)
+	mockCtx.userContent = &genai.Content{
+		Parts: []*genai.Part{{Text: "input"}},
+	}
+
+	events := outerWf.Run(mockCtx)
+
+	var lastOutput any
+	for ev, err := range events {
+		if err != nil {
+			t.Fatalf("unexpected error: %v", err)
+		}
+		if ev.Output != nil {
+			lastOutput = ev.Output
+		}
+	}
+
+	if lastOutput != "input-inner1-inner2" {
+		t.Errorf("expected last output 'input-inner1-inner2', got %v", lastOutput)
+	}
+}
+
+func TestNestedWorkflowUpdatesStateOuterReads(t *testing.T) {
+	// Create inner workflow edges
+	nestedStateUpdater := func(ctx agent.InvocationContext, input string) (string, error) {
+		err := ctx.Session().State().Set("my_key", "my_value")
+		if err != nil {
+			return "", err
+		}
+		return "nested agent finished", nil
+	}
+	nestedNode := NewFunctionNode("nested_state_updater", nestedStateUpdater, defaultNodeConfig)
+	nestedEdges := Chain(Start, nestedNode)
+
+	wfNode, err := NewWorkflowNode("nested_agent", nestedEdges)
+	if err != nil {
+		t.Fatalf("failed to create workflow node: %v", err)
+	}
+
+	// Create outer workflow
+	outerStateReader := func(ctx agent.InvocationContext, input string) (string, error) {
+		val, err := ctx.Session().State().Get("my_key")
+		if err != nil {
+			return "", err
+		}
+		return fmt.Sprintf("Nested agent output: %s, state value: %v", input, val), nil
+	}
+	outerNode := NewFunctionNode("outer_state_reader", outerStateReader, defaultNodeConfig)
+
+	outerEdges := Chain(Start, wfNode, outerNode)
+	outerWf := mustNew(t, outerEdges)
+
+	// Run outer workflow
+	mockCtx := newMockCtx(t)
+	mockCtx.userContent = &genai.Content{
+		Parts: []*genai.Part{{Text: "input"}},
+	}
+
+	mState := &mockWorkflowState{data: make(map[string]any)}
+	mSess := &mockWorkflowSession{state: mState}
+	mockCtx.sess = mSess
+
+	events := outerWf.Run(mockCtx)
+
+	var lastOutput any
+	for ev, err := range events {
+		if err != nil {
+			t.Fatalf("unexpected error: %v", err)
+		}
+		if ev.Output != nil {
+			lastOutput = ev.Output
+		}
+	}
+
+	expected := "Nested agent output: nested agent finished, state value: my_value"
+	if lastOutput != expected {
+		t.Errorf("expected last output %q, got %q", expected, lastOutput)
+	}
+}
+
+func TestNestedWorkflow_Cancellation(t *testing.T) {
+	// Arrange: Create inner workflow with a node that waits
+	// and the outer workflow that should be cancelled.
+	ch := make(chan struct{})
+	started := make(chan struct{})
+	waitingFn := func(ctx agent.InvocationContext, input string) (string, error) {
+		close(started)
+		select {
+		case <-ctx.Done():
+			return "", ctx.Err()
+		case <-ch:
+			return "done", nil
+		}
+	}
+	waitingNode := NewFunctionNode("waiting_node", waitingFn, defaultNodeConfig)
+	innerEdges := Chain(Start, waitingNode)
+
+	wfNode, err := NewWorkflowNode("nested_agent", innerEdges)
+	if err != nil {
+		t.Fatalf("failed to create workflow node: %v", err)
+	}
+	outerEdges := Chain(Start, wfNode)
+	outerWf := mustNew(t, outerEdges)
+
+	// Act: run the outer workflow with a cancellable context and cancel it.
+	baseCtx, cancel := context.WithCancel(t.Context())
+	mockCtx := &MockInvocationContext{Context: baseCtx}
+
+	var runErr error
+	var wg sync.WaitGroup
+	wg.Add(1)
+	go func() {
+		defer wg.Done()
+		for _, err := range outerWf.Run(mockCtx) {
+			if err != nil {
+				runErr = err
+			}
+		}
+	}()
+	// Wait for the node to start running deterministically
+	<-started
+	cancel()
+	wg.Wait()
+
+	// Assert: run finished without error (cancellation is handled gracefully) and context was cancelled.
+	if runErr != nil {
+		t.Errorf("expected no error on cancellation, got %v", runErr)
+	}
+	if !errors.Is(baseCtx.Err(), context.Canceled) {
+		t.Errorf("expected baseCtx.Err() to be context.Canceled, got %v", baseCtx.Err())
+	}
+}
+
+func TestNestedWorkflow_ErrorPropagation(t *testing.T) {
+	// Create inner workflow with a node that fails
+	failingFn := func(ctx agent.InvocationContext, input string) (string, error) {
+		return "", errors.New("intentional failure")
+	}
+	failingNode := NewFunctionNode("failing_node", failingFn, defaultNodeConfig)
+	innerEdges := Chain(Start, failingNode)
+
+	wfNode, err := NewWorkflowNode("nested_agent", innerEdges)
+	if err != nil {
+		t.Fatalf("failed to create workflow node: %v", err)
+	}
+
+	outerEdges := Chain(Start, wfNode)
+	outerWf := mustNew(t, outerEdges)
+
+	// Run outer workflow
+	mockCtx := newMockCtx(t)
+
+	var runErr error
+	for _, err := range outerWf.Run(mockCtx) {
+		if err != nil {
+			runErr = err
+		}
+	}
+
+	if runErr == nil {
+		t.Fatalf("expected error, got nil")
+	}
+	if !strings.Contains(runErr.Error(), "intentional failure") {
+		t.Errorf("expected error containing 'intentional failure', got %v", runErr)
+	}
+}

--- a/workflow/workflow_test.go
+++ b/workflow/workflow_test.go
@@ -59,11 +59,12 @@ func newSeededMockCtx(t *testing.T) *MockInvocationContext {
 	return ctx
 }
 
-// mustNew builds a workflow from edges and fails the test if
-// construction errors. The returned workflow is ready to Run.
+// mustNew builds an anonymous workflow from edges and fails the
+// test if construction errors. The returned workflow is ready to
+// Run; persistence is disabled.
 func mustNew(t *testing.T, edges []Edge) *Workflow {
 	t.Helper()
-	w, err := New(edges)
+	w, err := New("", edges)
 	if err != nil {
 		t.Fatalf("New: %v", err)
 	}

--- a/workflow/workflow_test.go
+++ b/workflow/workflow_test.go
@@ -1,0 +1,132 @@
+// Copyright 2026 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package workflow
+
+import (
+	"fmt"
+	"strings"
+	"testing"
+
+	"google.golang.org/genai"
+
+	"google.golang.org/adk/agent"
+	"google.golang.org/adk/session"
+)
+
+// MockInvocationContext is a minimal implementation of agent.InvocationContext for testing.
+type MockInvocationContext struct {
+	agent.InvocationContext
+	sess        session.Session
+	userContent *genai.Content
+}
+
+func (m *MockInvocationContext) Session() session.Session {
+	return m.sess
+}
+
+func (m *MockInvocationContext) InvocationID() string {
+	return "test-invocation-id"
+}
+
+func (m *MockInvocationContext) UserContent() *genai.Content {
+	return m.userContent
+}
+
+func TestFunctionNode(t *testing.T) {
+	upperFn := func(ctx agent.InvocationContext, input string) (string, error) {
+		return strings.ToUpper(input), nil
+	}
+
+	node := NewFunctionNode("upper", upperFn)
+
+	// Create a mock context
+	mockCtx := &MockInvocationContext{sess: nil}
+
+	// Run the node
+	events := node.Run(mockCtx, "hello")
+
+	count := 0
+	for ev, err := range events {
+		if err != nil {
+			t.Fatalf("unexpected error: %v", err)
+		}
+		count++
+		
+		output, ok := ev.Actions.StateDelta["output"]
+		if !ok {
+			t.Errorf("expected output in state delta")
+		}
+		if output != "HELLO" {
+			t.Errorf("expected output 'HELLO', got %v", output)
+		}
+	}
+
+	if count != 1 {
+		t.Errorf("expected 1 event, got %d", count)
+	}
+}
+
+func TestSequentialWorkflow(t *testing.T) {
+	upperFn := func(ctx agent.InvocationContext, input any) (string, error) {
+		s, ok := input.(string)
+		if !ok {
+			return "", fmt.Errorf("expected string input")
+		}
+		return strings.ToUpper(s), nil
+	}
+
+	suffixFn := func(ctx agent.InvocationContext, input string) (string, error) {
+		return input + " done", nil
+	}
+
+	nodeA := NewFunctionNode("upper", upperFn)
+	nodeB := NewFunctionNode("suffix", suffixFn)
+
+	edges := Chain(START, nodeA, nodeB)
+
+	w := New(edges)
+
+	mockCtx := &MockInvocationContext{
+		sess: nil,
+		userContent: &genai.Content{
+			Parts: []*genai.Part{{Text: "hello"}},
+		},
+	}
+
+	events := w.Run(mockCtx)
+
+	var lastOutput any
+	count := 0
+	for ev, err := range events {
+		if err != nil {
+			t.Fatalf("unexpected error: %v", err)
+		}
+		count++
+
+		if ev.Actions.StateDelta != nil {
+			if out, ok := ev.Actions.StateDelta["output"]; ok {
+				lastOutput = out
+			}
+		}
+	}
+
+	if count != 2 {
+		t.Errorf("expected 2 events, got %d", count)
+	}
+
+	if lastOutput != "HELLO done" {
+		t.Errorf("expected last output 'HELLO done', got %v", lastOutput)
+	}
+}

--- a/workflow/workflow_test.go
+++ b/workflow/workflow_test.go
@@ -71,17 +71,18 @@ func mustNew(t *testing.T, edges []Edge) *Workflow {
 	return w
 }
 
-func (m *MockInvocationContext) Session() session.Session    { return m.sess }
-func (m *MockInvocationContext) InvocationID() string        { return "test-invocation-id" }
-func (m *MockInvocationContext) UserContent() *genai.Content { return m.userContent }
-func (m *MockInvocationContext) TriggeredBy() string         { return "" }
-func (m *MockInvocationContext) Agent() agent.Agent          { return nil }
-func (m *MockInvocationContext) Artifacts() agent.Artifacts  { return nil }
-func (m *MockInvocationContext) Memory() agent.Memory        { return nil }
-func (m *MockInvocationContext) Branch() string              { return "" }
-func (m *MockInvocationContext) RunConfig() *agent.RunConfig { return nil }
-func (m *MockInvocationContext) Ended() bool                 { return false }
-func (m *MockInvocationContext) EndInvocation()              {}
+func (m *MockInvocationContext) Session() session.Session        { return m.sess }
+func (m *MockInvocationContext) InvocationID() string            { return "test-invocation-id" }
+func (m *MockInvocationContext) UserContent() *genai.Content     { return m.userContent }
+func (m *MockInvocationContext) TriggeredBy() string             { return "" }
+func (m *MockInvocationContext) ResumedInput(string) (any, bool) { return nil, false }
+func (m *MockInvocationContext) Agent() agent.Agent              { return nil }
+func (m *MockInvocationContext) Artifacts() agent.Artifacts      { return nil }
+func (m *MockInvocationContext) Memory() agent.Memory            { return nil }
+func (m *MockInvocationContext) Branch() string                  { return "" }
+func (m *MockInvocationContext) RunConfig() *agent.RunConfig     { return nil }
+func (m *MockInvocationContext) Ended() bool                     { return false }
+func (m *MockInvocationContext) EndInvocation()                  {}
 
 func (m *MockInvocationContext) WithContext(ctx context.Context) agent.InvocationContext {
 	cp := *m

--- a/workflow/workflow_test.go
+++ b/workflow/workflow_test.go
@@ -426,19 +426,15 @@ func TestWorkflowRouting(t *testing.T) {
 			expectedExec: nil,
 		},
 		{
-			name:        "duplicate edges to same node",
-			startRoutes: []string{"branchA"},
+			name:        "MultiRoute with multiple matching routes",
+			startRoutes: []string{"branchA", "branchB"},
 			edges: func(x *CustomRouteNode, a, b *FunctionNode, c *CustomRouteNode, d *FunctionNode) []Edge {
 				return []Edge{
 					{From: Start, To: x},
-					{From: x, To: a},
-					{From: x, To: a, Route: StringRoute("branchA")},
-					{From: x, To: b},
-					{From: x, To: c},
-					{From: c, To: d},
+					{From: x, To: a, Route: MultiRoute[string]{"branchA", "branchB"}},
 				}
 			},
-			expectedExec: []string{"A", "B", "C", "D"},
+			expectedExec: []string{"A"},
 		},
 	}
 

--- a/workflow/workflow_test.go
+++ b/workflow/workflow_test.go
@@ -16,6 +16,7 @@ package workflow
 
 import (
 	"fmt"
+	"iter"
 	"strings"
 	"testing"
 
@@ -128,5 +129,197 @@ func TestSequentialWorkflow(t *testing.T) {
 
 	if lastOutput != "HELLO done" {
 		t.Errorf("expected last output 'HELLO done', got %v", lastOutput)
+	}
+}
+
+func TestStringRoute(t *testing.T) {
+	event := &session.Event{
+		Routes: []string{"hello", "42", "true"},
+	}
+
+	if !StringRoute("hello").Matches(event) {
+		t.Errorf("StringRoute should match")
+	}
+	if StringRoute("world").Matches(event) {
+		t.Errorf("StringRoute should not match")
+	}
+}
+
+func TestIntRoute(t *testing.T) {
+	event := &session.Event{
+		Routes: []string{"hello", "42", "true"},
+	}
+
+	if !IntRoute(42).Matches(event) {
+		t.Errorf("IntRoute should match")
+	}
+	if IntRoute(10).Matches(event) {
+		t.Errorf("IntRoute should not match")
+	}
+}
+
+func TestBoolRoute(t *testing.T) {
+	event := &session.Event{
+		Routes: []string{"hello", "42", "true"},
+	}
+
+	if !BoolRoute(true).Matches(event) {
+		t.Errorf("BoolRoute should match")
+	}
+	if BoolRoute(false).Matches(event) {
+		t.Errorf("BoolRoute should not match")
+	}
+}
+
+type CustomRouteNode struct {
+	baseNode
+	route []string
+	onRun func()
+}
+
+func (n *CustomRouteNode) Run(ctx agent.InvocationContext, input any) iter.Seq2[*session.Event, error] {
+	if n.onRun != nil {
+		n.onRun()
+	}
+	return func(yield func(*session.Event, error) bool) {
+		ev := session.NewEvent(ctx.InvocationID())
+		ev.Routes = n.route
+		yield(ev, nil)
+	}
+}
+
+func TestWorkflowRouting(t *testing.T) {
+	type testTracker struct {
+		executed []string
+	}
+
+	type testCase struct {
+		name           string
+		startRoutes    []string
+		edges          func(nodeStart *CustomRouteNode, nodeA, nodeB *FunctionNode, nodeC *CustomRouteNode, nodeD *FunctionNode) []Edge
+		expectedExec   []string
+		expectErrorMsg string
+	}
+
+	createNodes := func() (*CustomRouteNode, *FunctionNode, *FunctionNode, *CustomRouteNode, *FunctionNode, *testTracker) {
+		tracker := &testTracker{}
+		nodeX := &CustomRouteNode{
+			baseNode: baseNode{name: "X"},
+		}
+		nodeA := NewFunctionNode("A", func(ctx agent.InvocationContext, input any) (string, error) {
+			tracker.executed = append(tracker.executed, "A")
+			return "pathA", nil
+		})
+		nodeB := NewFunctionNode("B", func(ctx agent.InvocationContext, input any) (string, error) {
+			tracker.executed = append(tracker.executed, "B")
+			return "pathB", nil
+		})
+		nodeC := &CustomRouteNode{
+			baseNode: baseNode{name: "C"},
+			route:    []string{"branchD"},
+			onRun: func() {
+				tracker.executed = append(tracker.executed, "C")
+			},
+		}
+		nodeD := NewFunctionNode("D", func(ctx agent.InvocationContext, input any) (string, error) {
+			tracker.executed = append(tracker.executed, "D")
+			return "pathD", nil
+		})
+		return nodeX, nodeA, nodeB, nodeC, nodeD, tracker
+	}
+
+	tests := []testCase{
+		{
+			name:        "all edges don't have routing",
+			startRoutes: []string{"branchA", "branchB"},
+			edges: func(x *CustomRouteNode, a *FunctionNode, b *FunctionNode, c *CustomRouteNode, d *FunctionNode) []Edge {
+				return []Edge{
+					{From: Start, To: x},
+					{From: x, To: a},
+					{From: x, To: b},
+					{From: x, To: c},
+					{From: c, To: d},
+				}
+			},
+			expectedExec: []string{"A", "B", "C", "D"},
+		},
+		{
+			name:        "only one edge has correct routing and the rest have no routing",
+			startRoutes: []string{"branchA"},
+			edges: func(x *CustomRouteNode, a *FunctionNode, b *FunctionNode, c *CustomRouteNode, d *FunctionNode) []Edge {
+				return []Edge{
+					{From: Start, To: x},
+					{From: x, To: a, Route: StringRoute("branchA")},
+					{From: x, To: b},
+					{From: x, To: c},
+					{From: c, To: d},
+				}
+			},
+			expectedExec: []string{"A", "B", "C", "D"},
+		},
+		{
+			name:        "one edge has no routing and the rest have a correct routing",
+			startRoutes: []string{"branchA", "branchB"},
+			edges: func(x *CustomRouteNode, a *FunctionNode, b *FunctionNode, c *CustomRouteNode, d *FunctionNode) []Edge {
+				return []Edge{
+					{From: Start, To: x},
+					{From: x, To: a, Route: StringRoute("branchA")},
+					{From: x, To: b, Route: StringRoute("branchB")},
+					{From: x, To: c},
+					{From: c, To: d, Route: StringRoute("branchD")},
+				}
+			},
+			expectedExec: []string{"A", "B", "C", "D"},
+		},
+		{
+			name:        "any edge has incorrect routing",
+			startRoutes: []string{"invalid"},
+			edges: func(x *CustomRouteNode, a *FunctionNode, b *FunctionNode, c *CustomRouteNode, d *FunctionNode) []Edge {
+				return []Edge{
+					{From: Start, To: x},
+					{From: x, To: a, Route: StringRoute("branchA")},
+					{From: x, To: b, Route: StringRoute("branchB")},
+					{From: x, To: c, Route: StringRoute("branchC")},
+					{From: c, To: d},
+				}
+			},
+			expectErrorMsg: "no outgoing edge matches the event with routes",
+		},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			start, a, b, c, d, tracker := createNodes()
+			start.route = tc.startRoutes
+			edges := tc.edges(start, a, b, c, d)
+
+			w := New(edges)
+			mockCtx := &MockInvocationContext{sess: nil}
+
+			var err error
+			for _, testErr := range w.Run(mockCtx) {
+				if testErr != nil {
+					err = testErr
+					break
+				}
+			}
+
+			if tc.expectErrorMsg != "" {
+				if err == nil {
+					t.Errorf("expected error matching %q, got none", tc.expectErrorMsg)
+				} else if !strings.Contains(err.Error(), tc.expectErrorMsg) {
+					t.Errorf("expected error containing %q, got %v", tc.expectErrorMsg, err)
+				}
+				return
+			}
+
+			if err != nil {
+				t.Fatalf("unexpected error: %v", err)
+			}
+
+			if len(tracker.executed) != len(tc.expectedExec) {
+				t.Errorf("expected %v executed, got %v", tc.expectedExec, tracker.executed)
+			}
+		})
 	}
 }

--- a/workflow/workflow_test.go
+++ b/workflow/workflow_test.go
@@ -27,6 +27,8 @@ import (
 	"google.golang.org/adk/session"
 )
 
+var defaultNodeConfig = NodeConfig{}
+
 // MockInvocationContext is a minimal implementation of agent.InvocationContext for testing.
 type MockInvocationContext struct {
 	agent.InvocationContext
@@ -53,7 +55,7 @@ func TestFunctionNode(t *testing.T) {
 		return strings.ToUpper(input), nil
 	}
 
-	node := NewFunctionNode("upper", upperFn)
+	node := NewFunctionNode("upper", upperFn, defaultNodeConfig)
 
 	// Create a mock context
 	mockCtx := &MockInvocationContext{sess: nil}
@@ -95,8 +97,8 @@ func TestSequentialWorkflow(t *testing.T) {
 		return input + " done", nil
 	}
 
-	nodeA := NewFunctionNode("upper", upperFn)
-	nodeB := NewFunctionNode("suffix", suffixFn)
+	nodeA := NewFunctionNode("upper", upperFn, defaultNodeConfig)
+	nodeB := NewFunctionNode("suffix", suffixFn, defaultNodeConfig)
 
 	edges := Chain(Start, nodeA, nodeB)
 
@@ -241,11 +243,11 @@ func TestWorkflowRouting(t *testing.T) {
 		nodeA := NewFunctionNode("A", func(ctx agent.InvocationContext, input any) (string, error) {
 			tracker.executed = append(tracker.executed, "A")
 			return "pathA", nil
-		})
+		}, defaultNodeConfig)
 		nodeB := NewFunctionNode("B", func(ctx agent.InvocationContext, input any) (string, error) {
 			tracker.executed = append(tracker.executed, "B")
 			return "pathB", nil
-		})
+		}, defaultNodeConfig)
 		nodeC := &CustomRouteNode{
 			baseNode: baseNode{name: "C"},
 			route:    []string{"branchD"},
@@ -256,7 +258,7 @@ func TestWorkflowRouting(t *testing.T) {
 		nodeD := NewFunctionNode("D", func(ctx agent.InvocationContext, input any) (string, error) {
 			tracker.executed = append(tracker.executed, "D")
 			return "pathD", nil
-		})
+		}, defaultNodeConfig)
 		return nodeX, nodeA, nodeB, nodeC, nodeD, tracker
 	}
 
@@ -264,7 +266,7 @@ func TestWorkflowRouting(t *testing.T) {
 		{
 			name:        "all edges don't have routing",
 			startRoutes: []string{"branchA", "branchB"},
-			edges: func(x *CustomRouteNode, a *FunctionNode, b *FunctionNode, c *CustomRouteNode, d *FunctionNode) []Edge {
+			edges: func(x *CustomRouteNode, a, b *FunctionNode, c *CustomRouteNode, d *FunctionNode) []Edge {
 				return []Edge{
 					{From: Start, To: x},
 					{From: x, To: a},
@@ -278,7 +280,7 @@ func TestWorkflowRouting(t *testing.T) {
 		{
 			name:        "only one edge has correct routing and the rest have no routing",
 			startRoutes: []string{"branchA"},
-			edges: func(x *CustomRouteNode, a *FunctionNode, b *FunctionNode, c *CustomRouteNode, d *FunctionNode) []Edge {
+			edges: func(x *CustomRouteNode, a, b *FunctionNode, c *CustomRouteNode, d *FunctionNode) []Edge {
 				return []Edge{
 					{From: Start, To: x},
 					{From: x, To: a, Route: StringRoute("branchA")},
@@ -292,7 +294,7 @@ func TestWorkflowRouting(t *testing.T) {
 		{
 			name:        "one edge has no routing and the rest have a correct routing",
 			startRoutes: []string{"branchA", "branchB"},
-			edges: func(x *CustomRouteNode, a *FunctionNode, b *FunctionNode, c *CustomRouteNode, d *FunctionNode) []Edge {
+			edges: func(x *CustomRouteNode, a, b *FunctionNode, c *CustomRouteNode, d *FunctionNode) []Edge {
 				return []Edge{
 					{From: Start, To: x},
 					{From: x, To: a, Route: StringRoute("branchA")},
@@ -306,7 +308,7 @@ func TestWorkflowRouting(t *testing.T) {
 		{
 			name:        "any edge has incorrect routing",
 			startRoutes: []string{"invalid"},
-			edges: func(x *CustomRouteNode, a *FunctionNode, b *FunctionNode, c *CustomRouteNode, d *FunctionNode) []Edge {
+			edges: func(x *CustomRouteNode, a, b *FunctionNode, c *CustomRouteNode, d *FunctionNode) []Edge {
 				return []Edge{
 					{From: Start, To: x},
 					{From: x, To: a, Route: StringRoute("branchA")},
@@ -355,7 +357,7 @@ func TestWorkflowRouting(t *testing.T) {
 		{
 			name:        "correct MultiRoute",
 			startRoutes: []string{"branchA"},
-			edges: func(x *CustomRouteNode, a *FunctionNode, b *FunctionNode, c *CustomRouteNode, d *FunctionNode) []Edge {
+			edges: func(x *CustomRouteNode, a, b *FunctionNode, c *CustomRouteNode, d *FunctionNode) []Edge {
 				return []Edge{
 					{From: Start, To: x},
 					{From: x, To: a, Route: MultiRoute[string]{"branchX", "branchA"}},
@@ -369,7 +371,7 @@ func TestWorkflowRouting(t *testing.T) {
 		{
 			name:        "no MultiRoute matches event routes",
 			startRoutes: []string{"invalid"},
-			edges: func(x *CustomRouteNode, a *FunctionNode, b *FunctionNode, c *CustomRouteNode, d *FunctionNode) []Edge {
+			edges: func(x *CustomRouteNode, a, b *FunctionNode, c *CustomRouteNode, d *FunctionNode) []Edge {
 				return []Edge{
 					{From: Start, To: x},
 					{From: x, To: a, Route: MultiRoute[string]{"branchX", "branchY"}},
@@ -381,7 +383,7 @@ func TestWorkflowRouting(t *testing.T) {
 		{
 			name:        "duplicate edges to same node",
 			startRoutes: []string{"branchA"},
-			edges: func(x *CustomRouteNode, a *FunctionNode, b *FunctionNode, c *CustomRouteNode, d *FunctionNode) []Edge {
+			edges: func(x *CustomRouteNode, a, b *FunctionNode, c *CustomRouteNode, d *FunctionNode) []Edge {
 				return []Edge{
 					{From: Start, To: x},
 					{From: x, To: a},

--- a/workflow/workflow_test.go
+++ b/workflow/workflow_test.go
@@ -19,6 +19,7 @@ import (
 	"fmt"
 	"iter"
 	"strings"
+	"sync"
 	"testing"
 
 	"google.golang.org/genai"
@@ -27,27 +28,64 @@ import (
 	"google.golang.org/adk/session"
 )
 
+// defaultNodeConfig is the explicit "use defaults" NodeConfig used
+// across this package's tests where no per-node knobs are exercised.
 var defaultNodeConfig = NodeConfig{}
 
-// MockInvocationContext is a minimal implementation of agent.InvocationContext for testing.
+// MockInvocationContext is a minimal implementation of
+// agent.InvocationContext for testing. It embeds a real
+// context.Context so child cancellation works.
 type MockInvocationContext struct {
-	agent.InvocationContext
+	context.Context
 	sess        session.Session
 	userContent *genai.Content
+}
+
+// newMockCtx returns a fresh MockInvocationContext backed by
+// t.Context(), which is automatically cancelled when the test ends
+// — preventing leaked scheduler goroutines from outliving the test.
+func newMockCtx(t *testing.T) *MockInvocationContext {
+	t.Helper()
+	return &MockInvocationContext{Context: t.Context()}
+}
+
+// newSeededMockCtx returns a mockCtx pre-loaded with a "seed" user
+// content part — the standard fixture for scheduler tests that need
+// an initial input flowing into Start.
+func newSeededMockCtx(t *testing.T) *MockInvocationContext {
+	t.Helper()
+	ctx := newMockCtx(t)
+	ctx.userContent = &genai.Content{Parts: []*genai.Part{{Text: "seed"}}}
+	return ctx
+}
+
+// mustNew builds a workflow from edges and fails the test if
+// construction errors. The returned workflow is ready to Run.
+func mustNew(t *testing.T, edges []Edge) *Workflow {
+	t.Helper()
+	w, err := New(edges)
+	if err != nil {
+		t.Fatalf("New: %v", err)
+	}
+	return w
 }
 
 func (m *MockInvocationContext) Session() session.Session    { return m.sess }
 func (m *MockInvocationContext) InvocationID() string        { return "test-invocation-id" }
 func (m *MockInvocationContext) UserContent() *genai.Content { return m.userContent }
+func (m *MockInvocationContext) TriggeredBy() string         { return "" }
+func (m *MockInvocationContext) Agent() agent.Agent          { return nil }
 func (m *MockInvocationContext) Artifacts() agent.Artifacts  { return nil }
 func (m *MockInvocationContext) Memory() agent.Memory        { return nil }
-func (m *MockInvocationContext) Agent() agent.Agent          { return nil }
 func (m *MockInvocationContext) Branch() string              { return "" }
 func (m *MockInvocationContext) RunConfig() *agent.RunConfig { return nil }
-func (m *MockInvocationContext) EndInvocation()              {}
 func (m *MockInvocationContext) Ended() bool                 { return false }
+func (m *MockInvocationContext) EndInvocation()              {}
+
 func (m *MockInvocationContext) WithContext(ctx context.Context) agent.InvocationContext {
-	return m
+	cp := *m
+	cp.Context = ctx
+	return &cp
 }
 
 func TestFunctionNode(t *testing.T) {
@@ -58,7 +96,7 @@ func TestFunctionNode(t *testing.T) {
 	node := NewFunctionNode("upper", upperFn, defaultNodeConfig)
 
 	// Create a mock context
-	mockCtx := &MockInvocationContext{sess: nil}
+	mockCtx := newMockCtx(t)
 
 	// Run the node
 	events := node.Run(mockCtx, "hello")
@@ -102,16 +140,11 @@ func TestSequentialWorkflow(t *testing.T) {
 
 	edges := Chain(Start, nodeA, nodeB)
 
-	w, err := New(edges)
-	if err != nil {
-		t.Fatalf("unexpected error: %v", err)
-	}
+	w := mustNew(t, edges)
 
-	mockCtx := &MockInvocationContext{
-		sess: nil,
-		userContent: &genai.Content{
-			Parts: []*genai.Part{{Text: "hello"}},
-		},
+	mockCtx := newMockCtx(t)
+	mockCtx.userContent = &genai.Content{
+		Parts: []*genai.Part{{Text: "hello"}},
 	}
 
 	events := w.Run(mockCtx)
@@ -210,7 +243,7 @@ func TestMultiRouteInt(t *testing.T) {
 }
 
 type CustomRouteNode struct {
-	baseNode
+	BaseNode
 	route []string
 	onRun func()
 }
@@ -227,8 +260,17 @@ func (n *CustomRouteNode) Run(ctx agent.InvocationContext, input any) iter.Seq2[
 }
 
 func TestWorkflowRouting(t *testing.T) {
+	// testTracker collects the names of nodes that ran. The
+	// scheduler runs sibling nodes concurrently, so appends must be
+	// serialised.
 	type testTracker struct {
+		mu       sync.Mutex
 		executed []string
+	}
+	record := func(tracker *testTracker, name string) {
+		tracker.mu.Lock()
+		tracker.executed = append(tracker.executed, name)
+		tracker.mu.Unlock()
 	}
 
 	type testCase struct {
@@ -241,25 +283,25 @@ func TestWorkflowRouting(t *testing.T) {
 	createNodes := func() (*CustomRouteNode, *FunctionNode, *FunctionNode, *CustomRouteNode, *FunctionNode, *testTracker) {
 		tracker := &testTracker{}
 		nodeX := &CustomRouteNode{
-			baseNode: baseNode{name: "X"},
+			BaseNode: NewBaseNode("X", "", defaultNodeConfig),
 		}
 		nodeA := NewFunctionNode("A", func(ctx agent.InvocationContext, input any) (string, error) {
-			tracker.executed = append(tracker.executed, "A")
+			record(tracker, "A")
 			return "pathA", nil
 		}, defaultNodeConfig)
 		nodeB := NewFunctionNode("B", func(ctx agent.InvocationContext, input any) (string, error) {
-			tracker.executed = append(tracker.executed, "B")
+			record(tracker, "B")
 			return "pathB", nil
 		}, defaultNodeConfig)
 		nodeC := &CustomRouteNode{
-			baseNode: baseNode{name: "C"},
+			BaseNode: NewBaseNode("C", "", defaultNodeConfig),
 			route:    []string{"branchD"},
 			onRun: func() {
-				tracker.executed = append(tracker.executed, "C")
+				record(tracker, "C")
 			},
 		}
 		nodeD := NewFunctionNode("D", func(ctx agent.InvocationContext, input any) (string, error) {
-			tracker.executed = append(tracker.executed, "D")
+			record(tracker, "D")
 			return "pathD", nil
 		}, defaultNodeConfig)
 		return nodeX, nodeA, nodeB, nodeC, nodeD, tracker
@@ -406,13 +448,10 @@ func TestWorkflowRouting(t *testing.T) {
 			start.route = tc.startRoutes
 			edges := tc.edges(start, a, b, c, d)
 
-			w, err := New(edges)
-			if err != nil {
-				t.Fatalf("unexpected error: %v", err)
-			}
+			w := mustNew(t, edges)
+			mockCtx := newMockCtx(t)
 
-			mockCtx := &MockInvocationContext{sess: nil}
-
+			var err error
 			for _, testErr := range w.Run(mockCtx) {
 				if testErr != nil {
 					err = testErr

--- a/workflow/workflow_test.go
+++ b/workflow/workflow_test.go
@@ -64,7 +64,7 @@ func TestFunctionNode(t *testing.T) {
 			t.Fatalf("unexpected error: %v", err)
 		}
 		count++
-		
+
 		output, ok := ev.Actions.StateDelta["output"]
 		if !ok {
 			t.Errorf("expected output in state delta")
@@ -168,6 +168,36 @@ func TestBoolRoute(t *testing.T) {
 	}
 	if BoolRoute(false).Matches(event) {
 		t.Errorf("BoolRoute should not match")
+	}
+}
+
+func TestMultiRouteString(t *testing.T) {
+	event := &session.Event{
+		Routes: []string{"hello", "42", "true"},
+	}
+
+	strMulti := MultiRoute[string]{"world", "hello"}
+	if !strMulti.Matches(event) {
+		t.Errorf("MultiRoute[string] should match")
+	}
+	strMultiNoMatch := MultiRoute[string]{"world", "golang"}
+	if strMultiNoMatch.Matches(event) {
+		t.Errorf("MultiRoute[string] should not match")
+	}
+}
+
+func TestMultiRouteInt(t *testing.T) {
+	event := &session.Event{
+		Routes: []string{"hello", "42", "true"},
+	}
+
+	intMulti := MultiRoute[int]{10, 42}
+	if !intMulti.Matches(event) {
+		t.Errorf("MultiRoute[int] should match")
+	}
+	intMultiNoMatch := MultiRoute[int]{10, 20}
+	if intMultiNoMatch.Matches(event) {
+		t.Errorf("MultiRoute[int] should not match")
 	}
 }
 
@@ -284,6 +314,47 @@ func TestWorkflowRouting(t *testing.T) {
 				}
 			},
 			expectErrorMsg: "no outgoing edge matches the event with routes",
+		},
+		{
+			name:        "correct MultiRoute",
+			startRoutes: []string{"branchA"},
+			edges: func(x *CustomRouteNode, a *FunctionNode, b *FunctionNode, c *CustomRouteNode, d *FunctionNode) []Edge {
+				return []Edge{
+					{From: Start, To: x},
+					{From: x, To: a, Route: MultiRoute[string]{"branchX", "branchA"}},
+					{From: x, To: b},
+					{From: x, To: c},
+					{From: c, To: d},
+				}
+			},
+			expectedExec: []string{"A", "B", "C", "D"},
+		},
+		{
+			name:        "no MultiRoute matches event routes",
+			startRoutes: []string{"invalid"},
+			edges: func(x *CustomRouteNode, a *FunctionNode, b *FunctionNode, c *CustomRouteNode, d *FunctionNode) []Edge {
+				return []Edge{
+					{From: Start, To: x},
+					{From: x, To: a, Route: MultiRoute[string]{"branchX", "branchY"}},
+					{From: x, To: b, Route: MultiRoute[string]{"branchZ"}},
+				}
+			},
+			expectErrorMsg: "no outgoing edge matches the event with routes",
+		},
+		{
+			name:        "duplicate edges to same node",
+			startRoutes: []string{"branchA"},
+			edges: func(x *CustomRouteNode, a *FunctionNode, b *FunctionNode, c *CustomRouteNode, d *FunctionNode) []Edge {
+				return []Edge{
+					{From: Start, To: x},
+					{From: x, To: a},
+					{From: x, To: a, Route: StringRoute("branchA")},
+					{From: x, To: b},
+					{From: x, To: c},
+					{From: c, To: d},
+				}
+			},
+			expectedExec: []string{"A", "B", "C", "D"},
 		},
 	}
 

--- a/workflow/workflow_test.go
+++ b/workflow/workflow_test.go
@@ -231,7 +231,6 @@ func TestWorkflowRouting(t *testing.T) {
 		startRoutes    []string
 		edges          func(nodeStart *CustomRouteNode, nodeA, nodeB *FunctionNode, nodeC *CustomRouteNode, nodeD *FunctionNode) []Edge
 		expectedExec   []string
-		expectErrorMsg string
 	}
 
 	createNodes := func() (*CustomRouteNode, *FunctionNode, *FunctionNode, *CustomRouteNode, *FunctionNode, *testTracker) {
@@ -316,7 +315,42 @@ func TestWorkflowRouting(t *testing.T) {
 					{From: c, To: d},
 				}
 			},
-			expectErrorMsg: "no outgoing edge matches the event with routes",
+		},
+		{
+			name:        "fallback to default route when no concrete route matches",
+			startRoutes: []string{"unmatched"},
+			edges: func(x *CustomRouteNode, a *FunctionNode, b *FunctionNode, c *CustomRouteNode, d *FunctionNode) []Edge {
+				return []Edge{
+					{From: Start, To: x},
+					{From: x, To: a, Route: StringRoute("branchA")},
+					{From: x, To: b, Route: (Default)},
+				}
+			},
+			expectedExec: []string{"B"},
+		},
+		{
+			name:        "default route is suppressed by concrete route match",
+			startRoutes: []string{"branchA"},
+			edges: func(x *CustomRouteNode, a *FunctionNode, b *FunctionNode, c *CustomRouteNode, d *FunctionNode) []Edge {
+				return []Edge{
+					{From: Start, To: x},
+					{From: x, To: a, Route: StringRoute("branchA")},
+					{From: x, To: b, Route: Default},
+				}
+			},
+			expectedExec: []string{"A"},
+		},
+		{
+			name:        "unconditional edge does not suppress default route",
+			startRoutes: []string{"unmatched"},
+			edges: func(x *CustomRouteNode, a *FunctionNode, b *FunctionNode, c *CustomRouteNode, d *FunctionNode) []Edge {
+				return []Edge{
+					{From: Start, To: x},
+					{From: x, To: a},
+					{From: x, To: b, Route: (Default)},
+				}
+			},
+			expectedExec: []string{"A", "B"},
 		},
 		{
 			name:        "correct MultiRoute",
@@ -342,7 +376,7 @@ func TestWorkflowRouting(t *testing.T) {
 					{From: x, To: b, Route: MultiRoute[string]{"branchZ"}},
 				}
 			},
-			expectErrorMsg: "no outgoing edge matches the event with routes",
+			expectedExec: nil,
 		},
 		{
 			name:        "duplicate edges to same node",
@@ -376,15 +410,6 @@ func TestWorkflowRouting(t *testing.T) {
 					err = testErr
 					break
 				}
-			}
-
-			if tc.expectErrorMsg != "" {
-				if err == nil {
-					t.Errorf("expected error matching %q, got none", tc.expectErrorMsg)
-				} else if !strings.Contains(err.Error(), tc.expectErrorMsg) {
-					t.Errorf("expected error containing %q, got %v", tc.expectErrorMsg, err)
-				}
-				return
 			}
 
 			if err != nil {

--- a/workflow/workflow_test.go
+++ b/workflow/workflow_test.go
@@ -101,7 +101,7 @@ func TestSequentialWorkflow(t *testing.T) {
 	nodeB := NewFunctionNode("suffix", suffixFn, defaultNodeConfig)
 
 	edges := Chain(Start, nodeA, nodeB)
-	
+
 	w, err := New(edges)
 	if err != nil {
 		t.Fatalf("unexpected error: %v", err)
@@ -232,10 +232,10 @@ func TestWorkflowRouting(t *testing.T) {
 	}
 
 	type testCase struct {
-		name           string
-		startRoutes    []string
-		edges          func(nodeStart *CustomRouteNode, nodeA, nodeB *FunctionNode, nodeC *CustomRouteNode, nodeD *FunctionNode) []Edge
-		expectedExec   []string
+		name         string
+		startRoutes  []string
+		edges        func(nodeStart *CustomRouteNode, nodeA, nodeB *FunctionNode, nodeC *CustomRouteNode, nodeD *FunctionNode) []Edge
+		expectedExec []string
 	}
 
 	createNodes := func() (*CustomRouteNode, *FunctionNode, *FunctionNode, *CustomRouteNode, *FunctionNode, *testTracker) {

--- a/workflow/workflow_test.go
+++ b/workflow/workflow_test.go
@@ -101,8 +101,11 @@ func TestSequentialWorkflow(t *testing.T) {
 	nodeB := NewFunctionNode("suffix", suffixFn, defaultNodeConfig)
 
 	edges := Chain(Start, nodeA, nodeB)
-
-	w := New(edges)
+	
+	w, err := New(edges)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
 
 	mockCtx := &MockInvocationContext{
 		sess: nil,
@@ -403,10 +406,13 @@ func TestWorkflowRouting(t *testing.T) {
 			start.route = tc.startRoutes
 			edges := tc.edges(start, a, b, c, d)
 
-			w := New(edges)
+			w, err := New(edges)
+			if err != nil {
+				t.Fatalf("unexpected error: %v", err)
+			}
+
 			mockCtx := &MockInvocationContext{sess: nil}
 
-			var err error
 			for _, testErr := range w.Run(mockCtx) {
 				if testErr != nil {
 					err = testErr

--- a/workflow/workflow_test.go
+++ b/workflow/workflow_test.go
@@ -74,7 +74,6 @@ func mustNew(t *testing.T, edges []Edge) *Workflow {
 func (m *MockInvocationContext) Session() session.Session        { return m.sess }
 func (m *MockInvocationContext) InvocationID() string            { return "test-invocation-id" }
 func (m *MockInvocationContext) UserContent() *genai.Content     { return m.userContent }
-func (m *MockInvocationContext) TriggeredBy() string             { return "" }
 func (m *MockInvocationContext) ResumedInput(string) (any, bool) { return nil, false }
 func (m *MockInvocationContext) Agent() agent.Agent              { return nil }
 func (m *MockInvocationContext) Artifacts() agent.Artifacts      { return nil }

--- a/workflow/workflow_test.go
+++ b/workflow/workflow_test.go
@@ -94,7 +94,7 @@ func TestSequentialWorkflow(t *testing.T) {
 	nodeA := NewFunctionNode("upper", upperFn)
 	nodeB := NewFunctionNode("suffix", suffixFn)
 
-	edges := Chain(START, nodeA, nodeB)
+	edges := Chain(Start, nodeA, nodeB)
 
 	w := New(edges)
 

--- a/workflow/workflow_test.go
+++ b/workflow/workflow_test.go
@@ -366,7 +366,7 @@ func TestWorkflowRouting(t *testing.T) {
 		{
 			name:        "fallback to default route when no concrete route matches",
 			startRoutes: []string{"unmatched"},
-			edges: func(x *CustomRouteNode, a *FunctionNode, b *FunctionNode, c *CustomRouteNode, d *FunctionNode) []Edge {
+			edges: func(x *CustomRouteNode, a, b *FunctionNode, c *CustomRouteNode, d *FunctionNode) []Edge {
 				return []Edge{
 					{From: Start, To: x},
 					{From: x, To: a, Route: StringRoute("branchA")},
@@ -378,7 +378,7 @@ func TestWorkflowRouting(t *testing.T) {
 		{
 			name:        "default route is suppressed by concrete route match",
 			startRoutes: []string{"branchA"},
-			edges: func(x *CustomRouteNode, a *FunctionNode, b *FunctionNode, c *CustomRouteNode, d *FunctionNode) []Edge {
+			edges: func(x *CustomRouteNode, a, b *FunctionNode, c *CustomRouteNode, d *FunctionNode) []Edge {
 				return []Edge{
 					{From: Start, To: x},
 					{From: x, To: a, Route: StringRoute("branchA")},
@@ -390,7 +390,7 @@ func TestWorkflowRouting(t *testing.T) {
 		{
 			name:        "unconditional edge does not suppress default route",
 			startRoutes: []string{"unmatched"},
-			edges: func(x *CustomRouteNode, a *FunctionNode, b *FunctionNode, c *CustomRouteNode, d *FunctionNode) []Edge {
+			edges: func(x *CustomRouteNode, a, b *FunctionNode, c *CustomRouteNode, d *FunctionNode) []Edge {
 				return []Edge{
 					{From: Start, To: x},
 					{From: x, To: a},

--- a/workflow/workflow_test.go
+++ b/workflow/workflow_test.go
@@ -15,6 +15,7 @@
 package workflow
 
 import (
+	"context"
 	"fmt"
 	"iter"
 	"strings"
@@ -33,16 +34,18 @@ type MockInvocationContext struct {
 	userContent *genai.Content
 }
 
-func (m *MockInvocationContext) Session() session.Session {
-	return m.sess
-}
-
-func (m *MockInvocationContext) InvocationID() string {
-	return "test-invocation-id"
-}
-
-func (m *MockInvocationContext) UserContent() *genai.Content {
-	return m.userContent
+func (m *MockInvocationContext) Session() session.Session    { return m.sess }
+func (m *MockInvocationContext) InvocationID() string        { return "test-invocation-id" }
+func (m *MockInvocationContext) UserContent() *genai.Content { return m.userContent }
+func (m *MockInvocationContext) Artifacts() agent.Artifacts  { return nil }
+func (m *MockInvocationContext) Memory() agent.Memory        { return nil }
+func (m *MockInvocationContext) Agent() agent.Agent          { return nil }
+func (m *MockInvocationContext) Branch() string              { return "" }
+func (m *MockInvocationContext) RunConfig() *agent.RunConfig { return nil }
+func (m *MockInvocationContext) EndInvocation()              {}
+func (m *MockInvocationContext) Ended() bool                 { return false }
+func (m *MockInvocationContext) WithContext(ctx context.Context) agent.InvocationContext {
+	return m
 }
 
 func TestFunctionNode(t *testing.T) {

--- a/workflow/workflow_test.go
+++ b/workflow/workflow_test.go
@@ -109,12 +109,8 @@ func TestFunctionNode(t *testing.T) {
 		}
 		count++
 
-		output, ok := ev.Actions.StateDelta["output"]
-		if !ok {
-			t.Errorf("expected output in state delta")
-		}
-		if output != "HELLO" {
-			t.Errorf("expected output 'HELLO', got %v", output)
+		if ev.Output != "HELLO" {
+			t.Errorf("expected Output 'HELLO', got %v", ev.Output)
 		}
 	}
 
@@ -158,10 +154,8 @@ func TestSequentialWorkflow(t *testing.T) {
 		}
 		count++
 
-		if ev.Actions.StateDelta != nil {
-			if out, ok := ev.Actions.StateDelta["output"]; ok {
-				lastOutput = out
-			}
+		if ev.Output != nil {
+			lastOutput = ev.Output
 		}
 	}
 


### PR DESCRIPTION
…llback

Implements the runtime side of the workflow output-validation pipeline: the scheduler now invokes node.ValidateOutput on every yielded event whose Output is non-nil, before the value is committed to the node-run accumulator and forwarded to the consumer. A validation failure is recorded on the accumulator and surfaces as NodeFailed via the normal completion path.

Helper (defaultValidateOutput)
- Extracted from base_node.go into a new workflow/output_validation.go to make room for the fallback strategy.
- Adds a passthrough short-circuit for framework control values (*session.Event, *session.RequestInput) that are routed through Event.Output by some nodes but are not user output payloads and must never be schema-validated.
- Adds a *genai.Content fallback: when standard validation fails on a *genai.Content value, extract concatenated text from the parts; if the schema's root type is "string" return the text directly, else JSON-parse the text and re-validate the parsed value. Mirrors the Python ADK _validate_output_data behavior and gives LlmAgent-like nodes that yield raw model output a deterministic projection onto their declared output schema.
- On total failure, the original validation error is returned so callers see the schema mismatch and not a downstream JSON-parse error.

Scheduler
- handleEvent now calls a new s.validateNodeOutput helper for events with ev.Output != nil. On success the (possibly coerced) value is written back to ev.Output and accumulated; on failure the wrapped error is recorded via nr.recordErr and the activation transitions to NodeFailed.
- Events without Output (progress/status events, RequestedInput-only events, routing-only events) bypass validation entirely.

Tests
- New workflow/output_validation_test.go covers the helper end-to-end: nil schema passthrough, valid payload, invalid payload, both passthrough types, Content fallback for string schemas, Content fallback with JSON parse, invalid JSON falling back to the original error, and empty-text falling back to the original error.
- New scheduler tests cover the three required cases: yielded output that validates is forwarded to the consumer; output that fails validation surfaces a wrapped "output validation failed for node X" error and ends the activation; progress events without Output are forwarded without ValidateOutput being invoked.

BUG=516382302
BUG=516381927

**Please ensure you have read the [contribution guide](./CONTRIBUTING.md) before creating a pull request.**

### Link to Issue or Description of Change

**1. Link to an existing issue (if applicable):**

- Closes: #_issue_number_
- Related: #_issue_number_

**2. Or, if no issue exists, describe the change:**

_If applicable, please follow the issue templates to provide as much detail as
possible._

**Problem:**
_A clear and concise description of what the problem is._

**Solution:**
_A clear and concise description of what you want to happen and why you choose
this solution._

### Testing Plan

_Please describe the tests that you ran to verify your changes. This is required
for all PRs that are not small documentation or typo fixes._

**Unit Tests:**

- [ ] I have added or updated unit tests for my change.
- [ ] All unit tests pass locally.

_Please include a summary of passed go test results._

**Manual End-to-End (E2E) Tests:**

_Please provide instructions on how to manually test your changes, including any
necessary setup or configuration. Please provide logs or screenshots to help
reviewers better understand the fix._

### Checklist

- [ ] I have read the [CONTRIBUTING.md](./CONTRIBUTING.md) document.
- [ ] I have performed a self-review of my own code.
- [ ] I have commented my code, particularly in hard-to-understand areas.
- [ ] I have added tests that prove my fix is effective or that my feature works.
- [ ] New and existing unit tests pass locally with my changes.
- [ ] I have manually tested my changes end-to-end.
- [ ] Any dependent changes have been merged and published in downstream modules.

### Additional context

_Add any other context or screenshots about the feature request here._

