### PR TITLE
feat(workflow): Node-to-Node Data Flows

### DIFF
--- a/workflow/agent_node_test.go
+++ b/workflow/agent_node_test.go
@@ -447,3 +447,49 @@ func TestAgentNode_SynthesizesOutputFromModelText(t *testing.T) {
 		t.Errorf("final event Output = %v, want %q", got, want)
 	}
 }
+
+func TestAgentNode_AutomaticOutputExtraction(t *testing.T) {
+	myAgent, err := agent.New(agent.Config{
+		Name: "text_only_agent",
+		Run: func(ctx agent.InvocationContext) iter.Seq2[*session.Event, error] {
+			return func(yield func(*session.Event, error) bool) {
+				event := session.NewEvent(ctx.InvocationID())
+				// Model response with plain text, but no Output set
+				event.Content = &genai.Content{
+					Parts: []*genai.Part{
+						{Text: "This is "},
+						{Text: "the output text."},
+					},
+					Role: "model",
+				}
+				yield(event, nil)
+			}
+		},
+	})
+	if err != nil {
+		t.Fatalf("failed to create agent: %v", err)
+	}
+
+	node, err := NewAgentNode(myAgent, defaultNodeConfig)
+	if err != nil {
+		t.Fatalf("failed to create AgentNode: %v", err)
+	}
+
+	mockCtx := newMockCtx(t)
+	mockCtx.sess = &mockSession{id: "test-session"}
+	events := node.Run(mockCtx, nil)
+
+	var finalOutput any
+	for ev, err := range events {
+		if err != nil {
+			t.Fatalf("Run returned error: %v", err)
+		}
+		if ev.Output != nil {
+			finalOutput = ev.Output
+		}
+	}
+
+	if got, want := finalOutput, "This is the output text."; got != want {
+		t.Errorf("expected automatically extracted output %q, got %q", want, got)
+	}
+}

--- a/workflow/function_node.go
+++ b/workflow/function_node.go
@@ -109,6 +109,17 @@ func (n *FunctionNode) Run(ctx agent.InvocationContext, input any) iter.Seq2[*se
 			return
 		}
 
+		// If the return type is already a *session.Event, yield it directly.
+		// This ensures that a custom FunctionNode can explicitly route its output
+		// (via event.Routes) to select conditional successors.
+		if ev, ok := output.(*session.Event); ok {
+			if ev.InvocationID == "" {
+				ev.InvocationID = ctx.InvocationID()
+			}
+			yield(ev, nil)
+			return
+		}
+
 		event := session.NewEvent(ctx.InvocationID())
 		event.Output = output
 		if s, ok := output.(string); ok {

--- a/workflow/function_node_test.go
+++ b/workflow/function_node_test.go
@@ -22,6 +22,7 @@ import (
 	"github.com/google/jsonschema-go/jsonschema"
 
 	"google.golang.org/adk/agent"
+	"google.golang.org/adk/session"
 )
 
 func TestNewFunctionNodeWithSchema(t *testing.T) {
@@ -132,4 +133,38 @@ func mustSchema[T any](t *testing.T) *jsonschema.Schema {
 		t.Fatalf("jsonschema.For failed: %v", err)
 	}
 	return s
+}
+
+func TestFunctionNodeDirectEventPropagation(t *testing.T) {
+	fn := func(ctx agent.InvocationContext, input string) (*session.Event, error) {
+		ev := session.NewEvent(ctx.InvocationID())
+		ev.Output = input + " processed"
+		ev.Routes = []string{"CUSTOM_ROUTE"}
+		return ev, nil
+	}
+
+	node := NewFunctionNode[string, *session.Event]("event_proc", fn, defaultNodeConfig)
+	mockCtx := &MockInvocationContext{sess: nil}
+
+	events := node.Run(mockCtx, "hello")
+
+	var yieldedEvents []*session.Event
+	for ev, err := range events {
+		if err != nil {
+			t.Fatalf("unexpected error running node: %v", err)
+		}
+		yieldedEvents = append(yieldedEvents, ev)
+	}
+
+	if len(yieldedEvents) != 1 {
+		t.Fatalf("expected 1 event, got %d", len(yieldedEvents))
+	}
+
+	ev := yieldedEvents[0]
+	if ev.Output != "hello processed" {
+		t.Errorf("expected Output 'hello processed', got %v", ev.Output)
+	}
+	if len(ev.Routes) != 1 || ev.Routes[0] != "CUSTOM_ROUTE" {
+		t.Errorf("expected Routes ['CUSTOM_ROUTE'], got %v", ev.Routes)
+	}
 }

--- a/workflow/tool_node.go
+++ b/workflow/tool_node.go
@@ -15,6 +15,7 @@
 package workflow
 
 import (
+	"encoding/json"
 	"fmt"
 	"iter"
 
@@ -89,6 +90,18 @@ func NewToolNode(t tool.Tool, cfg NodeConfig) (*ToolNode, error) {
 
 func (n *ToolNode) runTool(toolCtx tool.Context, input any) (any, error) {
 	runnable := n.tool.(runnableTool)
+	// Upstream nodes (like LLM Agents) frequently produce serialized JSON strings representing
+	// structured tool call arguments. Since ToolNodes expect structured key-value mappings (maps)
+	// to conform to their input validation schemas, receiving a raw JSON string would cause a crash.
+	// If the input is a raw string, we attempt to eagerly unmarshal it as JSON into a map[string]any
+	// to make the workflow node fully self-healing and compatible with upstream text outputs.
+	if s, ok := input.(string); ok {
+		var m map[string]any
+		if json.Unmarshal([]byte(s), &m) == nil {
+			input = m
+		}
+	}
+
 	toolInput, err := n.ValidateInput(input)
 	if err != nil {
 		return nil, fmt.Errorf("converting input for tool %q: %w", n.tool.Name(), err)


### PR DESCRIPTION
### Overview
This Pull Request implements self healing Node-to-Node Data Flows

To support the complex runtime dynamics of declarative graphs, this PR introduces robust, self-healing data adapters across core workflow nodes (`ToolNode`, `FunctionNode`). These adapters automatically bridge data formatting mismatches (e.g., stringified JSON, conversational envelopes) between upstream and downstream nodes without requiring manual glue code.

---

### Self-Healing Node-to-Node Data Flows (`workflow`)
* **`ToolNode` Self-Healing Input Parsing**: Upstream text nodes often serialize structured arguments into JSON strings. If the incoming input to `ToolNode` is a JSON-serialized string, it will automatically attempt to unmarshal it into a structured `map[string]any` conforming to the tool's input schema, preventing schema verification crashes.
* **`FunctionNode` Direct Event Propagation**: When a registered custom function explicitly returns a `*session.Event`, it is now propagated directly down the stream instead of being wrapped inside an `.Output` field. This allows custom workflow nodes to declare explicit routing tags (`ev.Routes`) to trigger complex conditional branches.