### PR TITLE
feat(runner): run LlmAgent through the node runtime with HITL support

### DIFF
--- a/examples/runner/hitl_node/main.go
+++ b/examples/runner/hitl_node/main.go
@@ -1,0 +1,167 @@
+// Copyright 2026 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+// Command hitl_node shows that a plain LlmAgent is automatically driven
+// through the ADK 2.0 node runtime by the Runner, including the
+// human-in-the-loop (HITL) pause/resume cycle. The user configures
+// nothing special — just runner.Config{Agent: <llmAgent>}.
+//
+// The agent has a long-running tool ("request_approval"). When the model
+// calls it, the LlmAgent emits LongRunningToolIDs; the Runner's node
+// wrapper bridges that into a workflow pause and persists the run state.
+// On the next turn we send the matching function response (the human's
+// decision) and the agent resumes to its final answer.
+//
+// This uses a real Gemini model, like the other examples. Set credentials
+// first (see examples/bidi/README.md):
+//
+//	export GOOGLE_API_KEY="your_api_key_here"
+//	go run ./examples/runner/hitl_node/
+package main
+
+import (
+	"context"
+	"fmt"
+	"log"
+
+	"google.golang.org/genai"
+
+	"google.golang.org/adk/agent"
+	"google.golang.org/adk/agent/llmagent"
+	"google.golang.org/adk/model/gemini"
+	"google.golang.org/adk/runner"
+	"google.golang.org/adk/session"
+	"google.golang.org/adk/tool"
+	"google.golang.org/adk/tool/functiontool"
+)
+
+const (
+	appName   = "hitl_node_sample"
+	userID    = "user-1"
+	sessionID = "session-1"
+)
+
+// approvalArgs is the argument schema for the long-running tool.
+type approvalArgs struct {
+	Action string `json:"action"`
+}
+
+func main() {
+	ctx := context.Background()
+
+	model, err := gemini.NewModel(ctx, "gemini-3.1-flash-lite", &genai.ClientConfig{})
+	if err != nil {
+		log.Fatalf("gemini.NewModel: %v", err)
+	}
+
+	// A long-running tool: when the model calls it, the run pauses until a
+	// human supplies the response on a later turn. The handler returns a
+	// "pending" marker; the real decision arrives as the resume reply.
+	requestApproval, err := functiontool.New(functiontool.Config{
+		Name:          "request_approval",
+		Description:   "Requests human approval for an action and waits for the decision.",
+		IsLongRunning: true,
+	}, func(_ agent.ToolContext, args approvalArgs) (map[string]string, error) {
+		return map[string]string{"status": "pending", "action": args.Action}, nil
+	})
+	if err != nil {
+		log.Fatalf("functiontool.New: %v", err)
+	}
+
+	// A plain LlmAgent with the long-running tool. Nothing here opts into
+	// the node runtime — the Runner detects the LlmAgent and routes it
+	// through the node path (with HITL) automatically.
+	approver, err := llmagent.New(llmagent.Config{
+		Name:        "approver",
+		Model:       model,
+		Description: "Performs actions only after human approval.",
+		Instruction: "When the user asks to perform an action, call request_approval " +
+			"with that action and wait. After approval, confirm in one short sentence.",
+		Tools: []tool.Tool{requestApproval},
+	})
+	if err != nil {
+		log.Fatalf("llmagent.New: %v", err)
+	}
+
+	r, err := runner.New(runner.Config{
+		AppName:           appName,
+		Agent:             approver, // <-- just an agent; no node/workflow config
+		SessionService:    session.InMemoryService(),
+		AutoCreateSession: true,
+	})
+	if err != nil {
+		log.Fatalf("runner.New: %v", err)
+	}
+
+	// --- Turn 1: the model calls the long-running tool and the run pauses.
+	fmt.Println("=== Turn 1: ask the agent to perform an action ===")
+	interruptID := ""
+	for ev, err := range r.Run(ctx, userID, sessionID, userText("Please delete the production database."), agent.RunConfig{}) {
+		if err != nil {
+			log.Fatalf("turn 1: %v", err)
+		}
+		if ev == nil {
+			continue
+		}
+		printText(ev)
+		if len(ev.LongRunningToolIDs) > 0 {
+			interruptID = ev.LongRunningToolIDs[0]
+		}
+		if ev.RequestedInput != nil {
+			fmt.Printf("[pause] awaiting human approval (interrupt %s)\n", ev.RequestedInput.InterruptID)
+		}
+	}
+	if interruptID == "" {
+		log.Fatal("the agent did not call the long-running tool; try rephrasing the prompt")
+	}
+
+	// --- Turn 2: the human approves; resume by sending the function response.
+	fmt.Println("=== Turn 2: human approves; resume the agent ===")
+	for ev, err := range r.Run(ctx, userID, sessionID, approvalReply(interruptID, "approved"), agent.RunConfig{}) {
+		if err != nil {
+			log.Fatalf("turn 2: %v", err)
+		}
+		printText(ev)
+	}
+}
+
+func userText(text string) *genai.Content {
+	return &genai.Content{Role: genai.RoleUser, Parts: []*genai.Part{{Text: text}}}
+}
+
+// approvalReply builds the resume message: a function response whose ID is
+// the long-running tool call ID being answered.
+func approvalReply(id, decision string) *genai.Content {
+	return &genai.Content{
+		Role: genai.RoleUser,
+		Parts: []*genai.Part{{
+			FunctionResponse: &genai.FunctionResponse{
+				ID:       id,
+				Name:     "request_approval",
+				Response: map[string]any{"decision": decision},
+			},
+		}},
+	}
+}
+
+func printText(ev *session.Event) {
+	if ev == nil || ev.LLMResponse.Content == nil {
+		return
+	}
+	for _, p := range ev.LLMResponse.Content.Parts {
+		if p.Text != "" {
+			fmt.Printf("[%s] %s\n", ev.Author, p.Text)
+		}
+	}
+}

