### PR TITLE
feat(workflow): long-running HITL pause, history rehydration, and eve…

### DIFF
--- a/workflow/persistence.go
+++ b/workflow/persistence.go
@@ -74,6 +74,90 @@ func LoadRunState(sess session.Session, workflowName string) (*RunState, error) 
 	}
 }
 
+// ReconstructRunState rebuilds the paused RunState for this workflow
+// by scanning session history, instead of loading a persisted
+// RunState blob. This mirrors adk-python, which does NOT persist a
+// run-state event: it reconstructs paused state from the session's
+// events on resume (workflow/utils/_rehydration_utils.py).
+//
+// For each node in the graph, it finds long-running tool call IDs the
+// node raised (Event.LongRunningToolIDs, attributed by event author ==
+// node name) that have no matching FunctionResponse later in history.
+// A node with such open interrupts is reconstructed as NodeWaiting
+// with those IDs in NodeState.Interrupts, so Resume can match a
+// human's FunctionResponse back to it.
+//
+// Returns (nil, nil) when no node has an open interrupt (nothing to
+// resume). Anonymous workflows (empty name) still reconstruct: unlike
+// the persisted path, rehydration needs no name.
+func (w *Workflow) ReconstructRunState(sess session.Session) (*RunState, error) {
+	if sess == nil {
+		return nil, nil
+	}
+	nodesByName := buildNodesByName(w.graph)
+	events := sess.Events()
+
+	// open maps nodeName -> set of unresolved long-running IDs. A
+	// FunctionResponse anywhere in history (without re-raising the ID)
+	// resolves it. Authorship attributes a raised ID to its node.
+	open := map[string]map[string]struct{}{}
+	answered := map[string]struct{}{}
+	for i := 0; i < events.Len(); i++ {
+		ev := events.At(i)
+		if ev == nil {
+			continue
+		}
+		for _, id := range ev.LongRunningToolIDs {
+			if id == "" {
+				continue
+			}
+			if _, ok := nodesByName[ev.Author]; !ok {
+				continue
+			}
+			if open[ev.Author] == nil {
+				open[ev.Author] = map[string]struct{}{}
+			}
+			open[ev.Author][id] = struct{}{}
+		}
+		// An interrupt is resolved only by a FunctionResponse the USER
+		// supplied (the human/external reply on a later turn). The
+		// long-running tool's own initial "pending" response is
+		// authored by the agent/node, not the user, so it does NOT
+		// resolve the interrupt. Mirrors adk-python rehydration, which
+		// gates resolution on event.author == 'user'.
+		if ev.Author != "user" || ev.Content == nil {
+			continue
+		}
+		for _, p := range ev.Content.Parts {
+			if p == nil || p.FunctionResponse == nil || p.FunctionResponse.ID == "" {
+				continue
+			}
+			answered[p.FunctionResponse.ID] = struct{}{}
+		}
+	}
+
+	var state *RunState
+	for nodeName, ids := range open {
+		var interrupts []string
+		for id := range ids {
+			if _, done := answered[id]; done {
+				continue
+			}
+			interrupts = append(interrupts, id)
+		}
+		if len(interrupts) == 0 {
+			continue
+		}
+		if state == nil {
+			state = NewRunState()
+		}
+		ns := state.EnsureNode(nodeName)
+		ns.Status = NodeWaiting
+		ns.Interrupts = interrupts
+	}
+	return state, nil
+}
+
 // NewRunStateEvent builds a session.Event whose Actions.StateDelta
 // carries the workflow's serialised RunState. Workflow.Run and
 // Workflow.Resume yield this event before returning so the

