### PR TITLE
Fix silent bug skipping custom tools wrapped in ToolCall envelopes

### DIFF
--- a/internal/utils/utils.go
+++ b/internal/utils/utils.go
@@ -83,6 +83,15 @@ func FunctionCalls(c *genai.Content) (ret []*genai.FunctionCall) {
 		if p.FunctionCall != nil {
 			ret = append(ret, p.FunctionCall)
 		}
+		if p.ToolCall != nil && string(p.ToolCall.ToolType) == "function_call" {
+			// Convert server-side ToolCall into a legacy FunctionCall format
+			// so the rest of the ADK logic continues functioning transparently.
+			ret = append(ret, &genai.FunctionCall{
+				ID:   p.ToolCall.ID,
+				Name: p.ToolCall.Args["name"].(string),
+				Args: p.ToolCall.Args["args"].(map[string]any),
+			})
+		}
 	}
 	return ret
 }
@@ -95,6 +104,13 @@ func FunctionResponses(c *genai.Content) (ret []*genai.FunctionResponse) {
 	for _, p := range c.Parts {
 		if p.FunctionResponse != nil {
 			ret = append(ret, p.FunctionResponse)
+		}
+		if p.ToolResponse != nil && string(p.ToolResponse.ToolType) == "function_call" {
+			ret = append(ret, &genai.FunctionResponse{
+				ID:       p.ToolResponse.ID,
+				Name:     p.ToolResponse.Response["name"].(string),
+				Response: p.ToolResponse.Response["response"].(map[string]any),
+			})
 		}
 	}
 	return ret

--- a/internal/utils/utils_test.go
+++ b/internal/utils/utils_test.go
@@ -12,10 +12,104 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-package utils_test
+package utils
 
-import "testing"
+import (
+	"testing"
 
-func TestNothing(t *testing.T) {
-	// To make it buildable.
+	"github.com/google/go-cmp/cmp"
+	"google.golang.org/genai"
+)
+
+func TestFunctionCalls(t *testing.T) {
+	tests := []struct {
+		name    string
+		content *genai.Content
+		want    []*genai.FunctionCall
+	}{
+		{
+			name:    "NilContent",
+			content: nil,
+			want:    nil,
+		},
+		{
+			name:    "NoFunctionCalls",
+			content: &genai.Content{Parts: []*genai.Part{{Text: "hello"}}},
+			want:    nil,
+		},
+		{
+			name: "TraditionalFunctionCall",
+			content: &genai.Content{Parts: []*genai.Part{{
+				FunctionCall: &genai.FunctionCall{ID: "1", Name: "my_func", Args: map[string]any{"arg1": "val1"}},
+			}}},
+			want: []*genai.FunctionCall{{ID: "1", Name: "my_func", Args: map[string]any{"arg1": "val1"}}},
+		},
+		{
+			name: "ToolCallFunctionCall",
+			content: &genai.Content{Parts: []*genai.Part{{
+				ToolCall: &genai.ToolCall{
+					ID:       "2",
+					ToolType: genai.ToolType("function_call"),
+					Args: map[string]any{
+						"name": "my_func2",
+						"args": map[string]any{"arg2": "val2"},
+					},
+				},
+			}}},
+			want: []*genai.FunctionCall{{ID: "2", Name: "my_func2", Args: map[string]any{"arg2": "val2"}}},
+		},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			got := FunctionCalls(tc.content)
+			if diff := cmp.Diff(tc.want, got); diff != "" {
+				t.Errorf("FunctionCalls() mismatch (-want +got):\n%s", diff)
+			}
+		})
+	}
+}
+
+func TestFunctionResponses(t *testing.T) {
+	tests := []struct {
+		name    string
+		content *genai.Content
+		want    []*genai.FunctionResponse
+	}{
+		{
+			name:    "NilContent",
+			content: nil,
+			want:    nil,
+		},
+		{
+			name: "TraditionalFunctionResponse",
+			content: &genai.Content{Parts: []*genai.Part{{
+				FunctionResponse: &genai.FunctionResponse{ID: "1", Name: "my_func", Response: map[string]any{"result": "success"}},
+			}}},
+			want: []*genai.FunctionResponse{{ID: "1", Name: "my_func", Response: map[string]any{"result": "success"}}},
+		},
+		{
+			name: "ToolResponseFunctionResponse",
+			content: &genai.Content{Parts: []*genai.Part{{
+				ToolResponse: &genai.ToolResponse{
+					ID:       "2",
+					ToolType: genai.ToolType("function_call"),
+					Response: map[string]any{
+						"name":     "my_func2",
+						"response": map[string]any{"result": "success2"},
+					},
+				},
+			}}},
+			want: []*genai.FunctionResponse{{ID: "2", Name: "my_func2", Response: map[string]any{"result": "success2"}}},
+		},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			got := FunctionResponses(tc.content)
+			if diff := cmp.Diff(tc.want, got); diff != "" {
+				t.Errorf("FunctionResponses() mismatch (-want +got):\n%s", diff)
+			}
+		})
+	}
 }

