### PR TITLE
feat(launcher): add HTTPMiddleware seam to launcher.Config

### DIFF
--- a/cmd/launcher/launcher.go
+++ b/cmd/launcher/launcher.go
@@ -17,6 +17,7 @@ package launcher
 
 import (
 	"context"
+	"net/http"
 
 	"github.com/a2aproject/a2a-go/v2/a2asrv"
 
@@ -63,4 +64,9 @@ type Config struct {
 	A2AOptions       []a2asrv.RequestHandlerOption
 	PluginConfig     runner.PluginConfig
 	TelemetryOptions []telemetry.Option
+	// HTTPMiddleware is applied in order to the HTTP handler before serving.
+	// Each entry wraps the handler returned by the previous one. The first
+	// middleware in the slice is the outermost (runs first on inbound requests).
+	// A nil or empty slice is a no-op; existing callers are unaffected.
+	HTTPMiddleware []func(http.Handler) http.Handler
 }

--- a/cmd/launcher/web/web.go
+++ b/cmd/launcher/web/web.go
@@ -182,12 +182,17 @@ func (w *webLauncher) Run(ctx context.Context, config *launcher.Config) error {
 	}
 	log.Println()
 
+	var handler http.Handler = router
+	for i := len(config.HTTPMiddleware) - 1; i >= 0; i-- {
+		handler = config.HTTPMiddleware[i](handler)
+	}
+
 	srv := http.Server{
 		Addr:         fmt.Sprintf(":%v", fmt.Sprint(w.config.port)),
 		WriteTimeout: w.config.writeTimeout,
 		ReadTimeout:  w.config.readTimeout,
 		IdleTimeout:  w.config.idleTimeout,
-		Handler:      router,
+		Handler:      handler,
 	}
 
 	errChan := make(chan error, 1)

--- a/cmd/launcher/web/web_test.go
+++ b/cmd/launcher/web/web_test.go
@@ -1,0 +1,118 @@
+// Copyright 2025 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package web_test
+
+import (
+	"context"
+	"fmt"
+	"net"
+	"net/http"
+	"testing"
+	"time"
+
+	"github.com/gorilla/mux"
+
+	"google.golang.org/adk/cmd/launcher"
+	"google.golang.org/adk/cmd/launcher/web"
+	"google.golang.org/adk/session"
+)
+
+// minimalSublauncher is a stub Sublauncher for testing the web launcher.
+type minimalSublauncher struct{}
+
+func (m *minimalSublauncher) Keyword() string                             { return "stub" }
+func (m *minimalSublauncher) Parse(args []string) ([]string, error)       { return args, nil }
+func (m *minimalSublauncher) CommandLineSyntax() string                   { return "" }
+func (m *minimalSublauncher) SimpleDescription() string                   { return "" }
+func (m *minimalSublauncher) UserMessage(_ string, _ func(v ...any))      {}
+func (m *minimalSublauncher) SetupSubrouters(router *mux.Router, _ *launcher.Config) error {
+	router.HandleFunc("/ping", func(w http.ResponseWriter, r *http.Request) {
+		w.WriteHeader(http.StatusOK)
+	})
+	return nil
+}
+
+func getFreePort(t *testing.T) int {
+	t.Helper()
+	addr, err := net.ResolveTCPAddr("tcp", "localhost:0")
+	if err != nil {
+		t.Fatalf("net.ResolveTCPAddr() error = %v", err)
+	}
+	l, err := net.ListenTCP("tcp", addr)
+	if err != nil {
+		t.Fatalf("net.ListenTCP() error = %v", err)
+	}
+	port := l.Addr().(*net.TCPAddr).Port
+	l.Close()
+	return port
+}
+
+func TestHTTPMiddleware_AppliedOutermostFirst(t *testing.T) {
+	var order []string
+
+	makeMiddleware := func(name string) func(http.Handler) http.Handler {
+		return func(next http.Handler) http.Handler {
+			return http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+				order = append(order, name)
+				next.ServeHTTP(w, r)
+			})
+		}
+	}
+
+	port := getFreePort(t)
+	config := &launcher.Config{
+		SessionService: session.InMemoryService(),
+		HTTPMiddleware: []func(http.Handler) http.Handler{
+			makeMiddleware("first"),
+			makeMiddleware("second"),
+		},
+	}
+
+	ctx, cancel := context.WithCancel(t.Context())
+	defer cancel()
+
+	webLauncher := web.NewLauncher(&minimalSublauncher{})
+	errCh := make(chan error, 1)
+	go func() {
+		args := []string{fmt.Sprintf("--port=%d", port), "stub"}
+		errCh <- webLauncher.Execute(ctx, config, args)
+	}()
+
+	// Wait for the server to start accepting connections.
+	deadline := time.Now().Add(5 * time.Second)
+	var pingErr error
+	for time.Now().Before(deadline) {
+		var resp *http.Response
+		resp, pingErr = http.Get(fmt.Sprintf("http://localhost:%d/ping", port))
+		if pingErr == nil {
+			resp.Body.Close()
+			break
+		}
+		time.Sleep(50 * time.Millisecond)
+	}
+	if pingErr != nil {
+		t.Fatalf("server did not start in time: %v", pingErr)
+	}
+
+	cancel()
+	<-errCh
+
+	if len(order) < 2 {
+		t.Fatalf("middleware not invoked; got invocation order: %v", order)
+	}
+	if order[0] != "first" || order[1] != "second" {
+		t.Errorf("middleware invocation order = %v, want [first second ...]", order)
+	}
+}

