### PR TITLE
feat(workflow): derive node output from message via NodeInfo.MessageAsOutput

### DIFF
--- a/session/session.go
+++ b/session/session.go
@@ -139,9 +139,10 @@ type Event struct {
 // NodeInfo carries the per-event metadata identifying which node in
 // a workflow activation emitted it.
 //
-// TODO(wolo): adk-python's NodeInfo also has OutputFor []string
-// (fan-in re-attribution) and MessageAsOutput bool (content-as-output
-// shorthand). Add as the corresponding features land in adk-go.
+// TODO(wolo): adk-python's NodeInfo also has OutputFor []string, which
+// attributes one event's output to its delegating ancestors. adk-go
+// re-emits on the parent instead; add it if multi-level delegation
+// resume needs python-equivalent de-dup.
 type NodeInfo struct {
 	// Path is the composite path of the emitting node within its
 	// workflow activation. Empty for top-level static nodes;
@@ -150,6 +151,12 @@ type NodeInfo struct {
 	// invariants to the emitter, allowing dynamic nodes to forward
 	// children's terminal events alongside their own.
 	Path string `json:"path,omitempty"`
+
+	// MessageAsOutput marks that this event's content IS the node's
+	// output: when set and Event.Output is nil, readers derive the
+	// node output from the event's model text. Mirrors adk-python's
+	// node_info.message_as_output.
+	MessageAsOutput bool `json:"messageAsOutput,omitempty"`
 }
 
 // RequestInput describes a single human-in-the-loop prompt emitted

--- a/workflow/agent_node.go
+++ b/workflow/agent_node.go
@@ -142,6 +142,11 @@ func (n *AgentNode) Run(ctx agent.InvocationContext, input any) iter.Seq2[*sessi
 // reply instead of the zero value. Empty model text yields an empty
 // "" output (a value, not "no output"), matching adk-python and
 // messageAsOutput; non-model events are left untouched.
+//
+// It also stamps NodeInfo.MessageAsOutput so readers (live and
+// resume) know this event's output was derived from the model
+// message, mirroring adk-python's process_llm_agent_output which
+// sets event.output and node_info.message_as_output together.
 func synthesizeAgentOutput(event *session.Event) {
 	if event == nil || event.Output != nil {
 		return
@@ -151,6 +156,10 @@ func synthesizeAgentOutput(event *session.Event) {
 	}
 	if text, ok := messageText(event); ok {
 		event.Output = text
+		if event.NodeInfo == nil {
+			event.NodeInfo = &session.NodeInfo{}
+		}
+		event.NodeInfo.MessageAsOutput = true
 	}
 }
 

--- a/workflow/agent_node.go
+++ b/workflow/agent_node.go
@@ -139,7 +139,9 @@ func (n *AgentNode) Run(ctx agent.InvocationContext, input any) iter.Seq2[*sessi
 
 // synthesizeAgentOutput sets Event.Output from concatenated model
 // text on final model responses so RunNode returns the agent's
-// reply instead of the zero value.
+// reply instead of the zero value. Empty model text yields an empty
+// "" output (a value, not "no output"), matching adk-python and
+// messageAsOutput; non-model events are left untouched.
 func synthesizeAgentOutput(event *session.Event) {
 	if event == nil || event.Output != nil {
 		return
@@ -147,9 +149,21 @@ func synthesizeAgentOutput(event *session.Event) {
 	if !event.IsFinalResponse() {
 		return
 	}
+	if text, ok := messageText(event); ok {
+		event.Output = text
+	}
+}
+
+// messageText concatenates the non-thought model text of an event. ok
+// is false when the event carries no model content, distinguishing it
+// from a model message with empty text.
+func messageText(event *session.Event) (text string, ok bool) {
+	if event == nil {
+		return "", false
+	}
 	content := event.LLMResponse.Content
 	if content == nil || content.Role != "model" {
-		return
+		return "", false
 	}
 	var b []byte
 	for _, p := range content.Parts {
@@ -158,8 +172,19 @@ func synthesizeAgentOutput(event *session.Event) {
 		}
 		b = append(b, p.Text...)
 	}
-	if len(b) == 0 {
-		return
+	return string(b), true
+}
+
+// childEventOutput returns the output an event carries: its Output, or
+// the model text when MessageAsOutput is set.
+func childEventOutput(event *session.Event) (any, bool) {
+	if event.Output != nil {
+		return event.Output, true
 	}
-	event.Output = string(b)
+	if event.NodeInfo != nil && event.NodeInfo.MessageAsOutput {
+		if text, ok := messageText(event); ok {
+			return text, true
+		}
+	}
+	return nil, false
 }

--- a/workflow/agent_node_test.go
+++ b/workflow/agent_node_test.go
@@ -443,4 +443,10 @@ func TestAgentNode_SynthesizesOutputFromModelText(t *testing.T) {
 	if got, want := gotFinal.Output, "Hello, world!"; got != want {
 		t.Errorf("final event Output = %v, want %q", got, want)
 	}
+	if gotFinal.NodeInfo == nil || !gotFinal.NodeInfo.MessageAsOutput {
+		t.Errorf("final event NodeInfo.MessageAsOutput = %v, want true", gotFinal.NodeInfo)
+	}
+	if gotPartial.NodeInfo != nil && gotPartial.NodeInfo.MessageAsOutput {
+		t.Errorf("partial event MessageAsOutput = true, want false/unset")
+	}
 }

--- a/workflow/dynamic_scheduler.go
+++ b/workflow/dynamic_scheduler.go
@@ -195,12 +195,10 @@ func (s *dynamicSubScheduler) runNode(child Node, input any, opts runNodeOptions
 		if ev.RequestedInput != nil {
 			interrupted = true
 		}
-		if ev.Output != nil {
-			out = ev.Output
-			// A delegated child's output is re-emitted by the
-			// parent's terminal event; drop it here to avoid a
-			// duplicate. Partial/state-only events (Output ==
-			// nil) still propagate.
+		// A delegated child's output is re-emitted on the parent's
+		// terminal event, so drop it here to avoid a duplicate.
+		if childOut, ok := childEventOutput(ev); ok {
+			out = childOut
 			if opts.useAsOutput {
 				continue
 			}

--- a/workflow/dynamic_scheduler_test.go
+++ b/workflow/dynamic_scheduler_test.go
@@ -21,6 +21,8 @@ import (
 	"sync"
 	"testing"
 
+	"google.golang.org/genai"
+
 	"google.golang.org/adk/agent"
 	"google.golang.org/adk/session"
 )
@@ -215,6 +217,33 @@ func (n *stubNode) Run(ctx agent.InvocationContext, _ any) iter.Seq2[*session.Ev
 	out := n.out
 	return func(yield func(*session.Event, error) bool) {
 		yield(&session.Event{Output: out}, nil)
+	}
+}
+
+// messageAsOutputNode emits a final model-text event whose content IS
+// its output (NodeInfo.MessageAsOutput set, Event.Output nil), like an
+// LlmAgent node in single_turn mode.
+type messageAsOutputNode struct {
+	BaseNode
+	text string
+}
+
+func newMessageAsOutputNode(name, text string) *messageAsOutputNode {
+	return &messageAsOutputNode{
+		BaseNode: NewBaseNode(name, "", NodeConfig{}),
+		text:     text,
+	}
+}
+
+func (n *messageAsOutputNode) Run(agent.InvocationContext, any) iter.Seq2[*session.Event, error] {
+	text := n.text
+	return func(yield func(*session.Event, error) bool) {
+		ev := &session.Event{NodeInfo: &session.NodeInfo{MessageAsOutput: true}}
+		ev.LLMResponse.Content = &genai.Content{
+			Role:  "model",
+			Parts: []*genai.Part{{Text: text}},
+		}
+		yield(ev, nil)
 	}
 }
 

--- a/workflow/persistence.go
+++ b/workflow/persistence.go
@@ -196,8 +196,13 @@ func collectNodeOutputs(events session.Events, nodesByName map[string]Node) (out
 			continue
 		}
 		completed[name] = true
-		if ev.Output != nil {
-			outputs[name] = ev.Output
+		// Prefer an explicit Output; otherwise derive it from the
+		// model message when the event is flagged MessageAsOutput,
+		// so a message-as-output node recovers its output on resume
+		// (mirrors adk-python _reconstruct_node_states'
+		// use_message_as_output branch).
+		if out, ok := childEventOutput(ev); ok {
+			outputs[name] = out
 		}
 	}
 	return outputs, completed

--- a/workflow/persistence_test.go
+++ b/workflow/persistence_test.go
@@ -1,0 +1,93 @@
+// Copyright 2026 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package workflow
+
+import (
+	"iter"
+	"testing"
+
+	"google.golang.org/genai"
+
+	"google.golang.org/adk/session"
+)
+
+// sliceEvents adapts a []*session.Event to session.Events for tests.
+type sliceEvents []*session.Event
+
+func (e sliceEvents) Len() int                { return len(e) }
+func (e sliceEvents) At(i int) *session.Event { return e[i] }
+func (e sliceEvents) All() iter.Seq[*session.Event] {
+	return func(yield func(*session.Event) bool) {
+		for _, ev := range e {
+			if !yield(ev) {
+				return
+			}
+		}
+	}
+}
+
+func modelEvent(path, text string, messageAsOutput bool) *session.Event {
+	ev := &session.Event{
+		NodeInfo: &session.NodeInfo{Path: path, MessageAsOutput: messageAsOutput},
+	}
+	ev.LLMResponse.Content = &genai.Content{
+		Role:  "model",
+		Parts: []*genai.Part{{Text: text}},
+	}
+	return ev
+}
+
+// Resume derives output from the model message when an event is
+// flagged MessageAsOutput with no explicit Output (adk-python parity).
+func TestCollectNodeOutputs_MessageAsOutput(t *testing.T) {
+	nodes := map[string]Node{"talky": &dummyNode{name: "talky"}}
+
+	events := sliceEvents{modelEvent("talky", "Hello, world!", true)}
+
+	outputs, completed := collectNodeOutputs(events, nodes)
+
+	if got, want := outputs["talky"], "Hello, world!"; got != want {
+		t.Errorf("outputs[talky] = %#v, want %q", got, want)
+	}
+	if !completed["talky"] {
+		t.Errorf("completed[talky] = false, want true")
+	}
+}
+
+func TestCollectNodeOutputs_MessageNotFlagged(t *testing.T) {
+	nodes := map[string]Node{"talky": &dummyNode{name: "talky"}}
+
+	events := sliceEvents{modelEvent("talky", "Hello, world!", false)}
+
+	outputs, _ := collectNodeOutputs(events, nodes)
+
+	if _, ok := outputs["talky"]; ok {
+		t.Errorf("outputs[talky] = %#v, want absent", outputs["talky"])
+	}
+}
+
+func TestCollectNodeOutputs_ExplicitOutputWins(t *testing.T) {
+	nodes := map[string]Node{"talky": &dummyNode{name: "talky"}}
+
+	ev := modelEvent("talky", "from message", true)
+	ev.Output = "explicit"
+	events := sliceEvents{ev}
+
+	outputs, _ := collectNodeOutputs(events, nodes)
+
+	if got, want := outputs["talky"], "explicit"; got != want {
+		t.Errorf("outputs[talky] = %#v, want %q", got, want)
+	}
+}

--- a/workflow/run_node_test.go
+++ b/workflow/run_node_test.go
@@ -200,6 +200,48 @@ func TestRunNode_WithUseAsOutput_ChildOutputBecomesParentOutput(t *testing.T) {
 	}
 }
 
+func TestRunNode_WithUseAsOutput_MessageAsOutputChildBecomesParentOutput(t *testing.T) {
+	// A delegated child whose message IS its output (NodeInfo.
+	// MessageAsOutput, no explicit Output — like an LlmAgent node)
+	// promotes its model text to the parent's terminal Output.
+	child := newMessageAsOutputNode("c", "child_text")
+	n := NewDynamicNode[string, string](
+		"orch",
+		func(ctx NodeContext, _ string, _ func(*session.Event) error) (string, error) {
+			if _, err := RunNode[string](ctx, child, nil, WithUseAsOutput()); err != nil {
+				return "", err
+			}
+			return "parent_value", nil
+		},
+		NodeConfig{},
+	)
+	events := drainDynamic(t, n, "")
+	if got := parentTerminalOutput(t, events, "orch"); got != "child_text" {
+		t.Errorf("parent terminal Output = %v, want %q", got, "child_text")
+	}
+}
+
+func TestRunNode_WithUseAsOutput_MessageAsOutputEmptyTextIsValidOutput(t *testing.T) {
+	// Empty model text under MessageAsOutput is a valid output ("",
+	// not "no output"), matching adk-python. The parent's terminal
+	// Output must be the empty string, not nil.
+	child := newMessageAsOutputNode("c", "")
+	n := NewDynamicNode[string, string](
+		"orch",
+		func(ctx NodeContext, _ string, _ func(*session.Event) error) (string, error) {
+			if _, err := RunNode[string](ctx, child, nil, WithUseAsOutput()); err != nil {
+				return "", err
+			}
+			return "parent_value", nil
+		},
+		NodeConfig{},
+	)
+	events := drainDynamic(t, n, "")
+	if got := parentTerminalOutput(t, events, "orch"); got != "" {
+		t.Errorf("parent terminal Output = %#v, want empty string (MessageAsOutput treats \"\" as a valid output)", got)
+	}
+}
+
 func TestRunNode_WithUseAsOutput_SecondDelegationReturnsError(t *testing.T) {
 	c1 := newStubNode("c1", "v1")
 	c2 := newStubNode("c2", "v2")

--- a/workflow/scheduler.go
+++ b/workflow/scheduler.go
@@ -653,8 +653,8 @@ func (s *scheduler) handleEvent(it eventItem) {
 	if it.ev.Routes != nil {
 		nr.setRoutingEvent(it.ev, it.nodeName)
 	}
-	if it.ev.Output != nil {
-		nr.setOutput(it.ev.Output, it.nodeName)
+	if out, ok := childEventOutput(it.ev); ok {
+		nr.setOutput(out, it.nodeName)
 	}
 }
 

--- a/workflow/scheduler_test.go
+++ b/workflow/scheduler_test.go
@@ -60,6 +60,28 @@ func TestScheduler_LinearChain(t *testing.T) {
 	}
 }
 
+// TestScheduler_MessageAsOutput_FeedsSuccessor verifies that a node
+// whose message IS its output (NodeInfo.MessageAsOutput, no explicit
+// Event.Output) has its model text derived as the node output and fed
+// to the successor as input.
+func TestScheduler_MessageAsOutput_FeedsSuccessor(t *testing.T) {
+	mockCtx := newSeededMockCtx(t)
+
+	a := newMessageAsOutputNode("A", "hello")
+	b := newRecordingNode("B")
+	b.release()
+
+	w := mustNew(t, Chain(Start, a, b))
+
+	gotEvents := drain(t, w.Run(mockCtx))
+
+	// B echoes "<input>:B"; the input must be A's derived output.
+	got := outputsOf(gotEvents)
+	if len(got) != 1 || got[0] != "hello:B" {
+		t.Errorf("outputs = %v, want [\"hello:B\"] (A's message text fed to B)", got)
+	}
+}
+
 // TestScheduler_FanOutConcurrency verifies that three nodes
 // downstream of START are mid-Run simultaneously, not serialised by
 // the legacy BFS. Each node blocks on its release channel until the


### PR DESCRIPTION
**Problem**
A workflow node's output normally lives in `Event.Output`. But an
`LlmAgent` node in chat mode emits its answer as message *content* with no
separate `Output` value — so anything consuming that node's output (a
successor on a handoff, or a `WithUseAsOutput` delegation) would see no
output. adk-python solves this with `node_info.message_as_output`;
adk-go had no equivalent.

**Solution**
Add `NodeInfo.MessageAsOutput`. When set and `Event.Output` is nil,
readers derive the node's output from the event's model text. This mirrors
adk-python's `_track_event_in_context` (explicit `Output` wins; message
text is the fallback).