--- a/examples/runner/hitl_reimbursement/main.go
+++ b/examples/runner/hitl_reimbursement/main.go
@@ -1,0 +1,135 @@
+// Copyright 2026 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+// Command hitl_reimbursement is an interactive human-in-the-loop (HITL)
+// example you can drive from the console launcher. It is the adk-go port
+// of adk-python's contributing/samples/human_in_loop.
+//
+// It is a plain LlmAgent — nothing opts into the node runtime. The Runner
+// detects the LlmAgent and routes it through the ADK 2.0 node path, which
+// bridges the agent's long-running tool into a workflow pause/resume.
+//
+// The reimbursement agent auto-approves amounts under $100. For larger
+// amounts it calls the long-running tool ask_for_approval, which returns
+// "pending" and pauses the run. The console renders the pending tool call
+// as a prompt; your reply is sent back as the tool's FunctionResponse,
+// resuming the agent (which then calls reimburse and confirms).
+//
+// Run it (needs Gemini credentials; see examples/bidi/README.md):
+//
+//	export GOOGLE_API_KEY="your_api_key_here"
+//	go run ./examples/runner/hitl_reimbursement/ console
+//
+// Example session:
+//
+//	User -> Reimburse $200 for my conference ticket.
+//	Agent -> ... (calls ask_for_approval; console shows the pending prompt)
+//	User -> {"status":"approved","ticketId":"reimbursement-ticket-001"}
+//	Agent -> Your $200 reimbursement has been approved and processed.
+package main
+
+import (
+	"context"
+	"log"
+	"os"
+
+	"google.golang.org/genai"
+
+	"google.golang.org/adk/agent"
+	"google.golang.org/adk/agent/llmagent"
+	"google.golang.org/adk/cmd/launcher"
+	"google.golang.org/adk/cmd/launcher/full"
+	"google.golang.org/adk/model/gemini"
+	"google.golang.org/adk/tool"
+	"google.golang.org/adk/tool/functiontool"
+)
+
+// reimburseArgs / approvalArgs are the tool argument schemas. Field names
+// map to the JSON the model produces for each tool call.
+type reimburseArgs struct {
+	Purpose string  `json:"purpose"`
+	Amount  float64 `json:"amount"`
+}
+
+type approvalArgs struct {
+	Purpose string  `json:"purpose"`
+	Amount  float64 `json:"amount"`
+}
+
+func main() {
+	ctx := context.Background()
+
+	model, err := gemini.NewModel(ctx, "gemini-3.1-flash-lite", &genai.ClientConfig{})
+	if err != nil {
+		log.Fatalf("gemini.NewModel: %v", err)
+	}
+
+	// reimburse: a normal tool that completes immediately.
+	reimburse, err := functiontool.New(functiontool.Config{
+		Name:        "reimburse",
+		Description: "Reimburse the amount of money to the employee.",
+	}, func(_ agent.ToolContext, _ reimburseArgs) (map[string]string, error) {
+		return map[string]string{"status": "ok"}, nil
+	})
+	if err != nil {
+		log.Fatalf("functiontool.New(reimburse): %v", err)
+	}
+
+	// ask_for_approval: a LONG-RUNNING tool. It returns "pending"
+	// immediately; the real decision arrives later as the human's reply,
+	// which the Runner's node path routes back to this call on resume.
+	askForApproval, err := functiontool.New(functiontool.Config{
+		Name:          "ask_for_approval",
+		Description:   "Ask for approval for the reimbursement.",
+		IsLongRunning: true,
+	}, func(_ agent.ToolContext, args approvalArgs) (map[string]any, error) {
+		return map[string]any{
+			"status":   "pending",
+			"amount":   args.Amount,
+			"ticketId": "reimbursement-ticket-001",
+		}, nil
+	})
+	if err != nil {
+		log.Fatalf("functiontool.New(ask_for_approval): %v", err)
+	}
+
+	// A plain LlmAgent. Same behavior as adk-python's human_in_loop sample.
+	reimbursementAgent, err := llmagent.New(llmagent.Config{
+		Name:  "reimbursement_agent",
+		Model: model,
+		Description: "Handles employee reimbursements, asking a manager for " +
+			"approval when the amount exceeds $100.",
+		Instruction: `You are an agent whose job is to handle the reimbursement process for
+the employees. If the amount is less than $100, you will automatically
+approve the reimbursement and call reimburse().
+
+If the amount is greater than $100, you will ask for approval from the
+manager by calling ask_for_approval(). If the manager approves, you will
+call reimburse() to reimburse the amount to the employee. If the manager
+rejects, you will inform the employee of the rejection.`,
+		Tools: []tool.Tool{reimburse, askForApproval},
+	})
+	if err != nil {
+		log.Fatalf("llmagent.New: %v", err)
+	}
+
+	log.Printf("hitl_reimbursement ready — try: \"Reimburse $200 for my conference ticket.\"")
+
+	l := full.NewLauncher()
+	if err := l.Execute(ctx, &launcher.Config{
+		AgentLoader: agent.NewSingleLoader(reimbursementAgent),
+	}, os.Args[1:]); err != nil {
+		log.Fatalf("Run failed: %v\n\n%s", err, l.CommandLineSyntax())
+	}
+}

