### PR TITLE
Context unification: merge interfaces ToolContext and CallbackContext into Context. Introduce aliases

### DIFF
--- a/README-v2.md
+++ b/README-v2.md
@@ -1,0 +1,27 @@
+# Agent Development Kit (ADK) for Go v 2.0
+
+[![License](https://img.shields.io/badge/License-Apache_2.0-blue.svg)](LICENSE)
+
+
+## Breaking changes
+
+### Unified contexts
+PR https://github.com/google/adk-go/pull/945 merges ToolContext and CallbackContext into single Context. 
+ToolContext and CallbackContext became aliases to Context. 
+
+This introduces a problem for mock contexts - new functions (ToolContext-related) are missing if the mock was created for the previous version of CallbackContext. 
+Solution:
+Add those functions to your mock:
+```go
+func (m *MockCallbackContext) Actions() *session.EventActions                       { return nil }
+func (m *MockCallbackContext) FunctionCallID() string                               { return "" }
+func (m *MockCallbackContext) ToolConfirmation() *toolconfirmation.ToolConfirmation { return nil }
+func (m *MockCallbackContext) RequestConfirmation(hint string, payload any) error {
+	return fmt.Errorf("RequestConfirmation() is not supported for MockCallbackContext")
+}
+func (m *MockCallbackContext) SearchMemory(ctx context.Context, query string) (*memory.SearchResponse, error) {
+	return nil, fmt.Errorf("SearchMemory() is not supported for MockCallbackContext")
+}
+
+var _ agent.CallbackContext = (*MockCallbackContext)(nil)
+```

--- a/README-v2.md
+++ b/README-v2.md
@@ -5,7 +5,7 @@
 
 ## Breaking changes
 
-### Unified contexts
+### Mocks update required for unified contexts 
 PR https://github.com/google/adk-go/pull/945 merges ToolContext and CallbackContext into single Context. 
 ToolContext and CallbackContext became aliases to Context. 
 

--- a/agent/callback_context.go
+++ b/agent/callback_context.go
@@ -38,7 +38,11 @@ func NewCallbackContext(ic InvocationContext, actions *session.EventActions) Cal
 		actions:           actions,
 		artifacts:         ic.Artifacts(),
 	}
-	return cc
+	// wrap the callbackContext in order to log information about someone using ToolContext-related methods for CallbackContext
+	wrapper := &callbackContextWrapper{
+		context: cc,
+	}
+	return wrapper
 }
 
 // NewCallbackContextWithArtifactTracking returns CallbackContext initialized with provided actions.
@@ -53,7 +57,11 @@ func NewCallbackContextWithArtifactTracking(ic InvocationContext, actions *sessi
 		actions:           actions,
 		artifacts:         &trackedArtifacts{Artifacts: ic.Artifacts(), actions: actions},
 	}
-	return cc
+	// wrap the callbackContext in order to log information about someone using ToolContext-related methods for CallbackContext
+	wrapper := &callbackContextWrapper{
+		context: cc,
+	}
+	return wrapper
 }
 
 // NewToolContext constructs a ToolContext for a tool execution.

--- a/agent/callback_wrapper.go
+++ b/agent/callback_wrapper.go
@@ -1,0 +1,139 @@
+// Copyright 2026 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package agent
+
+import (
+	"context"
+	"fmt"
+	"time"
+
+	"log"
+
+	"google.golang.org/adk/memory"
+	"google.golang.org/adk/session"
+	"google.golang.org/adk/tool/toolconfirmation"
+	"google.golang.org/genai"
+)
+
+type callbackContextWrapper struct {
+	context CallbackContext
+}
+
+// Actions implements [Context].
+func (c *callbackContextWrapper) Actions() *session.EventActions {
+	// return nil, Actions() do not make any sense for CallbackContext
+	log.Print("Actions() is not supported for CallbackContext")
+	return nil
+}
+
+// AgentName implements [Context].
+func (c *callbackContextWrapper) AgentName() string {
+	return c.context.AgentName()
+}
+
+// AppName implements [Context].
+func (c *callbackContextWrapper) AppName() string {
+	return c.context.AppName()
+}
+
+// Artifacts implements [Context].
+func (c *callbackContextWrapper) Artifacts() Artifacts {
+	return c.context.Artifacts()
+}
+
+// Branch implements [Context].
+func (c *callbackContextWrapper) Branch() string {
+	return c.context.Branch()
+}
+
+// Deadline implements [Context].
+func (c *callbackContextWrapper) Deadline() (deadline time.Time, ok bool) {
+	return c.context.Deadline()
+}
+
+// Done implements [Context].
+func (c *callbackContextWrapper) Done() <-chan struct{} {
+	return c.context.Done()
+}
+
+// Err implements [Context].
+func (c *callbackContextWrapper) Err() error {
+	return c.context.Err()
+}
+
+// FunctionCallID implements [Context].
+func (c *callbackContextWrapper) FunctionCallID() string {
+	// return "", FunctionCallID() do not make any sense for CallbackContext
+	log.Print("FunctionCallID() is not supported for CallbackContext")
+	return ""
+}
+
+// InvocationID implements [Context].
+func (c *callbackContextWrapper) InvocationID() string {
+	return c.context.InvocationID()
+}
+
+// ReadonlyState implements [Context].
+func (c *callbackContextWrapper) ReadonlyState() session.ReadonlyState {
+	return c.context.ReadonlyState()
+}
+
+// RequestConfirmation implements [Context].
+func (c *callbackContextWrapper) RequestConfirmation(hint string, payload any) error {
+	//  RequestConfirmation() does not make any sense for CallbackContext
+	log.Print("RequestConfirmation() is not supported for CallbackContext")
+	return fmt.Errorf("RequestConfirmation() is not supported for callback context")
+}
+
+// SearchMemory implements [Context].
+func (c *callbackContextWrapper) SearchMemory(ctx context.Context, query string) (*memory.SearchResponse, error) {
+	//  SearchMemory() does not make any sense for CallbackContext
+	log.Print("SearchMemory() is not supported for CallbackContext")
+	return nil, fmt.Errorf("SearchMemory() is not supported for callback context")
+}
+
+// SessionID implements [Context].
+func (c *callbackContextWrapper) SessionID() string {
+	return c.context.SessionID()
+}
+
+// State implements [Context].
+func (c *callbackContextWrapper) State() session.State {
+	return c.context.State()
+}
+
+// ToolConfirmation implements [Context].
+func (c *callbackContextWrapper) ToolConfirmation() *toolconfirmation.ToolConfirmation {
+	// ToolConfirmation() does not make any sense for CallbackContext
+	log.Print("ToolConfirmation() is not supported for CallbackContext")
+	return nil
+}
+
+// UserContent implements [Context].
+func (c *callbackContextWrapper) UserContent() *genai.Content {
+	return c.context.UserContent()
+}
+
+// UserID implements [Context].
+func (c *callbackContextWrapper) UserID() string {
+	return c.context.UserID()
+}
+
+// Value implements [Context].
+func (c *callbackContextWrapper) Value(key any) any {
+	return c.context.Value(key)
+}
+
+var _ Context = (*callbackContextWrapper)(nil)

