### PR TITLE
feat(workflow): stamp isolation_scope on delegated node events

### DIFF
--- a/internal/workflowinternal/task_agent_tool.go
+++ b/internal/workflowinternal/task_agent_tool.go
@@ -51,6 +51,7 @@ func (t *TaskAgentTool) Declaration() *genai.FunctionDeclaration {
 func (t *TaskAgentTool) Run(toolCtx agent.ToolContext, args any) (map[string]any, error) {
 	// Framework handles task delegation dispatch directly via the wrapper.
 	// TODO: add _defer_response logic.
+	// TODO: dispatch via RunNode with WithIsolationScope(fcID) and WithRunID(fcID).
 	return nil, nil
 }
 

--- a/workflow/agent_node.go
+++ b/workflow/agent_node.go
@@ -109,15 +109,16 @@ func (n *AgentNode) Run(ctx agent.InvocationContext, input any) iter.Seq2[*sessi
 		// fan-out, and the LLM flow's history filter scopes events
 		// by branch prefix.
 		params := internalcontext.InvocationContextParams{
-			Artifacts:     ctx.Artifacts(),
-			Memory:        ctx.Memory(),
-			Session:       ctx.Session(),
-			Branch:        ctx.Branch(),
-			Agent:         n.agent,
-			UserContent:   userContent,
-			RunConfig:     ctx.RunConfig(),
-			EndInvocation: ctx.Ended(),
-			InvocationID:  ctx.InvocationID(),
+			Artifacts:      ctx.Artifacts(),
+			Memory:         ctx.Memory(),
+			Session:        ctx.Session(),
+			Branch:         ctx.Branch(),
+			IsolationScope: ctx.IsolationScope(),
+			Agent:          n.agent,
+			UserContent:    userContent,
+			RunConfig:      ctx.RunConfig(),
+			EndInvocation:  ctx.Ended(),
+			InvocationID:   ctx.InvocationID(),
 		}
 		agentCtx := internalcontext.NewInvocationContext(ctx, params)
 
@@ -128,6 +129,13 @@ func (n *AgentNode) Run(ctx agent.InvocationContext, input any) iter.Seq2[*sessi
 			}
 
 			synthesizeAgentOutput(event)
+
+			// Tag the event for scope filtering (mirrors adk-python
+			// NodeRunner._enrich_event). The scheduler stamps delegated
+			// child events; this covers the direct agent-wrapper path.
+			if sc := ctx.IsolationScope(); sc != "" && event.IsolationScope == "" {
+				event.IsolationScope = sc
+			}
 
 			// TODO: add output validation
 			if !yield(event, nil) {

--- a/workflow/agent_node_test.go
+++ b/workflow/agent_node_test.go
@@ -450,3 +450,54 @@ func TestAgentNode_SynthesizesOutputFromModelText(t *testing.T) {
 		t.Errorf("partial event MessageAsOutput = true, want false/unset")
 	}
 }
+
+func TestAgentNode_StampsIsolationScopeOnEvents(t *testing.T) {
+	var gotAgentScope string
+	wrapped, err := agent.New(agent.Config{
+		Name: "scoped",
+		Run: func(ctx agent.InvocationContext) iter.Seq2[*session.Event, error] {
+			gotAgentScope = ctx.IsolationScope()
+			return func(yield func(*session.Event, error) bool) {
+				ev := session.NewEvent(ctx.InvocationID())
+				ev.Output = "v"
+				yield(ev, nil)
+				// An event that already carries a scope is left untouched.
+				pre := session.NewEvent(ctx.InvocationID())
+				pre.IsolationScope = "preset"
+				yield(pre, nil)
+			}
+		},
+	})
+	if err != nil {
+		t.Fatalf("agent.New: %v", err)
+	}
+	node, err := NewAgentNode(wrapped, NodeConfig{})
+	if err != nil {
+		t.Fatalf("NewAgentNode: %v", err)
+	}
+
+	mockCtx := newMockCtx(t)
+	mockCtx.sess = &mockSession{id: "test-session-id"}
+	mockCtx.isolationScope = "scope-x"
+
+	var events []*session.Event
+	for ev, err := range node.Run(mockCtx, "ignored") {
+		if err != nil {
+			t.Fatalf("node.Run: %v", err)
+		}
+		events = append(events, ev)
+	}
+
+	if gotAgentScope != "scope-x" {
+		t.Errorf("agent ctx IsolationScope = %q, want %q", gotAgentScope, "scope-x")
+	}
+	if len(events) != 2 {
+		t.Fatalf("got %d events, want 2", len(events))
+	}
+	if events[0].IsolationScope != "scope-x" {
+		t.Errorf("event[0] IsolationScope = %q, want %q", events[0].IsolationScope, "scope-x")
+	}
+	if events[1].IsolationScope != "preset" {
+		t.Errorf("event[1] IsolationScope = %q, want %q (preset must be kept)", events[1].IsolationScope, "preset")
+	}
+}

--- a/workflow/branch.go
+++ b/workflow/branch.go
@@ -147,3 +147,32 @@ func commonBranchPrefix(branches []string) string {
 	}
 	return strings.Join(splits[0][:commonCount], ".")
 }
+
+// Isolation scope, unlike branch (prefix match, empty is universal), is
+// an exact match — a scoped node sees only events tagged with its own
+// scope.
+
+func withIsolationScope(ctx agent.InvocationContext, scope string) agent.InvocationContext {
+	if ctx.IsolationScope() == scope {
+		return ctx
+	}
+	return &isolationScopeOverride{InvocationContext: ctx, scope: scope}
+}
+
+// isolationScopeOverride wraps an InvocationContext, overriding
+// IsolationScope(). Mirrors branchOverride.
+type isolationScopeOverride struct {
+	agent.InvocationContext
+	scope string
+}
+
+func (o *isolationScopeOverride) IsolationScope() string { return o.scope }
+
+// WithContext preserves the scope override through context-cancellation
+// wrapping.
+func (o *isolationScopeOverride) WithContext(ctx context.Context) agent.InvocationContext {
+	return &isolationScopeOverride{
+		InvocationContext: o.InvocationContext.WithContext(ctx),
+		scope:             o.scope,
+	}
+}

--- a/workflow/dynamic_scheduler.go
+++ b/workflow/dynamic_scheduler.go
@@ -174,6 +174,16 @@ func (s *dynamicSubScheduler) runNode(child Node, input any, opts runNodeOptions
 	}
 	childCtx := newDynamicNodeContext(s.parentCtx.WithBranch(childBranch), childPath, runID, s, childAncestors)
 
+	// Explicit scope wins over the node-path default; absent both,
+	// inherit. Matches adk-python _compute_isolation_scope_for_node.
+	childScope := childCtx.IsolationScope()
+	if opts.overrideIsolationScope != "" {
+		childScope = opts.overrideIsolationScope
+	} else if opts.scopeFromNodePath {
+		childScope = childPath
+	}
+	childCtx.InvocationContext = withIsolationScope(childCtx.InvocationContext, childScope)
+
 	// EXPERIMENTAL: stash childCtx (a *nodeContext with non-nil
 	// subScheduler) in the embedded context.Context so tools running
 	// inside an LlmAgent that is itself running as this dynamic
@@ -210,6 +220,11 @@ func (s *dynamicSubScheduler) runNode(child Node, input any, opts runNodeOptions
 			ev.NodeInfo = &session.NodeInfo{Path: childPath}
 		} else if ev.NodeInfo.Path == "" {
 			ev.NodeInfo.Path = childPath
+		}
+		// Tag the event for scope filtering; mirrors adk-python
+		// NodeRunner._enrich_event.
+		if childScope != "" && ev.IsolationScope == "" {
+			ev.IsolationScope = childScope
 		}
 		if ev.RequestedInput != nil {
 			interrupted = true

--- a/workflow/dynamic_scheduler_test.go
+++ b/workflow/dynamic_scheduler_test.go
@@ -200,6 +200,7 @@ type stubNode struct {
 	out        any
 	lastPath   string
 	lastBranch string
+	lastScope  string
 }
 
 func newStubNode(name string, out any) *stubNode {
@@ -214,6 +215,7 @@ func (n *stubNode) Run(ctx agent.InvocationContext, _ any) iter.Seq2[*session.Ev
 		n.lastPath = nc.Path()
 	}
 	n.lastBranch = ctx.Branch()
+	n.lastScope = ctx.IsolationScope()
 	out := n.out
 	return func(yield func(*session.Event, error) bool) {
 		yield(&session.Event{Output: out}, nil)

--- a/workflow/run_node.go
+++ b/workflow/run_node.go
@@ -20,10 +20,12 @@ import "fmt"
 type RunNodeOption func(*runNodeOptions)
 
 type runNodeOptions struct {
-	customRunID    string
-	useSubBranch   bool
-	overrideBranch string
-	useAsOutput    bool
+	customRunID            string
+	useSubBranch           bool
+	overrideBranch         string
+	useAsOutput            bool
+	overrideIsolationScope string
+	scopeFromNodePath      bool
 }
 
 // WithRunID overrides the auto-generated counter with a stable
@@ -76,6 +78,21 @@ func WithUseAsOutput() RunNodeOption {
 // root.
 func WithOverrideBranch(branch string) RunNodeOption {
 	return func(o *runNodeOptions) { o.overrideBranch = branch }
+}
+
+// WithIsolationScope tags the child and its emitted events with scope,
+// restricting the child's LLM history to matching events (see
+// session.Event.IsolationScope). Empty means no scope.
+func WithIsolationScope(scope string) RunNodeOption {
+	return func(o *runNodeOptions) { o.overrideIsolationScope = scope }
+}
+
+// WithIsolationScopeFromNodePath scopes the child under its own node
+// path. The full path (not just "<name>@<run_id>") keeps scopes unique
+// across nested workflows and reused node names. This is the task-mode
+// LlmAgent case. WithIsolationScope, if also set, takes precedence.
+func WithIsolationScopeFromNodePath() RunNodeOption {
+	return func(o *runNodeOptions) { o.scopeFromNodePath = true }
 }
 
 // RunNode schedules child as a sub-node of the currently-executing

--- a/workflow/run_node_test.go
+++ b/workflow/run_node_test.go
@@ -371,7 +371,110 @@ func TestRunNode_SequentialFanOut_PerSibling_DistinctBranches(t *testing.T) {
 	}
 }
 
+func TestRunNode_IsolationScopeFromNodePath(t *testing.T) {
+	// WithIsolationScopeFromNodePath scopes the child under its full
+	// node path on both the child context and its emitted events, so a
+	// task-mode node is isolated from peers (b/514866119).
+	child := newStubNode("c", "v")
+	events := drainDynamic(t, NewDynamicNode[string, string](
+		"orch",
+		func(ctx NodeContext, _ string, _ func(*session.Event) error) (string, error) {
+			if _, err := RunNode[string](ctx, child, nil, WithIsolationScopeFromNodePath()); err != nil {
+				return "", err
+			}
+			return "", nil
+		},
+		NodeConfig{},
+	), "")
+
+	if got, want := child.lastScope, "orch/c@1"; got != want {
+		t.Errorf("child ctx IsolationScope = %q, want %q", got, want)
+	}
+	if got := isolationScopeAtPath(events, "orch/c@1"); got != "orch/c@1" {
+		t.Errorf("emitted event IsolationScope = %q, want %q", got, "orch/c@1")
+	}
+}
+
+func TestRunNode_IsolationScope_Explicit(t *testing.T) {
+	child := newStubNode("c", "v")
+	events := drainDynamic(t, NewDynamicNode[string, string](
+		"orch",
+		func(ctx NodeContext, _ string, _ func(*session.Event) error) (string, error) {
+			if _, err := RunNode[string](ctx, child, nil, WithIsolationScope("fc-123")); err != nil {
+				return "", err
+			}
+			return "", nil
+		},
+		NodeConfig{},
+	), "")
+
+	if got, want := child.lastScope, "fc-123"; got != want {
+		t.Errorf("child ctx IsolationScope = %q, want %q", got, want)
+	}
+	if got := isolationScopeAtPath(events, "orch/c@1"); got != "fc-123" {
+		t.Errorf("emitted event IsolationScope = %q, want %q", got, "fc-123")
+	}
+}
+
+func TestRunNode_ExplicitScopeTakesPrecedenceOverNodePath(t *testing.T) {
+	child := newStubNode("c", "v")
+	runInOrchestrator[string](t, func(ctx NodeContext) (string, error) {
+		_, err := RunNode[string](ctx, child, nil,
+			WithIsolationScope("fc-123"), WithIsolationScopeFromNodePath())
+		return "", err
+	})
+	if got, want := child.lastScope, "fc-123"; got != want {
+		t.Errorf("child ctx IsolationScope = %q, want %q (explicit must win)", got, want)
+	}
+}
+
+func TestRunNode_NoIsolationScope_InheritsParent(t *testing.T) {
+	// Without a scope option the child inherits the parent's scope,
+	// which is empty for an unscoped orchestrator.
+	child := newStubNode("c", "v")
+	runInOrchestrator[string](t, func(ctx NodeContext) (string, error) {
+		_, err := RunNode[string](ctx, child, nil)
+		return "", err
+	})
+	if got := child.lastScope; got != "" {
+		t.Errorf("child ctx IsolationScope = %q, want empty (inherited)", got)
+	}
+}
+
+func TestRunNode_IsolationScope_DistinctPerNodePath(t *testing.T) {
+	// Two children sharing a name but at distinct run positions get
+	// distinct scopes, the uniqueness guarantee from b/514866119.
+	child := newStubNode("c", "v")
+	var scopes []string
+	runInOrchestrator[string](t, func(ctx NodeContext) (string, error) {
+		if _, err := RunNode[string](ctx, child, nil, WithIsolationScopeFromNodePath()); err != nil {
+			return "", err
+		}
+		scopes = append(scopes, child.lastScope)
+		if _, err := RunNode[string](ctx, child, nil, WithIsolationScopeFromNodePath()); err != nil {
+			return "", err
+		}
+		scopes = append(scopes, child.lastScope)
+		return "", nil
+	})
+	if want := []string{"orch/c@1", "orch/c@2"}; !reflect.DeepEqual(scopes, want) {
+		t.Errorf("scopes = %v, want %v", scopes, want)
+	}
+}
+
 // --- test helpers ---
+
+// isolationScopeAtPath returns the IsolationScope of the last event
+// stamped with nodePath.
+func isolationScopeAtPath(events []*session.Event, nodePath string) string {
+	for i := len(events) - 1; i >= 0; i-- {
+		ev := events[i]
+		if ev.NodeInfo != nil && ev.NodeInfo.Path == nodePath {
+			return ev.IsolationScope
+		}
+	}
+	return ""
+}
 
 // runInOrchestrator drives orchestratorFn inside a dynamic node so that
 // the RunNode calls inside have a valid NodeContext + sub-scheduler.

--- a/workflow/workflow_test.go
+++ b/workflow/workflow_test.go
@@ -37,8 +37,9 @@ var defaultNodeConfig = NodeConfig{}
 // context.Context so child cancellation works.
 type MockInvocationContext struct {
 	context.Context
-	sess        session.Session
-	userContent *genai.Content
+	sess           session.Session
+	userContent    *genai.Content
+	isolationScope string
 }
 
 // newMockCtx returns a fresh MockInvocationContext backed by
@@ -79,7 +80,7 @@ func (m *MockInvocationContext) Agent() agent.Agent              { return nil }
 func (m *MockInvocationContext) Artifacts() agent.Artifacts      { return nil }
 func (m *MockInvocationContext) Memory() agent.Memory            { return nil }
 func (m *MockInvocationContext) Branch() string                  { return "" }
-func (m *MockInvocationContext) IsolationScope() string          { return "" }
+func (m *MockInvocationContext) IsolationScope() string          { return m.isolationScope }
 func (m *MockInvocationContext) RunConfig() *agent.RunConfig     { return nil }
 func (m *MockInvocationContext) Ended() bool                     { return false }
 func (m *MockInvocationContext) EndInvocation()                  {}


### PR DESCRIPTION
### Problem
PR #987 added the isolation_scope filter (an agent's LLM history is
restricted to events whose scope matches its own), but nothing set or
stamped a scope — so the filter never engaged. In particular a task-mode
LlmAgent run as a node had no way to isolate its multi-turn conversation
from peer workflow nodes.

### Solution
Add the producer side. RunNode gains WithIsolationScope (explicit value)
and WithIsolationScopeFromNodePath (scope = the child's full node path,
the task-mode case). The dynamic scheduler resolves the scope (explicit >
node path > inherited), sets it on the child context, and stamps it onto
every event the child emits; the agent wrapper stamps the direct
(non-delegated) path. Using the full node path keeps scopes unique across
nested workflows and reused node names. Mirrors adk-python
_compute_isolation_scope_for_node and NodeRunner._enrich_event.

Wiring the task-delegation dispatch is left as a TODO on TaskAgentTool.