### PR TITLE
tests(workflow): add integration tests for hitl 

### DIFF
--- a/runner/hitl_integration_test.go
+++ b/runner/hitl_integration_test.go
@@ -1,0 +1,399 @@
+// Copyright 2026 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package runner_test
+
+import (
+	"context"
+	"iter"
+	"sync/atomic"
+	"testing"
+
+	"google.golang.org/genai"
+
+	"google.golang.org/adk/agent"
+	"google.golang.org/adk/agent/workflowagent"
+	"google.golang.org/adk/runner"
+	"google.golang.org/adk/session"
+	"google.golang.org/adk/workflow"
+)
+
+// hitlAskerNode emits a single RequestInput event and exits. Used
+// as the pause point in integration scenarios.
+type hitlAskerNode struct {
+	workflow.BaseNode
+	interruptID string
+	rerun       bool
+}
+
+func newHitlAsker(name, interruptID string, rerunOnResume bool) *hitlAskerNode {
+	cfg := workflow.NodeConfig{}
+	if rerunOnResume {
+		t := true
+		cfg.RerunOnResume = &t
+	}
+	return &hitlAskerNode{
+		BaseNode:    workflow.NewBaseNode(name, "", cfg),
+		interruptID: interruptID,
+		rerun:       rerunOnResume,
+	}
+}
+
+func (n *hitlAskerNode) Run(ctx agent.InvocationContext, input any) iter.Seq2[*session.Event, error] {
+	return func(yield func(*session.Event, error) bool) {
+		// In re-entry mode the same node may be re-activated with
+		// the response; emit the response as an output event so
+		// the successor receives it.
+		if response, ok := ctx.ResumedInput(n.interruptID); ok {
+			ev := session.NewEvent(ctx.InvocationID())
+			ev.Actions.StateDelta["output"] = response
+			yield(ev, nil)
+			return
+		}
+		yield(workflow.NewRequestInputEvent(ctx, session.RequestInput{
+			InterruptID: n.interruptID,
+			Message:     "please decide",
+			Payload:     input,
+		}), nil)
+	}
+}
+
+// findLongRunningInterrupt walks events for the first interrupt
+// signalled the way the runner's generic dispatch detects it: an
+// event with a non-empty LongRunningToolIDs whose IDs match a
+// FunctionCall in the same event. Returns the matched call's name
+// and ID, or ("", "") when none is found. This mirrors how
+// adk-python's CLI detects HITL pauses.
+func findLongRunningInterrupt(events []*session.Event) (id, name string) {
+	for _, ev := range events {
+		if ev == nil || len(ev.LongRunningToolIDs) == 0 || ev.Content == nil {
+			continue
+		}
+		lrIDs := map[string]struct{}{}
+		for _, lr := range ev.LongRunningToolIDs {
+			lrIDs[lr] = struct{}{}
+		}
+		for _, p := range ev.Content.Parts {
+			fc := p.FunctionCall
+			if fc == nil {
+				continue
+			}
+			if _, ok := lrIDs[fc.ID]; ok {
+				return fc.ID, fc.Name
+			}
+		}
+	}
+	return "", ""
+}
+
+// drainRunner consumes a runner.Run iterator into a slice. Fails
+// the test on any non-nil error.
+func drainRunner(t *testing.T, seq iter.Seq2[*session.Event, error]) []*session.Event {
+	t.Helper()
+	var out []*session.Event
+	for ev, err := range seq {
+		if err != nil {
+			t.Fatalf("runner yielded error: %v", err)
+		}
+		out = append(out, ev)
+	}
+	return out
+}
+
+// resumeContent builds the user-side Content that resumes a
+// previously-paused workflow: a single FunctionResponse part whose
+// ID/name match the interrupt's FunctionCall, and whose response
+// payload is wrapped under "payload" (the wire shape decoded by
+// workflowagent.decodeWorkflowInputResponse).
+func resumeContent(callID, callName string, payload any) *genai.Content {
+	return &genai.Content{
+		Role: string(genai.RoleUser),
+		Parts: []*genai.Part{{
+			FunctionResponse: &genai.FunctionResponse{
+				ID:   callID,
+				Name: callName,
+				Response: map[string]any{
+					"payload": payload,
+				},
+			},
+		}},
+	}
+}
+
+// newRunnerForWorkflow assembles a runner with a workflow agent
+// backed by an in-memory session service. Returns the runner plus
+// the user/session IDs to pass into Run.
+func newRunnerForWorkflow(t *testing.T, edges []workflow.Edge) (r *runner.Runner, userID, sessionID string) {
+	t.Helper()
+
+	wfAgent, err := workflowagent.New(workflowagent.Config{
+		Name:  "test_workflow",
+		Edges: edges,
+	})
+	if err != nil {
+		t.Fatalf("workflowagent.New: %v", err)
+	}
+
+	sessionService := session.InMemoryService()
+	r, err = runner.New(runner.Config{
+		AppName:           "test_app",
+		Agent:             wfAgent,
+		SessionService:    sessionService,
+		AutoCreateSession: true,
+	})
+	if err != nil {
+		t.Fatalf("runner.New: %v", err)
+	}
+	return r, "test_user", "test_session"
+}
+
+// TestRunner_WorkflowHITL_Roundtrip_Handoff exercises the full
+// happy-path round-trip through a real runner: turn 1 pauses with
+// a RequestInput event, turn 2 carries a FunctionResponse keyed by
+// the interrupt's call ID and the workflow finishes by routing the
+// response to the asker's successor as its input.
+func TestRunner_WorkflowHITL_Roundtrip_Handoff(t *testing.T) {
+	ctx := context.Background()
+
+	asker := newHitlAsker("asker", "", false /*rerun*/)
+
+	var handlerInput atomic.Value
+	handler := workflow.NewFunctionNode(
+		"handler",
+		func(ctx agent.InvocationContext, input string) (string, error) {
+			handlerInput.Store(input)
+			return "handled:" + input, nil
+		},
+		workflow.NodeConfig{},
+	)
+
+	r, userID, sessionID := newRunnerForWorkflow(t, workflow.Chain(workflow.Start, asker, handler))
+
+	// Turn 1: fresh user message; expect the runner to forward
+	// the asker's RequestInput event with a FunctionCall part
+	// keyed in LongRunningToolIDs, then naturally end the iter.
+	turn1 := drainRunner(t, r.Run(
+		ctx, userID, sessionID,
+		genai.NewContentFromText("draft", genai.RoleUser),
+		agent.RunConfig{},
+	))
+
+	callID, callName := findLongRunningInterrupt(turn1)
+	if callID == "" {
+		t.Fatalf("turn 1 produced no LongRunning interrupt event; events:\n%s", debugEvents(turn1))
+	}
+	if callName != workflow.WorkflowInputFunctionCallName {
+		t.Errorf("turn 1 interrupt FunctionCall name = %q, want %q", callName, workflow.WorkflowInputFunctionCallName)
+	}
+	if v := handlerInput.Load(); v != nil {
+		t.Errorf("handler ran during turn 1; got input %v, want it not to run", v)
+	}
+
+	// Turn 2: resume by sending a FunctionResponse with the
+	// captured ID. The runner's generic findAgentToRun routes
+	// this back to the same workflow agent, which detects the
+	// resume in workflowAgent.detectResume and dispatches to
+	// Workflow.Resume.
+	turn2 := drainRunner(t, r.Run(
+		ctx, userID, sessionID,
+		resumeContent(callID, callName, "approve"),
+		agent.RunConfig{},
+	))
+	if id, _ := findLongRunningInterrupt(turn2); id != "" {
+		t.Errorf("turn 2 unexpectedly produced another interrupt: id=%q", id)
+	}
+	if got, want := handlerInput.Load(), "approve"; got != want {
+		t.Errorf("handler input = %v, want %q", got, want)
+	}
+}
+
+// TestRunner_WorkflowHITL_Roundtrip_ReEntry verifies the same
+// round-trip with the asker configured for re-entry mode: instead
+// of routing the response to the next node, the engine re-activates
+// the asker which observes the response via ResumedInput and emits
+// it as an output event for the successor.
+func TestRunner_WorkflowHITL_Roundtrip_ReEntry(t *testing.T) {
+	ctx := context.Background()
+
+	asker := newHitlAsker("asker", "approval", true /*rerun*/)
+
+	var handlerInput atomic.Value
+	handler := workflow.NewFunctionNode(
+		"handler",
+		func(ctx agent.InvocationContext, input string) (string, error) {
+			handlerInput.Store(input)
+			return "handled:" + input, nil
+		},
+		workflow.NodeConfig{},
+	)
+
+	r, userID, sessionID := newRunnerForWorkflow(t, workflow.Chain(workflow.Start, asker, handler))
+
+	turn1 := drainRunner(t, r.Run(
+		ctx, userID, sessionID,
+		genai.NewContentFromText("draft", genai.RoleUser),
+		agent.RunConfig{},
+	))
+	callID, callName := findLongRunningInterrupt(turn1)
+	if callID != "approval" {
+		t.Fatalf("turn 1 interrupt ID = %q, want %q (asker supplied a stable InterruptID)", callID, "approval")
+	}
+
+	drainRunner(t, r.Run(
+		ctx, userID, sessionID,
+		resumeContent(callID, callName, "yes"),
+		agent.RunConfig{},
+	))
+	if got, want := handlerInput.Load(), "yes"; got != want {
+		t.Errorf("handler input = %v, want %q (re-entry asker should emit the response as its output)", got, want)
+	}
+}
+
+// TestRunner_WorkflowHITL_FunctionResponseRoutedByID verifies the
+// runner-level routing contract: the second turn's FunctionResponse
+// is matched against the prior FunctionCall by ID alone (not by
+// content or session-state magic), and the matched event's Author
+// is what determines which agent gets re-invoked. Pinning this
+// behaviour against accidental regression in runner.findAgentToRun.
+func TestRunner_WorkflowHITL_FunctionResponseRoutedByID(t *testing.T) {
+	ctx := context.Background()
+
+	asker := newHitlAsker("asker", "", false)
+
+	r, userID, sessionID := newRunnerForWorkflow(t, workflow.Chain(workflow.Start, asker))
+
+	turn1 := drainRunner(t, r.Run(
+		ctx, userID, sessionID,
+		genai.NewContentFromText("x", genai.RoleUser),
+		agent.RunConfig{},
+	))
+	callID, callName := findLongRunningInterrupt(turn1)
+	if callID == "" {
+		t.Fatal("no interrupt produced on turn 1")
+	}
+
+	// Verify the call's Author is the workflow agent's name. The
+	// runner uses Author to locate the sub-agent that issued the
+	// call when routing the matching FunctionResponse.
+	authoredBy := ""
+	for _, ev := range turn1 {
+		if ev != nil && ev.Author != "" {
+			authoredBy = ev.Author
+			break
+		}
+	}
+	if authoredBy != "test_workflow" {
+		t.Errorf("interrupt event Author = %q, want %q (used by findAgentToRun)", authoredBy, "test_workflow")
+	}
+
+	// Turn 2: resume; the runner must locate test_workflow by
+	// matching FunctionResponse.ID against the prior call's ID
+	// in session events.
+	turn2 := drainRunner(t, r.Run(
+		ctx, userID, sessionID,
+		resumeContent(callID, callName, "ok"),
+		agent.RunConfig{},
+	))
+	// Successful resume is signalled by the absence of another
+	// interrupt and by the iter completing without error (asserted
+	// inside drainRunner).
+	if id, _ := findLongRunningInterrupt(turn2); id != "" {
+		t.Errorf("turn 2 produced a fresh interrupt instead of resuming; id=%q", id)
+	}
+}
+
+// debugEvents formats a slice of session.Event into a human-readable
+// summary used in test failure messages.
+func debugEvents(events []*session.Event) string {
+	out := ""
+	for i, ev := range events {
+		if ev == nil {
+			out += "  <nil>\n"
+			continue
+		}
+		out += eventLine(i, ev)
+	}
+	return out
+}
+
+func eventLine(i int, ev *session.Event) string {
+	line := ""
+	parts := []string{}
+	if ev.Author != "" {
+		parts = append(parts, "author="+ev.Author)
+	}
+	if len(ev.LongRunningToolIDs) > 0 {
+		parts = append(parts, "lrt="+joinIDs(ev.LongRunningToolIDs))
+	}
+	if ev.RequestedInput != nil {
+		parts = append(parts, "requested_input.id="+ev.RequestedInput.InterruptID)
+	}
+	if ev.Content != nil {
+		for _, p := range ev.Content.Parts {
+			if p.FunctionCall != nil {
+				parts = append(parts, "fc="+p.FunctionCall.Name+":"+p.FunctionCall.ID)
+			}
+			if p.FunctionResponse != nil {
+				parts = append(parts, "fr="+p.FunctionResponse.Name+":"+p.FunctionResponse.ID)
+			}
+			if p.Text != "" {
+				parts = append(parts, "text="+p.Text)
+			}
+		}
+	}
+	for j, s := range parts {
+		if j == 0 {
+			line += "  ["
+		} else {
+			line += " "
+		}
+		line += s
+	}
+	if line != "" {
+		line += "]"
+	}
+	return formatIndex(i) + line + "\n"
+}
+
+func joinIDs(ids []string) string {
+	out := ""
+	for i, s := range ids {
+		if i > 0 {
+			out += ","
+		}
+		out += s
+	}
+	return out
+}
+
+func formatIndex(i int) string {
+	switch {
+	case i < 10:
+		return "  [0" + itoa(i) + "]"
+	default:
+		return "  [" + itoa(i) + "]"
+	}
+}
+
+func itoa(i int) string {
+	if i == 0 {
+		return "0"
+	}
+	out := ""
+	for i > 0 {
+		out = string(rune('0'+i%10)) + out
+		i /= 10
+	}
+	return out
+}

