### PR TITLE
ci: run triage + stale-issue bots via adk-samples reusable workflows

### DIFF
--- a/.github/workflows/stale-bot.yml
+++ b/.github/workflows/stale-bot.yml
@@ -1,0 +1,44 @@
+name: Stale Issue Auditor
+
+# Thin caller: the bot's code lives in google/adk-samples
+# (go/github-bots/stale-issues). This workflow only supplies adk-go's triggers,
+# permissions, the maintainer list, and the model secret; the reusable workflow
+# runs in this repo's context, so the built-in GITHUB_TOKEN writes to adk-go.
+#
+# NOTE: pin the `uses:` ref to the merged commit SHA of the adk-samples reusable
+# workflow (replace `@main`) once https://github.com/google/adk-samples/pull/2080
+# lands, and add a `GEMINI_API_KEY` repository secret. Keep `maintainers` in sync
+# with the ADK Go team.
+
+on:
+  schedule:
+    - cron: '0 7 * * *'
+  workflow_dispatch:
+    inputs:
+      issue:
+        description: 'Audit only this issue number (blank = sweep).'
+        required: false
+        type: string
+      dry_run:
+        description: 'Log intended actions without modifying issues.'
+        required: false
+        type: boolean
+        default: true
+
+concurrency:
+  group: ${{ github.workflow }}
+  cancel-in-progress: false
+
+jobs:
+  stale:
+    if: github.repository == 'google/adk-go'
+    permissions:
+      issues: write
+      contents: read
+    uses: google/adk-samples/.github/workflows/go-stale-issues.yml@main
+    with:
+      issue_number: ${{ inputs.issue }}
+      dry_run: ${{ github.event_name == 'workflow_dispatch' && inputs.dry_run || false }}
+      maintainers: 'wolo-lab,foxfrikses,dpasiukevich,hanorik,kdroste-google,jjsasha63,baptmont,karolpiotrowicz'
+    secrets:
+      GEMINI_API_KEY: ${{ secrets.GEMINI_API_KEY }}

--- a/.github/workflows/triage-bot.yml
+++ b/.github/workflows/triage-bot.yml
@@ -1,0 +1,45 @@
+name: Issue Triaging Agent
+
+# Thin caller: the bot's code lives in google/adk-samples
+# (go/github-bots/issue-triage). This workflow only supplies adk-go's triggers,
+# permissions, and the model secret; the reusable workflow runs in this repo's
+# context, so the built-in GITHUB_TOKEN writes to adk-go.
+#
+# NOTE: pin the `uses:` ref to the merged commit SHA of the adk-samples reusable
+# workflow (replace `@main`) once https://github.com/google/adk-samples/pull/2079
+# lands, and add a `GEMINI_API_KEY` repository secret.
+
+on:
+  issues:
+    types: [opened]
+  schedule:
+    - cron: '0 */6 * * *'
+  workflow_dispatch:
+    inputs:
+      issue:
+        description: 'Triage only this issue number (blank = sweep).'
+        required: false
+        type: string
+      dry_run:
+        description: 'Log intended actions without modifying issues.'
+        required: false
+        type: boolean
+        default: true
+
+concurrency:
+  group: ${{ github.workflow }}-${{ github.event.issue.number }}
+  cancel-in-progress: false
+
+jobs:
+  triage:
+    if: github.repository == 'google/adk-go'
+    permissions:
+      issues: write
+      contents: read
+    uses: google/adk-samples/.github/workflows/go-issue-triage.yml@main
+    with:
+      issue_number: ${{ github.event.issue.number || inputs.issue }}
+      dry_run: ${{ github.event_name == 'workflow_dispatch' && inputs.dry_run || false }}
+      issue_count: '3'
+    secrets:
+      GEMINI_API_KEY: ${{ secrets.GEMINI_API_KEY }}


### PR DESCRIPTION
> **Draft — blocked on adk-samples.** Do not merge until the reusable workflows land:
> - issue-triage: google/adk-samples#2079
> - stale-issues: google/adk-samples#2080
>
> **Before enabling:** (1) replace the `@main` refs with the merged adk-samples commit SHAs; (2) add a `GEMINI_API_KEY` repository secret; (3) confirm org Actions policy permits calling adk-samples reusable workflows.

## Summary
Adds two **thin caller workflows** that triage and audit adk-go's own issues. The bot **implementations live in `google/adk-samples`** (`go/github-bots/issue-triage`, `go/github-bots/stale-issues`) and are invoked here as **reusable workflows** — so adk-go carries **no bot code and no extra Go dependencies**.

- `triage-bot.yml` — on `issues: [opened]` + 6-hourly schedule + dispatch → sets issue type + a categorization label.
- `stale-bot.yml` — daily schedule + dispatch → warns then closes issues left waiting on the author (maintainer list passed inline).

## Why the token "just works"
A reusable workflow runs in the **caller's** context, so the built-in `GITHUB_TOKEN` (scoped here to `issues: write`) writes to adk-go — no PAT or GitHub App. `OWNER`/`REPO` resolve to adk-go automatically. Manual dispatch defaults to **dry-run**; both jobs are fork-guarded.

## Relation to existing PRs
Supersedes the in-repo samples #1005 (stale) and #1007 (triage): the code now lives once, in adk-samples. Those two PRs will be closed once these callers and the adk-samples PRs land.

## Validation
`actionlint` clean on both workflows. End-to-end behavior was verified by dry-run runs of the bots (from adk-samples, against this repo's live issues) — see #2079 / #2080.