--- a/runner/run_node.go
+++ b/runner/run_node.go
@@ -1,0 +1,555 @@
+// Copyright 2026 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package runner
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+	"iter"
+
+	"google.golang.org/genai"
+
+	"google.golang.org/adk/agent"
+	"google.golang.org/adk/internal/agent/parentmap"
+	"google.golang.org/adk/internal/agent/runconfig"
+	artifactinternal "google.golang.org/adk/internal/artifact"
+	icontext "google.golang.org/adk/internal/context"
+	"google.golang.org/adk/internal/llminternal"
+	imemory "google.golang.org/adk/internal/memory"
+	"google.golang.org/adk/internal/plugininternal"
+	"google.golang.org/adk/internal/utils"
+	"google.golang.org/adk/model"
+	"google.golang.org/adk/session"
+	"google.golang.org/adk/workflow"
+)
+
+// isLlmAgent reports whether a is an LlmAgent (i.e. backed by the
+// internal LLM agent state). The node runtime is used only for LlmAgent
+// roots, mirroring adk-python where _run_node_async is reached for an
+// LlmAgent.
+func isLlmAgent(a agent.Agent) bool {
+	_, ok := a.(llminternal.Agent)
+	return ok
+}
+
+// runNode is the Go equivalent of adk-python Runner._run_node_async. It
+// drives an LlmAgent (agentToRun) through the workflow engine by wrapping
+// it in a node and running a single-node workflow (START -> node),
+// reusing the same session/plugin/persist pipeline as the agent path.
+//
+// Detection and wrapping are automatic (see Run); the user does not
+// configure anything. The wrapping node bridges the LlmAgent's own HITL
+// (long-running tools / tool confirmation, which emit LongRunningToolIDs)
+// into a workflow pause; see llmAgentNode.
+//
+// The workflow scheduler owns the per-node goroutines and the event
+// channel (the analog of Python's ic.event_queue), and cancels in-flight
+// nodes when the caller stops consuming the returned iterator. There is
+// therefore no need for a done-sentinel or an explicit cleanup task here.
+func (r *Runner) runNode(
+	ctx context.Context,
+	storedSession session.Session,
+	agentToRun agent.Agent,
+	msg *genai.Content,
+	cfg agent.RunConfig,
+	opts runOptions,
+	yield func(*session.Event, error) bool,
+) {
+	// Wrap the LlmAgent in the HITL-bridging node and build a single-node
+	// workflow (START -> node). The workflow name must be stable and
+	// non-empty so its RunState persists across turns for HITL resume; we
+	// derive it from the app name and the agent name.
+	node := newLlmAgentNode(agentToRun)
+	wf, err := workflow.New(rootWorkflowName(r.appName, agentToRun), []workflow.Edge{
+		{From: workflow.Start, To: node},
+	})
+	if err != nil {
+		yield(nil, fmt.Errorf("failed to build node workflow: %w", err))
+		return
+	}
+
+	// 1. Build the invocation context. UserContent carries the user
+	// message, which Workflow.Run reads as the workflow's seed input
+	// (workflow.userInput); this mirrors Python's node_input.
+	ictx := r.newNodeInvocationContext(ctx, storedSession, agentToRun, msg, cfg)
+
+	// Append the incoming user message (fresh text or the function-
+	// response reply) to the session for history. Same helper the agent
+	// path uses; it also runs the on_user_message plugin callback.
+	ictx, userEvent, err := r.appendMessageToSession(ictx, storedSession, msg, cfg.SaveInputBlobsAsArtifacts, r.pluginManager, opts.stateDelta)
+	if err != nil {
+		yield(nil, err)
+		return
+	}
+	// Optionally yield the user message event before any node events,
+	// mirroring adk-python's yield_user_message.
+	if opts.yieldUserMessage && userEvent != nil {
+		if !yield(userEvent, nil) {
+			return
+		}
+	}
+
+	// 2. Plugin lifecycle: defer after_run, run before_run and honor an
+	// early-exit decision. Mirrors the agent path.
+	pluginManager := r.pluginManager
+	if pluginManager != nil {
+		defer pluginManager.RunAfterRunCallback(ictx)
+
+		earlyExitResult, err := pluginManager.RunBeforeRunCallback(ictx)
+		if earlyExitResult != nil || err != nil {
+			earlyExitEvent := session.NewEvent(ictx.InvocationID())
+			earlyExitEvent.Author = "user"
+			earlyExitEvent.LLMResponse = model.LLMResponse{
+				Content: msg,
+			}
+			if appendErr := r.sessionService.AppendEvent(ictx, storedSession, earlyExitEvent); appendErr != nil {
+				yield(nil, fmt.Errorf("failed to add event to session: %w", appendErr))
+				return
+			}
+			yield(earlyExitEvent, err)
+			return
+		}
+	}
+
+	// 3. Choose the producer: Resume (HITL continuation) vs Run (fresh).
+	// We treat the turn as a resume only when a function response in msg
+	// matches a node that is currently waiting in the persisted RunState.
+	state, err := workflow.LoadRunState(storedSession, wf.Name())
+	if err != nil {
+		yield(nil, fmt.Errorf("failed to load workflow run state: %w", err))
+		return
+	}
+
+	var events iter.Seq2[*session.Event, error]
+	if responses := buildResumeResponses(msg, state, storedSession); len(responses) > 0 {
+		events = wf.Resume(ictx, state, responses)
+	} else {
+		events = wf.Run(ictx)
+	}
+
+	// 4. Consume the workflow's event stream. This is the same loop the
+	// agent path runs (the equivalent of Python's _consume_event_queue):
+	// run the on_event plugin callback, persist non-partial events, and
+	// yield. The RunState StateDelta event emitted by Run/Resume flows
+	// through the same persist branch, so HITL pause state is saved here.
+	for event, evErr := range events {
+		if evErr != nil {
+			if !yield(nil, evErr) {
+				return
+			}
+			continue
+		}
+
+		// Stamp the agent name as author on internal control events that
+		// the workflow engine emits without one (e.g. the RunState
+		// StateDelta event from Run/Resume). Otherwise a later turn's
+		// findAgentToRun would scan these events and log a spurious
+		// "Event from an unknown agent" warning, since an empty author
+		// resolves to no agent in the tree.
+		if event.Author == "" {
+			event.Author = agentToRun.Name()
+		}
+
+		if pluginManager != nil {
+			modifiedEvent, perr := pluginManager.RunOnEventCallback(ictx, event)
+			if perr != nil {
+				if !yield(nil, perr) {
+					return
+				}
+				continue
+			}
+			if modifiedEvent != nil {
+				event = modifiedEvent
+			}
+		}
+
+		// Only commit non-partial events to the session service.
+		if !event.LLMResponse.Partial {
+			if err := r.sessionService.AppendEvent(ictx, storedSession, event); err != nil {
+				yield(nil, fmt.Errorf("failed to add event to session: %w", err))
+				return
+			}
+		}
+
+		if !yield(event, nil) {
+			return
+		}
+	}
+}
+
+// rootWorkflowName derives the persistence-namespacing name for the
+// per-run node workflow. It must be stable across turns (so a paused HITL
+// run can be resumed) and unique per agent within a session.
+func rootWorkflowName(appName string, a agent.Agent) string {
+	return appName + "/" + a.Name()
+}
+
+// newNodeInvocationContext builds the InvocationContext for the node
+// path. It mirrors the agent path's context wiring: the parent map is
+// attached so the wrapped LlmAgent can transfer / resolve tools, and the
+// resolved agent is set so the flow runs against it.
+func (r *Runner) newNodeInvocationContext(
+	ctx context.Context,
+	storedSession session.Session,
+	agentToRun agent.Agent,
+	msg *genai.Content,
+	cfg agent.RunConfig,
+) agent.InvocationContext {
+	ctx = parentmap.ToContext(ctx, r.parents)
+	ctx = runconfig.ToContext(ctx, &runconfig.RunConfig{
+		StreamingMode: runconfig.StreamingMode(cfg.StreamingMode),
+	})
+	ctx = plugininternal.ToContext(ctx, r.pluginManager)
+
+	var artifacts agent.Artifacts
+	if r.artifactService != nil {
+		artifacts = &artifactinternal.Artifacts{
+			Service:   r.artifactService,
+			SessionID: storedSession.ID(),
+			AppName:   storedSession.AppName(),
+			UserID:    storedSession.UserID(),
+		}
+	}
+
+	var memoryImpl agent.Memory
+	if r.memoryService != nil {
+		memoryImpl = &imemory.Memory{
+			Service:   r.memoryService,
+			SessionID: storedSession.ID(),
+			UserID:    storedSession.UserID(),
+			AppName:   storedSession.AppName(),
+		}
+	}
+
+	return icontext.NewInvocationContext(ctx, icontext.InvocationContextParams{
+		Artifacts:   artifacts,
+		Memory:      memoryImpl,
+		Session:     storedSession,
+		Agent:       agentToRun,
+		UserContent: msg,
+		RunConfig:   &cfg,
+	})
+}
+
+// buildResumeResponses maps each function response in msg to its
+// InterruptID -> payload, but only for responses that answer a
+// still-pending long-running call. This is the Go analog of adk-python's
+// _extract_resume_inputs.
+//
+// A turn is a HITL resume when msg carries a FunctionResponse whose ID
+// matches a long-running tool call that the node paused on. We accept a
+// match against EITHER the single interrupt currently recorded as waiting
+// in RunState OR any unanswered long-running call still open in session
+// history. The latter is essential when the model emitted more than one
+// long-running call in a turn: the workflow scheduler can only record one
+// RequestedInput per activation, so RunState.waiting tracks just one of
+// them, but the human may answer the others. Matching against open
+// history calls lets each answer drive a resume, after which the node
+// re-runs and re-pauses on whatever is still unanswered until all are
+// resolved.
+//
+// Returns nil when the turn answers no pending interrupt (a fresh turn).
+func buildResumeResponses(msg *genai.Content, state *workflow.RunState, sess session.Session) map[string]any {
+	if msg == nil {
+		return nil
+	}
+	pending := map[string]struct{}{}
+	if state != nil {
+		for id := range waitingInterruptIDs(state) {
+			pending[id] = struct{}{}
+		}
+	}
+	for id := range openLongRunningCallIDs(sess) {
+		pending[id] = struct{}{}
+	}
+	if len(pending) == 0 {
+		return nil
+	}
+
+	var out map[string]any
+	for _, fr := range utils.FunctionResponses(msg) {
+		if fr == nil || fr.ID == "" {
+			continue
+		}
+		if _, ok := pending[fr.ID]; !ok {
+			continue
+		}
+		if out == nil {
+			out = map[string]any{}
+		}
+		// Pass the response payload through opaquely. Workflow.Resume
+		// validates it against the request's ResponseSchema if any.
+		out[fr.ID] = decodeResumeResponse(fr)
+	}
+	return out
+}
+
+// openLongRunningCallIDs returns the set of long-running tool call IDs in
+// session history that do not yet have a matching FunctionResponse, i.e.
+// the interrupts still awaiting a human answer.
+func openLongRunningCallIDs(sess session.Session) map[string]struct{} {
+	open := map[string]struct{}{}
+	if sess == nil {
+		return open
+	}
+	answered := map[string]struct{}{}
+	events := sess.Events()
+	for i := 0; i < events.Len(); i++ {
+		ev := events.At(i)
+		for _, id := range ev.LongRunningToolIDs {
+			open[id] = struct{}{}
+		}
+		for _, fr := range utils.FunctionResponses(ev.Content) {
+			if fr != nil && fr.ID != "" {
+				answered[fr.ID] = struct{}{}
+			}
+		}
+	}
+	for id := range answered {
+		delete(open, id)
+	}
+	return open
+}
+
+// decodeResumeResponse extracts the user-supplied payload from a function
+// response. It accepts the shapes the console launcher and other ADK
+// runtimes produce: {"response": <value>}, {"payload": <any>}, or the raw
+// Response map. A string under "response" is parsed as JSON when possible.
+func decodeResumeResponse(fr *genai.FunctionResponse) any {
+	if fr.Response == nil {
+		return nil
+	}
+	if raw, ok := fr.Response["response"]; ok {
+		if s, isStr := raw.(string); isStr {
+			var decoded any
+			if err := json.Unmarshal([]byte(s), &decoded); err == nil {
+				return decoded
+			}
+			return s
+		}
+		return raw
+	}
+	if payload, ok := fr.Response["payload"]; ok {
+		return payload
+	}
+	return fr.Response
+}
+
+// waitingInterruptIDs returns the set of InterruptIDs for every node in
+// state that is currently paused on a human-input request.
+func waitingInterruptIDs(state *workflow.RunState) map[string]struct{} {
+	ids := map[string]struct{}{}
+	for _, ns := range state.Nodes {
+		if ns == nil {
+			continue
+		}
+		if ns.Status == workflow.NodeWaiting && ns.PendingRequest != nil && ns.PendingRequest.InterruptID != "" {
+			ids[ns.PendingRequest.InterruptID] = struct{}{}
+		}
+	}
+	return ids
+}
+
+// llmAgentNode wraps an LlmAgent as a workflow node and bridges the
+// LlmAgent's own HITL into a workflow pause.
+//
+// adk-go currently has two separate HITL signals: workflow RequestedInput
+// (which pauses the scheduler) and the LlmAgent's LongRunningToolIDs
+// (which does not). adk-python unifies them on long_running_tool_ids;
+// until adk-go does the same in the workflow core (see
+// runner/DESIGN_run_node.md section 10.5), this node performs the bridge
+// locally: when the wrapped agent emits an event with LongRunningToolIDs,
+// the node also yields a RequestedInput so the scheduler pauses and
+// persists RunState. On resume the node re-runs (RerunOnResume) and feeds
+// the human's reply back to the agent as a function response.
+type llmAgentNode struct {
+	workflow.BaseNode
+	agent agent.Agent
+}
+
+// rerunOnResume is referenced by value via &rerunOnResume below.
+var rerunOnResume = true
+
+func newLlmAgentNode(a agent.Agent) *llmAgentNode {
+	return &llmAgentNode{
+		// RerunOnResume puts the node in re-entry mode: on resume the node
+		// re-runs and reads the reply via ctx.ResumedInput, rather than
+		// handing the reply to a successor (this node has none).
+		BaseNode: workflow.NewBaseNode(a.Name(), a.Description(), workflow.NodeConfig{
+			RerunOnResume: &rerunOnResume,
+		}),
+		agent: a,
+	}
+}
+
+func (n *llmAgentNode) Run(ctx agent.InvocationContext, input any) iter.Seq2[*session.Event, error] {
+	return func(yield func(*session.Event, error) bool) {
+		// The node's input is the runner's user message: fresh text on a
+		// new turn, or the human's FunctionResponse(s) on a HITL resume.
+		// The runner already appended it to the session, and the LlmAgent
+		// flow's contents processor pairs a resume FunctionResponse with
+		// the pending long-running call by ID (replacing the original
+		// "pending" response). So we feed the message straight through —
+		// we do NOT synthesize a second FunctionResponse, which would
+		// duplicate it in history and confuse the model.
+		userContent := inputToUserContent(input)
+
+		// Interrupts answered by this turn: any long-running call ID for
+		// which the message carries a matching FunctionResponse. We must
+		// not re-pause for these even though the agent's history still
+		// shows the original long-running call.
+		resolved := resolvedInterruptIDs(userContent)
+
+		agentCtx := n.newAgentContext(ctx, userContent)
+
+		var pending []string // unresolved long-running interrupt IDs seen this run
+		for event, err := range n.agent.Run(agentCtx) {
+			if err != nil {
+				yield(nil, err)
+				return
+			}
+			synthesizeNodeOutput(event)
+			for _, id := range event.LongRunningToolIDs {
+				if !resolved[id] {
+					pending = append(pending, id)
+				}
+			}
+			if !yield(event, nil) {
+				return
+			}
+		}
+
+		// HITL bridge: if the agent emitted long-running tool calls that
+		// were not answered by this turn, pause the workflow by emitting an
+		// event that only sets RequestedInput (keyed by the real
+		// long-running call ID). The scheduler parks the node
+		// (NodeWaiting) on RequestedInput alone and persists RunState.
+		//
+		// We deliberately do NOT use workflow.NewRequestInputEvent: it
+		// injects a synthetic "adk_request_input" FunctionCall into the
+		// model conversation, which a real model rejects on resume (the
+		// agent already has its own real long-running FunctionCall
+		// pending). The pause event carries no model Content, so it does
+		// not pollute the LLM history.
+		//
+		// The scheduler enforces a single RequestedInput per activation,
+		// so we pause on the first unresolved interrupt. The console (and
+		// other clients) still see every long-running call from the
+		// agent's own events and can answer them across turns.
+		if len(pending) > 0 {
+			yield(newPauseEvent(ctx, pending[0]), nil)
+		}
+	}
+}
+
+// resolvedInterruptIDs returns the set of FunctionResponse IDs carried by
+// content, i.e. the long-running interrupts the current turn answers.
+func resolvedInterruptIDs(content *genai.Content) map[string]bool {
+	if content == nil {
+		return nil
+	}
+	out := map[string]bool{}
+	for _, p := range content.Parts {
+		if p.FunctionResponse != nil && p.FunctionResponse.ID != "" {
+			out[p.FunctionResponse.ID] = true
+		}
+	}
+	return out
+}
+
+// newPauseEvent builds a content-free event that only sets RequestedInput,
+// so the scheduler pauses the node (NodeWaiting) and persists RunState
+// without adding any synthetic FunctionCall to the model conversation. The
+// InterruptID is the LlmAgent's real long-running tool call ID, so the
+// follow-up FunctionResponse to that call resumes the run.
+func newPauseEvent(ctx agent.InvocationContext, interruptID string) *session.Event {
+	ev := session.NewEvent(ctx.InvocationID())
+	if a := ctx.Agent(); a != nil {
+		ev.Author = a.Name()
+	}
+	ev.Branch = ctx.Branch()
+	ev.RequestedInput = &session.RequestInput{
+		InterruptID: interruptID,
+		Message:     "Awaiting response for long-running tool call.",
+	}
+	return ev
+}
+
+// newAgentContext builds the per-agent InvocationContext, mirroring
+// workflow.AgentNode: it inherits services and branch from ctx and runs
+// the wrapped agent with the given user content.
+func (n *llmAgentNode) newAgentContext(ctx agent.InvocationContext, userContent *genai.Content) agent.InvocationContext {
+	return icontext.NewInvocationContext(ctx, icontext.InvocationContextParams{
+		Artifacts:     ctx.Artifacts(),
+		Memory:        ctx.Memory(),
+		Session:       ctx.Session(),
+		Branch:        ctx.Branch(),
+		Agent:         n.agent,
+		UserContent:   userContent,
+		RunConfig:     ctx.RunConfig(),
+		EndInvocation: ctx.Ended(),
+		InvocationID:  ctx.InvocationID(),
+	})
+}
+
+// inputToUserContent converts a node input value into a user Content for
+// the wrapped agent.
+func inputToUserContent(input any) *genai.Content {
+	switch v := input.(type) {
+	case nil:
+		return nil
+	case *genai.Content:
+		return v
+	case string:
+		if v == "" {
+			return nil
+		}
+		return &genai.Content{Role: genai.RoleUser, Parts: []*genai.Part{{Text: v}}}
+	default:
+		b, err := json.Marshal(v)
+		if err != nil {
+			return nil
+		}
+		return &genai.Content{Role: genai.RoleUser, Parts: []*genai.Part{{Text: string(b)}}}
+	}
+}
+
+// synthesizeNodeOutput sets Event.Output from a final model text response
+// so the node produces an output value (mirrors workflow.AgentNode's
+// synthesizeAgentOutput).
+func synthesizeNodeOutput(event *session.Event) {
+	if event == nil || event.Output != nil {
+		return
+	}
+	if !event.IsFinalResponse() {
+		return
+	}
+	content := event.LLMResponse.Content
+	if content == nil || content.Role != "model" {
+		return
+	}
+	var b []byte
+	for _, p := range content.Parts {
+		if p == nil || p.Text == "" || p.Thought {
+			continue
+		}
+		b = append(b, p.Text...)
+	}
+	if len(b) == 0 {
+		return
+	}
+	event.Output = string(b)
+}