--- a/workflow/resume.go
+++ b/workflow/resume.go
@@ -97,6 +97,37 @@ func (w *Workflow) Resume(
 		// Pass 1: dispatch every waiting asker matched by
 		// responses (handoff → defer; re-entry → reschedule now).
 		scheduled := 0
+
+		// Long-running-tool interrupts (NodeState.Interrupts) pause a
+		// node without a PendingRequest/RequestInput. They are always
+		// re-entry: on resume, re-activate the node so its flow
+		// continues from session history (the human's FunctionResponse
+		// is already appended). No schema/handoff handling — the reply
+		// is matched to the tool call by ID inside the LlmAgent flow.
+		for name, ns := range state.Nodes {
+			if ns.Status != NodeWaiting || len(ns.Interrupts) == 0 {
+				continue
+			}
+			matched := false
+			for _, id := range ns.Interrupts {
+				if _, ok := responses[id]; ok {
+					matched = true
+					break
+				}
+			}
+			if !matched {
+				continue
+			}
+			node := s.nodesByName[name]
+			if node == nil {
+				continue
+			}
+			ns.Interrupts = nil
+			ns.Status = NodePending
+			s.scheduleResumedNode(node, ns.Input, ns.TriggeredBy, ns.Branch, nil)
+			scheduled++
+		}
+
 		for name, ns := range state.Nodes {
 			if ns.Status != NodeWaiting || ns.PendingRequest == nil {
 				continue
@@ -199,7 +230,14 @@ func (w *Workflow) Resume(
 		// StateDelta. If new nodes paused during this Resume the
 		// next turn will see them; if the run completed the state
 		// reflects that too.
-		yieldRunStateEvent(ctx, w.name, s.state, yield)
+		//
+		// Skip when the caller rehydrates from session history
+		// (WithRehydratedRunState): re-pauses are reconstructed from
+		// the events themselves, so no run-state event is emitted
+		// (matches adk-python).
+		if !w.rehydrateRunState {
+			yieldRunStateEvent(ctx, w.name, s.state, yield)
+		}
 	}
 }
 

--- a/workflow/scheduler.go
+++ b/workflow/scheduler.go
@@ -135,6 +135,16 @@ type nodeRun struct {
 	inputRequest *session.RequestInput // at most one human-input request; multiple is an error
 	err          error                 // set on duplicate output, duplicate routing event, or duplicate input request
 	branch       string                // composite branch assigned at scheduling; used to stamp Event.Branch when the node leaves it empty
+
+	// interruptIDs accumulates long-running tool call IDs that the
+	// node's events raised but did not resolve within this run, i.e.
+	// the node is waiting for an external/human reply. Mirrors
+	// adk-python's Context._interrupt_ids: any event's
+	// LongRunningToolIDs are added; a later FunctionResponse with a
+	// matching ID removes it. A non-empty set at completion parks the
+	// node in NodeWaiting — no separate pause event is emitted (the
+	// long-running call event already in the session IS the signal).
+	interruptIDs map[string]struct{}
 }
 
 // recordErr stores err as the accumulator's first error. Subsequent
@@ -170,6 +180,34 @@ func (nr *nodeRun) setInputRequest(req *session.RequestInput, nodeName string) {
 	nr.inputRequest = req
 }
 
+// trackInterrupts accumulates the long-running tool call IDs the
+// node raised this run via Event.LongRunningToolIDs. A non-empty set
+// at completion parks the node in NodeWaiting (long-running pause).
+//
+// We deliberately do NOT resolve an interrupt from a FunctionResponse
+// seen in the same run: the tool's own initial "pending" response
+// arrives in the SAME run that raised the call, so treating it as a
+// reply would cancel the pause. The genuine reply (human/external)
+// arrives on a LATER turn — a fresh node run that continues from
+// session history and does not re-raise the call, so its interrupt
+// set is simply empty and the node completes. This mirrors
+// adk-python, where the long-running call event ends the turn and the
+// pause persists until a new invocation supplies the response.
+func (nr *nodeRun) trackInterrupts(ev *session.Event) {
+	if ev == nil {
+		return
+	}
+	for _, id := range ev.LongRunningToolIDs {
+		if id == "" {
+			continue
+		}
+		if nr.interruptIDs == nil {
+			nr.interruptIDs = map[string]struct{}{}
+		}
+		nr.interruptIDs[id] = struct{}{}
+	}
+}
+
 // setOutput stores out as the node's single output value. A second
 // call records ErrMultipleOutputs instead of overwriting.
 func (nr *nodeRun) setOutput(out any, nodeName string) {
@@ -189,9 +227,22 @@ type queueItem interface{ isQueueItem() }
 // consumer. nodeName is required so the consumer can correlate the
 // event with the right nodeRun without relying on channel-FIFO-
 // per-task semantics (which Go channels do not provide).
+//
+// processed, when non-nil, is a back-pressure handshake: the
+// producing goroutine blocks until the consumer closes it, which
+// happens only after the event has been yielded to (and thus
+// persisted by) the caller. This restores the ordering guarantee
+// that a non-partial event — notably a function-response — is
+// visible in the session before the producing LlmAgent flow loops
+// and rebuilds the next model request's contents from session
+// history. It mirrors adk-python's enqueue_event/processed_signal
+// handshake (invocation_context.enqueue_event ↔
+// _consume_event_queue). Nil for partial events, which are
+// fire-and-forget and never persisted.
 type eventItem struct {
-	nodeName string
-	ev       *session.Event
+	nodeName  string
+	ev        *session.Event
+	processed chan struct{}
 }
 
 func (eventItem) isQueueItem() {}
@@ -445,11 +496,30 @@ func runNode(
 			completion.err = err
 			return
 		}
+		// For non-partial events, install a processed handshake and
+		// block until the consumer has yielded (and thus persisted)
+		// the event. This guarantees a function-response is in the
+		// session before the node's LlmAgent flow loops and rebuilds
+		// the next model request from session history — otherwise the
+		// model would not see the tool result and would re-issue the
+		// call. Partial (streaming) events are fire-and-forget.
+		var processed chan struct{}
+		if ev != nil && !ev.LLMResponse.Partial {
+			processed = make(chan struct{})
+		}
 		select {
-		case out <- eventItem{nodeName: name, ev: ev}:
+		case out <- eventItem{nodeName: name, ev: ev, processed: processed}:
 		case <-ctx.Done():
 			completion.err = ctx.Err()
 			return
+		}
+		if processed != nil {
+			select {
+			case <-processed:
+			case <-ctx.Done():
+				completion.err = ctx.Err()
+				return
+			}
 		}
 	}
 	// If the node's iter returned cleanly but the context was
@@ -523,6 +593,17 @@ func (s *scheduler) run(yield func(*session.Event, error) bool) {
 					s.cancelAll()
 				}
 			}
+			// Release the producer's back-pressure handshake. By
+			// this point the event has been yielded to the caller
+			// (which persists non-partial events synchronously), so
+			// the producing node may safely resume and rebuild its
+			// next request from the now-updated session. Always
+			// signal — even when draining — so a blocked producer
+			// does not leak. Closed-channel double-signal is
+			// impossible: each eventItem carries a fresh channel.
+			if it.processed != nil {
+				close(it.processed)
+			}
 		case completionItem:
 			err := s.handleCompletion(it, !draining)
 			if err != nil && pendingErr == nil {
@@ -588,6 +669,13 @@ func (s *scheduler) handleEvent(it eventItem) {
 	isDescendant := path != "" && path != it.nodeName
 	if it.ev.RequestedInput != nil {
 		nr.setInputRequest(it.ev.RequestedInput, it.nodeName)
+	}
+	// Accumulate long-running interrupts from the node's own events.
+	// A non-empty open set at completion parks the node in
+	// NodeWaiting, with no separate pause event — the long-running
+	// call event already carries the signal (matches adk-python).
+	if !isDescendant {
+		nr.trackInterrupts(it.ev)
 	}
 	if isDescendant {
 		return
@@ -672,6 +760,21 @@ func (s *scheduler) handleCompletion(it completionItem, scheduleSuccessors bool)
 	if nr != nil && nr.inputRequest != nil {
 		ns.Status = NodeWaiting
 		ns.PendingRequest = nr.inputRequest
+		return nil
+	}
+
+	// Long-running-tool pause: the node raised LongRunningToolIDs
+	// that were not answered within this run. Park it WAITING and
+	// record the open interrupt IDs so resume can match a human's
+	// FunctionResponse back to this node — without any synthetic
+	// pause event (the long-running call event already in the
+	// session is the signal). Mirrors adk-python _handle_completion.
+	if nr != nil && len(nr.interruptIDs) > 0 {
+		ns.Status = NodeWaiting
+		ns.Interrupts = ns.Interrupts[:0]
+		for id := range nr.interruptIDs {
+			ns.Interrupts = append(ns.Interrupts, id)
+		}
 		return nil
 	}
 

--- a/workflow/state.go
+++ b/workflow/state.go
@@ -115,6 +115,15 @@ type NodeState struct {
 	// (as opposed to a fan-in barrier).
 	PendingRequest *session.RequestInput `json:"pendingRequest,omitempty"`
 
+	// Interrupts holds the long-running tool call IDs the node is
+	// waiting on (raised via Event.LongRunningToolIDs and not yet
+	// answered by a matching FunctionResponse). Non-empty iff
+	// Status == NodeWaiting due to a long-running tool pause.
+	// Mirrors adk-python NodeState.interrupts: it lets resume match
+	// a human's FunctionResponse to the waiting node without a
+	// synthetic RequestInput. A node can wait on more than one.
+	Interrupts []string `json:"interrupts,omitempty"`
+
 	// Attempt is the number of times this node has been failed.
 	Attempt int `json:"attempt,omitempty"`
 
@@ -145,6 +154,21 @@ type RunState struct {
 // initialised so callers can write to it without a nil check.
 func NewRunState() *RunState {
 	return &RunState{Nodes: map[string]*NodeState{}}
+}
+
+// HasWaiting reports whether any node is paused (NodeWaiting),
+// i.e. the run left work to resume on a later turn. When false,
+// the run finished and there is nothing to persist for resume.
+func (s *RunState) HasWaiting() bool {
+	if s == nil {
+		return false
+	}
+	for _, ns := range s.Nodes {
+		if ns != nil && ns.Status == NodeWaiting {
+			return true
+		}
+	}
+	return false
 }
 
 // EnsureNode returns the NodeState for the given node name,

--- a/workflow/workflow.go
+++ b/workflow/workflow.go
@@ -141,6 +141,15 @@ type Workflow struct {
 	// may run concurrently within a single Run invocation. 0
 	// (the default) means unlimited. Set via WithMaxConcurrency.
 	maxConcurrency int
+
+	// rehydrateRunState, when true, suppresses emitting the RunState
+	// StateDelta event from Run/Resume. The caller instead
+	// reconstructs paused state from session history via
+	// ReconstructRunState (matching adk-python, which never persists
+	// a run-state event). Used by the runner's LlmAgent node path so
+	// a HITL pause turn yields only the domain events, not an extra
+	// content-free state event. Set via WithRehydratedRunState.
+	rehydrateRunState bool
 }
 
 // Option configures a Workflow at construction time. Pass options
@@ -151,7 +160,21 @@ type Option func(*workflowOptions)
 // caller's Option list. Zero values mean "no override / use
 // engine defaults".
 type workflowOptions struct {
-	maxConcurrency int
+	maxConcurrency    int
+	rehydrateRunState bool
+}
+
+// WithRehydratedRunState makes the workflow suppress the RunState
+// StateDelta event normally yielded by Run/Resume. Use it when the
+// caller reconstructs paused state from session history (via
+// Workflow.ReconstructRunState) rather than from a persisted
+// run-state blob. This matches adk-python, which never persists a
+// run-state event. Without this option the workflow persists its
+// RunState as an event (the default, used by graph workflows).
+func WithRehydratedRunState() Option {
+	return func(o *workflowOptions) {
+		o.rehydrateRunState = true
+	}
 }
 
 // WithMaxConcurrency caps how many graph-scheduled nodes may run
@@ -209,9 +232,10 @@ func New(name string, edges []Edge, opts ...Option) (*Workflow, error) {
 		opt(&o)
 	}
 	return &Workflow{
-		graph:          graph,
-		name:           name,
-		maxConcurrency: o.maxConcurrency,
+		graph:             graph,
+		name:              name,
+		maxConcurrency:    o.maxConcurrency,
+		rehydrateRunState: o.rehydrateRunState,
 	}, nil
 }
 
@@ -259,7 +283,21 @@ func (w *Workflow) RunNode(ctx agent.InvocationContext, input any) iter.Seq2[*se
 		// surrounding event-append pipeline can propagate it to
 		// storage; see NewRunStateEvent for why a direct
 		// State.Set is not sufficient.
-		yieldRunStateEvent(ctx, w.name, s.state, yield)
+		//
+		// Only emit when the run actually paused (a node is
+		// NodeWaiting). A fully-completed run has nothing to
+		// resume, so persisting it would add a spurious,
+		// content-free StateDelta event to every turn — which
+		// breaks event-count and stream-aggregator expectations
+		// for plain (non-HITL) agent runs. Resume always persists
+		// (see resume.go) so a consumed pause is correctly cleared.
+		//
+		// Skip entirely when the caller rehydrates state from
+		// session history (WithRehydratedRunState): no run-state
+		// event is emitted, matching adk-python.
+		if !w.rehydrateRunState && s.state.HasWaiting() {
+			yieldRunStateEvent(ctx, w.name, s.state, yield)
+		}
 	}
 }
 


### PR DESCRIPTION
…nt back-pressure

Workflow-engine changes to support adk-python-style HITL for nodes, independent of the runner integration that consumes them.

1. Back-pressure handshake (scheduler): for non-partial events the producing node goroutine blocks until the consumer has yielded (and thus persisted) the event. This restores the ordering guarantee that a function-response is visible in the session before the node's flow loops and rebuilds the next model request — otherwise the model re-issues the same tool call (a non-deterministic data race). Mirrors adk-python enqueue_event/processed_signal.

2. Long-running interrupt pause (scheduler + state): accumulate a node's unresolved Event.LongRunningToolIDs and park it NodeWaiting at completion with the open IDs in NodeState.Interrupts — no synthetic RequestInput event. Adds RunState.HasWaiting().

3. History rehydration (persistence + workflow): Workflow.ReconstructRunState rebuilds the waiting set from session events (long-running IDs not yet answered by a user FunctionResponse) instead of a persisted run-state blob; WithRehydratedRunState suppresses the RunState StateDelta event for callers that rehydrate. Mirrors adk-python rehydration.

4. Resume (resume): re-activate a node matched by NodeState.Interrupts (re-entry), in addition to the existing PendingRequest path.

These are additive to the engine and do not change behavior until a caller opts in (the follow-up runner change wires the LlmAgent node).

**Please ensure you have read the [contribution guide](./CONTRIBUTING.md) before creating a pull request.**

### Link to Issue or Description of Change

**1. Link to an existing issue (if applicable):**

- Closes: #_issue_number_
- Related: #_issue_number_

**2. Or, if no issue exists, describe the change:**

_If applicable, please follow the issue templates to provide as much detail as
possible._

**Problem:**
_A clear and concise description of what the problem is._

**Solution:**
_A clear and concise description of what you want to happen and why you choose
this solution._

### Testing Plan

_Please describe the tests that you ran to verify your changes. This is required
for all PRs that are not small documentation or typo fixes._

**Unit Tests:**

- [ ] I have added or updated unit tests for my change.
- [ ] All unit tests pass locally.

_Please include a summary of passed go test results._

**Manual End-to-End (E2E) Tests:**

_Please provide instructions on how to manually test your changes, including any
necessary setup or configuration. Please provide logs or screenshots to help
reviewers better understand the fix._

### Checklist

- [ ] I have read the [CONTRIBUTING.md](./CONTRIBUTING.md) document.
- [ ] I have performed a self-review of my own code.
- [ ] I have commented my code, particularly in hard-to-understand areas.
- [ ] I have added tests that prove my fix is effective or that my feature works.
- [ ] New and existing unit tests pass locally with my changes.
- [ ] I have manually tested my changes end-to-end.
- [ ] Any dependent changes have been merged and published in downstream modules.

### Additional context

_Add any other context or screenshots about the feature request here._

