### PR TITLE
fix(llm): use set_model_response workaround for output schema + tools on Gemini API

### DIFF
--- a/internal/llminternal/googlellm/variant.go
+++ b/internal/llminternal/googlellm/variant.go
@@ -46,7 +46,6 @@ func IsGeminiModel(model string) bool {
 }
 
 // IsGemini25OrLower returns true if the model is a Gemini 2.5 or less.
-// These models do not support output schema with tools natively, so we need to use a processor to handle it.
 func IsGemini25OrLower(model string) bool {
 	model = extractModelName(model)
 	// extract the model version from model name - e.g. turn gemini-2.5-flash or gemini-2.5-flash-lite into 2.5
@@ -61,18 +60,48 @@ func IsGemini25OrLower(model string) bool {
 	return version <= 2.5
 }
 
+// IsGemini2OrAbove returns true for Gemini 2.0+ models.
+func IsGemini2OrAbove(model string) bool {
+	matches := geminiModelVersionRegex.FindStringSubmatch(extractModelName(model))
+	if len(matches) < 2 {
+		return false
+	}
+	version, err := strconv.ParseFloat(matches[1], 64)
+	if err != nil {
+		return false
+	}
+	return version >= 2.0
+}
+
+// CanUseOutputSchemaWithTools returns true if the model supports an output
+// schema together with tools natively. Mirrors adk-python's
+// can_use_output_schema_with_tools: only Vertex AI for Gemini 2.0+. The
+// Gemini API does not support the combination, so callers must fall back
+// to the set_model_response tool workaround there.
+func CanUseOutputSchemaWithTools(llm model.LLM) bool {
+	if llm == nil {
+		return false
+	}
+	return IsGeminiModel(llm.Name()) &&
+		GetGoogleLLMVariant(llm) == genai.BackendVertexAI &&
+		IsGemini2OrAbove(llm.Name())
+}
+
 // IsGeminiAPIVariant returns true if the model is a Gemini API model (not Vertex AI).
 func IsGeminiAPIVariant(llm model.LLM) bool {
 	return GetGoogleLLMVariant(llm) == genai.BackendGeminiAPI
 }
 
-// NeedsOutputSchemaProcessor returns true if the Gemini model doesn't support output schema with tools natively and requires a processor to handle it.
-// Only Gemini 2.5 models and lower and only in Gemini API don't support natively, so we enable the processor for them.
+// NeedsOutputSchemaProcessor returns true if the Gemini model doesn't
+// support output schema with tools natively and requires the
+// set_model_response tool workaround. Native support is Vertex AI only
+// (Gemini 2.0+); the Gemini API never supports the combination, so every
+// Gemini-API model needs the processor.
 func NeedsOutputSchemaProcessor(llm model.LLM) bool {
 	if llm == nil {
 		return false
 	}
-	return IsGeminiModel(llm.Name()) && IsGeminiAPIVariant(llm) && IsGemini25OrLower(llm.Name())
+	return IsGeminiModel(llm.Name()) && !CanUseOutputSchemaWithTools(llm)
 }
 
 func extractModelName(model string) string {

--- a/internal/llminternal/googlellm/variant_test.go
+++ b/internal/llminternal/googlellm/variant_test.go
@@ -76,10 +76,15 @@ func TestNeedsOutputSchemaProcessor(t *testing.T) {
 		{"Gemini2.0_Vertex", "gemini-2.0-flash", genai.BackendVertexAI, false},
 		{"Gemini2.0_GeminiAPI", "gemini-2.0-flash", genai.BackendGeminiAPI, true},
 		{"NonGemini_Vertex", "not-a-gemini", genai.BackendVertexAI, false},
-		{"Gemini3.0_GeminiAPI", "gemini-3.0", genai.BackendGeminiAPI, false},
+		// Gemini API never supports output schema + tools natively, so the
+		// processor is required regardless of version.
+		{"Gemini3.0_GeminiAPI", "gemini-3.0", genai.BackendGeminiAPI, true},
 		{"Gemini3.0_Vertex", "gemini-3.0", genai.BackendVertexAI, false},
-		{"CustomGemini2", "gemini-2.0-hack", genai.BackendUnspecified, false},
-		{"CustomGemini3", "gemini-3.0-hack", genai.BackendUnspecified, false},
+		// Non-Vertex backends (incl. unspecified) need the processor too.
+		{"CustomGemini2", "gemini-2.0-hack", genai.BackendUnspecified, true},
+		{"CustomGemini3", "gemini-3.0-hack", genai.BackendUnspecified, true},
+		// Gemini 1.x on Vertex predates native combo support → processor.
+		{"Gemini1.5_Vertex", "gemini-1.5-pro", genai.BackendVertexAI, true},
 	}
 
 	for _, tc := range testCases {
@@ -90,6 +95,34 @@ func TestNeedsOutputSchemaProcessor(t *testing.T) {
 			})
 			if got != tc.want {
 				t.Errorf("NeedsOutputSchemaProcessor(%q) = %v, want %v", tc.model, got, tc.want)
+			}
+		})
+	}
+}
+
+func TestCanUseOutputSchemaWithTools(t *testing.T) {
+	testCases := []struct {
+		name    string
+		model   string
+		variant genai.Backend
+		want    bool
+	}{
+		{"Gemini2.0_Vertex", "gemini-2.0-flash", genai.BackendVertexAI, true},
+		{"Gemini3.0_Vertex", "gemini-3.0", genai.BackendVertexAI, true},
+		{"Gemini1.5_Vertex", "gemini-1.5-pro", genai.BackendVertexAI, false},
+		{"Gemini3.0_GeminiAPI", "gemini-3.0", genai.BackendGeminiAPI, false},
+		{"Gemini2.0_GeminiAPI", "gemini-2.0-flash", genai.BackendGeminiAPI, false},
+		{"NonGemini_Vertex", "not-a-gemini", genai.BackendVertexAI, false},
+	}
+
+	for _, tc := range testCases {
+		t.Run(tc.name, func(t *testing.T) {
+			got := CanUseOutputSchemaWithTools(&mockGoogleLLM{
+				variant: tc.variant,
+				nameVal: tc.model,
+			})
+			if got != tc.want {
+				t.Errorf("CanUseOutputSchemaWithTools(%q) = %v, want %v", tc.model, got, tc.want)
 			}
 		})
 	}


### PR DESCRIPTION
## Problem
An agent configured with **both** an `OutputSchema` and tools was sent a request
with native JSON output (`ResponseMIMEType` + `ResponseSchema`) **and** tool
declarations at the same time on the Gemini API — a combination Gemini does not
support. The model never produced a final response, causing an infinite loop
(e.g. a `single_turn` sub-agent that has a tool emits hundreds of non-final
events and never terminates).
The gate keyed on "Gemini 2.5 or lower" (`IsGemini25OrLower`) instead of the
backend variant, so Gemini 3.x on the Gemini API wrongly skipped the
`set_model_response` workaround and went down the unsupported native path.

## Solution
Gate on whether the model can use output schema together with tools **natively**,
mirroring adk-python's `can_use_output_schema_with_tools`:
- `CanUseOutputSchemaWithTools` → true only on **Vertex AI** for **Gemini 2.0+**.
- `NeedsOutputSchemaProcessor` = `IsGeminiModel && !CanUseOutputSchemaWithTools`,
  so every Gemini API model (any version) and pre-2.0 / non-Vertex models use the
  `set_model_response` tool workaround instead of the unsupported native combo.


Mirrors `can_use_output_schema_with_tools` from adk python.