### PR TITLE
fix(skilltoolset): align load_skill instruction with schema

### DIFF
--- a/tool/skilltoolset/toolset.go
+++ b/tool/skilltoolset/toolset.go
@@ -39,9 +39,9 @@ Skills are folders of instructions and resources that extend your capabilities f
 This is very important:
 
 ` +
-		"1. If a skill seems relevant to the current user query, you MUST use the `load_skill` tool with `skill_name=\"<SKILL_NAME>\"` to read its full instructions before proceeding.\n" +
+		"1. If a skill seems relevant to the current user query, you MUST use the `load_skill` tool with `name=\"<SKILL_NAME>\"` to read its full instructions before proceeding.\n" +
 		"2. Once you have read the instructions, follow them exactly as documented before replying to the user. For example, If the instruction lists multiple steps, please make sure you complete all of them in order.\n" +
-		"3. The `load_skill_resource` tool is for viewing files within a skill's directory (e.g., `references/*`, `assets/*`, `scripts/*`). Do NOT use other tools to access these files.\n"
+		"3. Use the `load_skill_resource` tool with `skill_name=\"<SKILL_NAME>\"` and `resource_path=\"<PATH>\"` to view files within a skill's directory (e.g., `references/*`, `assets/*`, `scripts/*`). Do NOT use other tools to access these files.\n"
 )
 
 // Config holds the configuration for creating a Skill Toolset.

--- a/tool/skilltoolset/toolset_test.go
+++ b/tool/skilltoolset/toolset_test.go
@@ -79,6 +79,15 @@ func TestProcessRequest(t *testing.T) {
 			t.Errorf("ProcessRequest: got %q, want to contain %q", gotText, want)
 		}
 	}
+	if !strings.Contains(gotText, "`load_skill` tool with `name=\"<SKILL_NAME>\"`") {
+		t.Errorf("ProcessRequest: load_skill instruction should document name= param, got %q", gotText)
+	}
+	if strings.Contains(gotText, "`load_skill` tool with `skill_name=") {
+		t.Errorf("ProcessRequest: load_skill instruction must not document skill_name= param, got %q", gotText)
+	}
+	if !strings.Contains(gotText, "`load_skill_resource` tool with `skill_name=\"<SKILL_NAME>\"` and `resource_path=\"<PATH>\"`") {
+		t.Errorf("ProcessRequest: load_skill_resource instruction should document skill_name= and resource_path=, got %q", gotText)
+	}
 }
 
 func TestProcessRequest_NoSkills(t *testing.T) {


### PR DESCRIPTION
## Summary
- Fix the default `SkillToolset` system instruction to call `load_skill` with `name="<SKILL_NAME>"` instead of the incorrect `skill_name=`
- Document `load_skill_resource` parameters explicitly (`skill_name` + `resource_path`) so both tools' argument names are clear

Fixes #912

## Test plan
- [x] `go test ./tool/skilltoolset/... -count=1`
- [ ] Manual: agent with skills loads a skill on first attempt without schema validation retry

/cc @indurireddy-TF