### PR TITLE
feat(workflow): NodeInfo.OutputFor for delegation-chain output attrib…

### DIFF
--- a/session/session.go
+++ b/session/session.go
@@ -139,9 +139,10 @@ type Event struct {
 // NodeInfo carries the per-event metadata identifying which node in
 // a workflow activation emitted it.
 //
-// TODO(wolo): adk-python's NodeInfo also has OutputFor []string
-// (fan-in re-attribution) and MessageAsOutput bool (content-as-output
-// shorthand). Add as the corresponding features land in adk-go.
+// TODO(wolo): adk-python's NodeInfo also has OutputFor []string, which
+// attributes one event's output to its delegating ancestors. adk-go
+// re-emits on the parent instead; add it if multi-level delegation
+// resume needs python-equivalent de-dup.
 type NodeInfo struct {
 	// Path is the composite path of the emitting node within its
 	// workflow activation. Empty for top-level static nodes;
@@ -150,6 +151,12 @@ type NodeInfo struct {
 	// invariants to the emitter, allowing dynamic nodes to forward
 	// children's terminal events alongside their own.
 	Path string `json:"path,omitempty"`
+
+	// MessageAsOutput marks that this event's content IS the node's
+	// output: when set and Event.Output is nil, readers derive the
+	// node output from the event's model text. Mirrors adk-python's
+	// node_info.message_as_output.
+	MessageAsOutput bool `json:"messageAsOutput,omitempty"`
 }
 
 // RequestInput describes a single human-in-the-loop prompt emitted

--- a/session/session.go
+++ b/session/session.go
@@ -138,11 +138,6 @@ type Event struct {
 
 // NodeInfo carries the per-event metadata identifying which node in
 // a workflow activation emitted it.
-//
-// TODO(wolo): adk-python's NodeInfo also has OutputFor []string, which
-// attributes one event's output to its delegating ancestors. adk-go
-// re-emits on the parent instead; add it if multi-level delegation
-// resume needs python-equivalent de-dup.
 type NodeInfo struct {
 	// Path is the composite path of the emitting node within its
 	// workflow activation. Empty for top-level static nodes;
@@ -157,6 +152,13 @@ type NodeInfo struct {
 	// node output from the event's model text. Mirrors adk-python's
 	// node_info.message_as_output.
 	MessageAsOutput bool `json:"messageAsOutput,omitempty"`
+
+	// OutputFor lists the node paths this event's Output counts for: the
+	// emitting node plus any delegating ancestors (WithUseAsOutput). It
+	// lets one event stand in for a whole delegation chain instead of
+	// each level re-emitting a duplicate. Mirrors adk-python's
+	// node_info.output_for.
+	OutputFor []string `json:"outputFor,omitempty"`
 }
 
 // RequestInput describes a single human-in-the-loop prompt emitted

--- a/workflow/agent_node.go
+++ b/workflow/agent_node.go
@@ -139,7 +139,9 @@ func (n *AgentNode) Run(ctx agent.InvocationContext, input any) iter.Seq2[*sessi
 
 // synthesizeAgentOutput sets Event.Output from concatenated model
 // text on final model responses so RunNode returns the agent's
-// reply instead of the zero value.
+// reply instead of the zero value. Empty model text yields an empty
+// "" output (a value, not "no output"), matching adk-python and
+// messageAsOutput; non-model events are left untouched.
 func synthesizeAgentOutput(event *session.Event) {
 	if event == nil || event.Output != nil {
 		return
@@ -147,9 +149,21 @@ func synthesizeAgentOutput(event *session.Event) {
 	if !event.IsFinalResponse() {
 		return
 	}
+	if text, ok := messageText(event); ok {
+		event.Output = text
+	}
+}
+
+// messageText concatenates the non-thought model text of an event. ok
+// is false when the event carries no model content, distinguishing it
+// from a model message with empty text.
+func messageText(event *session.Event) (text string, ok bool) {
+	if event == nil {
+		return "", false
+	}
 	content := event.LLMResponse.Content
 	if content == nil || content.Role != "model" {
-		return
+		return "", false
 	}
 	var b []byte
 	for _, p := range content.Parts {
@@ -158,8 +172,19 @@ func synthesizeAgentOutput(event *session.Event) {
 		}
 		b = append(b, p.Text...)
 	}
-	if len(b) == 0 {
-		return
+	return string(b), true
+}
+
+// childEventOutput returns the output an event carries: its Output, or
+// the model text when MessageAsOutput is set.
+func childEventOutput(event *session.Event) (any, bool) {
+	if event.Output != nil {
+		return event.Output, true
 	}
-	event.Output = string(b)
+	if event.NodeInfo != nil && event.NodeInfo.MessageAsOutput {
+		if text, ok := messageText(event); ok {
+			return text, true
+		}
+	}
+	return nil, false
 }

--- a/workflow/dynamic_node.go
+++ b/workflow/dynamic_node.go
@@ -112,7 +112,12 @@ func (n *dynamicNode[IN, OUT]) Run(ctx agent.InvocationContext, input any) iter.
 
 		emit := makeEmit(yield, parentNC)
 		sub := newDynamicSubScheduler(parentNC, n.composePath(parentNC), emit)
-		orchestratorCtx := newDynamicNodeContext(parentNC, sub.parentPath, "", sub)
+		// If this node is itself a delegating child, carry its OutputFor
+		// chain so its own delegating children extend it.
+		if p, ok := parentNC.(*nodeContext); ok {
+			sub.outputForAncestors = p.outputForAncestors
+		}
+		orchestratorCtx := newDynamicNodeContext(parentNC, sub.parentPath, "", sub, nil)
 
 		out, err := n.fn(orchestratorCtx, typedInput, emit)
 		if err != nil {
@@ -125,12 +130,15 @@ func (n *dynamicNode[IN, OUT]) Run(ctx agent.InvocationContext, input any) iter.
 			return
 		}
 
-		ev := session.NewEvent(parentNC.InvocationID())
-		if delegated, ok := sub.delegatedOutput(); ok {
-			ev.Output = delegated
-		} else {
-			ev.Output = out
+		if sub.isDelegated() {
+			// A WithUseAsOutput child already carried this node's output
+			// up (its event is stamped OutputFor with this node's path),
+			// so don't emit a duplicate terminal event.
+			return
 		}
+
+		ev := session.NewEvent(parentNC.InvocationID())
+		ev.Output = out
 		ev.NodeInfo = &session.NodeInfo{Path: sub.parentPath}
 		// TODO(wolo): validate ev.Output against n.outputSchema,
 		// mirroring function_node.go:87-92.

--- a/workflow/dynamic_node.go
+++ b/workflow/dynamic_node.go
@@ -126,9 +126,13 @@ func (n *dynamicNode[IN, OUT]) Run(ctx agent.InvocationContext, input any) iter.
 		}
 
 		ev := session.NewEvent(parentNC.InvocationID())
-		ev.Output = out
+		if delegated, ok := sub.delegatedOutput(); ok {
+			ev.Output = delegated
+		} else {
+			ev.Output = out
+		}
 		ev.NodeInfo = &session.NodeInfo{Path: sub.parentPath}
-		// TODO(wolo): validate out against n.outputSchema before yielding,
+		// TODO(wolo): validate ev.Output against n.outputSchema,
 		// mirroring function_node.go:87-92.
 		yield(ev, nil)
 	}

--- a/workflow/dynamic_scheduler.go
+++ b/workflow/dynamic_scheduler.go
@@ -167,12 +167,10 @@ func (s *dynamicSubScheduler) runNode(child Node, input any, opts runNodeOptions
 		if ev.RequestedInput != nil {
 			interrupted = true
 		}
-		if ev.Output != nil {
-			out = ev.Output
-			// A delegated child's output is re-emitted by the
-			// parent's terminal event; drop it here to avoid a
-			// duplicate. Partial/state-only events (Output ==
-			// nil) still propagate.
+		// A delegated child's output is re-emitted on the parent's
+		// terminal event, so drop it here to avoid a duplicate.
+		if childOut, ok := childEventOutput(ev); ok {
+			out = childOut
 			if opts.useAsOutput {
 				continue
 			}

--- a/workflow/dynamic_scheduler.go
+++ b/workflow/dynamic_scheduler.go
@@ -38,6 +38,51 @@ type dynamicSubScheduler struct {
 	// childPath ("<parentPath>/<name>@<runID>"). Failures and HITL
 	// interrupts are not cached.
 	resultByPath map[string]any
+	delegation   outputDelegation
+}
+
+// outputDelegation is the at-most-one WithUseAsOutput delegation for a
+// parent activation. claim is set eagerly on the first delegating child
+// and never cleared within the activation (matching adk-python's
+// _output_delegated); a second delegating child is rejected. A fresh
+// sub-scheduler is built per activation, so there is nothing to reset
+// across turns. hasValue is the source of truth for readability because
+// nil is a valid delegated value.
+//
+// Methods require the enclosing scheduler's mu to be held.
+type outputDelegation struct {
+	claimed   bool
+	childPath string
+	childName string
+	value     any
+	hasValue  bool
+}
+
+// reserve claims the delegation for childPath. Re-claiming the same
+// childPath is a no-op (supports WithRunID replay). On conflict the
+// existing holder's name is returned for error reporting.
+func (d *outputDelegation) reserve(childPath, childName string) (existingName string, ok bool) {
+	if d.claimed && d.childPath != childPath {
+		return d.childName, false
+	}
+	d.claimed = true
+	d.childPath = childPath
+	d.childName = childName
+	return "", true
+}
+
+// commit publishes value for the claiming child. Mismatched childPath is
+// silently dropped rather than clobbering another child's delegation.
+func (d *outputDelegation) commit(childPath string, value any) {
+	if !d.claimed || d.childPath != childPath {
+		return
+	}
+	d.value = value
+	d.hasValue = true
+}
+
+func (d *outputDelegation) output() (any, bool) {
+	return d.value, d.hasValue
 }
 
 func newDynamicSubScheduler(parent NodeContext, parentPath string, emitUp func(*session.Event) error) *dynamicSubScheduler {
@@ -67,7 +112,18 @@ func (s *dynamicSubScheduler) runNode(child Node, input any, opts runNodeOptions
 	}
 	childPath := s.parentPath + "/" + name + "@" + runID
 
+	// Claim before child.Run so a sibling WithUseAsOutput fails fast
+	// rather than after the child finishes. The claim is not rolled back
+	// on interrupt/failure: the orchestrator body ends on the sentinel
+	// and resume rebuilds a fresh sub-scheduler.
+	if err := s.claimDelegation(childPath, name, opts.useAsOutput); err != nil {
+		return nil, err
+	}
+
+	// Cached (WithRunID replay): the child already ran, so publish its
+	// output for the delegation immediately.
 	if cached, ok := s.lookupCachedOutput(childPath); ok {
+		s.commitDelegation(childPath, cached)
 		return cached, nil
 	}
 
@@ -113,6 +169,13 @@ func (s *dynamicSubScheduler) runNode(child Node, input any, opts runNodeOptions
 		}
 		if ev.Output != nil {
 			out = ev.Output
+			// A delegated child's output is re-emitted by the
+			// parent's terminal event; drop it here to avoid a
+			// duplicate. Partial/state-only events (Output ==
+			// nil) still propagate.
+			if opts.useAsOutput {
+				continue
+			}
 		}
 		if err := s.emitUp(ev); err != nil {
 			return nil, &NodeRunError{
@@ -132,6 +195,7 @@ func (s *dynamicSubScheduler) runNode(child Node, input any, opts runNodeOptions
 	}
 
 	s.storeCachedOutput(childPath, out)
+	s.commitDelegation(childPath, out) // no-op unless this child claimed the delegation
 	return out, nil
 }
 
@@ -146,6 +210,39 @@ func (s *dynamicSubScheduler) storeCachedOutput(childPath string, out any) {
 	s.mu.Lock()
 	defer s.mu.Unlock()
 	s.resultByPath[childPath] = out
+}
+
+// claimDelegation reserves the at-most-one output delegation when
+// useAsOutput is set, mapping a conflict to NodeRunError. It is a no-op
+// (nil) when useAsOutput is false.
+func (s *dynamicSubScheduler) claimDelegation(childPath, childName string, useAsOutput bool) error {
+	if !useAsOutput {
+		return nil
+	}
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	existing, ok := s.delegation.reserve(childPath, childName)
+	if !ok {
+		return &NodeRunError{
+			ChildName: childName,
+			ChildPath: childPath,
+			Cause: fmt.Errorf("%w: %s already delegates to %s",
+				ErrOutputAlreadyDelegated, s.parentPath, existing),
+		}
+	}
+	return nil
+}
+
+func (s *dynamicSubScheduler) commitDelegation(childPath string, value any) {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	s.delegation.commit(childPath, value)
+}
+
+func (s *dynamicSubScheduler) delegatedOutput() (any, bool) {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	return s.delegation.output()
 }
 
 // resolveRunID validates a user-supplied id, or returns the next

--- a/workflow/dynamic_scheduler.go
+++ b/workflow/dynamic_scheduler.go
@@ -29,6 +29,12 @@ type dynamicSubScheduler struct {
 	parentCtx  NodeContext
 	emitUp     func(*session.Event) error
 
+	// outputForAncestors are the extra node paths this activation's
+	// output counts for, set when this activation is itself a
+	// WithUseAsOutput child. A delegating child's event is stamped
+	// OutputFor=[childPath, parentPath, ...outputForAncestors].
+	outputForAncestors []string
+
 	// mu guards everything below. Never held across child.Run.
 	mu sync.Mutex
 	// runCountByChild seeds the auto-counter per child name; the
@@ -41,21 +47,19 @@ type dynamicSubScheduler struct {
 	delegation   outputDelegation
 }
 
-// outputDelegation is the at-most-one WithUseAsOutput delegation for a
-// parent activation. claim is set eagerly on the first delegating child
-// and never cleared within the activation (matching adk-python's
-// _output_delegated); a second delegating child is rejected. A fresh
-// sub-scheduler is built per activation, so there is nothing to reset
-// across turns. hasValue is the source of truth for readability because
-// nil is a valid delegated value.
+// outputDelegation is the at-most-one WithUseAsOutput claim for a parent
+// activation. claimed is set eagerly on the first delegating child and
+// never cleared within the activation (matching adk-python's
+// _output_delegated); a second delegating child is rejected. The output
+// value flows up on the child's event (stamped OutputFor), so the claim
+// only needs to record that delegation happened, not the value. A fresh
+// sub-scheduler is built per activation, so nothing resets across turns.
 //
 // Methods require the enclosing scheduler's mu to be held.
 type outputDelegation struct {
 	claimed   bool
 	childPath string
 	childName string
-	value     any
-	hasValue  bool
 }
 
 // reserve claims the delegation for childPath. Re-claiming the same
@@ -69,20 +73,6 @@ func (d *outputDelegation) reserve(childPath, childName string) (existingName st
 	d.childPath = childPath
 	d.childName = childName
 	return "", true
-}
-
-// commit publishes value for the claiming child. Mismatched childPath is
-// silently dropped rather than clobbering another child's delegation.
-func (d *outputDelegation) commit(childPath string, value any) {
-	if !d.claimed || d.childPath != childPath {
-		return
-	}
-	d.value = value
-	d.hasValue = true
-}
-
-func (d *outputDelegation) output() (any, bool) {
-	return d.value, d.hasValue
 }
 
 func newDynamicSubScheduler(parent NodeContext, parentPath string, emitUp func(*session.Event) error) *dynamicSubScheduler {
@@ -120,15 +110,20 @@ func (s *dynamicSubScheduler) runNode(child Node, input any, opts runNodeOptions
 		return nil, err
 	}
 
-	// Cached (WithRunID replay): the child already ran, so publish its
-	// output for the delegation immediately.
+	// Cached (WithRunID replay): the child already ran.
 	if cached, ok := s.lookupCachedOutput(childPath); ok {
-		s.commitDelegation(childPath, cached)
 		return cached, nil
 	}
 
 	childBranch := deriveChildBranch(s.parentCtx.Branch(), name, runID, opts.useSubBranch, opts.overrideBranch)
-	childCtx := newDynamicNodeContext(s.parentCtx.WithBranch(childBranch), childPath, runID, s)
+	// A delegating child extends the OutputFor chain: its own delegating
+	// children must also count their output for this parent and its
+	// ancestors.
+	var childAncestors []string
+	if opts.useAsOutput {
+		childAncestors = append([]string{s.parentPath}, s.outputForAncestors...)
+	}
+	childCtx := newDynamicNodeContext(s.parentCtx.WithBranch(childBranch), childPath, runID, s, childAncestors)
 
 	// EXPERIMENTAL: stash childCtx (a *nodeContext with non-nil
 	// subScheduler) in the embedded context.Context so tools running
@@ -167,12 +162,22 @@ func (s *dynamicSubScheduler) runNode(child Node, input any, opts runNodeOptions
 		if ev.RequestedInput != nil {
 			interrupted = true
 		}
-		// A delegated child's output is re-emitted on the parent's
-		// terminal event, so drop it here to avoid a duplicate.
 		if childOut, ok := childEventOutput(ev); ok {
 			out = childOut
+			// Every output event records the paths its output counts
+			// for, starting with the emitter (mirrors adk-python
+			// _node_runner._enrich_event). Under delegation the same
+			// event also stands in for the parent and its ancestors, so
+			// the parent skips re-emitting a duplicate.
+			if ev.NodeInfo.OutputFor == nil {
+				ev.NodeInfo.OutputFor = []string{ev.NodeInfo.Path}
+			}
 			if opts.useAsOutput {
-				continue
+				ev.Output = childOut // may have been carried as message text
+				ev.NodeInfo.OutputFor = appendUnique(ev.NodeInfo.OutputFor, s.parentPath)
+				for _, a := range s.outputForAncestors {
+					ev.NodeInfo.OutputFor = appendUnique(ev.NodeInfo.OutputFor, a)
+				}
 			}
 		}
 		if err := s.emitUp(ev); err != nil {
@@ -193,7 +198,6 @@ func (s *dynamicSubScheduler) runNode(child Node, input any, opts runNodeOptions
 	}
 
 	s.storeCachedOutput(childPath, out)
-	s.commitDelegation(childPath, out) // no-op unless this child claimed the delegation
 	return out, nil
 }
 
@@ -231,16 +235,14 @@ func (s *dynamicSubScheduler) claimDelegation(childPath, childName string, useAs
 	return nil
 }
 
-func (s *dynamicSubScheduler) commitDelegation(childPath string, value any) {
+// isDelegated reports whether a child claimed this activation's output
+// via WithUseAsOutput. When true, that child's event already carried the
+// output up (stamped with OutputFor), so the parent must not emit its own
+// terminal output event.
+func (s *dynamicSubScheduler) isDelegated() bool {
 	s.mu.Lock()
 	defer s.mu.Unlock()
-	s.delegation.commit(childPath, value)
-}
-
-func (s *dynamicSubScheduler) delegatedOutput() (any, bool) {
-	s.mu.Lock()
-	defer s.mu.Unlock()
-	return s.delegation.output()
+	return s.delegation.claimed
 }
 
 // resolveRunID validates a user-supplied id, or returns the next
@@ -284,4 +286,14 @@ func isAllDigits(s string) bool {
 		}
 	}
 	return true
+}
+
+// appendUnique appends s to paths if not already present.
+func appendUnique(paths []string, s string) []string {
+	for _, p := range paths {
+		if p == s {
+			return paths
+		}
+	}
+	return append(paths, s)
 }

--- a/workflow/dynamic_scheduler_test.go
+++ b/workflow/dynamic_scheduler_test.go
@@ -21,6 +21,8 @@ import (
 	"sync"
 	"testing"
 
+	"google.golang.org/genai"
+
 	"google.golang.org/adk/agent"
 	"google.golang.org/adk/session"
 )
@@ -215,6 +217,33 @@ func (n *stubNode) Run(ctx agent.InvocationContext, _ any) iter.Seq2[*session.Ev
 	out := n.out
 	return func(yield func(*session.Event, error) bool) {
 		yield(&session.Event{Output: out}, nil)
+	}
+}
+
+// messageAsOutputNode emits a final model-text event whose content IS
+// its output (NodeInfo.MessageAsOutput set, Event.Output nil), like an
+// LlmAgent node in single_turn mode.
+type messageAsOutputNode struct {
+	BaseNode
+	text string
+}
+
+func newMessageAsOutputNode(name, text string) *messageAsOutputNode {
+	return &messageAsOutputNode{
+		BaseNode: NewBaseNode(name, "", NodeConfig{}),
+		text:     text,
+	}
+}
+
+func (n *messageAsOutputNode) Run(agent.InvocationContext, any) iter.Seq2[*session.Event, error] {
+	text := n.text
+	return func(yield func(*session.Event, error) bool) {
+		ev := &session.Event{NodeInfo: &session.NodeInfo{MessageAsOutput: true}}
+		ev.LLMResponse.Content = &genai.Content{
+			Role:  "model",
+			Parts: []*genai.Part{{Text: text}},
+		}
+		yield(ev, nil)
 	}
 }
 

--- a/workflow/errors.go
+++ b/workflow/errors.go
@@ -38,6 +38,10 @@ var (
 	// activation interrupting concurrently — at most one pending HITL
 	// per activation.
 	ErrParallelHITLUnsupported = errors.New("workflow: parallel HITL is not supported")
+
+	// ErrOutputAlreadyDelegated rejects a second WithUseAsOutput
+	// child in the same parent activation.
+	ErrOutputAlreadyDelegated = errors.New("workflow: parent already has a use_as_output child")
 )
 
 // NodeRunError wraps a sentinel with the failing child's identity.

--- a/workflow/node_context.go
+++ b/workflow/node_context.go
@@ -65,6 +65,11 @@ type nodeContext struct {
 	// subScheduler is non-nil only when this context belongs to a
 	// dynamic-node activation; RunNode uses it to schedule children.
 	subScheduler *dynamicSubScheduler
+
+	// outputForAncestors are the extra node paths this activation's
+	// output counts for, set when this activation is a WithUseAsOutput
+	// child so its own delegating children can extend the chain.
+	outputForAncestors []string
 }
 
 // Compile-time: *nodeContext implements NodeContext.
@@ -85,17 +90,18 @@ func newNodeContext(parent agent.InvocationContext, resumeInputs map[string]any)
 // dynamic node's own activation passes runID="" — it is not itself a
 // sub-scheduler child. Child inherits resumeInputs so HITL responses
 // reach dynamic children.
-func newDynamicNodeContext(parent NodeContext, path, runID string, sub *dynamicSubScheduler) *nodeContext {
+func newDynamicNodeContext(parent NodeContext, path, runID string, sub *dynamicSubScheduler, outputForAncestors []string) *nodeContext {
 	var inherited map[string]any
 	if p, ok := parent.(*nodeContext); ok {
 		inherited = p.resumeInputs
 	}
 	return &nodeContext{
-		InvocationContext: parent,
-		resumeInputs:      inherited,
-		path:              path,
-		runID:             runID,
-		subScheduler:      sub,
+		InvocationContext:  parent,
+		resumeInputs:       inherited,
+		path:               path,
+		runID:              runID,
+		subScheduler:       sub,
+		outputForAncestors: outputForAncestors,
 	}
 }
 
@@ -115,11 +121,12 @@ func (c *nodeContext) WithBranch(branch string) NodeContext {
 	// the underlying InvocationContext; preserve the NodeContext
 	// envelope (path, runID, resumeInputs, subScheduler) unchanged.
 	return &nodeContext{
-		InvocationContext: withBranch(c.InvocationContext, branch),
-		resumeInputs:      c.resumeInputs,
-		path:              c.path,
-		runID:             c.runID,
-		subScheduler:      c.subScheduler,
+		InvocationContext:  withBranch(c.InvocationContext, branch),
+		resumeInputs:       c.resumeInputs,
+		path:               c.path,
+		runID:              c.runID,
+		subScheduler:       c.subScheduler,
+		outputForAncestors: c.outputForAncestors,
 	}
 }
 
@@ -136,5 +143,6 @@ func (c *nodeContext) WithContext(ctx context.Context) agent.InvocationContext {
 		c.path,
 		c.runID,
 		c.subScheduler,
+		c.outputForAncestors,
 	}
 }

--- a/workflow/node_context_test.go
+++ b/workflow/node_context_test.go
@@ -60,7 +60,7 @@ func TestNodeContext_PathAndRunID(t *testing.T) {
 
 	t.Run("child populated from constructor", func(t *testing.T) {
 		parent := newNodeContext(newMockCtx(t), nil)
-		child := newDynamicNodeContext(parent, "wf/fixer@2", "2", nil)
+		child := newDynamicNodeContext(parent, "wf/fixer@2", "2", nil, nil)
 		if got, want := child.Path(), "wf/fixer@2"; got != want {
 			t.Errorf("Path() = %q, want %q", got, want)
 		}
@@ -71,7 +71,7 @@ func TestNodeContext_PathAndRunID(t *testing.T) {
 
 	t.Run("activation populated with empty runID", func(t *testing.T) {
 		parent := newNodeContext(newMockCtx(t), nil)
-		act := newDynamicNodeContext(parent, "city_workflow", "", nil)
+		act := newDynamicNodeContext(parent, "city_workflow", "", nil, nil)
 		if got, want := act.Path(), "city_workflow"; got != want {
 			t.Errorf("Path() = %q, want %q", got, want)
 		}
@@ -86,7 +86,7 @@ func TestNodeContext_DynamicInheritsResumeInputs(t *testing.T) {
 	sub := &dynamicSubScheduler{}
 
 	t.Run("child", func(t *testing.T) {
-		child := newDynamicNodeContext(parent, "wf/asker@1", "1", sub)
+		child := newDynamicNodeContext(parent, "wf/asker@1", "1", sub, nil)
 		if v, ok := child.ResumedInput("approval"); !ok || v != "yes" {
 			t.Errorf("child.ResumedInput(\"approval\") = (%v, %v), want (\"yes\", true)", v, ok)
 		}
@@ -96,7 +96,7 @@ func TestNodeContext_DynamicInheritsResumeInputs(t *testing.T) {
 	})
 
 	t.Run("activation", func(t *testing.T) {
-		act := newDynamicNodeContext(parent, "city_workflow", "", sub)
+		act := newDynamicNodeContext(parent, "city_workflow", "", sub, nil)
 		if v, ok := act.ResumedInput("approval"); !ok || v != "yes" {
 			t.Errorf("act.ResumedInput(\"approval\") = (%v, %v), want (\"yes\", true)", v, ok)
 		}

--- a/workflow/persistence.go
+++ b/workflow/persistence.go
@@ -190,6 +190,16 @@ func collectNodeOutputs(events session.Events, nodesByName map[string]Node) (out
 		completed[name] = true
 		if ev.Output != nil {
 			outputs[name] = ev.Output
+			// A delegated output (WithUseAsOutput) also counts for the
+			// static owners of the ancestor paths in OutputFor, so they
+			// recover their output without a re-emitted event.
+			for _, p := range ev.NodeInfo.OutputFor {
+				if owner := staticOwner(p); owner != name {
+					if _, ok := nodesByName[owner]; ok {
+						outputs[owner] = ev.Output
+					}
+				}
+			}
 		}
 	}
 	return outputs, completed
@@ -382,13 +392,18 @@ func firstUserInput(events session.Events) any {
 // LlmAgent node path, where Author == node name and no path is set.
 func eventNodeName(ev *session.Event) string {
 	if ev.NodeInfo != nil && ev.NodeInfo.Path != "" {
-		path := ev.NodeInfo.Path
-		if i := strings.IndexByte(path, '/'); i >= 0 {
-			return path[:i]
-		}
-		return path
+		return staticOwner(ev.NodeInfo.Path)
 	}
 	return ev.Author
+}
+
+// staticOwner returns the static graph node name owning a node path:
+// the first segment of a hierarchical "parent/child@1" path.
+func staticOwner(path string) string {
+	if i := strings.IndexByte(path, '/'); i >= 0 {
+		return path[:i]
+	}
+	return path
 }
 
 // frPart returns the FunctionResponse on a part if present and keyed.

--- a/workflow/run_node.go
+++ b/workflow/run_node.go
@@ -23,6 +23,7 @@ type runNodeOptions struct {
 	customRunID    string
 	useSubBranch   bool
 	overrideBranch string
+	useAsOutput    bool
 }
 
 // WithRunID overrides the auto-generated counter with a stable
@@ -52,6 +53,14 @@ func WithRunID(id string) RunNodeOption {
 // and the sub-branch segment is appended to it.
 func WithUseSubBranch() RunNodeOption {
 	return func(o *runNodeOptions) { o.useSubBranch = true }
+}
+
+// WithUseAsOutput promotes this child's output to the parent
+// dynamic node's terminal Output, discarding the value returned by
+// the orchestrator body. At most one delegating child per parent
+// activation; a second one fails with ErrOutputAlreadyDelegated.
+func WithUseAsOutput() RunNodeOption {
+	return func(o *runNodeOptions) { o.useAsOutput = true }
 }
 
 // WithOverrideBranch replaces the inherited branch verbatim,

--- a/workflow/run_node_test.go
+++ b/workflow/run_node_test.go
@@ -200,6 +200,48 @@ func TestRunNode_WithUseAsOutput_ChildOutputBecomesParentOutput(t *testing.T) {
 	}
 }
 
+func TestRunNode_WithUseAsOutput_MessageAsOutputChildBecomesParentOutput(t *testing.T) {
+	// A delegated child whose message IS its output (NodeInfo.
+	// MessageAsOutput, no explicit Output — like an LlmAgent node)
+	// promotes its model text to the parent's terminal Output.
+	child := newMessageAsOutputNode("c", "child_text")
+	n := NewDynamicNode[string, string](
+		"orch",
+		func(ctx NodeContext, _ string, _ func(*session.Event) error) (string, error) {
+			if _, err := RunNode[string](ctx, child, nil, WithUseAsOutput()); err != nil {
+				return "", err
+			}
+			return "parent_value", nil
+		},
+		NodeConfig{},
+	)
+	events := drainDynamic(t, n, "")
+	if got := parentTerminalOutput(t, events, "orch"); got != "child_text" {
+		t.Errorf("parent terminal Output = %v, want %q", got, "child_text")
+	}
+}
+
+func TestRunNode_WithUseAsOutput_MessageAsOutputEmptyTextIsValidOutput(t *testing.T) {
+	// Empty model text under MessageAsOutput is a valid output ("",
+	// not "no output"), matching adk-python. The parent's terminal
+	// Output must be the empty string, not nil.
+	child := newMessageAsOutputNode("c", "")
+	n := NewDynamicNode[string, string](
+		"orch",
+		func(ctx NodeContext, _ string, _ func(*session.Event) error) (string, error) {
+			if _, err := RunNode[string](ctx, child, nil, WithUseAsOutput()); err != nil {
+				return "", err
+			}
+			return "parent_value", nil
+		},
+		NodeConfig{},
+	)
+	events := drainDynamic(t, n, "")
+	if got := parentTerminalOutput(t, events, "orch"); got != "" {
+		t.Errorf("parent terminal Output = %#v, want empty string (MessageAsOutput treats \"\" as a valid output)", got)
+	}
+}
+
 func TestRunNode_WithUseAsOutput_SecondDelegationReturnsError(t *testing.T) {
 	c1 := newStubNode("c1", "v1")
 	c2 := newStubNode("c2", "v2")

--- a/workflow/run_node_test.go
+++ b/workflow/run_node_test.go
@@ -17,6 +17,7 @@ package workflow
 import (
 	"errors"
 	"iter"
+	"reflect"
 	"strings"
 	"sync"
 	"testing"
@@ -177,6 +178,43 @@ func TestRunNode_WithOverrideBranch_Empty_TreatedAsNoOverride(t *testing.T) {
 	}
 }
 
+func TestRunNode_WithUseAsOutput_ChildOutputBecomesParentOutput(t *testing.T) {
+	child := newStubNode("c", "child_value")
+	n := NewDynamicNode[string, string](
+		"orch",
+		func(ctx NodeContext, _ string, _ func(*session.Event) error) (string, error) {
+			if _, err := RunNode[string](ctx, child, nil, WithUseAsOutput()); err != nil {
+				return "", err
+			}
+			return "parent_value", nil
+		},
+		NodeConfig{},
+	)
+	events := drainDynamic(t, n, "")
+	if got := parentTerminalOutput(t, events, "orch"); got != "child_value" {
+		t.Errorf("parent terminal Output = %v, want %q", got, "child_value")
+	}
+	// Delegated child must not emit a duplicate output event.
+	if got := outputBearingPaths(events); !reflect.DeepEqual(got, []string{"orch"}) {
+		t.Errorf("paths of events with Output = %v, want exactly [\"orch\"]", got)
+	}
+}
+
+func TestRunNode_WithUseAsOutput_SecondDelegationReturnsError(t *testing.T) {
+	c1 := newStubNode("c1", "v1")
+	c2 := newStubNode("c2", "v2")
+	_, err := runInOrchestratorWithErr[string](t, func(ctx NodeContext) (string, error) {
+		if _, err := RunNode[string](ctx, c1, nil, WithUseAsOutput()); err != nil {
+			return "", err
+		}
+		_, err := RunNode[string](ctx, c2, nil, WithUseAsOutput())
+		return "", err
+	})
+	if !errors.Is(err, ErrOutputAlreadyDelegated) {
+		t.Errorf("err = %v, want errors.Is ErrOutputAlreadyDelegated", err)
+	}
+}
+
 func TestRunNode_WithRunID_IdempotentReplay(t *testing.T) {
 	child := newCountingStubNode("c", "the_value")
 	got1, got2 := "", ""
@@ -194,6 +232,32 @@ func TestRunNode_WithRunID_IdempotentReplay(t *testing.T) {
 	}
 	if got := child.runCount(); got != 1 {
 		t.Errorf("child.Run invocations = %d, want 1", got)
+	}
+}
+
+func TestRunNode_WithRunID_AndUseAsOutput_IdempotentReplay(t *testing.T) {
+	child := newCountingStubNode("c", "delegated_value")
+	n := NewDynamicNode[string, string](
+		"orch",
+		func(ctx NodeContext, _ string, _ func(*session.Event) error) (string, error) {
+			if _, err := RunNode[string](ctx, child, nil,
+				WithRunID("stable-id"), WithUseAsOutput()); err != nil {
+				return "", err
+			}
+			if _, err := RunNode[string](ctx, child, nil,
+				WithRunID("stable-id"), WithUseAsOutput()); err != nil {
+				return "", err
+			}
+			return "parent_value", nil
+		},
+		NodeConfig{},
+	)
+	events := drainDynamic(t, n, "")
+	if got := child.runCount(); got != 1 {
+		t.Errorf("child.Run invocations = %d, want 1", got)
+	}
+	if got := parentTerminalOutput(t, events, "orch"); got != "delegated_value" {
+		t.Errorf("parent terminal Output = %v, want %q", got, "delegated_value")
 	}
 }
 
@@ -245,7 +309,8 @@ func runInOrchestratorWithErr[OUT any](t *testing.T, orchestratorFn func(NodeCon
 		got    OUT
 		gotErr error
 	)
-	n := NewDynamicNode[string, OUT]("orch",
+	n := NewDynamicNode[string, OUT](
+		"orch",
 		func(ctx NodeContext, _ string, _ func(*session.Event) error) (OUT, error) {
 			got, gotErr = orchestratorFn(ctx)
 			if gotErr != nil {
@@ -260,6 +325,37 @@ func runInOrchestratorWithErr[OUT any](t *testing.T, orchestratorFn func(NodeCon
 		return got, runErr
 	}
 	return got, gotErr
+}
+
+// outputBearingPaths returns NodeInfo.Path of every event whose
+// Output is non-nil, preserving order.
+func outputBearingPaths(events []*session.Event) []string {
+	var paths []string
+	for _, ev := range events {
+		if ev.Output == nil {
+			continue
+		}
+		var path string
+		if ev.NodeInfo != nil {
+			path = ev.NodeInfo.Path
+		}
+		paths = append(paths, path)
+	}
+	return paths
+}
+
+// parentTerminalOutput returns the Output of the last event
+// stamped with parentPath.
+func parentTerminalOutput(t *testing.T, events []*session.Event, parentPath string) any {
+	t.Helper()
+	for i := len(events) - 1; i >= 0; i-- {
+		ev := events[i]
+		if ev.NodeInfo != nil && ev.NodeInfo.Path == parentPath {
+			return ev.Output
+		}
+	}
+	t.Fatalf("no event with NodeInfo.Path == %q found among %d events", parentPath, len(events))
+	return nil
 }
 
 // countingStubNode is a stubNode that counts Run invocations so

--- a/workflow/run_node_test.go
+++ b/workflow/run_node_test.go
@@ -17,7 +17,7 @@ package workflow
 import (
 	"errors"
 	"iter"
-	"reflect"
+	"slices"
 	"strings"
 	"sync"
 	"testing"
@@ -194,9 +194,14 @@ func TestRunNode_WithUseAsOutput_ChildOutputBecomesParentOutput(t *testing.T) {
 	if got := parentTerminalOutput(t, events, "orch"); got != "child_value" {
 		t.Errorf("parent terminal Output = %v, want %q", got, "child_value")
 	}
-	// Delegated child must not emit a duplicate output event.
-	if got := outputBearingPaths(events); !reflect.DeepEqual(got, []string{"orch"}) {
-		t.Errorf("paths of events with Output = %v, want exactly [\"orch\"]", got)
+	// Delegation produces exactly one output event (the child's, stamped
+	// OutputFor with the parent) — no duplicate parent re-emit.
+	outs := outputBearingEvents(events)
+	if len(outs) != 1 {
+		t.Fatalf("got %d output events, want 1 (no duplicate from delegation)", len(outs))
+	}
+	if !slices.Contains(outs[0].NodeInfo.OutputFor, "orch") {
+		t.Errorf("output event OutputFor = %v, want it to contain %q", outs[0].NodeInfo.OutputFor, "orch")
 	}
 }
 
@@ -240,6 +245,58 @@ func TestRunNode_WithUseAsOutput_MessageAsOutputEmptyTextIsValidOutput(t *testin
 	if got := parentTerminalOutput(t, events, "orch"); got != "" {
 		t.Errorf("parent terminal Output = %#v, want empty string (MessageAsOutput treats \"\" as a valid output)", got)
 	}
+}
+
+func TestRunNode_WithUseAsOutput_MultiLevelDelegationStampsAllAncestors(t *testing.T) {
+	// outer delegates to middle, which delegates to inner. inner's one
+	// output event must carry OutputFor for all three levels, and no
+	// duplicate output events are emitted.
+	inner := newStubNode("inner", "deep_value")
+	middle := NewDynamicNode[string, string](
+		"middle",
+		func(ctx NodeContext, _ string, _ func(*session.Event) error) (string, error) {
+			_, err := RunNode[string](ctx, inner, nil, WithUseAsOutput())
+			return "", err
+		},
+		NodeConfig{},
+	)
+	outer := NewDynamicNode[string, string](
+		"outer",
+		func(ctx NodeContext, _ string, _ func(*session.Event) error) (string, error) {
+			_, err := RunNode[string](ctx, middle, nil, WithUseAsOutput())
+			return "", err
+		},
+		NodeConfig{},
+	)
+	events := drainDynamic(t, outer, "")
+
+	outs := outputBearingEvents(events)
+	if len(outs) != 1 {
+		t.Fatalf("got %d output events, want 1 (multi-level delegation must not duplicate)", len(outs))
+	}
+	if outs[0].Output != "deep_value" {
+		t.Errorf("output = %v, want %q", outs[0].Output, "deep_value")
+	}
+	// Every level recovers its output from this single event: each
+	// node name appears as a segment of some OutputFor path.
+	for _, level := range []string{"outer", "middle", "inner"} {
+		if !slices.ContainsFunc(outs[0].NodeInfo.OutputFor, func(p string) bool {
+			return pathHasSegment(p, level)
+		}) {
+			t.Errorf("OutputFor %v does not cover level %q", outs[0].NodeInfo.OutputFor, level)
+		}
+	}
+}
+
+// pathHasSegment reports whether name appears as a path segment, with or
+// without a "@runID" suffix.
+func pathHasSegment(path, name string) bool {
+	for _, seg := range strings.Split(path, "/") {
+		if seg == name || strings.HasPrefix(seg, name+"@") {
+			return true
+		}
+	}
+	return false
 }
 
 func TestRunNode_WithUseAsOutput_SecondDelegationReturnsError(t *testing.T) {
@@ -369,34 +426,33 @@ func runInOrchestratorWithErr[OUT any](t *testing.T, orchestratorFn func(NodeCon
 	return got, gotErr
 }
 
-// outputBearingPaths returns NodeInfo.Path of every event whose
-// Output is non-nil, preserving order.
-func outputBearingPaths(events []*session.Event) []string {
-	var paths []string
+// outputBearingEvents returns every event whose Output is non-nil,
+// preserving order.
+func outputBearingEvents(events []*session.Event) []*session.Event {
+	var out []*session.Event
 	for _, ev := range events {
-		if ev.Output == nil {
-			continue
+		if ev.Output != nil {
+			out = append(out, ev)
 		}
-		var path string
-		if ev.NodeInfo != nil {
-			path = ev.NodeInfo.Path
-		}
-		paths = append(paths, path)
 	}
-	return paths
+	return out
 }
 
-// parentTerminalOutput returns the Output of the last event
-// stamped with parentPath.
+// parentTerminalOutput returns the Output of the last event that counts
+// as parentPath's output: either stamped with that Path, or carrying it
+// in OutputFor (the WithUseAsOutput delegation case).
 func parentTerminalOutput(t *testing.T, events []*session.Event, parentPath string) any {
 	t.Helper()
 	for i := len(events) - 1; i >= 0; i-- {
 		ev := events[i]
-		if ev.NodeInfo != nil && ev.NodeInfo.Path == parentPath {
+		if ev.NodeInfo == nil {
+			continue
+		}
+		if ev.NodeInfo.Path == parentPath || slices.Contains(ev.NodeInfo.OutputFor, parentPath) {
 			return ev.Output
 		}
 	}
-	t.Fatalf("no event with NodeInfo.Path == %q found among %d events", parentPath, len(events))
+	t.Fatalf("no event for node %q found among %d events", parentPath, len(events))
 	return nil
 }
 

--- a/workflow/scheduler.go
+++ b/workflow/scheduler.go
@@ -644,8 +644,8 @@ func (s *scheduler) handleEvent(it eventItem) {
 	if it.ev.Routes != nil {
 		nr.setRoutingEvent(it.ev, it.nodeName)
 	}
-	if it.ev.Output != nil {
-		nr.setOutput(it.ev.Output, it.nodeName)
+	if out, ok := childEventOutput(it.ev); ok {
+		nr.setOutput(out, it.nodeName)
 	}
 }
 

--- a/workflow/scheduler.go
+++ b/workflow/scheduler.go
@@ -645,6 +645,12 @@ func (s *scheduler) handleEvent(it eventItem) {
 		nr.setRoutingEvent(it.ev, it.nodeName)
 	}
 	if out, ok := childEventOutput(it.ev); ok {
+		// Record the paths this output counts for. Dynamic children
+		// arrive pre-stamped (delegation chain); other output events
+		// get their own path. Mirrors adk-python _enrich_event.
+		if it.ev.NodeInfo != nil && it.ev.NodeInfo.OutputFor == nil {
+			it.ev.NodeInfo.OutputFor = []string{it.ev.NodeInfo.Path}
+		}
 		nr.setOutput(out, it.nodeName)
 	}
 }

--- a/workflow/scheduler_test.go
+++ b/workflow/scheduler_test.go
@@ -57,6 +57,28 @@ func TestScheduler_LinearChain(t *testing.T) {
 	}
 }
 
+// TestScheduler_MessageAsOutput_FeedsSuccessor verifies that a node
+// whose message IS its output (NodeInfo.MessageAsOutput, no explicit
+// Event.Output) has its model text derived as the node output and fed
+// to the successor as input.
+func TestScheduler_MessageAsOutput_FeedsSuccessor(t *testing.T) {
+	mockCtx := newSeededMockCtx(t)
+
+	a := newMessageAsOutputNode("A", "hello")
+	b := newRecordingNode("B")
+	b.release()
+
+	w := mustNew(t, Chain(Start, a, b))
+
+	gotEvents := drain(t, w.Run(mockCtx))
+
+	// B echoes "<input>:B"; the input must be A's derived output.
+	got := outputsOf(gotEvents)
+	if len(got) != 1 || got[0] != "hello:B" {
+		t.Errorf("outputs = %v, want [\"hello:B\"] (A's message text fed to B)", got)
+	}
+}
+
 // TestScheduler_FanOutConcurrency verifies that three nodes
 // downstream of START are mid-Run simultaneously, not serialised by
 // the legacy BFS. Each node blocks on its release channel until the


### PR DESCRIPTION
…ution

Add NodeInfo.OutputFor: the node paths an event's Output counts for — the emitter plus any WithUseAsOutput delegating ancestors. A delegating child's single event is stamped OutputFor=[child, parent, ...] and flows up, and the parent no longer re-emits a duplicate terminal output event (full suppression, matching adk-python's _output_delegated + output_for). Resume attributes a descendant's output to its delegating ancestors via OutputFor. Every output event records OutputFor (own path minimum), mirroring adk-python _enrich_event.

Built on the temp integration branch (#960 + #920 + #966); rebase onto v2 once those merge.

**Please ensure you have read the [contribution guide](./CONTRIBUTING.md) before creating a pull request.**

### Link to Issue or Description of Change

**1. Link to an existing issue (if applicable):**

- Closes: #_issue_number_
- Related: #_issue_number_

**2. Or, if no issue exists, describe the change:**

_If applicable, please follow the issue templates to provide as much detail as
possible._

**Problem:**
_A clear and concise description of what the problem is._

**Solution:**
_A clear and concise description of what you want to happen and why you choose
this solution._

### Testing Plan

_Please describe the tests that you ran to verify your changes. This is required
for all PRs that are not small documentation or typo fixes._

**Unit Tests:**

- [ ] I have added or updated unit tests for my change.
- [ ] All unit tests pass locally.

_Please include a summary of passed go test results._

**Manual End-to-End (E2E) Tests:**

_Please provide instructions on how to manually test your changes, including any
necessary setup or configuration. Please provide logs or screenshots to help
reviewers better understand the fix._

### Checklist

- [ ] I have read the [CONTRIBUTING.md](./CONTRIBUTING.md) document.
- [ ] I have performed a self-review of my own code.
- [ ] I have commented my code, particularly in hard-to-understand areas.
- [ ] I have added tests that prove my fix is effective or that my feature works.
- [ ] New and existing unit tests pass locally with my changes.
- [ ] I have manually tested my changes end-to-end.
- [ ] Any dependent changes have been merged and published in downstream modules.

### Additional context

_Add any other context or screenshots about the feature request here._