--- a/agent/callback_wrapper.go
+++ b/agent/callback_wrapper.go
@@ -17,14 +17,14 @@ package agent
 import (
 	"context"
 	"fmt"
+	"log"
 	"time"
 
-	"log"
+	"google.golang.org/genai"
 
 	"google.golang.org/adk/memory"
 	"google.golang.org/adk/session"
 	"google.golang.org/adk/tool/toolconfirmation"
-	"google.golang.org/genai"
 )
 
 type callbackContextWrapper struct {

--- a/agent/callback_wrapper.go
+++ b/agent/callback_wrapper.go
@@ -27,9 +27,13 @@ import (
 	"google.golang.org/adk/tool/toolconfirmation"
 )
 
+// callbackContextWrapper is used to emit log entries for unexpected calls - those
+// related to ToolContext when Context is used as callback context
 type callbackContextWrapper struct {
 	context CallbackContext
 }
+
+// ToolContext-related: emit logs and return empty data
 
 // Actions implements [Context].
 func (c *callbackContextWrapper) Actions() *session.EventActions {
@@ -37,6 +41,36 @@ func (c *callbackContextWrapper) Actions() *session.EventActions {
 	log.Print("Actions() is not supported for CallbackContext")
 	return nil
 }
+
+// FunctionCallID implements [Context].
+func (c *callbackContextWrapper) FunctionCallID() string {
+	// return "", FunctionCallID() do not make any sense for CallbackContext
+	log.Print("FunctionCallID() is not supported for CallbackContext")
+	return ""
+}
+
+// RequestConfirmation implements [Context].
+func (c *callbackContextWrapper) RequestConfirmation(hint string, payload any) error {
+	//  RequestConfirmation() does not make any sense for CallbackContext
+	log.Print("RequestConfirmation() is not supported for CallbackContext")
+	return fmt.Errorf("RequestConfirmation() is not supported for callback context")
+}
+
+// SearchMemory implements [Context].
+func (c *callbackContextWrapper) SearchMemory(ctx context.Context, query string) (*memory.SearchResponse, error) {
+	//  SearchMemory() does not make any sense for CallbackContext
+	log.Print("SearchMemory() is not supported for CallbackContext")
+	return nil, fmt.Errorf("SearchMemory() is not supported for callback context")
+}
+
+// ToolConfirmation implements [Context].
+func (c *callbackContextWrapper) ToolConfirmation() *toolconfirmation.ToolConfirmation {
+	// ToolConfirmation() does not make any sense for CallbackContext
+	log.Print("ToolConfirmation() is not supported for CallbackContext")
+	return nil
+}
+
+// non ToolContext-related - call embedded context.
 
 // AgentName implements [Context].
 func (c *callbackContextWrapper) AgentName() string {
@@ -73,13 +107,6 @@ func (c *callbackContextWrapper) Err() error {
 	return c.context.Err()
 }
 
-// FunctionCallID implements [Context].
-func (c *callbackContextWrapper) FunctionCallID() string {
-	// return "", FunctionCallID() do not make any sense for CallbackContext
-	log.Print("FunctionCallID() is not supported for CallbackContext")
-	return ""
-}
-
 // InvocationID implements [Context].
 func (c *callbackContextWrapper) InvocationID() string {
 	return c.context.InvocationID()
@@ -90,20 +117,6 @@ func (c *callbackContextWrapper) ReadonlyState() session.ReadonlyState {
 	return c.context.ReadonlyState()
 }
 
-// RequestConfirmation implements [Context].
-func (c *callbackContextWrapper) RequestConfirmation(hint string, payload any) error {
-	//  RequestConfirmation() does not make any sense for CallbackContext
-	log.Print("RequestConfirmation() is not supported for CallbackContext")
-	return fmt.Errorf("RequestConfirmation() is not supported for callback context")
-}
-
-// SearchMemory implements [Context].
-func (c *callbackContextWrapper) SearchMemory(ctx context.Context, query string) (*memory.SearchResponse, error) {
-	//  SearchMemory() does not make any sense for CallbackContext
-	log.Print("SearchMemory() is not supported for CallbackContext")
-	return nil, fmt.Errorf("SearchMemory() is not supported for callback context")
-}
-
 // SessionID implements [Context].
 func (c *callbackContextWrapper) SessionID() string {
 	return c.context.SessionID()
@@ -112,13 +125,6 @@ func (c *callbackContextWrapper) SessionID() string {
 // State implements [Context].
 func (c *callbackContextWrapper) State() session.State {
 	return c.context.State()
-}
-
-// ToolConfirmation implements [Context].
-func (c *callbackContextWrapper) ToolConfirmation() *toolconfirmation.ToolConfirmation {
-	// ToolConfirmation() does not make any sense for CallbackContext
-	log.Print("ToolConfirmation() is not supported for CallbackContext")
-	return nil
 }
 
 // UserContent implements [Context].

--- a/agent/callback_wrapper_test.go
+++ b/agent/callback_wrapper_test.go
@@ -1,0 +1,15 @@
+// Copyright 2026 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package agent

--- a/agent/callback_wrapper_test.go
+++ b/agent/callback_wrapper_test.go
@@ -88,6 +88,7 @@ func (fakeArtifacts) List(context.Context) (*artifact.ListResponse, error) { ret
 func (fakeArtifacts) Load(context.Context, string) (*artifact.LoadResponse, error) {
 	return nil, nil
 }
+
 func (fakeArtifacts) LoadVersion(context.Context, string, int) (*artifact.LoadResponse, error) {
 	return nil, nil
 }

--- a/agent/callback_wrapper_test.go
+++ b/agent/callback_wrapper_test.go
@@ -13,3 +13,272 @@
 // limitations under the License.
 
 package agent
+
+import (
+	"bytes"
+	"context"
+	"iter"
+	"log"
+	"strings"
+	"testing"
+
+	"google.golang.org/genai"
+
+	"google.golang.org/adk/artifact"
+	"google.golang.org/adk/memory"
+	"google.golang.org/adk/session"
+	"google.golang.org/adk/tool/toolconfirmation"
+)
+
+// captureLog redirects the output of the default [log.Logger] for the
+// duration of fn and returns everything that was written to it.
+func captureLog(t *testing.T, fn func()) string {
+	t.Helper()
+	var buf bytes.Buffer
+	origOut := log.Writer()
+	origFlags := log.Flags()
+	origPrefix := log.Prefix()
+	log.SetOutput(&buf)
+	// Reset flags/prefix so the captured output is deterministic and easy to
+	// assert against.
+	log.SetFlags(0)
+	log.SetPrefix("")
+	t.Cleanup(func() {
+		log.SetOutput(origOut)
+		log.SetFlags(origFlags)
+		log.SetPrefix(origPrefix)
+	})
+	fn()
+	return buf.String()
+}
+
+// fakeSession is a minimal session.Session implementation sufficient for the
+// callback context wrapper tests.
+type fakeSession struct {
+	session.Session
+	id      string
+	appName string
+	userID  string
+	state   session.State
+}
+
+func (s *fakeSession) ID() string           { return s.id }
+func (s *fakeSession) AppName() string      { return s.appName }
+func (s *fakeSession) UserID() string       { return s.userID }
+func (s *fakeSession) State() session.State { return s.state }
+
+// fakeState is a no-op session.State implementation.
+type fakeState struct {
+	session.State
+}
+
+func (s *fakeState) Get(string) (any, error) { return nil, nil }
+func (s *fakeState) Set(string, any) error   { return nil }
+func (s *fakeState) All() iter.Seq2[string, any] {
+	return func(func(string, any) bool) {}
+}
+
+// fakeArtifacts is a no-op Artifacts implementation.
+type fakeArtifacts struct{}
+
+func (fakeArtifacts) Save(context.Context, string, *genai.Part) (*artifact.SaveResponse, error) {
+	return nil, nil
+}
+func (fakeArtifacts) List(context.Context) (*artifact.ListResponse, error) { return nil, nil }
+func (fakeArtifacts) Load(context.Context, string) (*artifact.LoadResponse, error) {
+	return nil, nil
+}
+func (fakeArtifacts) LoadVersion(context.Context, string, int) (*artifact.LoadResponse, error) {
+	return nil, nil
+}
+
+// fakeMemory is a no-op Memory implementation.
+type fakeMemory struct{}
+
+func (fakeMemory) AddSessionToMemory(context.Context, session.Session) error { return nil }
+func (fakeMemory) SearchMemory(context.Context, string) (*memory.SearchResponse, error) {
+	return &memory.SearchResponse{}, nil
+}
+
+// newTestCallbackContext builds a CallbackContext (a *callbackContextWrapper)
+// backed by a fully-populated invocationContext so that the supported methods
+// have meaningful values to delegate to.
+func newTestCallbackContext(t *testing.T) CallbackContext {
+	t.Helper()
+
+	a, err := New(Config{
+		Name: "test-agent",
+		Run: func(InvocationContext) iter.Seq2[*session.Event, error] {
+			return func(func(*session.Event, error) bool) {}
+		},
+	})
+	if err != nil {
+		t.Fatalf("failed to create agent: %v", err)
+	}
+
+	ic := &invocationContext{
+		Context:      t.Context(),
+		agent:        a,
+		artifacts:    fakeArtifacts{},
+		memory:       fakeMemory{},
+		session:      &fakeSession{id: "sess-1", appName: "app", userID: "user", state: &fakeState{}},
+		invocationID: "inv-1",
+		branch:       "branch-1",
+		userContent:  genai.NewContentFromText("hi", genai.RoleUser),
+	}
+	return NewCallbackContext(ic, nil)
+}
+
+// TestCallbackContextWrapper_LogsForToolContextMethods verifies that calling
+// ToolContext-only methods on a CallbackContext (obtained via
+// NewCallbackContext, which wraps the underlying commonContext in a
+// callbackContextWrapper) emits a log entry indicating the method is not
+// supported, and returns the documented "no-op" value.
+func TestCallbackContextWrapper_LogsForToolContextMethods(t *testing.T) {
+	t.Run("Actions logs and returns nil", func(t *testing.T) {
+		cc := newTestCallbackContext(t)
+		var got *session.EventActions
+		output := captureLog(t, func() { got = cc.Actions() })
+		if got != nil {
+			t.Errorf("Actions() = %v, want nil", got)
+		}
+		if !strings.Contains(output, "Actions()") || !strings.Contains(output, "not supported") {
+			t.Errorf("Actions() log = %q, want log mentioning %q and %q", output, "Actions()", "not supported")
+		}
+	})
+
+	t.Run("FunctionCallID logs and returns empty string", func(t *testing.T) {
+		cc := newTestCallbackContext(t)
+		var got string
+		output := captureLog(t, func() { got = cc.FunctionCallID() })
+		if got != "" {
+			t.Errorf("FunctionCallID() = %q, want \"\"", got)
+		}
+		if !strings.Contains(output, "FunctionCallID()") || !strings.Contains(output, "not supported") {
+			t.Errorf("FunctionCallID() log = %q, want log mentioning %q and %q", output, "FunctionCallID()", "not supported")
+		}
+	})
+
+	t.Run("RequestConfirmation logs and returns error", func(t *testing.T) {
+		cc := newTestCallbackContext(t)
+		var gotErr error
+		output := captureLog(t, func() { gotErr = cc.RequestConfirmation("hint", "payload") })
+		if gotErr == nil {
+			t.Errorf("RequestConfirmation() error = nil, want non-nil")
+		}
+		if !strings.Contains(output, "RequestConfirmation()") || !strings.Contains(output, "not supported") {
+			t.Errorf("RequestConfirmation() log = %q, want log mentioning %q and %q", output, "RequestConfirmation()", "not supported")
+		}
+	})
+
+	t.Run("SearchMemory logs and returns error", func(t *testing.T) {
+		cc := newTestCallbackContext(t)
+		var (
+			gotResp *memory.SearchResponse
+			gotErr  error
+		)
+		output := captureLog(t, func() { gotResp, gotErr = cc.SearchMemory(t.Context(), "query") })
+		if gotResp != nil {
+			t.Errorf("SearchMemory() resp = %v, want nil", gotResp)
+		}
+		if gotErr == nil {
+			t.Errorf("SearchMemory() error = nil, want non-nil")
+		}
+		if !strings.Contains(output, "SearchMemory()") || !strings.Contains(output, "not supported") {
+			t.Errorf("SearchMemory() log = %q, want log mentioning %q and %q", output, "SearchMemory()", "not supported")
+		}
+	})
+
+	t.Run("ToolConfirmation logs and returns nil", func(t *testing.T) {
+		cc := newTestCallbackContext(t)
+		var got *toolconfirmation.ToolConfirmation
+		output := captureLog(t, func() { got = cc.ToolConfirmation() })
+		if got != nil {
+			t.Errorf("ToolConfirmation() = %v, want nil", got)
+		}
+		if !strings.Contains(output, "ToolConfirmation()") || !strings.Contains(output, "not supported") {
+			t.Errorf("ToolConfirmation() log = %q, want log mentioning %q and %q", output, "ToolConfirmation()", "not supported")
+		}
+	})
+}
+
+// TestCallbackContextWrapper_NoLogForSupportedMethods verifies that methods
+// which are valid on a CallbackContext (i.e. the ones the wrapper simply
+// delegates to the underlying context) do not emit any log entry and return
+// the values produced by the underlying invocation context.
+func TestCallbackContextWrapper_NoLogForSupportedMethods(t *testing.T) {
+	cases := []struct {
+		name string
+		call func(cc CallbackContext) any
+		want any
+	}{
+		{"AgentName", func(cc CallbackContext) any { return cc.AgentName() }, "test-agent"},
+		{"AppName", func(cc CallbackContext) any { return cc.AppName() }, "app"},
+		{"Branch", func(cc CallbackContext) any { return cc.Branch() }, "branch-1"},
+		{"InvocationID", func(cc CallbackContext) any { return cc.InvocationID() }, "inv-1"},
+		{"SessionID", func(cc CallbackContext) any { return cc.SessionID() }, "sess-1"},
+		{"UserID", func(cc CallbackContext) any { return cc.UserID() }, "user"},
+	}
+
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			cc := newTestCallbackContext(t)
+			var got any
+			output := captureLog(t, func() { got = tc.call(cc) })
+			if got != tc.want {
+				t.Errorf("%s() = %v, want %v", tc.name, got, tc.want)
+			}
+			if output != "" {
+				t.Errorf("%s() unexpectedly emitted log output: %q", tc.name, output)
+			}
+		})
+	}
+
+	t.Run("Artifacts", func(t *testing.T) {
+		cc := newTestCallbackContext(t)
+		var got Artifacts
+		output := captureLog(t, func() { got = cc.Artifacts() })
+		if got == nil {
+			t.Errorf("Artifacts() = nil, want non-nil")
+		}
+		if output != "" {
+			t.Errorf("Artifacts() unexpectedly emitted log output: %q", output)
+		}
+	})
+
+	t.Run("UserContent", func(t *testing.T) {
+		cc := newTestCallbackContext(t)
+		var got *genai.Content
+		output := captureLog(t, func() { got = cc.UserContent() })
+		if got == nil {
+			t.Errorf("UserContent() = nil, want non-nil")
+		}
+		if output != "" {
+			t.Errorf("UserContent() unexpectedly emitted log output: %q", output)
+		}
+	})
+
+	t.Run("ReadonlyState", func(t *testing.T) {
+		cc := newTestCallbackContext(t)
+		var got session.ReadonlyState
+		output := captureLog(t, func() { got = cc.ReadonlyState() })
+		if got == nil {
+			t.Errorf("ReadonlyState() = nil, want non-nil")
+		}
+		if output != "" {
+			t.Errorf("ReadonlyState() unexpectedly emitted log output: %q", output)
+		}
+	})
+
+	t.Run("State", func(t *testing.T) {
+		cc := newTestCallbackContext(t)
+		var got session.State
+		output := captureLog(t, func() { got = cc.State() })
+		if got == nil {
+			t.Errorf("State() = nil, want non-nil")
+		}
+		if output != "" {
+			t.Errorf("State() unexpectedly emitted log output: %q", output)
+		}
+	})
+}

--- a/agent/common_context.go
+++ b/agent/common_context.go
@@ -32,7 +32,7 @@ import (
 // actions may be nil; if so, a new session.EventActions is created with empty StateDelta and ArtifactDelta
 func NewCallbackContext(ic InvocationContext, actions *session.EventActions) CallbackContext {
 	actions = prepareEventActions(actions)
-	cc := &callbackContext{
+	cc := &commonContext{
 		Context:           ic,
 		invocationContext: ic,
 		actions:           actions,
@@ -51,7 +51,7 @@ func NewCallbackContext(ic InvocationContext, actions *session.EventActions) Cal
 // actions may be nil; if so, a new session.EventActions is created with empty StateDelta and ArtifactDelta
 func NewCallbackContextWithArtifactTracking(ic InvocationContext, actions *session.EventActions) CallbackContext {
 	actions = prepareEventActions(actions)
-	cc := &callbackContext{
+	cc := &commonContext{
 		Context:           ic,
 		invocationContext: ic,
 		actions:           actions,
@@ -77,7 +77,7 @@ func NewToolContext(ic InvocationContext, functionCallID string, actions *sessio
 		functionCallID = uuid.NewString()
 	}
 	actions = prepareEventActions(actions)
-	return &callbackContext{
+	return &commonContext{
 		Context:           ic,
 		invocationContext: ic,
 		actions:           actions,
@@ -101,12 +101,12 @@ func prepareEventActions(actions *session.EventActions) *session.EventActions {
 	return actions
 }
 
-// callbackContext is the single concrete implementation of CallbackContext
+// commonContext is the single concrete implementation of CallbackContext
 // (and, when constructed via NewToolContext, of ToolContext as well). The
 // tool-specific methods (FunctionCallID, Actions, SearchMemory,
 // ToolConfirmation, RequestConfirmation) are always present on the concrete
 // type; they are only meaningful when the context is used as a ToolContext.
-type callbackContext struct {
+type commonContext struct {
 	context.Context
 	invocationContext InvocationContext
 	artifacts         Artifacts
@@ -117,49 +117,49 @@ type callbackContext struct {
 	toolConfirmation *toolconfirmation.ToolConfirmation
 }
 
-func (c *callbackContext) AgentName() string {
+func (c *commonContext) AgentName() string {
 	return c.invocationContext.Agent().Name()
 }
 
-func (c *callbackContext) ReadonlyState() session.ReadonlyState {
+func (c *commonContext) ReadonlyState() session.ReadonlyState {
 	return c.invocationContext.Session().State()
 }
 
-func (c *callbackContext) State() session.State {
+func (c *commonContext) State() session.State {
 	return &callbackContextState{ctx: c}
 }
 
-func (c *callbackContext) Artifacts() Artifacts {
+func (c *commonContext) Artifacts() Artifacts {
 	return c.artifacts
 }
 
-func (c *callbackContext) InvocationID() string {
+func (c *commonContext) InvocationID() string {
 	return c.invocationContext.InvocationID()
 }
 
-func (c *callbackContext) UserContent() *genai.Content {
+func (c *commonContext) UserContent() *genai.Content {
 	return c.invocationContext.UserContent()
 }
 
-func (c *callbackContext) AppName() string {
+func (c *commonContext) AppName() string {
 	return c.invocationContext.Session().AppName()
 }
 
-func (c *callbackContext) Branch() string {
+func (c *commonContext) Branch() string {
 	return c.invocationContext.Branch()
 }
 
-func (c *callbackContext) SessionID() string {
+func (c *commonContext) SessionID() string {
 	return c.invocationContext.Session().ID()
 }
 
-func (c *callbackContext) UserID() string {
+func (c *commonContext) UserID() string {
 	return c.invocationContext.Session().UserID()
 }
 
 var (
-	_ CallbackContext = (*callbackContext)(nil)
-	_ ToolContext     = (*callbackContext)(nil)
+	_ CallbackContext = (*commonContext)(nil)
+	_ ToolContext     = (*commonContext)(nil)
 )
 
 // --- ToolContext extensions ----------------------------------------------
@@ -171,19 +171,19 @@ var (
 // FunctionCallID returns the function call identifier associated with the
 // current tool execution, or "" if this context was not constructed for a
 // tool call.
-func (c *callbackContext) FunctionCallID() string {
+func (c *commonContext) FunctionCallID() string {
 	return c.functionCallID
 }
 
 // Actions returns the EventActions for the current event. Tools can mutate
 // the returned value to influence the agent loop (e.g. state deltas, agent
 // transfers).
-func (c *callbackContext) Actions() *session.EventActions {
+func (c *commonContext) Actions() *session.EventActions {
 	return c.actions
 }
 
 // SearchMemory performs a semantic search on the agent's memory.
-func (c *callbackContext) SearchMemory(ctx context.Context, query string) (*memory.SearchResponse, error) {
+func (c *commonContext) SearchMemory(ctx context.Context, query string) (*memory.SearchResponse, error) {
 	if c.invocationContext.Memory() == nil {
 		return nil, fmt.Errorf("memory service is not set")
 	}
@@ -193,7 +193,7 @@ func (c *callbackContext) SearchMemory(ctx context.Context, query string) (*memo
 // ToolConfirmation returns the Human-in-the-Loop confirmation handle for the
 // current tool execution, or nil if no confirmation is currently associated
 // with the call.
-func (c *callbackContext) ToolConfirmation() *toolconfirmation.ToolConfirmation {
+func (c *commonContext) ToolConfirmation() *toolconfirmation.ToolConfirmation {
 	return c.toolConfirmation
 }
 
@@ -201,7 +201,7 @@ func (c *callbackContext) ToolConfirmation() *toolconfirmation.ToolConfirmation 
 // for the current tool call. It records a pending confirmation in the
 // underlying EventActions and sets SkipSummarization so the agent loop halts
 // until the user responds.
-func (c *callbackContext) RequestConfirmation(hint string, payload any) error {
+func (c *commonContext) RequestConfirmation(hint string, payload any) error {
 	if c.functionCallID == "" {
 		return fmt.Errorf("error function call id not set when requesting confirmation for tool")
 	}
@@ -223,7 +223,7 @@ func (c *callbackContext) RequestConfirmation(hint string, payload any) error {
 // callbackContextState is a session.State implementation backed by the
 // callback context's EventActions.StateDelta and the underlying session state.
 type callbackContextState struct {
-	ctx *callbackContext
+	ctx *commonContext
 }
 
 func (c *callbackContextState) Get(key string) (any, error) {

--- a/agent/context.go
+++ b/agent/context.go
@@ -194,3 +194,7 @@ type ToolContext interface {
 	//     request to ask the user has not been sent.
 	RequestConfirmation(hint string, payload any) error
 }
+
+type Context interface {
+	ToolContext
+}

--- a/agent/context.go
+++ b/agent/context.go
@@ -128,19 +128,22 @@ type ReadonlyContext interface {
 }
 
 // CallbackContext is passed to user callbacks during agent execution.
-type CallbackContext interface {
-	ReadonlyContext
-
-	Artifacts() Artifacts
-	State() session.State
-}
+type CallbackContext = Context
 
 // ToolContext is the context passed to a tool when it is called. It extends
 // CallbackContext with tool-specific facilities: access to the originating
 // function call, mutable event actions, long-term memory search, and the
 // Human-in-the-Loop (HITL) confirmation flow.
-type ToolContext interface {
-	CallbackContext
+type ToolContext = Context
+
+type Context interface {
+	ReadonlyContext
+
+	// Callback context
+	Artifacts() Artifacts
+	State() session.State
+
+	// ToolContext section
 
 	// FunctionCallID returns the unique identifier of the function call
 	// that triggered this tool execution.
@@ -193,8 +196,4 @@ type ToolContext interface {
 	//     itself (e.g., invalid arguments, issue with the event system). The
 	//     request to ask the user has not been sent.
 	RequestConfirmation(hint string, payload any) error
-}
-
-type Context interface {
-	ToolContext
 }

--- a/agent/context.go
+++ b/agent/context.go
@@ -136,6 +136,7 @@ type CallbackContext = Context
 // Human-in-the-Loop (HITL) confirmation flow.
 type ToolContext = Context
 
+// Context is a common context used both in callbacks (aliased as CallbackContext) and tool calls (aliased as ToolContext).
 type Context interface {
 	ReadonlyContext
 

--- a/internal/configurable/conformance/recordplugin/record_plugin_test.go
+++ b/internal/configurable/conformance/recordplugin/record_plugin_test.go
@@ -491,6 +491,7 @@ func (m *MockCallbackContext) ToolConfirmation() *toolconfirmation.ToolConfirmat
 func (m *MockCallbackContext) RequestConfirmation(hint string, payload any) error {
 	return fmt.Errorf("RequestConfirmation() is not supported for MockCallbackContext")
 }
+
 func (m *MockCallbackContext) SearchMemory(ctx context.Context, query string) (*memory.SearchResponse, error) {
 	return nil, fmt.Errorf("SearchMemory() is not supported for MockCallbackContext")
 }

--- a/internal/configurable/conformance/recordplugin/record_plugin_test.go
+++ b/internal/configurable/conformance/recordplugin/record_plugin_test.go
@@ -16,6 +16,7 @@ package recordplugin_test
 
 import (
 	"context"
+	"fmt"
 	"iter"
 	"os"
 	"path/filepath"
@@ -470,20 +471,31 @@ type MockCallbackContext struct {
 	agentName    string
 }
 
-func (m *MockCallbackContext) State() session.State                    { return m.state }
-func (m *MockCallbackContext) ReadonlyState() session.ReadonlyState    { return m.state }
-func (m *MockCallbackContext) InvocationID() string                    { return m.invocationID }
-func (m *MockCallbackContext) AgentName() string                       { return m.agentName }
-func (m *MockCallbackContext) AppName() string                         { return "mock-app" }
-func (m *MockCallbackContext) Branch() string                          { return "" }
-func (m *MockCallbackContext) SessionID() string                       { return "mock-session-id" }
-func (m *MockCallbackContext) UserID() string                          { return "mock-user" }
-func (m *MockCallbackContext) UserContent() *genai.Content             { return nil }
-func (m *MockCallbackContext) Artifacts() agent.Artifacts              { return nil }
-func (m *MockCallbackContext) Value(key any) any                       { return nil }
-func (m *MockCallbackContext) Deadline() (deadline time.Time, ok bool) { return time.Time{}, false }
-func (m *MockCallbackContext) Done() <-chan struct{}                   { return nil }
-func (m *MockCallbackContext) Err() error                              { return nil }
+func (m *MockCallbackContext) State() session.State                                 { return m.state }
+func (m *MockCallbackContext) ReadonlyState() session.ReadonlyState                 { return m.state }
+func (m *MockCallbackContext) InvocationID() string                                 { return m.invocationID }
+func (m *MockCallbackContext) AgentName() string                                    { return m.agentName }
+func (m *MockCallbackContext) AppName() string                                      { return "mock-app" }
+func (m *MockCallbackContext) Branch() string                                       { return "" }
+func (m *MockCallbackContext) SessionID() string                                    { return "mock-session-id" }
+func (m *MockCallbackContext) UserID() string                                       { return "mock-user" }
+func (m *MockCallbackContext) UserContent() *genai.Content                          { return nil }
+func (m *MockCallbackContext) Artifacts() agent.Artifacts                           { return nil }
+func (m *MockCallbackContext) Value(key any) any                                    { return nil }
+func (m *MockCallbackContext) Deadline() (deadline time.Time, ok bool)              { return time.Time{}, false }
+func (m *MockCallbackContext) Done() <-chan struct{}                                { return nil }
+func (m *MockCallbackContext) Err() error                                           { return nil }
+func (m *MockCallbackContext) Actions() *session.EventActions                       { return nil }
+func (m *MockCallbackContext) FunctionCallID() string                               { return "" }
+func (m *MockCallbackContext) ToolConfirmation() *toolconfirmation.ToolConfirmation { return nil }
+func (m *MockCallbackContext) RequestConfirmation(hint string, payload any) error {
+	return fmt.Errorf("RequestConfirmation() is not supported for MockCallbackContext")
+}
+func (m *MockCallbackContext) SearchMemory(ctx context.Context, query string) (*memory.SearchResponse, error) {
+	return nil, fmt.Errorf("SearchMemory() is not supported for MockCallbackContext")
+}
+
+var _ agent.CallbackContext = (*MockCallbackContext)(nil)
 
 type MockToolContext struct {
 	state          session.State

--- a/internal/configurable/conformance/replayplugin/replay_plugin_test.go
+++ b/internal/configurable/conformance/replayplugin/replay_plugin_test.go
@@ -511,6 +511,7 @@ func (m *MockCallbackContext) ToolConfirmation() *toolconfirmation.ToolConfirmat
 func (m *MockCallbackContext) RequestConfirmation(hint string, payload any) error {
 	return fmt.Errorf("RequestConfirmation() is not supported for MockCallbackContext")
 }
+
 func (m *MockCallbackContext) SearchMemory(ctx context.Context, query string) (*memory.SearchResponse, error) {
 	return nil, fmt.Errorf("SearchMemory() is not supported for MockCallbackContext")
 }

--- a/internal/configurable/conformance/replayplugin/replay_plugin_test.go
+++ b/internal/configurable/conformance/replayplugin/replay_plugin_test.go
@@ -16,6 +16,7 @@ package replayplugin_test
 
 import (
 	"context"
+	"fmt"
 	"iter"
 	"os"
 	"path/filepath"
@@ -490,20 +491,31 @@ type MockCallbackContext struct {
 	agentName    string
 }
 
-func (m *MockCallbackContext) State() session.State                    { return m.state }
-func (m *MockCallbackContext) ReadonlyState() session.ReadonlyState    { return m.state }
-func (m *MockCallbackContext) InvocationID() string                    { return m.invocationID }
-func (m *MockCallbackContext) AgentName() string                       { return m.agentName }
-func (m *MockCallbackContext) AppName() string                         { return "mock-app" }
-func (m *MockCallbackContext) Branch() string                          { return "" }
-func (m *MockCallbackContext) SessionID() string                       { return "mock-session-id" }
-func (m *MockCallbackContext) UserID() string                          { return "mock-user" }
-func (m *MockCallbackContext) UserContent() *genai.Content             { return nil }
-func (m *MockCallbackContext) Artifacts() agent.Artifacts              { return nil }
-func (m *MockCallbackContext) Value(key any) any                       { return nil }
-func (m *MockCallbackContext) Deadline() (deadline time.Time, ok bool) { return time.Time{}, false }
-func (m *MockCallbackContext) Done() <-chan struct{}                   { return nil }
-func (m *MockCallbackContext) Err() error                              { return nil }
+func (m *MockCallbackContext) State() session.State                                 { return m.state }
+func (m *MockCallbackContext) ReadonlyState() session.ReadonlyState                 { return m.state }
+func (m *MockCallbackContext) InvocationID() string                                 { return m.invocationID }
+func (m *MockCallbackContext) AgentName() string                                    { return m.agentName }
+func (m *MockCallbackContext) AppName() string                                      { return "mock-app" }
+func (m *MockCallbackContext) Branch() string                                       { return "" }
+func (m *MockCallbackContext) SessionID() string                                    { return "mock-session-id" }
+func (m *MockCallbackContext) UserID() string                                       { return "mock-user" }
+func (m *MockCallbackContext) UserContent() *genai.Content                          { return nil }
+func (m *MockCallbackContext) Artifacts() agent.Artifacts                           { return nil }
+func (m *MockCallbackContext) Value(key any) any                                    { return nil }
+func (m *MockCallbackContext) Deadline() (deadline time.Time, ok bool)              { return time.Time{}, false }
+func (m *MockCallbackContext) Done() <-chan struct{}                                { return nil }
+func (m *MockCallbackContext) Err() error                                           { return nil }
+func (m *MockCallbackContext) Actions() *session.EventActions                       { return nil }
+func (m *MockCallbackContext) FunctionCallID() string                               { return "" }
+func (m *MockCallbackContext) ToolConfirmation() *toolconfirmation.ToolConfirmation { return nil }
+func (m *MockCallbackContext) RequestConfirmation(hint string, payload any) error {
+	return fmt.Errorf("RequestConfirmation() is not supported for MockCallbackContext")
+}
+func (m *MockCallbackContext) SearchMemory(ctx context.Context, query string) (*memory.SearchResponse, error) {
+	return nil, fmt.Errorf("SearchMemory() is not supported for MockCallbackContext")
+}
+
+var _ agent.CallbackContext = (*MockCallbackContext)(nil)
 
 // MockToolContext
 type MockToolContext struct {

--- a/tool/context_test.go
+++ b/tool/context_test.go
@@ -29,9 +29,6 @@ func TestNewToolContext_Interfaces(t *testing.T) {
 	if _, ok := toolCtx.(agent.ReadonlyContext); !ok {
 		t.Errorf("ToolContext(%+T) is unexpectedly not a ReadonlyContext", toolCtx)
 	}
-	if _, ok := toolCtx.(agent.CallbackContext); !ok {
-		t.Errorf("ToolContext(%+T) is unexpectedly not a CallbackContext", toolCtx)
-	}
 }
 
 func TestNewToolContext_RequestConfirmation_SetsSkipSummarization(t *testing.T) {


### PR DESCRIPTION
Further unification of contexts 
