### PR TITLE
feat: add ValidateInput override to JoinNode to validate individual predecessor outputs

### DIFF
--- a/workflow/join_node.go
+++ b/workflow/join_node.go
@@ -15,7 +15,10 @@
 package workflow
 
 import (
+	"fmt"
 	"iter"
+
+	"github.com/google/jsonschema-go/jsonschema"
 
 	"google.golang.org/adk/agent"
 	"google.golang.org/adk/session"
@@ -40,6 +43,18 @@ func NewJoinNode(name string) *JoinNode {
 	return &JoinNode{BaseNode: NewBaseNode(name, "", NodeConfig{})}
 }
 
+// NewJoinNodeWithSchema returns a JoinNode with the given name and input schema.
+//
+// The input schema is applied to each predecessor's output individually when validation is performed,
+// rather than being applied to the combined map structure itself.
+//
+// If a predecessor's output is nil, validation is bypassed and the nil value is preserved.
+func NewJoinNodeWithSchema(name string, schema *jsonschema.Resolved) *JoinNode {
+	return &JoinNode{
+		BaseNode: NewBaseNodeWithSchemas(name, "", NodeConfig{}, schema, nil),
+	}
+}
+
 // Run satisfies the Node interface. See JoinNode for the
 // aggregation contract.
 func (n *JoinNode) Run(ctx agent.InvocationContext, input any) iter.Seq2[*session.Event, error] {
@@ -48,4 +63,27 @@ func (n *JoinNode) Run(ctx agent.InvocationContext, input any) iter.Seq2[*sessio
 		event.Output = input
 		yield(event, nil)
 	}
+}
+
+// ValidateInput overrides BaseNode.ValidateInput. Instead of validating the
+// aggregated map as a single value, it validates each predecessor's output
+// individually against the node's InputSchema.
+func (n *JoinNode) ValidateInput(input any) (any, error) {
+	schema := n.InputSchema()
+	if schema == nil {
+		return input, nil
+	}
+	if m, ok := input.(map[string]any); ok {
+		out := make(map[string]any, len(m))
+		for predName, v := range m {
+			validated, err := defaultValidateInput(v, schema)
+			if err != nil {
+				return nil, fmt.Errorf("predecessor %q: %w", predName, err)
+			}
+			out[predName] = validated
+		}
+		return out, nil
+	}
+	// Fallback — 1-predecessor case or unexpected shape — fall back to default.
+	return n.BaseNode.ValidateInput(input)
 }

--- a/workflow/join_node_test.go
+++ b/workflow/join_node_test.go
@@ -17,7 +17,10 @@ package workflow
 import (
 	"reflect"
 	"sort"
+	"strings"
 	"testing"
+
+	"github.com/google/jsonschema-go/jsonschema"
 
 	"google.golang.org/adk/agent"
 )
@@ -228,4 +231,101 @@ func inputRecorder(name string, seen *any) *FunctionNode {
 			*seen = input
 			return "done", nil
 		}, defaultNodeConfig)
+}
+
+func TestJoinNode_ValidateInput(t *testing.T) {
+	stringSchema, err := (&jsonschema.Schema{Type: "string"}).Resolve(nil)
+	if err != nil {
+		t.Fatalf("failed to resolve string schema: %v", err)
+	}
+
+	joinWithSchema := NewJoinNodeWithSchema("join", stringSchema)
+
+	joinWithoutSchema := NewJoinNode("join")
+
+	tests := []struct {
+		name    string
+		node    *JoinNode
+		input   any
+		want    any
+		wantErr string
+	}{
+		{
+			name: "all match schema",
+			node: joinWithSchema,
+			input: map[string]any{
+				"pred1": "val1",
+				"pred2": "val2",
+				"pred3": "val3",
+			},
+			want: map[string]any{
+				"pred1": "val1",
+				"pred2": "val2",
+				"pred3": "val3",
+			},
+		},
+		{
+			name: "one fails validation",
+			node: joinWithSchema,
+			input: map[string]any{
+				"pred1": "val1",
+				"pred2": 42,
+				"pred3": "val3",
+			},
+			wantErr: `predecessor "pred2":`,
+		},
+		{
+			name:  "not a map falls back",
+			node:  joinWithSchema,
+			input: "raw string value",
+			want:  "raw string value",
+		},
+		{
+			name: "nil value in map",
+			node: joinWithSchema,
+			input: map[string]any{
+				"pred1": nil,
+			},
+			want: map[string]any{
+				"pred1": nil,
+			},
+		},
+		{
+			name:  "empty map",
+			node:  joinWithSchema,
+			input: map[string]any{},
+			want:  map[string]any{},
+		},
+		{
+			name: "nil schema returns as-is",
+			node: joinWithoutSchema,
+			input: map[string]any{
+				"pred1": 42,
+			},
+			want: map[string]any{
+				"pred1": 42,
+			},
+		},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			got, err := tc.node.ValidateInput(tc.input)
+			if tc.wantErr != "" {
+				if err == nil {
+					t.Fatalf("expected error containing %q, got nil", tc.wantErr)
+				}
+				if !strings.Contains(err.Error(), tc.wantErr) {
+					t.Errorf("expected error containing %q, got %v", tc.wantErr, err)
+				}
+				return
+			}
+			if err != nil {
+				t.Fatalf("unexpected error: %v", err)
+			}
+			if !reflect.DeepEqual(got, tc.want) {
+				t.Errorf("ValidateInput() got = %#v, want %#v", got, tc.want)
+			}
+		})
+	}
 }


### PR DESCRIPTION
This PR adds a `ValidateInput` override to `JoinNode` to validate the outputs of individual predecessor nodes against the node's input schema, rather than validating the aggregated map as a single value.

### Key Changes
- **`JoinNode.ValidateInput` implementation**:
  - Overrides the default base node input validation.
  - If the input is a `map[string]any` containing outputs from multiple predecessor nodes, it validates each predecessor's output value individually against `InputSchema()`.
  - Returns a map of validated values or returns a wrapped validation error including the predecessor's name (formatted as `predecessor "X": <inner error>`).
  - If the input is not a `map[string]any` (e.g., a raw single predecessor value), it falls back to `BaseNode.ValidateInput`.
  - If the node's `InputSchema()` is `nil`, the input is returned as-is.

## Verification Results

### Automated Tests
Added unit tests in [workflow/join_node_test.go](file:///usr/local/google/home/hanorik/adk-go/workflow/join_node_test.go) to verify:
- **All match schema**: Validation succeeds when three predecessor values all match the schema, returning the map of validated values.
- **One fails validation**: Returns a detailed error matching the format `predecessor "X": <inner error>` when one of three predecessor values fails validation.
- **Not a map falls back**: Correctly falls back to `BaseNode.ValidateInput` when the input is a raw value rather than a `map[string]any`.
- **Nil schema returns as-is**: Simply returns the input as-is when `InputSchema()` is `nil`.
