### PR TITLE
fix(adkrest): accept functionCallEventId in run requests

### DIFF
--- a/server/adkrest/controllers/runtime_test.go
+++ b/server/adkrest/controllers/runtime_test.go
@@ -91,6 +91,32 @@ func TestNewRuntimeAPIController_PluginsAssignment(t *testing.T) {
 	}
 }
 
+func TestDecodeRequestBodyAcceptsFunctionCallEventID(t *testing.T) {
+	body := []byte(`{
+		"appName": "testApp",
+		"userId": "testUser",
+		"sessionId": "testSession",
+		"newMessage": {
+			"role": "user",
+			"parts": [{"functionResponse": {
+				"id": "call-1",
+				"name": "adk_request_confirmation",
+				"response": {"confirmed": true}
+			}}]
+		},
+		"functionCallEventId": "event-123"
+	}`)
+	req := httptest.NewRequest(http.MethodPost, "/run_sse", bytes.NewReader(body))
+
+	got, err := decodeRequestBody(req)
+	if err != nil {
+		t.Fatalf("decodeRequestBody rejected functionCallEventId: %v", err)
+	}
+	if got.FunctionCallEventId != "event-123" {
+		t.Fatalf("FunctionCallEventId = %q, want %q", got.FunctionCallEventId, "event-123")
+	}
+}
+
 type recorderWithDeadline struct {
 	*httptest.ResponseRecorder
 }

--- a/server/adkrest/internal/models/runtime.go
+++ b/server/adkrest/internal/models/runtime.go
@@ -32,6 +32,10 @@ type RunAgentRequest struct {
 	Streaming bool `json:"streaming,omitempty"`
 
 	StateDelta *map[string]any `json:"stateDelta,omitempty"`
+
+	// FunctionCallEventId is sent by the bundled dev-ui when resuming a
+	// long-running function call (e.g. confirmation or OAuth flows).
+	FunctionCallEventId string `json:"functionCallEventId,omitempty"`
 }
 
 // AssertRunAgentRequestRequired checks if the required fields are not zero-ed


### PR DESCRIPTION
## Summary
- Add `FunctionCallEventId` to `RunAgentRequest` so the REST decoder accepts the field sent by the bundled dev-ui when resuming long-running function calls
- Keeps `DisallowUnknownFields()` strict for all other keys
- Regression test covers the dev-ui confirmation payload shape

Fixes #941

## Test plan
- [x] `go test ./server/adkrest/controllers/... -count=1`
- [ ] Manual: trigger `RequireConfirmation: true` tool in dev-ui and confirm the flow completes without HTTP 400

/cc @indurireddy-TF @st699pic