--- a/session/session.go
+++ b/session/session.go
@@ -186,6 +186,9 @@ func hasFunctionCalls(resp *model.LLMResponse) bool {
 		if part.FunctionCall != nil {
 			return true
 		}
+		if part.ToolCall != nil {
+			return true
+		}
 	}
 	return false
 }
@@ -196,6 +199,9 @@ func hasFunctionResponses(resp *model.LLMResponse) bool {
 	}
 	for _, part := range resp.Content.Parts {
 		if part.FunctionResponse != nil {
+			return true
+		}
+		if part.ToolResponse != nil {
 			return true
 		}
 	}

--- a/session/session_test.go
+++ b/session/session_test.go
@@ -1,0 +1,116 @@
+// Copyright 2025 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package session
+
+import (
+	"testing"
+
+  	"google.golang.org/adk/model"
+  	"google.golang.org/genai"
+)
+
+func TestHasFunctionCalls(t *testing.T) {
+	tests := []struct {
+		name string
+		resp *model.LLMResponse
+		want bool
+	}{
+		{
+			name: "NilResponse",
+			resp: nil,
+			want: false,
+		},
+		{
+			name: "NilContent",
+			resp: &model.LLMResponse{Content: nil},
+			want: false,
+		},
+		{
+			name: "HasFunctionCall",
+			resp: &model.LLMResponse{Content: &genai.Content{Parts: []*genai.Part{{
+				FunctionCall: &genai.FunctionCall{Name: "test", Args: map[string]any{}},
+			}}}},
+			want: true,
+		},
+		{
+			name: "HasToolCall",
+			resp: &model.LLMResponse{Content: &genai.Content{Parts: []*genai.Part{{
+				ToolCall: &genai.ToolCall{ID: "123", ToolType: "function_call", Args: map[string]any{"name": "test", "args": map[string]any{}}},
+			}}}},
+			want: true,
+		},
+		{
+			name: "Neither",
+			resp: &model.LLMResponse{Content: &genai.Content{Parts: []*genai.Part{{
+				Text: "hello world",
+			}}}},
+			want: false,
+		},
+	}
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			if got := hasFunctionCalls(tc.resp); got != tc.want {
+				t.Errorf("hasFunctionCalls() = %v, want %v", got, tc.want)
+			}
+		})
+	}
+}
+
+func TestHasFunctionResponses(t *testing.T) {
+	tests := []struct {
+		name string
+		resp *model.LLMResponse
+		want bool
+	}{
+		{
+			name: "NilResponse",
+			resp: nil,
+			want: false,
+		},
+		{
+			name: "NilContent",
+			resp: &model.LLMResponse{Content: nil},
+			want: false,
+		},
+		{
+			name: "HasFunctionResponse",
+			resp: &model.LLMResponse{Content: &genai.Content{Parts: []*genai.Part{{
+				FunctionResponse: &genai.FunctionResponse{Name: "test", Response: map[string]any{}},
+			}}}},
+			want: true,
+		},
+		{
+			name: "HasToolResponse",
+			resp: &model.LLMResponse{Content: &genai.Content{Parts: []*genai.Part{{
+				ToolResponse: &genai.ToolResponse{ID: "123", ToolType: "function_call", Response: map[string]any{"name": "test", "response": map[string]any{}}},
+			}}}},
+			want: true,
+		},
+		{
+			name: "Neither",
+			resp: &model.LLMResponse{Content: &genai.Content{Parts: []*genai.Part{{
+				Text: "hello world",
+			}}}},
+			want: false,
+		},
+	}
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			if got := hasFunctionResponses(tc.resp); got != tc.want {
+				t.Errorf("hasFunctionResponses() = %v, want %v", got, tc.want)
+			}
+		})
+	}
+}


### PR DESCRIPTION
Updated utils.go and session.go to recognize custom tools when returned
inside part.ToolCall (with type "function_call") rather than just part.FunctionCall.
This prevents the agent runner from discarding the tool calls.

- Closes: #1011 