### PR TITLE
feat(workflow): park parent on WaitForOutput child with no output

### DIFF
--- a/workflow/config.go
+++ b/workflow/config.go
@@ -65,12 +65,12 @@ type NodeConfig struct {
 	// the engine. The engine currently treats nil as handoff.
 	RerunOnResume *bool
 
-	// WaitForOutput, when true, keeps the node in NodeWaiting
-	// (re-triggerable) until it actually yields an event carrying an
-	// "output" key in Actions.StateDelta, instead of moving it to
-	// NodeCompleted on first return. JoinNode and any custom fan-in
-	// node sets this. nil means "use the engine default" — false for
-	// most node kinds.
+	// WaitForOutput, when true, parks the parent (ErrNodeInterrupted) to
+	// re-run instead of completing it when a child dispatched via RunNode
+	// finishes without setting an event Output — letting a multi-turn
+	// child be retried rather than falsely completed with the zero value.
+	// Only honored on the RunNode (dynamic sub-scheduler) path today. nil
+	// means "use the engine default" — false for most node kinds.
 	WaitForOutput *bool
 
 	// RetryConfig, when non-nil, makes the scheduler retry this node

--- a/workflow/dynamic_node.go
+++ b/workflow/dynamic_node.go
@@ -119,6 +119,12 @@ func (n *dynamicNode[IN, OUT]) Run(ctx agent.Context, input any) iter.Seq2[*sess
 
 		out, err := n.fn(orchestratorCtx, typedInput, emit)
 		if err != nil {
+			// WaitForOutput park emitted no interrupt event, so surface
+			// the sentinel for the scheduler to park the parent.
+			if errors.Is(err, ErrNodeWaitingForOutput) {
+				yield(nil, err)
+				return
+			}
 			// HITL: the RequestedInput was already forwarded upstream;
 			// swallow the sentinel so the engine sees only the pause event.
 			if errors.Is(err, ErrNodeInterrupted) {

--- a/workflow/dynamic_scheduler.go
+++ b/workflow/dynamic_scheduler.go
@@ -336,6 +336,7 @@ func (s *dynamicSubScheduler) runNode(child Node, input any, opts runNodeOptions
 
 	var (
 		out         any
+		hasOutput   bool
 		interrupted bool
 		// pendingLongRunningIDs collects FunctionCall IDs the child
 		// emitted as long-running (listed in the emitting event's
@@ -420,6 +421,7 @@ func (s *dynamicSubScheduler) runNode(child Node, input any, opts runNodeOptions
 				}
 			}
 			out = validated
+			hasOutput = true
 			// Stamp OutputFor so resume can attribute the output: the
 			// emitter's own path plus, under delegation, this parent and
 			// its ancestors (the parent then suppresses its own terminal
@@ -445,18 +447,40 @@ func (s *dynamicSubScheduler) runNode(child Node, input any, opts runNodeOptions
 	if opts.raiseOnWait && len(pendingLongRunningIDs) > 0 {
 		interrupted = true
 	}
+
+	// HITL (and raise-on-wait above): not cached, so resume re-runs and
+	// re-invokes RunNode.
 	if interrupted {
-		// HITL is not terminal — parent re-runs on resume and is
-		// expected to re-invoke RunNode. Do not cache.
-		return nil, &NodeRunError{
-			ChildName: name, ChildPath: childPath, RunID: runID,
-			Cause: ErrNodeInterrupted,
-		}
+		return nil, s.pause(name, childPath, runID, ErrNodeInterrupted)
+	}
+
+	// A WaitForOutput child that produced no output is not done; park so
+	// the parent re-runs. Mirrors adk-python's wait_for_output node field
+	// (parks on missing output), independent of the WithRaiseOnWait gate.
+	if !hasOutput && waitsForOutput(child) {
+		return nil, s.pause(name, childPath, runID, ErrNodeWaitingForOutput)
 	}
 
 	s.storeCachedOutput(childPath, out)
 	s.commitDelegation(childPath, out) // no-op unless this child claimed the delegation
 	return out, nil
+}
+
+// pause reports that a child did not finish this turn so the parent must
+// re-run later. cause is a pause sentinel, not a failure: ErrNodeInterrupted
+// for HITL, ErrNodeWaitingForOutput for a WaitForOutput child with no output.
+func (s *dynamicSubScheduler) pause(name, childPath, runID string, cause error) error {
+	return &NodeRunError{
+		ChildName: name, ChildPath: childPath, RunID: runID,
+		Cause: cause,
+	}
+}
+
+// waitsForOutput reports whether node opts into WaitForOutput (tri-state
+// pointer; nil means the engine default of false).
+func waitsForOutput(node Node) bool {
+	w := node.Config().WaitForOutput
+	return w != nil && *w
 }
 
 func (s *dynamicSubScheduler) lookupCachedOutput(childPath string) (any, bool) {

--- a/workflow/errors.go
+++ b/workflow/errors.go
@@ -26,6 +26,12 @@ var (
 	// ErrNodeInterrupted wraps a child node's HITL pause request.
 	ErrNodeInterrupted = errors.New("workflow: dynamic child interrupted")
 
+	// ErrNodeWaitingForOutput is a pause with no interrupt ID: a
+	// WaitForOutput child finished without output, so the parent parks
+	// instead of completing. Wraps ErrNodeInterrupted so existing
+	// errors.Is(ErrNodeInterrupted) checks still treat it as a pause.
+	ErrNodeWaitingForOutput = fmt.Errorf("%w: waiting for output", ErrNodeInterrupted)
+
 	// ErrInvalidRunNodeContext is returned by RunNode when ctx is not
 	// the NodeContext of a currently-executing dynamic node.
 	ErrInvalidRunNodeContext = errors.New("workflow: RunNode called outside a dynamic node")

--- a/workflow/hitl_test.go
+++ b/workflow/hitl_test.go
@@ -319,3 +319,36 @@ func TestResumeOrRequestInput(t *testing.T) {
 		}
 	})
 }
+
+// TestScheduler_WaitForOutputPause_SuspendsWorkflow drives the
+// WaitForOutput pause through a real workflow (Start -> orch ->
+// downstream). orch runs a WaitForOutput child that yields no output,
+// so RunNode parks the parent. A genuine pause must suspend the
+// workflow: orch lands NodeWaiting and downstream must NOT run.
+func TestScheduler_WaitForOutputPause_SuspendsWorkflow(t *testing.T) {
+	mockCtx := newSeededMockCtx(t)
+
+	child := newWaitForOutputNode("waiter")
+	orch := NewDynamicNode[any, any](
+		"orch",
+		func(ctx NodeContext, _ any, _ func(*session.Event) error) (any, error) {
+			return RunNode[any](ctx, child, nil)
+		},
+		NodeConfig{},
+	)
+	var downstreamRan atomic.Bool
+	downstream := newHitlNode("downstream", func(_ agent.Context, _ any, _ func(*session.Event, error) bool) {
+		downstreamRan.Store(true)
+	})
+
+	w := mustNew(t, []Edge{
+		{From: Start, To: orch},
+		{From: orch, To: downstream},
+	})
+
+	drain(t, w.Run(mockCtx))
+
+	if downstreamRan.Load() {
+		t.Error("downstream ran; a WaitForOutput pause must suspend the workflow, not complete the parent")
+	}
+}

--- a/workflow/run_node_test.go
+++ b/workflow/run_node_test.go
@@ -112,6 +112,46 @@ func TestRunNode_PropagatesErrNodeInterrupted(t *testing.T) {
 	}
 }
 
+func TestRunNode_WaitForOutputChildWithNoOutput_ParksParent(t *testing.T) {
+	// A WaitForOutput child that finishes without producing output must
+	// park the parent (ErrNodeInterrupted), not falsely complete it with
+	// the zero value. Mirrors adk-python ctx.run_node(raise_on_wait=True).
+	child := newWaitForOutputNode("waiter")
+	_, err := runInOrchestratorWithErr[string](t, func(ctx NodeContext) (string, error) {
+		return RunNode[string](ctx, child, nil)
+	})
+	if !errors.Is(err, ErrNodeInterrupted) {
+		t.Errorf("err = %v, want errors.Is ErrNodeInterrupted", err)
+	}
+}
+
+func TestRunNode_WaitForOutputChildWithOutput_Completes(t *testing.T) {
+	// A WaitForOutput child that does produce output completes normally;
+	// the gate must only fire on missing output.
+	child := newWaitForOutputWithValueNode("waiter", "done")
+	got := runInOrchestrator[string](t, func(ctx NodeContext) (string, error) {
+		return RunNode[string](ctx, child, nil)
+	})
+	if got != "done" {
+		t.Errorf("RunNode output = %q, want %q", got, "done")
+	}
+}
+
+func TestRunNode_NoWaitForOutputChildWithNoOutput_ReturnsZero(t *testing.T) {
+	// Without WaitForOutput, a child that emits no output still completes
+	// and yields the zero value — the gate must not change this default.
+	child := newStubNode("c", nil)
+	got, err := runInOrchestratorWithErr[string](t, func(ctx NodeContext) (string, error) {
+		return RunNode[string](ctx, child, nil)
+	})
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if got != "" {
+		t.Errorf("RunNode output = %q, want zero value", got)
+	}
+}
+
 func TestRunNode_PropagatesErrNodeFailed(t *testing.T) {
 	failer := newFailingNode("failer", errors.New("boom"))
 	_, err := runInOrchestratorWithErr[string](t, func(ctx NodeContext) (string, error) {
@@ -705,5 +745,43 @@ func TestRunNode_ConcurrentChildren_NoRace(t *testing.T) {
 	}
 	if want := n + 1; outputs != want {
 		t.Errorf("output-bearing events = %d, want %d", outputs, want)
+	}
+}
+
+// waitForOutputNode has WaitForOutput=true and emits a state-only event
+// (no Output), modeling an LlmAgent task/chat node that has not yet
+// produced its final output.
+type waitForOutputNode struct{ BaseNode }
+
+func newWaitForOutputNode(name string) *waitForOutputNode {
+	t := true
+	return &waitForOutputNode{BaseNode: NewBaseNode(name, "", NodeConfig{WaitForOutput: &t})}
+}
+
+func (n *waitForOutputNode) Run(agent.Context, any) iter.Seq2[*session.Event, error] {
+	return func(yield func(*session.Event, error) bool) {
+		yield(&session.Event{}, nil) // state-only: no Output, no RequestedInput
+	}
+}
+
+// waitForOutputWithValueNode has WaitForOutput=true and does emit an
+// Output, so RunNode must complete it normally.
+type waitForOutputWithValueNode struct {
+	BaseNode
+	out any
+}
+
+func newWaitForOutputWithValueNode(name string, out any) *waitForOutputWithValueNode {
+	t := true
+	return &waitForOutputWithValueNode{
+		BaseNode: NewBaseNode(name, "", NodeConfig{WaitForOutput: &t}),
+		out:      out,
+	}
+}
+
+func (n *waitForOutputWithValueNode) Run(agent.Context, any) iter.Seq2[*session.Event, error] {
+	out := n.out
+	return func(yield func(*session.Event, error) bool) {
+		yield(&session.Event{Output: out}, nil)
 	}
 }

--- a/workflow/scheduler.go
+++ b/workflow/scheduler.go
@@ -458,7 +458,11 @@ func runNode(
 		if r := recover(); r != nil {
 			completion.err = fmt.Errorf("node %q panicked: %v", name, r)
 		}
-		if completion.err != nil && !errors.Is(completion.err, context.Canceled) {
+		// ErrNodeWaitingForOutput is a pause, not a failure: don't mark
+		// the span as errored.
+		if completion.err != nil &&
+			!errors.Is(completion.err, context.Canceled) &&
+			!errors.Is(completion.err, ErrNodeWaitingForOutput) {
 			span.RecordError(completion.err)
 			span.SetStatus(codes.Error, completion.err.Error())
 		}
@@ -736,6 +740,12 @@ func (s *scheduler) handleCompletion(it completionItem, scheduleSuccessors bool)
 	if errors.Is(it.err, context.Canceled) {
 		ns.Status = NodeCancelled
 		return nil // sibling cancellation; not the original error
+	}
+	// WaitForOutput park: a pause, not a failure, and with no interrupt
+	// ID. Mirrors adk-python's wait_for_output WAITING state.
+	if errors.Is(it.err, ErrNodeWaitingForOutput) {
+		ns.Status = NodeWaiting
+		return nil
 	}
 	if it.err != nil {
 		currentNode := s.nodesByName[it.nodeName]


### PR DESCRIPTION

### Problem
NodeConfig.WaitForOutput existed but was never honored — no production code read it. A child dispatched via RunNode that opts into `WaitForOutput` but finishes without producing output (e.g. a task-mode LlmAgent that delegated to a sub-agent and has not yet yielded its final answer) returned the zero value, falsely completing the parent instead of waiting for it to finish.

### Solution
Honor `WaitForOutput` and make the pause visible to the graph scheduler so
the workflow actually suspends.
- **RunNode (dynamic sub-scheduler):** when a child opts into
  `WaitForOutput` and emits no output (and is not interrupting via HITL),
  the parent parks via the shared pause helper.
- **Pause signalling:** the park now uses a dedicated sentinel,
  `ErrNodeWaitingForOutput` (wraps `ErrNodeInterrupted`, so existing
  `errors.Is(ErrNodeInterrupted)` checks still treat it as a pause). Unlike
  a HITL pause — which already emits a `RequestedInput` event — a
  WaitForOutput park emits no event, so `dynamicNode.Run` surfaces the
  sentinel to the scheduler instead of swallowing it.
- **Scheduler:** `handleCompletion` recognises the sentinel as a pause (not
  a failure) and parks the parent as `NodeWaiting` with no interrupt ID, and
  does not schedule successors. Mirrors adk-python's `wait_for_output`
  WAITING state.

### Relationship to #1037 (WithRaiseOnWait)
This PR is rebased onto #1037 and the two parking mechanisms are unified into a single, consistent path in runNode:
- #1037 — WithRaiseOnWait (per-call flag): parks when the child finishes with an unresolved long-running tool (e.g. a tool awaiting ctx.RequestConfirmation).
- #986 — WaitForOutput (per-node field): parks when the child finishes with no output.

Both gates run independently and both return through the shared pause helper:
```go
if opts.raiseOnWait && len(pendingLongRunningIDs) > 0 {
    interrupted = true
}
if interrupted { // HITL + raise-on-wait
    return nil, s.pause(name, childPath, runID)
}
if !hasOutput && waitsForOutput(child) { // WaitForOutput
    return nil, s.pause(name, childPath, runID)
}
```
### adk-python parity
adk-python has both, and so do we now:
- `NodeConfig.WaitForOutput` mirrors adk-python's `wait_for_output` node field (_base_node.py) — parks unconditionally on missing output.
- `WithRaiseOnWait` (#1037) mirrors adk-python's per-call `run_node(raise_on_wait=True)` (agents/context.py) — parks on an unresolved long-running tool.

### Follow-up
This PR makes a WaitForOutput child **suspend** the workflow correctly
(parent → `NodeWaiting`, downstream halted). It does **not** yet
auto-resume the parked parent within the same turn once the child can
produce output.
