### PR TITLE
fix(workflow): select nested workflow output by terminal node, not arrival order

### DIFF
--- a/workflow/graph.go
+++ b/workflow/graph.go
@@ -77,3 +77,20 @@ func (g *graph) allNodes() []Node {
 	}
 	return res
 }
+
+// terminalNodeNames returns the names of terminal nodes: those with no
+// outgoing edges, excluding the Start sentinel.
+func (g *graph) terminalNodeNames() map[string]bool {
+	sources := make(map[string]bool)
+	for n := range g.successors {
+		sources[n.Name()] = true
+	}
+	terminals := make(map[string]bool)
+	for _, n := range g.allNodes() {
+		if n.Name() == Start.Name() || sources[n.Name()] {
+			continue
+		}
+		terminals[n.Name()] = true
+	}
+	return terminals
+}

--- a/workflow/workflow_node.go
+++ b/workflow/workflow_node.go
@@ -15,6 +15,7 @@
 package workflow
 
 import (
+	"fmt"
 	"iter"
 
 	"google.golang.org/adk/agent"
@@ -41,17 +42,24 @@ func NewWorkflowNode(name string, edges []Edge) (*WorkflowNode, error) {
 }
 
 // Run executes the sub-workflow with the given input.
-// It intercepts events from the sub-workflow to ensure that only the final
-// output is yielded to the parent scheduler, preventing ErrMultipleOutputs
-// if intermediate steps also produced outputs.
+//
+// The sub-workflow's output is the output of its terminal node(s) —
+// nodes with no outgoing edges — selected by graph topology, not by
+// event arrival order. Exactly one terminal output is forwarded as
+// this node's output; more than one is a graph-design error
+// (ErrMultipleOutputs); zero means the node produces no output.
+// Mirrors adk-python's _set_ctx_output_or_interrupts.
 func (n *WorkflowNode) Run(ctx agent.Context, input any) iter.Seq2[*session.Event, error] {
+	terminals := n.subWorkflow.graph.terminalNodeNames()
 	return func(yield func(*session.Event, error) bool) {
-		var lastOutput any
+		// terminalOutputs is keyed by terminal node name (last write
+		// wins), so re-running a terminal via loop-back does not inflate
+		// the count.
+		terminalOutputs := make(map[string]any)
 		var pendingErr error
 
 		// Create a cancellable context to signal the sub-workflow to stop on error or break.
 		subCtx, cancel := ctx.WithAgentCancel()
-		// subCtx, cancel := context.WithCancel(ctx)
 		defer cancel()
 		ctx = ctx.WithAgentContext(subCtx)
 
@@ -66,23 +74,26 @@ func (n *WorkflowNode) Run(ctx agent.Context, input any) iter.Seq2[*session.Even
 				continue
 			}
 
-			if ev.Output != nil {
-				lastOutput = ev.Output
-				// Create a shallow copy and clear Output so the parent
-				// scheduler doesn't fail on multiple outputs for this node.
-				evCopy := *ev
-				evCopy.Output = nil
-				if !yield(&evCopy, nil) {
-					// Same as above: cancel and drain to avoid leaks and panics.
-					cancel()
-					continue
-				}
-			} else {
+			// Capture the output only from terminal nodes. childEventOutput
+			// matches the scheduler: Event.Output, or model text when
+			// MessageAsOutput is set.
+			if out, ok := childEventOutput(ev); ok && ev.NodeInfo != nil && terminals[ev.NodeInfo.Path] {
+				terminalOutputs[ev.NodeInfo.Path] = out
+			}
+
+			if ev.Output == nil {
 				if !yield(ev, nil) {
-					// Same as above: cancel and drain to avoid leaks and panics.
 					cancel()
 					continue
 				}
+				continue
+			}
+			// Forward with Output stripped (see the doc comment).
+			evCopy := *ev
+			evCopy.Output = nil
+			if !yield(&evCopy, nil) {
+				cancel()
+				continue
 			}
 		}
 
@@ -92,10 +103,16 @@ func (n *WorkflowNode) Run(ctx agent.Context, input any) iter.Seq2[*session.Even
 			return
 		}
 
-		// Yield the final output at the end if we captured any.
-		if lastOutput != nil {
+		if len(terminalOutputs) > 1 {
+			yield(nil, fmt.Errorf("%w: sub-workflow %q has %d terminal nodes producing output; a workflow must have at most one terminal output",
+				ErrMultipleOutputs, n.subWorkflow.Name(), len(terminalOutputs)))
+			return
+		}
+
+		// Yield the terminal output at the end if one was produced.
+		for _, out := range terminalOutputs {
 			event := session.NewEvent(ctx.InvocationID())
-			event.Output = lastOutput
+			event.Output = out
 			yield(event, nil)
 		}
 	}

--- a/workflow/workflow_node_test.go
+++ b/workflow/workflow_node_test.go
@@ -152,6 +152,94 @@ func TestNestedWorkflow_MultipleOutputs(t *testing.T) {
 	}
 }
 
+// Two terminals producing output is an error, not a nondeterministic
+// pick.
+func TestNestedWorkflow_MultipleTerminals(t *testing.T) {
+	passthrough := func(ctx agent.Context, input string) (string, error) { return input, nil }
+	a := NewFunctionNode("a", passthrough, defaultNodeConfig)
+	b := NewFunctionNode("b", passthrough, defaultNodeConfig)
+	c := NewFunctionNode("c", passthrough, defaultNodeConfig)
+	innerEdges := NewEdgeBuilder().Add(Start, a).AddFanOut(a, b, c).Build()
+
+	wfNode, err := NewWorkflowNode("nested_step", innerEdges)
+	if err != nil {
+		t.Fatalf("failed to create workflow node: %v", err)
+	}
+	outerWf := mustNew(t, Chain(Start, wfNode))
+
+	mockCtx := newMockCtx(t)
+	mockCtx.userContent = &genai.Content{Parts: []*genai.Part{{Text: "input"}}}
+
+	var gotErr error
+	for _, err := range outerWf.Run(mockCtx) {
+		if err != nil {
+			gotErr = err
+		}
+	}
+	if !errors.Is(gotErr, ErrMultipleOutputs) {
+		t.Errorf("got error %v, want ErrMultipleOutputs", gotErr)
+	}
+}
+
+// A silent terminal (no output) yields no workflow output, even when an
+// earlier node produced one.
+func TestNestedWorkflow_SilentTerminal(t *testing.T) {
+	producer := func(ctx agent.Context, input string) (string, error) { return "intermediate", nil }
+	// Terminal returns a *session.Event with no Output (a side-effect sink).
+	sink := func(ctx agent.Context, input string) (*session.Event, error) {
+		return &session.Event{}, nil
+	}
+	a := NewFunctionNode("producer", producer, defaultNodeConfig)
+	b := NewFunctionNode("sink", sink, defaultNodeConfig)
+	innerEdges := Chain(Start, a, b)
+
+	wfNode, err := NewWorkflowNode("nested_step", innerEdges)
+	if err != nil {
+		t.Fatalf("failed to create workflow node: %v", err)
+	}
+	outerWf := mustNew(t, Chain(Start, wfNode))
+
+	mockCtx := newMockCtx(t)
+	mockCtx.userContent = &genai.Content{Parts: []*genai.Part{{Text: "input"}}}
+
+	for ev, err := range outerWf.Run(mockCtx) {
+		if err != nil {
+			t.Fatalf("unexpected error: %v", err)
+		}
+		if ev.Output != nil {
+			t.Errorf("expected no output, got %v", ev.Output)
+		}
+	}
+}
+
+// A terminal whose output is model text (MessageAsOutput) is still
+// picked up as the workflow output.
+func TestNestedWorkflow_MessageAsOutputTerminal(t *testing.T) {
+	innerEdges := Chain(Start, newMessageAsOutputNode("terminal", "from-message"))
+
+	wfNode, err := NewWorkflowNode("nested_step", innerEdges)
+	if err != nil {
+		t.Fatalf("failed to create workflow node: %v", err)
+	}
+	outerWf := mustNew(t, Chain(Start, wfNode))
+
+	mockCtx := newMockCtx(t)
+	mockCtx.userContent = &genai.Content{Parts: []*genai.Part{{Text: "input"}}}
+
+	var gotOutput any
+	for ev, err := range outerWf.Run(mockCtx) {
+		if err != nil {
+			t.Fatalf("unexpected error: %v", err)
+		}
+		if ev.Output != nil {
+			gotOutput = ev.Output
+		}
+	}
+	if gotOutput != "from-message" {
+		t.Errorf("got output %v, want %q", gotOutput, "from-message")
+	}
+}
+
 func TestNestedWorkflowUpdatesStateOuterReads(t *testing.T) {
 	// Create inner workflow edges
 	nestedStateUpdater := func(ctx agent.Context, input string) (string, error) {


### PR DESCRIPTION
## Problem
`WorkflowNode` surfaced a nested workflow's result as "the last yielded
event with non-nil `Output`" — which is iteration-order dependent. This
diverged from adk-python and was wrong for two common shapes:
- **Fan-out with multiple terminals:** whichever terminal finished last
  by wall-clock won, so the result was non-deterministic across runs.
- **Silent terminal:** if the terminal node produced no output but an
  earlier node did, the intermediate node's output was returned as if it
  were the workflow's result.
The existing linear tests passed only because the single terminal happens
to emit last (`TestNestedWorkflow_MultipleOutputs`, despite its name, is
a linear `Chain`).

## Solution
Select the output from the workflow's **terminal node(s)** — nodes with
no outgoing edges — computed from graph topology rather than event
arrival order, mirroring adk-python's `_set_ctx_output_or_interrupts`:
- exactly one terminal output → forward it;
- more than one distinct terminal produced output → `ErrMultipleOutputs`
  (a workflow must have a single output identity; use a `JoinNode` to
  merge branches);
- zero → no output.
Outputs are keyed by terminal **node name** (last write wins), matching
adk-python's `node_outputs` dict, so re-activating a single terminal
counts as one output rather than an error. Terminal output is read via
`childEventOutput`, so a terminal that carries its result as model text
(`MessageAsOutput`) is handled too.

A new `graph.terminalNodeNames()` helper computes the terminal set
(mirrors adk-python's `graph._terminal_node_names`).