### PR TITLE
fix(workflow): restore single_turn delegation after context unification

### DIFF
--- a/agent/common_context.go
+++ b/agent/common_context.go
@@ -172,8 +172,32 @@ type commonContext struct {
 	outputForAncestors []string
 }
 
+// subSchedulerKey keys the sub-scheduler in the embedded context value
+// chain, so it survives re-wrapping that drops the struct field.
+type subSchedulerKey struct{}
+
+// WithSubScheduler stashes sub in ctx's value chain for SubScheduler()
+// to recover after re-wrapping. Returns ctx unchanged if sub is nil.
+func WithSubScheduler(ctx context.Context, sub DynamicSubScheduler) context.Context {
+	if sub == nil {
+		return ctx
+	}
+	return context.WithValue(ctx, subSchedulerKey{}, sub)
+}
+
+// SubScheduler returns the sub-scheduler RunNode uses to schedule
+// children, or nil outside a dynamic-node activation. The struct field
+// is the fast path for a freshly built dynamic-node context (and takes
+// precedence); the embedded context value is the fallback that survives
+// context re-wrapping by agents and the LLM flow.
 func (c *commonContext) SubScheduler() DynamicSubScheduler {
-	return c.subScheduler
+	if c.subScheduler != nil {
+		return c.subScheduler
+	}
+	if sub, ok := c.Value(subSchedulerKey{}).(DynamicSubScheduler); ok {
+		return sub
+	}
+	return nil
 }
 
 // Path implements [Context].

--- a/agent/llmagent/llm_agent_wrapper.go
+++ b/agent/llmagent/llm_agent_wrapper.go
@@ -84,6 +84,13 @@ func RunLLMAgentAsNode(a agent.Agent, ctx agent.Context, nodeInput any) iter.Seq
 			state.IncludeContents = "none"
 		}
 
