### PR TITLE
refactor(agent): migrate all consumers to Context

### DIFF
--- a/agent/agent.go
+++ b/agent/agent.go
@@ -126,7 +126,7 @@ type Memory interface {
 // its run.
 // If it returns non-nil content or error, the agent run will be skipped and a
 // new event will be created.
-type BeforeAgentCallback func(CallbackContext) (*genai.Content, error)
+type BeforeAgentCallback func(Context) (*genai.Content, error)
 
 // AfterAgentCallback is a function that is called after the agent has completed
 // its run.
@@ -134,7 +134,7 @@ type BeforeAgentCallback func(CallbackContext) (*genai.Content, error)
 //
 // The callback will be skipped also if EndInvocation was called before or
 // BeforeAgentCallbacks returned non-nil results.
-type AfterAgentCallback func(CallbackContext) (*genai.Content, error)
+type AfterAgentCallback func(Context) (*genai.Content, error)
 
 type agent struct {
 	agentinternal.State
@@ -444,8 +444,8 @@ func pluginManagerFromContext(ctx context.Context) pluginManager {
 }
 
 type pluginManager interface {
-	RunBeforeAgentCallback(cctx CallbackContext) (*genai.Content, error)
-	RunAfterAgentCallback(cctx CallbackContext) (*genai.Content, error)
+	RunBeforeAgentCallback(cctx Context) (*genai.Content, error)
+	RunAfterAgentCallback(cctx Context) (*genai.Content, error)
 }
 
 var _ InvocationContext = (*invocationContext)(nil)

--- a/agent/agent_test.go
+++ b/agent/agent_test.go
@@ -40,7 +40,7 @@ func TestAgentCallbacks(t *testing.T) {
 		{
 			name: "before agent callback runs, no llm calls",
 			beforeAgent: []BeforeAgentCallback{
-				func(ctx CallbackContext) (*genai.Content, error) {
+				func(ctx Context) (*genai.Content, error) {
 					return genai.NewContentFromText("hello from before_agent_callback", genai.RoleModel), nil
 				},
 			},
@@ -60,12 +60,12 @@ func TestAgentCallbacks(t *testing.T) {
 		{
 			name: "no callback effect if callbacks return nil",
 			beforeAgent: []BeforeAgentCallback{
-				func(ctx CallbackContext) (*genai.Content, error) {
+				func(ctx Context) (*genai.Content, error) {
 					return nil, nil
 				},
 			},
 			afterAgent: []AfterAgentCallback{
-				func(CallbackContext) (*genai.Content, error) {
+				func(Context) (*genai.Content, error) {
 					return nil, nil
 				},
 			},
@@ -82,7 +82,7 @@ func TestAgentCallbacks(t *testing.T) {
 		{
 			name: "after agent callback create a new event with new content",
 			afterAgent: []AfterAgentCallback{
-				func(CallbackContext) (*genai.Content, error) {
+				func(Context) (*genai.Content, error) {
 					return genai.NewContentFromText("hello from after_agent_callback", genai.RoleModel), nil
 				},
 			},
@@ -158,7 +158,7 @@ func TestEndInvocation_EndsBeforeMainCall(t *testing.T) {
 	testAgent, err := New(Config{
 		Name: "test",
 		BeforeAgentCallbacks: []BeforeAgentCallback{
-			func(ctx CallbackContext) (*genai.Content, error) {
+			func(ctx Context) (*genai.Content, error) {
 				return nil, nil
 			},
 		},
@@ -193,7 +193,7 @@ func TestEndInvocation_EndsAfterMainCall(t *testing.T) {
 	testAgent, err := New(Config{
 		Name: "test",
 		AfterAgentCallbacks: []AfterAgentCallback{
-			func(CallbackContext) (*genai.Content, error) {
+			func(Context) (*genai.Content, error) {
 				return genai.NewContentFromText("hello from after_agent_callback", genai.RoleModel), nil
 			},
 		},

--- a/agent/callback_wrapper.go
+++ b/agent/callback_wrapper.go
@@ -30,7 +30,7 @@ import (
 // callbackContextWrapper is used to emit log entries for unexpected calls - those
 // related to ToolContext when Context is used as callback context
 type callbackContextWrapper struct {
-	context CallbackContext
+	context Context
 }
 
 // WithAgentCancel implements [Context].

--- a/agent/callback_wrapper_test.go
+++ b/agent/callback_wrapper_test.go
@@ -104,7 +104,7 @@ func (fakeMemory) SearchMemory(context.Context, string) (*memory.SearchResponse,
 // newTestCallbackContext builds a CallbackContext (a *callbackContextWrapper)
 // backed by a fully-populated invocationContext so that the supported methods
 // have meaningful values to delegate to.
-func newTestCallbackContext(t *testing.T) CallbackContext {
+func newTestCallbackContext(t *testing.T) Context {
 	t.Helper()
 
 	a, err := New(Config{
@@ -210,15 +210,15 @@ func TestCallbackContextWrapper_LogsForToolContextMethods(t *testing.T) {
 func TestCallbackContextWrapper_NoLogForSupportedMethods(t *testing.T) {
 	cases := []struct {
 		name string
-		call func(cc CallbackContext) any
+		call func(cc Context) any
 		want any
 	}{
-		{"AgentName", func(cc CallbackContext) any { return cc.AgentName() }, "test-agent"},
-		{"AppName", func(cc CallbackContext) any { return cc.AppName() }, "app"},
-		{"Branch", func(cc CallbackContext) any { return cc.Branch() }, "branch-1"},
-		{"InvocationID", func(cc CallbackContext) any { return cc.InvocationID() }, "inv-1"},
-		{"SessionID", func(cc CallbackContext) any { return cc.SessionID() }, "sess-1"},
-		{"UserID", func(cc CallbackContext) any { return cc.UserID() }, "user"},
+		{"AgentName", func(cc Context) any { return cc.AgentName() }, "test-agent"},
+		{"AppName", func(cc Context) any { return cc.AppName() }, "app"},
+		{"Branch", func(cc Context) any { return cc.Branch() }, "branch-1"},
+		{"InvocationID", func(cc Context) any { return cc.InvocationID() }, "inv-1"},
+		{"SessionID", func(cc Context) any { return cc.SessionID() }, "sess-1"},
+		{"UserID", func(cc Context) any { return cc.UserID() }, "user"},
 	}
 
 	for _, tc := range cases {

--- a/agent/common_context.go
+++ b/agent/common_context.go
@@ -55,7 +55,7 @@ func NewDynamicNodeContext(parent Context, path, runID string, sub DynamicSubSch
 
 // NewCallbackContext returns CallbackContext initialized with provided actions.
 // actions may be nil; if so, a new session.EventActions is created with empty StateDelta and ArtifactDelta
-func NewCallbackContext(ic InvocationContext, actions *session.EventActions) CallbackContext {
+func NewCallbackContext(ic InvocationContext, actions *session.EventActions) Context {
 	actions = prepareEventActions(actions)
 	cc := &commonContext{
 		Context:           ic,
@@ -74,7 +74,7 @@ func NewCallbackContext(ic InvocationContext, actions *session.EventActions) Cal
 // the returned context's Artifacts().Save(...) wrapper records each saved artifact's version into the underlying
 // EventActions.ArtifactDelta so the resulting Event reflects the saves.
 // actions may be nil; if so, a new session.EventActions is created with empty StateDelta and ArtifactDelta
-func NewCallbackContextWithArtifactTracking(ic InvocationContext, actions *session.EventActions) CallbackContext {
+func NewCallbackContextWithArtifactTracking(ic InvocationContext, actions *session.EventActions) Context {
 	actions = prepareEventActions(actions)
 	cc := &commonContext{
 		Context:           ic,
@@ -97,7 +97,7 @@ func NewCallbackContextWithArtifactTracking(ic InvocationContext, actions *sessi
 // backed by the same *callbackContext implementation used for CallbackContext,
 // so all callback-context semantics (state delta tracking, artifact delta
 // tracking, etc.) apply, plus the tool-specific extensions on ToolContext.
-func NewToolContext(ic InvocationContext, functionCallID string, actions *session.EventActions, confirmation *toolconfirmation.ToolConfirmation) ToolContext {
+func NewToolContext(ic InvocationContext, functionCallID string, actions *session.EventActions, confirmation *toolconfirmation.ToolConfirmation) Context {
 	var res commonContext
 	ctx, ok := ic.(*commonContext)
 	if ok {
@@ -386,8 +386,6 @@ func (c *commonContext) UserID() string {
 
 var (
 	_ Context           = (*commonContext)(nil)
-	_ CallbackContext   = (*commonContext)(nil)
-	_ ToolContext       = (*commonContext)(nil)
 	_ InvocationContext = (*commonContext)(nil)
 	_ ReadonlyContext   = (*commonContext)(nil)
 )

--- a/agent/context.go
+++ b/agent/context.go
@@ -134,15 +134,21 @@ type ReadonlyContext interface {
 }
 
 // CallbackContext is passed to user callbacks during agent execution.
+//
+// Deprecated: use [Context] directly. This alias exists only to ease the
+// migration to the unified context and will be removed in a future release.
 type CallbackContext = Context
 
-// ToolContext is the context passed to a tool when it is called. It extends
-// CallbackContext with tool-specific facilities: access to the originating
-// function call, mutable event actions, long-term memory search, and the
-// Human-in-the-Loop (HITL) confirmation flow.
+// ToolContext is the context passed to a tool when it is called.
+//
+// Deprecated: use [Context] directly. This alias exists only to ease the
+// migration to the unified context and will be removed in a future release.
 type ToolContext = Context
 
-// Context is a common context used both in callbacks (aliased as CallbackContext) and tool calls (aliased as ToolContext).
+// Context is the unified context passed to user callbacks during agent
+// execution and to tools when they are called. It provides access to the
+// originating function call, mutable event actions, long-term memory search,
+// and the Human-in-the-Loop (HITL) confirmation flow.
 type Context interface {
 	ReadonlyContext
 	InvocationContext

--- a/agent/llmagent/llmagent.go
+++ b/agent/llmagent/llmagent.go
@@ -363,19 +363,19 @@ const (
 //
 // If it returns non-nil LLMResponse or error, the actual model call is skipped
 // and the returned response/error is used.
-type BeforeModelCallback func(ctx agent.CallbackContext, llmRequest *model.LLMRequest) (*model.LLMResponse, error)
+type BeforeModelCallback func(ctx agent.Context, llmRequest *model.LLMRequest) (*model.LLMResponse, error)
 
 // AfterModelCallback that is called after receiving a response from the model.
 //
 // If it returns non-nil LLMResponse or error, the actual model response/error
 // is replaced with the returned response/error.
-type AfterModelCallback func(ctx agent.CallbackContext, llmResponse *model.LLMResponse, llmResponseError error) (*model.LLMResponse, error)
+type AfterModelCallback func(ctx agent.Context, llmResponse *model.LLMResponse, llmResponseError error) (*model.LLMResponse, error)
 
 // OnModelErrorCallback that is called when receiving an error response from the llm model.
 //
 // If it returns non-nil LLMResponse or error, the actual model response/error
 // is replaced with the returned response/error.
-type OnModelErrorCallback func(ctx agent.CallbackContext, llmRequest *model.LLMRequest, llmResponseError error) (*model.LLMResponse, error)
+type OnModelErrorCallback func(ctx agent.Context, llmRequest *model.LLMRequest, llmResponseError error) (*model.LLMResponse, error)
 
 // BeforeToolCallback is executed before a tool's Run method.
 //
@@ -387,7 +387,7 @@ type OnModelErrorCallback func(ctx agent.CallbackContext, llmRequest *model.LLMR
 //
 // To modify tool arguments and still run the tool,
 // update args in place and return (nil, nil).
-type BeforeToolCallback func(ctx agent.ToolContext, tool tool.Tool, args map[string]any) (map[string]any, error)
+type BeforeToolCallback func(ctx agent.Context, tool tool.Tool, args map[string]any) (map[string]any, error)
 
 // AfterToolCallback is a function type executed after a tool's Run method has completed,
 // regardless of whether the tool returned a result or an error.
@@ -396,13 +396,13 @@ type BeforeToolCallback func(ctx agent.ToolContext, tool tool.Tool, args map[str
 // If a callback returns a non-nil result or an error:
 //   - execution of remaining callbacks stops
 //   - the returned result and/or error is used as the final tool output
-type AfterToolCallback func(ctx agent.ToolContext, tool tool.Tool, args, result map[string]any, err error) (map[string]any, error)
+type AfterToolCallback func(ctx agent.Context, tool tool.Tool, args, result map[string]any, err error) (map[string]any, error)
 
 // OnToolErrorCallback that is called when receiving an error response from tool execution.
 //
 // If it returns non-nil LLMResponse or error, the actual model response/error
 // is replaced with the returned response/error.
-type OnToolErrorCallback func(ctx agent.ToolContext, tool tool.Tool, args map[string]any, err error) (map[string]any, error)
+type OnToolErrorCallback func(ctx agent.Context, tool tool.Tool, args map[string]any, err error) (map[string]any, error)
 
 // IncludeContents controls what parts of prior conversation history is received by llmagent.
 type IncludeContents string

--- a/agent/llmagent/llmagent_test.go
+++ b/agent/llmagent/llmagent_test.go
@@ -151,7 +151,7 @@ func TestModelCallbacks(t *testing.T) {
 		{
 			name: "before model callback doesn't modify anything",
 			beforeModelCallbacks: []llmagent.BeforeModelCallback{
-				func(ctx agent.CallbackContext, llmRequest *model.LLMRequest) (*model.LLMResponse, error) {
+				func(ctx agent.Context, llmRequest *model.LLMRequest) (*model.LLMResponse, error) {
 					return nil, nil
 				},
 			},
@@ -165,10 +165,10 @@ func TestModelCallbacks(t *testing.T) {
 		{
 			name: "before model callback returns an error",
 			beforeModelCallbacks: []llmagent.BeforeModelCallback{
-				func(ctx agent.CallbackContext, llmRequest *model.LLMRequest) (*model.LLMResponse, error) {
+				func(ctx agent.Context, llmRequest *model.LLMRequest) (*model.LLMResponse, error) {
 					return nil, fmt.Errorf("before_model_callback_error: %w", http.ErrNoCookie)
 				},
-				func(ctx agent.CallbackContext, llmRequest *model.LLMRequest) (*model.LLMResponse, error) {
+				func(ctx agent.Context, llmRequest *model.LLMRequest) (*model.LLMResponse, error) {
 					return nil, fmt.Errorf("before_model_callback_error: %w", http.ErrHijacked)
 				},
 			},
@@ -180,12 +180,12 @@ func TestModelCallbacks(t *testing.T) {
 		{
 			name: "before model callback returns new LLMResponse",
 			beforeModelCallbacks: []llmagent.BeforeModelCallback{
-				func(ctx agent.CallbackContext, llmRequest *model.LLMRequest) (*model.LLMResponse, error) {
+				func(ctx agent.Context, llmRequest *model.LLMRequest) (*model.LLMResponse, error) {
 					return &model.LLMResponse{
 						Content: genai.NewContentFromText("hello from before_model_callback", genai.RoleModel),
 					}, nil
 				},
-				func(ctx agent.CallbackContext, llmRequest *model.LLMRequest) (*model.LLMResponse, error) {
+				func(ctx agent.Context, llmRequest *model.LLMRequest) (*model.LLMResponse, error) {
 					return &model.LLMResponse{
 						Content: genai.NewContentFromText("unexpected text", genai.RoleModel),
 					}, nil
@@ -201,7 +201,7 @@ func TestModelCallbacks(t *testing.T) {
 		{
 			name: "before model callback returns both new LLMResponse and error",
 			beforeModelCallbacks: []llmagent.BeforeModelCallback{
-				func(ctx agent.CallbackContext, llmRequest *model.LLMRequest) (*model.LLMResponse, error) {
+				func(ctx agent.Context, llmRequest *model.LLMRequest) (*model.LLMResponse, error) {
 					return &model.LLMResponse{
 						Content: genai.NewContentFromText("hello from before_model_callback", genai.RoleModel),
 					}, fmt.Errorf("before_model_callback_error: %w", http.ErrNoCookie)
@@ -215,7 +215,7 @@ func TestModelCallbacks(t *testing.T) {
 		{
 			name: "after model callback doesn't modify anything",
 			afterModelCallbacks: []llmagent.AfterModelCallback{
-				func(ctx agent.CallbackContext, llmResponse *model.LLMResponse, llmResponseError error) (*model.LLMResponse, error) {
+				func(ctx agent.Context, llmResponse *model.LLMResponse, llmResponseError error) (*model.LLMResponse, error) {
 					return nil, nil
 				},
 			},
@@ -229,12 +229,12 @@ func TestModelCallbacks(t *testing.T) {
 		{
 			name: "after model callback returns new LLMResponse",
 			afterModelCallbacks: []llmagent.AfterModelCallback{
-				func(ctx agent.CallbackContext, llmResponse *model.LLMResponse, llmResponseError error) (*model.LLMResponse, error) {
+				func(ctx agent.Context, llmResponse *model.LLMResponse, llmResponseError error) (*model.LLMResponse, error) {
 					return &model.LLMResponse{
 						Content: genai.NewContentFromText("hello from after_model_callback", genai.RoleModel),
 					}, nil
 				},
-				func(ctx agent.CallbackContext, llmResponse *model.LLMResponse, llmResponseError error) (*model.LLMResponse, error) {
+				func(ctx agent.Context, llmResponse *model.LLMResponse, llmResponseError error) (*model.LLMResponse, error) {
 					return &model.LLMResponse{
 						Content: genai.NewContentFromText("unexpected text", genai.RoleModel),
 					}, nil
@@ -250,10 +250,10 @@ func TestModelCallbacks(t *testing.T) {
 		{
 			name: "after model callback returns error",
 			afterModelCallbacks: []llmagent.AfterModelCallback{
-				func(ctx agent.CallbackContext, llmResponse *model.LLMResponse, llmResponseError error) (*model.LLMResponse, error) {
+				func(ctx agent.Context, llmResponse *model.LLMResponse, llmResponseError error) (*model.LLMResponse, error) {
 					return nil, fmt.Errorf("error from after_model_callback: %w", http.ErrNoCookie)
 				},
-				func(ctx agent.CallbackContext, llmResponse *model.LLMResponse, llmResponseError error) (*model.LLMResponse, error) {
+				func(ctx agent.Context, llmResponse *model.LLMResponse, llmResponseError error) (*model.LLMResponse, error) {
 					return nil, fmt.Errorf("error from after_model_callback: %w", http.ErrHijacked)
 				},
 			},
@@ -265,7 +265,7 @@ func TestModelCallbacks(t *testing.T) {
 		{
 			name: "after model callback returns both new LLMResponse and error",
 			afterModelCallbacks: []llmagent.AfterModelCallback{
-				func(ctx agent.CallbackContext, llmResponse *model.LLMResponse, llmResponseError error) (*model.LLMResponse, error) {
+				func(ctx agent.Context, llmResponse *model.LLMResponse, llmResponseError error) (*model.LLMResponse, error) {
 					return &model.LLMResponse{
 						Content: genai.NewContentFromText("hello from after_model_callback", genai.RoleModel),
 					}, fmt.Errorf("error from after_model_callback: %w", http.ErrNoCookie)
@@ -279,7 +279,7 @@ func TestModelCallbacks(t *testing.T) {
 		{
 			name: "on model error callback is not called",
 			onModelErrorCallback: []llmagent.OnModelErrorCallback{
-				func(ctx agent.CallbackContext, llmRequest *model.LLMRequest, llmError error) (*model.LLMResponse, error) {
+				func(ctx agent.Context, llmRequest *model.LLMRequest, llmError error) (*model.LLMResponse, error) {
 					return &model.LLMResponse{
 						Content: genai.NewContentFromText("hello from on_model_error_callback", genai.RoleModel),
 					}, fmt.Errorf("on_model_error_callback: %w", http.ErrNoCookie)
@@ -295,7 +295,7 @@ func TestModelCallbacks(t *testing.T) {
 		{
 			name: "on model error callback changes message",
 			onModelErrorCallback: []llmagent.OnModelErrorCallback{
-				func(ctx agent.CallbackContext, llmRequest *model.LLMRequest, llmError error) (*model.LLMResponse, error) {
+				func(ctx agent.Context, llmRequest *model.LLMRequest, llmError error) (*model.LLMResponse, error) {
 					return &model.LLMResponse{
 						Content: genai.NewContentFromText("hello from on_model_error_callback", genai.RoleModel),
 					}, nil
@@ -309,12 +309,12 @@ func TestModelCallbacks(t *testing.T) {
 		{
 			name: "on model error callback changes err",
 			onModelErrorCallback: []llmagent.OnModelErrorCallback{
-				func(ctx agent.CallbackContext, llmRequest *model.LLMRequest, llmError error) (*model.LLMResponse, error) {
+				func(ctx agent.Context, llmRequest *model.LLMRequest, llmError error) (*model.LLMResponse, error) {
 					return &model.LLMResponse{
 						Content: genai.NewContentFromText("hello from on_model_error_callback", genai.RoleModel),
 					}, fmt.Errorf("error from on_model_error_callback: %w", http.ErrNoCookie)
 				},
-				func(ctx agent.CallbackContext, llmRequest *model.LLMRequest, llmError error) (*model.LLMResponse, error) {
+				func(ctx agent.Context, llmRequest *model.LLMRequest, llmError error) (*model.LLMResponse, error) {
 					return &model.LLMResponse{
 						Content: genai.NewContentFromText("hello from on_model_error_callback", genai.RoleModel),
 					}, fmt.Errorf("error from on_model_error_callback: %w", http.ErrHijacked)
@@ -326,7 +326,7 @@ func TestModelCallbacks(t *testing.T) {
 		{
 			name: "on model error callback returns both new LLMResponse and error",
 			onModelErrorCallback: []llmagent.OnModelErrorCallback{
-				func(ctx agent.CallbackContext, llmRequest *model.LLMRequest, llmError error) (*model.LLMResponse, error) {
+				func(ctx agent.Context, llmRequest *model.LLMRequest, llmError error) (*model.LLMResponse, error) {
 					return &model.LLMResponse{
 						Content: genai.NewContentFromText("hello from on_model_error_callback", genai.RoleModel),
 					}, fmt.Errorf("error from on_model_error_callback: %w", http.ErrNoCookie)
@@ -338,12 +338,12 @@ func TestModelCallbacks(t *testing.T) {
 		{
 			name: "on model error callback does not process before model callback error",
 			beforeModelCallbacks: []llmagent.BeforeModelCallback{
-				func(ctx agent.CallbackContext, llmRequest *model.LLMRequest) (*model.LLMResponse, error) {
+				func(ctx agent.Context, llmRequest *model.LLMRequest) (*model.LLMResponse, error) {
 					return nil, fmt.Errorf("before_model_callback_error: %w", http.ErrNoCookie)
 				},
 			},
 			onModelErrorCallback: []llmagent.OnModelErrorCallback{
-				func(ctx agent.CallbackContext, llmRequest *model.LLMRequest, llmError error) (*model.LLMResponse, error) {
+				func(ctx agent.Context, llmRequest *model.LLMRequest, llmError error) (*model.LLMResponse, error) {
 					return &model.LLMResponse{
 						Content: genai.NewContentFromText("hello from on_model_error_callback", genai.RoleModel),
 					}, fmt.Errorf("error from on_model_error_callback: %w", http.ErrHijacked)
@@ -357,14 +357,14 @@ func TestModelCallbacks(t *testing.T) {
 		{
 			name: "on model error callback does not process before model callback message",
 			beforeModelCallbacks: []llmagent.BeforeModelCallback{
-				func(ctx agent.CallbackContext, llmRequest *model.LLMRequest) (*model.LLMResponse, error) {
+				func(ctx agent.Context, llmRequest *model.LLMRequest) (*model.LLMResponse, error) {
 					return &model.LLMResponse{
 						Content: genai.NewContentFromText("hello from before_model_callback", genai.RoleModel),
 					}, nil
 				},
 			},
 			onModelErrorCallback: []llmagent.OnModelErrorCallback{
-				func(ctx agent.CallbackContext, llmRequest *model.LLMRequest, llmError error) (*model.LLMResponse, error) {
+				func(ctx agent.Context, llmRequest *model.LLMRequest, llmError error) (*model.LLMResponse, error) {
 					return &model.LLMResponse{
 						Content: genai.NewContentFromText("hello from on_model_error_callback", genai.RoleModel),
 					}, fmt.Errorf("error from on_model_error_callback: %w", http.ErrHijacked)
@@ -380,14 +380,14 @@ func TestModelCallbacks(t *testing.T) {
 		{
 			name: "after error callback process on model error callback message",
 			onModelErrorCallback: []llmagent.OnModelErrorCallback{
-				func(ctx agent.CallbackContext, llmRequest *model.LLMRequest, llmError error) (*model.LLMResponse, error) {
+				func(ctx agent.Context, llmRequest *model.LLMRequest, llmError error) (*model.LLMResponse, error) {
 					return &model.LLMResponse{
 						Content: genai.NewContentFromText("hello from on_model_error_callback", genai.RoleModel),
 					}, nil
 				},
 			},
 			afterModelCallbacks: []llmagent.AfterModelCallback{
-				func(ctx agent.CallbackContext, llmResponse *model.LLMResponse, llmResponseError error) (*model.LLMResponse, error) {
+				func(ctx agent.Context, llmResponse *model.LLMResponse, llmResponseError error) (*model.LLMResponse, error) {
 					return &model.LLMResponse{
 						Content: genai.NewContentFromText("hello from after_model_callback", genai.RoleModel),
 					}, nil
@@ -401,12 +401,12 @@ func TestModelCallbacks(t *testing.T) {
 		{
 			name: "after error callback does not process on model error callback error",
 			onModelErrorCallback: []llmagent.OnModelErrorCallback{
-				func(ctx agent.CallbackContext, llmRequest *model.LLMRequest, llmError error) (*model.LLMResponse, error) {
+				func(ctx agent.Context, llmRequest *model.LLMRequest, llmError error) (*model.LLMResponse, error) {
 					return nil, fmt.Errorf("error from on_model_error_callback: %w", http.ErrNoCookie)
 				},
 			},
 			afterModelCallbacks: []llmagent.AfterModelCallback{
-				func(ctx agent.CallbackContext, llmResponse *model.LLMResponse, llmResponseError error) (*model.LLMResponse, error) {
+				func(ctx agent.Context, llmResponse *model.LLMResponse, llmResponseError error) (*model.LLMResponse, error) {
 					return nil, fmt.Errorf("error from after_model_callback: %w", http.ErrHijacked)
 				},
 			},
@@ -453,7 +453,7 @@ func TestToolCallback(t *testing.T) {
 		Number int `json:"number"`
 	}
 
-	handler := func(_ agent.ToolContext, input Args) (Result, error) {
+	handler := func(_ agent.Context, input Args) (Result, error) {
 		return Result{Number: 1}, nil
 	}
 	rand, _ := functiontool.New(functiontool.Config{
@@ -472,10 +472,10 @@ func TestToolCallback(t *testing.T) {
 			DisallowTransferToPeers:  true,
 			Tools:                    []tool.Tool{rand},
 			BeforeToolCallbacks: []llmagent.BeforeToolCallback{
-				func(ctx agent.ToolContext, tool tool.Tool, args map[string]any) (map[string]any, error) {
+				func(ctx agent.Context, tool tool.Tool, args map[string]any) (map[string]any, error) {
 					return nil, nil
 				},
-				func(ctx agent.ToolContext, tool tool.Tool, args map[string]any) (map[string]any, error) {
+				func(ctx agent.Context, tool tool.Tool, args map[string]any) (map[string]any, error) {
 					return map[string]any{"number": "7"}, nil
 				},
 			},
@@ -508,10 +508,10 @@ func TestToolCallback(t *testing.T) {
 			Tools:                    []tool.Tool{rand},
 			BeforeToolCallbacks: []llmagent.BeforeToolCallback{
 				// Since it retursn non nil, the next callback won't be executed.
-				func(ctx agent.ToolContext, tool tool.Tool, args map[string]any) (map[string]any, error) {
+				func(ctx agent.Context, tool tool.Tool, args map[string]any) (map[string]any, error) {
 					return map[string]any{"number": "3"}, nil
 				},
-				func(ctx agent.ToolContext, tool tool.Tool, args map[string]any) (map[string]any, error) {
+				func(ctx agent.Context, tool tool.Tool, args map[string]any) (map[string]any, error) {
 					return map[string]any{"number": "7"}, nil
 				},
 			},
@@ -543,10 +543,10 @@ func TestToolCallback(t *testing.T) {
 			DisallowTransferToPeers:  true,
 			Tools:                    []tool.Tool{rand},
 			AfterToolCallbacks: []llmagent.AfterToolCallback{
-				func(ctx agent.ToolContext, tool tool.Tool, args, result map[string]any, err error) (map[string]any, error) {
+				func(ctx agent.Context, tool tool.Tool, args, result map[string]any, err error) (map[string]any, error) {
 					return nil, nil
 				},
-				func(ctx agent.ToolContext, tool tool.Tool, args, result map[string]any, err error) (map[string]any, error) {
+				func(ctx agent.Context, tool tool.Tool, args, result map[string]any, err error) (map[string]any, error) {
 					return map[string]any{"number": "7"}, nil
 				},
 			},
@@ -579,10 +579,10 @@ func TestToolCallback(t *testing.T) {
 			Tools:                    []tool.Tool{rand},
 			AfterToolCallbacks: []llmagent.AfterToolCallback{
 				// Since it retursn non nil, the next callback won't be executed.
-				func(ctx agent.ToolContext, tool tool.Tool, args, result map[string]any, err error) (map[string]any, error) {
+				func(ctx agent.Context, tool tool.Tool, args, result map[string]any, err error) (map[string]any, error) {
 					return map[string]any{"number": "3"}, nil
 				},
-				func(ctx agent.ToolContext, tool tool.Tool, args, result map[string]any, err error) (map[string]any, error) {
+				func(ctx agent.Context, tool tool.Tool, args, result map[string]any, err error) (map[string]any, error) {
 					return map[string]any{"number": "7"}, nil
 				},
 			},
@@ -614,12 +614,12 @@ func TestToolCallback(t *testing.T) {
 			DisallowTransferToPeers:  true,
 			Tools:                    []tool.Tool{rand},
 			BeforeToolCallbacks: []llmagent.BeforeToolCallback{
-				func(ctx agent.ToolContext, tool tool.Tool, args map[string]any) (map[string]any, error) {
+				func(ctx agent.Context, tool tool.Tool, args map[string]any) (map[string]any, error) {
 					return map[string]any{"number": "3"}, nil
 				},
 			},
 			AfterToolCallbacks: []llmagent.AfterToolCallback{
-				func(ctx agent.ToolContext, tool tool.Tool, args, result map[string]any, err error) (map[string]any, error) {
+				func(ctx agent.Context, tool tool.Tool, args, result map[string]any, err error) (map[string]any, error) {
 					return map[string]any{"number": "7"}, nil
 				},
 			},
@@ -651,12 +651,12 @@ func TestToolCallback(t *testing.T) {
 			DisallowTransferToPeers:  true,
 			Tools:                    []tool.Tool{rand},
 			BeforeToolCallbacks: []llmagent.BeforeToolCallback{
-				func(ctx agent.ToolContext, tool tool.Tool, args map[string]any) (map[string]any, error) {
+				func(ctx agent.Context, tool tool.Tool, args map[string]any) (map[string]any, error) {
 					return nil, nil
 				},
 			},
 			AfterToolCallbacks: []llmagent.AfterToolCallback{
-				func(ctx agent.ToolContext, tool tool.Tool, args, result map[string]any, err error) (map[string]any, error) {
+				func(ctx agent.Context, tool tool.Tool, args, result map[string]any, err error) (map[string]any, error) {
 					return nil, nil
 				},
 			},
@@ -861,7 +861,7 @@ func TestFunctionTool(t *testing.T) {
 	}
 
 	prompt := "what is the sum of 1 + 2?"
-	handler := func(_ agent.ToolContext, input Args) (Result, error) {
+	handler := func(_ agent.Context, input Args) (Result, error) {
 		if input.A != 1 || input.B != 2 {
 			t.Errorf("handler received %+v, want {a: 1, b: 2}", input)
 		}

--- a/agent/llmagent/state_agent_test.go
+++ b/agent/llmagent/state_agent_test.go
@@ -71,7 +71,7 @@ type assertSessionParams struct {
 
 func assertSessionValues(
 	t *testing.T,
-	cctx agent.CallbackContext,
+	cctx agent.Context,
 	params *assertSessionParams,
 ) {
 	t.Helper()
@@ -108,7 +108,7 @@ func assertSessionValues(
 
 // --- Callbacks (Modified to use *testing.T) ---
 func beforeAgentCallback(t *testing.T) agent.BeforeAgentCallback {
-	return func(cctx agent.CallbackContext) (*genai.Content, error) {
+	return func(cctx agent.Context) (*genai.Content, error) {
 		if _, err := cctx.State().Get("before_agent_callback_state_key"); err == nil {
 			return genai.NewContentFromText("Sorry, I can only reply once.", genai.RoleModel), nil
 		}
@@ -126,8 +126,8 @@ func beforeAgentCallback(t *testing.T) agent.BeforeAgentCallback {
 	}
 }
 
-func beforeModelCallback(t *testing.T) func(ctx agent.CallbackContext, llmRequest *model.LLMRequest) (*model.LLMResponse, error) {
-	return func(cctx agent.CallbackContext, llmRequest *model.LLMRequest) (*model.LLMResponse, error) {
+func beforeModelCallback(t *testing.T) func(ctx agent.Context, llmRequest *model.LLMRequest) (*model.LLMResponse, error) {
+	return func(cctx agent.Context, llmRequest *model.LLMRequest) (*model.LLMResponse, error) {
 		if err := cctx.State().Set("before_model_callback_state_key", "before_model_callback_state_value"); err != nil {
 			return nil, fmt.Errorf("failed to set state: %w", err)
 		}
@@ -142,8 +142,8 @@ func beforeModelCallback(t *testing.T) func(ctx agent.CallbackContext, llmReques
 	}
 }
 
-func afterModelCallback(t *testing.T) func(ctx agent.CallbackContext, llmResponse *model.LLMResponse, llmResponseError error) (*model.LLMResponse, error) {
-	return func(cctx agent.CallbackContext, llmResponse *model.LLMResponse, err error) (*model.LLMResponse, error) {
+func afterModelCallback(t *testing.T) func(ctx agent.Context, llmResponse *model.LLMResponse, llmResponseError error) (*model.LLMResponse, error) {
+	return func(cctx agent.Context, llmResponse *model.LLMResponse, err error) (*model.LLMResponse, error) {
 		if err := cctx.State().Set("after_model_callback_state_key", "after_model_callback_state_value"); err != nil {
 			return nil, fmt.Errorf("failed to set state: %w", err)
 		}
@@ -159,7 +159,7 @@ func afterModelCallback(t *testing.T) func(ctx agent.CallbackContext, llmRespons
 }
 
 func afterAgentCallback(t *testing.T) agent.AfterAgentCallback {
-	return func(cctx agent.CallbackContext) (*genai.Content, error) {
+	return func(cctx agent.Context) (*genai.Content, error) {
 		if err := cctx.State().Set("after_agent_callback_state_key", "after_agent_callback_state_value"); err != nil {
 			return nil, fmt.Errorf("failed to set state: %w", err)
 		}
@@ -263,7 +263,7 @@ type WeatherResult struct {
 	Timestamp   time.Time `json:"timestamp"`
 }
 
-func GetWeather(ctx agent.ToolContext, args WeatherArgs) (WeatherResult, error) {
+func GetWeather(ctx agent.Context, args WeatherArgs) (WeatherResult, error) {
 	// Simulate weather data
 	temperatures := []int{-10, -5, 0, 5, 10, 15, 20, 25, 30, 35}
 	conditions := []string{"sunny", "cloudy", "rainy", "snowy", "windy"}
@@ -291,7 +291,7 @@ type CalculationResult struct {
 	Timestamp time.Time `json:"timestamp"`
 }
 
-func Calculate(ctx agent.ToolContext, args CalculationArgs) (CalculationResult, error) {
+func Calculate(ctx agent.Context, args CalculationArgs) (CalculationResult, error) {
 	operations := map[string]float64{
 		"add":      args.X + args.Y,
 		"subtract": args.X - args.Y,
@@ -341,7 +341,7 @@ type LogActivityResult struct {
 	err          error
 }
 
-func LogActivity(ctx agent.ToolContext, params LogActivityParams) (LogActivityResult, error) {
+func LogActivity(ctx agent.Context, params LogActivityParams) (LogActivityResult, error) {
 	var activityLog []LogEntry
 	val, err := ctx.State().Get("activity_log")
 	if err == nil {
@@ -366,7 +366,7 @@ func LogActivity(ctx agent.ToolContext, params LogActivityParams) (LogActivityRe
 
 // --- Before Tool Callbacks ---
 
-func beforeToolAuditCallback(ctx agent.ToolContext, t tool.Tool, args map[string]any) (map[string]any, error) {
+func beforeToolAuditCallback(ctx agent.Context, t tool.Tool, args map[string]any) (map[string]any, error) {
 	fmt.Printf("🔍 AUDIT: About to call tool '%s' with args: %v\n", t.Name(), args)
 
 	var auditLog []map[string]any
@@ -387,7 +387,7 @@ func beforeToolAuditCallback(ctx agent.ToolContext, t tool.Tool, args map[string
 	return nil, nil // Continue execution
 }
 
-func beforeToolSecurityCallback(ctx agent.ToolContext, t tool.Tool, args map[string]any) (map[string]any, error) {
+func beforeToolSecurityCallback(ctx agent.Context, t tool.Tool, args map[string]any) (map[string]any, error) {
 	if t.Name() == "get_weather" {
 		location := ""
 		if loc, ok := args["location"].(string); ok {
@@ -411,7 +411,7 @@ func beforeToolSecurityCallback(ctx agent.ToolContext, t tool.Tool, args map[str
 	return nil, nil // Continue execution
 }
 
-func beforeToolValidationCallback(ctx agent.ToolContext, t tool.Tool, args map[string]any) (map[string]any, error) {
+func beforeToolValidationCallback(ctx agent.Context, t tool.Tool, args map[string]any) (map[string]any, error) {
 	if t.Name() == "calculate" {
 		operation, _ := args["operation"].(string)
 		y, yOK := args["y"].(float64)
@@ -430,7 +430,7 @@ func beforeToolValidationCallback(ctx agent.ToolContext, t tool.Tool, args map[s
 
 // --- After Tool Callbacks ---
 
-func afterToolEnhancementCallback(ctx agent.ToolContext, t tool.Tool, args, result map[string]any, err error) (map[string]any, error) {
+func afterToolEnhancementCallback(ctx agent.Context, t tool.Tool, args, result map[string]any, err error) (map[string]any, error) {
 	if err != nil {
 		return result, err // Don't enhance if there was an error
 	}
@@ -444,7 +444,7 @@ func afterToolEnhancementCallback(ctx agent.ToolContext, t tool.Tool, args, resu
 	return enhancedResponse, nil
 }
 
-func afterToolAsyncCallback(ctx agent.ToolContext, t tool.Tool, args, result map[string]any, err error) (map[string]any, error) {
+func afterToolAsyncCallback(ctx agent.Context, t tool.Tool, args, result map[string]any, err error) (map[string]any, error) {
 	if err != nil {
 		return result, err
 	}
@@ -653,7 +653,7 @@ func TestToolCallbacksAgent(t *testing.T) {
 
 type mockToolset struct{}
 
-func (m *mockToolset) ProcessRequest(ctx agent.ToolContext, req *model.LLMRequest) error {
+func (m *mockToolset) ProcessRequest(ctx agent.Context, req *model.LLMRequest) error {
 	utils.AppendInstructions(req, "Extra instruction from mockToolset")
 	return nil
 }

--- a/agent/remoteagent/a2a_agent.go
+++ b/agent/remoteagent/a2a_agent.go
@@ -43,7 +43,7 @@ import (
 //
 // If it returns non-nil result or error, the actual call is skipped and the returned value is used
 // as the agent invocation result.
-type BeforeA2ARequestCallback func(ctx agent.CallbackContext, req *a2a.MessageSendParams) (*session.Event, error)
+type BeforeA2ARequestCallback func(ctx agent.Context, req *a2a.MessageSendParams) (*session.Event, error)
 
 // A2AEventConverter can be used to provide a custom implementation of A2A event transformation logic.
 type A2AEventConverter func(ctx agent.InvocationContext, req *a2a.MessageSendParams, event a2a.Event, err error) (*session.Event, error)
@@ -53,7 +53,7 @@ type A2AEventConverter func(ctx agent.InvocationContext, req *a2a.MessageSendPar
 // decides to not emit an A2A event.
 //
 // If it returns non-nil result or error, it gets emitted instead of the original result.
-type AfterA2ARequestCallback func(ctx agent.CallbackContext, req *a2a.MessageSendParams, resp *session.Event, err error) (*session.Event, error)
+type AfterA2ARequestCallback func(ctx agent.Context, req *a2a.MessageSendParams, resp *session.Event, err error) (*session.Event, error)
 
 // A2ARemoteTaskCleanupCallback is called if Run exited before a terminal event was received from the remote A2A server.
 type A2ARemoteTaskCleanupCallback func(ctx context.Context, card *a2a.AgentCard, client *a2aclient.Client, taskInfo a2a.TaskInfo, cause error)
@@ -199,7 +199,7 @@ func NewA2A(cfg A2AConfig) (agent.Agent, error) {
 	if cfg.BeforeRequestCallbacks != nil {
 		v1Cfg.BeforeRequestCallbacks = make([]v2.BeforeA2ARequestCallback, 0, len(cfg.BeforeRequestCallbacks))
 		for _, cb := range cfg.BeforeRequestCallbacks {
-			v1Cfg.BeforeRequestCallbacks = append(v1Cfg.BeforeRequestCallbacks, func(ctx agent.CallbackContext, req *a2av2.SendMessageRequest) (*session.Event, error) {
+			v1Cfg.BeforeRequestCallbacks = append(v1Cfg.BeforeRequestCallbacks, func(ctx agent.Context, req *a2av2.SendMessageRequest) (*session.Event, error) {
 				legacyReq := a2av0.FromV1SendMessageRequest(req)
 				resp, err := cb(ctx, legacyReq)
 				if resp != nil || err != nil { // short-circuit, no need to convert the request back
@@ -219,7 +219,7 @@ func NewA2A(cfg A2AConfig) (agent.Agent, error) {
 	if cfg.AfterRequestCallbacks != nil {
 		v1Cfg.AfterRequestCallbacks = make([]v2.AfterA2ARequestCallback, 0, len(cfg.AfterRequestCallbacks))
 		for _, cb := range cfg.AfterRequestCallbacks {
-			v1Cfg.AfterRequestCallbacks = append(v1Cfg.AfterRequestCallbacks, func(ctx agent.CallbackContext, req *a2av2.SendMessageRequest, resp *session.Event, err error) (*session.Event, error) {
+			v1Cfg.AfterRequestCallbacks = append(v1Cfg.AfterRequestCallbacks, func(ctx agent.Context, req *a2av2.SendMessageRequest, resp *session.Event, err error) (*session.Event, error) {
 				legacyReq := a2av0.FromV1SendMessageRequest(req)
 				newResp, newErr := cb(ctx, legacyReq, resp, err)
 				if newResp != nil || newErr != nil { // short-circuit, no need to convert the request back

--- a/agent/remoteagent/a2a_agent_compat_test.go
+++ b/agent/remoteagent/a2a_agent_compat_test.go
@@ -117,7 +117,7 @@ func TestCompat_RemoteAgent(t *testing.T) {
 			},
 			updateConfig: func(config *A2AConfig) {
 				config.AfterRequestCallbacks = []AfterA2ARequestCallback{
-					func(ctx agent.CallbackContext, req *legacyA2A.MessageSendParams, resp *session.Event, err error) (*session.Event, error) {
+					func(ctx agent.Context, req *legacyA2A.MessageSendParams, resp *session.Event, err error) (*session.Event, error) {
 						if resp != nil && resp.Content != nil && len(resp.Content.Parts) > 0 {
 							resp.Content.Parts[0].Text = "modified-by-agent-callback"
 						}
@@ -142,7 +142,7 @@ func TestCompat_RemoteAgent(t *testing.T) {
 			},
 			updateConfig: func(config *A2AConfig) {
 				config.BeforeRequestCallbacks = []BeforeA2ARequestCallback{
-					func(ctx agent.CallbackContext, req *legacyA2A.MessageSendParams) (*session.Event, error) {
+					func(ctx agent.Context, req *legacyA2A.MessageSendParams) (*session.Event, error) {
 						req.Message = legacyA2A.NewMessage(legacyA2A.MessageRoleUser, legacyA2A.TextPart{Text: "42"})
 						return nil, nil
 					},
@@ -161,7 +161,7 @@ func TestCompat_RemoteAgent(t *testing.T) {
 			},
 			updateConfig: func(config *A2AConfig) {
 				config.BeforeRequestCallbacks = []BeforeA2ARequestCallback{
-					func(ctx agent.CallbackContext, req *legacyA2A.MessageSendParams) (*session.Event, error) {
+					func(ctx agent.Context, req *legacyA2A.MessageSendParams) (*session.Event, error) {
 						return &session.Event{
 							LLMResponse: model.LLMResponse{
 								Content: genai.NewContentFromText("cached-response", genai.RoleModel),
@@ -246,13 +246,13 @@ func TestCompat_RemoteAgent(t *testing.T) {
 			},
 			updateConfig: func(config *A2AConfig) {
 				config.AfterRequestCallbacks = []AfterA2ARequestCallback{
-					func(ctx agent.CallbackContext, req *legacyA2A.MessageSendParams, resp *session.Event, err error) (*session.Event, error) {
+					func(ctx agent.Context, req *legacyA2A.MessageSendParams, resp *session.Event, err error) (*session.Event, error) {
 						if resp != nil && resp.Content != nil && len(resp.Content.Parts) > 0 {
 							resp.Content.Parts[0].Text += "-first"
 						}
 						return nil, nil
 					},
-					func(ctx agent.CallbackContext, req *legacyA2A.MessageSendParams, resp *session.Event, err error) (*session.Event, error) {
+					func(ctx agent.Context, req *legacyA2A.MessageSendParams, resp *session.Event, err error) (*session.Event, error) {
 						if resp != nil && resp.Content != nil && len(resp.Content.Parts) > 0 {
 							resp.Content.Parts[0].Text += "-second"
 						}

--- a/agent/remoteagent/v2/a2a_agent.go
+++ b/agent/remoteagent/v2/a2a_agent.go
@@ -39,7 +39,7 @@ import (
 //
 // If it returns non-nil result or error, the actual call is skipped and the returned value is used
 // as the agent invocation result.
-type BeforeA2ARequestCallback func(ctx agent.CallbackContext, req *a2a.SendMessageRequest) (*session.Event, error)
+type BeforeA2ARequestCallback func(ctx agent.Context, req *a2a.SendMessageRequest) (*session.Event, error)
 
 // A2AEventConverter can be used to provide a custom implementation of A2A event transformation logic.
 type A2AEventConverter func(ctx agent.InvocationContext, req *a2a.SendMessageRequest, event a2a.Event, err error) (*session.Event, error)
@@ -49,7 +49,7 @@ type A2AEventConverter func(ctx agent.InvocationContext, req *a2a.SendMessageReq
 // decides to not emit an A2A event.
 //
 // If it returns non-nil result or error, it gets emitted instead of the original result.
-type AfterA2ARequestCallback func(ctx agent.CallbackContext, req *a2a.SendMessageRequest, resp *session.Event, err error) (*session.Event, error)
+type AfterA2ARequestCallback func(ctx agent.Context, req *a2a.SendMessageRequest, resp *session.Event, err error) (*session.Event, error)
 
 // A2ARemoteTaskCleanupCallback is called if Run exited before a terminal event was received from the remote A2A server.
 type A2ARemoteTaskCleanupCallback func(ctx context.Context, card *a2a.AgentCard, client A2AClient, taskInfo a2a.TaskInfo, cause error)

--- a/agent/remoteagent/v2/a2a_agent_test.go
+++ b/agent/remoteagent/v2/a2a_agent_test.go
@@ -676,13 +676,13 @@ func TestRemoteAgent_RequestCallbacks(t *testing.T) {
 				return []a2a.Event{a2a.NewMessage(a2a.MessageRoleAgent, a2a.NewTextPart("foo"))}
 			},
 			before: []BeforeA2ARequestCallback{
-				func(ctx agent.CallbackContext, req *a2a.SendMessageRequest) (*session.Event, error) {
+				func(ctx agent.Context, req *a2a.SendMessageRequest) (*session.Event, error) {
 					req.Metadata = map[string]any{"counter": 1}
 					return nil, nil
 				},
 			},
 			after: []AfterA2ARequestCallback{
-				func(ctx agent.CallbackContext, req *a2a.SendMessageRequest, result *session.Event, err error) (*session.Event, error) {
+				func(ctx agent.Context, req *a2a.SendMessageRequest, result *session.Event, err error) (*session.Event, error) {
 					result.Content = genai.NewContentFromText(result.Content.Parts[0].Text+"bar", genai.RoleModel)
 					result.CustomMetadata = req.Metadata
 					return nil, nil
@@ -708,7 +708,7 @@ func TestRemoteAgent_RequestCallbacks(t *testing.T) {
 				}
 			},
 			after: []AfterA2ARequestCallback{
-				func(ctx agent.CallbackContext, req *a2a.SendMessageRequest, result *session.Event, err error) (*session.Event, error) {
+				func(ctx agent.Context, req *a2a.SendMessageRequest, result *session.Event, err error) (*session.Event, error) {
 					result.CustomMetadata = map[string]any{"foo": "bar"}
 					return nil, nil
 				},
@@ -744,7 +744,7 @@ func TestRemoteAgent_RequestCallbacks(t *testing.T) {
 				}
 			},
 			after: []AfterA2ARequestCallback{
-				func(ctx agent.CallbackContext, req *a2a.SendMessageRequest, result *session.Event, err error) (*session.Event, error) {
+				func(ctx agent.Context, req *a2a.SendMessageRequest, result *session.Event, err error) (*session.Event, error) {
 					return nil, fmt.Errorf("rejected")
 				},
 			},
@@ -753,7 +753,7 @@ func TestRemoteAgent_RequestCallbacks(t *testing.T) {
 		{
 			name: "request overwrite with response",
 			before: []BeforeA2ARequestCallback{
-				func(ctx agent.CallbackContext, req *a2a.SendMessageRequest) (*session.Event, error) {
+				func(ctx agent.Context, req *a2a.SendMessageRequest) (*session.Event, error) {
 					return &session.Event{LLMResponse: model.LLMResponse{Content: genai.NewContentFromText("hello", genai.RoleModel)}}, nil
 				},
 			},
@@ -762,7 +762,7 @@ func TestRemoteAgent_RequestCallbacks(t *testing.T) {
 		{
 			name: "request overwrite with error",
 			before: []BeforeA2ARequestCallback{
-				func(ctx agent.CallbackContext, req *a2a.SendMessageRequest) (*session.Event, error) {
+				func(ctx agent.Context, req *a2a.SendMessageRequest) (*session.Event, error) {
 					return nil, fmt.Errorf("failed")
 				},
 			},
@@ -771,7 +771,7 @@ func TestRemoteAgent_RequestCallbacks(t *testing.T) {
 		{
 			name: "response overwrite",
 			after: []AfterA2ARequestCallback{
-				func(ctx agent.CallbackContext, req *a2a.SendMessageRequest, result *session.Event, err error) (*session.Event, error) {
+				func(ctx agent.Context, req *a2a.SendMessageRequest, result *session.Event, err error) (*session.Event, error) {
 					return &session.Event{LLMResponse: model.LLMResponse{Content: genai.NewContentFromText("hello", genai.RoleModel)}}, nil
 				},
 			},
@@ -780,7 +780,7 @@ func TestRemoteAgent_RequestCallbacks(t *testing.T) {
 		{
 			name: "response overwrite with error",
 			after: []AfterA2ARequestCallback{
-				func(ctx agent.CallbackContext, req *a2a.SendMessageRequest, result *session.Event, err error) (*session.Event, error) {
+				func(ctx agent.Context, req *a2a.SendMessageRequest, result *session.Event, err error) (*session.Event, error) {
 					return nil, fmt.Errorf("failed")
 				},
 			},
@@ -789,10 +789,10 @@ func TestRemoteAgent_RequestCallbacks(t *testing.T) {
 		{
 			name: "before interceptor short-circuit",
 			before: []BeforeA2ARequestCallback{
-				func(ctx agent.CallbackContext, req *a2a.SendMessageRequest) (*session.Event, error) {
+				func(ctx agent.Context, req *a2a.SendMessageRequest) (*session.Event, error) {
 					return nil, fmt.Errorf("failed")
 				},
-				func(ctx agent.CallbackContext, req *a2a.SendMessageRequest) (*session.Event, error) {
+				func(ctx agent.Context, req *a2a.SendMessageRequest) (*session.Event, error) {
 					t.Fatalf("not called")
 					return nil, nil
 				},
@@ -802,10 +802,10 @@ func TestRemoteAgent_RequestCallbacks(t *testing.T) {
 		{
 			name: "after interceptor short-circuit",
 			after: []AfterA2ARequestCallback{
-				func(ctx agent.CallbackContext, req *a2a.SendMessageRequest, result *session.Event, err error) (*session.Event, error) {
+				func(ctx agent.Context, req *a2a.SendMessageRequest, result *session.Event, err error) (*session.Event, error) {
 					return nil, fmt.Errorf("failed")
 				},
-				func(ctx agent.CallbackContext, req *a2a.SendMessageRequest, result *session.Event, err error) (*session.Event, error) {
+				func(ctx agent.Context, req *a2a.SendMessageRequest, result *session.Event, err error) (*session.Event, error) {
 					t.Fatalf("not called")
 					return nil, nil
 				},
@@ -816,7 +816,7 @@ func TestRemoteAgent_RequestCallbacks(t *testing.T) {
 			name:          "after interceptor for empty session",
 			sessionEvents: []*session.Event{},
 			after: []AfterA2ARequestCallback{
-				func(ctx agent.CallbackContext, req *a2a.SendMessageRequest, result *session.Event, err error) (*session.Event, error) {
+				func(ctx agent.Context, req *a2a.SendMessageRequest, result *session.Event, err error) (*session.Event, error) {
 					if len(req.Message.Parts) != 0 {
 						t.Fatalf("got %d parts, expected empty message", len(req.Message.Parts))
 					}
@@ -842,12 +842,12 @@ func TestRemoteAgent_RequestCallbacks(t *testing.T) {
 		{
 			name: "after interceptor invoked with before result",
 			before: []BeforeA2ARequestCallback{
-				func(ctx agent.CallbackContext, req *a2a.SendMessageRequest) (*session.Event, error) {
+				func(ctx agent.Context, req *a2a.SendMessageRequest) (*session.Event, error) {
 					return nil, fmt.Errorf("before error")
 				},
 			},
 			after: []AfterA2ARequestCallback{
-				func(ctx agent.CallbackContext, req *a2a.SendMessageRequest, result *session.Event, err error) (*session.Event, error) {
+				func(ctx agent.Context, req *a2a.SendMessageRequest, result *session.Event, err error) (*session.Event, error) {
 					return nil, fmt.Errorf("after error")
 				},
 			},
@@ -1053,7 +1053,7 @@ func TestRemoteAgent_RequestPayload(t *testing.T) {
 				Name:      remoteAgentName,
 				AgentCard: card,
 				BeforeRequestCallbacks: []BeforeA2ARequestCallback{
-					func(ctx agent.CallbackContext, req *a2a.SendMessageRequest) (*session.Event, error) {
+					func(ctx agent.Context, req *a2a.SendMessageRequest) (*session.Event, error) {
 						gotRequest = req
 						return nil, errRejected
 					},
@@ -1260,7 +1260,7 @@ func TestRemoteAgent_CleanupCallback(t *testing.T) {
 		{
 			name: "after request callback error",
 			afterRequestCallbacks: []AfterA2ARequestCallback{
-				func(ctx agent.CallbackContext, req *a2a.SendMessageRequest, resp *session.Event, err error) (*session.Event, error) {
+				func(ctx agent.Context, req *a2a.SendMessageRequest, resp *session.Event, err error) (*session.Event, error) {
 					return nil, fmt.Errorf("callback error")
 				},
 			},

--- a/agent/remoteagent/v2/a2a_e2e_test.go
+++ b/agent/remoteagent/v2/a2a_e2e_test.go
@@ -574,7 +574,7 @@ func TestA2ASingleHopFinalResponse(t *testing.T) {
 					Name:  "model-agent",
 					Model: llmModel,
 					AfterModelCallbacks: []llmagent.AfterModelCallback{
-						func(ctx agent.CallbackContext, llmResponse *model.LLMResponse, llmResponseError error) (*model.LLMResponse, error) {
+						func(ctx agent.Context, llmResponse *model.LLMResponse, llmResponseError error) (*model.LLMResponse, error) {
 							if event < 2 {
 								event++
 								return nil, nil
@@ -599,7 +599,7 @@ func TestA2ASingleHopFinalResponse(t *testing.T) {
 					Name:  "model-agent",
 					Model: llmModel,
 					AfterModelCallbacks: []llmagent.AfterModelCallback{
-						func(ctx agent.CallbackContext, llmResponse *model.LLMResponse, llmResponseError error) (*model.LLMResponse, error) {
+						func(ctx agent.Context, llmResponse *model.LLMResponse, llmResponseError error) (*model.LLMResponse, error) {
 							if event < 2 {
 								event++
 								return nil, nil
@@ -794,7 +794,7 @@ func TestA2ARemoteAgentStreamingGeminiError(t *testing.T) {
 		Model:       llmModel,
 		Instruction: "You are a helpful assistant.",
 		AfterModelCallbacks: []llmagent.AfterModelCallback{
-			func(ctx agent.CallbackContext, llmResponse *model.LLMResponse, llmResponseError error) (*model.LLMResponse, error) {
+			func(ctx agent.Context, llmResponse *model.LLMResponse, llmResponseError error) (*model.LLMResponse, error) {
 				if eventCount < 3 {
 					eventCount++
 					return nil, nil
@@ -886,7 +886,7 @@ func newLongRunningTool(t *testing.T) tool.Tool {
 		Name:          approvalToolName,
 		Description:   "Request approval before proceeding.",
 		IsLongRunning: true,
-	}, func(ctx agent.ToolContext, x map[string]any) (approval, error) {
+	}, func(ctx agent.Context, x map[string]any) (approval, error) {
 		return approval{Status: approvalStatusPending, TicketID: a2a.NewContextID()}, nil
 	})
 	if err != nil {
@@ -901,7 +901,7 @@ func newToolConfirmation(t *testing.T) tool.Tool {
 	requestApproval, err := functiontool.New(functiontool.Config{
 		Name:        approvalToolName,
 		Description: "Request approval before proceeding.",
-	}, func(ctx agent.ToolContext, x map[string]any) (approval, error) {
+	}, func(ctx agent.Context, x map[string]any) (approval, error) {
 		confirmation := ctx.ToolConfirmation()
 		if confirmation == nil {
 			ticketID := a2a.NewContextID()

--- a/agent/workflowagents/loopagent/agent_test.go
+++ b/agent/workflowagents/loopagent/agent_test.go
@@ -306,13 +306,13 @@ func (a *customAgent) Run(agent.InvocationContext) iter.Seq2[*session.Event, err
 
 type EmptyArgs struct{}
 
-func exampleFunctionThatEscalates(ctx agent.ToolContext, myArgs EmptyArgs) (map[string]string, error) {
+func exampleFunctionThatEscalates(ctx agent.Context, myArgs EmptyArgs) (map[string]string, error) {
 	ctx.Actions().Escalate = true
 	ctx.Actions().SkipSummarization = false
 	return map[string]string{}, nil
 }
 
-func exampleFunctionThatEscalatesAndSkips(ctx agent.ToolContext, myArgs EmptyArgs) (map[string]string, error) {
+func exampleFunctionThatEscalatesAndSkips(ctx agent.Context, myArgs EmptyArgs) (map[string]string, error) {
 	ctx.Actions().Escalate = true
 	ctx.Actions().SkipSummarization = true
 	return map[string]string{}, nil

--- a/agent/workflowagents/parallelagent/agent_test.go
+++ b/agent/workflowagents/parallelagent/agent_test.go
@@ -298,7 +298,7 @@ func createAgentWithGemini(t *testing.T, name string) agent.Agent {
 			Name:        fmt.Sprintf("search_tool_%s", name),
 			Description: "Search for information on the web",
 		},
-		func(ctx agent.ToolContext, args struct{ Query string }) (string, error) {
+		func(ctx agent.Context, args struct{ Query string }) (string, error) {
 			return fmt.Sprintf("search result for '%s' from %s", args.Query, name), nil
 		},
 	)
@@ -311,7 +311,7 @@ func createAgentWithGemini(t *testing.T, name string) agent.Agent {
 			Name:        fmt.Sprintf("analyze_tool_%s", name),
 			Description: "Analyze data and return insights",
 		},
-		func(ctx agent.ToolContext, args struct{ Data string }) (string, error) {
+		func(ctx agent.Context, args struct{ Data string }) (string, error) {
 			return fmt.Sprintf("analysis result for '%s' from %s", args.Data, name), nil
 		},
 	)
@@ -483,7 +483,7 @@ func TestParallelAgent_StateSync(t *testing.T) {
 			}
 		},
 		AfterAgentCallbacks: []agent.AfterAgentCallback{
-			func(c agent.CallbackContext) (*genai.Content, error) {
+			func(c agent.Context) (*genai.Content, error) {
 				gotValue, gotErr = c.State().Get("test_key")
 				return nil, nil
 			},

--- a/agent/workflowagents/sequentialagent/agent.go
+++ b/agent/workflowagents/sequentialagent/agent.go
@@ -137,7 +137,7 @@ func (a *sequentialAgent) RunLive(ctx agent.InvocationContext) (agent.LiveSessio
 	taskCompletedTool, err := functiontool.New(functiontool.Config{
 		Name:        "task_completed",
 		Description: "Signals that the agent has successfully completed the user's question or task.",
-	}, func(ctx agent.ToolContext, args taskCompletedArgs) (taskCompletedResults, error) {
+	}, func(ctx agent.Context, args taskCompletedArgs) (taskCompletedResults, error) {
 		return taskCompletedResults{Result: "Task completion signaled."}, nil
 	})
 	if err != nil {

--- a/examples/agentengine/main.go
+++ b/examples/agentengine/main.go
@@ -53,8 +53,8 @@ const (
 )
 
 // memorySearchToolFunc is the implementation of the memory search tool.
-// This function demonstrates accessing memory via agent.ToolContext.
-func memorySearchToolFunc(tctx agent.ToolContext, args Args) (Result, error) {
+// This function demonstrates accessing memory via agent.Context.
+func memorySearchToolFunc(tctx agent.Context, args Args) (Result, error) {
 	// The SearchMemory function is available on the context.
 	searchResults, err := tctx.SearchMemory(tctx, args.Query)
 	if err != nil {
@@ -98,7 +98,7 @@ func main() {
 	type Output struct {
 		Result int `json:"result"`
 	}
-	handler := func(ctx agent.ToolContext, input Input) (Output, error) {
+	handler := func(ctx agent.Context, input Input) (Output, error) {
 		return Output{
 			Result: input.Min + rand.IntN(input.Max-input.Min+1),
 		}, nil

--- a/examples/bidi/main.go
+++ b/examples/bidi/main.go
@@ -56,7 +56,7 @@ func main() {
 	cameraTool, err := functiontool.New(functiontool.Config{
 		Name:        "camera_toggle",
 		Description: "Turns the camera on or off.",
-	}, func(ctx agent.ToolContext, args EmptyArgs) (MessageResult, error) {
+	}, func(ctx agent.Context, args EmptyArgs) (MessageResult, error) {
 		fmt.Println("Camera tool was called!")
 		return MessageResult{Message: "Camera tool called successfully!"}, nil
 	})

--- a/examples/bidi/streamingtool/main.go
+++ b/examples/bidi/streamingtool/main.go
@@ -53,7 +53,7 @@ func main() {
 	counterTool, err := functiontool.NewStreaming(functiontool.Config{
 		Name:        "count_to",
 		Description: "Counts to a specified number, yielding each number with a delay.",
-	}, func(ctx agent.ToolContext, args struct {
+	}, func(ctx agent.Context, args struct {
 		N int `json:"n"`
 	},
 	) iter.Seq2[string, error] {
@@ -78,7 +78,7 @@ func main() {
 	stopTool, err := functiontool.New(functiontool.Config{
 		Name:        "stop_streaming",
 		Description: "Stops a running streaming function.",
-	}, func(ctx agent.ToolContext, args struct {
+	}, func(ctx agent.Context, args struct {
 		FunctionName string `json:"function_name"`
 	},
 	) (map[string]any, error) {
@@ -92,7 +92,7 @@ func main() {
 	checkDivisibleTool, err := functiontool.New(functiontool.Config{
 		Name:        "check_divisible",
 		Description: "Checks if a number is divisible by another number.",
-	}, func(ctx agent.ToolContext, args struct {
+	}, func(ctx agent.Context, args struct {
 		Number  int `json:"number"`
 		Divisor int `json:"divisor"`
 	},

--- a/examples/multiagent/single_turn/main.go
+++ b/examples/multiagent/single_turn/main.go
@@ -52,7 +52,7 @@ type CheckPhonePriceOutput struct {
 
 // checkPhonePrice is a mock tool to check the current price of a Pixel phone
 // model.
-func checkPhonePrice(_ agent.ToolContext, in CheckPhonePriceInput) (CheckPhonePriceOutput, error) {
+func checkPhonePrice(_ agent.Context, in CheckPhonePriceInput) (CheckPhonePriceOutput, error) {
 	prices := map[string]float64{
 		"Pixel 10a":         499.0,
 		"Pixel 10":          799.0,

--- a/examples/multiagent/task_sub_agent/main.go
+++ b/examples/multiagent/task_sub_agent/main.go
@@ -68,7 +68,7 @@ type PlaceOrderOutput struct {
 }
 
 // placeOrder mocks an order placement operation.
-func placeOrder(_ agent.ToolContext, in PlaceOrderInput) (PlaceOrderOutput, error) {
+func placeOrder(_ agent.Context, in PlaceOrderInput) (PlaceOrderOutput, error) {
 	totalItems := 0
 	for _, item := range in.Orders {
 		totalItems += item.Quantity
@@ -87,7 +87,7 @@ type ConfirmationOutput struct {
 }
 
 // confirmation confirms proceeding with the order.
-func confirmation(_ agent.ToolContext, _ ConfirmationInput) (ConfirmationOutput, error) {
+func confirmation(_ agent.Context, _ ConfirmationInput) (ConfirmationOutput, error) {
 	return ConfirmationOutput{Result: "Proceeding with order."}, nil
 }
 

--- a/examples/toolconfirmation/main.go
+++ b/examples/toolconfirmation/main.go
@@ -126,7 +126,7 @@ func main() {
 }
 
 // requestVacationDays simulates the *initiation* of a long-running ticket creation task.
-func requestVacationDays(ctx agent.ToolContext, args RequestVacationArgs) (*RequestVacationResults, error) {
+func requestVacationDays(ctx agent.Context, args RequestVacationArgs) (*RequestVacationResults, error) {
 	log.Printf("TOOL_EXEC: 'requestVacationDays' called with days: %d for user %s (Call ID: %s)\n", args.Days, args.UserID, ctx.FunctionCallID())
 
 	if args.Days <= 0 {

--- a/examples/tools/multipletools/main.go
+++ b/examples/tools/multipletools/main.go
@@ -67,7 +67,7 @@ func main() {
 	type Output struct {
 		Poem string `json:"poem"`
 	}
-	handler := func(ctx agent.ToolContext, input Input) (Output, error) {
+	handler := func(ctx agent.Context, input Input) (Output, error) {
 		return Output{
 			Poem: strings.Repeat("A line of a poem,", input.LineCount) + "\n",
 		}, nil

--- a/examples/vertexai/imagegenerator/main.go
+++ b/examples/vertexai/imagegenerator/main.go
@@ -91,7 +91,7 @@ func main() {
 }
 
 // This is a function tool to generate images using Vertex AI's Imagen model.
-func generateImage(ctx agent.ToolContext, input generateImageInput) (generateImageResult, error) {
+func generateImage(ctx agent.Context, input generateImageInput) (generateImageResult, error) {
 	client, err := genai.NewClient(ctx, &genai.ClientConfig{
 		Project:  os.Getenv("GOOGLE_CLOUD_PROJECT"),
 		Location: os.Getenv("GOOGLE_CLOUD_LOCATION"),
@@ -129,7 +129,7 @@ type generateImageResult struct {
 
 // This is function tool that loads image from the artifacts service and
 // saves is to the local filesystem.
-func saveImage(ctx agent.ToolContext, input saveImageInput) (saveImageResult, error) {
+func saveImage(ctx agent.Context, input saveImageInput) (saveImageResult, error) {
 	filename := input.Filename
 	resp, err := ctx.Artifacts().Load(ctx, filename)
 	if err != nil {

--- a/examples/web/agents/image_generator.go
+++ b/examples/web/agents/image_generator.go
@@ -30,7 +30,7 @@ import (
 	"google.golang.org/adk/tool/loadartifactstool"
 )
 
-func generateImage(ctx agent.ToolContext, input generateImageInput) (generateImageResult, error) {
+func generateImage(ctx agent.Context, input generateImageInput) (generateImageResult, error) {
 	client, err := genai.NewClient(ctx, &genai.ClientConfig{
 		Project:  os.Getenv("GOOGLE_CLOUD_PROJECT"),
 		Location: os.Getenv("GOOGLE_CLOUD_LOCATION"),

--- a/examples/web/agents/llmauditor.go
+++ b/examples/web/agents/llmauditor.go
@@ -153,7 +153,7 @@ The sun is sphere-shaped and very hot.
 Here are the question-answer pair and the reviewer-provided findings:
 `
 
-func afterCritic(ctx agent.CallbackContext, llmResponse *model.LLMResponse, llmResponseError error) (*model.LLMResponse, error) {
+func afterCritic(ctx agent.Context, llmResponse *model.LLMResponse, llmResponseError error) (*model.LLMResponse, error) {
 	if llmResponse == nil || llmResponse.Content == nil || llmResponse.Content.Parts == nil || llmResponse.GroundingMetadata == nil {
 		return llmResponse, nil
 	}
@@ -204,7 +204,7 @@ func afterCritic(ctx agent.CallbackContext, llmResponse *model.LLMResponse, llmR
 	return llmResponse, nil
 }
 
-func afterReviser(ctx agent.CallbackContext, llmResponse *model.LLMResponse, llmResponseError error) (*model.LLMResponse, error) {
+func afterReviser(ctx agent.Context, llmResponse *model.LLMResponse, llmResponseError error) (*model.LLMResponse, error) {
 	if llmResponse.Content == nil || llmResponse.Content.Parts == nil {
 		return llmResponse, nil
 	}

--- a/examples/web/main.go
+++ b/examples/web/main.go
@@ -36,7 +36,7 @@ import (
 	"google.golang.org/adk/tool/geminitool"
 )
 
-func saveReportfunc(ctx agent.CallbackContext, llmResponse *model.LLMResponse, llmResponseError error) (*model.LLMResponse, error) {
+func saveReportfunc(ctx agent.Context, llmResponse *model.LLMResponse, llmResponseError error) (*model.LLMResponse, error) {
 	if llmResponse == nil || llmResponse.Content == nil || llmResponseError != nil {
 		return llmResponse, llmResponseError
 	}

--- a/internal/configurable/configurable_workflow_test.go
+++ b/internal/configurable/configurable_workflow_test.go
@@ -399,7 +399,7 @@ type testTool struct{}
 func (t *testTool) Name() string        { return "test_tool" }
 func (t *testTool) Description() string { return "A simple test tool" }
 func (t *testTool) IsLongRunning() bool { return false }
-func (t *testTool) Run(ctx agent.ToolContext, args any) (map[string]any, error) {
+func (t *testTool) Run(ctx agent.Context, args any) (map[string]any, error) {
 	return map[string]any{"result": "tool_output"}, nil
 }
 

--- a/internal/configurable/conformance/callbacks.go
+++ b/internal/configurable/conformance/callbacks.go
@@ -25,12 +25,12 @@ import (
 	"google.golang.org/adk/session"
 )
 
-func beforeAgentCallback1(ctx agent.CallbackContext) (*genai.Content, error) {
+func beforeAgentCallback1(ctx agent.Context) (*genai.Content, error) {
 	err := ctx.State().Set("before_agent_callback_state_key", "value1")
 	return nil, err
 }
 
-func beforeAgentCallback2(ctx agent.CallbackContext) (*genai.Content, error) {
+func beforeAgentCallback2(ctx agent.Context) (*genai.Content, error) {
 	val, err := ctx.State().Get("before_agent_callback_state_key")
 	if err != nil {
 		return nil, err
@@ -43,7 +43,7 @@ func beforeAgentCallback2(ctx agent.CallbackContext) (*genai.Content, error) {
 	return nil, err
 }
 
-func shortcutAgentExecution(ctx agent.CallbackContext) (*genai.Content, error) {
+func shortcutAgentExecution(ctx agent.Context) (*genai.Content, error) {
 	val, err := ctx.State().Get("conversation_limit_reached")
 	if err != nil {
 		if !errors.Is(err, session.ErrStateKeyNotExist) {
@@ -63,12 +63,12 @@ func shortcutAgentExecution(ctx agent.CallbackContext) (*genai.Content, error) {
 	return nil, nil
 }
 
-func afterAgentCallback1(ctx agent.CallbackContext) (*genai.Content, error) {
+func afterAgentCallback1(ctx agent.Context) (*genai.Content, error) {
 	err := ctx.State().Set("after_agent_callback_state_key", "value1")
 	return nil, err
 }
 
-func afterAgentCallback2(ctx agent.CallbackContext) (*genai.Content, error) {
+func afterAgentCallback2(ctx agent.Context) (*genai.Content, error) {
 	val, err := ctx.State().Get("after_agent_callback_state_key")
 	if err != nil {
 		return nil, err

--- a/internal/configurable/conformance/functions.go
+++ b/internal/configurable/conformance/functions.go
@@ -33,11 +33,11 @@ type ValidateEmailArgs struct {
 
 var emailRegex = regexp.MustCompile(`^[a-zA-Z0-9._%+-]+@[a-zA-Z0-9.-]+\.[a-zA-Z]{2,}$`)
 
-func validateEmail(ctx agent.ToolContext, args ValidateEmailArgs) (bool, error) {
+func validateEmail(ctx agent.Context, args ValidateEmailArgs) (bool, error) {
 	return emailRegex.MatchString(args.Email), nil
 }
 
-func getUserID(ctx agent.ToolContext, args ValidateEmailArgs) (int, error) {
+func getUserID(ctx agent.Context, args ValidateEmailArgs) (int, error) {
 	valid, err := validateEmail(ctx, args)
 	if err != nil {
 		return 0, err
@@ -65,7 +65,7 @@ type CreateBookingArgs struct {
 	Details     string `json:"details"`
 }
 
-func createBooking(ctx agent.ToolContext, args CreateBookingArgs) (map[string]any, error) {
+func createBooking(ctx agent.Context, args CreateBookingArgs) (map[string]any, error) {
 	return map[string]any{
 		"user_id":           args.UserID,
 		"is_confirmed":      args.IsConfirmed,
@@ -95,7 +95,7 @@ type SearchFlightsArgs struct {
 	Preferences *FlightPreferences `json:"preferences"`
 }
 
-func searchFlights(ctx agent.ToolContext, args SearchFlightsArgs) (map[string]any, error) {
+func searchFlights(ctx agent.Context, args SearchFlightsArgs) (map[string]any, error) {
 	if args.Preferences == nil {
 		args.Preferences = &FlightPreferences{
 			CabinClass:    "Economy",
@@ -153,7 +153,7 @@ type CalculateTripCostArgs struct {
 	BaggageCount  *int    `json:"baggage_count"`
 }
 
-func calculateTripCost(ctx agent.ToolContext, args CalculateTripCostArgs) (map[string]any, error) {
+func calculateTripCost(ctx agent.Context, args CalculateTripCostArgs) (map[string]any, error) {
 	// Handle Python's default num_passengers=1 logic
 	// In Go, if the caller passes 0, we should ensure at least 1
 	// or handle it based on your specific business logic.
@@ -201,7 +201,7 @@ type reimburseArgs struct {
 	Amount  float64 `json:"amount"`
 }
 
-func reimburse(ctx agent.ToolContext, args reimburseArgs) (map[string]any, error) {
+func reimburse(ctx agent.Context, args reimburseArgs) (map[string]any, error) {
 	return map[string]any{
 		"status": "ok",
 	}, nil
@@ -212,7 +212,7 @@ type askForApprovalArgs struct {
 	Amount  float64 `json:"amount"`
 }
 
-func askForApproval(ctx agent.ToolContext, args askForApprovalArgs) (map[string]any, error) {
+func askForApproval(ctx agent.Context, args askForApprovalArgs) (map[string]any, error) {
 	return map[string]any{
 		"status":   "pending",
 		"amount":   args.Amount,

--- a/internal/configurable/conformance/recordplugin/record_plugin.go
+++ b/internal/configurable/conformance/recordplugin/record_plugin.go
@@ -83,7 +83,7 @@ func (p *recordPlugin) beforeRun(ctx agent.InvocationContext) (*genai.Content, e
 	return nil, err
 }
 
-func (p *recordPlugin) beforeModel(ctx agent.CallbackContext, req *model.LLMRequest) (*model.LLMResponse, error) {
+func (p *recordPlugin) beforeModel(ctx agent.Context, req *model.LLMRequest) (*model.LLMResponse, error) {
 	on, err := p.isRecordModeOn(ctx.State())
 	if err != nil || !on {
 		return nil, nil
@@ -101,7 +101,7 @@ func (p *recordPlugin) beforeModel(ctx agent.CallbackContext, req *model.LLMRequ
 	return nil, nil
 }
 
-func (p *recordPlugin) afterModel(ctx agent.CallbackContext, resp *model.LLMResponse, err error) (*model.LLMResponse, error) {
+func (p *recordPlugin) afterModel(ctx agent.Context, resp *model.LLMResponse, err error) (*model.LLMResponse, error) {
 	on, recordErr := p.isRecordModeOn(ctx.State())
 	if recordErr != nil || !on {
 		return nil, nil
@@ -126,7 +126,7 @@ func (p *recordPlugin) afterModel(ctx agent.CallbackContext, resp *model.LLMResp
 	return nil, nil
 }
 
-func (p *recordPlugin) beforeTool(ctx agent.ToolContext, t tool.Tool, args map[string]any) (map[string]any, error) {
+func (p *recordPlugin) beforeTool(ctx agent.Context, t tool.Tool, args map[string]any) (map[string]any, error) {
 	on, err := p.isRecordModeOn(ctx.State())
 	if err != nil || !on {
 		return nil, nil
@@ -147,7 +147,7 @@ func (p *recordPlugin) beforeTool(ctx agent.ToolContext, t tool.Tool, args map[s
 	return nil, nil
 }
 
-func (p *recordPlugin) afterTool(ctx agent.ToolContext, t tool.Tool, args, result map[string]any, err error) (map[string]any, error) {
+func (p *recordPlugin) afterTool(ctx agent.Context, t tool.Tool, args, result map[string]any, err error) (map[string]any, error) {
 	on, recordErr := p.isRecordModeOn(ctx.State())
 	if recordErr != nil || !on {
 		return nil, nil

--- a/internal/configurable/conformance/recordplugin/record_plugin_test.go
+++ b/internal/configurable/conformance/recordplugin/record_plugin_test.go
@@ -490,7 +490,7 @@ func (m *MockCallbackContext) SearchMemory(ctx context.Context, query string) (*
 	return nil, fmt.Errorf("SearchMemory() is not supported for MockCallbackContext")
 }
 
-var _ agent.CallbackContext = (*MockCallbackContext)(nil)
+var _ agent.Context = (*MockCallbackContext)(nil)
 
 type MockToolContext struct {
 	agent.ContextMock // inherit mocking responses

--- a/internal/configurable/conformance/replayplugin/replay_plugin.go
+++ b/internal/configurable/conformance/replayplugin/replay_plugin.go
@@ -109,7 +109,7 @@ func (p *replayPlugin) beforeRun(ctx agent.InvocationContext) (*genai.Content, e
 }
 
 // beforeModel intercepts LLM requests, verifies them against the recording, and returns the recorded response.
-func (p *replayPlugin) beforeModel(ctx agent.CallbackContext, req *model.LLMRequest) (*model.LLMResponse, error) {
+func (p *replayPlugin) beforeModel(ctx agent.Context, req *model.LLMRequest) (*model.LLMResponse, error) {
 	on, err := p.isReplayModeOn(ctx.State())
 	if err != nil {
 		return nil, err
@@ -137,7 +137,7 @@ func (p *replayPlugin) beforeModel(ctx agent.CallbackContext, req *model.LLMRequ
 }
 
 // beforeTool intercepts tool calls, verifies them against the recording, and returns the recorded response.
-func (p *replayPlugin) beforeTool(ctx agent.ToolContext, t tool.Tool, args map[string]any) (map[string]any, error) {
+func (p *replayPlugin) beforeTool(ctx agent.Context, t tool.Tool, args map[string]any) (map[string]any, error) {
 	on, err := p.isReplayModeOn(ctx.State())
 	if err != nil {
 		return nil, err
@@ -235,7 +235,7 @@ func (p *replayPlugin) isReplayModeOn(sessionState session.State) (bool, error) 
 }
 
 // getInvocationState retrieves the replay state for the current invocation.
-func (p *replayPlugin) getInvocationState(ctx agent.CallbackContext) (*invocationReplayState, error) {
+func (p *replayPlugin) getInvocationState(ctx agent.Context) (*invocationReplayState, error) {
 	invocationID := ctx.InvocationID()
 	state, ok := p.invocationStates[invocationID]
 	if !ok {

--- a/internal/configurable/conformance/replayplugin/replay_plugin_test.go
+++ b/internal/configurable/conformance/replayplugin/replay_plugin_test.go
@@ -512,7 +512,7 @@ func (m *MockCallbackContext) SearchMemory(ctx context.Context, query string) (*
 	return nil, fmt.Errorf("SearchMemory() is not supported for MockCallbackContext")
 }
 
-var _ agent.CallbackContext = (*MockCallbackContext)(nil)
+var _ agent.Context = (*MockCallbackContext)(nil)
 
 // MockToolContext
 type MockToolContext struct {

--- a/internal/context/callback_context.go
+++ b/internal/context/callback_context.go
@@ -22,7 +22,7 @@ import (
 // NewCallbackContext returns a CallbackContext suitable for model, tool, and
 // related callbacks. The returned context's Artifacts().Save tracks each saved
 // artifact's version into the underlying EventActions.ArtifactDelta.
-func NewCallbackContext(ctx agent.InvocationContext) agent.CallbackContext {
+func NewCallbackContext(ctx agent.InvocationContext) agent.Context {
 	return agent.NewCallbackContextWithArtifactTracking(ctx, nil)
 }
 
@@ -30,7 +30,7 @@ func NewCallbackContext(ctx agent.InvocationContext) agent.CallbackContext {
 // stateDelta and artifactDelta maps as the initial backing storage for its
 // EventActions. The returned context's Artifacts().Save tracks each saved
 // artifact's version into artifactDelta.
-func NewCallbackContextWithDelta(ctx agent.InvocationContext, stateDelta map[string]any, artifactDelta map[string]int64) agent.CallbackContext {
+func NewCallbackContextWithDelta(ctx agent.InvocationContext, stateDelta map[string]any, artifactDelta map[string]int64) agent.Context {
 	actions := &session.EventActions{StateDelta: stateDelta, ArtifactDelta: artifactDelta}
 	return agent.NewCallbackContextWithArtifactTracking(ctx, actions)
 }

--- a/internal/llminternal/agent_transfer.go
+++ b/internal/llminternal/agent_transfer.go
@@ -159,12 +159,12 @@ func (t *TransferToAgentTool) enums() []string {
 }
 
 // ProcessRequest implements types.Tool.
-func (t *TransferToAgentTool) ProcessRequest(ctx agent.ToolContext, req *model.LLMRequest) error {
+func (t *TransferToAgentTool) ProcessRequest(ctx agent.Context, req *model.LLMRequest) error {
 	return appendTools(req, t)
 }
 
 // Run implements types.Tool.
-func (t *TransferToAgentTool) Run(ctx agent.ToolContext, args any) (map[string]any, error) {
+func (t *TransferToAgentTool) Run(ctx agent.Context, args any) (map[string]any, error) {
 	if args == nil {
 		return nil, fmt.Errorf("missing argument")
 	}

--- a/internal/llminternal/agent_transfer_test.go
+++ b/internal/llminternal/agent_transfer_test.go
@@ -552,7 +552,7 @@ func TestAgentTransfer_ProcessRequest(t *testing.T) {
 		x int
 	}
 	var req model.LLMRequest
-	handler := func(ctx agent.ToolContext, input Input) (int, error) {
+	handler := func(ctx agent.Context, input Input) (int, error) {
 		return input.x, nil
 	}
 	identityTool, err := functiontool.New(functiontool.Config{

--- a/internal/llminternal/base_flow.go
+++ b/internal/llminternal/base_flow.go
@@ -47,17 +47,17 @@ import (
 
 var ErrModelNotConfigured = errors.New("model not configured; ensure Model is set in llmagent.Config")
 
-type BeforeModelCallback func(ctx agent.CallbackContext, llmRequest *model.LLMRequest) (*model.LLMResponse, error)
+type BeforeModelCallback func(ctx agent.Context, llmRequest *model.LLMRequest) (*model.LLMResponse, error)
 
-type AfterModelCallback func(ctx agent.CallbackContext, llmResponse *model.LLMResponse, llmResponseError error) (*model.LLMResponse, error)
+type AfterModelCallback func(ctx agent.Context, llmResponse *model.LLMResponse, llmResponseError error) (*model.LLMResponse, error)
 
-type OnModelErrorCallback func(ctx agent.CallbackContext, llmRequest *model.LLMRequest, llmResponseError error) (*model.LLMResponse, error)
+type OnModelErrorCallback func(ctx agent.Context, llmRequest *model.LLMRequest, llmResponseError error) (*model.LLMResponse, error)
 
-type BeforeToolCallback func(ctx agent.ToolContext, tool tool.Tool, args map[string]any) (map[string]any, error)
+type BeforeToolCallback func(ctx agent.Context, tool tool.Tool, args map[string]any) (map[string]any, error)
 
-type AfterToolCallback func(ctx agent.ToolContext, tool tool.Tool, args, result map[string]any, err error) (map[string]any, error)
+type AfterToolCallback func(ctx agent.Context, tool tool.Tool, args, result map[string]any, err error) (map[string]any, error)
 
-type OnToolErrorCallback func(ctx agent.ToolContext, tool tool.Tool, args map[string]any, err error) (map[string]any, error)
+type OnToolErrorCallback func(ctx agent.Context, tool tool.Tool, args map[string]any, err error) (map[string]any, error)
 
 type Flow struct {
 	Model model.LLM
@@ -985,7 +985,7 @@ Suggested fixes:
 }
 
 type cancelledToolContext struct {
-	agent.ToolContext
+	agent.Context
 	cancelCtx context.Context
 }
 
@@ -1069,8 +1069,8 @@ func (f *Flow) handleFunctionCalls(ctx agent.InvocationContext, toolsDict map[st
 						cancelCtx, cancel := toolCtx.WithAgentCancel()
 						// cancelCtx, cancel := context.WithCancel(toolCtx)
 						cancelToolCtx := &cancelledToolContext{
-							ToolContext: toolCtx,
-							cancelCtx:   cancelCtx,
+							Context:   toolCtx,
+							cancelCtx: cancelCtx,
 						}
 						if impl, ok := liveSess.(*liveSessionImpl); ok {
 							impl.RegisterStreamingTool(streamTool.Name(), fnCall.ID, cancel)
@@ -1188,7 +1188,7 @@ func (f *Flow) handleFunctionCalls(ctx agent.InvocationContext, toolsDict map[st
 	return mergedEvent, nil
 }
 
-func (f *Flow) runOnToolErrorCallbacks(toolCtx agent.ToolContext, tool tool.Tool, fArgs map[string]any, err error) (map[string]any, error) {
+func (f *Flow) runOnToolErrorCallbacks(toolCtx agent.Context, tool tool.Tool, fArgs map[string]any, err error) (map[string]any, error) {
 	pluginManager := pluginManagerFromContext(toolCtx)
 	if pluginManager != nil {
 		result, err := pluginManager.RunOnToolErrorCallback(toolCtx, tool, fArgs, err)
@@ -1199,7 +1199,7 @@ func (f *Flow) runOnToolErrorCallbacks(toolCtx agent.ToolContext, tool tool.Tool
 	return f.invokeOnToolErrorCallbacks(toolCtx, tool, fArgs, err)
 }
 
-func (f *Flow) callTool(toolCtx agent.ToolContext, tool toolinternal.FunctionTool, fArgs map[string]any) map[string]any {
+func (f *Flow) callTool(toolCtx agent.Context, tool toolinternal.FunctionTool, fArgs map[string]any) map[string]any {
 	var response map[string]any
 	var err error
 	pluginManager := pluginManagerFromContext(toolCtx)
@@ -1246,7 +1246,7 @@ func (f *Flow) callTool(toolCtx agent.ToolContext, tool toolinternal.FunctionToo
 	return response
 }
 
-func (f *Flow) invokeBeforeToolCallbacks(toolCtx agent.ToolContext, tool tool.Tool, fArgs map[string]any) (map[string]any, error) {
+func (f *Flow) invokeBeforeToolCallbacks(toolCtx agent.Context, tool tool.Tool, fArgs map[string]any) (map[string]any, error) {
 	for _, callback := range f.BeforeToolCallbacks {
 		result, err := callback(toolCtx, tool, fArgs)
 		if err != nil {
@@ -1261,7 +1261,7 @@ func (f *Flow) invokeBeforeToolCallbacks(toolCtx agent.ToolContext, tool tool.To
 	return nil, nil
 }
 
-func (f *Flow) invokeAfterToolCallbacks(toolCtx agent.ToolContext, tool toolinternal.FunctionTool, fArgs, fResult map[string]any, fErr error) (map[string]any, error) {
+func (f *Flow) invokeAfterToolCallbacks(toolCtx agent.Context, tool toolinternal.FunctionTool, fArgs, fResult map[string]any, fErr error) (map[string]any, error) {
 	for _, callback := range f.AfterToolCallbacks {
 		result, err := callback(toolCtx, tool, fArgs, fResult, fErr)
 		if err != nil {
@@ -1277,7 +1277,7 @@ func (f *Flow) invokeAfterToolCallbacks(toolCtx agent.ToolContext, tool toolinte
 	return fResult, fErr
 }
 
-func (f *Flow) invokeOnToolErrorCallbacks(toolCtx agent.ToolContext, tool tool.Tool, fArgs map[string]any, fErr error) (map[string]any, error) {
+func (f *Flow) invokeOnToolErrorCallbacks(toolCtx agent.Context, tool tool.Tool, fArgs map[string]any, fErr error) (map[string]any, error) {
 	for _, callback := range f.OnToolErrorCallbacks {
 		result, err := callback(toolCtx, tool, fArgs, fErr)
 		if err != nil {
@@ -1376,10 +1376,10 @@ func pluginManagerFromContext(ctx context.Context) pluginManager {
 }
 
 type pluginManager interface {
-	RunBeforeModelCallback(cctx agent.CallbackContext, llmRequest *model.LLMRequest) (*model.LLMResponse, error)
-	RunAfterModelCallback(cctx agent.CallbackContext, llmResponse *model.LLMResponse, llmResponseError error) (*model.LLMResponse, error)
-	RunOnModelErrorCallback(ctx agent.CallbackContext, llmRequest *model.LLMRequest, llmResponseError error) (*model.LLMResponse, error)
-	RunBeforeToolCallback(ctx agent.ToolContext, t tool.Tool, args map[string]any) (map[string]any, error)
-	RunAfterToolCallback(ctx agent.ToolContext, t tool.Tool, args, result map[string]any, err error) (map[string]any, error)
-	RunOnToolErrorCallback(ctx agent.ToolContext, t tool.Tool, args map[string]any, err error) (map[string]any, error)
+	RunBeforeModelCallback(cctx agent.Context, llmRequest *model.LLMRequest) (*model.LLMResponse, error)
+	RunAfterModelCallback(cctx agent.Context, llmResponse *model.LLMResponse, llmResponseError error) (*model.LLMResponse, error)
+	RunOnModelErrorCallback(ctx agent.Context, llmRequest *model.LLMRequest, llmResponseError error) (*model.LLMResponse, error)
+	RunBeforeToolCallback(ctx agent.Context, t tool.Tool, args map[string]any) (map[string]any, error)
+	RunAfterToolCallback(ctx agent.Context, t tool.Tool, args, result map[string]any, err error) (map[string]any, error)
+	RunOnToolErrorCallback(ctx agent.Context, t tool.Tool, args map[string]any, err error) (map[string]any, error)
 }

--- a/internal/llminternal/base_flow_test.go
+++ b/internal/llminternal/base_flow_test.go
@@ -31,7 +31,7 @@ import (
 
 type mockFunctionTool struct {
 	name    string
-	runFunc func(agent.ToolContext, map[string]any) (map[string]any, error)
+	runFunc func(agent.Context, map[string]any) (map[string]any, error)
 }
 
 func (m *mockFunctionTool) Name() string {
@@ -54,11 +54,11 @@ func (m *mockFunctionTool) IsLongRunning() bool {
 	return false
 }
 
-func (m *mockFunctionTool) ProcessRequest(ctx agent.ToolContext, req *model.LLMRequest) error {
+func (m *mockFunctionTool) ProcessRequest(ctx agent.Context, req *model.LLMRequest) error {
 	return nil
 }
 
-func (m *mockFunctionTool) Run(ctx agent.ToolContext, args any) (map[string]any, error) {
+func (m *mockFunctionTool) Run(ctx agent.Context, args any) (map[string]any, error) {
 	if m.runFunc != nil {
 		return m.runFunc(ctx, args.(map[string]any))
 	}
@@ -80,10 +80,10 @@ func (m *mockToolset) Tools(ctx agent.ReadonlyContext) ([]tool.Tool, error) {
 
 type mockRequestProcessorToolset struct {
 	name    string
-	process func(ctx agent.ToolContext, req *model.LLMRequest) error
+	process func(ctx agent.Context, req *model.LLMRequest) error
 }
 
-func (m *mockRequestProcessorToolset) ProcessRequest(ctx agent.ToolContext, req *model.LLMRequest) error {
+func (m *mockRequestProcessorToolset) ProcessRequest(ctx agent.Context, req *model.LLMRequest) error {
 	if m.process != nil {
 		return m.process(ctx, req)
 	}
@@ -110,7 +110,7 @@ func TestCallTool(t *testing.T) {
 			name: "tool runs successfully",
 			tool: &mockFunctionTool{
 				name: "testTool",
-				runFunc: func(ctx agent.ToolContext, args map[string]any) (map[string]any, error) {
+				runFunc: func(ctx agent.Context, args map[string]any) (map[string]any, error) {
 					return map[string]any{"result": "success"}, nil
 				},
 			},
@@ -121,7 +121,7 @@ func TestCallTool(t *testing.T) {
 			name: "tool error",
 			tool: &mockFunctionTool{
 				name: "testTool",
-				runFunc: func(ctx agent.ToolContext, args map[string]any) (map[string]any, error) {
+				runFunc: func(ctx agent.Context, args map[string]any) (map[string]any, error) {
 					return nil, errors.New("tool error")
 				},
 			},
@@ -132,16 +132,16 @@ func TestCallTool(t *testing.T) {
 			name: "before callback returns result",
 			tool: &mockFunctionTool{
 				name: "testTool",
-				runFunc: func(ctx agent.ToolContext, args map[string]any) (map[string]any, error) {
+				runFunc: func(ctx agent.Context, args map[string]any) (map[string]any, error) {
 					t.Error("tool should not be called")
 					return nil, nil
 				},
 			},
 			beforeToolCallbacks: []BeforeToolCallback{
-				func(ctx agent.ToolContext, tool tool.Tool, args map[string]any) (map[string]any, error) {
+				func(ctx agent.Context, tool tool.Tool, args map[string]any) (map[string]any, error) {
 					return map[string]any{"result": "intercepted"}, nil
 				},
-				func(ctx agent.ToolContext, tool tool.Tool, args map[string]any) (map[string]any, error) {
+				func(ctx agent.Context, tool tool.Tool, args map[string]any) (map[string]any, error) {
 					return map[string]any{"result": "2nd callback should not be called"}, nil
 				},
 			},
@@ -151,16 +151,16 @@ func TestCallTool(t *testing.T) {
 			name: "before callback returns error",
 			tool: &mockFunctionTool{
 				name: "testTool",
-				runFunc: func(ctx agent.ToolContext, args map[string]any) (map[string]any, error) {
+				runFunc: func(ctx agent.Context, args map[string]any) (map[string]any, error) {
 					t.Error("tool should not be called")
 					return nil, nil
 				},
 			},
 			beforeToolCallbacks: []BeforeToolCallback{
-				func(ctx agent.ToolContext, tool tool.Tool, args map[string]any) (map[string]any, error) {
+				func(ctx agent.Context, tool tool.Tool, args map[string]any) (map[string]any, error) {
 					return nil, errors.New("before callback error")
 				},
-				func(ctx agent.ToolContext, tool tool.Tool, args map[string]any) (map[string]any, error) {
+				func(ctx agent.Context, tool tool.Tool, args map[string]any) (map[string]any, error) {
 					return nil, errors.New("unexpected error")
 				},
 			},
@@ -170,12 +170,12 @@ func TestCallTool(t *testing.T) {
 			name: "after callback modifies result",
 			tool: &mockFunctionTool{
 				name: "testTool",
-				runFunc: func(ctx agent.ToolContext, args map[string]any) (map[string]any, error) {
+				runFunc: func(ctx agent.Context, args map[string]any) (map[string]any, error) {
 					return map[string]any{"result": "original"}, nil
 				},
 			},
 			afterToolCallbacks: []AfterToolCallback{
-				func(ctx agent.ToolContext, tool tool.Tool, args, result map[string]any, err error) (map[string]any, error) {
+				func(ctx agent.Context, tool tool.Tool, args, result map[string]any, err error) (map[string]any, error) {
 					return map[string]any{"result": "modified"}, nil
 				},
 			},
@@ -185,18 +185,18 @@ func TestCallTool(t *testing.T) {
 			name: "after callback handles error",
 			tool: &mockFunctionTool{
 				name: "testTool",
-				runFunc: func(ctx agent.ToolContext, args map[string]any) (map[string]any, error) {
+				runFunc: func(ctx agent.Context, args map[string]any) (map[string]any, error) {
 					return nil, errors.New("tool error")
 				},
 			},
 			afterToolCallbacks: []AfterToolCallback{
-				func(ctx agent.ToolContext, tool tool.Tool, args, result map[string]any, err error) (map[string]any, error) {
+				func(ctx agent.Context, tool tool.Tool, args, result map[string]any, err error) (map[string]any, error) {
 					if err != nil {
 						return map[string]any{"result": "error handled"}, nil
 					}
 					return nil, nil
 				},
-				func(ctx agent.ToolContext, tool tool.Tool, args, result map[string]any, err error) (map[string]any, error) {
+				func(ctx agent.Context, tool tool.Tool, args, result map[string]any, err error) (map[string]any, error) {
 					return map[string]any{"result": "unexpected output"}, nil
 				},
 			},
@@ -206,15 +206,15 @@ func TestCallTool(t *testing.T) {
 			name: "after callback returns error",
 			tool: &mockFunctionTool{
 				name: "testTool",
-				runFunc: func(ctx agent.ToolContext, args map[string]any) (map[string]any, error) {
+				runFunc: func(ctx agent.Context, args map[string]any) (map[string]any, error) {
 					return map[string]any{"result": "success"}, nil
 				},
 			},
 			afterToolCallbacks: []AfterToolCallback{
-				func(ctx agent.ToolContext, tool tool.Tool, args, result map[string]any, err error) (map[string]any, error) {
+				func(ctx agent.Context, tool tool.Tool, args, result map[string]any, err error) (map[string]any, error) {
 					return nil, errors.New("after callback error")
 				},
-				func(ctx agent.ToolContext, tool tool.Tool, args, result map[string]any, err error) (map[string]any, error) {
+				func(ctx agent.Context, tool tool.Tool, args, result map[string]any, err error) (map[string]any, error) {
 					return nil, errors.New("unexpected error")
 				},
 			},
@@ -224,17 +224,17 @@ func TestCallTool(t *testing.T) {
 			name: "no-op callbacks return func results",
 			tool: &mockFunctionTool{
 				name: "testTool",
-				runFunc: func(ctx agent.ToolContext, args map[string]any) (map[string]any, error) {
+				runFunc: func(ctx agent.Context, args map[string]any) (map[string]any, error) {
 					return map[string]any{"result": "success"}, nil
 				},
 			},
 			beforeToolCallbacks: []BeforeToolCallback{
-				func(ctx agent.ToolContext, tool tool.Tool, args map[string]any) (map[string]any, error) {
+				func(ctx agent.Context, tool tool.Tool, args map[string]any) (map[string]any, error) {
 					return nil, nil
 				},
 			},
 			afterToolCallbacks: []AfterToolCallback{
-				func(ctx agent.ToolContext, tool tool.Tool, args, result map[string]any, err error) (map[string]any, error) {
+				func(ctx agent.Context, tool tool.Tool, args, result map[string]any, err error) (map[string]any, error) {
 					return nil, nil
 				},
 			},
@@ -244,18 +244,18 @@ func TestCallTool(t *testing.T) {
 			name: "before callback result passed to after callback",
 			tool: &mockFunctionTool{
 				name: "testTool",
-				runFunc: func(ctx agent.ToolContext, args map[string]any) (map[string]any, error) {
+				runFunc: func(ctx agent.Context, args map[string]any) (map[string]any, error) {
 					t.Error("tool should not be called")
 					return nil, nil
 				},
 			},
 			beforeToolCallbacks: []BeforeToolCallback{
-				func(ctx agent.ToolContext, tool tool.Tool, args map[string]any) (map[string]any, error) {
+				func(ctx agent.Context, tool tool.Tool, args map[string]any) (map[string]any, error) {
 					return map[string]any{"result": "from_before"}, nil
 				},
 			},
 			afterToolCallbacks: []AfterToolCallback{
-				func(ctx agent.ToolContext, tool tool.Tool, args, result map[string]any, err error) (map[string]any, error) {
+				func(ctx agent.Context, tool tool.Tool, args, result map[string]any, err error) (map[string]any, error) {
 					if val, ok := result["result"]; !ok || val != "from_before" {
 						return nil, errors.New("unexpected result in after callback")
 					}
@@ -268,18 +268,18 @@ func TestCallTool(t *testing.T) {
 			name: "before callback error passed to after callback",
 			tool: &mockFunctionTool{
 				name: "testTool",
-				runFunc: func(ctx agent.ToolContext, args map[string]any) (map[string]any, error) {
+				runFunc: func(ctx agent.Context, args map[string]any) (map[string]any, error) {
 					t.Error("tool should not be called")
 					return nil, nil
 				},
 			},
 			beforeToolCallbacks: []BeforeToolCallback{
-				func(ctx agent.ToolContext, tool tool.Tool, args map[string]any) (map[string]any, error) {
+				func(ctx agent.Context, tool tool.Tool, args map[string]any) (map[string]any, error) {
 					return nil, errors.New("error_from_before")
 				},
 			},
 			afterToolCallbacks: []AfterToolCallback{
-				func(ctx agent.ToolContext, tool tool.Tool, args, result map[string]any, err error) (map[string]any, error) {
+				func(ctx agent.Context, tool tool.Tool, args, result map[string]any, err error) (map[string]any, error) {
 					if err == nil || err.Error() != "error_from_before" {
 						return nil, errors.New("unexpected error in after callback")
 					}
@@ -292,18 +292,18 @@ func TestCallTool(t *testing.T) {
 			name: "before callback error passed to on tool error callback",
 			tool: &mockFunctionTool{
 				name: "testTool",
-				runFunc: func(ctx agent.ToolContext, args map[string]any) (map[string]any, error) {
+				runFunc: func(ctx agent.Context, args map[string]any) (map[string]any, error) {
 					t.Error("tool should not be called")
 					return nil, nil
 				},
 			},
 			beforeToolCallbacks: []BeforeToolCallback{
-				func(ctx agent.ToolContext, tool tool.Tool, args map[string]any) (map[string]any, error) {
+				func(ctx agent.Context, tool tool.Tool, args map[string]any) (map[string]any, error) {
 					return nil, errors.New("error_from_before")
 				},
 			},
 			onToolErrorCallbacks: []OnToolErrorCallback{
-				func(ctx agent.ToolContext, tool tool.Tool, args map[string]any, err error) (map[string]any, error) {
+				func(ctx agent.Context, tool tool.Tool, args map[string]any, err error) (map[string]any, error) {
 					if err == nil || err.Error() != "error_from_before" {
 						t.Error("unexpected error in on tool error callback")
 						return nil, errors.New("unexpected error in on tool error callback")
@@ -317,18 +317,18 @@ func TestCallTool(t *testing.T) {
 			name: "before callback error passed to on tool error callback and after tool called",
 			tool: &mockFunctionTool{
 				name: "testTool",
-				runFunc: func(ctx agent.ToolContext, args map[string]any) (map[string]any, error) {
+				runFunc: func(ctx agent.Context, args map[string]any) (map[string]any, error) {
 					t.Error("tool should not be called")
 					return nil, nil
 				},
 			},
 			beforeToolCallbacks: []BeforeToolCallback{
-				func(ctx agent.ToolContext, tool tool.Tool, args map[string]any) (map[string]any, error) {
+				func(ctx agent.Context, tool tool.Tool, args map[string]any) (map[string]any, error) {
 					return nil, errors.New("error_from_before")
 				},
 			},
 			onToolErrorCallbacks: []OnToolErrorCallback{
-				func(ctx agent.ToolContext, tool tool.Tool, args map[string]any, err error) (map[string]any, error) {
+				func(ctx agent.Context, tool tool.Tool, args map[string]any, err error) (map[string]any, error) {
 					if err == nil || err.Error() != "error_from_before" {
 						t.Error("unexpected error in on tool error callback")
 						return nil, errors.New("unexpected error in on tool error callback")
@@ -337,7 +337,7 @@ func TestCallTool(t *testing.T) {
 				},
 			},
 			afterToolCallbacks: []AfterToolCallback{
-				func(ctx agent.ToolContext, tool tool.Tool, args, result map[string]any, err error) (map[string]any, error) {
+				func(ctx agent.Context, tool tool.Tool, args, result map[string]any, err error) (map[string]any, error) {
 					if err != nil {
 						return nil, errors.New("unexpected error in after callback")
 					}
@@ -350,18 +350,18 @@ func TestCallTool(t *testing.T) {
 			name: "before callback error passed to on tool error callback and passed to after tool called",
 			tool: &mockFunctionTool{
 				name: "testTool",
-				runFunc: func(ctx agent.ToolContext, args map[string]any) (map[string]any, error) {
+				runFunc: func(ctx agent.Context, args map[string]any) (map[string]any, error) {
 					t.Error("tool should not be called")
 					return nil, nil
 				},
 			},
 			beforeToolCallbacks: []BeforeToolCallback{
-				func(ctx agent.ToolContext, tool tool.Tool, args map[string]any) (map[string]any, error) {
+				func(ctx agent.Context, tool tool.Tool, args map[string]any) (map[string]any, error) {
 					return nil, errors.New("error_from_before")
 				},
 			},
 			onToolErrorCallbacks: []OnToolErrorCallback{
-				func(ctx agent.ToolContext, tool tool.Tool, args map[string]any, err error) (map[string]any, error) {
+				func(ctx agent.Context, tool tool.Tool, args map[string]any, err error) (map[string]any, error) {
 					if err == nil || err.Error() != "error_from_before" {
 						t.Error("unexpected error in on tool error callback")
 						return nil, errors.New("unexpected error in on tool error callback")
@@ -370,7 +370,7 @@ func TestCallTool(t *testing.T) {
 				},
 			},
 			afterToolCallbacks: []AfterToolCallback{
-				func(ctx agent.ToolContext, tool tool.Tool, args, result map[string]any, err error) (map[string]any, error) {
+				func(ctx agent.Context, tool tool.Tool, args, result map[string]any, err error) (map[string]any, error) {
 					if err == nil || err.Error() != "error_from_on_tool_error" {
 						return nil, errors.New("unexpected error in after callback")
 					}
@@ -383,18 +383,18 @@ func TestCallTool(t *testing.T) {
 			name: "before callback error passed to on tool error callback and passed to after tool called and handled",
 			tool: &mockFunctionTool{
 				name: "testTool",
-				runFunc: func(ctx agent.ToolContext, args map[string]any) (map[string]any, error) {
+				runFunc: func(ctx agent.Context, args map[string]any) (map[string]any, error) {
 					t.Error("tool should not be called")
 					return nil, nil
 				},
 			},
 			beforeToolCallbacks: []BeforeToolCallback{
-				func(ctx agent.ToolContext, tool tool.Tool, args map[string]any) (map[string]any, error) {
+				func(ctx agent.Context, tool tool.Tool, args map[string]any) (map[string]any, error) {
 					return nil, errors.New("error_from_before")
 				},
 			},
 			onToolErrorCallbacks: []OnToolErrorCallback{
-				func(ctx agent.ToolContext, tool tool.Tool, args map[string]any, err error) (map[string]any, error) {
+				func(ctx agent.Context, tool tool.Tool, args map[string]any, err error) (map[string]any, error) {
 					if err == nil || err.Error() != "error_from_before" {
 						t.Error("unexpected error in on tool error callback")
 						return nil, errors.New("unexpected error in on tool error callback")
@@ -403,7 +403,7 @@ func TestCallTool(t *testing.T) {
 				},
 			},
 			afterToolCallbacks: []AfterToolCallback{
-				func(ctx agent.ToolContext, tool tool.Tool, args, result map[string]any, err error) (map[string]any, error) {
+				func(ctx agent.Context, tool tool.Tool, args, result map[string]any, err error) (map[string]any, error) {
 					if err == nil || err.Error() != "error_from_on_tool_error" {
 						return nil, errors.New("unexpected error in after callback")
 					}
@@ -630,7 +630,7 @@ func TestPreprocess_Toolset(t *testing.T) {
 				s: &State{
 					Toolsets: []tool.Toolset{&mockRequestProcessorToolset{
 						name: "toolset",
-						process: func(_ agent.ToolContext, _ *model.LLMRequest) error {
+						process: func(_ agent.Context, _ *model.LLMRequest) error {
 							return errors.New("process error")
 						},
 					}},
@@ -646,7 +646,7 @@ func TestPreprocess_Toolset(t *testing.T) {
 						&mockToolset{name: "toolset_without_processor"},
 						&mockRequestProcessorToolset{
 							name: "toolset_with_processor",
-							process: func(_ agent.ToolContext, req *model.LLMRequest) error {
+							process: func(_ agent.Context, req *model.LLMRequest) error {
 								req.Model = "modified-model"
 								return nil
 							},

--- a/internal/llminternal/functions.go
+++ b/internal/llminternal/functions.go
@@ -26,7 +26,7 @@ import (
 
 // generateRequestConfirmationEvent creates a new Event containing
 // adk_request_confirmation function calls based on the requested confirmations.
-// NOTE: The trigger for this in ADK Go is usually a agent.ToolContext.RequestConfirmation call,
+// NOTE: The trigger for this in ADK Go is usually a agent.Context.RequestConfirmation call,
 // not parsing a function_response_event like in the Python example.
 // This function assumes you have a list of confirmations to process.
 func generateRequestConfirmationEvent(

--- a/internal/llminternal/handle_function_calls_async_test.go
+++ b/internal/llminternal/handle_function_calls_async_test.go
@@ -39,7 +39,7 @@ type SleepResult struct {
 	Success bool `json:"success"`
 }
 
-func sleepFunc(ctx agent.ToolContext, input SleepArgs) (SleepResult, error) {
+func sleepFunc(ctx agent.Context, input SleepArgs) (SleepResult, error) {
 	time.Sleep(time.Duration(input.DurationMS) * time.Millisecond)
 	return SleepResult{Success: true}, nil
 }
@@ -222,12 +222,12 @@ func (t *deferringTool) Declaration() *genai.FunctionDeclaration {
 	}
 }
 
-func (t *deferringTool) Run(ctx agent.ToolContext, args any) (map[string]any, error) {
+func (t *deferringTool) Run(ctx agent.Context, args any) (map[string]any, error) {
 	t.runCount++
 	return t.result, nil
 }
 
-func (t *deferringTool) ProcessRequest(ctx agent.ToolContext, req *model.LLMRequest) error {
+func (t *deferringTool) ProcessRequest(ctx agent.Context, req *model.LLMRequest) error {
 	return toolutils.PackTool(req, t)
 }
 

--- a/internal/llminternal/outputschema_processor.go
+++ b/internal/llminternal/outputschema_processor.go
@@ -128,7 +128,7 @@ func (t *setModelResponseTool) Declaration() *genai.FunctionDeclaration {
 	}
 }
 
-func (t *setModelResponseTool) Run(ctx agent.ToolContext, args any) (map[string]any, error) {
+func (t *setModelResponseTool) Run(ctx agent.Context, args any) (map[string]any, error) {
 	m, ok := args.(map[string]any)
 	if !ok {
 		return nil, fmt.Errorf("unexpected args type for set_model_response: %T", args)

--- a/internal/llminternal/outputschema_processor_test.go
+++ b/internal/llminternal/outputschema_processor_test.go
@@ -41,7 +41,7 @@ func (m *mockTool) IsLongRunning() bool { return false }
 func (m *mockTool) Declaration() *genai.FunctionDeclaration {
 	return &genai.FunctionDeclaration{Name: m.name}
 }
-func (m *mockTool) Run(ctx agent.ToolContext, args any) (map[string]any, error) { return nil, nil }
+func (m *mockTool) Run(ctx agent.Context, args any) (map[string]any, error) { return nil, nil }
 
 type mockLLM struct {
 	model.LLM

--- a/internal/llminternal/parallel_function_call_hitl_test.go
+++ b/internal/llminternal/parallel_function_call_hitl_test.go
@@ -42,7 +42,7 @@ type SecureActionResult struct {
 	Executed bool `json:"executed"`
 }
 
-func secureActionFunc(ctx agent.ToolContext, input SecureActionArgs) (SecureActionResult, error) {
+func secureActionFunc(ctx agent.Context, input SecureActionArgs) (SecureActionResult, error) {
 	return SecureActionResult{Executed: true}, nil
 }
 

--- a/internal/llminternal/parallel_function_call_test.go
+++ b/internal/llminternal/parallel_function_call_test.go
@@ -44,7 +44,7 @@ type SumResult struct {
 	Sum int `json:"sum"` // the sum of two integers
 }
 
-func sumFunc(ctx agent.ToolContext, input SumArgs) (SumResult, error) {
+func sumFunc(ctx agent.Context, input SumArgs) (SumResult, error) {
 	return SumResult{Sum: input.A + input.B}, nil
 }
 

--- a/internal/llminternal/request_confirmation_processor_test.go
+++ b/internal/llminternal/request_confirmation_processor_test.go
@@ -51,7 +51,7 @@ func (m *mockTool) Declaration() *genai.FunctionDeclaration {
 	return &genai.FunctionDeclaration{Name: m.name}
 }
 
-func (m *mockTool) Run(ctx agent.ToolContext, args any) (map[string]any, error) {
+func (m *mockTool) Run(ctx agent.Context, args any) (map[string]any, error) {
 	if ctx.ToolConfirmation() == nil || !ctx.ToolConfirmation().Confirmed {
 		return map[string]any{"error": string("Tool execution not confirmed")}, nil
 	}

--- a/internal/llminternal/stream_aggregator_test.go
+++ b/internal/llminternal/stream_aggregator_test.go
@@ -629,7 +629,7 @@ type GetWeatherArgs struct {
 	Location string `json:"location"`
 }
 
-func getWeather(ctx agent.ToolContext, args GetWeatherArgs) (map[string]any, error) {
+func getWeather(ctx agent.Context, args GetWeatherArgs) (map[string]any, error) {
 	return map[string]any{
 		"temperature": 22,
 		"condition":   "sunny",
@@ -945,7 +945,7 @@ func TestPartialFunctionCallsNotExecutedInNoneStreamingMode(t *testing.T) {
 		CallID string `json:"call_id"`
 	}
 
-	trackExecution := func(ctx agent.ToolContext, args TrackExecutionArgs) (string, error) {
+	trackExecution := func(ctx agent.Context, args TrackExecutionArgs) (string, error) {
 		executionLog = append(executionLog, args.CallID)
 		return "Executed: " + args.CallID, nil
 	}

--- a/internal/llminternal/streaming_tool_test.go
+++ b/internal/llminternal/streaming_tool_test.go
@@ -49,7 +49,7 @@ func TestHandleFunctionCalls_Streaming(t *testing.T) {
 		Count int `json:"count"`
 	}
 
-	handler := func(ctx agent.ToolContext, args Args) iter.Seq2[string, error] {
+	handler := func(ctx agent.Context, args Args) iter.Seq2[string, error] {
 		return func(yield func(string, error) bool) {
 			for i := 0; i < args.Count; i++ {
 				if !yield(fmt.Sprintf("chunk %d", i), nil) {
@@ -187,7 +187,7 @@ func TestHandleFunctionCalls_LiveControlPlane(t *testing.T) {
 	var cancelCount int
 	var cancelMu sync.Mutex
 
-	handler := func(ctx agent.ToolContext, args Args) iter.Seq2[string, error] {
+	handler := func(ctx agent.Context, args Args) iter.Seq2[string, error] {
 		return func(yield func(string, error) bool) {
 			for i := 0; ; i++ {
 				time.Sleep(time.Millisecond)

--- a/internal/plugininternal/plugin_manager.go
+++ b/internal/plugininternal/plugin_manager.go
@@ -134,7 +134,7 @@ func (pm *PluginManager) RunOnEventCallback(cctx agent.InvocationContext, event 
 }
 
 // RunBeforeAgentCallback runs the BeforeAgentCallback for all plugins.
-func (pm *PluginManager) RunBeforeAgentCallback(cctx agent.CallbackContext) (*genai.Content, error) {
+func (pm *PluginManager) RunBeforeAgentCallback(cctx agent.Context) (*genai.Content, error) {
 	for _, plugin := range pm.plugins {
 		callback := plugin.BeforeAgentCallback()
 		if callback != nil {
@@ -151,7 +151,7 @@ func (pm *PluginManager) RunBeforeAgentCallback(cctx agent.CallbackContext) (*ge
 }
 
 // RunAfterAgentCallback runs the AfterAgentCallback for all plugins.
-func (pm *PluginManager) RunAfterAgentCallback(cctx agent.CallbackContext) (*genai.Content, error) {
+func (pm *PluginManager) RunAfterAgentCallback(cctx agent.Context) (*genai.Content, error) {
 	for _, plugin := range pm.plugins {
 		callback := plugin.AfterAgentCallback()
 		if callback != nil {
@@ -168,7 +168,7 @@ func (pm *PluginManager) RunAfterAgentCallback(cctx agent.CallbackContext) (*gen
 }
 
 // RunBeforeToolCallback runs the BeforeToolCallback for all plugins.
-func (pm *PluginManager) RunBeforeToolCallback(ctx agent.ToolContext, tool tool.Tool, args map[string]any) (map[string]any, error) {
+func (pm *PluginManager) RunBeforeToolCallback(ctx agent.Context, tool tool.Tool, args map[string]any) (map[string]any, error) {
 	for _, plugin := range pm.plugins {
 		callback := plugin.BeforeToolCallback()
 		if callback != nil {
@@ -185,7 +185,7 @@ func (pm *PluginManager) RunBeforeToolCallback(ctx agent.ToolContext, tool tool.
 }
 
 // RunAfterToolCallback runs the AfterToolCallback for all plugins.
-func (pm *PluginManager) RunAfterToolCallback(ctx agent.ToolContext, tool tool.Tool, args, result map[string]any, err error) (map[string]any, error) {
+func (pm *PluginManager) RunAfterToolCallback(ctx agent.Context, tool tool.Tool, args, result map[string]any, err error) (map[string]any, error) {
 	for _, plugin := range pm.plugins {
 		callback := plugin.AfterToolCallback()
 		if callback != nil {
@@ -202,7 +202,7 @@ func (pm *PluginManager) RunAfterToolCallback(ctx agent.ToolContext, tool tool.T
 }
 
 // RunOnToolErrorCallback runs the OnToolErrorCallback for all plugins.
-func (pm *PluginManager) RunOnToolErrorCallback(ctx agent.ToolContext, tool tool.Tool, args map[string]any, err error) (map[string]any, error) {
+func (pm *PluginManager) RunOnToolErrorCallback(ctx agent.Context, tool tool.Tool, args map[string]any, err error) (map[string]any, error) {
 	for _, plugin := range pm.plugins {
 		callback := plugin.OnToolErrorCallback()
 		if callback != nil {
@@ -219,7 +219,7 @@ func (pm *PluginManager) RunOnToolErrorCallback(ctx agent.ToolContext, tool tool
 }
 
 // RunBeforeModelCallback runs the BeforeModelCallback for all plugins.
-func (pm *PluginManager) RunBeforeModelCallback(cctx agent.CallbackContext, llmRequest *model.LLMRequest) (*model.LLMResponse, error) {
+func (pm *PluginManager) RunBeforeModelCallback(cctx agent.Context, llmRequest *model.LLMRequest) (*model.LLMResponse, error) {
 	for _, plugin := range pm.plugins {
 		callback := plugin.BeforeModelCallback()
 		if callback != nil {
@@ -236,7 +236,7 @@ func (pm *PluginManager) RunBeforeModelCallback(cctx agent.CallbackContext, llmR
 }
 
 // RunAfterModelCallback runs the AfterModelCallback for all plugins.
-func (pm *PluginManager) RunAfterModelCallback(cctx agent.CallbackContext, llmResponse *model.LLMResponse, llmResponseError error) (*model.LLMResponse, error) {
+func (pm *PluginManager) RunAfterModelCallback(cctx agent.Context, llmResponse *model.LLMResponse, llmResponseError error) (*model.LLMResponse, error) {
 	for _, plugin := range pm.plugins {
 		callback := plugin.AfterModelCallback()
 		if callback != nil {
@@ -253,7 +253,7 @@ func (pm *PluginManager) RunAfterModelCallback(cctx agent.CallbackContext, llmRe
 }
 
 // RunOnModelErrorCallback runs the OnModelErrorCallback for all plugins.
-func (pm *PluginManager) RunOnModelErrorCallback(cctx agent.CallbackContext, llmRequest *model.LLMRequest, llmResponseError error) (*model.LLMResponse, error) {
+func (pm *PluginManager) RunOnModelErrorCallback(cctx agent.Context, llmRequest *model.LLMRequest, llmResponseError error) (*model.LLMResponse, error) {
 	for _, plugin := range pm.plugins {
 		callback := plugin.OnModelErrorCallback()
 		if callback != nil {

--- a/internal/telemetry/functionaltest/agent_telemetry_schema_test.go
+++ b/internal/telemetry/functionaltest/agent_telemetry_schema_test.go
@@ -129,7 +129,7 @@ func newAgentWithToolScenario(t *testing.T) agent.Agent {
 	sampleTool, err := functiontool.New(functiontool.Config{
 		Name:        "some_tool",
 		Description: "A sample tool.",
-	}, func(_ agent.ToolContext, in Args) (string, error) {
+	}, func(_ agent.Context, in Args) (string, error) {
 		return "processed " + in.Arg1, nil
 	})
 	if err != nil {

--- a/internal/toolinternal/tool.go
+++ b/internal/toolinternal/tool.go
@@ -28,17 +28,17 @@ import (
 type FunctionTool interface {
 	tool.Tool
 	Declaration() *genai.FunctionDeclaration
-	Run(ctx agent.ToolContext, args any) (result map[string]any, err error)
+	Run(ctx agent.Context, args any) (result map[string]any, err error)
 }
 
 type StreamingFunctionTool interface {
 	tool.Tool
 	Declaration() *genai.FunctionDeclaration
-	RunStream(ctx agent.ToolContext, args any) iter.Seq2[string, error]
+	RunStream(ctx agent.Context, args any) iter.Seq2[string, error]
 }
 
 type RequestProcessor interface {
-	ProcessRequest(ctx agent.ToolContext, req *model.LLMRequest) error
+	ProcessRequest(ctx agent.Context, req *model.LLMRequest) error
 }
 
 // ResponseDeferrer allows to skip generation of the FR by the tool.

--- a/internal/workflowinternal/finish_task_tool.go
+++ b/internal/workflowinternal/finish_task_tool.go
@@ -137,7 +137,7 @@ func (t *FinishTaskTool) Declaration() *genai.FunctionDeclaration {
 	}
 }
 
-func (t *FinishTaskTool) ProcessRequest(ctx agent.ToolContext, req *model.LLMRequest) error {
+func (t *FinishTaskTool) ProcessRequest(ctx agent.Context, req *model.LLMRequest) error {
 	instructions := `
 Do NOT call 'finish_task' prematurely. Use your available tools to
 fully complete every aspect of the delegated task first. If the
@@ -151,7 +151,7 @@ no accompanying text output.
 	return toolutils.PackTool(req, t)
 }
 
-func (t *FinishTaskTool) Run(ctx agent.ToolContext, args any) (map[string]any, error) {
+func (t *FinishTaskTool) Run(ctx agent.Context, args any) (map[string]any, error) {
 	if args == nil {
 		return nil, fmt.Errorf("missing argument")
 	}

--- a/internal/workflowinternal/single_turn_tool.go
+++ b/internal/workflowinternal/single_turn_tool.go
@@ -54,7 +54,7 @@ func (t *SingleTurnTool) IsLongRunning() bool {
 	return false
 }
 
-func (t *SingleTurnTool) Run(toolCtx agent.ToolContext, args any) (map[string]any, error) {
+func (t *SingleTurnTool) Run(toolCtx agent.Context, args any) (map[string]any, error) {
 	margs, ok := args.(map[string]any)
 	if !ok {
 		return nil, fmt.Errorf("single turn tool expects map[string]any arguments, got %T", args)
@@ -97,7 +97,7 @@ func (t *SingleTurnTool) Declaration() *genai.FunctionDeclaration {
 	return t.funcDeclaration
 }
 
-func (t *SingleTurnTool) ProcessRequest(ctx agent.ToolContext, req *model.LLMRequest) error {
+func (t *SingleTurnTool) ProcessRequest(ctx agent.Context, req *model.LLMRequest) error {
 	return toolutils.PackTool(req, t)
 }
 

--- a/internal/workflowinternal/task_agent_tool.go
+++ b/internal/workflowinternal/task_agent_tool.go
@@ -48,7 +48,7 @@ func (t *TaskAgentTool) Declaration() *genai.FunctionDeclaration {
 	return t.funcDeclaration
 }
 
-func (t *TaskAgentTool) Run(toolCtx agent.ToolContext, args any) (map[string]any, error) {
+func (t *TaskAgentTool) Run(toolCtx agent.Context, args any) (map[string]any, error) {
 	// Framework handles task delegation dispatch directly via the
 	// LlmAgent chat wrapper.
 	// TODO: dispatch via RunNode with WithIsolationScope(fcID) and WithRunID(fcID).
@@ -75,7 +75,7 @@ func (t *TaskAgentTool) IsLongRunning() bool {
 	return false
 }
 
-func (t *TaskAgentTool) ProcessRequest(ctx agent.ToolContext, req *model.LLMRequest) error {
+func (t *TaskAgentTool) ProcessRequest(ctx agent.Context, req *model.LLMRequest) error {
 	return toolutils.PackTool(req, t)
 }
 

--- a/plugin/functioncallmodifier/plugin.go
+++ b/plugin/functioncallmodifier/plugin.go
@@ -50,8 +50,8 @@ func MustNewPlugin(cfg FunctionCallModifierConfig) *plugin.Plugin {
 	return p
 }
 
-func beforeModelCallback(cfg FunctionCallModifierConfig) func(agent.CallbackContext, *model.LLMRequest) (*model.LLMResponse, error) {
-	return func(ctx agent.CallbackContext, req *model.LLMRequest) (*model.LLMResponse, error) {
+func beforeModelCallback(cfg FunctionCallModifierConfig) func(agent.Context, *model.LLMRequest) (*model.LLMResponse, error) {
+	return func(ctx agent.Context, req *model.LLMRequest) (*model.LLMResponse, error) {
 		if req.Config == nil || len(req.Config.Tools) == 0 {
 			return nil, nil
 		}
@@ -88,8 +88,8 @@ func beforeModelCallback(cfg FunctionCallModifierConfig) func(agent.CallbackCont
 	}
 }
 
-func afterModelCallback(cfg FunctionCallModifierConfig) func(agent.CallbackContext, *model.LLMResponse, error) (*model.LLMResponse, error) {
-	return func(ctx agent.CallbackContext, llmResponse *model.LLMResponse, llmResponseError error) (*model.LLMResponse, error) {
+func afterModelCallback(cfg FunctionCallModifierConfig) func(agent.Context, *model.LLMResponse, error) (*model.LLMResponse, error) {
+	return func(ctx agent.Context, llmResponse *model.LLMResponse, llmResponseError error) (*model.LLMResponse, error) {
 		if llmResponseError != nil {
 			return nil, llmResponseError // Pass through error
 		}

--- a/plugin/functioncallmodifier/plugin_test.go
+++ b/plugin/functioncallmodifier/plugin_test.go
@@ -41,7 +41,7 @@ type SimpleArgs struct {
 	Num int
 }
 
-func okFunc(_ agent.ToolContext, _ SimpleArgs) (string, error) {
+func okFunc(_ agent.Context, _ SimpleArgs) (string, error) {
 	return "ok", nil
 }
 

--- a/plugin/loggingplugin/logging_plugin.go
+++ b/plugin/loggingplugin/logging_plugin.go
@@ -191,7 +191,7 @@ func (p *loggingPlugin) afterRun(ctx agent.InvocationContext) {
 	p.log(fmt.Sprintf("   Final Agent: %s", agentName))
 }
 
-func (p *loggingPlugin) beforeAgent(ctx agent.CallbackContext) (*genai.Content, error) {
+func (p *loggingPlugin) beforeAgent(ctx agent.Context) (*genai.Content, error) {
 	p.log("🤖 AGENT STARTING")
 	p.log(fmt.Sprintf("   Agent Name: %s", ctx.AgentName()))
 	p.log(fmt.Sprintf("   Invocation ID: %s", ctx.InvocationID()))
@@ -201,14 +201,14 @@ func (p *loggingPlugin) beforeAgent(ctx agent.CallbackContext) (*genai.Content, 
 	return nil, nil
 }
 
-func (p *loggingPlugin) afterAgent(ctx agent.CallbackContext) (*genai.Content, error) {
+func (p *loggingPlugin) afterAgent(ctx agent.Context) (*genai.Content, error) {
 	p.log("🤖 AGENT COMPLETED")
 	p.log(fmt.Sprintf("   Agent Name: %s", ctx.AgentName()))
 	p.log(fmt.Sprintf("   Invocation ID: %s", ctx.InvocationID()))
 	return nil, nil
 }
 
-func (p *loggingPlugin) beforeModel(ctx agent.CallbackContext, req *model.LLMRequest) (*model.LLMResponse, error) {
+func (p *loggingPlugin) beforeModel(ctx agent.Context, req *model.LLMRequest) (*model.LLMResponse, error) {
 	p.log("🧠 LLM REQUEST")
 	modelName := "default"
 	if req.Model != "" {
@@ -240,7 +240,7 @@ func (p *loggingPlugin) beforeModel(ctx agent.CallbackContext, req *model.LLMReq
 	return nil, nil
 }
 
-func (p *loggingPlugin) afterModel(ctx agent.CallbackContext, resp *model.LLMResponse, err error) (*model.LLMResponse, error) {
+func (p *loggingPlugin) afterModel(ctx agent.Context, resp *model.LLMResponse, err error) (*model.LLMResponse, error) {
 	p.log("🧠 LLM RESPONSE")
 	p.log(fmt.Sprintf("   Agent: %s", ctx.AgentName()))
 
@@ -272,14 +272,14 @@ func (p *loggingPlugin) afterModel(ctx agent.CallbackContext, resp *model.LLMRes
 	return nil, nil
 }
 
-func (p *loggingPlugin) onModelError(ctx agent.CallbackContext, req *model.LLMRequest, err error) (*model.LLMResponse, error) {
+func (p *loggingPlugin) onModelError(ctx agent.Context, req *model.LLMRequest, err error) (*model.LLMResponse, error) {
 	p.log("🧠 LLM ERROR")
 	p.log(fmt.Sprintf("   Agent: %s", ctx.AgentName()))
 	p.log(fmt.Sprintf("   Error: %v", err))
 	return nil, nil
 }
 
-func (p *loggingPlugin) beforeTool(ctx agent.ToolContext, t tool.Tool, args map[string]any) (map[string]any, error) {
+func (p *loggingPlugin) beforeTool(ctx agent.Context, t tool.Tool, args map[string]any) (map[string]any, error) {
 	p.log("🔧 TOOL STARTING")
 	p.log(fmt.Sprintf("   Tool Name: %s", t.Name()))
 	p.log(fmt.Sprintf("   Agent: %s", ctx.AgentName()))
@@ -288,7 +288,7 @@ func (p *loggingPlugin) beforeTool(ctx agent.ToolContext, t tool.Tool, args map[
 	return nil, nil
 }
 
-func (p *loggingPlugin) afterTool(ctx agent.ToolContext, t tool.Tool, args, result map[string]any, err error) (map[string]any, error) {
+func (p *loggingPlugin) afterTool(ctx agent.Context, t tool.Tool, args, result map[string]any, err error) (map[string]any, error) {
 	p.log("🔧 TOOL COMPLETED")
 	p.log(fmt.Sprintf("   Tool Name: %s", t.Name()))
 	p.log(fmt.Sprintf("   Agent: %s", ctx.AgentName()))
@@ -301,7 +301,7 @@ func (p *loggingPlugin) afterTool(ctx agent.ToolContext, t tool.Tool, args, resu
 	return nil, nil
 }
 
-func (p *loggingPlugin) onToolError(ctx agent.ToolContext, t tool.Tool, args map[string]any, err error) (map[string]any, error) {
+func (p *loggingPlugin) onToolError(ctx agent.Context, t tool.Tool, args map[string]any, err error) (map[string]any, error) {
 	p.log("🔧 TOOL ERROR")
 	p.log(fmt.Sprintf("   Tool Name: %s", t.Name()))
 	p.log(fmt.Sprintf("   Agent: %s", ctx.AgentName()))

--- a/plugin/plugin_manager_test.go
+++ b/plugin/plugin_manager_test.go
@@ -36,7 +36,7 @@ import (
 
 type testCase struct {
 	name                            string
-	tool                            func(agent.ToolContext, map[string]any) (map[string]any, error)
+	tool                            func(agent.Context, map[string]any) (map[string]any, error)
 	args                            map[string]any
 	beforeToolCallbacks             []llmagent.BeforeToolCallback
 	afterToolCallbacks              []llmagent.AfterToolCallback
@@ -51,7 +51,7 @@ func TestCallTool(t *testing.T) {
 	testCases := []testCase{
 		{
 			name: "tool runs successfully",
-			tool: func(ctx agent.ToolContext, args map[string]any) (map[string]any, error) {
+			tool: func(ctx agent.Context, args map[string]any) (map[string]any, error) {
 				return map[string]any{"result": "success"}, nil
 			},
 			args:                            map[string]any{"key": "value"},
@@ -60,7 +60,7 @@ func TestCallTool(t *testing.T) {
 		},
 		{
 			name: "tool error",
-			tool: func(ctx agent.ToolContext, args map[string]any) (map[string]any, error) {
+			tool: func(ctx agent.Context, args map[string]any) (map[string]any, error) {
 				return nil, errors.New("tool error")
 			},
 			args: map[string]any{"key": "value"},
@@ -68,15 +68,15 @@ func TestCallTool(t *testing.T) {
 		},
 		{
 			name: "before callback returns result",
-			tool: func(ctx agent.ToolContext, args map[string]any) (map[string]any, error) {
+			tool: func(ctx agent.Context, args map[string]any) (map[string]any, error) {
 				t.Error("tool should not be called")
 				return nil, nil
 			},
 			beforeToolCallbacks: []llmagent.BeforeToolCallback{
-				func(ctx agent.ToolContext, tool tool.Tool, args map[string]any) (map[string]any, error) {
+				func(ctx agent.Context, tool tool.Tool, args map[string]any) (map[string]any, error) {
 					return map[string]any{"result": "intercepted"}, nil
 				},
-				func(ctx agent.ToolContext, tool tool.Tool, args map[string]any) (map[string]any, error) {
+				func(ctx agent.Context, tool tool.Tool, args map[string]any) (map[string]any, error) {
 					return map[string]any{"result": "2nd callback should not be called"}, nil
 				},
 			},
@@ -86,15 +86,15 @@ func TestCallTool(t *testing.T) {
 		},
 		{
 			name: "before callback returns error",
-			tool: func(ctx agent.ToolContext, args map[string]any) (map[string]any, error) {
+			tool: func(ctx agent.Context, args map[string]any) (map[string]any, error) {
 				t.Error("tool should not be called")
 				return nil, nil
 			},
 			beforeToolCallbacks: []llmagent.BeforeToolCallback{
-				func(ctx agent.ToolContext, tool tool.Tool, args map[string]any) (map[string]any, error) {
+				func(ctx agent.Context, tool tool.Tool, args map[string]any) (map[string]any, error) {
 					return nil, errors.New("before callback error")
 				},
-				func(ctx agent.ToolContext, tool tool.Tool, args map[string]any) (map[string]any, error) {
+				func(ctx agent.Context, tool tool.Tool, args map[string]any) (map[string]any, error) {
 					return nil, errors.New("unexpected error")
 				},
 			},
@@ -103,11 +103,11 @@ func TestCallTool(t *testing.T) {
 		},
 		{
 			name: "after callback modifies result",
-			tool: func(ctx agent.ToolContext, args map[string]any) (map[string]any, error) {
+			tool: func(ctx agent.Context, args map[string]any) (map[string]any, error) {
 				return map[string]any{"result": "original"}, nil
 			},
 			afterToolCallbacks: []llmagent.AfterToolCallback{
-				func(ctx agent.ToolContext, tool tool.Tool, args, result map[string]any, err error) (map[string]any, error) {
+				func(ctx agent.Context, tool tool.Tool, args, result map[string]any, err error) (map[string]any, error) {
 					return map[string]any{"result": "modified"}, nil
 				},
 			},
@@ -117,17 +117,17 @@ func TestCallTool(t *testing.T) {
 		},
 		{
 			name: "after callback handles error and are run in symmetrical order",
-			tool: func(ctx agent.ToolContext, args map[string]any) (map[string]any, error) {
+			tool: func(ctx agent.Context, args map[string]any) (map[string]any, error) {
 				return nil, errors.New("tool error")
 			},
 			afterToolCallbacks: []llmagent.AfterToolCallback{
-				func(ctx agent.ToolContext, tool tool.Tool, args, result map[string]any, err error) (map[string]any, error) {
+				func(ctx agent.Context, tool tool.Tool, args, result map[string]any, err error) (map[string]any, error) {
 					if err != nil {
 						return map[string]any{"result": "error handled"}, nil
 					}
 					return nil, nil
 				},
-				func(ctx agent.ToolContext, tool tool.Tool, args, result map[string]any, err error) (map[string]any, error) {
+				func(ctx agent.Context, tool tool.Tool, args, result map[string]any, err error) (map[string]any, error) {
 					t.Errorf("unexpected call to after tool callback")
 					return map[string]any{"result": "unexpected output"}, nil
 				},
@@ -137,14 +137,14 @@ func TestCallTool(t *testing.T) {
 		},
 		{
 			name: "after callback returns error and are run in symmetrical order",
-			tool: func(ctx agent.ToolContext, args map[string]any) (map[string]any, error) {
+			tool: func(ctx agent.Context, args map[string]any) (map[string]any, error) {
 				return map[string]any{"result": "success"}, nil
 			},
 			afterToolCallbacks: []llmagent.AfterToolCallback{
-				func(ctx agent.ToolContext, tool tool.Tool, args, result map[string]any, err error) (map[string]any, error) {
+				func(ctx agent.Context, tool tool.Tool, args, result map[string]any, err error) (map[string]any, error) {
 					return nil, errors.New("after callback error")
 				},
-				func(ctx agent.ToolContext, tool tool.Tool, args, result map[string]any, err error) (map[string]any, error) {
+				func(ctx agent.Context, tool tool.Tool, args, result map[string]any, err error) (map[string]any, error) {
 					t.Errorf("unexpected call to after tool callback")
 					return nil, errors.New("unexpected error")
 				},
@@ -155,16 +155,16 @@ func TestCallTool(t *testing.T) {
 		},
 		{
 			name: "no-op callbacks return func results",
-			tool: func(ctx agent.ToolContext, args map[string]any) (map[string]any, error) {
+			tool: func(ctx agent.Context, args map[string]any) (map[string]any, error) {
 				return map[string]any{"result": "success"}, nil
 			},
 			beforeToolCallbacks: []llmagent.BeforeToolCallback{
-				func(ctx agent.ToolContext, tool tool.Tool, args map[string]any) (map[string]any, error) {
+				func(ctx agent.Context, tool tool.Tool, args map[string]any) (map[string]any, error) {
 					return nil, nil
 				},
 			},
 			afterToolCallbacks: []llmagent.AfterToolCallback{
-				func(ctx agent.ToolContext, tool tool.Tool, args, result map[string]any, err error) (map[string]any, error) {
+				func(ctx agent.Context, tool tool.Tool, args, result map[string]any, err error) (map[string]any, error) {
 					return nil, nil
 				},
 			},
@@ -173,17 +173,17 @@ func TestCallTool(t *testing.T) {
 		},
 		{
 			name: "before callback result passed to after callback",
-			tool: func(ctx agent.ToolContext, args map[string]any) (map[string]any, error) {
+			tool: func(ctx agent.Context, args map[string]any) (map[string]any, error) {
 				t.Error("tool should not be called")
 				return nil, nil
 			},
 			beforeToolCallbacks: []llmagent.BeforeToolCallback{
-				func(ctx agent.ToolContext, tool tool.Tool, args map[string]any) (map[string]any, error) {
+				func(ctx agent.Context, tool tool.Tool, args map[string]any) (map[string]any, error) {
 					return map[string]any{"result": "from_before"}, nil
 				},
 			},
 			afterToolCallbacks: []llmagent.AfterToolCallback{
-				func(ctx agent.ToolContext, tool tool.Tool, args, result map[string]any, err error) (map[string]any, error) {
+				func(ctx agent.Context, tool tool.Tool, args, result map[string]any, err error) (map[string]any, error) {
 					if val, ok := result["result"]; !ok || val != "from_before" {
 						return nil, errors.New("unexpected result in after callback")
 					}
@@ -197,17 +197,17 @@ func TestCallTool(t *testing.T) {
 		},
 		{
 			name: "before callback error passed to after callback",
-			tool: func(ctx agent.ToolContext, args map[string]any) (map[string]any, error) {
+			tool: func(ctx agent.Context, args map[string]any) (map[string]any, error) {
 				t.Error("tool should not be called")
 				return nil, nil
 			},
 			beforeToolCallbacks: []llmagent.BeforeToolCallback{
-				func(ctx agent.ToolContext, tool tool.Tool, args map[string]any) (map[string]any, error) {
+				func(ctx agent.Context, tool tool.Tool, args map[string]any) (map[string]any, error) {
 					return nil, errors.New("error_from_before")
 				},
 			},
 			afterToolCallbacks: []llmagent.AfterToolCallback{
-				func(ctx agent.ToolContext, tool tool.Tool, args, result map[string]any, err error) (map[string]any, error) {
+				func(ctx agent.Context, tool tool.Tool, args, result map[string]any, err error) (map[string]any, error) {
 					if err == nil || err.Error() != "error_from_before" {
 						return nil, errors.New("unexpected error in after callback")
 					}
@@ -220,17 +220,17 @@ func TestCallTool(t *testing.T) {
 		},
 		{
 			name: "before callback error passed to on tool error callback",
-			tool: func(ctx agent.ToolContext, args map[string]any) (map[string]any, error) {
+			tool: func(ctx agent.Context, args map[string]any) (map[string]any, error) {
 				t.Error("tool should not be called")
 				return nil, nil
 			},
 			beforeToolCallbacks: []llmagent.BeforeToolCallback{
-				func(ctx agent.ToolContext, tool tool.Tool, args map[string]any) (map[string]any, error) {
+				func(ctx agent.Context, tool tool.Tool, args map[string]any) (map[string]any, error) {
 					return nil, errors.New("error_from_before")
 				},
 			},
 			onToolErrorCallbacks: []llmagent.OnToolErrorCallback{
-				func(ctx agent.ToolContext, tool tool.Tool, args map[string]any, err error) (map[string]any, error) {
+				func(ctx agent.Context, tool tool.Tool, args map[string]any, err error) (map[string]any, error) {
 					if err == nil || err.Error() != "error_from_before" {
 						return nil, errors.New("unexpected error in on tool error callback")
 					}
@@ -243,17 +243,17 @@ func TestCallTool(t *testing.T) {
 		},
 		{
 			name: "before callback error passed to on tool error callback and after tool called",
-			tool: func(ctx agent.ToolContext, args map[string]any) (map[string]any, error) {
+			tool: func(ctx agent.Context, args map[string]any) (map[string]any, error) {
 				t.Error("tool should not be called")
 				return nil, nil
 			},
 			beforeToolCallbacks: []llmagent.BeforeToolCallback{
-				func(ctx agent.ToolContext, tool tool.Tool, args map[string]any) (map[string]any, error) {
+				func(ctx agent.Context, tool tool.Tool, args map[string]any) (map[string]any, error) {
 					return nil, errors.New("error_from_before")
 				},
 			},
 			onToolErrorCallbacks: []llmagent.OnToolErrorCallback{
-				func(ctx agent.ToolContext, tool tool.Tool, args map[string]any, err error) (map[string]any, error) {
+				func(ctx agent.Context, tool tool.Tool, args map[string]any, err error) (map[string]any, error) {
 					if err == nil || err.Error() != "error_from_before" {
 						return nil, errors.New("unexpected error in on tool error callback")
 					}
@@ -261,7 +261,7 @@ func TestCallTool(t *testing.T) {
 				},
 			},
 			afterToolCallbacks: []llmagent.AfterToolCallback{
-				func(ctx agent.ToolContext, tool tool.Tool, args, result map[string]any, err error) (map[string]any, error) {
+				func(ctx agent.Context, tool tool.Tool, args, result map[string]any, err error) (map[string]any, error) {
 					if err != nil {
 						return nil, errors.New("unexpected error in after callback")
 					}
@@ -275,17 +275,17 @@ func TestCallTool(t *testing.T) {
 		},
 		{
 			name: "before callback error passed to on tool error callback and passed to after tool called",
-			tool: func(ctx agent.ToolContext, args map[string]any) (map[string]any, error) {
+			tool: func(ctx agent.Context, args map[string]any) (map[string]any, error) {
 				t.Error("tool should not be called")
 				return nil, nil
 			},
 			beforeToolCallbacks: []llmagent.BeforeToolCallback{
-				func(ctx agent.ToolContext, tool tool.Tool, args map[string]any) (map[string]any, error) {
+				func(ctx agent.Context, tool tool.Tool, args map[string]any) (map[string]any, error) {
 					return nil, errors.New("error_from_before")
 				},
 			},
 			onToolErrorCallbacks: []llmagent.OnToolErrorCallback{
-				func(ctx agent.ToolContext, tool tool.Tool, args map[string]any, err error) (map[string]any, error) {
+				func(ctx agent.Context, tool tool.Tool, args map[string]any, err error) (map[string]any, error) {
 					if err == nil || err.Error() != "error_from_before" {
 						return nil, errors.New("unexpected error in on tool error callback")
 					}
@@ -293,7 +293,7 @@ func TestCallTool(t *testing.T) {
 				},
 			},
 			afterToolCallbacks: []llmagent.AfterToolCallback{
-				func(ctx agent.ToolContext, tool tool.Tool, args, result map[string]any, err error) (map[string]any, error) {
+				func(ctx agent.Context, tool tool.Tool, args, result map[string]any, err error) (map[string]any, error) {
 					if err == nil || err.Error() != "error_from_on_tool_error" {
 						return nil, errors.New("unexpected error in after callback")
 					}
@@ -307,17 +307,17 @@ func TestCallTool(t *testing.T) {
 		},
 		{
 			name: "before callback error passed to on tool error callback and passed to after tool called and handled",
-			tool: func(ctx agent.ToolContext, args map[string]any) (map[string]any, error) {
+			tool: func(ctx agent.Context, args map[string]any) (map[string]any, error) {
 				t.Error("tool should not be called")
 				return nil, nil
 			},
 			beforeToolCallbacks: []llmagent.BeforeToolCallback{
-				func(ctx agent.ToolContext, tool tool.Tool, args map[string]any) (map[string]any, error) {
+				func(ctx agent.Context, tool tool.Tool, args map[string]any) (map[string]any, error) {
 					return nil, errors.New("error_from_before")
 				},
 			},
 			onToolErrorCallbacks: []llmagent.OnToolErrorCallback{
-				func(ctx agent.ToolContext, tool tool.Tool, args map[string]any, err error) (map[string]any, error) {
+				func(ctx agent.Context, tool tool.Tool, args map[string]any, err error) (map[string]any, error) {
 					if err == nil || err.Error() != "error_from_before" {
 						return nil, errors.New("unexpected error in on tool error callback")
 					}
@@ -325,7 +325,7 @@ func TestCallTool(t *testing.T) {
 				},
 			},
 			afterToolCallbacks: []llmagent.AfterToolCallback{
-				func(ctx agent.ToolContext, tool tool.Tool, args, result map[string]any, err error) (map[string]any, error) {
+				func(ctx agent.Context, tool tool.Tool, args, result map[string]any, err error) (map[string]any, error) {
 					if err == nil || err.Error() != "error_from_on_tool_error" {
 						return nil, errors.New("unexpected error in after tool callback")
 					}
@@ -386,7 +386,7 @@ func TestCallTool(t *testing.T) {
 			beforeToolCallbacksCalled := false
 			afterToolCallbacksCalled := false
 			onToolErrorCallbacks := []llmagent.OnToolErrorCallback{
-				func(ctx agent.ToolContext, tool tool.Tool, args map[string]any, err error) (map[string]any, error) {
+				func(ctx agent.Context, tool tool.Tool, args map[string]any, err error) (map[string]any, error) {
 					onToolErrorCallbacksCalled = true
 					if tc.dontRunOnErrorCanonicalCallback {
 						t.Error("on tool error should not be called")
@@ -395,7 +395,7 @@ func TestCallTool(t *testing.T) {
 				},
 			}
 			beforeToolCallbacks := []llmagent.BeforeToolCallback{
-				func(ctx agent.ToolContext, tool tool.Tool, args map[string]any) (map[string]any, error) {
+				func(ctx agent.Context, tool tool.Tool, args map[string]any) (map[string]any, error) {
 					beforeToolCallbacksCalled = true
 					if tc.dontRunBeforeCanonicalCallback {
 						t.Error("before Tool Callback should not be called")
@@ -404,7 +404,7 @@ func TestCallTool(t *testing.T) {
 				},
 			}
 			afterToolCallbacks := []llmagent.AfterToolCallback{
-				func(ctx agent.ToolContext, tool tool.Tool, args, result map[string]any, err error) (map[string]any, error) {
+				func(ctx agent.Context, tool tool.Tool, args, result map[string]any, err error) (map[string]any, error) {
 					afterToolCallbacksCalled = true
 					if tc.dontRunAfterCanonicalCallback {
 						t.Error("after Tool Callback should not be called")
@@ -477,7 +477,7 @@ func TestModelCallbacks(t *testing.T) {
 		{
 			name: "before model callback doesn't modify anything",
 			beforeModelCallbacks: []llmagent.BeforeModelCallback{
-				func(ctx agent.CallbackContext, llmRequest *model.LLMRequest) (*model.LLMResponse, error) {
+				func(ctx agent.Context, llmRequest *model.LLMRequest) (*model.LLMResponse, error) {
 					return nil, nil
 				},
 			},
@@ -492,10 +492,10 @@ func TestModelCallbacks(t *testing.T) {
 		{
 			name: "before model callback returns an error",
 			beforeModelCallbacks: []llmagent.BeforeModelCallback{
-				func(ctx agent.CallbackContext, llmRequest *model.LLMRequest) (*model.LLMResponse, error) {
+				func(ctx agent.Context, llmRequest *model.LLMRequest) (*model.LLMResponse, error) {
 					return nil, fmt.Errorf("before_model_callback_error: %w", http.ErrNoCookie)
 				},
-				func(ctx agent.CallbackContext, llmRequest *model.LLMRequest) (*model.LLMResponse, error) {
+				func(ctx agent.Context, llmRequest *model.LLMRequest) (*model.LLMResponse, error) {
 					return nil, fmt.Errorf("before_model_callback_error: %w", http.ErrHijacked)
 				},
 			},
@@ -510,12 +510,12 @@ func TestModelCallbacks(t *testing.T) {
 		{
 			name: "before model callback returns new LLMResponse",
 			beforeModelCallbacks: []llmagent.BeforeModelCallback{
-				func(ctx agent.CallbackContext, llmRequest *model.LLMRequest) (*model.LLMResponse, error) {
+				func(ctx agent.Context, llmRequest *model.LLMRequest) (*model.LLMResponse, error) {
 					return &model.LLMResponse{
 						Content: genai.NewContentFromText("hello from before_model_callback", genai.RoleModel),
 					}, nil
 				},
-				func(ctx agent.CallbackContext, llmRequest *model.LLMRequest) (*model.LLMResponse, error) {
+				func(ctx agent.Context, llmRequest *model.LLMRequest) (*model.LLMResponse, error) {
 					return &model.LLMResponse{
 						Content: genai.NewContentFromText("unexpected text", genai.RoleModel),
 					}, nil
@@ -534,7 +534,7 @@ func TestModelCallbacks(t *testing.T) {
 		{
 			name: "before model callback returns both new LLMResponse and error",
 			beforeModelCallbacks: []llmagent.BeforeModelCallback{
-				func(ctx agent.CallbackContext, llmRequest *model.LLMRequest) (*model.LLMResponse, error) {
+				func(ctx agent.Context, llmRequest *model.LLMRequest) (*model.LLMResponse, error) {
 					return &model.LLMResponse{
 						Content: genai.NewContentFromText("hello from before_model_callback", genai.RoleModel),
 					}, fmt.Errorf("before_model_callback_error: %w", http.ErrNoCookie)
@@ -551,7 +551,7 @@ func TestModelCallbacks(t *testing.T) {
 		{
 			name: "after model callback doesn't modify anything",
 			afterModelCallbacks: []llmagent.AfterModelCallback{
-				func(ctx agent.CallbackContext, llmResponse *model.LLMResponse, llmResponseError error) (*model.LLMResponse, error) {
+				func(ctx agent.Context, llmResponse *model.LLMResponse, llmResponseError error) (*model.LLMResponse, error) {
 					return nil, nil
 				},
 			},
@@ -566,12 +566,12 @@ func TestModelCallbacks(t *testing.T) {
 		{
 			name: "after model callback returns new LLMResponse and are run in symmetrical order",
 			afterModelCallbacks: []llmagent.AfterModelCallback{
-				func(ctx agent.CallbackContext, llmResponse *model.LLMResponse, llmResponseError error) (*model.LLMResponse, error) {
+				func(ctx agent.Context, llmResponse *model.LLMResponse, llmResponseError error) (*model.LLMResponse, error) {
 					return &model.LLMResponse{
 						Content: genai.NewContentFromText("hello from after_model_callback", genai.RoleModel),
 					}, nil
 				},
-				func(ctx agent.CallbackContext, llmResponse *model.LLMResponse, llmResponseError error) (*model.LLMResponse, error) {
+				func(ctx agent.Context, llmResponse *model.LLMResponse, llmResponseError error) (*model.LLMResponse, error) {
 					return &model.LLMResponse{
 						Content: genai.NewContentFromText("unexpected text", genai.RoleModel),
 					}, nil
@@ -589,10 +589,10 @@ func TestModelCallbacks(t *testing.T) {
 		{
 			name: "after model callback returns error and are run in symmetrical order",
 			afterModelCallbacks: []llmagent.AfterModelCallback{
-				func(ctx agent.CallbackContext, llmResponse *model.LLMResponse, llmResponseError error) (*model.LLMResponse, error) {
+				func(ctx agent.Context, llmResponse *model.LLMResponse, llmResponseError error) (*model.LLMResponse, error) {
 					return nil, fmt.Errorf("error from after_model_callback: %w", http.ErrNoCookie)
 				},
-				func(ctx agent.CallbackContext, llmResponse *model.LLMResponse, llmResponseError error) (*model.LLMResponse, error) {
+				func(ctx agent.Context, llmResponse *model.LLMResponse, llmResponseError error) (*model.LLMResponse, error) {
 					return nil, fmt.Errorf("error from after_model_callback: %w", http.ErrHijacked)
 				},
 			},
@@ -606,7 +606,7 @@ func TestModelCallbacks(t *testing.T) {
 		{
 			name: "after model callback returns both new LLMResponse and error",
 			afterModelCallbacks: []llmagent.AfterModelCallback{
-				func(ctx agent.CallbackContext, llmResponse *model.LLMResponse, llmResponseError error) (*model.LLMResponse, error) {
+				func(ctx agent.Context, llmResponse *model.LLMResponse, llmResponseError error) (*model.LLMResponse, error) {
 					return &model.LLMResponse{
 						Content: genai.NewContentFromText("hello from after_model_callback", genai.RoleModel),
 					}, fmt.Errorf("error from after_model_callback: %w", http.ErrNoCookie)
@@ -622,7 +622,7 @@ func TestModelCallbacks(t *testing.T) {
 		{
 			name: "on model error callback is not called",
 			onModelErrorCallback: []llmagent.OnModelErrorCallback{
-				func(ctx agent.CallbackContext, llmRequest *model.LLMRequest, llmError error) (*model.LLMResponse, error) {
+				func(ctx agent.Context, llmRequest *model.LLMRequest, llmError error) (*model.LLMResponse, error) {
 					return &model.LLMResponse{
 						Content: genai.NewContentFromText("hello from on_model_error_callback", genai.RoleModel),
 					}, fmt.Errorf("on_model_error_callback: %w", http.ErrNoCookie)
@@ -639,7 +639,7 @@ func TestModelCallbacks(t *testing.T) {
 		{
 			name: "on model error callback changes message",
 			onModelErrorCallback: []llmagent.OnModelErrorCallback{
-				func(ctx agent.CallbackContext, llmRequest *model.LLMRequest, llmError error) (*model.LLMResponse, error) {
+				func(ctx agent.Context, llmRequest *model.LLMRequest, llmError error) (*model.LLMResponse, error) {
 					return &model.LLMResponse{
 						Content: genai.NewContentFromText("hello from on_model_error_callback", genai.RoleModel),
 					}, nil
@@ -654,12 +654,12 @@ func TestModelCallbacks(t *testing.T) {
 		{
 			name: "on model error callback changes err",
 			onModelErrorCallback: []llmagent.OnModelErrorCallback{
-				func(ctx agent.CallbackContext, llmRequest *model.LLMRequest, llmError error) (*model.LLMResponse, error) {
+				func(ctx agent.Context, llmRequest *model.LLMRequest, llmError error) (*model.LLMResponse, error) {
 					return &model.LLMResponse{
 						Content: genai.NewContentFromText("hello from on_model_error_callback", genai.RoleModel),
 					}, fmt.Errorf("error from on_model_error_callback: %w", http.ErrNoCookie)
 				},
-				func(ctx agent.CallbackContext, llmRequest *model.LLMRequest, llmError error) (*model.LLMResponse, error) {
+				func(ctx agent.Context, llmRequest *model.LLMRequest, llmError error) (*model.LLMResponse, error) {
 					return &model.LLMResponse{
 						Content: genai.NewContentFromText("hello from on_model_error_callback", genai.RoleModel),
 					}, fmt.Errorf("error from on_model_error_callback: %w", http.ErrHijacked)
@@ -673,7 +673,7 @@ func TestModelCallbacks(t *testing.T) {
 		{
 			name: "on model error callback returns both new LLMResponse and error",
 			onModelErrorCallback: []llmagent.OnModelErrorCallback{
-				func(ctx agent.CallbackContext, llmRequest *model.LLMRequest, llmError error) (*model.LLMResponse, error) {
+				func(ctx agent.Context, llmRequest *model.LLMRequest, llmError error) (*model.LLMResponse, error) {
 					return &model.LLMResponse{
 						Content: genai.NewContentFromText("hello from on_model_error_callback", genai.RoleModel),
 					}, fmt.Errorf("error from on_model_error_callback: %w", http.ErrNoCookie)
@@ -687,12 +687,12 @@ func TestModelCallbacks(t *testing.T) {
 		{
 			name: "on model error callback does not process before model callback error",
 			beforeModelCallbacks: []llmagent.BeforeModelCallback{
-				func(ctx agent.CallbackContext, llmRequest *model.LLMRequest) (*model.LLMResponse, error) {
+				func(ctx agent.Context, llmRequest *model.LLMRequest) (*model.LLMResponse, error) {
 					return nil, fmt.Errorf("before_model_callback_error: %w", http.ErrNoCookie)
 				},
 			},
 			onModelErrorCallback: []llmagent.OnModelErrorCallback{
-				func(ctx agent.CallbackContext, llmRequest *model.LLMRequest, llmError error) (*model.LLMResponse, error) {
+				func(ctx agent.Context, llmRequest *model.LLMRequest, llmError error) (*model.LLMResponse, error) {
 					return &model.LLMResponse{
 						Content: genai.NewContentFromText("hello from on_model_error_callback", genai.RoleModel),
 					}, fmt.Errorf("error from on_model_error_callback: %w", http.ErrHijacked)
@@ -709,14 +709,14 @@ func TestModelCallbacks(t *testing.T) {
 		{
 			name: "on model error callback does not process before model callback message",
 			beforeModelCallbacks: []llmagent.BeforeModelCallback{
-				func(ctx agent.CallbackContext, llmRequest *model.LLMRequest) (*model.LLMResponse, error) {
+				func(ctx agent.Context, llmRequest *model.LLMRequest) (*model.LLMResponse, error) {
 					return &model.LLMResponse{
 						Content: genai.NewContentFromText("hello from before_model_callback", genai.RoleModel),
 					}, nil
 				},
 			},
 			onModelErrorCallback: []llmagent.OnModelErrorCallback{
-				func(ctx agent.CallbackContext, llmRequest *model.LLMRequest, llmError error) (*model.LLMResponse, error) {
+				func(ctx agent.Context, llmRequest *model.LLMRequest, llmError error) (*model.LLMResponse, error) {
 					return &model.LLMResponse{
 						Content: genai.NewContentFromText("hello from on_model_error_callback", genai.RoleModel),
 					}, fmt.Errorf("error from on_model_error_callback: %w", http.ErrHijacked)
@@ -735,14 +735,14 @@ func TestModelCallbacks(t *testing.T) {
 		{
 			name: "after error callback process on model error callback message",
 			onModelErrorCallback: []llmagent.OnModelErrorCallback{
-				func(ctx agent.CallbackContext, llmRequest *model.LLMRequest, llmError error) (*model.LLMResponse, error) {
+				func(ctx agent.Context, llmRequest *model.LLMRequest, llmError error) (*model.LLMResponse, error) {
 					return &model.LLMResponse{
 						Content: genai.NewContentFromText("hello from on_model_error_callback", genai.RoleModel),
 					}, nil
 				},
 			},
 			afterModelCallbacks: []llmagent.AfterModelCallback{
-				func(ctx agent.CallbackContext, llmResponse *model.LLMResponse, llmResponseError error) (*model.LLMResponse, error) {
+				func(ctx agent.Context, llmResponse *model.LLMResponse, llmResponseError error) (*model.LLMResponse, error) {
 					return &model.LLMResponse{
 						Content: genai.NewContentFromText("hello from after_model_callback", genai.RoleModel),
 					}, nil
@@ -758,12 +758,12 @@ func TestModelCallbacks(t *testing.T) {
 		{
 			name: "after error callback does not process on model error callback error",
 			onModelErrorCallback: []llmagent.OnModelErrorCallback{
-				func(ctx agent.CallbackContext, llmRequest *model.LLMRequest, llmError error) (*model.LLMResponse, error) {
+				func(ctx agent.Context, llmRequest *model.LLMRequest, llmError error) (*model.LLMResponse, error) {
 					return nil, fmt.Errorf("error from on_model_error_callback: %w", http.ErrNoCookie)
 				},
 			},
 			afterModelCallbacks: []llmagent.AfterModelCallback{
-				func(ctx agent.CallbackContext, llmResponse *model.LLMResponse, llmResponseError error) (*model.LLMResponse, error) {
+				func(ctx agent.Context, llmResponse *model.LLMResponse, llmResponseError error) (*model.LLMResponse, error) {
 					return nil, fmt.Errorf("error from after_model_callback: %w", http.ErrHijacked)
 				},
 			},
@@ -808,7 +808,7 @@ func TestModelCallbacks(t *testing.T) {
 			afterModelCallbacksCalled := false
 
 			onModelErrorCallbacks := []llmagent.OnModelErrorCallback{
-				func(ctx agent.CallbackContext, llmRequest *model.LLMRequest, llmError error) (*model.LLMResponse, error) {
+				func(ctx agent.Context, llmRequest *model.LLMRequest, llmError error) (*model.LLMResponse, error) {
 					onModelErrorCallbacksCalled = true
 					if tc.dontRunOnErrorCanonicalCallback {
 						t.Error("on model error should not be called")
@@ -817,7 +817,7 @@ func TestModelCallbacks(t *testing.T) {
 				},
 			}
 			beforeModelCallbacks := []llmagent.BeforeModelCallback{
-				func(ctx agent.CallbackContext, llmRequest *model.LLMRequest) (*model.LLMResponse, error) {
+				func(ctx agent.Context, llmRequest *model.LLMRequest) (*model.LLMResponse, error) {
 					beforeModelCallbacksCalled = true
 					if tc.dontRunBeforeCanonicalCallback {
 						t.Error("before model Callback should not be called")
@@ -826,7 +826,7 @@ func TestModelCallbacks(t *testing.T) {
 				},
 			}
 			afterModelCallbacks := []llmagent.AfterModelCallback{
-				func(ctx agent.CallbackContext, llmResponse *model.LLMResponse, llmResponseError error) (*model.LLMResponse, error) {
+				func(ctx agent.Context, llmResponse *model.LLMResponse, llmResponseError error) (*model.LLMResponse, error) {
 					afterModelCallbacksCalled = true
 					if tc.dontRunAfterCanonicalCallback {
 						t.Error("after model Callback should not be called")

--- a/plugin/retryandreflect/plugin.go
+++ b/plugin/retryandreflect/plugin.go
@@ -125,7 +125,7 @@ func MustNew(opts ...PluginOption) *plugin.Plugin {
 	return p
 }
 
-func (r *retryAndReflect) afterTool(ctx agent.ToolContext, tool tool.Tool, args, result map[string]any, err error) (map[string]any, error) {
+func (r *retryAndReflect) afterTool(ctx agent.Context, tool tool.Tool, args, result map[string]any, err error) (map[string]any, error) {
 	if err == nil {
 		isReflectResponse := false
 		if rt, ok := result["response_type"].(string); ok && rt == reflectAndRetryResponseType {
@@ -140,11 +140,11 @@ func (r *retryAndReflect) afterTool(ctx agent.ToolContext, tool tool.Tool, args,
 	return nil, nil
 }
 
-func (r *retryAndReflect) onToolError(ctx agent.ToolContext, tool tool.Tool, args map[string]any, err error) (map[string]any, error) {
+func (r *retryAndReflect) onToolError(ctx agent.Context, tool tool.Tool, args map[string]any, err error) (map[string]any, error) {
 	return r.handleToolError(ctx, tool, args, err)
 }
 
-func (r *retryAndReflect) handleToolError(ctx agent.ToolContext, failedTool tool.Tool, args map[string]any, err error) (map[string]any, error) {
+func (r *retryAndReflect) handleToolError(ctx agent.Context, failedTool tool.Tool, args map[string]any, err error) (map[string]any, error) {
 	// skip if the error is tool.ErrConfirmationRequired.
 	if errors.Is(err, tool.ErrConfirmationRequired) || errors.Is(err, tool.ErrConfirmationRejected) {
 		return nil, nil
@@ -180,14 +180,14 @@ func (r *retryAndReflect) handleToolError(ctx agent.ToolContext, failedTool tool
 	return r.createToolRetryExceedMsg(failedTool, args, err), nil
 }
 
-func (r *retryAndReflect) scopeKey(ctx agent.ToolContext) string {
+func (r *retryAndReflect) scopeKey(ctx agent.Context) string {
 	if r.scope == Global {
 		return globalScopeKey
 	}
 	return ctx.InvocationID()
 }
 
-func (r *retryAndReflect) resetFailuresForTool(ctx agent.ToolContext, toolName string) {
+func (r *retryAndReflect) resetFailuresForTool(ctx agent.Context, toolName string) {
 	scopeKey := r.scopeKey(ctx)
 
 	r.mu.Lock()

--- a/plugin/retryandreflect/plugin_test.go
+++ b/plugin/retryandreflect/plugin_test.go
@@ -31,7 +31,7 @@ func (m *mockTool) Description() string { return "" }
 func (m *mockTool) IsLongRunning() bool { return false }
 
 type mockContext struct {
-	agent.ToolContext
+	agent.Context
 	invocationID string
 }
 

--- a/runner/run_node_test.go
+++ b/runner/run_node_test.go
@@ -149,7 +149,7 @@ func TestRunner_LlmAgent_LongRunningTool_PausesAndResumes(t *testing.T) {
 		Name:          "ask_human",
 		Description:   "asks a human and waits",
 		IsLongRunning: true,
-	}, func(_ agent.ToolContext, _ askArgs) (map[string]string, error) {
+	}, func(_ agent.Context, _ askArgs) (map[string]string, error) {
 		return map[string]string{"status": "pending"}, nil
 	})
 	if err != nil {

--- a/server/agentengine/controllers/method/stream_query_test.go
+++ b/server/agentengine/controllers/method/stream_query_test.go
@@ -43,7 +43,7 @@ func TestSimpleText(t *testing.T) {
 	a, err := llmagent.New(llmagent.Config{
 		Name: "Echo",
 		BeforeAgentCallbacks: []agent.BeforeAgentCallback{
-			func(cc agent.CallbackContext) (*genai.Content, error) {
+			func(cc agent.Context) (*genai.Content, error) {
 				return cc.UserContent(), nil
 			},
 		},

--- a/tool/agenttool/agent_tool.go
+++ b/tool/agenttool/agent_tool.go
@@ -91,7 +91,7 @@ func (t *agentTool) Declaration() *genai.FunctionDeclaration {
 // Run executes the wrapped agent with the provided arguments.
 // It creates a new session for the sub-agent, runs the agent, and returns
 // the final result.
-func (t *agentTool) Run(toolCtx agent.ToolContext, args any) (map[string]any, error) {
+func (t *agentTool) Run(toolCtx agent.Context, args any) (map[string]any, error) {
 	margs, ok := args.(map[string]any)
 	if !ok {
 		return nil, fmt.Errorf("agentTool expects map[string]any arguments, got %T", args)
@@ -224,6 +224,6 @@ func (t *agentTool) Run(toolCtx agent.ToolContext, args any) (map[string]any, er
 }
 
 // ProcessRequest adds the agent tool's function declaration to the LLM request.
-func (t *agentTool) ProcessRequest(ctx agent.ToolContext, req *model.LLMRequest) error {
+func (t *agentTool) ProcessRequest(ctx agent.Context, req *model.LLMRequest) error {
 	return toolutils.PackTool(req, t)
 }

--- a/tool/agenttool/agent_tool_test.go
+++ b/tool/agenttool/agent_tool_test.go
@@ -346,7 +346,7 @@ func createAgentWithModel(t *testing.T, inputSchema, outputSchema *genai.Schema,
 	return agent
 }
 
-func createToolContext(t *testing.T, testAgent agent.Agent) agent.ToolContext {
+func createToolContext(t *testing.T, testAgent agent.Agent) agent.Context {
 	t.Helper()
 
 	sessionService := session.InMemoryService()

--- a/tool/context.go
+++ b/tool/context.go
@@ -25,6 +25,6 @@ import (
 // Deprecated: use agent.NewToolContext directly. This wrapper exists only
 // to minimize churn during the migration and will be removed in a future
 // release.
-func NewToolContext(ic agent.InvocationContext, functionCallID string, actions *session.EventActions, confirmation *toolconfirmation.ToolConfirmation) agent.ToolContext {
+func NewToolContext(ic agent.InvocationContext, functionCallID string, actions *session.EventActions, confirmation *toolconfirmation.ToolConfirmation) agent.Context {
 	return agent.NewToolContext(ic, functionCallID, actions, confirmation)
 }

--- a/tool/exampletool/tool.go
+++ b/tool/exampletool/tool.go
@@ -55,7 +55,7 @@ func (s exampleTool) Description() string {
 }
 
 // ProcessRequest adds the exampleTool examples to the LLM request.
-func (s exampleTool) ProcessRequest(ctx agent.ToolContext, req *model.LLMRequest) error {
+func (s exampleTool) ProcessRequest(ctx agent.Context, req *model.LLMRequest) error {
 	parts := ctx.UserContent().Parts
 	if len(parts) == 0 || parts[0].Text == "" {
 		return nil

--- a/tool/exampletool/tool_test.go
+++ b/tool/exampletool/tool_test.go
@@ -97,7 +97,7 @@ func (m *mockToolContext) Session() session.Session                             
 func (m *mockToolContext) SubScheduler() agent.DynamicSubScheduler                 { return nil }
 func (m *mockToolContext) WithBranch(branch string) agent.Context                  { return nil }
 
-var _ agent.ToolContext = (*mockToolContext)(nil)
+var _ agent.Context = (*mockToolContext)(nil)
 
 // --- Tests ---
 

--- a/tool/exitlooptool/tool.go
+++ b/tool/exitlooptool/tool.go
@@ -23,7 +23,7 @@ import (
 	"google.golang.org/adk/tool/functiontool"
 )
 
-func exitLoop(ctx agent.ToolContext, myArgs struct{}) (map[string]string, error) {
+func exitLoop(ctx agent.Context, myArgs struct{}) (map[string]string, error) {
 	ctx.Actions().Escalate = true
 	ctx.Actions().SkipSummarization = true
 	return map[string]string{}, nil

--- a/tool/functiontool/function.go
+++ b/tool/functiontool/function.go
@@ -68,8 +68,8 @@ type Config struct {
 }
 
 // Func represents a Go function that can be wrapped in a tool.
-// It takes a agent.ToolContext and a generic argument type, and returns a generic result type.
-type Func[TArgs, TResults any] func(agent.ToolContext, TArgs) (TResults, error)
+// It takes a agent.Context and a generic argument type, and returns a generic result type.
+type Func[TArgs, TResults any] func(agent.Context, TArgs) (TResults, error)
 
 // ErrInvalidArgument indicates the input parameter type is invalid.
 var ErrInvalidArgument = errors.New("invalid argument")
@@ -152,7 +152,7 @@ func (f *functionTool[TArgs, TResults]) IsLongRunning() bool {
 }
 
 // ProcessRequest packs the function tool's declaration into the LLM request.
-func (f *functionTool[TArgs, TResults]) ProcessRequest(ctx agent.ToolContext, req *model.LLMRequest) error {
+func (f *functionTool[TArgs, TResults]) ProcessRequest(ctx agent.Context, req *model.LLMRequest) error {
 	return toolutils.PackTool(req, f)
 }
 
@@ -182,7 +182,7 @@ func (f *functionTool[TArgs, TResults]) Declaration() *genai.FunctionDeclaration
 }
 
 // Run executes the tool with the provided context and yields events.
-func (f *functionTool[TArgs, TResults]) Run(ctx agent.ToolContext, args any) (result map[string]any, err error) {
+func (f *functionTool[TArgs, TResults]) Run(ctx agent.Context, args any) (result map[string]any, err error) {
 	// TODO: Handle function call request from tc.InvocationContext.
 	defer func() {
 		if r := recover(); r != nil {

--- a/tool/functiontool/function_test.go
+++ b/tool/functiontool/function_test.go
@@ -50,7 +50,7 @@ type SumResult struct {
 	Sum int `json:"sum"` // the sum of two integers
 }
 
-func sumFunc(ctx agent.ToolContext, input SumArgs) (SumResult, error) {
+func sumFunc(ctx agent.Context, input SumArgs) (SumResult, error) {
 	return SumResult{Sum: input.A + input.B}, nil
 }
 
@@ -65,7 +65,7 @@ func ExampleNew() {
 	_ = sumTool // use the tool
 }
 
-func createToolContext(t *testing.T) agent.ToolContext {
+func createToolContext(t *testing.T) agent.Context {
 	invCtx := icontext.NewInvocationContext(t.Context(), icontext.InvocationContextParams{})
 	return agent.NewToolContext(invCtx, "", &session.EventActions{}, nil)
 }
@@ -101,7 +101,7 @@ func TestFunctionTool_Simple(t *testing.T) {
 		},
 	}
 
-	weatherReport := func(ctx agent.ToolContext, input Args) (Result, error) {
+	weatherReport := func(ctx agent.Context, input Args) (Result, error) {
 		city := strings.ToLower(input.City)
 		if ret, ok := resultSet[city]; ok {
 			return ret, nil
@@ -202,7 +202,7 @@ func TestFunctionTool_DifferentFunctionDeclarations_ConsolidatedInOneGenAiTool(t
 	type IntOutput struct {
 		Result int `json:"result"`
 	}
-	identityFunc := func(ctx agent.ToolContext, input IntInput) (IntOutput, error) {
+	identityFunc := func(ctx agent.Context, input IntInput) (IntOutput, error) {
 		return IntOutput{Result: input.X}, nil
 	}
 	identityTool, err := functiontool.New(functiontool.Config{
@@ -220,7 +220,7 @@ func TestFunctionTool_DifferentFunctionDeclarations_ConsolidatedInOneGenAiTool(t
 	type StringOutput struct {
 		Result string `json:"result"`
 	}
-	stringIdentityFunc := func(ctx agent.ToolContext, input StringInput) (StringOutput, error) {
+	stringIdentityFunc := func(ctx agent.Context, input StringInput) (StringOutput, error) {
 		return StringOutput{Result: input.Value}, nil
 	}
 	stringIdentityTool, err := functiontool.New(
@@ -266,7 +266,7 @@ func TestFunctionTool_ReturnsBasicType(t *testing.T) {
 		"paris":  "The weather in Paris is sunny with a temperature of 25 derees Celsius.",
 	}
 
-	weatherReport := func(ctx agent.ToolContext, input Args) (string, error) {
+	weatherReport := func(ctx agent.Context, input Args) (string, error) {
 		city := strings.ToLower(input.City)
 		if ret, ok := resultSet[city]; ok {
 			return ret, nil
@@ -356,7 +356,7 @@ func TestFunctionTool_MapInput(t *testing.T) {
 			Name:        "sum_map",
 			Description: "sums numbers provided in a map input",
 		},
-		func(ctx agent.ToolContext, input map[string]int) (Output, error) {
+		func(ctx agent.Context, input map[string]int) (Output, error) {
 			return Output{Sum: input["a"] + input["b"]}, nil
 		})
 	if err != nil {
@@ -441,7 +441,7 @@ func TestFunctionTool_CustomSchema(t *testing.T) {
 		Name:        "print_quantity",
 		Description: "print the remaining quantity of the given fruit.",
 		InputSchema: ischema,
-	}, func(ctx agent.ToolContext, input Args) (any, error) {
+	}, func(ctx agent.Context, input Args) (any, error) {
 		fruit := strings.ToLower(input.Fruit)
 		if fruit != "mandarin" && fruit != "kiwi" {
 			t.Errorf("unexpected fruit: %q", fruit)
@@ -553,7 +553,7 @@ type SimpleArgs struct {
 	Num int
 }
 
-func okFunc(_ agent.ToolContext, _ SimpleArgs) (string, error) {
+func okFunc(_ agent.Context, _ SimpleArgs) (string, error) {
 	return "ok", nil
 }
 
@@ -927,7 +927,7 @@ type TestResult struct {
 
 func TestNew_RequireConfirmationProvider_Validation(t *testing.T) {
 	// A dummy handler to satisfy the function signature
-	dummyHandler := func(_ agent.ToolContext, _ TestArgs) (TestResult, error) {
+	dummyHandler := func(_ agent.Context, _ TestArgs) (TestResult, error) {
 		return TestResult{Value: 1}, nil
 	}
 
@@ -1038,7 +1038,7 @@ func TestNew_InvalidInputType(t *testing.T) {
 				return functiontool.New(functiontool.Config{
 					Name:        "string_tool",
 					Description: "a tool with string input",
-				}, func(ctx agent.ToolContext, input string) (string, error) {
+				}, func(ctx agent.Context, input string) (string, error) {
 					return input, nil
 				})
 			},
@@ -1050,7 +1050,7 @@ func TestNew_InvalidInputType(t *testing.T) {
 				return functiontool.New(functiontool.Config{
 					Name:        "int_tool",
 					Description: "a tool with int input",
-				}, func(ctx agent.ToolContext, input int) (int, error) {
+				}, func(ctx agent.Context, input int) (int, error) {
 					return input, nil
 				})
 			},
@@ -1062,7 +1062,7 @@ func TestNew_InvalidInputType(t *testing.T) {
 				return functiontool.New(functiontool.Config{
 					Name:        "bool_tool",
 					Description: "a tool with bool input",
-				}, func(ctx agent.ToolContext, input bool) (bool, error) {
+				}, func(ctx agent.Context, input bool) (bool, error) {
 					return input, nil
 				})
 			},
@@ -1088,7 +1088,7 @@ func TestFunctionTool_PanicRecovery(t *testing.T) {
 		Value string `json:"value"`
 	}
 
-	panicHandler := func(ctx agent.ToolContext, input Args) (string, error) {
+	panicHandler := func(ctx agent.Context, input Args) (string, error) {
 		panic("intentional panic for testing")
 	}
 

--- a/tool/functiontool/long_running_function_test.go
+++ b/tool/functiontool/long_running_function_test.go
@@ -40,7 +40,7 @@ func TestNewLongRunningFunctionTool(t *testing.T) {
 		Result string `json:"result"` // the operation result
 	}
 
-	handler := func(ctx agent.ToolContext, input SumArgs) (SumResult, error) {
+	handler := func(ctx agent.Context, input SumArgs) (SumResult, error) {
 		return SumResult{Result: "Processing sum"}, nil
 	}
 	sumTool, err := functiontool.New(functiontool.Config{
@@ -81,7 +81,7 @@ type IncArgs struct{}
 
 func TestLongRunningFunctionFlow(t *testing.T) {
 	functionCalled := 0
-	increaseByOne := func(ctx agent.ToolContext, x IncArgs) (map[string]string, error) {
+	increaseByOne := func(ctx agent.Context, x IncArgs) (map[string]string, error) {
 		functionCalled++
 		return map[string]string{"status": "pending"}, nil
 	}
@@ -90,7 +90,7 @@ func TestLongRunningFunctionFlow(t *testing.T) {
 
 func TestLongRunningStringFunctionFlow(t *testing.T) {
 	functionCalled := 0
-	increaseByOne := func(ctx agent.ToolContext, x IncArgs) (string, error) {
+	increaseByOne := func(ctx agent.Context, x IncArgs) (string, error) {
 		functionCalled++
 		return "pending", nil
 	}
@@ -98,7 +98,7 @@ func TestLongRunningStringFunctionFlow(t *testing.T) {
 }
 
 // --- Test Suite ---
-func testLongRunningFunctionFlow[Out any](t *testing.T, increaseByOne func(ctx agent.ToolContext, x IncArgs) (Out, error), resultKey string, callCount *int) {
+func testLongRunningFunctionFlow[Out any](t *testing.T, increaseByOne func(ctx agent.Context, x IncArgs) (Out, error), resultKey string, callCount *int) {
 	// 1. Setup
 	responses := []*genai.Content{
 		genai.NewContentFromFunctionCall("increaseByOne", map[string]any{}, "model"),
@@ -267,7 +267,7 @@ func TestLongRunningToolIDsAreSet(t *testing.T) {
 
 	type IncArgs struct{}
 
-	increaseByOne := func(ctx agent.ToolContext, x IncArgs) (map[string]string, error) {
+	increaseByOne := func(ctx agent.Context, x IncArgs) (map[string]string, error) {
 		functionCalled++
 		return map[string]string{"status": "pending"}, nil
 	}

--- a/tool/functiontool/streaming_function.go
+++ b/tool/functiontool/streaming_function.go
@@ -32,7 +32,7 @@ import (
 )
 
 // StreamingFunc represents a Go function that streams results.
-type StreamingFunc[TArgs any] func(agent.ToolContext, TArgs) iter.Seq2[string, error]
+type StreamingFunc[TArgs any] func(agent.Context, TArgs) iter.Seq2[string, error]
 
 // NewStreaming creates a new streaming tool.
 func NewStreaming[TArgs any](cfg Config, handler StreamingFunc[TArgs]) (tool.Tool, error) {
@@ -100,7 +100,7 @@ func (f *streamingFunctionTool[TArgs]) IsLongRunning() bool {
 }
 
 // ProcessRequest packs the function tool's declaration into the LLM request.
-func (f *streamingFunctionTool[TArgs]) ProcessRequest(ctx agent.ToolContext, req *model.LLMRequest) error {
+func (f *streamingFunctionTool[TArgs]) ProcessRequest(ctx agent.Context, req *model.LLMRequest) error {
 	return toolutils.PackTool(req, f)
 }
 
@@ -127,7 +127,7 @@ func (f *streamingFunctionTool[TArgs]) Declaration() *genai.FunctionDeclaration 
 }
 
 // RunStream executes the tool with the provided context and yields events.
-func (f *streamingFunctionTool[TArgs]) RunStream(ctx agent.ToolContext, args any) iter.Seq2[string, error] {
+func (f *streamingFunctionTool[TArgs]) RunStream(ctx agent.Context, args any) iter.Seq2[string, error] {
 	return func(yield func(string, error) bool) {
 		defer func() {
 			if r := recover(); r != nil {

--- a/tool/geminitool/google_search.go
+++ b/tool/geminitool/google_search.go
@@ -38,7 +38,7 @@ func (s GoogleSearch) Description() string {
 }
 
 // ProcessRequest adds the GoogleSearch tool to the LLM request.
-func (s GoogleSearch) ProcessRequest(ctx agent.ToolContext, req *model.LLMRequest) error {
+func (s GoogleSearch) ProcessRequest(ctx agent.Context, req *model.LLMRequest) error {
 	return setTool(req, &genai.Tool{
 		GoogleSearch: &genai.GoogleSearch{},
 	})

--- a/tool/geminitool/tool.go
+++ b/tool/geminitool/tool.go
@@ -56,7 +56,7 @@ type geminiTool struct {
 }
 
 // ProcessRequest adds the Gemini tool to the LLM request.
-func (t *geminiTool) ProcessRequest(ctx agent.ToolContext, req *model.LLMRequest) error {
+func (t *geminiTool) ProcessRequest(ctx agent.Context, req *model.LLMRequest) error {
 	return setTool(req, t.value)
 }
 

--- a/tool/loadartifactstool/load_artifacts_tool.go
+++ b/tool/loadartifactstool/load_artifacts_tool.go
@@ -85,7 +85,7 @@ func (t *artifactsTool) Declaration() *genai.FunctionDeclaration {
 }
 
 // Run implements tool.Tool.
-func (t *artifactsTool) Run(ctx agent.ToolContext, args any) (map[string]any, error) {
+func (t *artifactsTool) Run(ctx agent.Context, args any) (map[string]any, error) {
 	m, ok := args.(map[string]any)
 	if !ok {
 		return nil, fmt.Errorf("unexpected args type, got: %T", args)
@@ -117,7 +117,7 @@ func (t *artifactsTool) Run(ctx agent.ToolContext, args any) (map[string]any, er
 
 // ProcessRequest processes the LLM request. It packs the tool, appends initial
 // instructions, and processes any load artifacts function calls.
-func (t *artifactsTool) ProcessRequest(ctx agent.ToolContext, req *model.LLMRequest) error {
+func (t *artifactsTool) ProcessRequest(ctx agent.Context, req *model.LLMRequest) error {
 	if err := toolutils.PackTool(req, t); err != nil {
 		return err
 	}
@@ -127,7 +127,7 @@ func (t *artifactsTool) ProcessRequest(ctx agent.ToolContext, req *model.LLMRequ
 	return t.processLoadArtifactsFunctionCall(ctx, req)
 }
 
-func (t *artifactsTool) appendInitialInstructions(ctx agent.ToolContext, req *model.LLMRequest) error {
+func (t *artifactsTool) appendInitialInstructions(ctx agent.Context, req *model.LLMRequest) error {
 	resp, err := ctx.Artifacts().List(ctx)
 	if err != nil {
 		return fmt.Errorf("failed to list artifacts: %w", err)
@@ -151,7 +151,7 @@ func (t *artifactsTool) appendInitialInstructions(ctx agent.ToolContext, req *mo
 	return nil
 }
 
-func (t *artifactsTool) processLoadArtifactsFunctionCall(ctx agent.ToolContext, req *model.LLMRequest) error {
+func (t *artifactsTool) processLoadArtifactsFunctionCall(ctx agent.Context, req *model.LLMRequest) error {
 	if len(req.Contents) == 0 {
 		return nil
 	}

--- a/tool/loadartifactstool/load_artifacts_tool_test.go
+++ b/tool/loadartifactstool/load_artifacts_tool_test.go
@@ -277,7 +277,7 @@ func TestLoadArtifactsTool_ProcessRequest_Artifacts_OtherFunctionCall(t *testing
 	}
 }
 
-func createToolContext(t *testing.T) agent.ToolContext {
+func createToolContext(t *testing.T) agent.Context {
 	t.Helper()
 
 	artifacts := &artifactinternal.Artifacts{

--- a/tool/loadmemorytool/tool.go
+++ b/tool/loadmemorytool/tool.go
@@ -80,7 +80,7 @@ func (t *loadMemoryTool) Declaration() *genai.FunctionDeclaration {
 }
 
 // Run executes the tool with the provided context and arguments.
-func (t *loadMemoryTool) Run(toolCtx agent.ToolContext, args any) (map[string]any, error) {
+func (t *loadMemoryTool) Run(toolCtx agent.Context, args any) (map[string]any, error) {
 	m, ok := args.(map[string]any)
 	if !ok {
 		return nil, fmt.Errorf("unexpected args type, got: %T", args)
@@ -109,7 +109,7 @@ func (t *loadMemoryTool) Run(toolCtx agent.ToolContext, args any) (map[string]an
 
 // ProcessRequest processes the LLM request by packing the tool and appending
 // memory-related instructions.
-func (t *loadMemoryTool) ProcessRequest(ctx agent.ToolContext, req *model.LLMRequest) error {
+func (t *loadMemoryTool) ProcessRequest(ctx agent.Context, req *model.LLMRequest) error {
 	if err := toolutils.PackTool(req, t); err != nil {
 		return err
 	}

--- a/tool/loadmemorytool/tool_test.go
+++ b/tool/loadmemorytool/tool_test.go
@@ -170,7 +170,7 @@ func TestLoadMemoryTool_ProcessRequest(t *testing.T) {
 	}
 }
 
-func createToolContext(t *testing.T, mem *mockMemory) agent.ToolContext {
+func createToolContext(t *testing.T, mem *mockMemory) agent.Context {
 	t.Helper()
 
 	ctx := icontext.NewInvocationContext(t.Context(), icontext.InvocationContextParams{

--- a/tool/mcptoolset/tool.go
+++ b/tool/mcptoolset/tool.go
@@ -83,7 +83,7 @@ func (t *mcpTool) IsLongRunning() bool {
 	return false
 }
 
-func (t *mcpTool) ProcessRequest(ctx agent.ToolContext, req *model.LLMRequest) error {
+func (t *mcpTool) ProcessRequest(ctx agent.Context, req *model.LLMRequest) error {
 	return toolutils.PackTool(req, t)
 }
 
@@ -91,7 +91,7 @@ func (t *mcpTool) Declaration() *genai.FunctionDeclaration {
 	return t.funcDeclaration
 }
 
-func (t *mcpTool) Run(ctx agent.ToolContext, args any) (map[string]any, error) {
+func (t *mcpTool) Run(ctx agent.Context, args any) (map[string]any, error) {
 	if confirmation := ctx.ToolConfirmation(); confirmation != nil {
 		if !confirmation.Confirmed {
 			return nil, fmt.Errorf("error tool %q %w", t.Name(), tool.ErrConfirmationRejected)

--- a/tool/preloadmemorytool/tool.go
+++ b/tool/preloadmemorytool/tool.go
@@ -71,7 +71,7 @@ func (t *preloadMemoryTool) IsLongRunning() bool {
 
 // ProcessRequest processes the LLM request by searching memory using the user's
 // current query and injecting relevant past conversations into system instructions.
-func (t *preloadMemoryTool) ProcessRequest(ctx agent.ToolContext, req *model.LLMRequest) error {
+func (t *preloadMemoryTool) ProcessRequest(ctx agent.Context, req *model.LLMRequest) error {
 	userContent := ctx.UserContent()
 	if userContent == nil || len(userContent.Parts) == 0 ||
 		userContent.Parts[0] == nil || userContent.Parts[0].Text == "" {

--- a/tool/preloadmemorytool/tool_test.go
+++ b/tool/preloadmemorytool/tool_test.go
@@ -206,7 +206,7 @@ func TestPreloadMemoryTool_ProcessRequest(t *testing.T) {
 	}
 }
 
-func createToolContext(t *testing.T, mem *mockMemory, userContent *genai.Content) agent.ToolContext {
+func createToolContext(t *testing.T, mem *mockMemory, userContent *genai.Content) agent.Context {
 	t.Helper()
 
 	ctx := icontext.NewInvocationContext(t.Context(), icontext.InvocationContextParams{

--- a/tool/skilltoolset/internal/skilltool/list_skills.go
+++ b/tool/skilltoolset/internal/skilltool/list_skills.go
@@ -39,13 +39,13 @@ func ListSkills(source skill.Source) (tool.Tool, error) {
 			Name:        "list_skills",
 			Description: "Lists all available skills with their names and descriptions.",
 		},
-		func(ctx agent.ToolContext, args ListSkillsArgs) (*ListSkillsResult, error) {
+		func(ctx agent.Context, args ListSkillsArgs) (*ListSkillsResult, error) {
 			return listSkills(ctx, args, source)
 		},
 	)
 }
 
-func listSkills(ctx agent.ToolContext, _ ListSkillsArgs, source skill.Source) (*ListSkillsResult, error) {
+func listSkills(ctx agent.Context, _ ListSkillsArgs, source skill.Source) (*ListSkillsResult, error) {
 	skills, err := source.ListFrontmatters(ctx)
 	if err != nil {
 		return nil, err

--- a/tool/skilltoolset/internal/skilltool/load_skill.go
+++ b/tool/skilltoolset/internal/skilltool/load_skill.go
@@ -52,13 +52,13 @@ func LoadSkill(source skill.Source) (tool.Tool, error) {
 			Name:        "load_skill",
 			Description: "Loads the SKILL.md instructions for a given skill.",
 		},
-		func(ctx agent.ToolContext, args LoadSkillArgs) (*LoadSkillResult, error) {
+		func(ctx agent.Context, args LoadSkillArgs) (*LoadSkillResult, error) {
 			return loadSkill(ctx, args, source)
 		},
 	)
 }
 
-func loadSkill(ctx agent.ToolContext, args LoadSkillArgs, source skill.Source) (*LoadSkillResult, error) {
+func loadSkill(ctx agent.Context, args LoadSkillArgs, source skill.Source) (*LoadSkillResult, error) {
 	if args.Name == "" {
 		return nil, fmt.Errorf("skill name is required to load a skill")
 	}

--- a/tool/skilltoolset/internal/skilltool/load_skill_resource.go
+++ b/tool/skilltoolset/internal/skilltool/load_skill_resource.go
@@ -46,13 +46,13 @@ func LoadSkillResource(source skill.Source) (tool.Tool, error) {
 			Name:        "load_skill_resource",
 			Description: "Loads a resource file (e.g., from references/ or assets/) associated with the specified skill.",
 		},
-		func(ctx agent.ToolContext, args LoadSkillResourceArgs) (*LoadSkillResourceResult, error) {
+		func(ctx agent.Context, args LoadSkillResourceArgs) (*LoadSkillResourceResult, error) {
 			return loadSkillResource(ctx, args, source)
 		},
 	)
 }
 
-func loadSkillResource(ctx agent.ToolContext, args LoadSkillResourceArgs, source skill.Source) (*LoadSkillResourceResult, error) {
+func loadSkillResource(ctx agent.Context, args LoadSkillResourceArgs, source skill.Source) (*LoadSkillResourceResult, error) {
 	if args.SkillName == "" {
 		return nil, fmt.Errorf("skill name is required to load a resource")
 	}

--- a/tool/skilltoolset/internal/skilltool/tools_test.go
+++ b/tool/skilltoolset/internal/skilltool/tools_test.go
@@ -74,7 +74,7 @@ func (m *mockSource) LoadResource(ctx context.Context, name, resourcePath string
 	return io.NopCloser(strings.NewReader(res)), nil
 }
 
-func createToolContext(t *testing.T) agent.ToolContext {
+func createToolContext(t *testing.T) agent.Context {
 	invCtx := icontext.NewInvocationContext(t.Context(), icontext.InvocationContextParams{})
 	return agent.NewToolContext(invCtx, "", nil, nil)
 }

--- a/tool/skilltoolset/toolset.go
+++ b/tool/skilltoolset/toolset.go
@@ -104,7 +104,7 @@ func (ts *SkillToolset) Tools(ctx agent.ReadonlyContext) ([]tool.Tool, error) { 
 // ProcessRequest implements toolinternal.RequestProcessor. It attaches
 // the list of available skills and the system instruction explaining to the
 // agent what it can do with these skills.
-func (ts *SkillToolset) ProcessRequest(ctx agent.ToolContext, req *model.LLMRequest) error {
+func (ts *SkillToolset) ProcessRequest(ctx agent.Context, req *model.LLMRequest) error {
 	skills, err := ts.source.ListFrontmatters(ctx)
 	if err != nil {
 		return err

--- a/tool/tool.go
+++ b/tool/tool.go
@@ -45,12 +45,12 @@ type Tool interface {
 	IsLongRunning() bool
 }
 
-// Context is an alias for agent.ToolContext.
+// Context is an alias for agent.Context.
 //
 // Deprecated: use agent.Context directly. This alias exists only to
 // minimize churn during the migration and will be removed in a future
 // release.
-type Context = agent.ToolContext
+type Context = agent.Context
 
 // Toolset is an interface for a collection of tools. It allows grouping
 // related tools together and providing them to an agent.
@@ -189,18 +189,18 @@ type confirmationTool struct {
 type runnableTool interface {
 	Tool
 	Declaration() *genai.FunctionDeclaration
-	Run(ctx agent.ToolContext, args any) (result map[string]any, err error)
+	Run(ctx agent.Context, args any) (result map[string]any, err error)
 }
 
 func (t *confirmationTool) Declaration() *genai.FunctionDeclaration {
 	return t.runnableTool.Declaration()
 }
 
-func (t *confirmationTool) ProcessRequest(ctx agent.ToolContext, req *model.LLMRequest) error {
+func (t *confirmationTool) ProcessRequest(ctx agent.Context, req *model.LLMRequest) error {
 	return toolutils.PackTool(req, t)
 }
 
-func (t *confirmationTool) Run(ctx agent.ToolContext, args any) (map[string]any, error) {
+func (t *confirmationTool) Run(ctx agent.Context, args any) (map[string]any, error) {
 	ft := t.runnableTool
 
 	// Check for Human-in-the-Loop confirmation.

--- a/tool/tool_test.go
+++ b/tool/tool_test.go
@@ -55,7 +55,7 @@ func TestTypes(t *testing.T) {
 		{
 			name: "FunctionTool",
 			constructor: func() (tool.Tool, error) {
-				return functiontool.New(functiontool.Config{}, func(_ agent.ToolContext, input intInput) (intOutput, error) {
+				return functiontool.New(functiontool.Config{}, func(_ agent.Context, input intInput) (intOutput, error) {
 					return intOutput(input), nil
 				})
 			},
@@ -185,7 +185,7 @@ func (tts *testToolset) Tools(agent.ReadonlyContext) ([]tool.Tool, error) {
 
 func TestWithConfirmation(t *testing.T) {
 	toolRan := false
-	noOpTool, err := functiontool.New(functiontool.Config{Name: "noOpTool"}, func(ctx agent.ToolContext, input struct{}) (struct{}, error) {
+	noOpTool, err := functiontool.New(functiontool.Config{Name: "noOpTool"}, func(ctx agent.Context, input struct{}) (struct{}, error) {
 		toolRan = true
 		return struct{}{}, nil
 	})

--- a/workflow/tool_node.go
+++ b/workflow/tool_node.go
@@ -36,7 +36,7 @@ type ToolNode struct {
 
 // runnableTool is the internal interface that Node uses to invoke tools.
 type runnableTool interface {
-	Run(ctx agent.ToolContext, args any) (map[string]any, error)
+	Run(ctx agent.Context, args any) (map[string]any, error)
 }
 
 // newToolNodeWithSchemasTyped creates a new node wrapping a tool with explicitly provided schemas.
@@ -88,7 +88,7 @@ func NewToolNode(t tool.Tool, cfg NodeConfig) (*ToolNode, error) {
 	return NewToolNodeTyped[any, any](t, cfg)
 }
 
-func (n *ToolNode) runTool(toolCtx agent.ToolContext, input any) (any, error) {
+func (n *ToolNode) runTool(toolCtx agent.Context, input any) (any, error) {
 	runnable := n.tool.(runnableTool)
 	// Upstream nodes (like LLM Agents) frequently produce serialized JSON strings representing
 	// structured tool call arguments. Since ToolNodes expect structured key-value mappings (maps)

--- a/workflow/tool_node_test.go
+++ b/workflow/tool_node_test.go
@@ -39,7 +39,7 @@ func TestToolNode_New(t *testing.T) {
 	myTool, err := functiontool.New(functiontool.Config{
 		Name:        "test_tool",
 		Description: "a test tool",
-	}, func(ctx agent.ToolContext, in Input) (Output, error) {
+	}, func(ctx agent.Context, in Input) (Output, error) {
 		return Output{Result: strings.ToUpper(in.Value)}, nil
 	})
 	if err != nil {
@@ -128,7 +128,7 @@ func TestToolNode_Run(t *testing.T) {
 			tool: func() (tool.Tool, error) {
 				return functiontool.New(functiontool.Config{
 					Name: "greet",
-				}, func(ctx agent.ToolContext, in Input) (Output, error) {
+				}, func(ctx agent.Context, in Input) (Output, error) {
 					return Output{Greeting: "Hello " + in.Name}, nil
 				})
 			},
@@ -154,7 +154,7 @@ func TestToolNode_Run(t *testing.T) {
 			tool: func() (tool.Tool, error) {
 				return functiontool.New(functiontool.Config{
 					Name: "greet",
-				}, func(ctx agent.ToolContext, in Input) (string, error) {
+				}, func(ctx agent.Context, in Input) (string, error) {
 					return "HELLO " + strings.ToUpper(in.Name), nil
 				})
 			},
@@ -172,7 +172,7 @@ func TestToolNode_Run(t *testing.T) {
 			tool: func() (tool.Tool, error) {
 				return functiontool.New(functiontool.Config{
 					Name: "test_tool",
-				}, func(ctx agent.ToolContext, in map[string]any) (map[string]any, error) {
+				}, func(ctx agent.Context, in map[string]any) (map[string]any, error) {
 					return map[string]any{"result": "not-an-int"}, nil
 				})
 			},
@@ -187,7 +187,7 @@ func TestToolNode_Run(t *testing.T) {
 			tool: func() (tool.Tool, error) {
 				return functiontool.New(functiontool.Config{
 					Name: "fail_tool",
-				}, func(ctx agent.ToolContext, in Input) (*Output, error) {
+				}, func(ctx agent.Context, in Input) (*Output, error) {
 					return nil, errors.New("something went wrong")
 				})
 			},
@@ -202,7 +202,7 @@ func TestToolNode_Run(t *testing.T) {
 			tool: func() (tool.Tool, error) {
 				return functiontool.New(functiontool.Config{
 					Name: "greet",
-				}, func(ctx agent.ToolContext, in Input) (Output, error) {
+				}, func(ctx agent.Context, in Input) (Output, error) {
 					return Output{Greeting: "Hello " + in.Name}, nil
 				})
 			},
@@ -305,7 +305,7 @@ func TestToolNode_WorkflowIntegration(t *testing.T) {
 		t.Run(tc.name, func(t *testing.T) {
 			doubleTool, err := functiontool.New(functiontool.Config{
 				Name: "double",
-			}, func(ctx agent.ToolContext, in *Input) (Output, error) {
+			}, func(ctx agent.Context, in *Input) (Output, error) {
 				return Output{Result: in.Val * 2}, nil
 			})
 			if err != nil {


### PR DESCRIPTION
The context unification introduced a single unified Context, with agent.CallbackContext, agent.ToolContext and tool.Context kept as aliases to ease migration.

Migrate every consumer (~90 files) to use agent.Context directly. The three aliases remain defined (now marked Deprecated) so this change is safe to import into downstream repositories that still reference them; a follow-up removes the aliases for a clean open-source surface.