--- a/cmd/launcher/web/web_test.go
+++ b/cmd/launcher/web/web_test.go
@@ -33,11 +33,11 @@ import (
 // minimalSublauncher is a stub Sublauncher for testing the web launcher.
 type minimalSublauncher struct{}
 
-func (m *minimalSublauncher) Keyword() string                             { return "stub" }
-func (m *minimalSublauncher) Parse(args []string) ([]string, error)       { return args, nil }
-func (m *minimalSublauncher) CommandLineSyntax() string                   { return "" }
-func (m *minimalSublauncher) SimpleDescription() string                   { return "" }
-func (m *minimalSublauncher) UserMessage(_ string, _ func(v ...any))      {}
+func (m *minimalSublauncher) Keyword() string                        { return "stub" }
+func (m *minimalSublauncher) Parse(args []string) ([]string, error)  { return args, nil }
+func (m *minimalSublauncher) CommandLineSyntax() string              { return "" }
+func (m *minimalSublauncher) SimpleDescription() string              { return "" }
+func (m *minimalSublauncher) UserMessage(_ string, _ func(v ...any)) {}
 func (m *minimalSublauncher) SetupSubrouters(router *mux.Router, _ *launcher.Config) error {
 	router.HandleFunc("/ping", func(w http.ResponseWriter, r *http.Request) {
 		w.WriteHeader(http.StatusOK)

--- a/cmd/launcher/web/web_test.go
+++ b/cmd/launcher/web/web_test.go
@@ -24,10 +24,10 @@ import (
 
 	"github.com/gorilla/mux"
 
-	"google.golang.org/adk/cmd/launcher"
-	"google.golang.org/adk/cmd/launcher/universal"
-	"google.golang.org/adk/cmd/launcher/web"
-	"google.golang.org/adk/session"
+	"google.golang.org/adk/v2/cmd/launcher"
+	"google.golang.org/adk/v2/cmd/launcher/universal"
+	"google.golang.org/adk/v2/cmd/launcher/web"
+	"google.golang.org/adk/v2/session"
 )
 
 // minimalSublauncher is a stub Sublauncher for testing the web launcher.
@@ -56,7 +56,9 @@ func getFreePort(t *testing.T) int {
 		t.Fatalf("net.ListenTCP() error = %v", err)
 	}
 	port := l.Addr().(*net.TCPAddr).Port
-	l.Close()
+	if err := l.Close(); err != nil {
+		t.Fatalf("l.Close() error = %v", err)
+	}
 	return port
 }
 
@@ -99,7 +101,9 @@ func TestHTTPMiddleware_AppliedOutermostFirst(t *testing.T) {
 		var resp *http.Response
 		resp, pingErr = http.Get(fmt.Sprintf("http://localhost:%d/ping", port))
 		if pingErr == nil {
-			resp.Body.Close()
+			if err := resp.Body.Close(); err != nil {
+				t.Fatalf("resp.Body.Close() error = %v", err)
+			}
 			break
 		}
 		time.Sleep(50 * time.Millisecond)

--- a/cmd/launcher/web/web_test.go
+++ b/cmd/launcher/web/web_test.go
@@ -25,6 +25,7 @@ import (
 	"github.com/gorilla/mux"
 
 	"google.golang.org/adk/cmd/launcher"
+	"google.golang.org/adk/cmd/launcher/universal"
 	"google.golang.org/adk/cmd/launcher/web"
 	"google.golang.org/adk/session"
 )
@@ -84,10 +85,11 @@ func TestHTTPMiddleware_AppliedOutermostFirst(t *testing.T) {
 	defer cancel()
 
 	webLauncher := web.NewLauncher(&minimalSublauncher{})
+	l := universal.NewLauncher(webLauncher)
 	errCh := make(chan error, 1)
 	go func() {
 		args := []string{fmt.Sprintf("--port=%d", port), "stub"}
-		errCh <- webLauncher.Execute(ctx, config, args)
+		errCh <- l.Execute(ctx, config, args)
 	}()
 
 	// Wait for the server to start accepting connections.


### PR DESCRIPTION
**Please ensure you have read the contribution guide before creating a pull request.**

### Link to Issue or Description of Change
- Closes: #965

### Root Cause / Motivation

Embedders that wrap ADK Go inside a larger application have no way to insert HTTP middleware into the launcher's request pipeline. `webLauncher.Run` builds the `http.Server` directly from the router with no public hook for wrapping the handler. The concrete case described in the issue is distributed-tracing context extraction (`otelhttp.NewHandler`), but the pattern applies to any cross-cutting concern (auth, rate-limiting, request-ID injection, etc.).

### Change

Add `HTTPMiddleware []func(http.Handler) http.Handler` to `launcher.Config`:

```go
// HTTPMiddleware is applied in order to the HTTP handler before serving.
// Each entry wraps the handler returned by the previous one. The first
// middleware in the slice is the outermost (runs first on inbound requests).
// A nil or empty slice is a no-op; existing callers are unaffected.
HTTPMiddleware []func(http.Handler) http.Handler
```

Apply the chain in `webLauncher.Run` before constructing `http.Server`:

```go
var handler http.Handler = router
for i := len(config.HTTPMiddleware) - 1; i >= 0; i-- {
    handler = config.HTTPMiddleware[i](handler)
}
```

The reverse-index loop produces outer-first ordering (slice index 0 runs first on inbound requests), matching `chi.Use` / `mux.Use` conventions. The zero-value (nil slice) is a no-op, so all existing callers are unaffected.

### Testing Plan
**Unit Tests:**
- [x] Added `TestHTTPMiddleware_AppliedOutermostFirst` in `cmd/launcher/web/web_test.go`: starts the web server with two named middlewares, fires a `/ping` request, and asserts that the invocation order matches slice order (`["first", "second", ...]`).
- [x] All existing tests in `./cmd/launcher/...` continue to pass.

**Manual End-to-End (E2E) Tests:**
Embedder usage after the change:
```go
config := &launcher.Config{
    AgentLoader: agent.NewSingleLoader(myAgent),
    TelemetryOptions: []telemetry.Option{
        telemetry.WithTracerProvider(myTP),
    },
    HTTPMiddleware: []func(http.Handler) http.Handler{
        func(h http.Handler) http.Handler {
            return otelhttp.NewHandler(h, "agent-name",
                otelhttp.WithPropagators(otel.GetTextMapPropagator()))
        },
    },
}
return full.NewLauncher().Execute(ctx, config, args)
```

### Checklist
- [x] Read CONTRIBUTING.md
- [x] Self-reviewed code
- [x] Commented field doc (ordering semantics are non-obvious)
- [x] Added tests proving the feature
- [x] New and existing tests pass
- [x] Purely additive — zero-value is a no-op, no existing callers affected