### PR TITLE
fix(skilltoolset): use name arg in load_skill instruction

### DIFF
--- a/tool/skilltoolset/toolset.go
+++ b/tool/skilltoolset/toolset.go
@@ -39,7 +39,7 @@ Skills are folders of instructions and resources that extend your capabilities f
 This is very important:
 
 ` +
-		"1. If a skill seems relevant to the current user query, you MUST use the `load_skill` tool with `skill_name=\"<SKILL_NAME>\"` to read its full instructions before proceeding.\n" +
+		"1. If a skill seems relevant to the current user query, you MUST use the `load_skill` tool with `name=\"<SKILL_NAME>\"` to read its full instructions before proceeding.\n" +
 		"2. Once you have read the instructions, follow them exactly as documented before replying to the user. For example, If the instruction lists multiple steps, please make sure you complete all of them in order.\n" +
 		"3. The `load_skill_resource` tool is for viewing files within a skill's directory (e.g., `references/*`, `assets/*`, `scripts/*`). Do NOT use other tools to access these files.\n"
 )

--- a/tool/skilltoolset/toolset_test.go
+++ b/tool/skilltoolset/toolset_test.go
@@ -79,6 +79,12 @@ func TestProcessRequest(t *testing.T) {
 			t.Errorf("ProcessRequest: got %q, want to contain %q", gotText, want)
 		}
 	}
+	if want := "`load_skill` tool with `name=\"<SKILL_NAME>\"`"; !strings.Contains(gotText, want) {
+		t.Errorf("ProcessRequest: got %q, want to contain %q", gotText, want)
+	}
+	if notWant := "`load_skill` tool with `skill_name=\"<SKILL_NAME>\"`"; strings.Contains(gotText, notWant) {
+		t.Errorf("ProcessRequest: got %q, want not to contain %q", gotText, notWant)
+	}
 }
 
 func TestProcessRequest_NoSkills(t *testing.T) {


### PR DESCRIPTION
## Summary
- correct the default `SkillToolset` instruction to call `load_skill` with `name="<SKILL_NAME>"`, matching `LoadSkillArgs`
- add regression assertions so `ProcessRequest` no longer reintroduces the stale `skill_name` argument for `load_skill`

Fixes #912.

## Testing
- `go test ./tool/skilltoolset/...`
- `go test ./...` was also run; it currently fails in `google.golang.org/adk/server/adkrest/internal/services` on `TestDebugTelemetryGetSpansBySessionID` due span ordering mismatches unrelated to this `tool/skilltoolset` change. Re-running that package with `-count=3` reproduces the same ordering failure.
