### PR TITLE
docs: fix incorrect comment for OutputSchema field in LLMAgentConfig

### DIFF
--- a/agent/llmagent/llmagent.go
+++ b/agent/llmagent/llmagent.go
@@ -254,8 +254,9 @@ type Config struct {
 	InputSchema *genai.Schema
 	// The output schema when agent replies.
 	//
-	// NOTE: when this is set, agent can only reply and cannot use any tools,
-	// such as function tools, RAGs, agent transfer, etc.
+	// When set, the agent can still use tools (function tools, RAGs, agent transfer, etc.).
+	// The framework automatically handles structured output alongside tools via the
+	// set_model_response tool (see internal/llminternal/outputschema_processor.go).
 	OutputSchema *genai.Schema
 
 	// Callbacks are executed in the order they are provided.


### PR DESCRIPTION
The comment for `OutputSchema` in `agent/llmagent/llmagent.go` stated:

```go
// NOTE: when this is set, agent can only reply and cannot use any tools,
// such as function tools, RAGs, agent transfer, etc.
OutputSchema *genai.Schema
```

This is inaccurate. `OutputSchema` can be used together with tools when needed. The framework automatically handles this via the `set_model_response` tool workaround (see `internal/llminternal/outputschema_processor.go`).

This PR updates the comment to reflect the actual behavior.

Fixes #756