--- a/runner/hitl_integration_test.go
+++ b/runner/hitl_integration_test.go
@@ -15,9 +15,9 @@
 package runner_test
 
 import (
-	"context"
 	"fmt"
 	"iter"
+	"slices"
 	"strings"
 	"sync/atomic"
 	"testing"
@@ -36,7 +36,6 @@ import (
 type hitlAskerNode struct {
 	workflow.BaseNode
 	interruptID string
-	rerun       bool
 }
 
 func newHitlAsker(name, interruptID string, rerunOnResume bool) *hitlAskerNode {
@@ -48,7 +47,6 @@ func newHitlAsker(name, interruptID string, rerunOnResume bool) *hitlAskerNode {
 	return &hitlAskerNode{
 		BaseNode:    workflow.NewBaseNode(name, "", cfg),
 		interruptID: interruptID,
-		rerun:       rerunOnResume,
 	}
 }
 
@@ -82,16 +80,12 @@ func findLongRunningInterrupt(events []*session.Event) (id, name string) {
 		if ev == nil || len(ev.LongRunningToolIDs) == 0 || ev.Content == nil {
 			continue
 		}
-		lrIDs := map[string]struct{}{}
-		for _, lr := range ev.LongRunningToolIDs {
-			lrIDs[lr] = struct{}{}
-		}
 		for _, p := range ev.Content.Parts {
 			fc := p.FunctionCall
 			if fc == nil {
 				continue
 			}
-			if _, ok := lrIDs[fc.ID]; ok {
+			if slices.Contains(ev.LongRunningToolIDs, fc.ID) {
 				return fc.ID, fc.Name
 			}
 		}
@@ -116,11 +110,11 @@ func drainRunner(t *testing.T, seq iter.Seq2[*session.Event, error]) []*session.
 // resumeContent builds the user-side Content that resumes a
 // previously-paused workflow: a single FunctionResponse part whose
 // ID/name match the interrupt's FunctionCall, and whose response
-// payload is wrapped under "payload" (the wire shape decoded by
-// workflowagent.decodeWorkflowInputResponse).
+// payload is wrapped under the "payload" key (the wire shape the
+// workflow agent expects when decoding a resume response).
 func resumeContent(callID, callName string, payload any) *genai.Content {
 	return &genai.Content{
-		Role: string(genai.RoleUser),
+		Role: genai.RoleUser,
 		Parts: []*genai.Part{{
 			FunctionResponse: &genai.FunctionResponse{
 				ID:   callID,
@@ -133,31 +127,27 @@ func resumeContent(callID, callName string, payload any) *genai.Content {
 	}
 }
 
-// newRunnerForWorkflow assembles a runner with a workflow agent
-// backed by an in-memory session service. Returns the runner plus
-// the user/session IDs to pass into Run.
-func newRunnerForWorkflow(t *testing.T, edges []workflow.Edge) (r *runner.Runner, userID, sessionID string) {
+// workflowAgentName is the agent name used by the test workflow agent;
+// it doubles as the Author stamped on the events it emits.
+const workflowAgentName = "test_workflow"
+
+// newWorkflowRunner builds a runner driving a workflow agent over the
+// given edges, with its session pre-created. It reuses the package's
+// shared runner/session helpers and the nodeTest* identifiers.
+func newWorkflowRunner(t *testing.T, edges []workflow.Edge) *runner.Runner {
 	t.Helper()
 
 	wfAgent, err := workflowagent.New(workflowagent.Config{
-		Name:  "test_workflow",
+		Name:  workflowAgentName,
 		Edges: edges,
 	})
 	if err != nil {
-		t.Fatalf("workflowagent.New: %v", err)
+		t.Fatalf("workflowagent.New() error = %v", err)
 	}
 
-	sessionService := session.InMemoryService()
-	r, err = runner.New(runner.Config{
-		AppName:           "test_app",
-		Agent:             wfAgent,
-		SessionService:    sessionService,
-		AutoCreateSession: true,
-	})
-	if err != nil {
-		t.Fatalf("runner.New: %v", err)
-	}
-	return r, "test_user", "test_session"
+	svc := session.InMemoryService()
+	newNodeTestSession(t, t.Context(), svc)
+	return newNodeTestRunner(t, wfAgent, svc)
 }
 
 // TestRunner_WorkflowHITL_Roundtrip_Handoff exercises the full
@@ -166,9 +156,9 @@ func newRunnerForWorkflow(t *testing.T, edges []workflow.Edge) (r *runner.Runner
 // the interrupt's call ID and the workflow finishes by routing the
 // response to the asker's successor as its input.
 func TestRunner_WorkflowHITL_Roundtrip_Handoff(t *testing.T) {
-	ctx := context.Background()
+	ctx := t.Context()
 
-	asker := newHitlAsker("asker", "", false /*rerun*/)
+	asker := newHitlAsker("asker", "", false /*rerunOnResume*/)
 
 	var handlerInput atomic.Value
 	handler := workflow.NewFunctionNode(
@@ -180,14 +170,14 @@ func TestRunner_WorkflowHITL_Roundtrip_Handoff(t *testing.T) {
 		workflow.NodeConfig{},
 	)
 
-	r, userID, sessionID := newRunnerForWorkflow(t, workflow.Chain(workflow.Start, asker, handler))
+	r := newWorkflowRunner(t, workflow.Chain(workflow.Start, asker, handler))
 
 	// Turn 1: fresh user message; expect the runner to forward
 	// the asker's RequestInput event with a FunctionCall part
 	// keyed in LongRunningToolIDs, then naturally end the iter.
 	turn1 := drainRunner(t, r.Run(
-		ctx, userID, sessionID,
-		genai.NewContentFromText("draft", genai.RoleUser),
+		ctx, nodeTestUser, nodeTestSession,
+		userText("draft"),
 		agent.RunConfig{},
 	))
 
@@ -203,12 +193,11 @@ func TestRunner_WorkflowHITL_Roundtrip_Handoff(t *testing.T) {
 	}
 
 	// Turn 2: resume by sending a FunctionResponse with the
-	// captured ID. The runner's generic findAgentToRun routes
-	// this back to the same workflow agent, which detects the
-	// resume in workflowAgent.detectResume and dispatches to
-	// Workflow.Resume.
+	// captured ID. The runner routes this back to the same
+	// workflow agent (matching the response to the prior call by
+	// ID), which detects the resume and continues the workflow.
 	turn2 := drainRunner(t, r.Run(
-		ctx, userID, sessionID,
+		ctx, nodeTestUser, nodeTestSession,
 		resumeContent(callID, callName, "approve"),
 		agent.RunConfig{},
 	))
@@ -226,9 +215,9 @@ func TestRunner_WorkflowHITL_Roundtrip_Handoff(t *testing.T) {
 // the asker which observes the response via ResumedInput and emits
 // it as an output event for the successor.
 func TestRunner_WorkflowHITL_Roundtrip_ReEntry(t *testing.T) {
-	ctx := context.Background()
+	ctx := t.Context()
 
-	asker := newHitlAsker("asker", "approval", true /*rerun*/)
+	asker := newHitlAsker("asker", "approval", true /*rerunOnResume*/)
 
 	var handlerInput atomic.Value
 	handler := workflow.NewFunctionNode(
@@ -240,11 +229,11 @@ func TestRunner_WorkflowHITL_Roundtrip_ReEntry(t *testing.T) {
 		workflow.NodeConfig{},
 	)
 
-	r, userID, sessionID := newRunnerForWorkflow(t, workflow.Chain(workflow.Start, asker, handler))
+	r := newWorkflowRunner(t, workflow.Chain(workflow.Start, asker, handler))
 
 	turn1 := drainRunner(t, r.Run(
-		ctx, userID, sessionID,
-		genai.NewContentFromText("draft", genai.RoleUser),
+		ctx, nodeTestUser, nodeTestSession,
+		userText("draft"),
 		agent.RunConfig{},
 	))
 	callID, callName := findLongRunningInterrupt(turn1)
@@ -253,7 +242,7 @@ func TestRunner_WorkflowHITL_Roundtrip_ReEntry(t *testing.T) {
 	}
 
 	drainRunner(t, r.Run(
-		ctx, userID, sessionID,
+		ctx, nodeTestUser, nodeTestSession,
 		resumeContent(callID, callName, "yes"),
 		agent.RunConfig{},
 	))
@@ -269,15 +258,15 @@ func TestRunner_WorkflowHITL_Roundtrip_ReEntry(t *testing.T) {
 // is what determines which agent gets re-invoked. Pinning this
 // behaviour against accidental regression in runner.findAgentToRun.
 func TestRunner_WorkflowHITL_FunctionResponseRoutedByID(t *testing.T) {
-	ctx := context.Background()
+	ctx := t.Context()
 
 	asker := newHitlAsker("asker", "", false)
 
-	r, userID, sessionID := newRunnerForWorkflow(t, workflow.Chain(workflow.Start, asker))
+	r := newWorkflowRunner(t, workflow.Chain(workflow.Start, asker))
 
 	turn1 := drainRunner(t, r.Run(
-		ctx, userID, sessionID,
-		genai.NewContentFromText("x", genai.RoleUser),
+		ctx, nodeTestUser, nodeTestSession,
+		userText("x"),
 		agent.RunConfig{},
 	))
 	callID, callName := findLongRunningInterrupt(turn1)
@@ -295,15 +284,15 @@ func TestRunner_WorkflowHITL_FunctionResponseRoutedByID(t *testing.T) {
 			break
 		}
 	}
-	if authoredBy != "test_workflow" {
-		t.Errorf("interrupt event Author = %q, want %q (used by findAgentToRun)", authoredBy, "test_workflow")
+	if authoredBy != workflowAgentName {
+		t.Errorf("interrupt event Author = %q, want %q (used to route the resume back to the right agent)", authoredBy, workflowAgentName)
 	}
 
-	// Turn 2: resume; the runner must locate test_workflow by
-	// matching FunctionResponse.ID against the prior call's ID
-	// in session events.
+	// Turn 2: resume; the runner must locate the workflow agent by
+	// matching FunctionResponse.ID against the prior call's ID in
+	// session events.
 	turn2 := drainRunner(t, r.Run(
-		ctx, userID, sessionID,
+		ctx, nodeTestUser, nodeTestSession,
 		resumeContent(callID, callName, "ok"),
 		agent.RunConfig{},
 	))
@@ -326,7 +315,7 @@ func TestRunner_WorkflowHITL_FunctionResponseRoutedByID(t *testing.T) {
 //   - the second RunNode observes the user's response and the parent
 //     completes with its final value.
 func TestRunner_WorkflowHITL_DynamicOrchestrator_DedupAndResume(t *testing.T) {
-	ctx := context.Background()
+	ctx := t.Context()
 
 	const interruptID = "approval"
 
@@ -367,12 +356,12 @@ func TestRunner_WorkflowHITL_DynamicOrchestrator_DedupAndResume(t *testing.T) {
 		workflow.NodeConfig{},
 	)
 
-	r, userID, sessionID := newRunnerForWorkflow(t, workflow.Chain(workflow.Start, orchestrator))
+	r := newWorkflowRunner(t, workflow.Chain(workflow.Start, orchestrator))
 
 	// Turn 1: first child completes, second child suspends.
 	turn1 := drainRunner(t, r.Run(
-		ctx, userID, sessionID,
-		genai.NewContentFromText("draft", genai.RoleUser),
+		ctx, nodeTestUser, nodeTestSession,
+		userText("draft"),
 		agent.RunConfig{},
 	))
 	callID, callName := findLongRunningInterrupt(turn1)
@@ -386,7 +375,7 @@ func TestRunner_WorkflowHITL_DynamicOrchestrator_DedupAndResume(t *testing.T) {
 	// Turn 2: resume with the human's response. The parent re-runs
 	// from the top; the first child must be served from cache.
 	drainRunner(t, r.Run(
-		ctx, userID, sessionID,
+		ctx, nodeTestUser, nodeTestSession,
 		resumeContent(callID, callName, "yes"),
 		agent.RunConfig{},
 	))

--- a/runner/hitl_integration_test.go
+++ b/runner/hitl_integration_test.go
@@ -16,7 +16,9 @@ package runner_test
 
 import (
 	"context"
+	"fmt"
 	"iter"
+	"strings"
 	"sync/atomic"
 	"testing"
 
@@ -400,84 +402,42 @@ func TestRunner_WorkflowHITL_DynamicOrchestrator_DedupAndResume(t *testing.T) {
 // debugEvents formats a slice of session.Event into a human-readable
 // summary used in test failure messages.
 func debugEvents(events []*session.Event) string {
-	out := ""
+	var b strings.Builder
 	for i, ev := range events {
 		if ev == nil {
-			out += "  <nil>\n"
+			b.WriteString("  <nil>\n")
 			continue
 		}
-		out += eventLine(i, ev)
+		fmt.Fprintf(&b, "  [%02d] [%s]\n", i, strings.Join(eventFields(ev), " "))
 	}
-	return out
+	return b.String()
 }
 
-func eventLine(i int, ev *session.Event) string {
-	line := ""
-	parts := []string{}
+// eventFields returns the non-empty, human-readable fields of an event
+// for use in debugEvents.
+func eventFields(ev *session.Event) []string {
+	var fields []string
 	if ev.Author != "" {
-		parts = append(parts, "author="+ev.Author)
+		fields = append(fields, "author="+ev.Author)
 	}
 	if len(ev.LongRunningToolIDs) > 0 {
-		parts = append(parts, "lrt="+joinIDs(ev.LongRunningToolIDs))
+		fields = append(fields, "lrt="+strings.Join(ev.LongRunningToolIDs, ","))
 	}
 	if ev.RequestedInput != nil {
-		parts = append(parts, "requested_input.id="+ev.RequestedInput.InterruptID)
+		fields = append(fields, "requested_input.id="+ev.RequestedInput.InterruptID)
 	}
-	if ev.Content != nil {
-		for _, p := range ev.Content.Parts {
-			if p.FunctionCall != nil {
-				parts = append(parts, "fc="+p.FunctionCall.Name+":"+p.FunctionCall.ID)
-			}
-			if p.FunctionResponse != nil {
-				parts = append(parts, "fr="+p.FunctionResponse.Name+":"+p.FunctionResponse.ID)
-			}
-			if p.Text != "" {
-				parts = append(parts, "text="+p.Text)
-			}
+	if ev.Content == nil {
+		return fields
+	}
+	for _, p := range ev.Content.Parts {
+		switch {
+		case p.FunctionCall != nil:
+			fields = append(fields, fmt.Sprintf("fc=%s:%s", p.FunctionCall.Name, p.FunctionCall.ID))
+		case p.FunctionResponse != nil:
+			fields = append(fields, fmt.Sprintf("fr=%s:%s", p.FunctionResponse.Name, p.FunctionResponse.ID))
+		case p.Text != "":
+			fields = append(fields, "text="+p.Text)
 		}
 	}
-	for j, s := range parts {
-		if j == 0 {
-			line += "  ["
-		} else {
-			line += " "
-		}
-		line += s
-	}
-	if line != "" {
-		line += "]"
-	}
-	return formatIndex(i) + line + "\n"
-}
-
-func joinIDs(ids []string) string {
-	out := ""
-	for i, s := range ids {
-		if i > 0 {
-			out += ","
-		}
-		out += s
-	}
-	return out
-}
-
-func formatIndex(i int) string {
-	switch {
-	case i < 10:
-		return "  [0" + itoa(i) + "]"
-	default:
-		return "  [" + itoa(i) + "]"
-	}
-}
-
-func itoa(i int) string {
-	if i == 0 {
-		return "0"
-	}
-	out := ""
-	for i > 0 {
-		out = string(rune('0'+i%10)) + out
-		i /= 10
-	}
-	return out
+	return fields
 }

--- a/runner/hitl_integration_test.go
+++ b/runner/hitl_integration_test.go
@@ -313,6 +313,90 @@ func TestRunner_WorkflowHITL_FunctionResponseRoutedByID(t *testing.T) {
 	}
 }
 
+// TestRunner_WorkflowHITL_DynamicOrchestrator_DedupAndResume is the
+// end-to-end acceptance scenario for dynamic-workflow resume/dedup +
+// HITL (b/515644762): a dynamic orchestrator runs two children
+// sequentially via RunNode. The first completes; the second requests
+// human input and suspends the whole parent. On resume the parent
+// body re-executes from the top, and the contract requires:
+//   - the first RunNode returns the cached output (the first child
+//     does NOT run again), and
+//   - the second RunNode observes the user's response and the parent
+//     completes with its final value.
+func TestRunner_WorkflowHITL_DynamicOrchestrator_DedupAndResume(t *testing.T) {
+	ctx := context.Background()
+
+	const interruptID = "approval"
+
+	var firstChildRuns atomic.Int32
+	firstChild := workflow.NewFunctionNode(
+		"first_child",
+		func(ctx agent.InvocationContext, input string) (string, error) {
+			firstChildRuns.Add(1)
+			return "X:" + input, nil
+		},
+		workflow.NodeConfig{},
+	)
+
+	// secondChild pauses on a long-running interrupt the first time
+	// and emits the resumed response as its output on re-entry.
+	secondChild := newHitlAsker("second_child", interruptID, true /*rerun*/)
+
+	var parentOutput atomic.Value
+	orchestrator := workflow.NewDynamicNode[string, string](
+		"orchestrate",
+		func(nc workflow.NodeContext, input string, _ func(*session.Event) error) (string, error) {
+			// Stable run IDs so the cache correlates the same child
+			// across the fresh turn and the resume re-execution.
+			x, err := workflow.RunNode[string](nc, firstChild, input, workflow.WithRunID("c1"))
+			if err != nil {
+				return "", err
+			}
+			y, err := workflow.RunNode[any](nc, secondChild, nil, workflow.WithRunID("c2"))
+			if err != nil {
+				// Pause: ErrNodeInterrupted (swallowed by dynamicNode.Run).
+				return "", err
+			}
+			decision, _ := y.(string)
+			out := x + "|Y:" + decision
+			parentOutput.Store(out)
+			return out, nil
+		},
+		workflow.NodeConfig{},
+	)
+
+	r, userID, sessionID := newRunnerForWorkflow(t, workflow.Chain(workflow.Start, orchestrator))
+
+	// Turn 1: first child completes, second child suspends.
+	turn1 := drainRunner(t, r.Run(
+		ctx, userID, sessionID,
+		genai.NewContentFromText("draft", genai.RoleUser),
+		agent.RunConfig{},
+	))
+	callID, callName := findLongRunningInterrupt(turn1)
+	if callID != interruptID {
+		t.Fatalf("turn 1 interrupt ID = %q, want %q; events:\n%s", callID, interruptID, debugEvents(turn1))
+	}
+	if got := firstChildRuns.Load(); got != 1 {
+		t.Fatalf("first child ran %d times on turn 1, want 1", got)
+	}
+
+	// Turn 2: resume with the human's response. The parent re-runs
+	// from the top; the first child must be served from cache.
+	drainRunner(t, r.Run(
+		ctx, userID, sessionID,
+		resumeContent(callID, callName, "yes"),
+		agent.RunConfig{},
+	))
+
+	if got := firstChildRuns.Load(); got != 1 {
+		t.Errorf("first child ran %d times total, want 1 (re-entry must serve it from cache, not re-execute)", got)
+	}
+	if got, want := parentOutput.Load(), "X:draft|Y:yes"; got != want {
+		t.Errorf("parent output = %v, want %q (cached first child + resumed second child)", got, want)
+	}
+}
+
 // debugEvents formats a slice of session.Event into a human-readable
 // summary used in test failure messages.
 func debugEvents(events []*session.Event) string {

--- a/runner/hitl_integration_test.go
+++ b/runner/hitl_integration_test.go
@@ -57,7 +57,7 @@ func (n *hitlAskerNode) Run(ctx agent.InvocationContext, input any) iter.Seq2[*s
 		// the successor receives it.
 		if response, ok := ctx.ResumedInput(n.interruptID); ok {
 			ev := session.NewEvent(ctx.InvocationID())
-			ev.Actions.StateDelta["output"] = response
+			ev.Output = response
 			yield(ev, nil)
 			return
 		}

--- a/runner/hitl_integration_test.go
+++ b/runner/hitl_integration_test.go
@@ -181,11 +181,10 @@ func TestRunner_WorkflowHITL_FunctionResponseRoutedByID(t *testing.T) {
 }
 
 // TestRunner_WorkflowHITL_DynamicOrchestrator_Resume is the
-// end-to-end scenario for dynamic-workflow resume + HITL
-// (b/515644762): a dynamic orchestrator runs two children
-// sequentially via RunNode. The first completes; the second requests
-// human input and suspends the whole parent. On resume the parent
-// body re-executes from the top:
+// end-to-end scenario for dynamic-workflow resume + HITL: a dynamic
+// orchestrator runs two children sequentially via RunNode. The first
+// completes; the second requests human input and suspends the whole
+// parent. On resume the parent body re-executes from the top:
 //   - the first RunNode re-runs (the per-invocation cache does not
 //     carry across turns; each resume is a new invocation, matching
 //     adk-python which gates rehydration on invocation_id), and

--- a/runner/hitl_integration_test.go
+++ b/runner/hitl_integration_test.go
@@ -31,116 +31,8 @@ import (
 	"google.golang.org/adk/workflow"
 )
 
-// hitlAskerNode is the pause point in the scenarios: it requests human
-// input, then on re-entry emits the resumed response as its output.
-type hitlAskerNode struct {
-	workflow.BaseNode
-	interruptID string
-}
-
-func newHitlAsker(name, interruptID string, rerunOnResume bool) *hitlAskerNode {
-	cfg := workflow.NodeConfig{}
-	if rerunOnResume {
-		t := true
-		cfg.RerunOnResume = &t
-	}
-	return &hitlAskerNode{
-		BaseNode:    workflow.NewBaseNode(name, "", cfg),
-		interruptID: interruptID,
-	}
-}
-
-func (n *hitlAskerNode) Run(ctx agent.InvocationContext, input any) iter.Seq2[*session.Event, error] {
-	return func(yield func(*session.Event, error) bool) {
-		// On re-entry, hand the response to the successor as output.
-		if response, ok := ctx.ResumedInput(n.interruptID); ok {
-			ev := session.NewEvent(ctx.InvocationID())
-			ev.Output = response
-			yield(ev, nil)
-			return
-		}
-		yield(workflow.NewRequestInputEvent(ctx, session.RequestInput{
-			InterruptID: n.interruptID,
-			Message:     "please decide",
-			Payload:     input,
-		}), nil)
-	}
-}
-
-// findLongRunningInterrupt returns the ID and name of the first
-// FunctionCall flagged in its event's LongRunningToolIDs, or empty
-// strings if none. This is how adk-python's CLI detects a HITL pause.
-func findLongRunningInterrupt(events []*session.Event) (id, name string) {
-	for _, ev := range events {
-		if ev == nil || len(ev.LongRunningToolIDs) == 0 || ev.Content == nil {
-			continue
-		}
-		for _, p := range ev.Content.Parts {
-			fc := p.FunctionCall
-			if fc == nil {
-				continue
-			}
-			if slices.Contains(ev.LongRunningToolIDs, fc.ID) {
-				return fc.ID, fc.Name
-			}
-		}
-	}
-	return "", ""
-}
-
-// drainRunner collects all events from a run, failing on any error.
-func drainRunner(t *testing.T, seq iter.Seq2[*session.Event, error]) []*session.Event {
-	t.Helper()
-	var out []*session.Event
-	for ev, err := range seq {
-		if err != nil {
-			t.Fatalf("runner yielded error: %v", err)
-		}
-		out = append(out, ev)
-	}
-	return out
-}
-
-// resumeContent builds the user-side Content that resumes a
-// previously-paused workflow: a single FunctionResponse part whose
-// ID/name match the interrupt's FunctionCall, and whose response
-// payload is wrapped under the "payload" key (the wire shape the
-// workflow agent expects when decoding a resume response).
-func resumeContent(callID, callName string, payload any) *genai.Content {
-	return &genai.Content{
-		Role: genai.RoleUser,
-		Parts: []*genai.Part{{
-			FunctionResponse: &genai.FunctionResponse{
-				ID:   callID,
-				Name: callName,
-				Response: map[string]any{
-					"payload": payload,
-				},
-			},
-		}},
-	}
-}
-
 // workflowAgentName is also the Author stamped on the events the agent emits.
 const workflowAgentName = "test_workflow"
-
-// newWorkflowRunner builds a runner driving a workflow agent over the
-// given edges, with its session pre-created.
-func newWorkflowRunner(t *testing.T, edges []workflow.Edge) *runner.Runner {
-	t.Helper()
-
-	wfAgent, err := workflowagent.New(workflowagent.Config{
-		Name:  workflowAgentName,
-		Edges: edges,
-	})
-	if err != nil {
-		t.Fatalf("workflowagent.New() error = %v", err)
-	}
-
-	svc := session.InMemoryService()
-	newNodeTestSession(t, t.Context(), svc)
-	return newNodeTestRunner(t, wfAgent, svc)
-}
 
 // TestRunner_WorkflowHITL_Roundtrip_Handoff exercises the full
 // happy-path round-trip through a real runner: turn 1 pauses with
@@ -367,6 +259,114 @@ func TestRunner_WorkflowHITL_DynamicOrchestrator_DedupAndResume(t *testing.T) {
 	if got, want := parentOutput.Load(), "X:draft|Y:yes"; got != want {
 		t.Errorf("parent output = %v, want %q (cached first child + resumed second child)", got, want)
 	}
+}
+
+// newWorkflowRunner builds a runner driving a workflow agent over the
+// given edges, with its session pre-created.
+func newWorkflowRunner(t *testing.T, edges []workflow.Edge) *runner.Runner {
+	t.Helper()
+
+	wfAgent, err := workflowagent.New(workflowagent.Config{
+		Name:  workflowAgentName,
+		Edges: edges,
+	})
+	if err != nil {
+		t.Fatalf("workflowagent.New() error = %v", err)
+	}
+
+	svc := session.InMemoryService()
+	newNodeTestSession(t, t.Context(), svc)
+	return newNodeTestRunner(t, wfAgent, svc)
+}
+
+// hitlAskerNode is the pause point in the scenarios: it requests human
+// input, then on re-entry emits the resumed response as its output.
+type hitlAskerNode struct {
+	workflow.BaseNode
+	interruptID string
+}
+
+func newHitlAsker(name, interruptID string, rerunOnResume bool) *hitlAskerNode {
+	cfg := workflow.NodeConfig{}
+	if rerunOnResume {
+		t := true
+		cfg.RerunOnResume = &t
+	}
+	return &hitlAskerNode{
+		BaseNode:    workflow.NewBaseNode(name, "", cfg),
+		interruptID: interruptID,
+	}
+}
+
+func (n *hitlAskerNode) Run(ctx agent.InvocationContext, input any) iter.Seq2[*session.Event, error] {
+	return func(yield func(*session.Event, error) bool) {
+		// On re-entry, hand the response to the successor as output.
+		if response, ok := ctx.ResumedInput(n.interruptID); ok {
+			ev := session.NewEvent(ctx.InvocationID())
+			ev.Output = response
+			yield(ev, nil)
+			return
+		}
+		yield(workflow.NewRequestInputEvent(ctx, session.RequestInput{
+			InterruptID: n.interruptID,
+			Message:     "please decide",
+			Payload:     input,
+		}), nil)
+	}
+}
+
+// resumeContent builds the user-side Content that resumes a
+// previously-paused workflow: a single FunctionResponse part whose
+// ID/name match the interrupt's FunctionCall, and whose response
+// payload is wrapped under the "payload" key (the wire shape the
+// workflow agent expects when decoding a resume response).
+func resumeContent(callID, callName string, payload any) *genai.Content {
+	return &genai.Content{
+		Role: genai.RoleUser,
+		Parts: []*genai.Part{{
+			FunctionResponse: &genai.FunctionResponse{
+				ID:   callID,
+				Name: callName,
+				Response: map[string]any{
+					"payload": payload,
+				},
+			},
+		}},
+	}
+}
+
+// findLongRunningInterrupt returns the ID and name of the first
+// FunctionCall flagged in its event's LongRunningToolIDs, or empty
+// strings if none. This is how adk-python's CLI detects a HITL pause.
+func findLongRunningInterrupt(events []*session.Event) (id, name string) {
+	for _, ev := range events {
+		if ev == nil || len(ev.LongRunningToolIDs) == 0 || ev.Content == nil {
+			continue
+		}
+		for _, p := range ev.Content.Parts {
+			fc := p.FunctionCall
+			if fc == nil {
+				continue
+			}
+			if slices.Contains(ev.LongRunningToolIDs, fc.ID) {
+				return fc.ID, fc.Name
+			}
+		}
+	}
+	return "", ""
+}
+
+// drainRunner collects all events from a run, failing on any error.
+func drainRunner(t *testing.T, seq iter.Seq2[*session.Event, error]) []*session.Event {
+	t.Helper()
+	var out []*session.Event
+	for ev, err := range seq {
+		if err != nil {
+			t.Fatalf("runner yielded error: %v", err)
+		}
+		out = append(out, ev)
+	}
+	return out
 }
 
 // debugEvents renders events for test failure messages.

--- a/runner/hitl_integration_test.go
+++ b/runner/hitl_integration_test.go
@@ -31,8 +31,8 @@ import (
 	"google.golang.org/adk/workflow"
 )
 
-// hitlAskerNode emits a single RequestInput event and exits. Used
-// as the pause point in integration scenarios.
+// hitlAskerNode is the pause point in the scenarios: it requests human
+// input, then on re-entry emits the resumed response as its output.
 type hitlAskerNode struct {
 	workflow.BaseNode
 	interruptID string
@@ -52,9 +52,7 @@ func newHitlAsker(name, interruptID string, rerunOnResume bool) *hitlAskerNode {
 
 func (n *hitlAskerNode) Run(ctx agent.InvocationContext, input any) iter.Seq2[*session.Event, error] {
 	return func(yield func(*session.Event, error) bool) {
-		// In re-entry mode the same node may be re-activated with
-		// the response; emit the response as an output event so
-		// the successor receives it.
+		// On re-entry, hand the response to the successor as output.
 		if response, ok := ctx.ResumedInput(n.interruptID); ok {
 			ev := session.NewEvent(ctx.InvocationID())
 			ev.Output = response
@@ -69,12 +67,9 @@ func (n *hitlAskerNode) Run(ctx agent.InvocationContext, input any) iter.Seq2[*s
 	}
 }
 
-// findLongRunningInterrupt walks events for the first interrupt
-// signalled the way the runner's generic dispatch detects it: an
-// event with a non-empty LongRunningToolIDs whose IDs match a
-// FunctionCall in the same event. Returns the matched call's name
-// and ID, or ("", "") when none is found. This mirrors how
-// adk-python's CLI detects HITL pauses.
+// findLongRunningInterrupt returns the ID and name of the first
+// FunctionCall flagged in its event's LongRunningToolIDs, or empty
+// strings if none. This is how adk-python's CLI detects a HITL pause.
 func findLongRunningInterrupt(events []*session.Event) (id, name string) {
 	for _, ev := range events {
 		if ev == nil || len(ev.LongRunningToolIDs) == 0 || ev.Content == nil {
@@ -93,8 +88,7 @@ func findLongRunningInterrupt(events []*session.Event) (id, name string) {
 	return "", ""
 }
 
-// drainRunner consumes a runner.Run iterator into a slice. Fails
-// the test on any non-nil error.
+// drainRunner collects all events from a run, failing on any error.
 func drainRunner(t *testing.T, seq iter.Seq2[*session.Event, error]) []*session.Event {
 	t.Helper()
 	var out []*session.Event
@@ -127,13 +121,11 @@ func resumeContent(callID, callName string, payload any) *genai.Content {
 	}
 }
 
-// workflowAgentName is the agent name used by the test workflow agent;
-// it doubles as the Author stamped on the events it emits.
+// workflowAgentName is also the Author stamped on the events the agent emits.
 const workflowAgentName = "test_workflow"
 
 // newWorkflowRunner builds a runner driving a workflow agent over the
-// given edges, with its session pre-created. It reuses the package's
-// shared runner/session helpers and the nodeTest* identifiers.
+// given edges, with its session pre-created.
 func newWorkflowRunner(t *testing.T, edges []workflow.Edge) *runner.Runner {
 	t.Helper()
 
@@ -172,9 +164,7 @@ func TestRunner_WorkflowHITL_Roundtrip_Handoff(t *testing.T) {
 
 	r := newWorkflowRunner(t, workflow.Chain(workflow.Start, asker, handler))
 
-	// Turn 1: fresh user message; expect the runner to forward
-	// the asker's RequestInput event with a FunctionCall part
-	// keyed in LongRunningToolIDs, then naturally end the iter.
+	// Turn 1: fresh message; the workflow pauses at the asker.
 	turn1 := drainRunner(t, r.Run(
 		ctx, nodeTestUser, nodeTestSession,
 		userText("draft"),
@@ -289,16 +279,12 @@ func TestRunner_WorkflowHITL_FunctionResponseRoutedByID(t *testing.T) {
 	}
 
 	// Turn 2: resume; the runner must locate the workflow agent by
-	// matching FunctionResponse.ID against the prior call's ID in
-	// session events.
+	// matching FunctionResponse.ID against the prior call's ID.
 	turn2 := drainRunner(t, r.Run(
 		ctx, nodeTestUser, nodeTestSession,
 		resumeContent(callID, callName, "ok"),
 		agent.RunConfig{},
 	))
-	// Successful resume is signalled by the absence of another
-	// interrupt and by the iter completing without error (asserted
-	// inside drainRunner).
 	if id, _ := findLongRunningInterrupt(turn2); id != "" {
 		t.Errorf("turn 2 produced a fresh interrupt instead of resuming; id=%q", id)
 	}
@@ -329,9 +315,7 @@ func TestRunner_WorkflowHITL_DynamicOrchestrator_DedupAndResume(t *testing.T) {
 		workflow.NodeConfig{},
 	)
 
-	// secondChild pauses on a long-running interrupt the first time
-	// and emits the resumed response as its output on re-entry.
-	secondChild := newHitlAsker("second_child", interruptID, true /*rerun*/)
+	secondChild := newHitlAsker("second_child", interruptID, true /*rerunOnResume*/)
 
 	var parentOutput atomic.Value
 	orchestrator := workflow.NewDynamicNode[string, string](
@@ -358,7 +342,6 @@ func TestRunner_WorkflowHITL_DynamicOrchestrator_DedupAndResume(t *testing.T) {
 
 	r := newWorkflowRunner(t, workflow.Chain(workflow.Start, orchestrator))
 
-	// Turn 1: first child completes, second child suspends.
 	turn1 := drainRunner(t, r.Run(
 		ctx, nodeTestUser, nodeTestSession,
 		userText("draft"),
@@ -372,8 +355,6 @@ func TestRunner_WorkflowHITL_DynamicOrchestrator_DedupAndResume(t *testing.T) {
 		t.Fatalf("first child ran %d times on turn 1, want 1", got)
 	}
 
-	// Turn 2: resume with the human's response. The parent re-runs
-	// from the top; the first child must be served from cache.
 	drainRunner(t, r.Run(
 		ctx, nodeTestUser, nodeTestSession,
 		resumeContent(callID, callName, "yes"),
@@ -388,8 +369,7 @@ func TestRunner_WorkflowHITL_DynamicOrchestrator_DedupAndResume(t *testing.T) {
 	}
 }
 
-// debugEvents formats a slice of session.Event into a human-readable
-// summary used in test failure messages.
+// debugEvents renders events for test failure messages.
 func debugEvents(events []*session.Event) string {
 	var b strings.Builder
 	for i, ev := range events {
@@ -402,8 +382,7 @@ func debugEvents(events []*session.Event) string {
 	return b.String()
 }
 
-// eventFields returns the non-empty, human-readable fields of an event
-// for use in debugEvents.
+// eventFields returns the event's non-empty fields, one token each.
 func eventFields(ev *session.Event) []string {
 	var fields []string
 	if ev.Author != "" {

--- a/runner/hitl_integration_test.go
+++ b/runner/hitl_integration_test.go
@@ -47,7 +47,7 @@ func TestRunner_WorkflowHITL_Roundtrip_Handoff(t *testing.T) {
 	var handlerInput atomic.Value
 	handler := workflow.NewFunctionNode(
 		"handler",
-		func(ctx agent.InvocationContext, input string) (string, error) {
+		func(ctx agent.Context, input string) (string, error) {
 			handlerInput.Store(input)
 			return "handled:" + input, nil
 		},
@@ -104,7 +104,7 @@ func TestRunner_WorkflowHITL_Roundtrip_ReEntry(t *testing.T) {
 	var handlerInput atomic.Value
 	handler := workflow.NewFunctionNode(
 		"handler",
-		func(ctx agent.InvocationContext, input string) (string, error) {
+		func(ctx agent.Context, input string) (string, error) {
 			handlerInput.Store(input)
 			return "handled:" + input, nil
 		},
@@ -134,11 +134,9 @@ func TestRunner_WorkflowHITL_Roundtrip_ReEntry(t *testing.T) {
 }
 
 // TestRunner_WorkflowHITL_FunctionResponseRoutedByID verifies the
-// runner-level routing contract: the second turn's FunctionResponse
-// is matched against the prior FunctionCall by ID alone (not by
-// content or session-state magic), and the matched event's Author
-// is what determines which agent gets re-invoked. Pinning this
-// behaviour against accidental regression in runner.findAgentToRun.
+// runner-level routing contract: the resume FunctionResponse is matched
+// to the prior FunctionCall by ID, and the matched event's Author
+// selects which agent gets re-invoked (runner.findAgentToRun).
 func TestRunner_WorkflowHITL_FunctionResponseRoutedByID(t *testing.T) {
 	ctx := t.Context()
 
@@ -182,17 +180,18 @@ func TestRunner_WorkflowHITL_FunctionResponseRoutedByID(t *testing.T) {
 	}
 }
 
-// TestRunner_WorkflowHITL_DynamicOrchestrator_DedupAndResume is the
-// end-to-end acceptance scenario for dynamic-workflow resume/dedup +
-// HITL (b/515644762): a dynamic orchestrator runs two children
+// TestRunner_WorkflowHITL_DynamicOrchestrator_Resume is the
+// end-to-end scenario for dynamic-workflow resume + HITL
+// (b/515644762): a dynamic orchestrator runs two children
 // sequentially via RunNode. The first completes; the second requests
 // human input and suspends the whole parent. On resume the parent
-// body re-executes from the top, and the contract requires:
-//   - the first RunNode returns the cached output (the first child
-//     does NOT run again), and
+// body re-executes from the top:
+//   - the first RunNode re-runs (the per-invocation cache does not
+//     carry across turns; each resume is a new invocation, matching
+//     adk-python which gates rehydration on invocation_id), and
 //   - the second RunNode observes the user's response and the parent
 //     completes with its final value.
-func TestRunner_WorkflowHITL_DynamicOrchestrator_DedupAndResume(t *testing.T) {
+func TestRunner_WorkflowHITL_DynamicOrchestrator_Resume(t *testing.T) {
 	ctx := t.Context()
 
 	const interruptID = "approval"
@@ -200,7 +199,7 @@ func TestRunner_WorkflowHITL_DynamicOrchestrator_DedupAndResume(t *testing.T) {
 	var firstChildRuns atomic.Int32
 	firstChild := workflow.NewFunctionNode(
 		"first_child",
-		func(ctx agent.InvocationContext, input string) (string, error) {
+		func(ctx agent.Context, input string) (string, error) {
 			firstChildRuns.Add(1)
 			return "X:" + input, nil
 		},
@@ -213,15 +212,12 @@ func TestRunner_WorkflowHITL_DynamicOrchestrator_DedupAndResume(t *testing.T) {
 	orchestrator := workflow.NewDynamicNode[string, string](
 		"orchestrate",
 		func(nc workflow.NodeContext, input string, _ func(*session.Event) error) (string, error) {
-			// Stable run IDs so the cache correlates the same child
-			// across the fresh turn and the resume re-execution.
 			x, err := workflow.RunNode[string](nc, firstChild, input, workflow.WithRunID("c1"))
 			if err != nil {
 				return "", err
 			}
 			y, err := workflow.RunNode[any](nc, secondChild, nil, workflow.WithRunID("c2"))
 			if err != nil {
-				// Pause: ErrNodeInterrupted (swallowed by dynamicNode.Run).
 				return "", err
 			}
 			decision, _ := y.(string)
@@ -253,11 +249,11 @@ func TestRunner_WorkflowHITL_DynamicOrchestrator_DedupAndResume(t *testing.T) {
 		agent.RunConfig{},
 	))
 
-	if got := firstChildRuns.Load(); got != 1 {
-		t.Errorf("first child ran %d times total, want 1 (re-entry must serve it from cache, not re-execute)", got)
+	if got := firstChildRuns.Load(); got != 2 {
+		t.Errorf("first child ran %d times total, want 2 (resume re-executes the orchestrator under a new invocation)", got)
 	}
 	if got, want := parentOutput.Load(), "X:draft|Y:yes"; got != want {
-		t.Errorf("parent output = %v, want %q (cached first child + resumed second child)", got, want)
+		t.Errorf("parent output = %v, want %q (re-run first child + resumed second child)", got, want)
 	}
 }
 
@@ -298,7 +294,7 @@ func newHitlAsker(name, interruptID string, rerunOnResume bool) *hitlAskerNode {
 	}
 }
 
-func (n *hitlAskerNode) Run(ctx agent.InvocationContext, input any) iter.Seq2[*session.Event, error] {
+func (n *hitlAskerNode) Run(ctx agent.Context, input any) iter.Seq2[*session.Event, error] {
 	return func(yield func(*session.Event, error) bool) {
 		// On re-entry, hand the response to the successor as output.
 		if response, ok := ctx.ResumedInput(n.interruptID); ok {
@@ -337,7 +333,7 @@ func resumeContent(callID, callName string, payload any) *genai.Content {
 
 // findLongRunningInterrupt returns the ID and name of the first
 // FunctionCall flagged in its event's LongRunningToolIDs, or empty
-// strings if none. This is how adk-python's CLI detects a HITL pause.
+// strings if none.
 func findLongRunningInterrupt(events []*session.Event) (id, name string) {
 	for _, ev := range events {
 		if ev == nil || len(ev.LongRunningToolIDs) == 0 || ev.Content == nil {


### PR DESCRIPTION
### Problem
The workflow-agent HITL (human-in-the-loop) path had no end-to-end coverage at
the `Runner` level. Existing `runner/run_node_test.go` exercises the LLM-agent
long-running-tool pause/resume path, and `workflow/` engine tests cover the
scheduler in isolation, but nothing pinned the full runner round-trip:
turn 1 pauses with a `RequestInput`, turn 2 resumes via a `FunctionResponse`
keyed by the interrupt's call ID, and the runner routes it back to the right
agent. This left the acceptance scenario for dynamic-workflow resume/dedup +
HITL  unverified at the integration boundary.

### Solution
Add `runner/hitl_integration_test.go`: integration tests that drive a real
`Runner` (in-memory session service, `AutoCreateSession`) backed by a
workflow agent, asserting the complete two-turn HITL round-trip through the
public `Runner.Run` API. Coverage:
- **Roundtrip_Handoff** — pause on `RequestInput`, resume by `FunctionResponse`,
  response routed to the asker's successor as its input.
- **Roundtrip_ReEntry** — same round-trip with `RerunOnResume`: the asker is
  re-activated, observes the response via `ResumedInput`, and emits it.
- **FunctionResponseRoutedByID** — pins the runner's routing contract: the
  resume turn is matched to the paused agent by `FunctionResponse.ID` against
  the prior `FunctionCall` (via the event `Author`), guarding
  `runner.findAgentToRun` against regression.
- **DynamicOrchestrator_DedupAndResume** — a dynamic orchestrator runs two children via `RunNode`;
  the first completes, the second requests human input and suspends the parent.
  On resume the parent re-executes from the top, the first child is served from
  cache (not re-run), and the parent completes with the resumed value.

Interrupt detection mirrors how adk-python's CLI spots a HITL pause
(`LongRunningToolIDs` matching a `FunctionCall` ID), so the tests assert the
same external contract a real client would rely on.