### PR TITLE
fix: run after callbacks for aggregated A2A events

### DIFF
--- a/agent/remoteagent/v2/a2a_agent.go
+++ b/agent/remoteagent/v2/a2a_agent.go
@@ -281,6 +281,14 @@ func (a *a2aAgent) run(ctx agent.InvocationContext, cfg A2AConfig) iter.Seq2[*se
 
 			if event != nil { // an event might be skipped
 				for _, toEmit := range processor.aggregatePartial(ctx, a2aEvent, event) {
+					if toEmit != event {
+						if cbResp, cbErr := processor.runAfterA2ARequestCallbacks(ctx, toEmit, nil); cbResp != nil || cbErr != nil {
+							if cbErr != nil {
+								return yieldErr(cbErr)
+							}
+							toEmit = cbResp
+						}
+					}
 					if !yield(toEmit, nil) {
 						return false
 					}

--- a/agent/remoteagent/v2/a2a_agent_test.go
+++ b/agent/remoteagent/v2/a2a_agent_test.go
@@ -735,6 +735,43 @@ func TestRemoteAgent_RequestCallbacks(t *testing.T) {
 			},
 		},
 		{
+			name: "after invoked for aggregated partial events",
+			events: func(rc *a2asrv.ExecutorContext) []a2a.Event {
+				lastChunkArtifact := a2a.NewArtifactEvent(rc, a2a.NewTextPart("Hel"))
+				lastChunk := a2a.NewArtifactUpdateEvent(rc, lastChunkArtifact.Artifact.ID, a2a.NewTextPart("lo"))
+				lastChunk.LastChunk = true
+				flushedArtifact := a2a.NewArtifactEvent(rc, a2a.NewTextPart("bye"))
+				return []a2a.Event{
+					a2a.NewSubmittedTask(rc, rc.Message),
+					lastChunkArtifact,
+					lastChunk,
+					flushedArtifact,
+					a2a.NewStatusUpdateEvent(rc, a2a.TaskStateCompleted, nil),
+				}
+			},
+			after: []AfterA2ARequestCallback{
+				func(ctx agent.CallbackContext, req *a2a.SendMessageRequest, result *session.Event, err error) (*session.Event, error) {
+					if result == nil {
+						return nil, nil
+					}
+					result.CustomMetadata = nil
+					if result.Content == nil || result.Partial || result.TurnComplete {
+						return nil, nil
+					}
+					result.Content = genai.NewContentFromText(result.Content.Parts[0].Text+"!", genai.RoleModel)
+					return nil, nil
+				},
+			},
+			wantResponses: []model.LLMResponse{
+				{Content: genai.NewContentFromText("Hel", genai.RoleModel), Partial: true},
+				{Content: genai.NewContentFromText("lo", genai.RoleModel), Partial: true},
+				{Content: genai.NewContentFromText("Hello!", genai.RoleModel)},
+				{Content: genai.NewContentFromText("bye", genai.RoleModel), Partial: true},
+				{Content: genai.NewContentFromText("bye!", genai.RoleModel)},
+				{TurnComplete: true},
+			},
+		},
+		{
 			name: "after error stops the run",
 			events: func(rc *a2asrv.ExecutorContext) []a2a.Event {
 				finalEvent := a2a.NewStatusUpdateEvent(rc, a2a.TaskStateCompleted, nil)


### PR DESCRIPTION
## Summary
- Run after-request callbacks for synthetic events emitted by partial artifact aggregation.
- Avoid invoking callbacks twice for the original converted event.
- Add regression coverage for LastChunk and terminal flush aggregation paths.

Fixes #948

## Tests
- go test ./agent/remoteagent/v2 -run 'TestRemoteAgent_RequestCallbacks/after_invoked_for_aggregated_partial_events' -count=1
- go test ./agent/remoteagent/v2 -count=1
- go test ./agent/remoteagent/... -p 1 -count=1
- git diff --check