### PR TITLE
fix(workflow): make RunNode work from tools inside a static dynamic node

### DIFF
--- a/workflow/dynamic_node.go
+++ b/workflow/dynamic_node.go
@@ -114,6 +114,14 @@ func (n *dynamicNode[IN, OUT]) Run(ctx agent.InvocationContext, input any) iter.
 		sub := newDynamicSubScheduler(parentNC, n.composePath(parentNC), emit)
 		orchestratorCtx := newDynamicNodeContext(parentNC, sub.parentPath, "", sub, sub.outputForAncestors)
 
+		// Re-stash orchestratorCtx (carries a live subScheduler) into the
+		// embedded context.Context so a tool running inside an LlmAgent that
+		// is itself this node's body can recover a RunNode-capable
+		// NodeContext via NodeContextFromGoContext.
+		orchestratorCtx.InvocationContext = orchestratorCtx.InvocationContext.WithContext(
+			WithNodeContext(orchestratorCtx.InvocationContext, orchestratorCtx),
+		)
+
 		out, err := n.fn(orchestratorCtx, typedInput, emit)
 		if err != nil {
 			// HITL: the RequestedInput was already forwarded upstream;

--- a/workflow/run_node_test.go
+++ b/workflow/run_node_test.go
@@ -34,6 +34,49 @@ func TestRunNode_ErrInvalidRunNodeContext_OnStaticContext(t *testing.T) {
 	}
 }
 
+// TestRunNode_FromBridgedContext_DynamicNodeUnderScheduler checks that
+// a tool inside a dynamic node recovers a RunNode-capable NodeContext
+// from the bridge (NodeContextFromGoContext), not from its argument.
+func TestRunNode_FromBridgedContext_DynamicNodeUnderScheduler(t *testing.T) {
+	child := newStubNode("c", "ok")
+
+	var (
+		gotOut string
+		gotErr error
+	)
+	// orch is a static graph node that is itself a dynamic node,
+	// mirroring an AgentNode run by the main scheduler.
+	orch := NewDynamicNode[string, string]("orch",
+		func(ctx NodeContext, _ string, _ func(*session.Event) error) (string, error) {
+			// Recover the way a tool does: from the bridge, not the arg.
+			recovered, ok := NodeContextFromGoContext(ctx)
+			if !ok {
+				t.Fatal("NodeContextFromGoContext: no NodeContext on the bridge")
+			}
+			gotOut, gotErr = RunNode[string](recovered, child, nil)
+			return gotOut, gotErr
+		},
+		NodeConfig{},
+	)
+
+	w, err := New("root", Chain(Start, orch))
+	if err != nil {
+		t.Fatalf("workflow.New: %v", err)
+	}
+	for _, err := range w.Run(newMockCtx(t)) {
+		if err != nil {
+			t.Fatalf("workflow.Run error: %v", err)
+		}
+	}
+
+	if gotErr != nil {
+		t.Fatalf("RunNode via bridged context err = %v, want nil", gotErr)
+	}
+	if gotOut != "ok" {
+		t.Errorf("RunNode via bridged context = %q, want %q", gotOut, "ok")
+	}
+}
+
 func TestRunNode_ReturnsTypedOutput(t *testing.T) {
 	child := newStubNode("c", "hello")
 	got := runInOrchestrator[string](t, func(ctx NodeContext) (string, error) {


### PR DESCRIPTION
## Problem
A tool running inside an `LlmAgent` that is itself a dynamic node's body
(e.g. `SingleTurnTool` delegating to a `single_turn` sub-agent under a root
coordinator) failed with `ErrInvalidRunNodeContext` when calling `RunNode`.
Such a tool doesn't receive a `NodeContext` as an argument — it recovers one
from the context bridge via `NodeContextFromGoContext`. But only the main
scheduler's top-level `NodeContext` (with `subScheduler == nil`) was stashed
on the bridge. The orchestrator `NodeContext` built inside `dynamicNode.Run`
— the one carrying a live `subScheduler` — was never re-stashed, so the tool
recovered a `RunNode`-incapable context.

## Solution
Re-stash the orchestrator `NodeContext` onto the context bridge in
`dynamicNode.Run`, mirroring the existing child-path re-stash in
`dynamicSubScheduler.runNode`. The recovered context is then `RunNode`-capable.