### PR TITLE
feat: add tool deferred response

### DIFF
--- a/internal/llminternal/base_flow.go
+++ b/internal/llminternal/base_flow.go
@@ -1129,7 +1129,15 @@ func (f *Flow) handleFunctionCalls(ctx agent.InvocationContext, toolsDict map[st
 				}
 			}
 
-			// TODO: handle long-running tool.
+			if result == nil {
+				if d, ok := curTool.(toolinternal.ResponseDeferrer); ok && d.DefersResponse() {
+					return
+				}
+				if curTool != nil && curTool.IsLongRunning() {
+					return
+				}
+			}
+
 			ev := session.NewEvent(ctx.InvocationID())
 			ev.LLMResponse = model.LLMResponse{
 				Content: &genai.Content{

--- a/internal/llminternal/handle_function_calls_async_test.go
+++ b/internal/llminternal/handle_function_calls_async_test.go
@@ -24,6 +24,7 @@ import (
 
 	"google.golang.org/adk/agent"
 	"google.golang.org/adk/agent/llmagent"
+	"google.golang.org/adk/internal/toolinternal/toolutils"
 	"google.golang.org/adk/model"
 	"google.golang.org/adk/runner"
 	"google.golang.org/adk/session"
@@ -192,5 +193,206 @@ func TestHandleFunctionCallsAsync(t *testing.T) {
 
 	if elapsed > 1000*time.Millisecond {
 		t.Errorf("Elapsed time %v is greater than expected 1000ms for async execution", elapsed)
+	}
+}
+
+type deferringTool struct {
+	name        string
+	description string
+	result      map[string]any
+	defers      bool
+	longRunning bool
+	runCount    int
+}
+
+func (t *deferringTool) Name() string        { return t.name }
+func (t *deferringTool) Description() string { return t.description }
+func (t *deferringTool) IsLongRunning() bool { return t.longRunning }
+func (t *deferringTool) DefersResponse() bool {
+	return t.defers
+}
+
+func (t *deferringTool) Declaration() *genai.FunctionDeclaration {
+	return &genai.FunctionDeclaration{
+		Name:        t.name,
+		Description: t.description,
+		Parameters: &genai.Schema{
+			Type: genai.TypeObject,
+		},
+	}
+}
+
+func (t *deferringTool) Run(ctx agent.ToolContext, args any) (map[string]any, error) {
+	t.runCount++
+	return t.result, nil
+}
+
+func (t *deferringTool) ProcessRequest(ctx agent.ToolContext, req *model.LLMRequest) error {
+	return toolutils.PackTool(req, t)
+}
+
+type singleCallMockModel struct {
+	model.LLM
+	toolName string
+	fcID     string
+	calls    int
+}
+
+func (m *singleCallMockModel) Name() string { return "single-call-mock" }
+
+func (m *singleCallMockModel) GenerateContent(ctx context.Context, req *model.LLMRequest, useStream bool) iter.Seq2[*model.LLMResponse, error] {
+	return func(yield func(*model.LLMResponse, error) bool) {
+		m.calls++
+		if m.calls > 1 {
+			yield(&model.LLMResponse{
+				Content: &genai.Content{
+					Parts: []*genai.Part{genai.NewPartFromText("done")},
+					Role:  "model",
+				},
+			}, nil)
+			return
+		}
+		yield(&model.LLMResponse{
+			Content: &genai.Content{
+				Parts: []*genai.Part{{FunctionCall: &genai.FunctionCall{
+					ID:   m.fcID,
+					Name: m.toolName,
+					Args: map[string]any{},
+				}}},
+				Role: "model",
+			},
+		}, nil)
+	}
+}
+
+func TestHandleFunctionCalls_FRSkipGates(t *testing.T) {
+	cases := []struct {
+		name             string
+		defers           bool
+		longRunning      bool
+		toolResult       map[string]any
+		wantEventCount   int
+		wantFREventIndex int // -1 if no FR event expected
+	}{
+		{
+			name:             "deferred + nil: gate fires, no FR event",
+			defers:           true,
+			toolResult:       nil,
+			wantEventCount:   2, // FC + final text only
+			wantFREventIndex: -1,
+		},
+		{
+			// generate FC only, no subsequent LLM call
+			name:             "long-running + nil: gate fires, no FR; node parks after FC only",
+			longRunning:      true,
+			toolResult:       nil,
+			wantEventCount:   1,
+			wantFREventIndex: -1,
+		},
+		{
+			name:             "deferred + long-running + nil: gate fires, no FR; node parks after FC only",
+			defers:           true,
+			longRunning:      true,
+			toolResult:       nil,
+			wantEventCount:   1,
+			wantFREventIndex: -1,
+		},
+		{
+			name:             "plain + nil: no gate, FR(nil) still emitted (no-op tool legacy)",
+			toolResult:       nil,
+			wantEventCount:   3, // FC + FR(nil) + text
+			wantFREventIndex: 1,
+		},
+		{
+			name:             "deferred + non-nil: FR event still emitted (gate is nil-only)",
+			defers:           true,
+			toolResult:       map[string]any{"answer": "ok"},
+			wantEventCount:   3, // FC + FR + text
+			wantFREventIndex: 1,
+		},
+		{
+			name:             "long-running + non-nil (pending dict): FR event still emitted",
+			longRunning:      true,
+			toolResult:       map[string]any{"status": "pending"},
+			wantEventCount:   3, // FC + FR(pending) + text — the canonical HITL pattern
+			wantFREventIndex: 1,
+		},
+	}
+
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			const toolName = "deferring"
+			const fcID = "fc-x"
+
+			dtool := &deferringTool{
+				name:        toolName,
+				description: "test deferring tool",
+				result:      tc.toolResult,
+				defers:      tc.defers,
+				longRunning: tc.longRunning,
+			}
+			mockLLM := &singleCallMockModel{toolName: toolName, fcID: fcID}
+
+			a, err := llmagent.New(llmagent.Config{
+				Name:        "tester",
+				Description: "tester",
+				Model:       mockLLM,
+				Tools:       []tool.Tool{dtool},
+			})
+			if err != nil {
+				t.Fatal(err)
+			}
+
+			svc := session.InMemoryService()
+			if _, err := svc.Create(t.Context(), &session.CreateRequest{
+				AppName: "app", UserID: "u", SessionID: "s",
+			}); err != nil {
+				t.Fatal(err)
+			}
+			r, err := runner.New(runner.Config{Agent: a, SessionService: svc, AppName: "app"})
+			if err != nil {
+				t.Fatal(err)
+			}
+
+			events := []*session.Event{}
+			for ev, err := range r.Run(t.Context(), "u", "s",
+				&genai.Content{Parts: []*genai.Part{genai.NewPartFromText("go")}, Role: "user"},
+				agent.RunConfig{StreamingMode: agent.StreamingModeSSE}) {
+				if err != nil {
+					t.Fatal(err)
+				}
+				events = append(events, ev)
+			}
+
+			if dtool.runCount != 1 {
+				t.Errorf("tool.Run called %d times, want 1", dtool.runCount)
+			}
+			if len(events) != tc.wantEventCount {
+				t.Fatalf("got %d events, want %d:\n%v",
+					len(events), tc.wantEventCount, events)
+			}
+			if tc.wantFREventIndex >= 0 {
+				fr := events[tc.wantFREventIndex]
+				if fr.Content == nil || len(fr.Content.Parts) == 0 ||
+					fr.Content.Parts[0].FunctionResponse == nil {
+					t.Errorf("event[%d] should be a FunctionResponse, got:\n%v",
+						tc.wantFREventIndex, events)
+				}
+			} else {
+				// Assert NO event carries a FunctionResponse part.
+				for i, ev := range events {
+					if ev.Content == nil {
+						continue
+					}
+					for _, p := range ev.Content.Parts {
+						if p.FunctionResponse != nil {
+							t.Errorf("event[%d] unexpectedly carries a FunctionResponse "+
+								"(deferred tool's FR should have been skipped):\n%v",
+								i, events)
+						}
+					}
+				}
+			}
+		})
 	}
 }

