### PR TITLE
feat(adkgo/deploy): add --env flag to agentengine deploy subcommand

### DIFF
--- a/cmd/adkgo/internal/deploy/agentengine/agentengine.go
+++ b/cmd/adkgo/internal/deploy/agentengine/agentengine.go
@@ -57,6 +57,7 @@ type agentEngineServiceFlags struct {
 	serverPort    int
 	agentEngineID string
 	memoryBank    memoryBankFlags
+	envVars       []string
 }
 
 type buildFlags struct {
@@ -110,6 +111,21 @@ func init() {
 		" https://${LOCATION_ID}-aiplatform.googleapis.com/v1beta1/publishers/google/models. It will be prefixed with projects/<project_name>/locations/<region> forming for instance full model name like "+
 		" 'projects/project_name/locations/us-central1/publishers/google/models/gemini-2.5-flash'")
 	agentEngineCmd.PersistentFlags().DurationVar(&flags.agentEngine.memoryBank.ttl, "mem_ttl", time.Hour*24*365, "Time-To-Live for memories")
+	agentEngineCmd.PersistentFlags().StringArrayVar(&flags.agentEngine.envVars, "env", nil, "Additional environment variable in KEY=VALUE format. Repeatable.")
+}
+
+// parseEnvVars converts a slice of "KEY=VALUE" strings into EnvVar protos.
+// Returns an error for any entry that does not contain "=".
+func parseEnvVars(raw []string) ([]*aiplatformpb.EnvVar, error) {
+	vars := make([]*aiplatformpb.EnvVar, 0, len(raw))
+	for _, s := range raw {
+		parts := strings.SplitN(s, "=", 2)
+		if len(parts) != 2 {
+			return nil, fmt.Errorf("invalid --env value %q: expected KEY=VALUE", s)
+		}
+		vars = append(vars, &aiplatformpb.EnvVar{Name: parts[0], Value: parts[1]})
+	}
+	return vars, nil
 }
 
 // computeFlags uses command line arguments to create a full config
@@ -255,6 +271,17 @@ func (f *deployAgentEngineFlags) gcloudDeployToAgentEngine() error {
 			}
 			p("Methods:", string(methodsJSON))
 