+		// Carry the node's sub-scheduler in the value chain so it
+		// survives the context re-wrapping below (and inside Agent.Run),
+		// letting a tool delegate via RunNode (e.g. SingleTurnTool).
+		if sub := ctx.SubScheduler(); sub != nil {
+			ctx = ctx.WithAgentContext(agent.WithSubScheduler(ctx, sub))
+		}
+
 		if seed := PrepareLLMAgentInput(a, ctx, nodeInput); seed != nil {
 			if !yield(seed, nil) {
 				return

--- a/internal/workflowinternal/single_turn_tool.go
+++ b/internal/workflowinternal/single_turn_tool.go
@@ -71,11 +71,6 @@ func (t *SingleTurnTool) Run(toolCtx agent.Context, args any) (map[string]any, e
 		nodeInput = margs["request"]
 	}
 
-	// nc, ok := workflow.NodeContextFromGoContext(toolCtx)
-	// if !ok {
-	// 	return nil, fmt.Errorf("failed to infer node context")
-	// }
-
 	node, err := workflow.NewAgentNode(t.agent, workflow.NodeConfig{})
 	if err != nil {
 		return nil, fmt.Errorf("failed to create agent node: %w", err)

--- a/internal/workflowinternal/single_turn_tool_test.go
+++ b/internal/workflowinternal/single_turn_tool_test.go
@@ -27,6 +27,7 @@ import (
 
 	"google.golang.org/adk/agent"
 	"google.golang.org/adk/agent/llmagent"
+	icontext "google.golang.org/adk/internal/context"
 	"google.golang.org/adk/internal/utils"
 	"google.golang.org/adk/internal/workflowinternal"
 	"google.golang.org/adk/model"
@@ -260,6 +261,87 @@ func TestSingleTurnTool_Run_HappyPath(t *testing.T) {
 	want := map[string]any{"result": wantOutput}
 	if diff := cmp.Diff(want, gotResult); diff != "" {
 		t.Errorf("SingleTurnTool.Run result diff (-want +got):\n%s", diff)
+	}
+}
+
+// TestSingleTurnTool_Run_SurvivesContextRewrap runs the tool inside a
+// node body that re-wraps the context before handing it to the agent, as
+// the runner's agent-node wrapper does. It checks the sub-scheduler
+// survives the re-wrap (so RunNode works) and that the sub-agent's output
+// reaches the node's event stream.
+func TestSingleTurnTool_Run_SurvivesContextRewrap(t *testing.T) {
+	const wantOutput = "world"
+
+	sub, err := agent.New(agent.Config{
+		Name:        "echo_agent",
+		Description: "Yields a single fixed-output event.",
+		Run: func(_ agent.InvocationContext) iter.Seq2[*session.Event, error] {
+			return func(yield func(*session.Event, error) bool) {
+				yield(&session.Event{Output: wantOutput}, nil)
+			}
+		},
+	})
+	if err != nil {
+		t.Fatalf("agent.New(sub): %v", err)
+	}
+	st := newSingleTurnTool(t, sub)
+
+	var (
+		gotResult map[string]any
+		gotErr    error
+	)
+	// Body mirrors runner.runAgentNodeBody: re-wrap ctx, then re-stash
+	// the sub-scheduler in the value chain before building the tool context.
+	orchestrator := workflow.NewDynamicNode("orchestrator",
+		func(ctx workflow.NodeContext, _ string, _ func(*session.Event) error) (any, error) {
+			agentCtx := icontext.NewInvocationContext(ctx, icontext.InvocationContextParams{
+				Session:      ctx.Session(),
+				InvocationID: ctx.InvocationID(),
+			})
+			if s := ctx.SubScheduler(); s != nil {
+				agentCtx = agentCtx.WithContext(agent.WithSubScheduler(agentCtx, s))
+			}
+			toolCtx := agent.NewToolContext(agentCtx, "fc-id", &session.EventActions{}, nil)
+			gotResult, gotErr = st.Run(toolCtx, map[string]any{"request": "hello"})
+			return nil, gotErr
+		},
+		workflow.NodeConfig{},
+	)
+
+	w, err := workflow.New("root", workflow.Chain(workflow.Start, orchestrator))
+	if err != nil {
+		t.Fatalf("workflow.New: %v", err)
+	}
+
+	sessResp, err := session.InMemoryService().Create(t.Context(), &session.CreateRequest{
+		AppName:   "test_app",
+		UserID:    "test_user",
+		SessionID: "test_session",
+	})
+	if err != nil {
+		t.Fatalf("session.Create: %v", err)
+	}
+
+	ic := &fakeInvocationContext{Context: t.Context(), sess: sessResp.Session}
+	var sawSubOutput bool
+	for ev, err := range w.Run(ic) {
+		if err != nil {
+			t.Fatalf("workflow.Run error: %v", err)
+		}
+		if ev != nil && ev.Output == wantOutput {
+			sawSubOutput = true
+		}
+	}
+
+	if gotErr != nil {
+		t.Fatalf("SingleTurnTool.Run err = %v, want nil", gotErr)
+	}
+	want := map[string]any{"result": wantOutput}
+	if diff := cmp.Diff(want, gotResult); diff != "" {
+		t.Errorf("SingleTurnTool.Run result diff (-want +got):\n%s", diff)
+	}
+	if !sawSubOutput {
+		t.Errorf("sub-agent output %q did not reach the session events", wantOutput)
 	}
 }
 

--- a/runner/agent_node.go
+++ b/runner/agent_node.go
@@ -190,9 +190,12 @@ func answeredOpenInterrupts(sess session.Session) map[string]bool {
 }
 
 // newAgentContext builds the per-agent InvocationContext, inheriting
-// services and branch from ctx (mirrors workflow.AgentNode).
-func newAgentContext(ctx agent.InvocationContext, a agent.Agent, userContent *genai.Content) agent.InvocationContext {
-	return icontext.NewInvocationContext(ctx, icontext.InvocationContextParams{
+// services and branch from ctx (mirrors workflow.AgentNode). The fresh
+// context drops the node's sub-scheduler, so it is re-stashed in the
+// value chain — letting a tool inside the agent (e.g. SingleTurnTool)
+// recover it via RunNode.
+func newAgentContext(ctx agent.Context, a agent.Agent, userContent *genai.Content) agent.InvocationContext {
+	agentCtx := icontext.NewInvocationContext(ctx, icontext.InvocationContextParams{
 		Artifacts:     ctx.Artifacts(),
 		Memory:        ctx.Memory(),
 		Session:       ctx.Session(),
@@ -203,6 +206,10 @@ func newAgentContext(ctx agent.InvocationContext, a agent.Agent, userContent *ge
 		EndInvocation: ctx.Ended(),
 		InvocationID:  ctx.InvocationID(),
 	})
+	if sub := ctx.SubScheduler(); sub != nil {
+		agentCtx = agentCtx.WithContext(agent.WithSubScheduler(agentCtx, sub))
+	}
+	return agentCtx
 }
 
 // inputToUserContent converts a node input value into a user Content for

--- a/workflow/run_node.go
+++ b/workflow/run_node.go
@@ -113,6 +113,9 @@ func RunNode[OUT any](ctx agent.Context, child Node, input any, opts ...RunNodeO
 	var zero OUT
 
 	ss := ctx.SubScheduler()
+	if ss == nil {
+		return zero, ErrInvalidRunNodeContext
+	}
 
 	var o runNodeOptions
 	for _, opt := range opts {


### PR DESCRIPTION
## Problem
After the context unification (#1008/#1004), `SingleTurnTool` panicked with a
nil-pointer dereference when an LlmAgent delegated to a `single_turn` sub-agent:
```
panic: runtime error: invalid memory address or nil pointer dereference
  workflow.RunNode[...] run_node.go
  internal/workflowinternal.(*SingleTurnTool).Run single_turn_tool.go
```
`RunNode` schedules the child via `ctx.SubScheduler()`, which is only non-nil on
a freshly built dynamic-node context. The sub-scheduler is carried on a struct
field, so it is **dropped** every time the context is re-wrapped before the agent
runs — in the runner's agent-node body and again inside the llmagent wrapper.
By the time the tool was invoked, `SubScheduler()` returned nil and `RunNode`
dereferenced it.
## Solution
Stash the sub-scheduler in the embedded `context.Context` value chain so it
survives re-wrapping (values on `context.Context` propagate through every
re-wrap automatically), and recover it in `Context.SubScheduler()` when the
struct field is absent. This mirrors how adk-python keeps its shared run-node
machinery alive across context boundaries.
- `agent.WithSubScheduler` + `Context.SubScheduler()` fallback to the value
  chain (struct field still takes precedence, so a child sees its own scheduler).
- The llmagent wrapper and the runner's generic agent body re-stash it before
  running the agent.
- `RunNode` now returns `ErrInvalidRunNodeContext` instead of panicking on a
  nil sub-scheduler.
Adds `TestSingleTurnTool_Run_SurvivesContextRewrap`, which reproduces the real
invocation path (context re-wrapped before the tool runs) and fails without the
fix with the exact production error.