### PR TITLE
fix: prevent nil pointer panic when artifact service is not configured

### DIFF
--- a/agent/callback_context.go
+++ b/agent/callback_context.go
@@ -47,11 +47,15 @@ func NewCallbackContext(ic InvocationContext, actions *session.EventActions) Cal
 // actions may be nil; if so, a new session.EventActions is created with empty StateDelta and ArtifactDelta
 func NewCallbackContextWithArtifactTracking(ic InvocationContext, actions *session.EventActions) CallbackContext {
 	actions = prepareEventActions(actions)
+	var artifacts Artifacts
+	if ic.Artifacts() != nil {
+		artifacts = &trackedArtifacts{Artifacts: ic.Artifacts(), actions: actions}
+	}
 	cc := &callbackContext{
 		Context:           ic,
 		invocationContext: ic,
 		actions:           actions,
-		artifacts:         &trackedArtifacts{Artifacts: ic.Artifacts(), actions: actions},
+		artifacts:         artifacts,
 	}
 	return cc
 }
@@ -69,11 +73,15 @@ func NewToolContext(ic InvocationContext, functionCallID string, actions *sessio
 		functionCallID = uuid.NewString()
 	}
 	actions = prepareEventActions(actions)
+	var artifacts Artifacts
+	if ic.Artifacts() != nil {
+		artifacts = &trackedArtifacts{Artifacts: ic.Artifacts(), actions: actions}
+	}
 	return &callbackContext{
 		Context:           ic,
 		invocationContext: ic,
 		actions:           actions,
-		artifacts:         &trackedArtifacts{Artifacts: ic.Artifacts(), actions: actions},
+		artifacts:         artifacts,
 		functionCallID:    functionCallID,
 		toolConfirmation:  confirmation,
 	}

