### PR TITLE
fix(adka2a): align input-required A2A responses with adk-python

### DIFF
--- a/server/adka2a/v2/executor.go
+++ b/server/adka2a/v2/executor.go
@@ -383,7 +383,8 @@ func (e *Executor) writeFinalTaskStatus(
 			return
 		}
 	}
-	if partialReset != nil {
+	// Do not send artifacts for input-required tasks to maintain compatibility with adk-python/adk-web.
+	if partialReset != nil && status.Status.State != a2a.TaskStateInputRequired {
 		if !yield(partialReset, nil) {
 			return
 		}

--- a/server/adka2a/v2/input_required.go
+++ b/server/adka2a/v2/input_required.go
@@ -91,6 +91,26 @@ func (p *inputRequiredProcessor) process(ctx context.Context, event *session.Eve
 			ev := a2a.NewStatusUpdateEvent(p.reqCtx, a2a.TaskStateInputRequired, msg)
 			p.event = ev
 		}
+
+		// For input-required tasks, include remaining parts (like text messages) in the status
+		// message instead of sending them as artifacts, to maintain compatibility with adk-python/adk-web.
+		if len(remainingParts) > 0 {
+			remainingA2AParts, err := p.convertParts(ctx, event, remainingParts, nil)
+			if err != nil {
+				return nil, fmt.Errorf("failed to convert remaining parts to A2A parts: %w", err)
+			}
+			p.event.Status.Message.Parts = append(p.event.Status.Message.Parts, remainingA2AParts...)
+			remainingParts = nil
+		}
+	} else if p.event != nil && len(remainingParts) > 0 {
+		// If we've already created an input-required event, add subsequent parts to it instead of
+		// sending them as artifacts, to maintain compatibility with adk-python/adk-web.
+		remainingA2AParts, err := p.convertParts(ctx, event, remainingParts, nil)
+		if err != nil {
+			return nil, fmt.Errorf("failed to convert parts to A2A parts: %w", err)
+		}
+		p.event.Status.Message.Parts = append(p.event.Status.Message.Parts, remainingA2AParts...)
+		remainingParts = nil
 	}
 
 	if len(remainingParts) == len(resp.Content.Parts) {

--- a/server/adka2a/v2/processor_test.go
+++ b/server/adka2a/v2/processor_test.go
@@ -235,9 +235,7 @@ func TestEventProcessor_Process(t *testing.T) {
 					LLMResponse: modelResponseFromParts(genai.NewPartFromText("This will take a while")),
 				},
 			},
-			processed: []*a2a.TaskArtifactUpdateEvent{
-				newNonPartialArtifactEvent(task, a2a.NewTextPart("This will take a while")),
-			},
+			processed: nil,
 
 			terminal: []a2a.Event{
 				newFinalStatusUpdate(task, a2a.TaskStateInputRequired, &a2a.Message{
@@ -249,6 +247,7 @@ func TestEventProcessor_Process(t *testing.T) {
 							p.SetMeta(a2aDataPartMetaLongRunningKey, true)
 							return p
 						}(),
+						a2a.NewTextPart("This will take a while"),
 					},
 				}),
 			},


### PR DESCRIPTION
## Summary
- For `input-required` tasks, keep accompanying text in `status.message` instead of emitting separate artifacts (matches adk-python / adk-web format)
- Skip partial artifact reset events on the final input-required status update so clients do not see an `artifacts` section that triggers `mock_function_call_for_required_user_input` in adk-python

Fixes #913

## Test plan
- [x] `go test ./server/adka2a/v2/... -count=1`
- [ ] Manual: adk-python `RemoteA2aAgent` against adk-go HITL agent; confirm no mock function call and confirmation flow works

/cc @anishesg