--- a/runner/run_node_test.go
+++ b/runner/run_node_test.go
@@ -1,0 +1,293 @@
+// Copyright 2026 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package runner_test
+
+import (
+	"context"
+	"iter"
+	"testing"
+
+	"google.golang.org/genai"
+
+	"google.golang.org/adk/agent"
+	"google.golang.org/adk/agent/llmagent"
+	"google.golang.org/adk/model"
+	"google.golang.org/adk/runner"
+	"google.golang.org/adk/session"
+	"google.golang.org/adk/tool"
+	"google.golang.org/adk/tool/functiontool"
+	"google.golang.org/adk/workflow"
+)
+
+const (
+	nodeTestApp     = "node_test_app"
+	nodeTestUser    = "u"
+	nodeTestSession = "s"
+)
+
+// scriptedModel is a fake model.LLM that yields a fixed sequence of
+// contents, one per GenerateContent call. It avoids importing
+// internal/testutil (which imports runner, creating a cycle).
+type scriptedModel struct {
+	responses []*genai.Content
+	call      int
+}
+
+func (m *scriptedModel) Name() string { return "scripted" }
+
+func (m *scriptedModel) GenerateContent(_ context.Context, _ *model.LLMRequest, _ bool) iter.Seq2[*model.LLMResponse, error] {
+	return func(yield func(*model.LLMResponse, error) bool) {
+		i := m.call
+		if i >= len(m.responses) {
+			i = len(m.responses) - 1
+		}
+		m.call++
+		yield(&model.LLMResponse{Content: m.responses[i]}, nil)
+	}
+}
+
+func newNodeTestRunner(t *testing.T, a agent.Agent, svc session.Service) *runner.Runner {
+	t.Helper()
+	r, err := runner.New(runner.Config{
+		AppName:        nodeTestApp,
+		Agent:          a,
+		SessionService: svc,
+	})
+	if err != nil {
+		t.Fatalf("New() error = %v", err)
+	}
+	return r
+}
+
+func newNodeTestSession(t *testing.T, ctx context.Context, svc session.Service) {
+	t.Helper()
+	if _, err := svc.Create(ctx, &session.CreateRequest{
+		AppName:   nodeTestApp,
+		UserID:    nodeTestUser,
+		SessionID: nodeTestSession,
+	}); err != nil {
+		t.Fatalf("sessionService.Create() error = %v", err)
+	}
+}
+
+func userText(text string) *genai.Content {
+	return &genai.Content{Role: genai.RoleUser, Parts: []*genai.Part{{Text: text}}}
+}
+
+// runStateForAgent loads the RunState the node path persists, using the
+// same naming scheme the runner uses internally ("<app>/<agent name>").
+func runStateForAgent(t *testing.T, ctx context.Context, svc session.Service, a agent.Agent) *workflow.RunState {
+	t.Helper()
+	got, err := svc.Get(ctx, &session.GetRequest{AppName: nodeTestApp, UserID: nodeTestUser, SessionID: nodeTestSession})
+	if err != nil {
+		t.Fatalf("Get() error = %v", err)
+	}
+	state, err := workflow.LoadRunState(got.Session, nodeTestApp+"/"+a.Name())
+	if err != nil {
+		t.Fatalf("LoadRunState() error = %v", err)
+	}
+	return state
+}
+
+// hasWaitingInterrupt reports whether the RunState has a node parked on a
+// human-input request with the given InterruptID.
+func hasWaitingInterrupt(state *workflow.RunState, id string) bool {
+	if state == nil {
+		return false
+	}
+	for _, ns := range state.Nodes {
+		if ns != nil && ns.Status == workflow.NodeWaiting && ns.PendingRequest != nil && ns.PendingRequest.InterruptID == id {
+			return true
+		}
+	}
+	return false
+}
+
+// TestRunner_LlmAgent_FreshTurn verifies that a plain LlmAgent root is
+// automatically driven through the node path and yields its model text.
+// The user configures nothing special — only Config.Agent.
+func TestRunner_LlmAgent_FreshTurn(t *testing.T) {
+	ctx := t.Context()
+	svc := session.InMemoryService()
+	newNodeTestSession(t, ctx, svc)
+
+	m := &scriptedModel{responses: []*genai.Content{
+		genai.NewContentFromText("hello there", "model"),
+	}}
+	a, err := llmagent.New(llmagent.Config{Name: "greeter", Model: m})
+	if err != nil {
+		t.Fatalf("llmagent.New() error = %v", err)
+	}
+
+	r := newNodeTestRunner(t, a, svc)
+
+	var texts []string
+	for ev, err := range r.Run(ctx, nodeTestUser, nodeTestSession, userText("hi"), agent.RunConfig{}) {
+		if err != nil {
+			t.Fatalf("Run() error = %v", err)
+		}
+		if ev != nil && ev.LLMResponse.Content != nil {
+			for _, p := range ev.LLMResponse.Content.Parts {
+				if p.Text != "" {
+					texts = append(texts, p.Text)
+				}
+			}
+		}
+	}
+	if len(texts) == 0 {
+		t.Fatal("expected at least one model text event from the LlmAgent")
+	}
+}
+
+// TestRunner_LlmAgent_YieldUserMessage verifies WithYieldUserMessage makes
+// the node path emit the user message event before any agent events.
+func TestRunner_LlmAgent_YieldUserMessage(t *testing.T) {
+	ctx := t.Context()
+	svc := session.InMemoryService()
+	newNodeTestSession(t, ctx, svc)
+
+	m := &scriptedModel{responses: []*genai.Content{
+		genai.NewContentFromText("hi back", "model"),
+	}}
+	a, err := llmagent.New(llmagent.Config{Name: "greeter", Model: m})
+	if err != nil {
+		t.Fatalf("llmagent.New() error = %v", err)
+	}
+	r := newNodeTestRunner(t, a, svc)
+
+	var firstAuthor string
+	var sawUser bool
+	for ev, err := range r.Run(ctx, nodeTestUser, nodeTestSession, userText("hi"), agent.RunConfig{}, runner.WithYieldUserMessage()) {
+		if err != nil {
+			t.Fatalf("Run() error = %v", err)
+		}
+		if ev == nil {
+			continue
+		}
+		if firstAuthor == "" {
+			firstAuthor = ev.Author
+		}
+		if ev.Author == "user" {
+			sawUser = true
+		}
+	}
+	if !sawUser {
+		t.Error("expected a user message event to be yielded")
+	}
+	if firstAuthor != "user" {
+		t.Errorf("first yielded event author = %q, want the user message first", firstAuthor)
+	}
+}
+
+// TestRunner_LlmAgent_LongRunningTool_PausesAndResumes covers the HITL
+// bridge: an LlmAgent that calls a long-running tool emits
+// LongRunningToolIDs; the node wrapper translates that into a workflow
+// pause (RequestedInput) and persists RunState. A follow-up turn carrying
+// the matching FunctionResponse resumes the LlmAgent.
+func TestRunner_LlmAgent_LongRunningTool_PausesAndResumes(t *testing.T) {
+	ctx := t.Context()
+	svc := session.InMemoryService()
+	newNodeTestSession(t, ctx, svc)
+
+	// Turn 1: model calls the long-running tool.
+	// Turn 2 (resume): model produces a final text answer.
+	m := &scriptedModel{responses: []*genai.Content{
+		genai.NewContentFromFunctionCall("ask_human", map[string]any{}, "model"),
+		genai.NewContentFromText("all done", "model"),
+	}}
+
+	type askArgs struct{}
+	longTool, err := functiontool.New(functiontool.Config{
+		Name:          "ask_human",
+		Description:   "asks a human and waits",
+		IsLongRunning: true,
+	}, func(_ agent.ToolContext, _ askArgs) (map[string]string, error) {
+		return map[string]string{"status": "pending"}, nil
+	})
+	if err != nil {
+		t.Fatalf("functiontool.New() error = %v", err)
+	}
+
+	a, err := llmagent.New(llmagent.Config{
+		Name:  "approver",
+		Model: m,
+		Tools: []tool.Tool{longTool},
+	})
+	if err != nil {
+		t.Fatalf("llmagent.New() error = %v", err)
+	}
+
+	r := newNodeTestRunner(t, a, svc)
+
+	// --- Turn 1: should pause on the long-running tool -----------------
+	var (
+		longRunningID string
+		sawPause      bool
+	)
+	for ev, err := range r.Run(ctx, nodeTestUser, nodeTestSession, userText("please approve"), agent.RunConfig{}) {
+		if err != nil {
+			t.Fatalf("turn 1 Run() error = %v", err)
+		}
+		if ev == nil {
+			continue
+		}
+		if len(ev.LongRunningToolIDs) > 0 {
+			longRunningID = ev.LongRunningToolIDs[0]
+		}
+		if ev.RequestedInput != nil {
+			sawPause = true
+		}
+	}
+	if longRunningID == "" {
+		t.Fatal("did not observe a long-running tool call from the LlmAgent")
+	}
+	if !sawPause {
+		t.Fatal("node wrapper did not bridge the long-running tool into a workflow RequestedInput pause")
+	}
+
+	// RunState must be persisted with the pause so turn 2 can resume.
+	state := runStateForAgent(t, ctx, svc, a)
+	if !hasWaitingInterrupt(state, longRunningID) {
+		t.Errorf("expected a waiting node with InterruptID %q in persisted state", longRunningID)
+	}
+
+	// --- Turn 2: resume with the function response --------------------
+	reply := &genai.Content{
+		Role: genai.RoleUser,
+		Parts: []*genai.Part{{
+			FunctionResponse: &genai.FunctionResponse{
+				ID:       longRunningID,
+				Name:     "ask_human",
+				Response: map[string]any{"output": "approved"},
+			},
+		}},
+	}
+	var sawDone bool
+	for ev, err := range r.Run(ctx, nodeTestUser, nodeTestSession, reply, agent.RunConfig{}) {
+		if err != nil {
+			t.Fatalf("turn 2 Run() error = %v", err)
+		}
+		if ev != nil && ev.LLMResponse.Content != nil {
+			for _, p := range ev.LLMResponse.Content.Parts {
+				if p.Text == "all done" {
+					sawDone = true
+				}
+			}
+		}
+	}
+	if !sawDone {
+		t.Error("did not observe the LlmAgent's final answer after resume")
+	}
+}

