### PR TITLE
feat: create contents for isolated agents

### DIFF
--- a/internal/llminternal/contents_processor.go
+++ b/internal/llminternal/contents_processor.go
@@ -42,8 +42,9 @@ func ContentsRequestProcessor(ctx agent.InvocationContext, req *model.LLMRequest
 			// Do nothing.
 			return // In python, no error is yielded.
 		}
+		state := llmAgent.internal()
 		fn := buildContentsDefault // "" or "default".
-		if llmAgent.internal().IncludeContents == "none" {
+		if state.IncludeContents == "none" {
 			// Include current turn context only (no conversation history)
 			fn = buildContentsCurrentTurnContextOnly
 		}
@@ -53,7 +54,8 @@ func ContentsRequestProcessor(ctx agent.InvocationContext, req *model.LLMRequest
 				events = append(events, e)
 			}
 		}
-		contents, err := fn(ctx.Agent().Name(), ctx.Branch(), ctx.IsolationScope(), events)
+		isSingleTurn := state.Mode == ModeSingleTurn
+		contents, err := fn(ctx.Agent().Name(), ctx.Branch(), ctx.IsolationScope(), events, isSingleTurn, ctx.UserContent())
 		if err != nil {
 			yield(nil, err)
 			return
@@ -64,7 +66,7 @@ func ContentsRequestProcessor(ctx agent.InvocationContext, req *model.LLMRequest
 
 // buildContentsDefault returns the contents for the LLM request by applying
 // filtering, rearrangement, and content processing to the given events.
-func buildContentsDefault(agentName, invocationBranch, isolationScope string, events []*session.Event) ([]*genai.Content, error) {
+func buildContentsDefault(agentName, invocationBranch, isolationScope string, events []*session.Event, isSingleTurn bool, userContent *genai.Content) ([]*genai.Content, error) {
 	// parse the events, leaving the contents and the function calls and responses from the current agent.
 	var filtered []*session.Event
 	for _, ev := range events {
@@ -176,6 +178,19 @@ func buildContentsDefault(agentName, invocationBranch, isolationScope string, ev
 
 		utils.RemoveClientFunctionCallID(content)
 		contents = append(contents, content)
+	}
+
+	// For scoped agents (task / single_turn), prepend a synthetic user
+	// content built from the originating FC's args. The FC lives in an
+	// UNSCOPED parent event (e.g. the coordinator's task-delegation FC)
+	// which the strict isolation filter above just excluded, so we
+	// re-derive it directly from the (pre-filter) events slice we were
+	// handed. This becomes the agent's first turn: "your task is X"
+	// instead of starting cold from the system instruction only.
+	if isolationScope != "" {
+		if leading := buildTaskInputUserContent(events, isolationScope, isSingleTurn, userContent); leading != nil {
+			contents = append([]*genai.Content{leading}, contents...)
+		}
 	}
 	return contents, nil
 }
@@ -505,7 +520,7 @@ func mergeFunctionResponseEvents(functionResponseEvents []*session.Event) (*sess
 //
 //	In multi-agent scenarios, the "current turn" for an agent starts from an
 //	actual user or from another agent.
-func buildContentsCurrentTurnContextOnly(agentName, branch, isolationScope string, events []*session.Event) ([]*genai.Content, error) {
+func buildContentsCurrentTurnContextOnly(agentName, branch, isolationScope string, events []*session.Event, isSingleTurn bool, userContent *genai.Content) ([]*genai.Content, error) {
 	// Find the latest event that starts the current turn and process from there
 	for i := len(events) - 1; i >= 0; i-- {
 		event := events[i]
@@ -516,12 +531,12 @@ func buildContentsCurrentTurnContextOnly(agentName, branch, isolationScope strin
 			continue
 		}
 		if event.Author == "user" || isOtherAgentReply(agentName, event) {
-			return buildContentsDefault(agentName, branch, isolationScope, events[i:])
+			return buildContentsDefault(agentName, branch, isolationScope, events[i:], isSingleTurn, userContent)
 		}
 	}
 	// NOTE: in Python, it returns [] if there is no event authored by a user or another agent,
 	// but that may be a bug.
-	return buildContentsDefault(agentName, branch, isolationScope, events)
+	return buildContentsDefault(agentName, branch, isolationScope, events, isSingleTurn, userContent)
 }
 
 func isOtherAgentReply(currentAgentName string, ev *session.Event) bool {
@@ -601,6 +616,73 @@ func shouldExcludeEvent(ev *session.Event) bool {
 		}
 	}
 	return false
+}
+
+// SingleTurnNudge is appended as a second user-content text part for
+// single_turn agents.
+const SingleTurnNudge = "Important: You will not receive any user replies or clarifications." +
+	" Complete the task using only the information provided above."
+
+// buildTaskInputUserContent finds the originating task-delegation FC in
+// events and converts its args into a user-role Content for use as the
+// first turn of a scoped (task / single_turn) agent.
+//
+// A task agent runs under isolation_scope == <fc_id>, where fc_id
+// matches the FunctionCall.ID that delegated to it. The FC itself
+// lives on a parent (coordinator) event that is filtered out of the
+// agent's view by the strict isolation_scope match, so this helper
+// rebuilds it here.
+//
+// When no matching FC is found (workflow-node task case — task agent
+// dispatched directly by a Workflow, not via FC delegation), falls
+// back to userContent (set on the InvocationContext by the wrapper to
+// the rendered node input). Returns nil if neither source yields
+// content.
+//
+// When isSingleTurn is true, appends singleTurnNudge as an additional
+// user-content text part.
+func buildTaskInputUserContent(events []*session.Event, isolationScope string, isSingleTurn bool, userContent *genai.Content) *genai.Content {
+	if isolationScope == "" {
+		return nil
+	}
+	for _, ev := range events {
+		content := utils.Content(ev)
+		if content == nil || len(content.Parts) == 0 {
+			continue
+		}
+		for _, p := range content.Parts {
+			if p == nil || p.FunctionCall == nil {
+				continue
+			}
+			fc := p.FunctionCall
+			if fc.ID != isolationScope || len(fc.Args) == 0 {
+				continue
+			}
+			// Render args as JSON — the same shape an LLM would emit.
+			text, err := json.Marshal(fc.Args)
+			var argText string
+			if err != nil {
+				argText = fmt.Sprint(fc.Args)
+			} else {
+				argText = string(text)
+			}
+			parts := []*genai.Part{{Text: argText}}
+			if isSingleTurn {
+				parts = append(parts, &genai.Part{Text: SingleTurnNudge})
+			}
+			return &genai.Content{Role: genai.RoleUser, Parts: parts}
+		}
+	}
+
+	if userContent == nil || len(userContent.Parts) == 0 {
+		return nil
+	}
+	parts := make([]*genai.Part, 0, len(userContent.Parts)+1)
+	parts = append(parts, userContent.Parts...)
+	if isSingleTurn {
+		parts = append(parts, &genai.Part{Text: SingleTurnNudge})
+	}
+	return &genai.Content{Role: genai.RoleUser, Parts: parts}
 }
 
 func cloneEvent(e *session.Event) *session.Event {

--- a/internal/llminternal/contents_processor_test.go
+++ b/internal/llminternal/contents_processor_test.go
@@ -15,6 +15,7 @@
 package llminternal_test
 
 import (
+	"encoding/json"
 	"iter"
 	"slices"
 	"strings"
@@ -289,6 +290,141 @@ func TestContentsRequestProcessor_IncludeContentsNone_IsolationScopePivot(t *tes
 		}
 	}
 	want := []*genai.Content{genai.NewContentFromText("unscoped turn", "user")}
+	if diff := cmp.Diff(want, req.Contents); diff != "" {
+		t.Errorf("contents mismatch (-want +got):\n%s", diff)
+	}
+}
+
+func TestContentsRequestProcessor_TaskInputFromOriginatingFC(t *testing.T) {
+	t.Parallel()
+	const taskAgentName = "taskAgent"
+	const coordName = "coord"
+	const fcID = "fc-1"
+	args := map[string]any{"goal": "summarize"}
+	events := []*session.Event{
+		{
+			Author: coordName,
+			LLMResponse: model.LLMResponse{
+				Content: &genai.Content{
+					Role: "model",
+					Parts: []*genai.Part{{FunctionCall: &genai.FunctionCall{
+						ID: fcID, Name: taskAgentName, Args: args,
+					}}},
+				},
+			},
+		},
+		{
+			Author:         taskAgentName,
+			IsolationScope: fcID,
+			LLMResponse: model.LLMResponse{
+				Content: genai.NewContentFromText("working on it", "model"),
+			},
+		},
+	}
+
+	argsJSON, err := json.Marshal(args)
+	if err != nil {
+		t.Fatalf("marshal args: %v", err)
+	}
+
+	t.Run("task mode prepends FC args without nudge", func(t *testing.T) {
+		taskAgent := utils.Must(llmagent.New(llmagent.Config{
+			Name:  taskAgentName,
+			Model: &testModel{},
+			Mode:  llmagent.ModeTask,
+		}))
+		ctx := icontext.NewInvocationContext(t.Context(), icontext.InvocationContextParams{
+			Agent:          taskAgent,
+			IsolationScope: fcID,
+			Session:        &fakeSession{events: events},
+		})
+		req := &model.LLMRequest{}
+		for _, err := range llminternal.ContentsRequestProcessor(ctx, req, &llminternal.Flow{}) {
+			if err != nil {
+				t.Fatalf("contentsRequestProcessor failed: %v", err)
+			}
+		}
+		want := []*genai.Content{
+			{Role: genai.RoleUser, Parts: []*genai.Part{{Text: string(argsJSON)}}},
+			genai.NewContentFromText("working on it", "model"),
+		}
+		if diff := cmp.Diff(want, req.Contents); diff != "" {
+			t.Errorf("contents mismatch (-want +got):\n%s", diff)
+		}
+	})
+
+	t.Run("single_turn mode appends nudge after FC args", func(t *testing.T) {
+		stAgent := utils.Must(llmagent.New(llmagent.Config{
+			Name:            taskAgentName,
+			Model:           &testModel{},
+			Mode:            llmagent.ModeSingleTurn,
+			IncludeContents: "none",
+		}))
+		ctx := icontext.NewInvocationContext(t.Context(), icontext.InvocationContextParams{
+			Agent:          stAgent,
+			IsolationScope: fcID,
+			Session:        &fakeSession{events: events},
+		})
+		req := &model.LLMRequest{}
+		for _, err := range llminternal.ContentsRequestProcessor(ctx, req, &llminternal.Flow{}) {
+			if err != nil {
+				t.Fatalf("contentsRequestProcessor failed: %v", err)
+			}
+		}
+		wantLeading := &genai.Content{
+			Role: genai.RoleUser,
+			Parts: []*genai.Part{
+				{Text: string(argsJSON)},
+				{Text: llminternal.SingleTurnNudge},
+			},
+		}
+		if len(req.Contents) == 0 {
+			t.Fatal("expected at least one content; got none")
+		}
+		if diff := cmp.Diff(wantLeading, req.Contents[0]); diff != "" {
+			t.Errorf("leading content mismatch (-want +got):\n%s", diff)
+		}
+	})
+}
+
+func TestContentsRequestProcessor_TaskInputFromUserContentFallback(t *testing.T) {
+	t.Parallel()
+	const taskAgentName = "taskAgent"
+	const scope = "wf:node-1"
+	userInput := genai.NewContentFromText("do the thing", genai.RoleUser)
+
+	// Session has no event carrying a FunctionCall with ID == scope.
+	events := []*session.Event{
+		{
+			Author:         taskAgentName,
+			IsolationScope: scope,
+			LLMResponse: model.LLMResponse{
+				Content: genai.NewContentFromText("ack", "model"),
+			},
+		},
+	}
+
+	taskAgent := utils.Must(llmagent.New(llmagent.Config{
+		Name:  taskAgentName,
+		Model: &testModel{},
+		Mode:  llmagent.ModeTask,
+	}))
+	ctx := icontext.NewInvocationContext(t.Context(), icontext.InvocationContextParams{
+		Agent:          taskAgent,
+		IsolationScope: scope,
+		UserContent:    userInput,
+		Session:        &fakeSession{events: events},
+	})
+	req := &model.LLMRequest{}
+	for _, err := range llminternal.ContentsRequestProcessor(ctx, req, &llminternal.Flow{}) {
+		if err != nil {
+			t.Fatalf("contentsRequestProcessor failed: %v", err)
+		}
+	}
+	want := []*genai.Content{
+		{Role: genai.RoleUser, Parts: userInput.Parts},
+		genai.NewContentFromText("ack", "model"),
+	}
 	if diff := cmp.Diff(want, req.Contents); diff != "" {
 		t.Errorf("contents mismatch (-want +got):\n%s", diff)
 	}


### PR DESCRIPTION
Scoped agents (task/single_turn) are invoked by task-delegation FC. This commit handles proper content construction for such agents: making FC args visible to the agent + adding SingleTurnNudge text part for single_turn agent.
