### PR TITLE
feat: exclude task&single_turn from direct transfer

### DIFF
--- a/internal/llminternal/agent_transfer.go
+++ b/internal/llminternal/agent_transfer.go
@@ -182,10 +182,16 @@ func (t *TransferToAgentTool) Run(ctx agent.ToolContext, args any) (map[string]a
 
 var _ tool.Tool = (*TransferToAgentTool)(nil)
 
-func transferTargets(agent, parent agent.Agent) []agent.Agent {
-	targets := slices.Clone(agent.SubAgents())
+func transferTargets(curAgent, parent agent.Agent) []agent.Agent {
+	var targets []agent.Agent
+	for _, sub := range curAgent.SubAgents() {
+		if isUntransferableMode(sub) {
+			continue
+		}
+		targets = append(targets, sub)
+	}
 
-	llmAgent := asLLMAgent(agent)
+	llmAgent := asLLMAgent(curAgent)
 	llmParent := asLLMAgent(parent)
 
 	if llmParent == nil {
@@ -201,13 +207,32 @@ func transferTargets(agent, parent agent.Agent) []agent.Agent {
 	if !llmAgent.internal().DisallowTransferToPeers {
 		if shouldUseAutoFlow(parent) {
 			for _, peer := range parent.SubAgents() {
-				if peer.Name() != agent.Name() {
-					targets = append(targets, peer)
+				if peer.Name() == curAgent.Name() {
+					continue
 				}
+				if isUntransferableMode(peer) {
+					continue
+				}
+				targets = append(targets, peer)
 			}
 		}
 	}
 	return targets
+}
+
+// isUntransferableMode skips the agents which have different delegation
+// mechanism (e.g. task & single_turn agents are handled by llmagent
+// wrapper code).
+func isUntransferableMode(a agent.Agent) bool {
+	llmA := asLLMAgent(a)
+	if llmA == nil {
+		return false
+	}
+	switch llmA.internal().Mode {
+	case ModeTask, ModeSingleTurn:
+		return true
+	}
+	return false
 }
 
 func asLLMAgent(agent agent.Agent) Agent {
@@ -282,7 +307,16 @@ var transferToAgentPromptTmpl = template.Must(
 	template.New("transfer_to_agent_prompt").Parse(agentTransferInstructionTemplate))
 
 func instructionsForTransferToAgent(curAgent, parent agent.Agent, targets []agent.Agent) (string, error) {
-	if asLLMAgent(curAgent).internal().DisallowTransferToParent {
+	cur := asLLMAgent(curAgent)
+	// Suppress transfer instructions for task / single_turn agents:
+	// they reach their callees via FC delegation (TaskAgentTool /
+	// SingleTurnTool), not via transfer.
+	switch cur.internal().Mode {
+	case ModeTask, ModeSingleTurn:
+		return "", nil
+	}
+
+	if cur.internal().DisallowTransferToParent {
 		parent = nil
 	}
 

--- a/internal/llminternal/agent_transfer_test.go
+++ b/internal/llminternal/agent_transfer_test.go
@@ -427,6 +427,123 @@ func TestAgentTransferRequestProcessor(t *testing.T) {
 		}))
 		check(t, agent, agent, "", []string{"Sub1", "Sub2"}, []string{"Current"})
 	})
+
+	t.Run("TaskAndSingleTurnSubagentsExcludedAsTargets", func(t *testing.T) {
+		taskSub := utils.Must(llmagent.New(llmagent.Config{
+			Name:  "TaskSub",
+			Model: llm,
+			Mode:  llmagent.ModeTask,
+		}))
+		singleTurnSub := utils.Must(llmagent.New(llmagent.Config{
+			Name:  "SingleTurnSub",
+			Model: llm,
+			Mode:  llmagent.ModeSingleTurn,
+		}))
+		chatSub := utils.Must(llmagent.New(llmagent.Config{
+			Name:  "ChatSub",
+			Model: llm,
+		}))
+		curAgent := utils.Must(llmagent.New(llmagent.Config{
+			Name:      "Current",
+			Model:     llm,
+			SubAgents: []agent.Agent{taskSub, singleTurnSub, chatSub},
+		}))
+		check(t, curAgent, curAgent, "",
+			[]string{"ChatSub"},
+			[]string{"TaskSub", "SingleTurnSub", "Current"})
+	})
+
+	t.Run("TaskAndSingleTurnPeersExcludedAsTargets", func(t *testing.T) {
+		curAgent := utils.Must(llmagent.New(llmagent.Config{
+			Name:  "Current",
+			Model: llm,
+		}))
+		taskPeer := utils.Must(llmagent.New(llmagent.Config{
+			Name:  "TaskPeer",
+			Model: llm,
+			Mode:  llmagent.ModeTask,
+		}))
+		singleTurnPeer := utils.Must(llmagent.New(llmagent.Config{
+			Name:  "SingleTurnPeer",
+			Model: llm,
+			Mode:  llmagent.ModeSingleTurn,
+		}))
+		chatPeer := utils.Must(llmagent.New(llmagent.Config{
+			Name:  "ChatPeer",
+			Model: llm,
+		}))
+		root := utils.Must(llmagent.New(llmagent.Config{
+			Name:      "Parent",
+			Model:     llm,
+			SubAgents: []agent.Agent{curAgent, taskPeer, singleTurnPeer, chatPeer},
+		}))
+		check(t, curAgent, root, "Parent",
+			[]string{"ChatPeer"},
+			[]string{"TaskPeer", "SingleTurnPeer", "Current"})
+	})
+}
+
+// TestAgentTransferRequestProcessor_TaskSingleTurnCurrentAgent verifies
+// that LLM doesn't see transfer guidance for task / single_turn agents
+// because they reach their callees via FC delegation (TaskAgentTool /
+// SingleTurnTool), not via transfer.
+func TestAgentTransferRequestProcessor_TaskSingleTurnCurrentAgent(t *testing.T) {
+	llm := &struct{ model.LLM }{}
+
+	for _, tc := range []struct {
+		name string
+		mode llmagent.Mode
+	}{
+		{"task", llmagent.ModeTask},
+		{"single_turn", llmagent.ModeSingleTurn},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			cur := utils.Must(llmagent.New(llmagent.Config{
+				Name:  "Current",
+				Model: llm,
+				Mode:  tc.mode,
+			}))
+			root := utils.Must(llmagent.New(llmagent.Config{
+				Name:      "Parent",
+				Model:     llm,
+				SubAgents: []agent.Agent{cur},
+			}))
+
+			req := &model.LLMRequest{}
+			parents, err := parentmap.New(root)
+			if err != nil {
+				t.Fatal(err)
+			}
+			ctx := icontext.NewInvocationContext(
+				parentmap.ToContext(t.Context(), parents),
+				icontext.InvocationContextParams{Agent: cur},
+			)
+
+			for ev, err := range llminternal.AgentTransferRequestProcessor(ctx, req, &llminternal.Flow{}) {
+				if ev != nil {
+					t.Fatal("AgentTransferRequestProcessor generated an unexpected event")
+				}
+				if err != nil {
+					t.Fatalf("AgentTransferRequestProcessor failed: %v", err)
+				}
+			}
+
+			// No transfer-prose instructions should be appended.
+			// The processor's only path to instruction text is
+			// instructionsForTransferToAgent, which returns ""
+			// for task/single_turn; AppendInstructions("") is a
+			// no-op, leaving Config.SystemInstruction empty.
+			if req.Config != nil {
+				if got := utils.TextParts(req.Config.SystemInstruction); len(got) > 0 {
+					for _, s := range got {
+						if s != "" {
+							t.Errorf("expected no transfer instructions for mode=%q, got: %q", tc.mode, s)
+						}
+					}
+				}
+			}
+		})
+	}
 }
 
 func TestAgentTransfer_ProcessRequest(t *testing.T) {


### PR DESCRIPTION
task and single_turn agents are reached via FC delegation (the wrapper sniffs TaskAgentTool / SingleTurnTool function calls), not via transfer_to_agent