### PR TITLE
fix(remoteagent/v2): run AfterA2ARequestCallbacks on aggregated events

### DIFF
--- a/agent/remoteagent/v2/a2a_agent.go
+++ b/agent/remoteagent/v2/a2a_agent.go
@@ -281,6 +281,17 @@ func (a *a2aAgent) run(ctx agent.InvocationContext, cfg A2AConfig) iter.Seq2[*se
 
 			if event != nil { // an event might be skipped
 				for _, toEmit := range processor.aggregatePartial(ctx, a2aEvent, event) {
+					// aggregatePartial may synthesize new events (e.g. aggregated non-partial
+					// artifact events). Run callbacks on those; the original event already went
+					// through callbacks above.
+					if toEmit != event {
+						if cbResp, cbErr := processor.runAfterA2ARequestCallbacks(ctx, toEmit, nil); cbResp != nil || cbErr != nil {
+							if cbErr != nil {
+								return yieldErr(cbErr)
+							}
+							toEmit = cbResp
+						}
+					}
 					if !yield(toEmit, nil) {
 						return false
 					}

--- a/agent/remoteagent/v2/a2a_agent_test.go
+++ b/agent/remoteagent/v2/a2a_agent_test.go
@@ -1435,3 +1435,64 @@ func TestRemoteAgent_PartConverter(t *testing.T) {
 		}
 	}
 }
+
+func TestRemoteAgent_AfterCallbackInvokedOnAggregatedEvent(t *testing.T) {
+	var cbInvocations int
+	var sawNonPartialContent []string
+
+	executor := &mockA2AExecutor{
+		executeFn: func(ctx context.Context, execCtx *a2asrv.ExecutorContext) iter.Seq2[a2a.Event, error] {
+			return func(yield func(a2a.Event, error) bool) {
+				artifactEvent := a2a.NewArtifactEvent(execCtx, a2a.NewTextPart("Hel"))
+				for _, ev := range []a2a.Event{
+					a2a.NewSubmittedTask(execCtx, a2a.NewMessage(a2a.MessageRoleUser, a2a.NewTextPart("hi"))),
+					artifactEvent,
+					a2a.NewArtifactUpdateEvent(execCtx, artifactEvent.Artifact.ID, a2a.NewTextPart("lo")),
+					a2a.NewStatusUpdateEvent(execCtx, a2a.TaskStateCompleted, nil),
+				} {
+					if !yield(ev, nil) {
+						return
+					}
+				}
+			}
+		},
+	}
+
+	server := startA2AServer(executor)
+	card := &a2a.AgentCard{
+		SupportedInterfaces: []*a2a.AgentInterface{
+			a2a.NewAgentInterface(server.URL, a2a.TransportProtocolJSONRPC),
+		},
+		Capabilities: a2a.AgentCapabilities{Streaming: true},
+	}
+	remoteAgent, err := NewA2A(A2AConfig{
+		Name:      "a2a",
+		AgentCard: card,
+		AfterRequestCallbacks: []AfterA2ARequestCallback{
+			func(ctx agent.CallbackContext, req *a2a.SendMessageRequest, result *session.Event, err error) (*session.Event, error) {
+				cbInvocations++
+				if !result.Partial && !result.TurnComplete && result.Content != nil {
+					for _, p := range result.Content.Parts {
+						sawNonPartialContent = append(sawNonPartialContent, p.Text)
+					}
+				}
+				return nil, nil
+			},
+		},
+	})
+	if err != nil {
+		t.Fatalf("remoteagent.NewA2A() error = %v", err)
+	}
+
+	ictx := newInvocationContext(t, []*session.Event{newUserHello()})
+	if _, err = runAndCollect(ictx, remoteAgent); err != nil {
+		t.Fatalf("agent.Run() error = %v", err)
+	}
+
+	if cbInvocations != 4 {
+		t.Errorf("callback invoked %d times, want 4", cbInvocations)
+	}
+	if diff := cmp.Diff([]string{"Hello"}, sawNonPartialContent); diff != "" {
+		t.Errorf("non-partial content seen by callback (-want +got):\n%s", diff)
+	}
+}


### PR DESCRIPTION
## Summary
- Route events synthesized by `aggregatePartial` (non-partial reassembled artifact events) through `AfterA2ARequestCallbacks` before yielding them to callers
- Covers both the last-chunk aggregation path and the terminal-status flush path
- Add regression test verifying callbacks observe the aggregated `"Hello"` content

Fixes #948

## Test plan
- [x] `go test ./agent/remoteagent/v2/... -count=1`
- [ ] Manual: register an after-request callback that strips large inline artifact bytes; verify chunked artifacts are transformed before persistence

/cc @abhinav-1504