### PR TITLE
refactor: Migrate existing nodes (Function/Tool/start + test nodes) to new Node interface

### DIFF
--- a/workflow/edgebuilder_test.go
+++ b/workflow/edgebuilder_test.go
@@ -19,16 +19,14 @@ import (
 	"reflect"
 	"testing"
 
-	"github.com/google/jsonschema-go/jsonschema"
-
 	"google.golang.org/adk/agent"
 	"google.golang.org/adk/session"
 )
 
 func TestEdgeBuilder(t *testing.T) {
-	nodeA := &dummyNode{name: "A"}
-	nodeB := &dummyNode{name: "B"}
-	nodeC := &dummyNode{name: "C"}
+	nodeA := &dummyNode{BaseNode: NewBaseNode("A", "", NodeConfig{})}
+	nodeB := &dummyNode{BaseNode: NewBaseNode("B", "", NodeConfig{})}
+	nodeC := &dummyNode{BaseNode: NewBaseNode("C", "", NodeConfig{})}
 
 	tests := []struct {
 		name     string
@@ -117,16 +115,11 @@ func TestEdgeBuilder(t *testing.T) {
 
 // dummyNode is a minimal implementation of Node for testing purposes.
 type dummyNode struct {
-	name string
+	BaseNode
 }
 
-func (n *dummyNode) Name() string                       { return n.name }
-func (n *dummyNode) Description() string                { return "" }
-func (n *dummyNode) Config() NodeConfig                 { return NodeConfig{} }
-func (n *dummyNode) InputSchema() *jsonschema.Resolved  { return nil }
-func (n *dummyNode) OutputSchema() *jsonschema.Resolved { return nil }
-func (n *dummyNode) ValidateInput(input any) (any, error) {
-	return input, nil
+func newDummyNode(name string) *dummyNode {
+	return &dummyNode{BaseNode: NewBaseNode(name, "", NodeConfig{})}
 }
 
 func (n *dummyNode) ValidateOutput(output any) (any, error) {

--- a/workflow/retry_loop_test.go
+++ b/workflow/retry_loop_test.go
@@ -31,10 +31,7 @@ import (
 type retryLoopTestNode struct {
 	BaseNode
 	calls atomic.Int32
-	cfg   NodeConfig
 }
-
-func (n *retryLoopTestNode) Config() NodeConfig { return n.cfg }
 
 func (n *retryLoopTestNode) Run(ctx agent.InvocationContext, input any) iter.Seq2[*session.Event, error] {
 	return func(yield func(*session.Event, error) bool) {
@@ -71,7 +68,6 @@ func TestScheduler_RetryLoop(t *testing.T) {
 
 	nodeA := &retryLoopTestNode{
 		BaseNode: NewBaseNode("A", "", cfg),
-		cfg:      cfg,
 	}
 
 	nodeFinish := newRecordingNode("Finish")

--- a/workflow/scheduler_test.go
+++ b/workflow/scheduler_test.go
@@ -205,7 +205,7 @@ func TestScheduler_NodeTimeout(t *testing.T) {
 	mockCtx := newSeededMockCtx(t)
 
 	slow := newCancelObservingNode("slow")
-	slow.cfg = NodeConfig{Timeout: 50 * time.Millisecond}
+	slow.config = NodeConfig{Timeout: 50 * time.Millisecond}
 
 	w := mustNew(t, []Edge{{From: Start, To: slow}})
 
@@ -380,16 +380,12 @@ func (n *erroringNode) Run(_ agent.InvocationContext, _ any) iter.Seq2[*session.
 // cancellation and timeout behaviour.
 type cancelObservingNode struct {
 	BaseNode
-	cfg            NodeConfig
 	cancelObserved atomic.Bool
 }
 
 func newCancelObservingNode(name string) *cancelObservingNode {
 	return &cancelObservingNode{BaseNode: NewBaseNode(name, "", NodeConfig{})}
 }
-
-// Config returns n.cfg, which tests may mutate after construction.
-func (n *cancelObservingNode) Config() NodeConfig { return n.cfg }
 
 func (n *cancelObservingNode) Run(ctx agent.InvocationContext, _ any) iter.Seq2[*session.Event, error] {
 	return func(yield func(*session.Event, error) bool) {
@@ -524,18 +520,14 @@ type retryTestNode struct {
 	BaseNode
 	failCount int
 	calls     atomic.Int32
-	cfg       NodeConfig
 }
 
 func newRetryTestNode(name string, failCount int, cfg NodeConfig) *retryTestNode {
 	return &retryTestNode{
 		BaseNode:  NewBaseNode(name, "", cfg),
 		failCount: failCount,
-		cfg:       cfg,
 	}
 }
-
-func (n *retryTestNode) Config() NodeConfig { return n.cfg }
 
 func (n *retryTestNode) Run(ctx agent.InvocationContext, input any) iter.Seq2[*session.Event, error] {
 	return func(yield func(*session.Event, error) bool) {

--- a/workflow/tool_node.go
+++ b/workflow/tool_node.go
@@ -88,12 +88,7 @@ func NewToolNode(t tool.Tool, cfg NodeConfig) (*ToolNode, error) {
 
 func (n *ToolNode) runTool(toolCtx agent.ToolContext, input any) (any, error) {
 	runnable := n.tool.(runnableTool)
-	toolInput, err := n.ValidateInput(input)
-	if err != nil {
-		return nil, fmt.Errorf("converting input for tool %q: %w", n.tool.Name(), err)
-	}
-
-	output, err := runnable.Run(toolCtx, toolInput)
+	output, err := runnable.Run(toolCtx, input)
 	if err != nil {
 		return nil, fmt.Errorf("tool %q execution failed: %w", n.tool.Name(), err)
 	}

--- a/workflow/tool_node_test.go
+++ b/workflow/tool_node_test.go
@@ -233,7 +233,11 @@ func TestToolNode_Run(t *testing.T) {
 			}
 
 			mockCtx := newMockCtx(t)
-			events := node.Run(mockCtx, tc.nodeInput)
+			validatedInput, err := node.ValidateInput(tc.nodeInput)
+			if err != nil {
+				t.Fatalf("ValidateInput failed: %v", err)
+			}
+			events := node.Run(mockCtx, validatedInput)
 
 			var got string
 			count := 0

--- a/workflow/validation_test.go
+++ b/workflow/validation_test.go
@@ -49,9 +49,9 @@ func TestUniqueNames(t *testing.T) {
 
 	for _, tc := range tests {
 		t.Run(tc.name, func(t *testing.T) {
-			nodeA := &dummyNode{name: tc.setup.aName}
-			nodeB := &dummyNode{name: tc.setup.bName}
-			nodeC := &dummyNode{name: tc.setup.cName}
+			nodeA := newDummyNode(tc.setup.aName)
+			nodeB := newDummyNode(tc.setup.bName)
+			nodeC := newDummyNode(tc.setup.cName)
 			edges := []Edge{
 				{From: nodeA, To: nodeB},
 				{From: nodeB, To: nodeC},
@@ -79,8 +79,8 @@ func TestStartNodePresent(t *testing.T) {
 		{
 			name: "with start node",
 			edges: func() []Edge {
-				nodeA := &dummyNode{name: "A"}
-				nodeB := &dummyNode{name: "B"}
+				nodeA := newDummyNode("A")
+				nodeB := newDummyNode("B")
 				return []Edge{
 					{From: Start, To: nodeA},
 					{From: nodeA, To: nodeB},
@@ -90,8 +90,8 @@ func TestStartNodePresent(t *testing.T) {
 		{
 			name: "no start node",
 			edges: func() []Edge {
-				nodeA := &dummyNode{name: "A"}
-				nodeB := &dummyNode{name: "B"}
+				nodeA := newDummyNode("A")
+				nodeB := newDummyNode("B")
 				return []Edge{
 					{From: nodeA, To: nodeB},
 				}
@@ -123,8 +123,8 @@ func TestStartNodeNoIncomingEdges(t *testing.T) {
 		{
 			name: "start node with no incoming edges",
 			edges: func() []Edge {
-				nodeA := &dummyNode{name: "A"}
-				nodeB := &dummyNode{name: "B"}
+				nodeA := newDummyNode("A")
+				nodeB := newDummyNode("B")
 				return []Edge{
 					{From: Start, To: nodeA},
 					{From: nodeA, To: nodeB},
@@ -134,8 +134,8 @@ func TestStartNodeNoIncomingEdges(t *testing.T) {
 		{
 			name: "start node has incoming edges",
 			edges: func() []Edge {
-				nodeA := &dummyNode{name: "A"}
-				nodeB := &dummyNode{name: "B"}
+				nodeA := newDummyNode("A")
+				nodeB := newDummyNode("B")
 				return []Edge{
 					{From: nodeA, To: Start},
 					{From: Start, To: nodeB},
@@ -160,8 +160,8 @@ func TestStartNodeNoIncomingEdges(t *testing.T) {
 }
 
 func TestDuplicateEdges(t *testing.T) {
-	nodeA := &dummyNode{name: "A"}
-	nodeB := &dummyNode{name: "B"}
+	nodeA := newDummyNode("A")
+	nodeB := newDummyNode("B")
 	tests := []struct {
 		name      string
 		edges     []Edge
@@ -204,9 +204,9 @@ func TestDuplicateEdges(t *testing.T) {
 }
 
 func TestDefaultRoute(t *testing.T) {
-	nodeA := &dummyNode{name: "A"}
-	nodeB := &dummyNode{name: "B"}
-	nodeC := &dummyNode{name: "C"}
+	nodeA := newDummyNode("A")
+	nodeB := newDummyNode("B")
+	nodeC := newDummyNode("C")
 	tests := []struct {
 		name      string
 		edges     []Edge
@@ -233,9 +233,9 @@ func TestDefaultRoute(t *testing.T) {
 }
 
 func TestConnectivity(t *testing.T) {
-	nodeA := &dummyNode{name: "A"}
-	nodeB := &dummyNode{name: "B"}
-	nodeC := &dummyNode{name: "C"}
+	nodeA := newDummyNode("A")
+	nodeB := newDummyNode("B")
+	nodeC := newDummyNode("C")
 	tests := []struct {
 		name           string
 		edges          []Edge
@@ -283,8 +283,8 @@ func TestValidateCycles(t *testing.T) {
 		{
 			name: "no cycles",
 			edges: func() []Edge {
-				nodeA := &dummyNode{name: "A"}
-				nodeB := &dummyNode{name: "B"}
+				nodeA := newDummyNode("A")
+				nodeB := newDummyNode("B")
 				return []Edge{
 					{From: Start, To: nodeA},
 					{From: nodeA, To: nodeB},
@@ -295,10 +295,10 @@ func TestValidateCycles(t *testing.T) {
 		{
 			name: "no cycles diamond graph",
 			edges: func() []Edge {
-				nodeA := &dummyNode{name: "A"}
-				nodeB := &dummyNode{name: "B"}
-				nodeC := &dummyNode{name: "C"}
-				nodeD := &dummyNode{name: "D"}
+				nodeA := newDummyNode("A")
+				nodeB := newDummyNode("B")
+				nodeC := newDummyNode("C")
+				nodeD := newDummyNode("D")
 				return []Edge{
 					{From: Start, To: nodeA},
 					{From: nodeA, To: nodeB},
@@ -312,8 +312,8 @@ func TestValidateCycles(t *testing.T) {
 		{
 			name: "only conditional cycle",
 			edges: func() []Edge {
-				nodeA := &dummyNode{name: "A"}
-				nodeB := &dummyNode{name: "B"}
+				nodeA := newDummyNode("A")
+				nodeB := newDummyNode("B")
 				return []Edge{
 					{From: Start, To: nodeA},
 					{From: nodeA, To: nodeB},
@@ -325,10 +325,10 @@ func TestValidateCycles(t *testing.T) {
 		{
 			name: "both conditional and unconditional cycles",
 			edges: func() []Edge {
-				nodeA := &dummyNode{name: "A"}
-				nodeB := &dummyNode{name: "B"}
-				nodeC := &dummyNode{name: "C"}
-				nodeD := &dummyNode{name: "D"}
+				nodeA := newDummyNode("A")
+				nodeB := newDummyNode("B")
+				nodeC := newDummyNode("C")
+				nodeD := newDummyNode("D")
 				return []Edge{
 					{From: Start, To: nodeA},
 					{From: nodeA, To: nodeB},
@@ -343,8 +343,8 @@ func TestValidateCycles(t *testing.T) {
 		{
 			name: "cycle with default route",
 			edges: func() []Edge {
-				nodeA := &dummyNode{name: "A"}
-				nodeB := &dummyNode{name: "B"}
+				nodeA := newDummyNode("A")
+				nodeB := newDummyNode("B")
 				return []Edge{
 					{From: Start, To: nodeA},
 					{From: nodeA, To: nodeB},
@@ -374,7 +374,7 @@ func TestValidateCycles(t *testing.T) {
 
 func TestValidateSubWorkflowNames(t *testing.T) {
 	// Create a valid sub-workflow
-	subWf, err := New("inner_wf", []Edge{{From: Start, To: &dummyNode{name: "A"}}})
+	subWf, err := New("inner_wf", []Edge{{From: Start, To: newDummyNode("A")}})
 	if err != nil {
 		t.Fatalf("failed to create sub-workflow: %v", err)
 	}

--- a/workflow/workflow.go
+++ b/workflow/workflow.go
@@ -115,17 +115,12 @@ type Edge struct {
 }
 
 // Start is a sentinel node used to indicate the entry point of the workflow.
-var Start Node = &startNode{}
+var Start Node = &startNode{
+	BaseNode: NewBaseNode("START", "Start node", NodeConfig{}),
+}
 
-type startNode struct{}
-
-func (s *startNode) Name() string                       { return "START" }
-func (s *startNode) Description() string                { return "Start node" }
-func (s *startNode) Config() NodeConfig                 { return NodeConfig{} }
-func (s *startNode) InputSchema() *jsonschema.Resolved  { return nil }
-func (s *startNode) OutputSchema() *jsonschema.Resolved { return nil }
-func (s *startNode) ValidateInput(input any) (any, error) {
-	return input, nil
+type startNode struct {
+	BaseNode
 }
 
 func (s *startNode) ValidateOutput(output any) (any, error) {


### PR DESCRIPTION
This PR updates the workflow system's node architecture to adopt the new `Node` interface, delegating schema routing and config management to `BaseNode`, and consolidating validation in the scheduler.

## Key Changes

* **Production Nodes Migration**: Updated `*FunctionNode`, `*ToolNode`, and `*startNode` to satisfy the new `Node` interface by routing schemas and configurations through `BaseNode`.
* **Test Nodes Migration**: Refactored all 10 test nodes (e.g., `dummyNode`, `cancelObservingNode`, `retryTestNode`, etc.) to satisfy the new interface, primarily via `BaseNode` embedding.
* **Consolidated Schema Validation**: Removed lingering/redundant validation and conversion logic in execution paths (`wrappedFn` and `runTool` paths in `function_node.go` and `tool_node.go`). Input validation is now exclusively handled by the scheduler.
* **Test Alignment**: Updated test suites (e.g., `tool_node_test.go` and `agent_node_test.go`) to accommodate new constructors and ensure input validation is invoked prior to running nodes where required.

## Verification

* All tests in the workflow package pass successfully:
  ```bash
  go test ./workflow/...