--- a/runner/runner.go
+++ b/runner/runner.go
@@ -65,13 +65,23 @@ type PluginConfig struct {
 type RunOption func(*runOptions)
 
 type runOptions struct {
-	stateDelta map[string]any
+	stateDelta       map[string]any
+	yieldUserMessage bool
 }
 
 // WithStateDelta sets a state delta for the run invocation.
 func WithStateDelta(delta map[string]any) RunOption {
 	return func(o *runOptions) {
 		o.stateDelta = delta
+	}
+}
+
+// WithYieldUserMessage makes Run yield the user message event (after it is
+// appended to the session) before any agent/node events. Mirrors
+// adk-python's yield_user_message. Currently honored by the node path.
+func WithYieldUserMessage() RunOption {
+	return func(o *runOptions) {
+		o.yieldUserMessage = true
 	}
 }
 
@@ -173,6 +183,15 @@ func (r *Runner) Run(ctx context.Context, userID, sessionID string, msg *genai.C
 			return
 		}
 
+		// Node path: an LlmAgent runs through the ADK 2.0 node runtime
+		// (the Go equivalent of adk-python's _run_node_async, reached for
+		// an LlmAgent root). Detection is automatic — the user does not
+		// configure anything. See run_node.go.
+		if isLlmAgent(agentToRun) {
+			r.runNode(ctx, storedSession, agentToRun, msg, cfg, options, yield)
+			return
+		}
+
 		ctx = parentmap.ToContext(ctx, r.parents)
 		ctx = runconfig.ToContext(ctx, &runconfig.RunConfig{
 			StreamingMode: runconfig.StreamingMode(cfg.StreamingMode),
@@ -207,7 +226,7 @@ func (r *Runner) Run(ctx context.Context, userID, sessionID string, msg *genai.C
 			UserContent: msg,
 			RunConfig:   &cfg,
 		})
-		ctx, err = r.appendMessageToSession(ctx, storedSession, msg, cfg.SaveInputBlobsAsArtifacts, r.pluginManager, options.stateDelta)
+		ctx, _, err = r.appendMessageToSession(ctx, storedSession, msg, cfg.SaveInputBlobsAsArtifacts, r.pluginManager, options.stateDelta)
 		if err != nil {
 			yield(nil, err)
 			return
@@ -516,14 +535,14 @@ func (r *Runner) RunLive(ctx context.Context, userID, sessionID string, cfg agen
 	}, wrappedIter, nil
 }
 
-func (r *Runner) appendMessageToSession(ctx agent.InvocationContext, storedSession session.Session, msg *genai.Content, saveInputBlobsAsArtifacts bool, pluginManager *plugininternal.PluginManager, stateDelta map[string]any) (agent.InvocationContext, error) {
+func (r *Runner) appendMessageToSession(ctx agent.InvocationContext, storedSession session.Session, msg *genai.Content, saveInputBlobsAsArtifacts bool, pluginManager *plugininternal.PluginManager, stateDelta map[string]any) (agent.InvocationContext, *session.Event, error) {
 	if msg == nil {
-		return ctx, nil
+		return ctx, nil, nil
 	}
 	if pluginManager != nil {
 		modifiedMsg, err := pluginManager.RunOnUserMessageCallback(ctx, msg)
 		if err != nil {
-			return ctx, fmt.Errorf("error running on run user message callback : %w", err)
+			return ctx, nil, fmt.Errorf("error running on run user message callback : %w", err)
 		}
 		if modifiedMsg != nil {
 			msg = modifiedMsg
@@ -548,7 +567,7 @@ func (r *Runner) appendMessageToSession(ctx agent.InvocationContext, storedSessi
 			}
 			fileName := fmt.Sprintf("artifact_%s_%d", ctx.InvocationID(), i)
 			if _, err := artifactsService.Save(ctx, fileName, part); err != nil {
-				return ctx, fmt.Errorf("failed to save artifact %s: %w", fileName, err)
+				return ctx, nil, fmt.Errorf("failed to save artifact %s: %w", fileName, err)
 			}
 			// Replace the part with a text placeholder
 			msg.Parts[i] = &genai.Part{
@@ -568,9 +587,9 @@ func (r *Runner) appendMessageToSession(ctx agent.InvocationContext, storedSessi
 	}
 
 	if err := r.sessionService.AppendEvent(ctx, storedSession, event); err != nil {
-		return ctx, fmt.Errorf("failed to append event to sessionService: %w", err)
+		return ctx, nil, fmt.Errorf("failed to append event to sessionService: %w", err)
 	}
-	return ctx, nil
+	return ctx, event, nil
 }
 
 // findAgentToRun returns the agent that should handle the next request based on


### PR DESCRIPTION
Detect an LlmAgent root and drive it through the workflow node runtime (the Go equivalent of adk-python's Runner._run_node_async, which is reached for an LlmAgent). Detection and wrapping are automatic and require no user configuration: after findAgentToRun, if the resolved agent is an LlmAgent it is wrapped in a node and run as a single-node workflow (START -> node) named "<AppName>/<agent name>".

HITL bridge: adk-go pauses the workflow scheduler only on RequestedInput, whereas an LlmAgent's own HITL (long-running tools / tool confirmation) emits LongRunningToolIDs. The wrapping node bridges the two locally: when the agent emits LongRunningToolIDs it also yields a RequestedInput so the scheduler pauses and persists RunState; on resume (RerunOnResume) it feeds the human's function response back to the agent. adk-python unifies these on long_running_tool_ids; the deferred full unification in the workflow core is documented in runner/DESIGN_run_node.md section 10.

Also add WithYieldUserMessage() to optionally yield the user message event before node events (parity with adk-python yield_user_message); appendMessageToSession now returns the appended event to support this.

Includes an offline example (examples/runner/hitl_node) using a plain LlmAgent with a long-running tool, and tests covering a fresh LlmAgent turn, the yield-user-message option, and the full long-running-tool pause/resume cycle.

**Please ensure you have read the [contribution guide](./CONTRIBUTING.md) before creating a pull request.**

### Link to Issue or Description of Change

**1. Link to an existing issue (if applicable):**

- Closes: #_issue_number_
- Related: #_issue_number_

**2. Or, if no issue exists, describe the change:**

_If applicable, please follow the issue templates to provide as much detail as
possible._

**Problem:**
_A clear and concise description of what the problem is._

**Solution:**
_A clear and concise description of what you want to happen and why you choose
this solution._

### Testing Plan

_Please describe the tests that you ran to verify your changes. This is required
for all PRs that are not small documentation or typo fixes._

**Unit Tests:**

- [ ] I have added or updated unit tests for my change.
- [ ] All unit tests pass locally.

_Please include a summary of passed go test results._

**Manual End-to-End (E2E) Tests:**

_Please provide instructions on how to manually test your changes, including any
necessary setup or configuration. Please provide logs or screenshots to help
reviewers better understand the fix._

### Checklist

- [ ] I have read the [CONTRIBUTING.md](./CONTRIBUTING.md) document.
- [ ] I have performed a self-review of my own code.
- [ ] I have commented my code, particularly in hard-to-understand areas.
- [ ] I have added tests that prove my fix is effective or that my feature works.
- [ ] New and existing unit tests pass locally with my changes.
- [ ] I have manually tested my changes end-to-end.
- [ ] Any dependent changes have been merged and published in downstream modules.

### Additional context

_Add any other context or screenshots about the feature request here._

