### PR TITLE
fix(console): dedup pending HITL interrupts across SSE partial events

### DIFF
--- a/cmd/launcher/console/hitl.go
+++ b/cmd/launcher/console/hitl.go
@@ -40,8 +40,20 @@ type pendingInterrupt struct {
 // returns them in order of appearance.
 func collectPendingInterrupts(events []*session.Event) []pendingInterrupt {
 	var out []pendingInterrupt
+	// seen dedups by call ID: in SSE streaming mode the same
+	// function-call event can be emitted multiple times (partial
+	// chunks plus the final aggregated event), each carrying the
+	// same LongRunningToolIDs. Without dedup the console would
+	// queue one prompt per duplicate and consume the user's reply
+	// against a phantom interrupt instead of resuming the run.
+	seen := map[string]struct{}{}
 	for _, ev := range events {
 		if ev == nil || len(ev.LongRunningToolIDs) == 0 {
+			continue
+		}
+		// Skip partial streaming chunks; only the final aggregated
+		// event represents a settled interrupt.
+		if ev.LLMResponse.Partial {
 			continue
 		}
 		lr := map[string]struct{}{}
@@ -60,6 +72,10 @@ func collectPendingInterrupts(events []*session.Event) []pendingInterrupt {
 			if _, isInterrupt := lr[fc.ID]; !isInterrupt {
 				continue
 			}
+			if _, dup := seen[fc.ID]; dup {
+				continue
+			}
+			seen[fc.ID] = struct{}{}
 			out = append(out, pendingInterrupt{
 				id:   fc.ID,
 				name: fc.Name,

--- a/cmd/launcher/console/hitl_test.go
+++ b/cmd/launcher/console/hitl_test.go
@@ -137,6 +137,55 @@ func TestCollectPendingInterrupts_DetectionByLongRunningToolIDs(t *testing.T) {
 				{id: "int-2", name: "x", args: nil},
 			},
 		},
+		{
+			// SSE streaming emits the same function-call event
+			// repeatedly (partial chunks + a final aggregated
+			// event), each carrying the same LongRunningToolIDs.
+			// The interrupt must surface exactly once, from the
+			// final event, so the console queues a single prompt.
+			name: "duplicate call ID across partial and final events dedups to one",
+			events: []*session.Event{
+				{
+					LongRunningToolIDs: []string{"dup-1"},
+					LLMResponse: model.LLMResponse{
+						Partial: true,
+						Content: &genai.Content{
+							Parts: []*genai.Part{{FunctionCall: &genai.FunctionCall{ID: "dup-1", Name: "ask", Args: map[string]any{"a": float64(1)}}}},
+						},
+					},
+				},
+				{
+					LongRunningToolIDs: []string{"dup-1"},
+					LLMResponse: model.LLMResponse{
+						Partial: false,
+						Content: &genai.Content{
+							Parts: []*genai.Part{{FunctionCall: &genai.FunctionCall{ID: "dup-1", Name: "ask", Args: map[string]any{"a": float64(1)}}}},
+						},
+					},
+				},
+			},
+			want: []pendingInterrupt{
+				{id: "dup-1", name: "ask", args: map[string]any{"a": float64(1)}},
+			},
+		},
+		{
+			// A partial-only event must never surface an
+			// interrupt on its own; the settled prompt always
+			// comes from the final aggregated event.
+			name: "partial-only event does not surface an interrupt",
+			events: []*session.Event{
+				{
+					LongRunningToolIDs: []string{"p-1"},
+					LLMResponse: model.LLMResponse{
+						Partial: true,
+						Content: &genai.Content{
+							Parts: []*genai.Part{{FunctionCall: &genai.FunctionCall{ID: "p-1", Name: "ask"}}},
+						},
+					},
+				},
+			},
+			want: nil,
+		},
 	}
 	for _, tc := range tests {
 		t.Run(tc.name, func(t *testing.T) {


### PR DESCRIPTION
In SSE streaming mode the same long-running function-call event is emitted multiple times (partial chunks plus the final aggregated event), each carrying the same LongRunningToolIDs. collectPendingInterrupts queued one prompt per duplicate, so the user's reply was consumed against a phantom interrupt instead of resuming the run.

Skip partial events and dedup by call ID so each interrupt surfaces exactly once, from the final aggregated event.
