### PR TITLE
chore: complete Node 24 migration for GitHub Actions

### DIFF
--- a/.github/actions/setup/action.yml
+++ b/.github/actions/setup/action.yml
@@ -11,13 +11,13 @@ runs:
   steps:
     - name: Set up Go
       id: setup-go
-      uses: actions/setup-go@d35c59abb061a4a6fb18e82ac0862c26744d6ab5 # v5.5.0
+      uses: actions/setup-go@4a3601121dd01d1626a1e23e37211e3254c1c06c # v6.4.0
       with:
         go-version-file: 'go.mod'
         cache: false # wrapper for actions/cache that doesn't support all functionality
 
     - name: Load Go cache
-      uses: actions/cache@5a3ec84eff668545956fd18022155c47e93e2684 # v4.2.3
+      uses: actions/cache@27d5ce7f107fe9357f9df03efb73ab90386fccae # v5.0.5
       with:
         path: |
           ~/.cache/go-build

--- a/.github/workflows/nightly.yml
+++ b/.github/workflows/nightly.yml
@@ -22,7 +22,11 @@ jobs:
     runs-on: ubuntu-latest
     steps:
     - name: Run govulncheck
-      uses: golang/govulncheck-action@b625fbe08f3bccbe446d94fbf87fcc875a4f50ee # v1.0.4
+      # NOTE: pinned to master HEAD instead of a tag. The latest release (v1.0.4)
+      # internally uses actions/checkout@v4.1.1 and actions/setup-go@v5.0.0 (Node 20),
+      # which are deprecated. master uses checkout v6.0.2 + setup-go v6.2.0 (Node 24).
+      # TODO: re-pin to a tagged release once upstream tags one past v1.0.4.
+      uses: golang/govulncheck-action@31f7c5463448f83528bd771c2d978d940080c9fd # master, post-v1.0.4 (Node 24)
       with:
            go-version-file: go.mod
            repo-checkout: true


### PR DESCRIPTION
## Summary

Finishes migrating CI off the deprecated Node 20 actions runtime. GitHub forces JavaScript actions to Node 24 starting June 16, 2026 and removes Node 20 from runners on Sept 16, 2026, so anything still declaring Node 20 currently emits a deprecation warning and will eventually break.

An earlier pass bumped `actions/checkout` to v6, but three references were left on Node 20 — two of them indirect, which is why they were easy to miss:

| Action | Where | Was | Now | Runtime |
|---|---|---|---|---|
| `actions/setup-go` | `.github/actions/setup` composite | v5.5.0 | v6.4.0 | Node 20 → 24 |
| `actions/cache` | `.github/actions/setup` composite | v4.2.3 | v5.0.5 | Node 20 → 24 |
| `golang/govulncheck-action` | `nightly.yml` vulncheck job | v1.0.4 | master HEAD | Node 20 → 24 |

### Notes

- `actions/setup-go` only switched to Node 24 in **v6.2.0** (v5.x and even v6.0.0/v6.1.0 are still Node 20), so the composite action affected every job that uses it (`test`, `lint`, `nightly` test).
- `golang/govulncheck-action`'s latest tagged release (v1.0.4) internally pins `actions/checkout@v4.1.1` and `actions/setup-go@v5.0.0` (Node 20). Its default branch already uses Node 24 actions but hasn't been tagged, so it's pinned to the master commit with an inline `TODO` to re-pin to a proper tag once upstream cuts a release past v1.0.4.
- All SHAs are full-length pinned with version comments, matching the repo's existing convention.

### Verification

- Both edited YAML files parse cleanly.
- Verified each new pinned SHA declares `using: node24` in its `action.yml` (and that govulncheck-action's master uses checkout v6.0.2 + setup-go v6.2.0 internally).