### PR TITLE
fix: align skill tool instruction with schema

### DIFF
--- a/tool/skilltoolset/toolset.go
+++ b/tool/skilltoolset/toolset.go
@@ -39,7 +39,7 @@ Skills are folders of instructions and resources that extend your capabilities f
 This is very important:
 
 ` +
-		"1. If a skill seems relevant to the current user query, you MUST use the `load_skill` tool with `skill_name=\"<SKILL_NAME>\"` to read its full instructions before proceeding.\n" +
+		"1. If a skill seems relevant to the current user query, you MUST use the `load_skill` tool with `name=\"<SKILL_NAME>\"` to read its full instructions before proceeding.\n" +
 		"2. Once you have read the instructions, follow them exactly as documented before replying to the user. For example, If the instruction lists multiple steps, please make sure you complete all of them in order.\n" +
 		"3. The `load_skill_resource` tool is for viewing files within a skill's directory (e.g., `references/*`, `assets/*`, `scripts/*`). Do NOT use other tools to access these files.\n"
 )

--- a/tool/skilltoolset/toolset_test.go
+++ b/tool/skilltoolset/toolset_test.go
@@ -79,6 +79,12 @@ func TestProcessRequest(t *testing.T) {
 			t.Errorf("ProcessRequest: got %q, want to contain %q", gotText, want)
 		}
 	}
+	if !strings.Contains(gotText, "`load_skill` tool with `name=\"<SKILL_NAME>\"`") {
+		t.Errorf("ProcessRequest: default instruction should document load_skill name parameter, got %q", gotText)
+	}
+	if strings.Contains(gotText, "`load_skill` tool with `skill_name=\"<SKILL_NAME>\"`") {
+		t.Errorf("ProcessRequest: default instruction documents unsupported load_skill skill_name parameter")
+	}
 }
 
 func TestProcessRequest_NoSkills(t *testing.T) {


### PR DESCRIPTION
## Summary
- Update the default skill toolset instruction to call load_skill with name="<SKILL_NAME>".
- Add coverage that the generated system instruction matches the load_skill schema and no longer documents skill_name for that tool.

Fixes #912

## Tests
- go test ./tool/skilltoolset -run TestProcessRequest -count=1
- go test ./tool/skilltoolset -count=1
- go test ./tool/... -count=1
- git diff --check