### PR TITLE
feat(llm): isolation_scope to filter agent prompt history by scope

### DIFF
--- a/agent/agent.go
+++ b/agent/agent.go
@@ -177,11 +177,12 @@ func (a *agent) Run(ctx InvocationContext) iter.Seq2[*session.Event, error] {
 			memory:    ctx.Memory(),
 			session:   ctx.Session(),
 
-			invocationID:  ctx.InvocationID(),
-			branch:        ctx.Branch(),
-			userContent:   ctx.UserContent(),
-			runConfig:     ctx.RunConfig(),
-			endInvocation: ctx.Ended(),
+			invocationID:   ctx.InvocationID(),
+			branch:         ctx.Branch(),
+			isolationScope: ctx.IsolationScope(),
+			userContent:    ctx.UserContent(),
+			runConfig:      ctx.RunConfig(),
+			endInvocation:  ctx.Ended(),
 		}
 		event, err := runBeforeAgentCallbacks(ctx)
 		if event != nil || err != nil {
@@ -367,11 +368,12 @@ type invocationContext struct {
 	memory    Memory
 	session   session.Session
 
-	invocationID  string
-	branch        string
-	userContent   *genai.Content
-	runConfig     *RunConfig
-	endInvocation bool
+	invocationID   string
+	branch         string
+	isolationScope string
+	userContent    *genai.Content
+	runConfig      *RunConfig
+	endInvocation  bool
 }
 
 func (c *invocationContext) Agent() Agent {
@@ -396,6 +398,10 @@ func (c *invocationContext) InvocationID() string {
 
 func (c *invocationContext) Branch() string {
 	return c.branch
+}
+
+func (c *invocationContext) IsolationScope() string {
+	return c.isolationScope
 }
 
 func (c *invocationContext) UserContent() *genai.Content {

--- a/agent/context.go
+++ b/agent/context.go
@@ -86,6 +86,11 @@ type InvocationContext interface {
 	// Applicable to parallel agent because its sub-agents run concurrently.
 	Branch() string
 
+	// IsolationScope of the invocation context. When set, the agent's LLM
+	// prompt history includes only session events whose IsolationScope
+	// matches exactly. Empty means unscoped.
+	IsolationScope() string
+
 	// UserContent that started this invocation.
 	UserContent() *genai.Content
 

--- a/agent/llmagent/llmagent_test.go
+++ b/agent/llmagent/llmagent_test.go
@@ -1289,6 +1289,7 @@ func (m *mockInvocationContext) Agent() agent.Agent              { return nil }
 func (m *mockInvocationContext) Artifacts() agent.Artifacts      { return nil }
 func (m *mockInvocationContext) Memory() agent.Memory            { return nil }
 func (m *mockInvocationContext) Branch() string                  { return "" }
+func (m *mockInvocationContext) IsolationScope() string          { return "" }
 func (m *mockInvocationContext) RunConfig() *agent.RunConfig     { return nil }
 func (m *mockInvocationContext) Ended() bool                     { return false }
 func (m *mockInvocationContext) EndInvocation()                  {}

--- a/agent/workflowagent/workflow_test.go
+++ b/agent/workflowagent/workflow_test.go
@@ -98,6 +98,7 @@ func (m *MockInvocationContext) Value(key any) any {
 func (m *MockInvocationContext) Artifacts() agent.Artifacts      { return nil }
 func (m *MockInvocationContext) Memory() agent.Memory            { return nil }
 func (m *MockInvocationContext) Branch() string                  { return "" }
+func (m *MockInvocationContext) IsolationScope() string          { return "" }
 func (m *MockInvocationContext) RunConfig() *agent.RunConfig     { return nil }
 func (m *MockInvocationContext) Ended() bool                     { return false }
 func (m *MockInvocationContext) EndInvocation()                  {}

--- a/internal/configurable/conformance/recordplugin/record_plugin_test.go
+++ b/internal/configurable/conformance/recordplugin/record_plugin_test.go
@@ -454,6 +454,7 @@ func (m *MockInvocationContext) Agent() agent.Agent                             
 func (m *MockInvocationContext) Artifacts() agent.Artifacts                              { return nil }
 func (m *MockInvocationContext) Memory() agent.Memory                                    { return nil }
 func (m *MockInvocationContext) Branch() string                                          { return "" }
+func (m *MockInvocationContext) IsolationScope() string                                  { return "" }
 func (m *MockInvocationContext) UserContent() *genai.Content                             { return nil }
 func (m *MockInvocationContext) RunConfig() *agent.RunConfig                             { return nil }
 func (m *MockInvocationContext) EndInvocation()                                          {}

--- a/internal/configurable/conformance/replayplugin/replay_plugin_test.go
+++ b/internal/configurable/conformance/replayplugin/replay_plugin_test.go
@@ -473,6 +473,7 @@ func (m *MockInvocationContext) Agent() agent.Agent                             
 func (m *MockInvocationContext) Artifacts() agent.Artifacts                              { return nil }
 func (m *MockInvocationContext) Memory() agent.Memory                                    { return nil }
 func (m *MockInvocationContext) Branch() string                                          { return "" }
+func (m *MockInvocationContext) IsolationScope() string                                  { return "" }
 func (m *MockInvocationContext) UserContent() *genai.Content                             { return nil }
 func (m *MockInvocationContext) RunConfig() *agent.RunConfig                             { return nil } // Use context? No, RunConfig struct.
 func (m *MockInvocationContext) EndInvocation()                                          {}

--- a/internal/context/invocation_context.go
+++ b/internal/context/invocation_context.go
@@ -29,8 +29,9 @@ type InvocationContextParams struct {
 	Memory    agent.Memory
 	Session   session.Session
 
-	Branch string
-	Agent  agent.Agent
+	Branch         string
+	IsolationScope string
+	Agent          agent.Agent
 
 	UserContent                 *genai.Content
 	RunConfig                   *agent.RunConfig
@@ -65,6 +66,10 @@ func (c *InvocationContext) Agent() agent.Agent {
 
 func (c *InvocationContext) Branch() string {
 	return c.params.Branch
+}
+
+func (c *InvocationContext) IsolationScope() string {
+	return c.params.IsolationScope
 }
 
 func (c *InvocationContext) InvocationID() string {

--- a/internal/llminternal/contents_processor.go
+++ b/internal/llminternal/contents_processor.go
@@ -53,7 +53,7 @@ func ContentsRequestProcessor(ctx agent.InvocationContext, req *model.LLMRequest
 				events = append(events, e)
 			}
 		}
-		contents, err := fn(ctx.Agent().Name(), ctx.Branch(), events)
+		contents, err := fn(ctx.Agent().Name(), ctx.Branch(), ctx.IsolationScope(), events)
 		if err != nil {
 			yield(nil, err)
 			return
@@ -64,7 +64,7 @@ func ContentsRequestProcessor(ctx agent.InvocationContext, req *model.LLMRequest
 
 // buildContentsDefault returns the contents for the LLM request by applying
 // filtering, rearrangement, and content processing to the given events.
-func buildContentsDefault(agentName, invocationBranch string, events []*session.Event) ([]*genai.Content, error) {
+func buildContentsDefault(agentName, invocationBranch, isolationScope string, events []*session.Event) ([]*genai.Content, error) {
 	// parse the events, leaving the contents and the function calls and responses from the current agent.
 	var filtered []*session.Event
 	for _, ev := range events {
@@ -81,6 +81,13 @@ func buildContentsDefault(agentName, invocationBranch string, events []*session.
 		// Skip events that do not belong to the current branch.
 		// TODO: can we use a richer type for branch (e.g. []string) instead of using string prefix test?
 		if !eventBelongsToBranch(invocationBranch, ev) {
+			continue
+		}
+		// Skip events outside the agent's isolation scope. Unlike branch
+		// (where empty is universally visible), isolation scope is an
+		// exact match: a scoped agent sees only its own scope, an
+		// unscoped agent sees only unscoped events.
+		if ev.IsolationScope != isolationScope {
 			continue
 		}
 		if shouldExcludeEvent(ev) {
@@ -498,17 +505,23 @@ func mergeFunctionResponseEvents(functionResponseEvents []*session.Event) (*sess
 //
 //	In multi-agent scenarios, the "current turn" for an agent starts from an
 //	actual user or from another agent.
-func buildContentsCurrentTurnContextOnly(agentName, branch string, events []*session.Event) ([]*genai.Content, error) {
+func buildContentsCurrentTurnContextOnly(agentName, branch, isolationScope string, events []*session.Event) ([]*genai.Content, error) {
 	// Find the latest event that starts the current turn and process from there
 	for i := len(events) - 1; i >= 0; i-- {
 		event := events[i]
+		// An out-of-scope event cannot start this agent's turn: it is
+		// invisible to the agent, so skip it as a pivot (matching
+		// adk-python's _should_include_event_in_context gate here).
+		if event.IsolationScope != isolationScope {
+			continue
+		}
 		if event.Author == "user" || isOtherAgentReply(agentName, event) {
-			return buildContentsDefault(agentName, branch, events[i:])
+			return buildContentsDefault(agentName, branch, isolationScope, events[i:])
 		}
 	}
 	// NOTE: in Python, it returns [] if there is no event authored by a user or another agent,
 	// but that may be a bug.
-	return buildContentsDefault(agentName, branch, events)
+	return buildContentsDefault(agentName, branch, isolationScope, events)
 }
 
 func isOtherAgentReply(currentAgentName string, ev *session.Event) bool {
@@ -597,12 +610,13 @@ func cloneEvent(e *session.Event) *session.Event {
 
 	// 1. Create a new Event instance
 	newEvent := &session.Event{
-		ID:           e.ID,
-		Timestamp:    e.Timestamp,
-		InvocationID: e.InvocationID,
-		Branch:       e.Branch,
-		Author:       e.Author,
-		Actions:      e.Actions,
+		ID:             e.ID,
+		Timestamp:      e.Timestamp,
+		InvocationID:   e.InvocationID,
+		Branch:         e.Branch,
+		IsolationScope: e.IsolationScope,
+		Author:         e.Author,
+		Actions:        e.Actions,
 	}
 
 	// 2. Deep copy the LongRunningToolIDs slice

--- a/internal/llminternal/contents_processor_test.go
+++ b/internal/llminternal/contents_processor_test.go
@@ -247,16 +247,64 @@ func TestContentsRequestProcessor_IncludeContents(t *testing.T) {
 	}
 }
 
+// TestContentsRequestProcessor_IncludeContentsNone_IsolationScopePivot
+// guards the include_contents="none" pivot against an out-of-scope
+// event: a scoped event must not be chosen as the turn start, otherwise
+// the unscoped agent would see an empty/truncated turn. Mirrors
+// adk-python's _should_include_event_in_context gate in
+// _get_current_turn_contents.
+func TestContentsRequestProcessor_IncludeContentsNone_IsolationScopePivot(t *testing.T) {
+	t.Parallel()
+	events := []*session.Event{
+		{
+			Author: "user",
+			LLMResponse: model.LLMResponse{
+				Content: genai.NewContentFromText("unscoped turn", "user"),
+			},
+		},
+		{
+			Author:         "user",
+			IsolationScope: "task-1",
+			LLMResponse: model.LLMResponse{
+				Content: genai.NewContentFromText("scoped task", "user"),
+			},
+		},
+	}
+	testAgent := utils.Must(llmagent.New(llmagent.Config{
+		Name:            "testAgent",
+		Model:           &testModel{},
+		IncludeContents: "none",
+	}))
+	// Unscoped agent: the trailing scoped event must be skipped as the
+	// pivot, so the unscoped user turn is what the agent sees.
+	ctx := icontext.NewInvocationContext(t.Context(), icontext.InvocationContextParams{
+		Agent:   testAgent,
+		Session: &fakeSession{events: events},
+	})
+
+	req := &model.LLMRequest{}
+	for _, err := range llminternal.ContentsRequestProcessor(ctx, req, &llminternal.Flow{}) {
+		if err != nil {
+			t.Fatalf("contentsRequestProcessor failed: %v", err)
+		}
+	}
+	want := []*genai.Content{genai.NewContentFromText("unscoped turn", "user")}
+	if diff := cmp.Diff(want, req.Contents); diff != "" {
+		t.Errorf("contents mismatch (-want +got):\n%s", diff)
+	}
+}
+
 func TestContentsRequestProcessor(t *testing.T) {
 	const agentName = "testAgent"
 	testModel := &testModel{}
 
 	t.Parallel()
 	testCases := []struct {
-		name   string
-		branch string
-		events []*session.Event
-		want   []*genai.Content
+		name           string
+		branch         string
+		isolationScope string
+		events         []*session.Event
+		want           []*genai.Content
 	}{
 		{
 			name:   "NilEvent",
@@ -396,6 +444,60 @@ func TestContentsRequestProcessor(t *testing.T) {
 			},
 		},
 		{
+			// Isolation scope is exact-match (unlike branch, where empty
+			// is universally visible): a scoped agent sees ONLY events
+			// with the same scope, not unscoped ones.
+			name:           "FilterByIsolationScope_Scoped",
+			isolationScope: "task-1",
+			events: []*session.Event{
+				{
+					Author:         "user",
+					IsolationScope: "task-1",
+					LLMResponse: model.LLMResponse{
+						Content: genai.NewContentFromText("in task 1", "user"),
+					},
+				},
+				{
+					Author:         "user",
+					IsolationScope: "task-2",
+					LLMResponse: model.LLMResponse{
+						Content: genai.NewContentFromText("in task 2", "user"),
+					},
+				},
+				{
+					Author: "user",
+					LLMResponse: model.LLMResponse{
+						Content: genai.NewContentFromText("unscoped", "user"),
+					},
+				},
+			},
+			want: []*genai.Content{
+				genai.NewContentFromText("in task 1", "user"),
+			},
+		},
+		{
+			// An unscoped agent (empty scope) sees ONLY unscoped events.
+			name: "FilterByIsolationScope_Unscoped",
+			events: []*session.Event{
+				{
+					Author:         "user",
+					IsolationScope: "task-1",
+					LLMResponse: model.LLMResponse{
+						Content: genai.NewContentFromText("in task 1", "user"),
+					},
+				},
+				{
+					Author: "user",
+					LLMResponse: model.LLMResponse{
+						Content: genai.NewContentFromText("unscoped", "user"),
+					},
+				},
+			},
+			want: []*genai.Content{
+				genai.NewContentFromText("unscoped", "user"),
+			},
+		},
+		{
 			name: "AuthEvent",
 			events: []*session.Event{
 				{
@@ -469,8 +571,9 @@ func TestContentsRequestProcessor(t *testing.T) {
 			}))
 
 			ctx := icontext.NewInvocationContext(t.Context(), icontext.InvocationContextParams{
-				Agent:  testAgent,
-				Branch: tc.branch,
+				Agent:          testAgent,
+				Branch:         tc.branch,
+				IsolationScope: tc.isolationScope,
 				Session: &fakeSession{
 					events: tc.events,
 				},

--- a/internal/workflowinternal/single_turn_tool_test.go
+++ b/internal/workflowinternal/single_turn_tool_test.go
@@ -327,6 +327,7 @@ func (c *fakeInvocationContext) Memory() agent.Memory            { return nil }
 func (c *fakeInvocationContext) Session() session.Session        { return c.sess }
 func (c *fakeInvocationContext) InvocationID() string            { return "test-invocation-id" }
 func (c *fakeInvocationContext) Branch() string                  { return "" }
+func (c *fakeInvocationContext) IsolationScope() string          { return "" }
 func (c *fakeInvocationContext) UserContent() *genai.Content     { return nil }
 func (c *fakeInvocationContext) RunConfig() *agent.RunConfig     { return nil }
 func (c *fakeInvocationContext) EndInvocation()                  {}

--- a/session/database/service_test.go
+++ b/session/database/service_test.go
@@ -33,7 +33,8 @@ func Test_databaseService(t *testing.T) {
 
 // TestDatabaseService_AppendEvent_WorkflowFieldsRoundTrip guards that
 // the storage layer serializes/deserializes the workflow event fields
-// (NodeInfo, RequestedInput, Routes); dropping them breaks HITL resume.
+// (NodeInfo, RequestedInput, Routes, IsolationScope); dropping them
+// breaks HITL resume and scope-isolated history.
 func TestDatabaseService_AppendEvent_WorkflowFieldsRoundTrip(t *testing.T) {
 	ctx := t.Context()
 	s := emptyService(t)
@@ -49,6 +50,7 @@ func TestDatabaseService_AppendEvent_WorkflowFieldsRoundTrip(t *testing.T) {
 		NodeInfo:       &session.NodeInfo{Path: "ask_name"},
 		RequestedInput: &session.RequestInput{InterruptID: "ask_name", Message: "What's your name?"},
 		Routes:         []string{"route_a"},
+		IsolationScope: "task-1",
 	}
 	if err := s.AppendEvent(ctx, created.Session, event); err != nil {
 		t.Fatalf("AppendEvent: %v", err)
@@ -71,6 +73,9 @@ func TestDatabaseService_AppendEvent_WorkflowFieldsRoundTrip(t *testing.T) {
 	}
 	if len(ev.Routes) != 1 || ev.Routes[0] != "route_a" {
 		t.Errorf("Routes not persisted: %#v", ev.Routes)
+	}
+	if ev.IsolationScope != "task-1" {
+		t.Errorf("IsolationScope not persisted: got %q, want %q", ev.IsolationScope, "task-1")
 	}
 }
 

--- a/session/database/storage_session.go
+++ b/session/database/storage_session.go
@@ -84,6 +84,7 @@ type storageEvent struct {
 	NodeInfoJSON           dynamicJSON
 	RequestedInputJSON     dynamicJSON
 	Branch                 *string
+	IsolationScope         *string
 	Timestamp              time.Time `gorm:"precision:6"`
 
 	// Fields from llm_response
@@ -175,6 +176,9 @@ func createStorageEvent(session session.Session, event *session.Event) (*storage
 	// An empty string from the event becomes a nil pointer in storage.
 	if event.Branch != "" {
 		storageEv.Branch = &event.Branch
+	}
+	if event.IsolationScope != "" {
+		storageEv.IsolationScope = &event.IsolationScope
 	}
 	if event.ErrorCode != "" {
 		storageEv.ErrorCode = &event.ErrorCode
@@ -317,6 +321,7 @@ func createEventFromStorageEvent(se *storageEvent) (*session.Event, error) {
 	// --- Handle simple pointer fields (dereference or use zero value) ---
 	// Use the helper to safely get the value or its zero-value default
 	branch := derefOrZero(se.Branch)
+	isolationScope := derefOrZero(se.IsolationScope)
 	errorCode := derefOrZero(se.ErrorCode)
 	errorMessage := derefOrZero(se.ErrorMessage)
 	partial := derefOrZero(se.Partial)
@@ -333,6 +338,7 @@ func createEventFromStorageEvent(se *storageEvent) (*session.Event, error) {
 		LongRunningToolIDs: toolIDs,
 		Routes:             routes,
 		Branch:             branch,
+		IsolationScope:     isolationScope,
 		Output:             output,
 		NodeInfo:           nodeInfo,
 		RequestedInput:     requestedInput,

--- a/session/session.go
+++ b/session/session.go
@@ -107,6 +107,11 @@ type Event struct {
 	// Branch is used when multiple sub-agent shouldn't see their peer agents'
 	// conversation history.
 	Branch string
+	// IsolationScope, when set, restricts which agent contexts include this
+	// event in LLM prompt history: an event is visible only when
+	// event.IsolationScope equals the agent's isolation scope (exact match;
+	// empty sees only empty). Empty for non-scoped events.
+	IsolationScope string `json:"isolationScope,omitempty"`
 	// Author is the name of the event's author
 	Author string
 

--- a/workflow/workflow_test.go
+++ b/workflow/workflow_test.go
@@ -79,6 +79,7 @@ func (m *MockInvocationContext) Agent() agent.Agent              { return nil }
 func (m *MockInvocationContext) Artifacts() agent.Artifacts      { return nil }
 func (m *MockInvocationContext) Memory() agent.Memory            { return nil }
 func (m *MockInvocationContext) Branch() string                  { return "" }
+func (m *MockInvocationContext) IsolationScope() string          { return "" }
 func (m *MockInvocationContext) RunConfig() *agent.RunConfig     { return nil }
 func (m *MockInvocationContext) Ended() bool                     { return false }
 func (m *MockInvocationContext) EndInvocation()                  {}


### PR DESCRIPTION
**Problem**
adk-python scopes session events via `isolation_scope`: an event is
visible to an agent's LLM prompt history only when the event's scope
matches the agent's own. This isolates a delegated task agent's
conversation from the chat coordinator's broader history. adk-go had no
equivalent — every agent saw all branch-matching events regardless of
scope — so there was no way to isolate a sub-context's history.

**Solution**
Port the `isolation_scope` mechanism:
- `session.Event.IsolationScope` — per-event scope tag (empty = unscoped).
- `InvocationContext.IsolationScope()` — the running agent's scope,
  threaded through `agent.Run`.
- Exact-match filter in the content builder, next to the branch filter:
  an event is included only when `event.IsolationScope ==
  agent.IsolationScope()`. Unlike branch (where empty is universally
  visible), scope is exact — a scoped agent sees only its own scope, an
  unscoped agent sees only unscoped events.
The `include_contents="none"` pivot is gated the same way, so an
out-of-scope event cannot start the agent's turn (mirrors adk-python's
`_should_include_event_in_context` in `_get_current_turn_contents`).
This is the standalone filter mechanism. Scope stamping on append
(`_find_active_task_isolation_scope`) and task-input reconstruction
(`_build_task_input_user_content`) belong to the task-delegation layer
that will consume this, and are intentionally out of scope here.