### PR TITLE
Context unification: switch all to not deprecated 

### DIFF
--- a/agent/llmagent/llmagent.go
+++ b/agent/llmagent/llmagent.go
@@ -310,7 +310,7 @@ type OnModelErrorCallback func(ctx agent.CallbackContext, llmRequest *model.LLMR
 //
 // To modify tool arguments and still run the tool,
 // update args in place and return (nil, nil).
-type BeforeToolCallback func(ctx tool.Context, tool tool.Tool, args map[string]any) (map[string]any, error)
+type BeforeToolCallback func(ctx agent.ToolContext, tool tool.Tool, args map[string]any) (map[string]any, error)
 
 // AfterToolCallback is a function type executed after a tool's Run method has completed,
 // regardless of whether the tool returned a result or an error.
@@ -319,13 +319,13 @@ type BeforeToolCallback func(ctx tool.Context, tool tool.Tool, args map[string]a
 // If a callback returns a non-nil result or an error:
 //   - execution of remaining callbacks stops
 //   - the returned result and/or error is used as the final tool output
-type AfterToolCallback func(ctx tool.Context, tool tool.Tool, args, result map[string]any, err error) (map[string]any, error)
+type AfterToolCallback func(ctx agent.ToolContext, tool tool.Tool, args, result map[string]any, err error) (map[string]any, error)
 
 // OnToolErrorCallback that is called when receiving an error response from tool execution.
 //
 // If it returns non-nil LLMResponse or error, the actual model response/error
 // is replaced with the returned response/error.
-type OnToolErrorCallback func(ctx tool.Context, tool tool.Tool, args map[string]any, err error) (map[string]any, error)
+type OnToolErrorCallback func(ctx agent.ToolContext, tool tool.Tool, args map[string]any, err error) (map[string]any, error)
 
 // IncludeContents controls what parts of prior conversation history is received by llmagent.
 type IncludeContents string

--- a/agent/llmagent/llmagent_test.go
+++ b/agent/llmagent/llmagent_test.go
@@ -449,7 +449,7 @@ func TestToolCallback(t *testing.T) {
 		Number int `json:"number"`
 	}
 
-	handler := func(_ tool.Context, input Args) (Result, error) {
+	handler := func(_ agent.ToolContext, input Args) (Result, error) {
 		return Result{Number: 1}, nil
 	}
 	rand, _ := functiontool.New(functiontool.Config{
@@ -468,10 +468,10 @@ func TestToolCallback(t *testing.T) {
 			DisallowTransferToPeers:  true,
 			Tools:                    []tool.Tool{rand},
 			BeforeToolCallbacks: []llmagent.BeforeToolCallback{
-				func(ctx tool.Context, tool tool.Tool, args map[string]any) (map[string]any, error) {
+				func(ctx agent.ToolContext, tool tool.Tool, args map[string]any) (map[string]any, error) {
 					return nil, nil
 				},
-				func(ctx tool.Context, tool tool.Tool, args map[string]any) (map[string]any, error) {
+				func(ctx agent.ToolContext, tool tool.Tool, args map[string]any) (map[string]any, error) {
 					return map[string]any{"number": "7"}, nil
 				},
 			},
@@ -504,10 +504,10 @@ func TestToolCallback(t *testing.T) {
 			Tools:                    []tool.Tool{rand},
 			BeforeToolCallbacks: []llmagent.BeforeToolCallback{
 				// Since it retursn non nil, the next callback won't be executed.
-				func(ctx tool.Context, tool tool.Tool, args map[string]any) (map[string]any, error) {
+				func(ctx agent.ToolContext, tool tool.Tool, args map[string]any) (map[string]any, error) {
 					return map[string]any{"number": "3"}, nil
 				},
-				func(ctx tool.Context, tool tool.Tool, args map[string]any) (map[string]any, error) {
+				func(ctx agent.ToolContext, tool tool.Tool, args map[string]any) (map[string]any, error) {
 					return map[string]any{"number": "7"}, nil
 				},
 			},
@@ -539,10 +539,10 @@ func TestToolCallback(t *testing.T) {
 			DisallowTransferToPeers:  true,
 			Tools:                    []tool.Tool{rand},
 			AfterToolCallbacks: []llmagent.AfterToolCallback{
-				func(ctx tool.Context, tool tool.Tool, args, result map[string]any, err error) (map[string]any, error) {
+				func(ctx agent.ToolContext, tool tool.Tool, args, result map[string]any, err error) (map[string]any, error) {
 					return nil, nil
 				},
-				func(ctx tool.Context, tool tool.Tool, args, result map[string]any, err error) (map[string]any, error) {
+				func(ctx agent.ToolContext, tool tool.Tool, args, result map[string]any, err error) (map[string]any, error) {
 					return map[string]any{"number": "7"}, nil
 				},
 			},
@@ -575,10 +575,10 @@ func TestToolCallback(t *testing.T) {
 			Tools:                    []tool.Tool{rand},
 			AfterToolCallbacks: []llmagent.AfterToolCallback{
 				// Since it retursn non nil, the next callback won't be executed.
-				func(ctx tool.Context, tool tool.Tool, args, result map[string]any, err error) (map[string]any, error) {
+				func(ctx agent.ToolContext, tool tool.Tool, args, result map[string]any, err error) (map[string]any, error) {
 					return map[string]any{"number": "3"}, nil
 				},
-				func(ctx tool.Context, tool tool.Tool, args, result map[string]any, err error) (map[string]any, error) {
+				func(ctx agent.ToolContext, tool tool.Tool, args, result map[string]any, err error) (map[string]any, error) {
 					return map[string]any{"number": "7"}, nil
 				},
 			},
@@ -610,12 +610,12 @@ func TestToolCallback(t *testing.T) {
 			DisallowTransferToPeers:  true,
 			Tools:                    []tool.Tool{rand},
 			BeforeToolCallbacks: []llmagent.BeforeToolCallback{
-				func(ctx tool.Context, tool tool.Tool, args map[string]any) (map[string]any, error) {
+				func(ctx agent.ToolContext, tool tool.Tool, args map[string]any) (map[string]any, error) {
 					return map[string]any{"number": "3"}, nil
 				},
 			},
 			AfterToolCallbacks: []llmagent.AfterToolCallback{
-				func(ctx tool.Context, tool tool.Tool, args, result map[string]any, err error) (map[string]any, error) {
+				func(ctx agent.ToolContext, tool tool.Tool, args, result map[string]any, err error) (map[string]any, error) {
 					return map[string]any{"number": "7"}, nil
 				},
 			},
@@ -647,12 +647,12 @@ func TestToolCallback(t *testing.T) {
 			DisallowTransferToPeers:  true,
 			Tools:                    []tool.Tool{rand},
 			BeforeToolCallbacks: []llmagent.BeforeToolCallback{
-				func(ctx tool.Context, tool tool.Tool, args map[string]any) (map[string]any, error) {
+				func(ctx agent.ToolContext, tool tool.Tool, args map[string]any) (map[string]any, error) {
 					return nil, nil
 				},
 			},
 			AfterToolCallbacks: []llmagent.AfterToolCallback{
-				func(ctx tool.Context, tool tool.Tool, args, result map[string]any, err error) (map[string]any, error) {
+				func(ctx agent.ToolContext, tool tool.Tool, args, result map[string]any, err error) (map[string]any, error) {
 					return nil, nil
 				},
 			},
@@ -857,7 +857,7 @@ func TestFunctionTool(t *testing.T) {
 	}
 
 	prompt := "what is the sum of 1 + 2?"
-	handler := func(_ tool.Context, input Args) (Result, error) {
+	handler := func(_ agent.ToolContext, input Args) (Result, error) {
 		if input.A != 1 || input.B != 2 {
 			t.Errorf("handler received %+v, want {a: 1, b: 2}", input)
 		}

--- a/agent/llmagent/state_agent_test.go
+++ b/agent/llmagent/state_agent_test.go
@@ -263,7 +263,7 @@ type WeatherResult struct {
 	Timestamp   time.Time `json:"timestamp"`
 }
 
-func GetWeather(ctx tool.Context, args WeatherArgs) (WeatherResult, error) {
+func GetWeather(ctx agent.ToolContext, args WeatherArgs) (WeatherResult, error) {
 	// Simulate weather data
 	temperatures := []int{-10, -5, 0, 5, 10, 15, 20, 25, 30, 35}
 	conditions := []string{"sunny", "cloudy", "rainy", "snowy", "windy"}
@@ -291,7 +291,7 @@ type CalculationResult struct {
 	Timestamp time.Time `json:"timestamp"`
 }
 
-func Calculate(ctx tool.Context, args CalculationArgs) (CalculationResult, error) {
+func Calculate(ctx agent.ToolContext, args CalculationArgs) (CalculationResult, error) {
 	operations := map[string]float64{
 		"add":      args.X + args.Y,
 		"subtract": args.X - args.Y,
@@ -341,7 +341,7 @@ type LogActivityResult struct {
 	err          error
 }
 
-func LogActivity(ctx tool.Context, params LogActivityParams) (LogActivityResult, error) {
+func LogActivity(ctx agent.ToolContext, params LogActivityParams) (LogActivityResult, error) {
 	var activityLog []LogEntry
 	val, err := ctx.State().Get("activity_log")
 	if err == nil {
@@ -366,7 +366,7 @@ func LogActivity(ctx tool.Context, params LogActivityParams) (LogActivityResult,
 
 // --- Before Tool Callbacks ---
 
-func beforeToolAuditCallback(ctx tool.Context, t tool.Tool, args map[string]any) (map[string]any, error) {
+func beforeToolAuditCallback(ctx agent.ToolContext, t tool.Tool, args map[string]any) (map[string]any, error) {
 	fmt.Printf("🔍 AUDIT: About to call tool '%s' with args: %v\n", t.Name(), args)
 
 	var auditLog []map[string]any
@@ -387,7 +387,7 @@ func beforeToolAuditCallback(ctx tool.Context, t tool.Tool, args map[string]any)
 	return nil, nil // Continue execution
 }
 
-func beforeToolSecurityCallback(ctx tool.Context, t tool.Tool, args map[string]any) (map[string]any, error) {
+func beforeToolSecurityCallback(ctx agent.ToolContext, t tool.Tool, args map[string]any) (map[string]any, error) {
 	if t.Name() == "get_weather" {
 		location := ""
 		if loc, ok := args["location"].(string); ok {
@@ -411,7 +411,7 @@ func beforeToolSecurityCallback(ctx tool.Context, t tool.Tool, args map[string]a
 	return nil, nil // Continue execution
 }
 
-func beforeToolValidationCallback(ctx tool.Context, t tool.Tool, args map[string]any) (map[string]any, error) {
+func beforeToolValidationCallback(ctx agent.ToolContext, t tool.Tool, args map[string]any) (map[string]any, error) {
 	if t.Name() == "calculate" {
 		operation, _ := args["operation"].(string)
 		y, yOK := args["y"].(float64)
@@ -430,7 +430,7 @@ func beforeToolValidationCallback(ctx tool.Context, t tool.Tool, args map[string
 
 // --- After Tool Callbacks ---
 
-func afterToolEnhancementCallback(ctx tool.Context, t tool.Tool, args, result map[string]any, err error) (map[string]any, error) {
+func afterToolEnhancementCallback(ctx agent.ToolContext, t tool.Tool, args, result map[string]any, err error) (map[string]any, error) {
 	if err != nil {
 		return result, err // Don't enhance if there was an error
 	}
@@ -444,7 +444,7 @@ func afterToolEnhancementCallback(ctx tool.Context, t tool.Tool, args, result ma
 	return enhancedResponse, nil
 }
 
-func afterToolAsyncCallback(ctx tool.Context, t tool.Tool, args, result map[string]any, err error) (map[string]any, error) {
+func afterToolAsyncCallback(ctx agent.ToolContext, t tool.Tool, args, result map[string]any, err error) (map[string]any, error) {
 	if err != nil {
 		return result, err
 	}
@@ -653,7 +653,7 @@ func TestToolCallbacksAgent(t *testing.T) {
 
 type mockToolset struct{}
 
-func (m *mockToolset) ProcessRequest(ctx tool.Context, req *model.LLMRequest) error {
+func (m *mockToolset) ProcessRequest(ctx agent.ToolContext, req *model.LLMRequest) error {
 	utils.AppendInstructions(req, "Extra instruction from mockToolset")
 	return nil
 }

--- a/agent/remoteagent/v2/a2a_e2e_test.go
+++ b/agent/remoteagent/v2/a2a_e2e_test.go
@@ -886,7 +886,7 @@ func newLongRunningTool(t *testing.T) tool.Tool {
 		Name:          approvalToolName,
 		Description:   "Request approval before proceeding.",
 		IsLongRunning: true,
-	}, func(ctx tool.Context, x map[string]any) (approval, error) {
+	}, func(ctx agent.ToolContext, x map[string]any) (approval, error) {
 		return approval{Status: approvalStatusPending, TicketID: a2a.NewContextID()}, nil
 	})
 	if err != nil {
@@ -901,7 +901,7 @@ func newToolConfirmation(t *testing.T) tool.Tool {
 	requestApproval, err := functiontool.New(functiontool.Config{
 		Name:        approvalToolName,
 		Description: "Request approval before proceeding.",
-	}, func(ctx tool.Context, x map[string]any) (approval, error) {
+	}, func(ctx agent.ToolContext, x map[string]any) (approval, error) {
 		confirmation := ctx.ToolConfirmation()
 		if confirmation == nil {
 			ticketID := a2a.NewContextID()

--- a/agent/workflowagents/loopagent/agent_test.go
+++ b/agent/workflowagents/loopagent/agent_test.go
@@ -306,13 +306,13 @@ func (a *customAgent) Run(agent.InvocationContext) iter.Seq2[*session.Event, err
 
 type EmptyArgs struct{}
 
-func exampleFunctionThatEscalates(ctx tool.Context, myArgs EmptyArgs) (map[string]string, error) {
+func exampleFunctionThatEscalates(ctx agent.ToolContext, myArgs EmptyArgs) (map[string]string, error) {
 	ctx.Actions().Escalate = true
 	ctx.Actions().SkipSummarization = false
 	return map[string]string{}, nil
 }
 
-func exampleFunctionThatEscalatesAndSkips(ctx tool.Context, myArgs EmptyArgs) (map[string]string, error) {
+func exampleFunctionThatEscalatesAndSkips(ctx agent.ToolContext, myArgs EmptyArgs) (map[string]string, error) {
 	ctx.Actions().Escalate = true
 	ctx.Actions().SkipSummarization = true
 	return map[string]string{}, nil

--- a/agent/workflowagents/parallelagent/agent_test.go
+++ b/agent/workflowagents/parallelagent/agent_test.go
@@ -298,7 +298,7 @@ func createAgentWithGemini(t *testing.T, name string) agent.Agent {
 			Name:        fmt.Sprintf("search_tool_%s", name),
 			Description: "Search for information on the web",
 		},
-		func(ctx tool.Context, args struct{ Query string }) (string, error) {
+		func(ctx agent.ToolContext, args struct{ Query string }) (string, error) {
 			return fmt.Sprintf("search result for '%s' from %s", args.Query, name), nil
 		},
 	)
@@ -311,7 +311,7 @@ func createAgentWithGemini(t *testing.T, name string) agent.Agent {
 			Name:        fmt.Sprintf("analyze_tool_%s", name),
 			Description: "Analyze data and return insights",
 		},
-		func(ctx tool.Context, args struct{ Data string }) (string, error) {
+		func(ctx agent.ToolContext, args struct{ Data string }) (string, error) {
 			return fmt.Sprintf("analysis result for '%s' from %s", args.Data, name), nil
 		},
 	)

--- a/agent/workflowagents/sequentialagent/agent.go
+++ b/agent/workflowagents/sequentialagent/agent.go
@@ -25,7 +25,6 @@ import (
 	agentinternal "google.golang.org/adk/internal/agent"
 	"google.golang.org/adk/internal/llminternal"
 	"google.golang.org/adk/session"
-	"google.golang.org/adk/tool"
 	"google.golang.org/adk/tool/functiontool"
 )
 
@@ -138,7 +137,7 @@ func (a *sequentialAgent) RunLive(ctx agent.InvocationContext) (agent.LiveSessio
 	taskCompletedTool, err := functiontool.New(functiontool.Config{
 		Name:        "task_completed",
 		Description: "Signals that the agent has successfully completed the user's question or task.",
-	}, func(ctx tool.Context, args taskCompletedArgs) (taskCompletedResults, error) {
+	}, func(ctx agent.ToolContext, args taskCompletedArgs) (taskCompletedResults, error) {
 		return taskCompletedResults{Result: "Task completion signaled."}, nil
 	})
 	if err != nil {

--- a/examples/agentengine/main.go
+++ b/examples/agentengine/main.go
@@ -53,8 +53,8 @@ const (
 )
 
 // memorySearchToolFunc is the implementation of the memory search tool.
-// This function demonstrates accessing memory via tool.Context.
-func memorySearchToolFunc(tctx tool.Context, args Args) (Result, error) {
+// This function demonstrates accessing memory via agent.ToolContext.
+func memorySearchToolFunc(tctx agent.ToolContext, args Args) (Result, error) {
 	// The SearchMemory function is available on the context.
 	searchResults, err := tctx.SearchMemory(tctx, args.Query)
 	if err != nil {
@@ -98,7 +98,7 @@ func main() {
 	type Output struct {
 		Result int `json:"result"`
 	}
-	handler := func(ctx tool.Context, input Input) (Output, error) {
+	handler := func(ctx agent.ToolContext, input Input) (Output, error) {
 		return Output{
 			Result: input.Min + rand.IntN(input.Max-input.Min+1),
 		}, nil

--- a/examples/bidi/main.go
+++ b/examples/bidi/main.go
@@ -56,7 +56,7 @@ func main() {
 	cameraTool, err := functiontool.New(functiontool.Config{
 		Name:        "camera_toggle",
 		Description: "Turns the camera on or off.",
-	}, func(ctx tool.Context, args EmptyArgs) (MessageResult, error) {
+	}, func(ctx agent.ToolContext, args EmptyArgs) (MessageResult, error) {
 		fmt.Println("Camera tool was called!")
 		return MessageResult{Message: "Camera tool called successfully!"}, nil
 	})

--- a/examples/bidi/streamingtool/main.go
+++ b/examples/bidi/streamingtool/main.go
@@ -53,7 +53,7 @@ func main() {
 	counterTool, err := functiontool.NewStreaming(functiontool.Config{
 		Name:        "count_to",
 		Description: "Counts to a specified number, yielding each number with a delay.",
-	}, func(ctx tool.Context, args struct {
+	}, func(ctx agent.ToolContext, args struct {
 		N int `json:"n"`
 	},
 	) iter.Seq2[string, error] {
@@ -78,7 +78,7 @@ func main() {
 	stopTool, err := functiontool.New(functiontool.Config{
 		Name:        "stop_streaming",
 		Description: "Stops a running streaming function.",
-	}, func(ctx tool.Context, args struct {
+	}, func(ctx agent.ToolContext, args struct {
 		FunctionName string `json:"function_name"`
 	},
 	) (map[string]any, error) {
@@ -92,7 +92,7 @@ func main() {
 	checkDivisibleTool, err := functiontool.New(functiontool.Config{
 		Name:        "check_divisible",
 		Description: "Checks if a number is divisible by another number.",
-	}, func(ctx tool.Context, args struct {
+	}, func(ctx agent.ToolContext, args struct {
 		Number  int `json:"number"`
 		Divisor int `json:"divisor"`
 	},

--- a/examples/toolconfirmation/main.go
+++ b/examples/toolconfirmation/main.go
@@ -126,7 +126,7 @@ func main() {
 }
 
 // requestVacationDays simulates the *initiation* of a long-running ticket creation task.
-func requestVacationDays(ctx tool.Context, args RequestVacationArgs) (*RequestVacationResults, error) {
+func requestVacationDays(ctx agent.ToolContext, args RequestVacationArgs) (*RequestVacationResults, error) {
 	log.Printf("TOOL_EXEC: 'requestVacationDays' called with days: %d for user %s (Call ID: %s)\n", args.Days, args.UserID, ctx.FunctionCallID())
 
 	if args.Days <= 0 {

--- a/examples/tools/multipletools/main.go
+++ b/examples/tools/multipletools/main.go
@@ -68,7 +68,7 @@ func main() {
 	type Output struct {
 		Poem string `json:"poem"`
 	}
-	handler := func(ctx tool.Context, input Input) (Output, error) {
+	handler := func(ctx agent.ToolContext, input Input) (Output, error) {
 		return Output{
 			Poem: strings.Repeat("A line of a poem,", input.LineCount) + "\n",
 		}, nil

--- a/examples/vertexai/imagegenerator/main.go
+++ b/examples/vertexai/imagegenerator/main.go
@@ -91,7 +91,7 @@ func main() {
 }
 
 // This is a function tool to generate images using Vertex AI's Imagen model.
-func generateImage(ctx tool.Context, input generateImageInput) (generateImageResult, error) {
+func generateImage(ctx agent.ToolContext, input generateImageInput) (generateImageResult, error) {
 	client, err := genai.NewClient(ctx, &genai.ClientConfig{
 		Project:  os.Getenv("GOOGLE_CLOUD_PROJECT"),
 		Location: os.Getenv("GOOGLE_CLOUD_LOCATION"),
@@ -129,7 +129,7 @@ type generateImageResult struct {
 
 // This is function tool that loads image from the artifacts service and
 // saves is to the local filesystem.
-func saveImage(ctx tool.Context, input saveImageInput) (saveImageResult, error) {
+func saveImage(ctx agent.ToolContext, input saveImageInput) (saveImageResult, error) {
 	filename := input.Filename
 	resp, err := ctx.Artifacts().Load(ctx, filename)
 	if err != nil {

--- a/examples/web/agents/image_generator.go
+++ b/examples/web/agents/image_generator.go
@@ -30,7 +30,7 @@ import (
 	"google.golang.org/adk/tool/loadartifactstool"
 )
 
-func generateImage(ctx tool.Context, input generateImageInput) (generateImageResult, error) {
+func generateImage(ctx agent.ToolContext, input generateImageInput) (generateImageResult, error) {
 	client, err := genai.NewClient(ctx, &genai.ClientConfig{
 		Project:  os.Getenv("GOOGLE_CLOUD_PROJECT"),
 		Location: os.Getenv("GOOGLE_CLOUD_LOCATION"),

--- a/internal/configurable/conformance/functions.go
+++ b/internal/configurable/conformance/functions.go
@@ -21,6 +21,7 @@ import (
 	"math"
 	"regexp"
 
+	"google.golang.org/adk/agent"
 	"google.golang.org/adk/internal/configurable"
 	"google.golang.org/adk/tool"
 	"google.golang.org/adk/tool/functiontool"
@@ -32,11 +33,11 @@ type ValidateEmailArgs struct {
 
 var emailRegex = regexp.MustCompile(`^[a-zA-Z0-9._%+-]+@[a-zA-Z0-9.-]+\.[a-zA-Z]{2,}$`)
 
-func validateEmail(ctx tool.Context, args ValidateEmailArgs) (bool, error) {
+func validateEmail(ctx agent.ToolContext, args ValidateEmailArgs) (bool, error) {
 	return emailRegex.MatchString(args.Email), nil
 }
 
-func getUserID(ctx tool.Context, args ValidateEmailArgs) (int, error) {
+func getUserID(ctx agent.ToolContext, args ValidateEmailArgs) (int, error) {
 	valid, err := validateEmail(ctx, args)
 	if err != nil {
 		return 0, err
@@ -64,7 +65,7 @@ type CreateBookingArgs struct {
 	Details     string `json:"details"`
 }
 
-func createBooking(ctx tool.Context, args CreateBookingArgs) (map[string]any, error) {
+func createBooking(ctx agent.ToolContext, args CreateBookingArgs) (map[string]any, error) {
 	return map[string]any{
 		"user_id":           args.UserID,
 		"is_confirmed":      args.IsConfirmed,
@@ -94,7 +95,7 @@ type SearchFlightsArgs struct {
 	Preferences *FlightPreferences `json:"preferences"`
 }
 
-func searchFlights(ctx tool.Context, args SearchFlightsArgs) (map[string]any, error) {
+func searchFlights(ctx agent.ToolContext, args SearchFlightsArgs) (map[string]any, error) {
 	if args.Preferences == nil {
 		args.Preferences = &FlightPreferences{
 			CabinClass:    "Economy",
@@ -152,7 +153,7 @@ type CalculateTripCostArgs struct {
 	BaggageCount  *int    `json:"baggage_count"`
 }
 
-func calculateTripCost(ctx tool.Context, args CalculateTripCostArgs) (map[string]any, error) {
+func calculateTripCost(ctx agent.ToolContext, args CalculateTripCostArgs) (map[string]any, error) {
 	// Handle Python's default num_passengers=1 logic
 	// In Go, if the caller passes 0, we should ensure at least 1
 	// or handle it based on your specific business logic.
@@ -200,7 +201,7 @@ type reimburseArgs struct {
 	Amount  float64 `json:"amount"`
 }
 
-func reimburse(ctx tool.Context, args reimburseArgs) (map[string]any, error) {
+func reimburse(ctx agent.ToolContext, args reimburseArgs) (map[string]any, error) {
 	return map[string]any{
 		"status": "ok",
 	}, nil
@@ -211,7 +212,7 @@ type askForApprovalArgs struct {
 	Amount  float64 `json:"amount"`
 }
 
-func askForApproval(ctx tool.Context, args askForApprovalArgs) (map[string]any, error) {
+func askForApproval(ctx agent.ToolContext, args askForApprovalArgs) (map[string]any, error) {
 	return map[string]any{
 		"status":   "pending",
 		"amount":   args.Amount,

--- a/internal/configurable/conformance/recordplugin/record_plugin.go
+++ b/internal/configurable/conformance/recordplugin/record_plugin.go
@@ -126,7 +126,7 @@ func (p *recordPlugin) afterModel(ctx agent.CallbackContext, resp *model.LLMResp
 	return nil, nil
 }
 
-func (p *recordPlugin) beforeTool(ctx tool.Context, t tool.Tool, args map[string]any) (map[string]any, error) {
+func (p *recordPlugin) beforeTool(ctx agent.ToolContext, t tool.Tool, args map[string]any) (map[string]any, error) {
 	on, err := p.isRecordModeOn(ctx.State())
 	if err != nil || !on {
 		return nil, nil
@@ -147,7 +147,7 @@ func (p *recordPlugin) beforeTool(ctx tool.Context, t tool.Tool, args map[string
 	return nil, nil
 }
 
-func (p *recordPlugin) afterTool(ctx tool.Context, t tool.Tool, args, result map[string]any, err error) (map[string]any, error) {
+func (p *recordPlugin) afterTool(ctx agent.ToolContext, t tool.Tool, args, result map[string]any, err error) (map[string]any, error) {
 	on, recordErr := p.isRecordModeOn(ctx.State())
 	if recordErr != nil || !on {
 		return nil, nil

--- a/internal/configurable/conformance/replayplugin/replay_plugin.go
+++ b/internal/configurable/conformance/replayplugin/replay_plugin.go
@@ -137,7 +137,7 @@ func (p *replayPlugin) beforeModel(ctx agent.CallbackContext, req *model.LLMRequ
 }
 
 // beforeTool intercepts tool calls, verifies them against the recording, and returns the recorded response.
-func (p *replayPlugin) beforeTool(ctx tool.Context, t tool.Tool, args map[string]any) (map[string]any, error) {
+func (p *replayPlugin) beforeTool(ctx agent.ToolContext, t tool.Tool, args map[string]any) (map[string]any, error) {
 	on, err := p.isReplayModeOn(ctx.State())
 	if err != nil {
 		return nil, err

--- a/internal/llminternal/agent_transfer.go
+++ b/internal/llminternal/agent_transfer.go
@@ -159,12 +159,12 @@ func (t *TransferToAgentTool) enums() []string {
 }
 
 // ProcessRequest implements types.Tool.
-func (t *TransferToAgentTool) ProcessRequest(ctx tool.Context, req *model.LLMRequest) error {
+func (t *TransferToAgentTool) ProcessRequest(ctx agent.ToolContext, req *model.LLMRequest) error {
 	return appendTools(req, t)
 }
 
 // Run implements types.Tool.
-func (t *TransferToAgentTool) Run(ctx tool.Context, args any) (map[string]any, error) {
+func (t *TransferToAgentTool) Run(ctx agent.ToolContext, args any) (map[string]any, error) {
 	if args == nil {
 		return nil, fmt.Errorf("missing argument")
 	}

--- a/internal/llminternal/agent_transfer_test.go
+++ b/internal/llminternal/agent_transfer_test.go
@@ -435,7 +435,7 @@ func TestAgentTransfer_ProcessRequest(t *testing.T) {
 		x int
 	}
 	var req model.LLMRequest
-	handler := func(ctx tool.Context, input Input) (int, error) {
+	handler := func(ctx agent.ToolContext, input Input) (int, error) {
 		return input.x, nil
 	}
 	identityTool, err := functiontool.New(functiontool.Config{

--- a/internal/llminternal/base_flow.go
+++ b/internal/llminternal/base_flow.go
@@ -53,11 +53,11 @@ type AfterModelCallback func(ctx agent.CallbackContext, llmResponse *model.LLMRe
 
 type OnModelErrorCallback func(ctx agent.CallbackContext, llmRequest *model.LLMRequest, llmResponseError error) (*model.LLMResponse, error)
 
-type BeforeToolCallback func(ctx tool.Context, tool tool.Tool, args map[string]any) (map[string]any, error)
+type BeforeToolCallback func(ctx agent.ToolContext, tool tool.Tool, args map[string]any) (map[string]any, error)
 
-type AfterToolCallback func(ctx tool.Context, tool tool.Tool, args, result map[string]any, err error) (map[string]any, error)
+type AfterToolCallback func(ctx agent.ToolContext, tool tool.Tool, args, result map[string]any, err error) (map[string]any, error)
 
-type OnToolErrorCallback func(ctx tool.Context, tool tool.Tool, args map[string]any, err error) (map[string]any, error)
+type OnToolErrorCallback func(ctx agent.ToolContext, tool tool.Tool, args map[string]any, err error) (map[string]any, error)
 
 type Flow struct {
 	Model model.LLM
@@ -985,7 +985,7 @@ Suggested fixes:
 }
 
 type cancelledToolContext struct {
-	tool.Context
+	agent.ToolContext
 	cancelCtx context.Context
 }
 
@@ -1068,8 +1068,8 @@ func (f *Flow) handleFunctionCalls(ctx agent.InvocationContext, toolsDict map[st
 						result = map[string]any{"status": "The function is running asynchronously and the results are pending."}
 						cancelCtx, cancel := context.WithCancel(toolCtx)
 						cancelToolCtx := &cancelledToolContext{
-							Context:   toolCtx,
-							cancelCtx: cancelCtx,
+							ToolContext: toolCtx,
+							cancelCtx:   cancelCtx,
 						}
 						if impl, ok := liveSess.(*liveSessionImpl); ok {
 							impl.RegisterStreamingTool(streamTool.Name(), fnCall.ID, cancel)
@@ -1179,7 +1179,7 @@ func (f *Flow) handleFunctionCalls(ctx agent.InvocationContext, toolsDict map[st
 	return mergedEvent, nil
 }
 
-func (f *Flow) runOnToolErrorCallbacks(toolCtx tool.Context, tool tool.Tool, fArgs map[string]any, err error) (map[string]any, error) {
+func (f *Flow) runOnToolErrorCallbacks(toolCtx agent.ToolContext, tool tool.Tool, fArgs map[string]any, err error) (map[string]any, error) {
 	pluginManager := pluginManagerFromContext(toolCtx)
 	if pluginManager != nil {
 		result, err := pluginManager.RunOnToolErrorCallback(toolCtx, tool, fArgs, err)
@@ -1190,7 +1190,7 @@ func (f *Flow) runOnToolErrorCallbacks(toolCtx tool.Context, tool tool.Tool, fAr
 	return f.invokeOnToolErrorCallbacks(toolCtx, tool, fArgs, err)
 }
 
-func (f *Flow) callTool(toolCtx tool.Context, tool toolinternal.FunctionTool, fArgs map[string]any) map[string]any {
+func (f *Flow) callTool(toolCtx agent.ToolContext, tool toolinternal.FunctionTool, fArgs map[string]any) map[string]any {
 	var response map[string]any
 	var err error
 	pluginManager := pluginManagerFromContext(toolCtx)
@@ -1237,7 +1237,7 @@ func (f *Flow) callTool(toolCtx tool.Context, tool toolinternal.FunctionTool, fA
 	return response
 }
 
-func (f *Flow) invokeBeforeToolCallbacks(toolCtx tool.Context, tool tool.Tool, fArgs map[string]any) (map[string]any, error) {
+func (f *Flow) invokeBeforeToolCallbacks(toolCtx agent.ToolContext, tool tool.Tool, fArgs map[string]any) (map[string]any, error) {
 	for _, callback := range f.BeforeToolCallbacks {
 		result, err := callback(toolCtx, tool, fArgs)
 		if err != nil {
@@ -1252,7 +1252,7 @@ func (f *Flow) invokeBeforeToolCallbacks(toolCtx tool.Context, tool tool.Tool, f
 	return nil, nil
 }
 
-func (f *Flow) invokeAfterToolCallbacks(toolCtx tool.Context, tool toolinternal.FunctionTool, fArgs, fResult map[string]any, fErr error) (map[string]any, error) {
+func (f *Flow) invokeAfterToolCallbacks(toolCtx agent.ToolContext, tool toolinternal.FunctionTool, fArgs, fResult map[string]any, fErr error) (map[string]any, error) {
 	for _, callback := range f.AfterToolCallbacks {
 		result, err := callback(toolCtx, tool, fArgs, fResult, fErr)
 		if err != nil {
@@ -1268,7 +1268,7 @@ func (f *Flow) invokeAfterToolCallbacks(toolCtx tool.Context, tool toolinternal.
 	return fResult, fErr
 }
 
-func (f *Flow) invokeOnToolErrorCallbacks(toolCtx tool.Context, tool tool.Tool, fArgs map[string]any, fErr error) (map[string]any, error) {
+func (f *Flow) invokeOnToolErrorCallbacks(toolCtx agent.ToolContext, tool tool.Tool, fArgs map[string]any, fErr error) (map[string]any, error) {
 	for _, callback := range f.OnToolErrorCallbacks {
 		result, err := callback(toolCtx, tool, fArgs, fErr)
 		if err != nil {
@@ -1370,7 +1370,7 @@ type pluginManager interface {
 	RunBeforeModelCallback(cctx agent.CallbackContext, llmRequest *model.LLMRequest) (*model.LLMResponse, error)
 	RunAfterModelCallback(cctx agent.CallbackContext, llmResponse *model.LLMResponse, llmResponseError error) (*model.LLMResponse, error)
 	RunOnModelErrorCallback(ctx agent.CallbackContext, llmRequest *model.LLMRequest, llmResponseError error) (*model.LLMResponse, error)
-	RunBeforeToolCallback(ctx tool.Context, t tool.Tool, args map[string]any) (map[string]any, error)
-	RunAfterToolCallback(ctx tool.Context, t tool.Tool, args, result map[string]any, err error) (map[string]any, error)
-	RunOnToolErrorCallback(ctx tool.Context, t tool.Tool, args map[string]any, err error) (map[string]any, error)
+	RunBeforeToolCallback(ctx agent.ToolContext, t tool.Tool, args map[string]any) (map[string]any, error)
+	RunAfterToolCallback(ctx agent.ToolContext, t tool.Tool, args, result map[string]any, err error) (map[string]any, error)
+	RunOnToolErrorCallback(ctx agent.ToolContext, t tool.Tool, args map[string]any, err error) (map[string]any, error)
 }

--- a/internal/llminternal/base_flow_test.go
+++ b/internal/llminternal/base_flow_test.go
@@ -31,7 +31,7 @@ import (
 
 type mockFunctionTool struct {
 	name    string
-	runFunc func(tool.Context, map[string]any) (map[string]any, error)
+	runFunc func(agent.ToolContext, map[string]any) (map[string]any, error)
 }
 
 func (m *mockFunctionTool) Name() string {
@@ -54,11 +54,11 @@ func (m *mockFunctionTool) IsLongRunning() bool {
 	return false
 }
 
-func (m *mockFunctionTool) ProcessRequest(ctx tool.Context, req *model.LLMRequest) error {
+func (m *mockFunctionTool) ProcessRequest(ctx agent.ToolContext, req *model.LLMRequest) error {
 	return nil
 }
 
-func (m *mockFunctionTool) Run(ctx tool.Context, args any) (map[string]any, error) {
+func (m *mockFunctionTool) Run(ctx agent.ToolContext, args any) (map[string]any, error) {
 	if m.runFunc != nil {
 		return m.runFunc(ctx, args.(map[string]any))
 	}
@@ -80,10 +80,10 @@ func (m *mockToolset) Tools(ctx agent.ReadonlyContext) ([]tool.Tool, error) {
 
 type mockRequestProcessorToolset struct {
 	name    string
-	process func(ctx tool.Context, req *model.LLMRequest) error
+	process func(ctx agent.ToolContext, req *model.LLMRequest) error
 }
 
-func (m *mockRequestProcessorToolset) ProcessRequest(ctx tool.Context, req *model.LLMRequest) error {
+func (m *mockRequestProcessorToolset) ProcessRequest(ctx agent.ToolContext, req *model.LLMRequest) error {
 	if m.process != nil {
 		return m.process(ctx, req)
 	}
@@ -110,7 +110,7 @@ func TestCallTool(t *testing.T) {
 			name: "tool runs successfully",
 			tool: &mockFunctionTool{
 				name: "testTool",
-				runFunc: func(ctx tool.Context, args map[string]any) (map[string]any, error) {
+				runFunc: func(ctx agent.ToolContext, args map[string]any) (map[string]any, error) {
 					return map[string]any{"result": "success"}, nil
 				},
 			},
@@ -121,7 +121,7 @@ func TestCallTool(t *testing.T) {
 			name: "tool error",
 			tool: &mockFunctionTool{
 				name: "testTool",
-				runFunc: func(ctx tool.Context, args map[string]any) (map[string]any, error) {
+				runFunc: func(ctx agent.ToolContext, args map[string]any) (map[string]any, error) {
 					return nil, errors.New("tool error")
 				},
 			},
@@ -132,16 +132,16 @@ func TestCallTool(t *testing.T) {
 			name: "before callback returns result",
 			tool: &mockFunctionTool{
 				name: "testTool",
-				runFunc: func(ctx tool.Context, args map[string]any) (map[string]any, error) {
+				runFunc: func(ctx agent.ToolContext, args map[string]any) (map[string]any, error) {
 					t.Error("tool should not be called")
 					return nil, nil
 				},
 			},
 			beforeToolCallbacks: []BeforeToolCallback{
-				func(ctx tool.Context, tool tool.Tool, args map[string]any) (map[string]any, error) {
+				func(ctx agent.ToolContext, tool tool.Tool, args map[string]any) (map[string]any, error) {
 					return map[string]any{"result": "intercepted"}, nil
 				},
-				func(ctx tool.Context, tool tool.Tool, args map[string]any) (map[string]any, error) {
+				func(ctx agent.ToolContext, tool tool.Tool, args map[string]any) (map[string]any, error) {
 					return map[string]any{"result": "2nd callback should not be called"}, nil
 				},
 			},
@@ -151,16 +151,16 @@ func TestCallTool(t *testing.T) {
 			name: "before callback returns error",
 			tool: &mockFunctionTool{
 				name: "testTool",
-				runFunc: func(ctx tool.Context, args map[string]any) (map[string]any, error) {
+				runFunc: func(ctx agent.ToolContext, args map[string]any) (map[string]any, error) {
 					t.Error("tool should not be called")
 					return nil, nil
 				},
 			},
 			beforeToolCallbacks: []BeforeToolCallback{
-				func(ctx tool.Context, tool tool.Tool, args map[string]any) (map[string]any, error) {
+				func(ctx agent.ToolContext, tool tool.Tool, args map[string]any) (map[string]any, error) {
 					return nil, errors.New("before callback error")
 				},
-				func(ctx tool.Context, tool tool.Tool, args map[string]any) (map[string]any, error) {
+				func(ctx agent.ToolContext, tool tool.Tool, args map[string]any) (map[string]any, error) {
 					return nil, errors.New("unexpected error")
 				},
 			},
@@ -170,12 +170,12 @@ func TestCallTool(t *testing.T) {
 			name: "after callback modifies result",
 			tool: &mockFunctionTool{
 				name: "testTool",
-				runFunc: func(ctx tool.Context, args map[string]any) (map[string]any, error) {
+				runFunc: func(ctx agent.ToolContext, args map[string]any) (map[string]any, error) {
 					return map[string]any{"result": "original"}, nil
 				},
 			},
 			afterToolCallbacks: []AfterToolCallback{
-				func(ctx tool.Context, tool tool.Tool, args, result map[string]any, err error) (map[string]any, error) {
+				func(ctx agent.ToolContext, tool tool.Tool, args, result map[string]any, err error) (map[string]any, error) {
 					return map[string]any{"result": "modified"}, nil
 				},
 			},
@@ -185,18 +185,18 @@ func TestCallTool(t *testing.T) {
 			name: "after callback handles error",
 			tool: &mockFunctionTool{
 				name: "testTool",
-				runFunc: func(ctx tool.Context, args map[string]any) (map[string]any, error) {
+				runFunc: func(ctx agent.ToolContext, args map[string]any) (map[string]any, error) {
 					return nil, errors.New("tool error")
 				},
 			},
 			afterToolCallbacks: []AfterToolCallback{
-				func(ctx tool.Context, tool tool.Tool, args, result map[string]any, err error) (map[string]any, error) {
+				func(ctx agent.ToolContext, tool tool.Tool, args, result map[string]any, err error) (map[string]any, error) {
 					if err != nil {
 						return map[string]any{"result": "error handled"}, nil
 					}
 					return nil, nil
 				},
-				func(ctx tool.Context, tool tool.Tool, args, result map[string]any, err error) (map[string]any, error) {
+				func(ctx agent.ToolContext, tool tool.Tool, args, result map[string]any, err error) (map[string]any, error) {
 					return map[string]any{"result": "unexpected output"}, nil
 				},
 			},
@@ -206,15 +206,15 @@ func TestCallTool(t *testing.T) {
 			name: "after callback returns error",
 			tool: &mockFunctionTool{
 				name: "testTool",
-				runFunc: func(ctx tool.Context, args map[string]any) (map[string]any, error) {
+				runFunc: func(ctx agent.ToolContext, args map[string]any) (map[string]any, error) {
 					return map[string]any{"result": "success"}, nil
 				},
 			},
 			afterToolCallbacks: []AfterToolCallback{
-				func(ctx tool.Context, tool tool.Tool, args, result map[string]any, err error) (map[string]any, error) {
+				func(ctx agent.ToolContext, tool tool.Tool, args, result map[string]any, err error) (map[string]any, error) {
 					return nil, errors.New("after callback error")
 				},
-				func(ctx tool.Context, tool tool.Tool, args, result map[string]any, err error) (map[string]any, error) {
+				func(ctx agent.ToolContext, tool tool.Tool, args, result map[string]any, err error) (map[string]any, error) {
 					return nil, errors.New("unexpected error")
 				},
 			},
@@ -224,17 +224,17 @@ func TestCallTool(t *testing.T) {
 			name: "no-op callbacks return func results",
 			tool: &mockFunctionTool{
 				name: "testTool",
-				runFunc: func(ctx tool.Context, args map[string]any) (map[string]any, error) {
+				runFunc: func(ctx agent.ToolContext, args map[string]any) (map[string]any, error) {
 					return map[string]any{"result": "success"}, nil
 				},
 			},
 			beforeToolCallbacks: []BeforeToolCallback{
-				func(ctx tool.Context, tool tool.Tool, args map[string]any) (map[string]any, error) {
+				func(ctx agent.ToolContext, tool tool.Tool, args map[string]any) (map[string]any, error) {
 					return nil, nil
 				},
 			},
 			afterToolCallbacks: []AfterToolCallback{
-				func(ctx tool.Context, tool tool.Tool, args, result map[string]any, err error) (map[string]any, error) {
+				func(ctx agent.ToolContext, tool tool.Tool, args, result map[string]any, err error) (map[string]any, error) {
 					return nil, nil
 				},
 			},
@@ -244,18 +244,18 @@ func TestCallTool(t *testing.T) {
 			name: "before callback result passed to after callback",
 			tool: &mockFunctionTool{
 				name: "testTool",
-				runFunc: func(ctx tool.Context, args map[string]any) (map[string]any, error) {
+				runFunc: func(ctx agent.ToolContext, args map[string]any) (map[string]any, error) {
 					t.Error("tool should not be called")
 					return nil, nil
 				},
 			},
 			beforeToolCallbacks: []BeforeToolCallback{
-				func(ctx tool.Context, tool tool.Tool, args map[string]any) (map[string]any, error) {
+				func(ctx agent.ToolContext, tool tool.Tool, args map[string]any) (map[string]any, error) {
 					return map[string]any{"result": "from_before"}, nil
 				},
 			},
 			afterToolCallbacks: []AfterToolCallback{
-				func(ctx tool.Context, tool tool.Tool, args, result map[string]any, err error) (map[string]any, error) {
+				func(ctx agent.ToolContext, tool tool.Tool, args, result map[string]any, err error) (map[string]any, error) {
 					if val, ok := result["result"]; !ok || val != "from_before" {
 						return nil, errors.New("unexpected result in after callback")
 					}
@@ -268,18 +268,18 @@ func TestCallTool(t *testing.T) {
 			name: "before callback error passed to after callback",
 			tool: &mockFunctionTool{
 				name: "testTool",
-				runFunc: func(ctx tool.Context, args map[string]any) (map[string]any, error) {
+				runFunc: func(ctx agent.ToolContext, args map[string]any) (map[string]any, error) {
 					t.Error("tool should not be called")
 					return nil, nil
 				},
 			},
 			beforeToolCallbacks: []BeforeToolCallback{
-				func(ctx tool.Context, tool tool.Tool, args map[string]any) (map[string]any, error) {
+				func(ctx agent.ToolContext, tool tool.Tool, args map[string]any) (map[string]any, error) {
 					return nil, errors.New("error_from_before")
 				},
 			},
 			afterToolCallbacks: []AfterToolCallback{
-				func(ctx tool.Context, tool tool.Tool, args, result map[string]any, err error) (map[string]any, error) {
+				func(ctx agent.ToolContext, tool tool.Tool, args, result map[string]any, err error) (map[string]any, error) {
 					if err == nil || err.Error() != "error_from_before" {
 						return nil, errors.New("unexpected error in after callback")
 					}
@@ -292,18 +292,18 @@ func TestCallTool(t *testing.T) {
 			name: "before callback error passed to on tool error callback",
 			tool: &mockFunctionTool{
 				name: "testTool",
-				runFunc: func(ctx tool.Context, args map[string]any) (map[string]any, error) {
+				runFunc: func(ctx agent.ToolContext, args map[string]any) (map[string]any, error) {
 					t.Error("tool should not be called")
 					return nil, nil
 				},
 			},
 			beforeToolCallbacks: []BeforeToolCallback{
-				func(ctx tool.Context, tool tool.Tool, args map[string]any) (map[string]any, error) {
+				func(ctx agent.ToolContext, tool tool.Tool, args map[string]any) (map[string]any, error) {
 					return nil, errors.New("error_from_before")
 				},
 			},
 			onToolErrorCallbacks: []OnToolErrorCallback{
-				func(ctx tool.Context, tool tool.Tool, args map[string]any, err error) (map[string]any, error) {
+				func(ctx agent.ToolContext, tool tool.Tool, args map[string]any, err error) (map[string]any, error) {
 					if err == nil || err.Error() != "error_from_before" {
 						t.Error("unexpected error in on tool error callback")
 						return nil, errors.New("unexpected error in on tool error callback")
@@ -317,18 +317,18 @@ func TestCallTool(t *testing.T) {
 			name: "before callback error passed to on tool error callback and after tool called",
 			tool: &mockFunctionTool{
 				name: "testTool",
-				runFunc: func(ctx tool.Context, args map[string]any) (map[string]any, error) {
+				runFunc: func(ctx agent.ToolContext, args map[string]any) (map[string]any, error) {
 					t.Error("tool should not be called")
 					return nil, nil
 				},
 			},
 			beforeToolCallbacks: []BeforeToolCallback{
-				func(ctx tool.Context, tool tool.Tool, args map[string]any) (map[string]any, error) {
+				func(ctx agent.ToolContext, tool tool.Tool, args map[string]any) (map[string]any, error) {
 					return nil, errors.New("error_from_before")
 				},
 			},
 			onToolErrorCallbacks: []OnToolErrorCallback{
-				func(ctx tool.Context, tool tool.Tool, args map[string]any, err error) (map[string]any, error) {
+				func(ctx agent.ToolContext, tool tool.Tool, args map[string]any, err error) (map[string]any, error) {
 					if err == nil || err.Error() != "error_from_before" {
 						t.Error("unexpected error in on tool error callback")
 						return nil, errors.New("unexpected error in on tool error callback")
@@ -337,7 +337,7 @@ func TestCallTool(t *testing.T) {
 				},
 			},
 			afterToolCallbacks: []AfterToolCallback{
-				func(ctx tool.Context, tool tool.Tool, args, result map[string]any, err error) (map[string]any, error) {
+				func(ctx agent.ToolContext, tool tool.Tool, args, result map[string]any, err error) (map[string]any, error) {
 					if err != nil {
 						return nil, errors.New("unexpected error in after callback")
 					}
@@ -350,18 +350,18 @@ func TestCallTool(t *testing.T) {
 			name: "before callback error passed to on tool error callback and passed to after tool called",
 			tool: &mockFunctionTool{
 				name: "testTool",
-				runFunc: func(ctx tool.Context, args map[string]any) (map[string]any, error) {
+				runFunc: func(ctx agent.ToolContext, args map[string]any) (map[string]any, error) {
 					t.Error("tool should not be called")
 					return nil, nil
 				},
 			},
 			beforeToolCallbacks: []BeforeToolCallback{
-				func(ctx tool.Context, tool tool.Tool, args map[string]any) (map[string]any, error) {
+				func(ctx agent.ToolContext, tool tool.Tool, args map[string]any) (map[string]any, error) {
 					return nil, errors.New("error_from_before")
 				},
 			},
 			onToolErrorCallbacks: []OnToolErrorCallback{
-				func(ctx tool.Context, tool tool.Tool, args map[string]any, err error) (map[string]any, error) {
+				func(ctx agent.ToolContext, tool tool.Tool, args map[string]any, err error) (map[string]any, error) {
 					if err == nil || err.Error() != "error_from_before" {
 						t.Error("unexpected error in on tool error callback")
 						return nil, errors.New("unexpected error in on tool error callback")
@@ -370,7 +370,7 @@ func TestCallTool(t *testing.T) {
 				},
 			},
 			afterToolCallbacks: []AfterToolCallback{
-				func(ctx tool.Context, tool tool.Tool, args, result map[string]any, err error) (map[string]any, error) {
+				func(ctx agent.ToolContext, tool tool.Tool, args, result map[string]any, err error) (map[string]any, error) {
 					if err == nil || err.Error() != "error_from_on_tool_error" {
 						return nil, errors.New("unexpected error in after callback")
 					}
@@ -383,18 +383,18 @@ func TestCallTool(t *testing.T) {
 			name: "before callback error passed to on tool error callback and passed to after tool called and handled",
 			tool: &mockFunctionTool{
 				name: "testTool",
-				runFunc: func(ctx tool.Context, args map[string]any) (map[string]any, error) {
+				runFunc: func(ctx agent.ToolContext, args map[string]any) (map[string]any, error) {
 					t.Error("tool should not be called")
 					return nil, nil
 				},
 			},
 			beforeToolCallbacks: []BeforeToolCallback{
-				func(ctx tool.Context, tool tool.Tool, args map[string]any) (map[string]any, error) {
+				func(ctx agent.ToolContext, tool tool.Tool, args map[string]any) (map[string]any, error) {
 					return nil, errors.New("error_from_before")
 				},
 			},
 			onToolErrorCallbacks: []OnToolErrorCallback{
-				func(ctx tool.Context, tool tool.Tool, args map[string]any, err error) (map[string]any, error) {
+				func(ctx agent.ToolContext, tool tool.Tool, args map[string]any, err error) (map[string]any, error) {
 					if err == nil || err.Error() != "error_from_before" {
 						t.Error("unexpected error in on tool error callback")
 						return nil, errors.New("unexpected error in on tool error callback")
@@ -403,7 +403,7 @@ func TestCallTool(t *testing.T) {
 				},
 			},
 			afterToolCallbacks: []AfterToolCallback{
-				func(ctx tool.Context, tool tool.Tool, args, result map[string]any, err error) (map[string]any, error) {
+				func(ctx agent.ToolContext, tool tool.Tool, args, result map[string]any, err error) (map[string]any, error) {
 					if err == nil || err.Error() != "error_from_on_tool_error" {
 						return nil, errors.New("unexpected error in after callback")
 					}
@@ -630,7 +630,7 @@ func TestPreprocess_Toolset(t *testing.T) {
 				s: &State{
 					Toolsets: []tool.Toolset{&mockRequestProcessorToolset{
 						name: "toolset",
-						process: func(_ tool.Context, _ *model.LLMRequest) error {
+						process: func(_ agent.ToolContext, _ *model.LLMRequest) error {
 							return errors.New("process error")
 						},
 					}},
@@ -646,7 +646,7 @@ func TestPreprocess_Toolset(t *testing.T) {
 						&mockToolset{name: "toolset_without_processor"},
 						&mockRequestProcessorToolset{
 							name: "toolset_with_processor",
-							process: func(_ tool.Context, req *model.LLMRequest) error {
+							process: func(_ agent.ToolContext, req *model.LLMRequest) error {
 								req.Model = "modified-model"
 								return nil
 							},

--- a/internal/llminternal/functions.go
+++ b/internal/llminternal/functions.go
@@ -26,7 +26,7 @@ import (
 
 // generateRequestConfirmationEvent creates a new Event containing
 // adk_request_confirmation function calls based on the requested confirmations.
-// NOTE: The trigger for this in ADK Go is usually a tool.Context.RequestConfirmation call,
+// NOTE: The trigger for this in ADK Go is usually a agent.ToolContext.RequestConfirmation call,
 // not parsing a function_response_event like in the Python example.
 // This function assumes you have a list of confirmations to process.
 func generateRequestConfirmationEvent(

--- a/internal/llminternal/handle_function_calls_async_test.go
+++ b/internal/llminternal/handle_function_calls_async_test.go
@@ -38,7 +38,7 @@ type SleepResult struct {
 	Success bool `json:"success"`
 }
 
-func sleepFunc(ctx tool.Context, input SleepArgs) (SleepResult, error) {
+func sleepFunc(ctx agent.ToolContext, input SleepArgs) (SleepResult, error) {
 	time.Sleep(time.Duration(input.DurationMS) * time.Millisecond)
 	return SleepResult{Success: true}, nil
 }

--- a/internal/llminternal/outputschema_processor.go
+++ b/internal/llminternal/outputschema_processor.go
@@ -27,7 +27,6 @@ import (
 	"google.golang.org/adk/internal/utils"
 	"google.golang.org/adk/model"
 	"google.golang.org/adk/session"
-	"google.golang.org/adk/tool"
 )
 
 const (
@@ -129,7 +128,7 @@ func (t *setModelResponseTool) Declaration() *genai.FunctionDeclaration {
 	}
 }
 
-func (t *setModelResponseTool) Run(ctx tool.Context, args any) (map[string]any, error) {
+func (t *setModelResponseTool) Run(ctx agent.ToolContext, args any) (map[string]any, error) {
 	m, ok := args.(map[string]any)
 	if !ok {
 		return nil, fmt.Errorf("unexpected args type for set_model_response: %T", args)

--- a/internal/llminternal/outputschema_processor_test.go
+++ b/internal/llminternal/outputschema_processor_test.go
@@ -41,7 +41,7 @@ func (m *mockTool) IsLongRunning() bool { return false }
 func (m *mockTool) Declaration() *genai.FunctionDeclaration {
 	return &genai.FunctionDeclaration{Name: m.name}
 }
-func (m *mockTool) Run(ctx tool.Context, args any) (map[string]any, error) { return nil, nil }
+func (m *mockTool) Run(ctx agent.ToolContext, args any) (map[string]any, error) { return nil, nil }
 
 type mockLLM struct {
 	model.LLM

--- a/internal/llminternal/parallel_function_call_hitl_test.go
+++ b/internal/llminternal/parallel_function_call_hitl_test.go
@@ -42,7 +42,7 @@ type SecureActionResult struct {
 	Executed bool `json:"executed"`
 }
 
-func secureActionFunc(ctx tool.Context, input SecureActionArgs) (SecureActionResult, error) {
+func secureActionFunc(ctx agent.ToolContext, input SecureActionArgs) (SecureActionResult, error) {
 	return SecureActionResult{Executed: true}, nil
 }
 

--- a/internal/llminternal/parallel_function_call_test.go
+++ b/internal/llminternal/parallel_function_call_test.go
@@ -44,7 +44,7 @@ type SumResult struct {
 	Sum int `json:"sum"` // the sum of two integers
 }
 
-func sumFunc(ctx tool.Context, input SumArgs) (SumResult, error) {
+func sumFunc(ctx agent.ToolContext, input SumArgs) (SumResult, error) {
 	return SumResult{Sum: input.A + input.B}, nil
 }
 

--- a/internal/llminternal/request_confirmation_processor_test.go
+++ b/internal/llminternal/request_confirmation_processor_test.go
@@ -51,7 +51,7 @@ func (m *mockTool) Declaration() *genai.FunctionDeclaration {
 	return &genai.FunctionDeclaration{Name: m.name}
 }
 
-func (m *mockTool) Run(ctx tool.Context, args any) (map[string]any, error) {
+func (m *mockTool) Run(ctx agent.ToolContext, args any) (map[string]any, error) {
 	if ctx.ToolConfirmation() == nil || !ctx.ToolConfirmation().Confirmed {
 		return map[string]any{"error": string("Tool execution not confirmed")}, nil
 	}

--- a/internal/llminternal/stream_aggregator_test.go
+++ b/internal/llminternal/stream_aggregator_test.go
@@ -629,7 +629,7 @@ type GetWeatherArgs struct {
 	Location string `json:"location"`
 }
 
-func getWeather(ctx tool.Context, args GetWeatherArgs) (map[string]any, error) {
+func getWeather(ctx agent.ToolContext, args GetWeatherArgs) (map[string]any, error) {
 	return map[string]any{
 		"temperature": 22,
 		"condition":   "sunny",
@@ -945,7 +945,7 @@ func TestPartialFunctionCallsNotExecutedInNoneStreamingMode(t *testing.T) {
 		CallID string `json:"call_id"`
 	}
 
-	trackExecution := func(ctx tool.Context, args TrackExecutionArgs) (string, error) {
+	trackExecution := func(ctx agent.ToolContext, args TrackExecutionArgs) (string, error) {
 		executionLog = append(executionLog, args.CallID)
 		return "Executed: " + args.CallID, nil
 	}

--- a/internal/llminternal/streaming_tool_test.go
+++ b/internal/llminternal/streaming_tool_test.go
@@ -49,7 +49,7 @@ func TestHandleFunctionCalls_Streaming(t *testing.T) {
 		Count int `json:"count"`
 	}
 
-	handler := func(ctx tool.Context, args Args) iter.Seq2[string, error] {
+	handler := func(ctx agent.ToolContext, args Args) iter.Seq2[string, error] {
 		return func(yield func(string, error) bool) {
 			for i := 0; i < args.Count; i++ {
 				if !yield(fmt.Sprintf("chunk %d", i), nil) {
@@ -187,7 +187,7 @@ func TestHandleFunctionCalls_LiveControlPlane(t *testing.T) {
 	var cancelCount int
 	var cancelMu sync.Mutex
 
-	handler := func(ctx tool.Context, args Args) iter.Seq2[string, error] {
+	handler := func(ctx agent.ToolContext, args Args) iter.Seq2[string, error] {
 		return func(yield func(string, error) bool) {
 			for i := 0; ; i++ {
 				time.Sleep(time.Millisecond)

--- a/internal/plugininternal/plugin_manager.go
+++ b/internal/plugininternal/plugin_manager.go
@@ -168,7 +168,7 @@ func (pm *PluginManager) RunAfterAgentCallback(cctx agent.CallbackContext) (*gen
 }
 
 // RunBeforeToolCallback runs the BeforeToolCallback for all plugins.
-func (pm *PluginManager) RunBeforeToolCallback(ctx tool.Context, tool tool.Tool, args map[string]any) (map[string]any, error) {
+func (pm *PluginManager) RunBeforeToolCallback(ctx agent.ToolContext, tool tool.Tool, args map[string]any) (map[string]any, error) {
 	for _, plugin := range pm.plugins {
 		callback := plugin.BeforeToolCallback()
 		if callback != nil {
@@ -185,7 +185,7 @@ func (pm *PluginManager) RunBeforeToolCallback(ctx tool.Context, tool tool.Tool,
 }
 
 // RunAfterToolCallback runs the AfterToolCallback for all plugins.
-func (pm *PluginManager) RunAfterToolCallback(ctx tool.Context, tool tool.Tool, args, result map[string]any, err error) (map[string]any, error) {
+func (pm *PluginManager) RunAfterToolCallback(ctx agent.ToolContext, tool tool.Tool, args, result map[string]any, err error) (map[string]any, error) {
 	for _, plugin := range pm.plugins {
 		callback := plugin.AfterToolCallback()
 		if callback != nil {
@@ -202,7 +202,7 @@ func (pm *PluginManager) RunAfterToolCallback(ctx tool.Context, tool tool.Tool, 
 }
 
 // RunOnToolErrorCallback runs the OnToolErrorCallback for all plugins.
-func (pm *PluginManager) RunOnToolErrorCallback(ctx tool.Context, tool tool.Tool, args map[string]any, err error) (map[string]any, error) {
+func (pm *PluginManager) RunOnToolErrorCallback(ctx agent.ToolContext, tool tool.Tool, args map[string]any, err error) (map[string]any, error) {
 	for _, plugin := range pm.plugins {
 		callback := plugin.OnToolErrorCallback()
 		if callback != nil {

--- a/internal/toolinternal/tool.go
+++ b/internal/toolinternal/tool.go
@@ -20,6 +20,7 @@ import (
 
 	"google.golang.org/genai"
 
+	"google.golang.org/adk/agent"
 	"google.golang.org/adk/model"
 	"google.golang.org/adk/tool"
 )
@@ -27,15 +28,15 @@ import (
 type FunctionTool interface {
 	tool.Tool
 	Declaration() *genai.FunctionDeclaration
-	Run(ctx tool.Context, args any) (result map[string]any, err error)
+	Run(ctx agent.ToolContext, args any) (result map[string]any, err error)
 }
 
 type StreamingFunctionTool interface {
 	tool.Tool
 	Declaration() *genai.FunctionDeclaration
-	RunStream(ctx tool.Context, args any) iter.Seq2[string, error]
+	RunStream(ctx agent.ToolContext, args any) iter.Seq2[string, error]
 }
 
 type RequestProcessor interface {
-	ProcessRequest(ctx tool.Context, req *model.LLMRequest) error
+	ProcessRequest(ctx agent.ToolContext, req *model.LLMRequest) error
 }

--- a/plugin/functioncallmodifier/plugin_test.go
+++ b/plugin/functioncallmodifier/plugin_test.go
@@ -41,7 +41,7 @@ type SimpleArgs struct {
 	Num int
 }
 
-func okFunc(_ tool.Context, _ SimpleArgs) (string, error) {
+func okFunc(_ agent.ToolContext, _ SimpleArgs) (string, error) {
 	return "ok", nil
 }
 

--- a/plugin/loggingplugin/logging_plugin.go
+++ b/plugin/loggingplugin/logging_plugin.go
@@ -279,7 +279,7 @@ func (p *loggingPlugin) onModelError(ctx agent.CallbackContext, req *model.LLMRe
 	return nil, nil
 }
 
-func (p *loggingPlugin) beforeTool(ctx tool.Context, t tool.Tool, args map[string]any) (map[string]any, error) {
+func (p *loggingPlugin) beforeTool(ctx agent.ToolContext, t tool.Tool, args map[string]any) (map[string]any, error) {
 	p.log("🔧 TOOL STARTING")
 	p.log(fmt.Sprintf("   Tool Name: %s", t.Name()))
 	p.log(fmt.Sprintf("   Agent: %s", ctx.AgentName()))
@@ -288,7 +288,7 @@ func (p *loggingPlugin) beforeTool(ctx tool.Context, t tool.Tool, args map[strin
 	return nil, nil
 }
 
-func (p *loggingPlugin) afterTool(ctx tool.Context, t tool.Tool, args, result map[string]any, err error) (map[string]any, error) {
+func (p *loggingPlugin) afterTool(ctx agent.ToolContext, t tool.Tool, args, result map[string]any, err error) (map[string]any, error) {
 	p.log("🔧 TOOL COMPLETED")
 	p.log(fmt.Sprintf("   Tool Name: %s", t.Name()))
 	p.log(fmt.Sprintf("   Agent: %s", ctx.AgentName()))
@@ -301,7 +301,7 @@ func (p *loggingPlugin) afterTool(ctx tool.Context, t tool.Tool, args, result ma
 	return nil, nil
 }
 
-func (p *loggingPlugin) onToolError(ctx tool.Context, t tool.Tool, args map[string]any, err error) (map[string]any, error) {
+func (p *loggingPlugin) onToolError(ctx agent.ToolContext, t tool.Tool, args map[string]any, err error) (map[string]any, error) {
 	p.log("🔧 TOOL ERROR")
 	p.log(fmt.Sprintf("   Tool Name: %s", t.Name()))
 	p.log(fmt.Sprintf("   Agent: %s", ctx.AgentName()))

--- a/plugin/plugin_manager_test.go
+++ b/plugin/plugin_manager_test.go
@@ -36,7 +36,7 @@ import (
 
 type testCase struct {
 	name                            string
-	tool                            func(tool.Context, map[string]any) (map[string]any, error)
+	tool                            func(agent.ToolContext, map[string]any) (map[string]any, error)
 	args                            map[string]any
 	beforeToolCallbacks             []llmagent.BeforeToolCallback
 	afterToolCallbacks              []llmagent.AfterToolCallback
@@ -51,7 +51,7 @@ func TestCallTool(t *testing.T) {
 	testCases := []testCase{
 		{
 			name: "tool runs successfully",
-			tool: func(ctx tool.Context, args map[string]any) (map[string]any, error) {
+			tool: func(ctx agent.ToolContext, args map[string]any) (map[string]any, error) {
 				return map[string]any{"result": "success"}, nil
 			},
 			args:                            map[string]any{"key": "value"},
@@ -60,7 +60,7 @@ func TestCallTool(t *testing.T) {
 		},
 		{
 			name: "tool error",
-			tool: func(ctx tool.Context, args map[string]any) (map[string]any, error) {
+			tool: func(ctx agent.ToolContext, args map[string]any) (map[string]any, error) {
 				return nil, errors.New("tool error")
 			},
 			args: map[string]any{"key": "value"},
@@ -68,15 +68,15 @@ func TestCallTool(t *testing.T) {
 		},
 		{
 			name: "before callback returns result",
-			tool: func(ctx tool.Context, args map[string]any) (map[string]any, error) {
+			tool: func(ctx agent.ToolContext, args map[string]any) (map[string]any, error) {
 				t.Error("tool should not be called")
 				return nil, nil
 			},
 			beforeToolCallbacks: []llmagent.BeforeToolCallback{
-				func(ctx tool.Context, tool tool.Tool, args map[string]any) (map[string]any, error) {
+				func(ctx agent.ToolContext, tool tool.Tool, args map[string]any) (map[string]any, error) {
 					return map[string]any{"result": "intercepted"}, nil
 				},
-				func(ctx tool.Context, tool tool.Tool, args map[string]any) (map[string]any, error) {
+				func(ctx agent.ToolContext, tool tool.Tool, args map[string]any) (map[string]any, error) {
 					return map[string]any{"result": "2nd callback should not be called"}, nil
 				},
 			},
@@ -86,15 +86,15 @@ func TestCallTool(t *testing.T) {
 		},
 		{
 			name: "before callback returns error",
-			tool: func(ctx tool.Context, args map[string]any) (map[string]any, error) {
+			tool: func(ctx agent.ToolContext, args map[string]any) (map[string]any, error) {
 				t.Error("tool should not be called")
 				return nil, nil
 			},
 			beforeToolCallbacks: []llmagent.BeforeToolCallback{
-				func(ctx tool.Context, tool tool.Tool, args map[string]any) (map[string]any, error) {
+				func(ctx agent.ToolContext, tool tool.Tool, args map[string]any) (map[string]any, error) {
 					return nil, errors.New("before callback error")
 				},
-				func(ctx tool.Context, tool tool.Tool, args map[string]any) (map[string]any, error) {
+				func(ctx agent.ToolContext, tool tool.Tool, args map[string]any) (map[string]any, error) {
 					return nil, errors.New("unexpected error")
 				},
 			},
@@ -103,11 +103,11 @@ func TestCallTool(t *testing.T) {
 		},
 		{
 			name: "after callback modifies result",
-			tool: func(ctx tool.Context, args map[string]any) (map[string]any, error) {
+			tool: func(ctx agent.ToolContext, args map[string]any) (map[string]any, error) {
 				return map[string]any{"result": "original"}, nil
 			},
 			afterToolCallbacks: []llmagent.AfterToolCallback{
-				func(ctx tool.Context, tool tool.Tool, args, result map[string]any, err error) (map[string]any, error) {
+				func(ctx agent.ToolContext, tool tool.Tool, args, result map[string]any, err error) (map[string]any, error) {
 					return map[string]any{"result": "modified"}, nil
 				},
 			},
@@ -117,17 +117,17 @@ func TestCallTool(t *testing.T) {
 		},
 		{
 			name: "after callback handles error and are run in symmetrical order",
-			tool: func(ctx tool.Context, args map[string]any) (map[string]any, error) {
+			tool: func(ctx agent.ToolContext, args map[string]any) (map[string]any, error) {
 				return nil, errors.New("tool error")
 			},
 			afterToolCallbacks: []llmagent.AfterToolCallback{
-				func(ctx tool.Context, tool tool.Tool, args, result map[string]any, err error) (map[string]any, error) {
+				func(ctx agent.ToolContext, tool tool.Tool, args, result map[string]any, err error) (map[string]any, error) {
 					if err != nil {
 						return map[string]any{"result": "error handled"}, nil
 					}
 					return nil, nil
 				},
-				func(ctx tool.Context, tool tool.Tool, args, result map[string]any, err error) (map[string]any, error) {
+				func(ctx agent.ToolContext, tool tool.Tool, args, result map[string]any, err error) (map[string]any, error) {
 					t.Errorf("unexpected call to after tool callback")
 					return map[string]any{"result": "unexpected output"}, nil
 				},
@@ -137,14 +137,14 @@ func TestCallTool(t *testing.T) {
 		},
 		{
 			name: "after callback returns error and are run in symmetrical order",
-			tool: func(ctx tool.Context, args map[string]any) (map[string]any, error) {
+			tool: func(ctx agent.ToolContext, args map[string]any) (map[string]any, error) {
 				return map[string]any{"result": "success"}, nil
 			},
 			afterToolCallbacks: []llmagent.AfterToolCallback{
-				func(ctx tool.Context, tool tool.Tool, args, result map[string]any, err error) (map[string]any, error) {
+				func(ctx agent.ToolContext, tool tool.Tool, args, result map[string]any, err error) (map[string]any, error) {
 					return nil, errors.New("after callback error")
 				},
-				func(ctx tool.Context, tool tool.Tool, args, result map[string]any, err error) (map[string]any, error) {
+				func(ctx agent.ToolContext, tool tool.Tool, args, result map[string]any, err error) (map[string]any, error) {
 					t.Errorf("unexpected call to after tool callback")
 					return nil, errors.New("unexpected error")
 				},
@@ -155,16 +155,16 @@ func TestCallTool(t *testing.T) {
 		},
 		{
 			name: "no-op callbacks return func results",
-			tool: func(ctx tool.Context, args map[string]any) (map[string]any, error) {
+			tool: func(ctx agent.ToolContext, args map[string]any) (map[string]any, error) {
 				return map[string]any{"result": "success"}, nil
 			},
 			beforeToolCallbacks: []llmagent.BeforeToolCallback{
-				func(ctx tool.Context, tool tool.Tool, args map[string]any) (map[string]any, error) {
+				func(ctx agent.ToolContext, tool tool.Tool, args map[string]any) (map[string]any, error) {
 					return nil, nil
 				},
 			},
 			afterToolCallbacks: []llmagent.AfterToolCallback{
-				func(ctx tool.Context, tool tool.Tool, args, result map[string]any, err error) (map[string]any, error) {
+				func(ctx agent.ToolContext, tool tool.Tool, args, result map[string]any, err error) (map[string]any, error) {
 					return nil, nil
 				},
 			},
@@ -173,17 +173,17 @@ func TestCallTool(t *testing.T) {
 		},
 		{
 			name: "before callback result passed to after callback",
-			tool: func(ctx tool.Context, args map[string]any) (map[string]any, error) {
+			tool: func(ctx agent.ToolContext, args map[string]any) (map[string]any, error) {
 				t.Error("tool should not be called")
 				return nil, nil
 			},
 			beforeToolCallbacks: []llmagent.BeforeToolCallback{
-				func(ctx tool.Context, tool tool.Tool, args map[string]any) (map[string]any, error) {
+				func(ctx agent.ToolContext, tool tool.Tool, args map[string]any) (map[string]any, error) {
 					return map[string]any{"result": "from_before"}, nil
 				},
 			},
 			afterToolCallbacks: []llmagent.AfterToolCallback{
-				func(ctx tool.Context, tool tool.Tool, args, result map[string]any, err error) (map[string]any, error) {
+				func(ctx agent.ToolContext, tool tool.Tool, args, result map[string]any, err error) (map[string]any, error) {
 					if val, ok := result["result"]; !ok || val != "from_before" {
 						return nil, errors.New("unexpected result in after callback")
 					}
@@ -197,17 +197,17 @@ func TestCallTool(t *testing.T) {
 		},
 		{
 			name: "before callback error passed to after callback",
-			tool: func(ctx tool.Context, args map[string]any) (map[string]any, error) {
+			tool: func(ctx agent.ToolContext, args map[string]any) (map[string]any, error) {
 				t.Error("tool should not be called")
 				return nil, nil
 			},
 			beforeToolCallbacks: []llmagent.BeforeToolCallback{
-				func(ctx tool.Context, tool tool.Tool, args map[string]any) (map[string]any, error) {
+				func(ctx agent.ToolContext, tool tool.Tool, args map[string]any) (map[string]any, error) {
 					return nil, errors.New("error_from_before")
 				},
 			},
 			afterToolCallbacks: []llmagent.AfterToolCallback{
-				func(ctx tool.Context, tool tool.Tool, args, result map[string]any, err error) (map[string]any, error) {
+				func(ctx agent.ToolContext, tool tool.Tool, args, result map[string]any, err error) (map[string]any, error) {
 					if err == nil || err.Error() != "error_from_before" {
 						return nil, errors.New("unexpected error in after callback")
 					}
@@ -220,17 +220,17 @@ func TestCallTool(t *testing.T) {
 		},
 		{
 			name: "before callback error passed to on tool error callback",
-			tool: func(ctx tool.Context, args map[string]any) (map[string]any, error) {
+			tool: func(ctx agent.ToolContext, args map[string]any) (map[string]any, error) {
 				t.Error("tool should not be called")
 				return nil, nil
 			},
 			beforeToolCallbacks: []llmagent.BeforeToolCallback{
-				func(ctx tool.Context, tool tool.Tool, args map[string]any) (map[string]any, error) {
+				func(ctx agent.ToolContext, tool tool.Tool, args map[string]any) (map[string]any, error) {
 					return nil, errors.New("error_from_before")
 				},
 			},
 			onToolErrorCallbacks: []llmagent.OnToolErrorCallback{
-				func(ctx tool.Context, tool tool.Tool, args map[string]any, err error) (map[string]any, error) {
+				func(ctx agent.ToolContext, tool tool.Tool, args map[string]any, err error) (map[string]any, error) {
 					if err == nil || err.Error() != "error_from_before" {
 						return nil, errors.New("unexpected error in on tool error callback")
 					}
@@ -243,17 +243,17 @@ func TestCallTool(t *testing.T) {
 		},
 		{
 			name: "before callback error passed to on tool error callback and after tool called",
-			tool: func(ctx tool.Context, args map[string]any) (map[string]any, error) {
+			tool: func(ctx agent.ToolContext, args map[string]any) (map[string]any, error) {
 				t.Error("tool should not be called")
 				return nil, nil
 			},
 			beforeToolCallbacks: []llmagent.BeforeToolCallback{
-				func(ctx tool.Context, tool tool.Tool, args map[string]any) (map[string]any, error) {
+				func(ctx agent.ToolContext, tool tool.Tool, args map[string]any) (map[string]any, error) {
 					return nil, errors.New("error_from_before")
 				},
 			},
 			onToolErrorCallbacks: []llmagent.OnToolErrorCallback{
-				func(ctx tool.Context, tool tool.Tool, args map[string]any, err error) (map[string]any, error) {
+				func(ctx agent.ToolContext, tool tool.Tool, args map[string]any, err error) (map[string]any, error) {
 					if err == nil || err.Error() != "error_from_before" {
 						return nil, errors.New("unexpected error in on tool error callback")
 					}
@@ -261,7 +261,7 @@ func TestCallTool(t *testing.T) {
 				},
 			},
 			afterToolCallbacks: []llmagent.AfterToolCallback{
-				func(ctx tool.Context, tool tool.Tool, args, result map[string]any, err error) (map[string]any, error) {
+				func(ctx agent.ToolContext, tool tool.Tool, args, result map[string]any, err error) (map[string]any, error) {
 					if err != nil {
 						return nil, errors.New("unexpected error in after callback")
 					}
@@ -275,17 +275,17 @@ func TestCallTool(t *testing.T) {
 		},
 		{
 			name: "before callback error passed to on tool error callback and passed to after tool called",
-			tool: func(ctx tool.Context, args map[string]any) (map[string]any, error) {
+			tool: func(ctx agent.ToolContext, args map[string]any) (map[string]any, error) {
 				t.Error("tool should not be called")
 				return nil, nil
 			},
 			beforeToolCallbacks: []llmagent.BeforeToolCallback{
-				func(ctx tool.Context, tool tool.Tool, args map[string]any) (map[string]any, error) {
+				func(ctx agent.ToolContext, tool tool.Tool, args map[string]any) (map[string]any, error) {
 					return nil, errors.New("error_from_before")
 				},
 			},
 			onToolErrorCallbacks: []llmagent.OnToolErrorCallback{
-				func(ctx tool.Context, tool tool.Tool, args map[string]any, err error) (map[string]any, error) {
+				func(ctx agent.ToolContext, tool tool.Tool, args map[string]any, err error) (map[string]any, error) {
 					if err == nil || err.Error() != "error_from_before" {
 						return nil, errors.New("unexpected error in on tool error callback")
 					}
@@ -293,7 +293,7 @@ func TestCallTool(t *testing.T) {
 				},
 			},
 			afterToolCallbacks: []llmagent.AfterToolCallback{
-				func(ctx tool.Context, tool tool.Tool, args, result map[string]any, err error) (map[string]any, error) {
+				func(ctx agent.ToolContext, tool tool.Tool, args, result map[string]any, err error) (map[string]any, error) {
 					if err == nil || err.Error() != "error_from_on_tool_error" {
 						return nil, errors.New("unexpected error in after callback")
 					}
@@ -307,17 +307,17 @@ func TestCallTool(t *testing.T) {
 		},
 		{
 			name: "before callback error passed to on tool error callback and passed to after tool called and handled",
-			tool: func(ctx tool.Context, args map[string]any) (map[string]any, error) {
+			tool: func(ctx agent.ToolContext, args map[string]any) (map[string]any, error) {
 				t.Error("tool should not be called")
 				return nil, nil
 			},
 			beforeToolCallbacks: []llmagent.BeforeToolCallback{
-				func(ctx tool.Context, tool tool.Tool, args map[string]any) (map[string]any, error) {
+				func(ctx agent.ToolContext, tool tool.Tool, args map[string]any) (map[string]any, error) {
 					return nil, errors.New("error_from_before")
 				},
 			},
 			onToolErrorCallbacks: []llmagent.OnToolErrorCallback{
-				func(ctx tool.Context, tool tool.Tool, args map[string]any, err error) (map[string]any, error) {
+				func(ctx agent.ToolContext, tool tool.Tool, args map[string]any, err error) (map[string]any, error) {
 					if err == nil || err.Error() != "error_from_before" {
 						return nil, errors.New("unexpected error in on tool error callback")
 					}
@@ -325,7 +325,7 @@ func TestCallTool(t *testing.T) {
 				},
 			},
 			afterToolCallbacks: []llmagent.AfterToolCallback{
-				func(ctx tool.Context, tool tool.Tool, args, result map[string]any, err error) (map[string]any, error) {
+				func(ctx agent.ToolContext, tool tool.Tool, args, result map[string]any, err error) (map[string]any, error) {
 					if err == nil || err.Error() != "error_from_on_tool_error" {
 						return nil, errors.New("unexpected error in after tool callback")
 					}
@@ -386,7 +386,7 @@ func TestCallTool(t *testing.T) {
 			beforeToolCallbacksCalled := false
 			afterToolCallbacksCalled := false
 			onToolErrorCallbacks := []llmagent.OnToolErrorCallback{
-				func(ctx tool.Context, tool tool.Tool, args map[string]any, err error) (map[string]any, error) {
+				func(ctx agent.ToolContext, tool tool.Tool, args map[string]any, err error) (map[string]any, error) {
 					onToolErrorCallbacksCalled = true
 					if tc.dontRunOnErrorCanonicalCallback {
 						t.Error("on tool error should not be called")
@@ -395,7 +395,7 @@ func TestCallTool(t *testing.T) {
 				},
 			}
 			beforeToolCallbacks := []llmagent.BeforeToolCallback{
-				func(ctx tool.Context, tool tool.Tool, args map[string]any) (map[string]any, error) {
+				func(ctx agent.ToolContext, tool tool.Tool, args map[string]any) (map[string]any, error) {
 					beforeToolCallbacksCalled = true
 					if tc.dontRunBeforeCanonicalCallback {
 						t.Error("before Tool Callback should not be called")
@@ -404,7 +404,7 @@ func TestCallTool(t *testing.T) {
 				},
 			}
 			afterToolCallbacks := []llmagent.AfterToolCallback{
-				func(ctx tool.Context, tool tool.Tool, args, result map[string]any, err error) (map[string]any, error) {
+				func(ctx agent.ToolContext, tool tool.Tool, args, result map[string]any, err error) (map[string]any, error) {
 					afterToolCallbacksCalled = true
 					if tc.dontRunAfterCanonicalCallback {
 						t.Error("after Tool Callback should not be called")

--- a/plugin/retryandreflect/plugin.go
+++ b/plugin/retryandreflect/plugin.go
@@ -28,6 +28,7 @@ import (
 	"sync"
 	"text/template"
 
+	"google.golang.org/adk/agent"
 	"google.golang.org/adk/plugin"
 	"google.golang.org/adk/tool"
 
@@ -124,7 +125,7 @@ func MustNew(opts ...PluginOption) *plugin.Plugin {
 	return p
 }
 
-func (r *retryAndReflect) afterTool(ctx tool.Context, tool tool.Tool, args, result map[string]any, err error) (map[string]any, error) {
+func (r *retryAndReflect) afterTool(ctx agent.ToolContext, tool tool.Tool, args, result map[string]any, err error) (map[string]any, error) {
 	if err == nil {
 		isReflectResponse := false
 		if rt, ok := result["response_type"].(string); ok && rt == reflectAndRetryResponseType {
@@ -139,11 +140,11 @@ func (r *retryAndReflect) afterTool(ctx tool.Context, tool tool.Tool, args, resu
 	return nil, nil
 }
 
-func (r *retryAndReflect) onToolError(ctx tool.Context, tool tool.Tool, args map[string]any, err error) (map[string]any, error) {
+func (r *retryAndReflect) onToolError(ctx agent.ToolContext, tool tool.Tool, args map[string]any, err error) (map[string]any, error) {
 	return r.handleToolError(ctx, tool, args, err)
 }
 
-func (r *retryAndReflect) handleToolError(ctx tool.Context, failedTool tool.Tool, args map[string]any, err error) (map[string]any, error) {
+func (r *retryAndReflect) handleToolError(ctx agent.ToolContext, failedTool tool.Tool, args map[string]any, err error) (map[string]any, error) {
 	// skip if the error is tool.ErrConfirmationRequired.
 	if errors.Is(err, tool.ErrConfirmationRequired) || errors.Is(err, tool.ErrConfirmationRejected) {
 		return nil, nil
@@ -179,14 +180,14 @@ func (r *retryAndReflect) handleToolError(ctx tool.Context, failedTool tool.Tool
 	return r.createToolRetryExceedMsg(failedTool, args, err), nil
 }
 
-func (r *retryAndReflect) scopeKey(ctx tool.Context) string {
+func (r *retryAndReflect) scopeKey(ctx agent.ToolContext) string {
 	if r.scope == Global {
 		return globalScopeKey
 	}
 	return ctx.InvocationID()
 }
 
-func (r *retryAndReflect) resetFailuresForTool(ctx tool.Context, toolName string) {
+func (r *retryAndReflect) resetFailuresForTool(ctx agent.ToolContext, toolName string) {
 	scopeKey := r.scopeKey(ctx)
 
 	r.mu.Lock()

--- a/plugin/retryandreflect/plugin_test.go
+++ b/plugin/retryandreflect/plugin_test.go
@@ -19,7 +19,7 @@ import (
 	"strings"
 	"testing"
 
-	"google.golang.org/adk/tool"
+	"google.golang.org/adk/agent"
 )
 
 type mockTool struct {
@@ -31,7 +31,7 @@ func (m *mockTool) Description() string { return "" }
 func (m *mockTool) IsLongRunning() bool { return false }
 
 type mockContext struct {
-	tool.Context
+	agent.ToolContext
 	invocationID string
 }
 

--- a/tool/agenttool/agent_tool.go
+++ b/tool/agenttool/agent_tool.go
@@ -118,7 +118,7 @@ func (t *agentTool) Declaration() *genai.FunctionDeclaration {
 // Run executes the wrapped agent with the provided arguments.
 // It creates a new session for the sub-agent, runs the agent, and returns
 // the final result.
-func (t *agentTool) Run(toolCtx tool.Context, args any) (map[string]any, error) {
+func (t *agentTool) Run(toolCtx agent.ToolContext, args any) (map[string]any, error) {
 	margs, ok := args.(map[string]any)
 	if !ok {
 		return nil, fmt.Errorf("agentTool expects map[string]any arguments, got %T", args)
@@ -251,6 +251,6 @@ func (t *agentTool) Run(toolCtx tool.Context, args any) (map[string]any, error) 
 }
 
 // ProcessRequest adds the agent tool's function declaration to the LLM request.
-func (t *agentTool) ProcessRequest(ctx tool.Context, req *model.LLMRequest) error {
+func (t *agentTool) ProcessRequest(ctx agent.ToolContext, req *model.LLMRequest) error {
 	return toolutils.PackTool(req, t)
 }

--- a/tool/agenttool/agent_tool_test.go
+++ b/tool/agenttool/agent_tool_test.go
@@ -29,7 +29,6 @@ import (
 	"google.golang.org/adk/model"
 	"google.golang.org/adk/model/gemini"
 	"google.golang.org/adk/session"
-	"google.golang.org/adk/tool"
 	"google.golang.org/adk/tool/agenttool"
 )
 
@@ -347,7 +346,7 @@ func createAgentWithModel(t *testing.T, inputSchema, outputSchema *genai.Schema,
 	return agent
 }
 
-func createToolContext(t *testing.T, testAgent agent.Agent) tool.Context {
+func createToolContext(t *testing.T, testAgent agent.Agent) agent.ToolContext {
 	t.Helper()
 
 	sessionService := session.InMemoryService()

--- a/tool/exampletool/tool.go
+++ b/tool/exampletool/tool.go
@@ -21,9 +21,9 @@ import (
 
 	"google.golang.org/genai"
 
+	"google.golang.org/adk/agent"
 	"google.golang.org/adk/internal/utils"
 	"google.golang.org/adk/model"
-	"google.golang.org/adk/tool"
 )
 
 type Example struct {
@@ -55,7 +55,7 @@ func (s exampleTool) Description() string {
 }
 
 // ProcessRequest adds the exampleTool examples to the LLM request.
-func (s exampleTool) ProcessRequest(ctx tool.Context, req *model.LLMRequest) error {
+func (s exampleTool) ProcessRequest(ctx agent.ToolContext, req *model.LLMRequest) error {
 	parts := ctx.UserContent().Parts
 	if len(parts) == 0 || parts[0].Text == "" {
 		return nil

--- a/tool/exitlooptool/tool.go
+++ b/tool/exitlooptool/tool.go
@@ -18,11 +18,12 @@ package exitlooptool
 import (
 	"fmt"
 
+	"google.golang.org/adk/agent"
 	"google.golang.org/adk/tool"
 	"google.golang.org/adk/tool/functiontool"
 )
 
-func exitLoop(ctx tool.Context, myArgs struct{}) (map[string]string, error) {
+func exitLoop(ctx agent.ToolContext, myArgs struct{}) (map[string]string, error) {
 	ctx.Actions().Escalate = true
 	ctx.Actions().SkipSummarization = true
 	return map[string]string{}, nil

--- a/tool/functiontool/function.go
+++ b/tool/functiontool/function.go
@@ -24,6 +24,7 @@ import (
 	"github.com/google/jsonschema-go/jsonschema"
 	"google.golang.org/genai"
 
+	"google.golang.org/adk/agent"
 	"google.golang.org/adk/internal/toolinternal/toolutils"
 	"google.golang.org/adk/internal/typeutil"
 	"google.golang.org/adk/model"
@@ -67,8 +68,8 @@ type Config struct {
 }
 
 // Func represents a Go function that can be wrapped in a tool.
-// It takes a tool.Context and a generic argument type, and returns a generic result type.
-type Func[TArgs, TResults any] func(tool.Context, TArgs) (TResults, error)
+// It takes a agent.ToolContext and a generic argument type, and returns a generic result type.
+type Func[TArgs, TResults any] func(agent.ToolContext, TArgs) (TResults, error)
 
 // ErrInvalidArgument indicates the input parameter type is invalid.
 var ErrInvalidArgument = errors.New("invalid argument")
@@ -151,7 +152,7 @@ func (f *functionTool[TArgs, TResults]) IsLongRunning() bool {
 }
 
 // ProcessRequest packs the function tool's declaration into the LLM request.
-func (f *functionTool[TArgs, TResults]) ProcessRequest(ctx tool.Context, req *model.LLMRequest) error {
+func (f *functionTool[TArgs, TResults]) ProcessRequest(ctx agent.ToolContext, req *model.LLMRequest) error {
 	return toolutils.PackTool(req, f)
 }
 
@@ -181,7 +182,7 @@ func (f *functionTool[TArgs, TResults]) Declaration() *genai.FunctionDeclaration
 }
 
 // Run executes the tool with the provided context and yields events.
-func (f *functionTool[TArgs, TResults]) Run(ctx tool.Context, args any) (result map[string]any, err error) {
+func (f *functionTool[TArgs, TResults]) Run(ctx agent.ToolContext, args any) (result map[string]any, err error) {
 	// TODO: Handle function call request from tc.InvocationContext.
 	defer func() {
 		if r := recover(); r != nil {

--- a/tool/functiontool/function_test.go
+++ b/tool/functiontool/function_test.go
@@ -50,7 +50,7 @@ type SumResult struct {
 	Sum int `json:"sum"` // the sum of two integers
 }
 
-func sumFunc(ctx tool.Context, input SumArgs) (SumResult, error) {
+func sumFunc(ctx agent.ToolContext, input SumArgs) (SumResult, error) {
 	return SumResult{Sum: input.A + input.B}, nil
 }
 
@@ -65,7 +65,7 @@ func ExampleNew() {
 	_ = sumTool // use the tool
 }
 
-func createToolContext(t *testing.T) tool.Context {
+func createToolContext(t *testing.T) agent.ToolContext {
 	invCtx := icontext.NewInvocationContext(t.Context(), icontext.InvocationContextParams{})
 	return agent.NewToolContext(invCtx, "", &session.EventActions{}, nil)
 }
@@ -101,7 +101,7 @@ func TestFunctionTool_Simple(t *testing.T) {
 		},
 	}
 
-	weatherReport := func(ctx tool.Context, input Args) (Result, error) {
+	weatherReport := func(ctx agent.ToolContext, input Args) (Result, error) {
 		city := strings.ToLower(input.City)
 		if ret, ok := resultSet[city]; ok {
 			return ret, nil
@@ -202,7 +202,7 @@ func TestFunctionTool_DifferentFunctionDeclarations_ConsolidatedInOneGenAiTool(t
 	type IntOutput struct {
 		Result int `json:"result"`
 	}
-	identityFunc := func(ctx tool.Context, input IntInput) (IntOutput, error) {
+	identityFunc := func(ctx agent.ToolContext, input IntInput) (IntOutput, error) {
 		return IntOutput{Result: input.X}, nil
 	}
 	identityTool, err := functiontool.New(functiontool.Config{
@@ -220,7 +220,7 @@ func TestFunctionTool_DifferentFunctionDeclarations_ConsolidatedInOneGenAiTool(t
 	type StringOutput struct {
 		Result string `json:"result"`
 	}
-	stringIdentityFunc := func(ctx tool.Context, input StringInput) (StringOutput, error) {
+	stringIdentityFunc := func(ctx agent.ToolContext, input StringInput) (StringOutput, error) {
 		return StringOutput{Result: input.Value}, nil
 	}
 	stringIdentityTool, err := functiontool.New(
@@ -266,7 +266,7 @@ func TestFunctionTool_ReturnsBasicType(t *testing.T) {
 		"paris":  "The weather in Paris is sunny with a temperature of 25 derees Celsius.",
 	}
 
-	weatherReport := func(ctx tool.Context, input Args) (string, error) {
+	weatherReport := func(ctx agent.ToolContext, input Args) (string, error) {
 		city := strings.ToLower(input.City)
 		if ret, ok := resultSet[city]; ok {
 			return ret, nil
@@ -356,7 +356,7 @@ func TestFunctionTool_MapInput(t *testing.T) {
 			Name:        "sum_map",
 			Description: "sums numbers provided in a map input",
 		},
-		func(ctx tool.Context, input map[string]int) (Output, error) {
+		func(ctx agent.ToolContext, input map[string]int) (Output, error) {
 			return Output{Sum: input["a"] + input["b"]}, nil
 		})
 	if err != nil {
@@ -441,7 +441,7 @@ func TestFunctionTool_CustomSchema(t *testing.T) {
 		Name:        "print_quantity",
 		Description: "print the remaining quantity of the given fruit.",
 		InputSchema: ischema,
-	}, func(ctx tool.Context, input Args) (any, error) {
+	}, func(ctx agent.ToolContext, input Args) (any, error) {
 		fruit := strings.ToLower(input.Fruit)
 		if fruit != "mandarin" && fruit != "kiwi" {
 			t.Errorf("unexpected fruit: %q", fruit)
@@ -553,7 +553,7 @@ type SimpleArgs struct {
 	Num int
 }
 
-func okFunc(_ tool.Context, _ SimpleArgs) (string, error) {
+func okFunc(_ agent.ToolContext, _ SimpleArgs) (string, error) {
 	return "ok", nil
 }
 
@@ -927,7 +927,7 @@ type TestResult struct {
 
 func TestNew_RequireConfirmationProvider_Validation(t *testing.T) {
 	// A dummy handler to satisfy the function signature
-	dummyHandler := func(_ tool.Context, _ TestArgs) (TestResult, error) {
+	dummyHandler := func(_ agent.ToolContext, _ TestArgs) (TestResult, error) {
 		return TestResult{Value: 1}, nil
 	}
 
@@ -1038,7 +1038,7 @@ func TestNew_InvalidInputType(t *testing.T) {
 				return functiontool.New(functiontool.Config{
 					Name:        "string_tool",
 					Description: "a tool with string input",
-				}, func(ctx tool.Context, input string) (string, error) {
+				}, func(ctx agent.ToolContext, input string) (string, error) {
 					return input, nil
 				})
 			},
@@ -1050,7 +1050,7 @@ func TestNew_InvalidInputType(t *testing.T) {
 				return functiontool.New(functiontool.Config{
 					Name:        "int_tool",
 					Description: "a tool with int input",
-				}, func(ctx tool.Context, input int) (int, error) {
+				}, func(ctx agent.ToolContext, input int) (int, error) {
 					return input, nil
 				})
 			},
@@ -1062,7 +1062,7 @@ func TestNew_InvalidInputType(t *testing.T) {
 				return functiontool.New(functiontool.Config{
 					Name:        "bool_tool",
 					Description: "a tool with bool input",
-				}, func(ctx tool.Context, input bool) (bool, error) {
+				}, func(ctx agent.ToolContext, input bool) (bool, error) {
 					return input, nil
 				})
 			},
@@ -1088,7 +1088,7 @@ func TestFunctionTool_PanicRecovery(t *testing.T) {
 		Value string `json:"value"`
 	}
 
-	panicHandler := func(ctx tool.Context, input Args) (string, error) {
+	panicHandler := func(ctx agent.ToolContext, input Args) (string, error) {
 		panic("intentional panic for testing")
 	}
 

--- a/tool/functiontool/long_running_function_test.go
+++ b/tool/functiontool/long_running_function_test.go
@@ -23,6 +23,7 @@ import (
 	"github.com/google/go-cmp/cmp/cmpopts"
 	"google.golang.org/genai"
 
+	"google.golang.org/adk/agent"
 	"google.golang.org/adk/agent/llmagent"
 	"google.golang.org/adk/internal/testutil"
 	"google.golang.org/adk/internal/toolinternal"
@@ -39,7 +40,7 @@ func TestNewLongRunningFunctionTool(t *testing.T) {
 		Result string `json:"result"` // the operation result
 	}
 
-	handler := func(ctx tool.Context, input SumArgs) (SumResult, error) {
+	handler := func(ctx agent.ToolContext, input SumArgs) (SumResult, error) {
 		return SumResult{Result: "Processing sum"}, nil
 	}
 	sumTool, err := functiontool.New(functiontool.Config{
@@ -80,7 +81,7 @@ type IncArgs struct{}
 
 func TestLongRunningFunctionFlow(t *testing.T) {
 	functionCalled := 0
-	increaseByOne := func(ctx tool.Context, x IncArgs) (map[string]string, error) {
+	increaseByOne := func(ctx agent.ToolContext, x IncArgs) (map[string]string, error) {
 		functionCalled++
 		return map[string]string{"status": "pending"}, nil
 	}
@@ -89,7 +90,7 @@ func TestLongRunningFunctionFlow(t *testing.T) {
 
 func TestLongRunningStringFunctionFlow(t *testing.T) {
 	functionCalled := 0
-	increaseByOne := func(ctx tool.Context, x IncArgs) (string, error) {
+	increaseByOne := func(ctx agent.ToolContext, x IncArgs) (string, error) {
 		functionCalled++
 		return "pending", nil
 	}
@@ -97,7 +98,7 @@ func TestLongRunningStringFunctionFlow(t *testing.T) {
 }
 
 // --- Test Suite ---
-func testLongRunningFunctionFlow[Out any](t *testing.T, increaseByOne func(ctx tool.Context, x IncArgs) (Out, error), resultKey string, callCount *int) {
+func testLongRunningFunctionFlow[Out any](t *testing.T, increaseByOne func(ctx agent.ToolContext, x IncArgs) (Out, error), resultKey string, callCount *int) {
 	// 1. Setup
 	responses := []*genai.Content{
 		genai.NewContentFromFunctionCall("increaseByOne", map[string]any{}, "model"),
@@ -266,7 +267,7 @@ func TestLongRunningToolIDsAreSet(t *testing.T) {
 
 	type IncArgs struct{}
 
-	increaseByOne := func(ctx tool.Context, x IncArgs) (map[string]string, error) {
+	increaseByOne := func(ctx agent.ToolContext, x IncArgs) (map[string]string, error) {
 		functionCalled++
 		return map[string]string{"status": "pending"}, nil
 	}

--- a/tool/functiontool/streaming_function.go
+++ b/tool/functiontool/streaming_function.go
@@ -24,6 +24,7 @@ import (
 	"github.com/google/jsonschema-go/jsonschema"
 	"google.golang.org/genai"
 
+	"google.golang.org/adk/agent"
 	"google.golang.org/adk/internal/toolinternal/toolutils"
 	"google.golang.org/adk/internal/typeutil"
 	"google.golang.org/adk/model"
@@ -31,7 +32,7 @@ import (
 )
 
 // StreamingFunc represents a Go function that streams results.
-type StreamingFunc[TArgs any] func(tool.Context, TArgs) iter.Seq2[string, error]
+type StreamingFunc[TArgs any] func(agent.ToolContext, TArgs) iter.Seq2[string, error]
 
 // NewStreaming creates a new streaming tool.
 func NewStreaming[TArgs any](cfg Config, handler StreamingFunc[TArgs]) (tool.Tool, error) {
@@ -99,7 +100,7 @@ func (f *streamingFunctionTool[TArgs]) IsLongRunning() bool {
 }
 
 // ProcessRequest packs the function tool's declaration into the LLM request.
-func (f *streamingFunctionTool[TArgs]) ProcessRequest(ctx tool.Context, req *model.LLMRequest) error {
+func (f *streamingFunctionTool[TArgs]) ProcessRequest(ctx agent.ToolContext, req *model.LLMRequest) error {
 	return toolutils.PackTool(req, f)
 }
 
@@ -126,7 +127,7 @@ func (f *streamingFunctionTool[TArgs]) Declaration() *genai.FunctionDeclaration 
 }
 
 // RunStream executes the tool with the provided context and yields events.
-func (f *streamingFunctionTool[TArgs]) RunStream(ctx tool.Context, args any) iter.Seq2[string, error] {
+func (f *streamingFunctionTool[TArgs]) RunStream(ctx agent.ToolContext, args any) iter.Seq2[string, error] {
 	return func(yield func(string, error) bool) {
 		defer func() {
 			if r := recover(); r != nil {

--- a/tool/geminitool/google_search.go
+++ b/tool/geminitool/google_search.go
@@ -17,8 +17,8 @@ package geminitool
 import (
 	"google.golang.org/genai"
 
+	"google.golang.org/adk/agent"
 	"google.golang.org/adk/model"
-	"google.golang.org/adk/tool"
 )
 
 // GoogleSearch is a built-in tool that is automatically invoked by Gemini 2
@@ -38,7 +38,7 @@ func (s GoogleSearch) Description() string {
 }
 
 // ProcessRequest adds the GoogleSearch tool to the LLM request.
-func (s GoogleSearch) ProcessRequest(ctx tool.Context, req *model.LLMRequest) error {
+func (s GoogleSearch) ProcessRequest(ctx agent.ToolContext, req *model.LLMRequest) error {
 	return setTool(req, &genai.Tool{
 		GoogleSearch: &genai.GoogleSearch{},
 	})

--- a/tool/geminitool/tool.go
+++ b/tool/geminitool/tool.go
@@ -34,6 +34,7 @@ import (
 
 	"google.golang.org/genai"
 
+	"google.golang.org/adk/agent"
 	"google.golang.org/adk/model"
 	"google.golang.org/adk/tool"
 )
@@ -55,7 +56,7 @@ type geminiTool struct {
 }
 
 // ProcessRequest adds the Gemini tool to the LLM request.
-func (t *geminiTool) ProcessRequest(ctx tool.Context, req *model.LLMRequest) error {
+func (t *geminiTool) ProcessRequest(ctx agent.ToolContext, req *model.LLMRequest) error {
 	return setTool(req, t.value)
 }
 

--- a/tool/loadartifactstool/load_artifacts_tool.go
+++ b/tool/loadartifactstool/load_artifacts_tool.go
@@ -85,7 +85,7 @@ func (t *artifactsTool) Declaration() *genai.FunctionDeclaration {
 }
 
 // Run implements tool.Tool.
-func (t *artifactsTool) Run(ctx tool.Context, args any) (map[string]any, error) {
+func (t *artifactsTool) Run(ctx agent.ToolContext, args any) (map[string]any, error) {
 	m, ok := args.(map[string]any)
 	if !ok {
 		return nil, fmt.Errorf("unexpected args type, got: %T", args)
@@ -117,7 +117,7 @@ func (t *artifactsTool) Run(ctx tool.Context, args any) (map[string]any, error) 
 
 // ProcessRequest processes the LLM request. It packs the tool, appends initial
 // instructions, and processes any load artifacts function calls.
-func (t *artifactsTool) ProcessRequest(ctx tool.Context, req *model.LLMRequest) error {
+func (t *artifactsTool) ProcessRequest(ctx agent.ToolContext, req *model.LLMRequest) error {
 	if err := toolutils.PackTool(req, t); err != nil {
 		return err
 	}
@@ -127,7 +127,7 @@ func (t *artifactsTool) ProcessRequest(ctx tool.Context, req *model.LLMRequest) 
 	return t.processLoadArtifactsFunctionCall(ctx, req)
 }
 
-func (t *artifactsTool) appendInitialInstructions(ctx tool.Context, req *model.LLMRequest) error {
+func (t *artifactsTool) appendInitialInstructions(ctx agent.ToolContext, req *model.LLMRequest) error {
 	resp, err := ctx.Artifacts().List(ctx)
 	if err != nil {
 		return fmt.Errorf("failed to list artifacts: %w", err)
@@ -151,7 +151,7 @@ func (t *artifactsTool) appendInitialInstructions(ctx tool.Context, req *model.L
 	return nil
 }
 
-func (t *artifactsTool) processLoadArtifactsFunctionCall(ctx tool.Context, req *model.LLMRequest) error {
+func (t *artifactsTool) processLoadArtifactsFunctionCall(ctx agent.ToolContext, req *model.LLMRequest) error {
 	if len(req.Contents) == 0 {
 		return nil
 	}

--- a/tool/loadartifactstool/load_artifacts_tool_test.go
+++ b/tool/loadartifactstool/load_artifacts_tool_test.go
@@ -27,7 +27,6 @@ import (
 	icontext "google.golang.org/adk/internal/context"
 	"google.golang.org/adk/internal/toolinternal"
 	"google.golang.org/adk/model"
-	"google.golang.org/adk/tool"
 	"google.golang.org/adk/tool/loadartifactstool"
 )
 
@@ -278,7 +277,7 @@ func TestLoadArtifactsTool_ProcessRequest_Artifacts_OtherFunctionCall(t *testing
 	}
 }
 
-func createToolContext(t *testing.T) tool.Context {
+func createToolContext(t *testing.T) agent.ToolContext {
 	t.Helper()
 
 	artifacts := &artifactinternal.Artifacts{

--- a/tool/loadmemorytool/tool.go
+++ b/tool/loadmemorytool/tool.go
@@ -22,12 +22,12 @@ import (
 
 	"google.golang.org/genai"
 
+	"google.golang.org/adk/agent"
 	"google.golang.org/adk/internal/toolinternal"
 	"google.golang.org/adk/internal/toolinternal/toolutils"
 	"google.golang.org/adk/internal/utils"
 	"google.golang.org/adk/memory"
 	"google.golang.org/adk/model"
-	"google.golang.org/adk/tool"
 )
 
 const memoryInstructions = `You have memory. You can use it to answer questions. If any questions need
@@ -80,7 +80,7 @@ func (t *loadMemoryTool) Declaration() *genai.FunctionDeclaration {
 }
 
 // Run executes the tool with the provided context and arguments.
-func (t *loadMemoryTool) Run(toolCtx tool.Context, args any) (map[string]any, error) {
+func (t *loadMemoryTool) Run(toolCtx agent.ToolContext, args any) (map[string]any, error) {
 	m, ok := args.(map[string]any)
 	if !ok {
 		return nil, fmt.Errorf("unexpected args type, got: %T", args)
@@ -109,7 +109,7 @@ func (t *loadMemoryTool) Run(toolCtx tool.Context, args any) (map[string]any, er
 
 // ProcessRequest processes the LLM request by packing the tool and appending
 // memory-related instructions.
-func (t *loadMemoryTool) ProcessRequest(ctx tool.Context, req *model.LLMRequest) error {
+func (t *loadMemoryTool) ProcessRequest(ctx agent.ToolContext, req *model.LLMRequest) error {
 	if err := toolutils.PackTool(req, t); err != nil {
 		return err
 	}

--- a/tool/loadmemorytool/tool_test.go
+++ b/tool/loadmemorytool/tool_test.go
@@ -28,7 +28,6 @@ import (
 	"google.golang.org/adk/memory"
 	"google.golang.org/adk/model"
 	"google.golang.org/adk/session"
-	"google.golang.org/adk/tool"
 	"google.golang.org/adk/tool/loadmemorytool"
 )
 
@@ -171,7 +170,7 @@ func TestLoadMemoryTool_ProcessRequest(t *testing.T) {
 	}
 }
 
-func createToolContext(t *testing.T, mem *mockMemory) tool.Context {
+func createToolContext(t *testing.T, mem *mockMemory) agent.ToolContext {
 	t.Helper()
 
 	ctx := icontext.NewInvocationContext(t.Context(), icontext.InvocationContextParams{

--- a/tool/mcptoolset/tool.go
+++ b/tool/mcptoolset/tool.go
@@ -22,6 +22,7 @@ import (
 	"github.com/modelcontextprotocol/go-sdk/mcp"
 	"google.golang.org/genai"
 
+	"google.golang.org/adk/agent"
 	"google.golang.org/adk/internal/toolinternal"
 	"google.golang.org/adk/internal/toolinternal/toolutils"
 	"google.golang.org/adk/model"
@@ -82,7 +83,7 @@ func (t *mcpTool) IsLongRunning() bool {
 	return false
 }
 
-func (t *mcpTool) ProcessRequest(ctx tool.Context, req *model.LLMRequest) error {
+func (t *mcpTool) ProcessRequest(ctx agent.ToolContext, req *model.LLMRequest) error {
 	return toolutils.PackTool(req, t)
 }
 
@@ -90,7 +91,7 @@ func (t *mcpTool) Declaration() *genai.FunctionDeclaration {
 	return t.funcDeclaration
 }
 
-func (t *mcpTool) Run(ctx tool.Context, args any) (map[string]any, error) {
+func (t *mcpTool) Run(ctx agent.ToolContext, args any) (map[string]any, error) {
 	if confirmation := ctx.ToolConfirmation(); confirmation != nil {
 		if !confirmation.Confirmed {
 			return nil, fmt.Errorf("error tool %q %w", t.Name(), tool.ErrConfirmationRejected)

--- a/tool/preloadmemorytool/tool.go
+++ b/tool/preloadmemorytool/tool.go
@@ -26,10 +26,10 @@ import (
 	"strings"
 	"time"
 
+	"google.golang.org/adk/agent"
 	"google.golang.org/adk/internal/utils"
 	"google.golang.org/adk/memory"
 	"google.golang.org/adk/model"
-	"google.golang.org/adk/tool"
 )
 
 const preloadInstructions = `The following content is from your previous conversations with the user.
@@ -71,7 +71,7 @@ func (t *preloadMemoryTool) IsLongRunning() bool {
 
 // ProcessRequest processes the LLM request by searching memory using the user's
 // current query and injecting relevant past conversations into system instructions.
-func (t *preloadMemoryTool) ProcessRequest(ctx tool.Context, req *model.LLMRequest) error {
+func (t *preloadMemoryTool) ProcessRequest(ctx agent.ToolContext, req *model.LLMRequest) error {
 	userContent := ctx.UserContent()
 	if userContent == nil || len(userContent.Parts) == 0 ||
 		userContent.Parts[0] == nil || userContent.Parts[0].Text == "" {

--- a/tool/preloadmemorytool/tool_test.go
+++ b/tool/preloadmemorytool/tool_test.go
@@ -28,7 +28,6 @@ import (
 	"google.golang.org/adk/memory"
 	"google.golang.org/adk/model"
 	"google.golang.org/adk/session"
-	"google.golang.org/adk/tool"
 	"google.golang.org/adk/tool/preloadmemorytool"
 )
 
@@ -207,7 +206,7 @@ func TestPreloadMemoryTool_ProcessRequest(t *testing.T) {
 	}
 }
 
-func createToolContext(t *testing.T, mem *mockMemory, userContent *genai.Content) tool.Context {
+func createToolContext(t *testing.T, mem *mockMemory, userContent *genai.Content) agent.ToolContext {
 	t.Helper()
 
 	ctx := icontext.NewInvocationContext(t.Context(), icontext.InvocationContextParams{

--- a/tool/skilltoolset/internal/skilltool/list_skills.go
+++ b/tool/skilltoolset/internal/skilltool/list_skills.go
@@ -18,6 +18,7 @@ import (
 	"html"
 	"strings"
 
+	"google.golang.org/adk/agent"
 	"google.golang.org/adk/tool"
 	"google.golang.org/adk/tool/functiontool"
 	"google.golang.org/adk/tool/skilltoolset/skill"
@@ -38,13 +39,13 @@ func ListSkills(source skill.Source) (tool.Tool, error) {
 			Name:        "list_skills",
 			Description: "Lists all available skills with their names and descriptions.",
 		},
-		func(ctx tool.Context, args ListSkillsArgs) (*ListSkillsResult, error) {
+		func(ctx agent.ToolContext, args ListSkillsArgs) (*ListSkillsResult, error) {
 			return listSkills(ctx, args, source)
 		},
 	)
 }
 
-func listSkills(ctx tool.Context, _ ListSkillsArgs, source skill.Source) (*ListSkillsResult, error) {
+func listSkills(ctx agent.ToolContext, _ ListSkillsArgs, source skill.Source) (*ListSkillsResult, error) {
 	skills, err := source.ListFrontmatters(ctx)
 	if err != nil {
 		return nil, err

--- a/tool/skilltoolset/internal/skilltool/load_skill.go
+++ b/tool/skilltoolset/internal/skilltool/load_skill.go
@@ -18,6 +18,7 @@ package skilltool
 import (
 	"fmt"
 
+	"google.golang.org/adk/agent"
 	"google.golang.org/adk/tool"
 	"google.golang.org/adk/tool/functiontool"
 	"google.golang.org/adk/tool/skilltoolset/skill"
@@ -51,13 +52,13 @@ func LoadSkill(source skill.Source) (tool.Tool, error) {
 			Name:        "load_skill",
 			Description: "Loads the SKILL.md instructions for a given skill.",
 		},
-		func(ctx tool.Context, args LoadSkillArgs) (*LoadSkillResult, error) {
+		func(ctx agent.ToolContext, args LoadSkillArgs) (*LoadSkillResult, error) {
 			return loadSkill(ctx, args, source)
 		},
 	)
 }
 
-func loadSkill(ctx tool.Context, args LoadSkillArgs, source skill.Source) (*LoadSkillResult, error) {
+func loadSkill(ctx agent.ToolContext, args LoadSkillArgs, source skill.Source) (*LoadSkillResult, error) {
 	if args.Name == "" {
 		return nil, fmt.Errorf("skill name is required to load a skill")
 	}

--- a/tool/skilltoolset/internal/skilltool/load_skill_resource.go
+++ b/tool/skilltoolset/internal/skilltool/load_skill_resource.go
@@ -18,6 +18,7 @@ import (
 	"fmt"
 	"io"
 
+	"google.golang.org/adk/agent"
 	"google.golang.org/adk/tool"
 	"google.golang.org/adk/tool/functiontool"
 	"google.golang.org/adk/tool/skilltoolset/skill"
@@ -45,13 +46,13 @@ func LoadSkillResource(source skill.Source) (tool.Tool, error) {
 			Name:        "load_skill_resource",
 			Description: "Loads a resource file (e.g., from references/ or assets/) associated with the specified skill.",
 		},
-		func(ctx tool.Context, args LoadSkillResourceArgs) (*LoadSkillResourceResult, error) {
+		func(ctx agent.ToolContext, args LoadSkillResourceArgs) (*LoadSkillResourceResult, error) {
 			return loadSkillResource(ctx, args, source)
 		},
 	)
 }
 
-func loadSkillResource(ctx tool.Context, args LoadSkillResourceArgs, source skill.Source) (*LoadSkillResourceResult, error) {
+func loadSkillResource(ctx agent.ToolContext, args LoadSkillResourceArgs, source skill.Source) (*LoadSkillResourceResult, error) {
 	if args.SkillName == "" {
 		return nil, fmt.Errorf("skill name is required to load a resource")
 	}

--- a/tool/skilltoolset/internal/skilltool/tools_test.go
+++ b/tool/skilltoolset/internal/skilltool/tools_test.go
@@ -25,7 +25,6 @@ import (
 	"google.golang.org/adk/agent"
 	icontext "google.golang.org/adk/internal/context"
 	"google.golang.org/adk/internal/toolinternal"
-	"google.golang.org/adk/tool"
 	"google.golang.org/adk/tool/skilltoolset/internal/skilltool"
 	"google.golang.org/adk/tool/skilltoolset/skill"
 )
@@ -75,7 +74,7 @@ func (m *mockSource) LoadResource(ctx context.Context, name, resourcePath string
 	return io.NopCloser(strings.NewReader(res)), nil
 }
 
-func createToolContext(t *testing.T) tool.Context {
+func createToolContext(t *testing.T) agent.ToolContext {
 	invCtx := icontext.NewInvocationContext(t.Context(), icontext.InvocationContextParams{})
 	return agent.NewToolContext(invCtx, "", nil, nil)
 }

--- a/tool/skilltoolset/toolset.go
+++ b/tool/skilltoolset/toolset.go
@@ -104,7 +104,7 @@ func (ts *SkillToolset) Tools(ctx agent.ReadonlyContext) ([]tool.Tool, error) { 
 // ProcessRequest implements toolinternal.RequestProcessor. It attaches
 // the list of available skills and the system instruction explaining to the
 // agent what it can do with these skills.
-func (ts *SkillToolset) ProcessRequest(ctx tool.Context, req *model.LLMRequest) error {
+func (ts *SkillToolset) ProcessRequest(ctx agent.ToolContext, req *model.LLMRequest) error {
 	skills, err := ts.source.ListFrontmatters(ctx)
 	if err != nil {
 		return err

--- a/tool/tool.go
+++ b/tool/tool.go
@@ -189,18 +189,18 @@ type confirmationTool struct {
 type runnableTool interface {
 	Tool
 	Declaration() *genai.FunctionDeclaration
-	Run(ctx Context, args any) (result map[string]any, err error)
+	Run(ctx agent.ToolContext, args any) (result map[string]any, err error)
 }
 
 func (t *confirmationTool) Declaration() *genai.FunctionDeclaration {
 	return t.runnableTool.Declaration()
 }
 
-func (t *confirmationTool) ProcessRequest(ctx Context, req *model.LLMRequest) error {
+func (t *confirmationTool) ProcessRequest(ctx agent.ToolContext, req *model.LLMRequest) error {
 	return toolutils.PackTool(req, t)
 }
 
-func (t *confirmationTool) Run(ctx Context, args any) (map[string]any, error) {
+func (t *confirmationTool) Run(ctx agent.ToolContext, args any) (map[string]any, error) {
 	ft := t.runnableTool
 
 	// Check for Human-in-the-Loop confirmation.

--- a/tool/tool_test.go
+++ b/tool/tool_test.go
@@ -54,7 +54,7 @@ func TestTypes(t *testing.T) {
 		{
 			name: "FunctionTool",
 			constructor: func() (tool.Tool, error) {
-				return functiontool.New(functiontool.Config{}, func(_ tool.Context, input intInput) (intOutput, error) {
+				return functiontool.New(functiontool.Config{}, func(_ agent.ToolContext, input intInput) (intOutput, error) {
 					return intOutput(input), nil
 				})
 			},
@@ -160,7 +160,7 @@ func (tts *testToolset) Tools(agent.ReadonlyContext) ([]tool.Tool, error) {
 
 func TestWithConfirmation(t *testing.T) {
 	toolRan := false
-	noOpTool, err := functiontool.New(functiontool.Config{Name: "noOpTool"}, func(ctx tool.Context, input struct{}) (struct{}, error) {
+	noOpTool, err := functiontool.New(functiontool.Config{Name: "noOpTool"}, func(ctx agent.ToolContext, input struct{}) (struct{}, error) {
 		toolRan = true
 		return struct{}{}, nil
 	})


### PR DESCRIPTION
Removing all referenced to deprecated tool.Context (without removing tool.Context)

### Testing Plan

**Unit Tests:**

- [ ] All unit tests pass locally.

_Please include a summary of passed go test results._

**Manual End-to-End (E2E) Tests:**

Verified that using tool.Context works by adding plugin callback to an agent

```go
		BeforeToolCallbacks: []llmagent.BeforeToolCallback{
			func(ctx tool.Context, tool tool.Tool, args map[string]any) (map[string]any, error) {
				log.Printf("Hello from BeforeToolCallback")
				return nil, nil
			},
		},

```

### Checklist

- [X] I have read the [CONTRIBUTING.md](./CONTRIBUTING.md) document.
- [X] I have performed a self-review of my own code.
- [X] New and existing unit tests pass locally with my changes.
- [X] I have manually tested my changes end-to-end.
- [X] Any dependent changes have been merged and published in downstream modules.
