### PR TITLE
fix(remoteagent/v2): invoke AfterA2ARequestCallbacks on synthesized aggregated events

### DIFF
--- a/agent/remoteagent/v2/a2a_agent.go
+++ b/agent/remoteagent/v2/a2a_agent.go
@@ -281,6 +281,17 @@ func (a *a2aAgent) run(ctx agent.InvocationContext, cfg A2AConfig) iter.Seq2[*se
 
 			if event != nil { // an event might be skipped
 				for _, toEmit := range processor.aggregatePartial(ctx, a2aEvent, event) {
+					// aggregatePartial may synthesize new events (e.g. aggregated non-partial artifact
+					// events). Run callbacks on those synthesized events; the original event already
+					// went through callbacks above.
+					if toEmit != event {
+						if cbResp, cbErr := processor.runAfterA2ARequestCallbacks(ctx, toEmit, nil); cbResp != nil || cbErr != nil {
+							if cbErr != nil {
+								return yieldErr(cbErr)
+							}
+							toEmit = cbResp
+						}
+					}
 					if !yield(toEmit, nil) {
 						return false
 					}

--- a/agent/remoteagent/v2/a2a_agent_test.go
+++ b/agent/remoteagent/v2/a2a_agent_test.go
@@ -1435,3 +1435,68 @@ func TestRemoteAgent_PartConverter(t *testing.T) {
 		}
 	}
 }
+
+func TestRemoteAgent_AfterCallbackInvokedOnAggregatedEvent(t *testing.T) {
+	// Regression: AfterA2ARequestCallbacks must be invoked on the aggregated non-partial event
+	// synthesized from partial artifact chunks, not only on the individual chunk events.
+	var cbInvocations int
+	var sawNonPartialContent []string
+
+	executor := &mockA2AExecutor{
+		executeFn: func(ctx context.Context, execCtx *a2asrv.ExecutorContext) iter.Seq2[a2a.Event, error] {
+			return func(yield func(a2a.Event, error) bool) {
+				artifactEvent := a2a.NewArtifactEvent(execCtx, a2a.NewTextPart("Hel"))
+				for _, ev := range []a2a.Event{
+					a2a.NewSubmittedTask(execCtx, a2a.NewMessage(a2a.MessageRoleUser, a2a.NewTextPart("hi"))),
+					artifactEvent,
+					a2a.NewArtifactUpdateEvent(execCtx, artifactEvent.Artifact.ID, a2a.NewTextPart("lo")),
+					a2a.NewStatusUpdateEvent(execCtx, a2a.TaskStateCompleted, nil),
+				} {
+					if !yield(ev, nil) {
+						return
+					}
+				}
+			}
+		},
+	}
+
+	server := startA2AServer(executor)
+	card := &a2a.AgentCard{
+		SupportedInterfaces: []*a2a.AgentInterface{
+			a2a.NewAgentInterface(server.URL, a2a.TransportProtocolJSONRPC),
+		},
+		Capabilities: a2a.AgentCapabilities{Streaming: true},
+	}
+	remoteAgent, err := NewA2A(A2AConfig{
+		Name:      "a2a",
+		AgentCard: card,
+		AfterRequestCallbacks: []AfterA2ARequestCallback{
+			func(ctx agent.CallbackContext, req *a2a.SendMessageRequest, result *session.Event, err error) (*session.Event, error) {
+				cbInvocations++
+				if !result.Partial && !result.TurnComplete && result.Content != nil {
+					for _, p := range result.Content.Parts {
+						sawNonPartialContent = append(sawNonPartialContent, p.Text)
+					}
+				}
+				return nil, nil
+			},
+		},
+	})
+	if err != nil {
+		t.Fatalf("remoteagent.NewA2A() error = %v", err)
+	}
+
+	ictx := newInvocationContext(t, []*session.Event{newUserHello()})
+	if _, err = runAndCollect(ictx, remoteAgent); err != nil {
+		t.Fatalf("agent.Run() error = %v", err)
+	}
+
+	// Expect 4 callback invocations: "Hel" (partial), "lo" (partial), aggregated "Hello" (non-partial), terminal.
+	if cbInvocations != 4 {
+		t.Errorf("callback invoked %d times, want 4", cbInvocations)
+	}
+	// The synthesized aggregated event must be received by the callback.
+	if diff := cmp.Diff([]string{"Hello"}, sawNonPartialContent); diff != "" {
+		t.Errorf("non-partial content seen by callback (-want +got):\n%s", diff)
+	}
+}


### PR DESCRIPTION
**Please ensure you have read the contribution guide before creating a pull request.**

### Link to Issue or Description of Change
- Closes: #948

### Root Cause

`aggregatePartial` synthesizes new non-partial events via `buildNonPartialAggregation` when accumulated partial artifact chunks arrive before a terminal status update. These synthesized events were emitted directly via `yield` without going through `runAfterA2ARequestCallbacks`, so registered `AfterA2ARequestCallback` handlers never received them.

The original event (converted from the individual A2A chunk) correctly went through the callbacks, but the aggregated result—which is the event callers actually care about—did not.

### Fix

In `processEvent`, after calling `aggregatePartial`, run `runAfterA2ARequestCallbacks` on each emitted event whose pointer differs from the original `event` (i.e., synthesized aggregated events). The original event already went through callbacks above the `aggregatePartial` call.

```go
for _, toEmit := range processor.aggregatePartial(ctx, a2aEvent, event) {
    if toEmit != event {
        if cbResp, cbErr := processor.runAfterA2ARequestCallbacks(ctx, toEmit, nil); cbResp != nil || cbErr != nil {
            if cbErr != nil {
                return yieldErr(cbErr)
            }
            toEmit = cbResp
        }
    }
    if !yield(toEmit, nil) {
        return false
    }
}
```

### Testing Plan
**Unit Tests:**
- [x] Added `TestRemoteAgent_AfterCallbackInvokedOnAggregatedEvent`: streams two partial artifact chunks ("Hel" + "lo") followed by a terminal status. Registers a callback that counts invocations and records non-partial content text. Asserts 4 callback invocations (partial×2 + aggregated + terminal) and `["Hello"]` as the text seen by the callback for the aggregated non-partial event.
- [x] All existing tests in `./agent/remoteagent/v2/...` continue to pass.

**Manual End-to-End (E2E) Tests:**
The fix is contained to the callback dispatch path in `processEvent`. The change is additive—existing behavior is preserved for the common case (single-event slice from `aggregatePartial`) and the new path only fires when a synthesized aggregated event is present.

### Checklist
- [x] Read CONTRIBUTING.md
- [x] Self-reviewed code
- [x] Added tests proving fix
- [x] New and existing tests pass