### PR TITLE
feat: introduce robust JSON-aware input validation in base node for string-encoded types

### DIFF
--- a/workflow/base_node.go
+++ b/workflow/base_node.go
@@ -16,8 +16,6 @@ package workflow
 
 import (
 	"github.com/google/jsonschema-go/jsonschema"
-
-	"google.golang.org/adk/internal/typeutil"
 )
 
 // BaseNode provides identity and a default Config implementation for
@@ -80,11 +78,4 @@ func (b BaseNode) OutputSchema() *jsonschema.Resolved { return b.outputSchema }
 // ValidateInput validates and coerces the input using the node's input schema.
 func (b BaseNode) ValidateInput(in any) (any, error) {
 	return defaultValidateInput(in, b.inputSchema)
-}
-
-func defaultValidateInput(in any, schema *jsonschema.Resolved) (any, error) {
-	if schema == nil {
-		return in, nil
-	}
-	return typeutil.ConvertToWithJSONSchema[any, any](in, schema)
 }

--- a/workflow/validation.go
+++ b/workflow/validation.go
@@ -15,10 +15,15 @@
 package workflow
 
 import (
+	"encoding/json"
 	"errors"
 	"fmt"
 	"slices"
 	"strings"
+
+	"github.com/google/jsonschema-go/jsonschema"
+
+	"google.golang.org/adk/internal/typeutil"
 )
 
 // ErrDuplicateNodeName is returned when an edge set contains two
@@ -265,4 +270,65 @@ func validateCycles(workflow *graph) error {
 	}
 
 	return nil
+}
+
+// defaultValidateInput validates data against schema. When data is a
+// string and the schema expects a non-string shape, it first tries to
+// parse the string as JSON. If parsing or validation fails, it falls
+// back to validating the raw string (useful for enum/literal schemas).
+// If both attempts fail, it returns the error from standard schema
+// validation.
+func defaultValidateInput(data any, schema *jsonschema.Resolved) (any, error) {
+	if schema == nil {
+		return data, nil
+	}
+	if data == nil {
+		return nil, nil
+	}
+	// Bypasses ConvertToWithJSONSchema for all string inputs since ConvertToWithJSONSchema
+	// expects the value to marshal into map[string]any for validation, which fails for string types.
+	if text, ok := data.(string); ok {
+		if !schemaIsString(schema) {
+			// Step 1: try JSON parse
+			var parsed any
+			if err := json.Unmarshal([]byte(text), &parsed); err == nil {
+				if err := schema.Validate(parsed); err == nil {
+					return parsed, nil
+				}
+			}
+			// Step 2: raw string may match an enum/literal schema
+			if err := schema.Validate(text); err == nil {
+				return text, nil
+			}
+			// Step 3: fall through to standard validation (which will return an error)
+		} else {
+			// If schema expects string, validate the raw string directly.
+			if err := schema.Validate(text); err != nil {
+				return nil, err
+			}
+			return text, nil
+		}
+	}
+	return typeutil.ConvertToWithJSONSchema[any, any](data, schema)
+}
+
+// schemaIsString reports whether the resolved schema expects a JSON
+// string at the top level.
+func schemaIsString(s *jsonschema.Resolved) bool {
+	if s == nil {
+		return false
+	}
+	schema := s.Schema()
+	if schema == nil {
+		return false
+	}
+	if schema.Type == "string" {
+		return true
+	}
+	for _, t := range schema.Types {
+		if t == "string" {
+			return true
+		}
+	}
+	return false
 }

--- a/workflow/validation_test.go
+++ b/workflow/validation_test.go
@@ -504,10 +504,10 @@ func TestDefaultValidateInput(t *testing.T) {
 			want:   "hello",
 		},
 		{
-      name: "valid JSON object missing required field",
-      data: `{"x":1}`,
-      schema: structSchema,
-      wantErrSubstr: "missing properties", 
+			name:          "valid JSON object missing required field",
+			data:          `{"x":1}`,
+			schema:        structSchema,
+			wantErrSubstr: "missing properties",
 		},
 	}
 

