### PR TITLE
ci: run the spam-detection bot via the adk-samples reusable workflow

### DIFF
--- a/.github/workflows/spam-bot.yml
+++ b/.github/workflows/spam-bot.yml
@@ -1,0 +1,51 @@
+name: Spam Detection Agent
+
+# Thin caller: the bot's code lives in google/adk-samples
+# (go/github-bots/spam-detection). This workflow only supplies adk-go's triggers,
+# permissions, the maintainer list, and the model secret; the reusable workflow
+# runs in this repo's context, so the built-in GITHUB_TOKEN writes to adk-go.
+#
+# NOTE: pin the `uses:` ref to the merged commit SHA of the adk-samples reusable
+# workflow (replace `@main`) once https://github.com/google/adk-samples/pull/2082
+# lands, and add a `GEMINI_API_KEY` repository secret. Keep `maintainers` in sync
+# with the ADK Go team (whose comments are trusted and never reviewed for spam).
+
+on:
+  issues:
+    types: [opened]
+  issue_comment:
+    types: [created]
+  schedule:
+    - cron: '30 */6 * * *'
+  workflow_dispatch:
+    inputs:
+      issue:
+        description: 'Review only this issue number (blank = sweep).'
+        required: false
+        type: string
+      dry_run:
+        description: 'Log intended actions without modifying issues.'
+        required: false
+        type: boolean
+        default: true
+
+concurrency:
+  group: ${{ github.workflow }}-${{ github.event.issue.number }}
+  cancel-in-progress: false
+
+jobs:
+  spam:
+    # Skip comments on pull requests (PRs are issues too, but the bot only
+    # moderates issues; the reusable workflow would fetch and skip them anyway).
+    if: github.repository == 'google/adk-go' && (github.event_name != 'issue_comment' || github.event.issue.pull_request == null)
+    permissions:
+      issues: write
+      contents: read
+    uses: google/adk-samples/.github/workflows/go-spam-detection.yml@main
+    with:
+      issue_number: ${{ github.event.issue.number || inputs.issue }}
+      dry_run: ${{ github.event_name == 'workflow_dispatch' && inputs.dry_run || false }}
+      issue_count: '3'
+      maintainers: 'wolo-lab,foxfrikses,dpasiukevich,hanorik,kdroste-google,jjsasha63,baptmont,karolpiotrowicz'
+    secrets:
+      GEMINI_API_KEY: ${{ secrets.GEMINI_API_KEY }}


### PR DESCRIPTION
## Summary

Adds a thin **caller** workflow (`.github/workflows/spam-bot.yml`) that runs the **spam-detection** bot against adk-go's own issues. The bot's code lives in `google/adk-samples` (`go/github-bots/spam-detection`) and is invoked via its reusable workflow — no bot code is copied here.

It labels suspected-spam issues and posts one comment alerting maintainers. Because a reusable workflow runs in the **caller's** context, the built-in `GITHUB_TOKEN` (scoped by the `permissions:` block) writes to adk-go.

- **Triggers:** new issues (`opened`), new comments (`issue_comment: created`, spam often arrives as a comment), a 6-hourly backstop `schedule`, and manual `workflow_dispatch` (`issue`, `dry_run`).
- Comments on **pull requests** are skipped (the bot only moderates issues).
- Passes the ADK Go **maintainer allowlist** (their comments are trusted and never reviewed) — kept in sync with the stale-issue caller.

Mirrors the existing `triage-bot.yml` / `stale-bot.yml` callers.

## Before this can run (draft blockers)

1. Merge the bot + reusable workflow: https://github.com/google/adk-samples/pull/2082
2. **Pin** the `uses:` ref from `@main` to that merged commit SHA.
3. Add a `GEMINI_API_KEY` repository secret (or configure Vertex AI).

`actionlint` clean. The `spam` label already exists on this repo.