--- a/tool/loadartifactstool/load_artifacts_tool.go
+++ b/tool/loadartifactstool/load_artifacts_tool.go
@@ -128,6 +128,9 @@ func (t *artifactsTool) ProcessRequest(ctx agent.ToolContext, req *model.LLMRequ
 }
 
 func (t *artifactsTool) appendInitialInstructions(ctx agent.ToolContext, req *model.LLMRequest) error {
+	if ctx.Artifacts() == nil {
+		return fmt.Errorf("artifact service is not configured; the load_artifacts tool requires an artifact service to be set up")
+	}
 	resp, err := ctx.Artifacts().List(ctx)
 	if err != nil {
 		return fmt.Errorf("failed to list artifacts: %w", err)
@@ -179,6 +182,10 @@ func (t *artifactsTool) processLoadArtifactsFunctionCall(ctx agent.ToolContext, 
 	}
 	if len(artifactNames) == 0 {
 		return nil
+	}
+
+	if ctx.Artifacts() == nil {
+		return fmt.Errorf("artifact service is not configured; the load_artifacts tool requires an artifact service to be set up")
 	}
 
 	results := make([]*genai.Content, len(artifactNames))

--- a/tool/loadartifactstool/load_artifacts_tool_test.go
+++ b/tool/loadartifactstool/load_artifacts_tool_test.go
@@ -277,6 +277,61 @@ func TestLoadArtifactsTool_ProcessRequest_Artifacts_OtherFunctionCall(t *testing
 	}
 }
 
+func TestLoadArtifactsTool_ProcessRequest_NilArtifacts(t *testing.T) {
+	loadArtifactsTool := loadartifactstool.New()
+
+	tc := createToolContextWithNilArtifacts(t)
+
+	requestProcessor, ok := loadArtifactsTool.(toolinternal.RequestProcessor)
+	if !ok {
+		t.Fatal("loadArtifactsTool does not implement RequestProcessor")
+	}
+
+	err := requestProcessor.ProcessRequest(tc, &model.LLMRequest{})
+	if err == nil {
+		t.Fatal("Expected error when Artifacts is nil, got nil")
+	}
+	if !strings.Contains(err.Error(), "artifact service is not configured") {
+		t.Errorf("Expected error about artifact service not configured, got: %v", err)
+	}
+}
+
+func TestLoadArtifactsTool_ProcessRequest_NilArtifacts_LoadFunctionCall(t *testing.T) {
+	loadArtifactsTool := loadartifactstool.New()
+
+	tc := createToolContextWithNilArtifacts(t)
+
+	functionResponse := &genai.FunctionResponse{
+		Name: "load_artifacts",
+		Response: map[string]any{
+			"artifact_names": []string{"doc1.txt"},
+		},
+	}
+	llmRequest := &model.LLMRequest{
+		Contents: []*genai.Content{
+			{
+				Role: "model",
+				Parts: []*genai.Part{
+					genai.NewPartFromFunctionResponse(functionResponse.Name, functionResponse.Response),
+				},
+			},
+		},
+	}
+
+	requestProcessor, ok := loadArtifactsTool.(toolinternal.RequestProcessor)
+	if !ok {
+		t.Fatal("loadArtifactsTool does not implement RequestProcessor")
+	}
+
+	err := requestProcessor.ProcessRequest(tc, llmRequest)
+	if err == nil {
+		t.Fatal("Expected error when Artifacts is nil, got nil")
+	}
+	if !strings.Contains(err.Error(), "artifact service is not configured") {
+		t.Errorf("Expected error about artifact service not configured, got: %v", err)
+	}
+}
+
 func createToolContext(t *testing.T) agent.ToolContext {
 	t.Helper()
 
@@ -290,6 +345,14 @@ func createToolContext(t *testing.T) agent.ToolContext {
 	ctx := icontext.NewInvocationContext(t.Context(), icontext.InvocationContextParams{
 		Artifacts: artifacts,
 	})
+
+	return agent.NewToolContext(ctx, "", nil, nil)
+}
+
+func createToolContextWithNilArtifacts(t *testing.T) agent.ToolContext {
+	t.Helper()
+
+	ctx := icontext.NewInvocationContext(t.Context(), icontext.InvocationContextParams{})
 
 	return agent.NewToolContext(ctx, "", nil, nil)
 }


### PR DESCRIPTION
When the load_artifacts tool is used without configuring an artifact service, ctx.Artifacts() returns a trackedArtifacts wrapping a nil Artifacts interface. Calling List/Load on this wrapper causes a nil pointer dereference panic.

Changes:
- agent/callback_context.go: In NewToolContext and NewCallbackContextWithArtifactTracking, only wrap Artifacts in trackedArtifacts when the underlying service is not nil. This prevents the nil dereference at the source.
- tool/loadartifactstool/load_artifacts_tool.go: Add nil checks for ctx.Artifacts() in appendInitialInstructions and processLoadArtifactsFunctionCall to return a clear error message instead of panicking.
- tool/loadartifactstool/load_artifacts_tool_test.go: Add two test cases covering nil Artifacts scenarios (ProcessRequest with no function call and with a load_artifacts function call).

Fixes #283

**Please ensure you have read the [contribution guide](./CONTRIBUTING.md) before creating a pull request.**

### Link to Issue or Description of Change

**1. Link to an existing issue (if applicable):**

- Closes: #_issue_number_
- Related: #_issue_number_

**2. Or, if no issue exists, describe the change:**

_If applicable, please follow the issue templates to provide as much detail as
possible._

**Problem:**
_A clear and concise description of what the problem is._

**Solution:**
_A clear and concise description of what you want to happen and why you choose
this solution._

### Testing Plan

_Please describe the tests that you ran to verify your changes. This is required
for all PRs that are not small documentation or typo fixes._

**Unit Tests:**

- [ ] I have added or updated unit tests for my change.
- [ ] All unit tests pass locally.

_Please include a summary of passed go test results._

**Manual End-to-End (E2E) Tests:**

_Please provide instructions on how to manually test your changes, including any
necessary setup or configuration. Please provide logs or screenshots to help
reviewers better understand the fix._

### Checklist

- [ ] I have read the [CONTRIBUTING.md](./CONTRIBUTING.md) document.
- [ ] I have performed a self-review of my own code.
- [ ] I have commented my code, particularly in hard-to-understand areas.
- [ ] I have added tests that prove my fix is effective or that my feature works.
- [ ] New and existing unit tests pass locally with my changes.
- [ ] I have manually tested my changes end-to-end.
- [ ] Any dependent changes have been merged and published in downstream modules.

### Additional context

_Add any other context or screenshots about the feature request here._