--- a/workflow/validation_test.go
+++ b/workflow/validation_test.go
@@ -18,6 +18,10 @@ import (
 	"errors"
 	"strings"
 	"testing"
+
+	"github.com/google/go-cmp/cmp"
+	"github.com/google/go-cmp/cmp/cmpopts"
+	"github.com/google/jsonschema-go/jsonschema"
 )
 
 func TestUniqueNames(t *testing.T) {
@@ -410,6 +414,182 @@ func TestValidateSubWorkflowNames(t *testing.T) {
 				}
 			} else if err != nil {
 				t.Errorf("expected no error, got %v", err)
+			}
+		})
+	}
+}
+
+func TestDefaultValidateInput(t *testing.T) {
+	// Set up schemas
+	intSchema, err := (&jsonschema.Schema{Type: "integer"}).Resolve(nil)
+	if err != nil {
+		t.Fatalf("failed to resolve integer schema: %v", err)
+	}
+
+	enumSchema, err := (&jsonschema.Schema{
+		Type: "string",
+		Enum: []any{"yes", "no"},
+	}).Resolve(nil)
+	if err != nil {
+		t.Fatalf("failed to resolve enum schema: %v", err)
+	}
+
+	structSchemaRaw, err := jsonschema.For[testValidationStruct](nil)
+	if err != nil {
+		t.Fatalf("failed to generate struct schema: %v", err)
+	}
+	structSchema, err := structSchemaRaw.Resolve(nil)
+	if err != nil {
+		t.Fatalf("failed to resolve struct schema: %v", err)
+	}
+
+	stringSchema, err := (&jsonschema.Schema{Type: "string"}).Resolve(nil)
+	if err != nil {
+		t.Fatalf("failed to resolve string schema: %v", err)
+	}
+
+	tests := []struct {
+		name          string
+		data          any
+		schema        *jsonschema.Resolved
+		want          any
+		wantErrSubstr string
+	}{
+		{
+			name:   "nil schema returns data as-is",
+			data:   "hello",
+			schema: nil,
+			want:   "hello",
+		},
+		{
+			name:   "nil data returns nil",
+			data:   nil,
+			schema: intSchema,
+			want:   nil,
+		},
+		{
+			name:   "string integer parsed as JSON integer",
+			data:   "123",
+			schema: intSchema,
+			want:   float64(123), // JSON numbers unmarshal as float64 in any
+		},
+		{
+			name:   "string matching enum element (raw fallback)",
+			data:   "yes",
+			schema: enumSchema,
+			want:   "yes",
+		},
+		{
+			name:          "plain text string failing integer schema",
+			data:          "plain text",
+			schema:        intSchema,
+			wantErrSubstr: "loading",
+		},
+		{
+			name: "map coerced to struct type via standard schema validation/conversion",
+			data: map[string]any{
+				"x": 42,
+				"y": "hello",
+			},
+			schema: structSchema,
+			want: map[string]any{
+				"x": float64(42),
+				"y": "hello",
+			},
+		},
+		{
+			name:   "string matching string schema does not attempt JSON parse",
+			data:   "hello",
+			schema: stringSchema,
+			want:   "hello",
+		},
+		{
+      name: "valid JSON object missing required field",
+      data: `{"x":1}`,
+      schema: structSchema,
+      wantErrSubstr: "missing properties", 
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got, err := defaultValidateInput(tt.data, tt.schema)
+			if tt.wantErrSubstr != "" {
+				if err == nil {
+					t.Fatalf("expected error containing %q, got nil", tt.wantErrSubstr)
+				}
+				return
+			}
+			if err != nil {
+				t.Fatalf("unexpected error: %v", err)
+			}
+
+			if diff := cmp.Diff(tt.want, got, cmpopts.EquateEmpty()); diff != "" {
+				t.Errorf("defaultValidateInput() mismatch (-want +got):\n%s", diff)
+			}
+		})
+	}
+}
+
+type testValidationStruct struct {
+	X int    `json:"x"`
+	Y string `json:"y"`
+}
+
+func TestSchemaIsString(t *testing.T) {
+	tests := []struct {
+		name   string
+		schema *jsonschema.Schema
+		want   bool
+	}{
+		{
+			name:   "nil schema",
+			schema: nil,
+			want:   false,
+		},
+		{
+			name: "type string",
+			schema: &jsonschema.Schema{
+				Type: "string",
+			},
+			want: true,
+		},
+		{
+			name: "type integer",
+			schema: &jsonschema.Schema{
+				Type: "integer",
+			},
+			want: false,
+		},
+		{
+			name: "types with string",
+			schema: &jsonschema.Schema{
+				Types: []string{"integer", "string"},
+			},
+			want: true,
+		},
+		{
+			name: "types without string",
+			schema: &jsonschema.Schema{
+				Types: []string{"integer", "boolean"},
+			},
+			want: false,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			var resolved *jsonschema.Resolved
+			if tt.schema != nil {
+				var err error
+				resolved, err = tt.schema.Resolve(nil)
+				if err != nil {
+					t.Fatalf("failed to resolve schema: %v", err)
+				}
+			}
+			got := schemaIsString(resolved)
+			if got != tt.want {
+				t.Errorf("schemaIsString() = %v, want %v", got, tt.want)
 			}
 		})
 	}


### PR DESCRIPTION
Introduces robust, JSON-aware input validation for workflow base nodes. When a string-encoded input is provided for a non-string target schema, the validator attempts to parse the string as JSON first before falling back to raw-string evaluation or structured schema validation. This facilitates seamless integration with stringified payload formats.

### Key Changes
- **`defaultValidateInput`**: Implemented as a package-private utility function in the `workflow` package to handle input data validation and coercion against schema specifications. The primary user-facing entry point is exposed via `BaseNode.ValidateInput`.
- **`schemaIsString`**: A helper implemented to identify whether a resolved schema expects a string. It correctly supports both the singular `Type` field and the plural `Types` field of `*jsonschema.Schema`.
- **Edge Cases Handled**:
  - A `nil` schema returns input data as-is.
  - A `nil` input data returns `nil` directly.
- **Validation Flow**:
  - For string inputs targeting string schemas, it bypasses JSON parsing entirely (`schemaIsString` short-circuit).
  - For string inputs targeting non-string schemas, it attempts JSON parsing first. If that fails or is invalid, it falls back to validating the raw string (supporting enums and literals).
  - For structured inputs (e.g., `map[string]any`), it leverages standard validation and conversion paths.

### Test Coverage
Added comprehensive test cases under `TestDefaultValidateInput` and `TestSchemaIsString` covering the following scenarios:
- `"123"` (string) + `int` schema $\rightarrow$ returns parsed `123` (JSON parse path).
- `"yes"` (string) + `enum["yes","no"]` schema $\rightarrow$ returns `"yes"` (raw-string fallback path).
- `"plain text"` (string) + `int` schema $\rightarrow$ returns an error.
- `map[string]any{...}` + `struct` schema $\rightarrow$ returns coerced struct mapping (standard path).
- `nil` input + any schema $\rightarrow$ returns `nil`.
- `"hello"` (string) + `string` schema $\rightarrow$ returns `"hello"` directly without attempting JSON parsing (`schemaIsString` short-circuit).