--- a/internal/toolinternal/tool.go
+++ b/internal/toolinternal/tool.go
@@ -40,3 +40,9 @@ type StreamingFunctionTool interface {
 type RequestProcessor interface {
 	ProcessRequest(ctx agent.ToolContext, req *model.LLMRequest) error
 }
+
+// ResponseDeferrer allows to skip generation of the FR by the tool.
+// Used in the cases when FR is generated externally (e.g. TaskAgentTool)
+type ResponseDeferrer interface {
+	DefersResponse() bool
+}

--- a/internal/workflowinternal/task_agent_tool.go
+++ b/internal/workflowinternal/task_agent_tool.go
@@ -49,10 +49,18 @@ func (t *TaskAgentTool) Declaration() *genai.FunctionDeclaration {
 }
 
 func (t *TaskAgentTool) Run(toolCtx agent.ToolContext, args any) (map[string]any, error) {
-	// Framework handles task delegation dispatch directly via the wrapper.
-	// TODO: add _defer_response logic.
+	// Framework handles task delegation dispatch directly via the
+	// LlmAgent chat wrapper.
 	// TODO: dispatch via RunNode with WithIsolationScope(fcID) and WithRunID(fcID).
 	return nil, nil
+}
+
+// DefersResponse implements toolinternal.ResponseDeferrer: the
+// FunctionResponse for a task delegation is produced by the chat
+// wrapper (synthesizeTaskFREvent), not by the standard tool-execution
+// pipeline.
+func (t *TaskAgentTool) DefersResponse() bool {
+	return true
 }
 
 func (t *TaskAgentTool) Name() string {

--- a/internal/workflowinternal/task_agent_tool_test.go
+++ b/internal/workflowinternal/task_agent_tool_test.go
@@ -66,6 +66,17 @@ func TestTaskAgentTool_Metadata(t *testing.T) {
 	if tt.IsLongRunning() {
 		t.Errorf("IsLongRunning() = true, want false")
 	}
+	if !tt.DefersResponse() {
+		t.Errorf("DefersResponse() = false, want true")
+	}
+	result, err := tt.Run(nil, nil)
+	if err != nil {
+		t.Errorf("Run() returned err = %v, want nil", err)
+	}
+	if result != nil {
+		t.Errorf("Run() = %v, want nil (Run must be a no-op so the "+
+			"DefersResponse gate skips auto-FR build)", result)
+	}
 }
 
 func TestTaskAgentTool_Declaration(t *testing.T) {


### PR DESCRIPTION
It's needed by the TaskAgentTool, where we don't need to generate FR immediately and it's generated by the external entity later (llmagent_wrapper code).