+			defaultEnv := []*aiplatformpb.EnvVar{
+				{Name: "GOOGLE_CLOUD_REGION", Value: f.gcloud.region},
+				{Name: "NUM_WORKERS", Value: "1"},
+				{Name: "GOOGLE_CLOUD_AGENT_ENGINE_ENABLE_TELEMETRY", Value: "true"},
+				{Name: "OTEL_INSTRUMENTATION_GENAI_CAPTURE_MESSAGE_CONTENT", Value: "true"},
+			}
+			extraEnv, err := parseEnvVars(f.agentEngine.envVars)
+			if err != nil {
+				return err
+			}
+
 			req := &aiplatformpb.CreateReasoningEngineRequest{
 				Parent: parent,
 				ReasoningEngine: &aiplatformpb.ReasoningEngine{
@@ -274,11 +301,9 @@ func (f *deployAgentEngineFlags) gcloudDeployToAgentEngine() error {
 						},
 						AgentFramework: "google-adk",
 						DeploymentSpec: &aiplatformpb.ReasoningEngineSpec_DeploymentSpec{
-							Env: []*aiplatformpb.EnvVar{
-								{Name: "GOOGLE_CLOUD_REGION", Value: f.gcloud.region},
-								{Name: "NUM_WORKERS", Value: "1"},
-								{Name: "GOOGLE_CLOUD_AGENT_ENGINE_ENABLE_TELEMETRY", Value: "true"},
-								{Name: "OTEL_INSTRUMENTATION_GENAI_CAPTURE_MESSAGE_CONTENT", Value: "true"},
+							Env: append(defaultEnv, extraEnv...),
+							SecretEnv: []*aiplatformpb.SecretEnvVar{
+								{Name: "GOOGLE_API_KEY", SecretRef: &aiplatformpb.SecretRef{Secret: "GOOGLE_API_KEY", Version: "latest"}},
 							},
 						},
 						ClassMethods: methods,
@@ -352,6 +377,11 @@ func (f *deployAgentEngineFlags) gcloudUpdateAgentEngine() error {
 			}
 			p("Methods:", string(methodsJSON))
 
+			extraEnv, err := parseEnvVars(f.agentEngine.envVars)
+			if err != nil {
+				return err
+			}
+
 			req := &aiplatformpb.UpdateReasoningEngineRequest{
 				ReasoningEngine: &aiplatformpb.ReasoningEngine{
 					Name: name,
@@ -372,6 +402,19 @@ func (f *deployAgentEngineFlags) gcloudUpdateAgentEngine() error {
 					},
 				},
 				UpdateMask: &fieldmaskpb.FieldMask{Paths: []string{"spec.source_code_spec", "spec.class_methods"}},
+			}
+
+			if len(extraEnv) > 0 {
+				defaultEnv := []*aiplatformpb.EnvVar{
+					{Name: "GOOGLE_CLOUD_REGION", Value: f.gcloud.region},
+					{Name: "NUM_WORKERS", Value: "1"},
+					{Name: "GOOGLE_CLOUD_AGENT_ENGINE_ENABLE_TELEMETRY", Value: "true"},
+					{Name: "OTEL_INSTRUMENTATION_GENAI_CAPTURE_MESSAGE_CONTENT", Value: "true"},
+				}
+				req.ReasoningEngine.Spec.DeploymentSpec = &aiplatformpb.ReasoningEngineSpec_DeploymentSpec{
+					Env: append(defaultEnv, extraEnv...),
+				}
+				req.UpdateMask.Paths = append(req.UpdateMask.Paths, "spec.deployment_spec")
 			}
 
 			if f.agentEngine.memoryBank.deploy {

--- a/cmd/adkgo/internal/deploy/agentengine/agentengine_test.go
+++ b/cmd/adkgo/internal/deploy/agentengine/agentengine_test.go
@@ -1,0 +1,87 @@
+// Copyright 2026 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package agentengine
+
+import (
+	"testing"
+
+	"cloud.google.com/go/aiplatform/apiv1beta1/aiplatformpb"
+	"github.com/google/go-cmp/cmp"
+	"google.golang.org/protobuf/testing/protocmp"
+)
+
+func TestParseEnvVars(t *testing.T) {
+	tests := []struct {
+		name    string
+		raw     []string
+		want    []*aiplatformpb.EnvVar
+		wantErr bool
+	}{
+		{
+			name: "nil input returns empty",
+			raw:  nil,
+			want: []*aiplatformpb.EnvVar{},
+		},
+		{
+			name: "single key=value",
+			raw:  []string{"FOO=bar"},
+			want: []*aiplatformpb.EnvVar{{Name: "FOO", Value: "bar"}},
+		},
+		{
+			name: "value contains equals sign",
+			raw:  []string{"URL=http://example.com?a=1&b=2"},
+			want: []*aiplatformpb.EnvVar{{Name: "URL", Value: "http://example.com?a=1&b=2"}},
+		},
+		{
+			name: "empty value",
+			raw:  []string{"EMPTY="},
+			want: []*aiplatformpb.EnvVar{{Name: "EMPTY", Value: ""}},
+		},
+		{
+			name: "multiple vars",
+			raw:  []string{"A=1", "B=2", "C=three"},
+			want: []*aiplatformpb.EnvVar{
+				{Name: "A", Value: "1"},
+				{Name: "B", Value: "2"},
+				{Name: "C", Value: "three"},
+			},
+		},
+		{
+			name:    "missing equals returns error",
+			raw:     []string{"NOEQUALS"},
+			wantErr: true,
+		},
+		{
+			name:    "empty string returns error",
+			raw:     []string{""},
+			wantErr: true,
+		},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			got, err := parseEnvVars(tc.raw)
+			if (err != nil) != tc.wantErr {
+				t.Fatalf("parseEnvVars(%v) error = %v, wantErr %v", tc.raw, err, tc.wantErr)
+			}
+			if tc.wantErr {
+				return
+			}
+			if diff := cmp.Diff(tc.want, got, protocmp.Transform()); diff != "" {
+				t.Errorf("parseEnvVars(%v) mismatch (-want +got):\n%s", tc.raw, diff)
+			}
+		})
+	}
+}


### PR DESCRIPTION
**Please ensure you have read the contribution guide before creating a pull request.**

### Link to Issue or Description of Change
- Closes: #848

### Root Cause / Motivation

`adkgo deploy agentengine` passes a fixed set of environment variables to the Agent Engine deployment. Users that need custom env vars (e.g. `VERTEX_AI_LOCATION`, `LOG_LEVEL`, third-party API keys that are not secrets) have no way to inject them.

### Change

Add a repeatable `--env=KEY=VALUE` flag to the `agentengine` deploy subcommand:

```
adkgo deploy agentengine \
  --env=VERTEX_AI_LOCATION=us-central1 \
  --env=LOG_LEVEL=debug \
  --region=... --project_name=...
```

**On create:** extra env vars are appended after the built-in defaults (`GOOGLE_CLOUD_REGION`, `NUM_WORKERS`, OTel flags) in `DeploymentSpec.Env`.

**On update:** if `--env` flags are provided, `DeploymentSpec` is set with defaults + extra vars and `"spec.deployment_spec"` is added to the update mask. If no `--env` flags are given, update behavior is unchanged.

Values containing `=` are handled correctly (`URL=http://x?a=1&b=2` splits on the first `=` only). Entries without `=` return a clear error.

### Testing Plan
**Unit Tests:**
- [x] Added `TestParseEnvVars` in `agentengine_test.go` covering: nil input, single var, value-contains-equals, empty value, multiple vars, missing-equals error, empty-string error.
- [x] All existing tests pass.

**Manual End-to-End (E2E) Tests:**
The flag wires correctly into the cobra command. The `parseEnvVars` function can be verified without a live GCP project; the proto field is identical to the existing hardcoded env var entries.

```
$ adkgo deploy agentengine --env=FOO=bar --env=BAZ=qux ...
# DeploymentSpec.Env will contain: GOOGLE_CLOUD_REGION, NUM_WORKERS, otel vars, FOO, BAZ
```

### Checklist
- [x] Read CONTRIBUTING.md
- [x] Self-reviewed code
- [x] Added tests proving the feature (parseEnvVars unit tests)
- [x] New and existing tests pass
- [x] Symmetric with the existing env var pattern in the proto request