### PR TITLE
feat: add WithRaiseOnWait option

### DIFF
--- a/agent/llmagent/llm_agent_wrapper.go
+++ b/agent/llmagent/llm_agent_wrapper.go
@@ -403,17 +403,6 @@ func dispatchTaskFC(parentAgent agent.Agent, fc *genai.FunctionCall, ctx workflo
 	if err != nil {
 		return nil, fmt.Errorf("dispatchTaskFC: build node for %q: %w", fc.Name, err)
 	}
-	// WithRaiseOnWait: when the task sub-agent emits a long-running
-	// tool call (e.g. ctx.RequestConfirmation) and finishes its
-	// iteration without producing a matching FunctionResponse, treat
-	// it as an interruption rather than a clean completion. The
-	// caller (runChat's dispatchAndYield) catches ErrNodeInterrupted
-	// and skips synthesising the delegation-closing FR — leaving the
-	// delegation unresolved so the next user turn re-dispatches into
-	// the same scope, where the request_confirmation processor will
-	// see the user's reply and resume the tool. Mirrors adk-python's
-	// ctx.run_node(raise_on_wait=True) at
-	// src/google/adk/workflow/_llm_agent_wrapper.py:159.
 	out, err := workflow.RunNode[any](ctx, node, fc.Args,
 		workflow.WithRunID(fc.ID),
 		workflow.WithIsolationScope(fc.ID),

--- a/agent/llmagent/llm_agent_wrapper.go
+++ b/agent/llmagent/llm_agent_wrapper.go
@@ -41,6 +41,7 @@ package llmagent
 
 import (
 	"encoding/json"
+	"errors"
 	"fmt"
 	"iter"
 	"maps"
@@ -402,9 +403,21 @@ func dispatchTaskFC(parentAgent agent.Agent, fc *genai.FunctionCall, ctx workflo
 	if err != nil {
 		return nil, fmt.Errorf("dispatchTaskFC: build node for %q: %w", fc.Name, err)
 	}
+	// WithRaiseOnWait: when the task sub-agent emits a long-running
+	// tool call (e.g. ctx.RequestConfirmation) and finishes its
+	// iteration without producing a matching FunctionResponse, treat
+	// it as an interruption rather than a clean completion. The
+	// caller (runChat's dispatchAndYield) catches ErrNodeInterrupted
+	// and skips synthesising the delegation-closing FR — leaving the
+	// delegation unresolved so the next user turn re-dispatches into
+	// the same scope, where the request_confirmation processor will
+	// see the user's reply and resume the tool. Mirrors adk-python's
+	// ctx.run_node(raise_on_wait=True) at
+	// src/google/adk/workflow/_llm_agent_wrapper.py:159.
 	out, err := workflow.RunNode[any](ctx, node, fc.Args,
 		workflow.WithRunID(fc.ID),
 		workflow.WithIsolationScope(fc.ID),
+		workflow.WithRaiseOnWait(),
 	)
 	if err != nil {
 		return nil, err
@@ -495,16 +508,61 @@ func runChat(a agent.Agent, ctx agent.Context, yield func(*session.Event, error)
 	dispatchAndYield := func(fc *genai.FunctionCall) (ok bool) {
 		out, err := dispatchTaskFC(a, fc, ctx)
 		if err != nil {
-			// HITL pause propagates as ErrNodeInterrupted; bubble it
-			// up so the outer scheduler can park the coordinator.
+			if errors.Is(err, workflow.ErrNodeInterrupted) {
+				// Task sub-agent paused on a long-running tool
+				// (e.g. its tool called ctx.RequestConfirmation
+				// and is awaiting the user's reply). Do NOT
+				// synthesise a delegation-closing FR: leaving
+				// the delegation unresolved makes
+				// findUnresolvedTaskDelegations re-dispatch it on
+				// the next user turn, where the
+				// request_confirmation processor will see the
+				// reply and resume the tool inside the same
+				// isolation scope.
+				//
+				// Return false to stop both the inner Agent.Run
+				// iterator and the outer re-entry loop. Without
+				// stopping, the coordinator's LLM would be invoked
+				// again with no new information and produce
+				// duplicate user-facing text plus duplicate
+				// pending-interrupt prompts. The runner's iterator
+				// drains cleanly; the console launcher then
+				// scans collected events for LongRunningToolIDs
+				// and renders the (single) interrupt prompt.
+				return false
+			}
 			yield(nil, err)
+			return false
+		}
+		if out == nil {
+			// Task sub-agent drained its iterator without ever
+			// calling finish_task (e.g. it emitted a natural-
+			// language question to the user and is waiting for
+			// the reply). runTask only sets ev.Output when it
+			// observes a successful finish_task FR, so out==nil
+			// means the task did not actually finish.
+			//
+			// Treating this as a completion would (a) synthesise
+			// a misleading delegation-closing FR, and (b) route
+			// the user's next message to the coordinator instead
+			// of back into the paused task, causing the
+			// coordinator to re-dispatch a fresh task on every
+			// reply and loop forever.
+			//
+			// Leave the delegation unresolved: the next user
+			// turn will be stamped (by the runner's active-task
+			// scope helper) into this task's scope, and
+			// findUnresolvedTaskDelegations will re-dispatch
+			// into the same scope so the task agent sees the
+			// reply in its conversation history.
 			return false
 		}
 		return yield(synthesizeTaskFREvent(ctx.InvocationID(), fc, out), nil)
 	}
 
 	// Step 1: pre-LLM scan for unresolved task FCs from prior turns.
-	for _, fc := range findUnresolvedTaskDelegations(ctx.Session(), a.Name(), toolsDict) {
+	unresolved := findUnresolvedTaskDelegations(ctx.Session(), a.Name(), toolsDict)
+	for _, fc := range unresolved {
 		if !dispatchAndYield(fc) {
 			return
 		}

--- a/agent/llmagent/llmagent.go
+++ b/agent/llmagent/llmagent.go
@@ -438,14 +438,15 @@ type agentState = agentinternal.State
 func (a *llmAgent) run(ctx agent.InvocationContext) iter.Seq2[*session.Event, error] {
 	// TODO: branch context?
 	ctx = icontext.NewInvocationContext(ctx, icontext.InvocationContextParams{
-		Artifacts:    ctx.Artifacts(),
-		Memory:       ctx.Memory(),
-		Session:      ctx.Session(),
-		Branch:       ctx.Branch(),
-		Agent:        a,
-		UserContent:  ctx.UserContent(),
-		RunConfig:    ctx.RunConfig(),
-		InvocationID: ctx.InvocationID(),
+		Artifacts:      ctx.Artifacts(),
+		Memory:         ctx.Memory(),
+		Session:        ctx.Session(),
+		Branch:         ctx.Branch(),
+		IsolationScope: ctx.IsolationScope(),
+		Agent:          a,
+		UserContent:    ctx.UserContent(),
+		RunConfig:      ctx.RunConfig(),
+		InvocationID:   ctx.InvocationID(),
 	})
 
 	f := &llminternal.Flow{
@@ -472,14 +473,15 @@ func (a *llmAgent) run(ctx agent.InvocationContext) iter.Seq2[*session.Event, er
 
 func (a *llmAgent) RunLive(ctx agent.InvocationContext) (agent.LiveSession, iter.Seq2[*session.Event, error], error) {
 	ctx = icontext.NewInvocationContext(ctx, icontext.InvocationContextParams{
-		Artifacts:    ctx.Artifacts(),
-		Memory:       ctx.Memory(),
-		Session:      ctx.Session(),
-		Branch:       ctx.Branch(),
-		Agent:        a,
-		UserContent:  ctx.UserContent(),
-		RunConfig:    ctx.RunConfig(),
-		InvocationID: ctx.InvocationID(),
+		Artifacts:      ctx.Artifacts(),
+		Memory:         ctx.Memory(),
+		Session:        ctx.Session(),
+		Branch:         ctx.Branch(),
+		IsolationScope: ctx.IsolationScope(),
+		Agent:          a,
+		UserContent:    ctx.UserContent(),
+		RunConfig:      ctx.RunConfig(),
+		InvocationID:   ctx.InvocationID(),
 	})
 
 	f := &llminternal.Flow{

--- a/examples/multiagent/task_sub_agent/main.go
+++ b/examples/multiagent/task_sub_agent/main.go
@@ -94,7 +94,7 @@ func confirmation(_ agent.Context, _ ConfirmationInput) (ConfirmationOutput, err
 func main() {
 	ctx := context.Background()
 
-	model, err := gemini.NewModel(ctx, "gemini-3.1-flash-lite", &genai.ClientConfig{
+	model, err := gemini.NewModel(ctx, "gemini-3.5-flash", &genai.ClientConfig{
 		APIKey: os.Getenv("GOOGLE_API_KEY"),
 	})
 	if err != nil {
@@ -190,6 +190,7 @@ Once you have both pieces of information, finish your task.
 		Tools:     []tool.Tool{placeOrderTool},
 		Instruction: `You are a helpful coordinator for a food delivery service.
 You need both order and payment information to place an order.
+You must verify food order with 'order_collector'
 `,
 	})
 	if err != nil {

--- a/runner/find_active_task_isolation_scope_test.go
+++ b/runner/find_active_task_isolation_scope_test.go
@@ -1,0 +1,187 @@
+// Copyright 2026 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package runner
+
+import (
+	"context"
+	"testing"
+
+	"google.golang.org/genai"
+
+	"google.golang.org/adk/internal/workflowinternal"
+	"google.golang.org/adk/model"
+	"google.golang.org/adk/session"
+)
+
+// TestFindActiveTaskIsolationScope walks session events backwards and
+// returns the most-recent non-empty IsolationScope not closed by a
+// successful finish_task FR.
+func TestFindActiveTaskIsolationScope(t *testing.T) {
+	t.Parallel()
+
+	const (
+		scopeA = "adk-task-A"
+		scopeB = "adk-task-B"
+	)
+
+	// modelEventWithFC opens a task scope: a model-role event in
+	// `scope` carrying a single FC.
+	modelEventWithFC := func(scope, name, id string) *session.Event {
+		return &session.Event{
+			Author:         "task_agent",
+			IsolationScope: scope,
+			LLMResponse: model.LLMResponse{
+				Content: &genai.Content{
+					Role:  "model",
+					Parts: []*genai.Part{{FunctionCall: &genai.FunctionCall{Name: name, ID: id}}},
+				},
+			},
+		}
+	}
+
+	userEventWithFR := func(scope, name, id string, resp map[string]any) *session.Event {
+		return &session.Event{
+			Author:         "user",
+			IsolationScope: scope,
+			LLMResponse: model.LLMResponse{
+				Content: &genai.Content{
+					Role: "user",
+					Parts: []*genai.Part{{FunctionResponse: &genai.FunctionResponse{
+						Name:     name,
+						ID:       id,
+						Response: resp,
+					}}},
+				},
+			},
+		}
+	}
+	finishSuccessFR := func(scope, id string) *session.Event {
+		return userEventWithFR(scope, workflowinternal.FinishTaskToolName, id,
+			map[string]any{"result": workflowinternal.FinishTaskSuccessResult})
+	}
+	finishErrorFR := func(scope, id string) *session.Event {
+		return userEventWithFR(scope, workflowinternal.FinishTaskToolName, id,
+			map[string]any{"error": "validation failed: ..."})
+	}
+
+	tests := []struct {
+		name   string
+		events []*session.Event
+		want   string
+	}{
+		{
+			name:   "empty_session",
+			events: nil,
+			want:   "",
+		},
+		{
+			// Pre-delegation: only unscoped events.
+			name: "no_scoped_events",
+			events: []*session.Event{
+				{Author: "user"},
+				{Author: "coordinator"},
+			},
+			want: "",
+		},
+		{
+			// Happy path: one open scope, not yet closed.
+			name: "single_open_scope",
+			events: []*session.Event{
+				{Author: "user"},
+				modelEventWithFC(scopeA, "confirmation", "fc-A"),
+			},
+			want: scopeA,
+		},
+		{
+			// Successful finish_task FR closes the scope.
+			name: "scope_closed_by_finish_task_success",
+			events: []*session.Event{
+				modelEventWithFC(scopeA, "finish_task", "ft-A"),
+				finishSuccessFR(scopeA, "ft-A"),
+			},
+			want: "",
+		},
+		{
+			// Error FR does NOT close the scope (task retries).
+			name: "error_finish_task_fr_keeps_scope_open",
+			events: []*session.Event{
+				modelEventWithFC(scopeA, "finish_task", "ft-A"),
+				finishErrorFR(scopeA, "ft-A"),
+			},
+			want: scopeA,
+		},
+		{
+			// Newer open, older closed: backward walk hits the
+			// newer one first and returns it.
+			name: "newer_open_older_closed",
+			events: []*session.Event{
+				modelEventWithFC(scopeA, "finish_task", "ft-A"),
+				finishSuccessFR(scopeA, "ft-A"),
+				modelEventWithFC(scopeB, "confirmation", "fc-B"),
+			},
+			want: scopeB,
+		},
+		{
+			// Newer closed, older open: helper must skip the
+			// closed newer one — proves it's "most-recent
+			// unclosed", not just "most-recent".
+			name: "newer_closed_older_open",
+			events: []*session.Event{
+				modelEventWithFC(scopeA, "confirmation", "fc-A"),
+				modelEventWithFC(scopeB, "finish_task", "ft-B"),
+				finishSuccessFR(scopeB, "ft-B"),
+			},
+			want: scopeA,
+		},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			t.Parallel()
+			sess := buildSessionWithEvents(t, tc.events)
+			if got := findActiveTaskIsolationScope(sess); got != tc.want {
+				t.Errorf("findActiveTaskIsolationScope = %q, want %q", got, tc.want)
+			}
+		})
+	}
+}
+
+func TestFindActiveTaskIsolationScope_NilSession(t *testing.T) {
+	t.Parallel()
+	if got := findActiveTaskIsolationScope(nil); got != "" {
+		t.Errorf("findActiveTaskIsolationScope(nil) = %q, want \"\"", got)
+	}
+}
+
+// buildSessionWithEvents creates an in-memory session and appends
+// each event in order, preserving IsolationScope.
+func buildSessionWithEvents(t *testing.T, events []*session.Event) session.Session {
+	t.Helper()
+	ctx := context.Background()
+	svc := session.InMemoryService()
+	resp, err := svc.Create(ctx, &session.CreateRequest{
+		AppName: "test-app",
+		UserID:  "test-user",
+	})
+	if err != nil {
+		t.Fatalf("create session: %v", err)
+	}
+	for i, ev := range events {
+		if err := svc.AppendEvent(ctx, resp.Session, ev); err != nil {
+			t.Fatalf("AppendEvent[%d]: %v", i, err)
+		}
+	}
+	return resp.Session
+}

--- a/runner/runner.go
+++ b/runner/runner.go
@@ -628,16 +628,6 @@ func (r *Runner) appendMessageToSession(ctx agent.Context, storedSession session
 	if stateDelta != nil {
 		event.Actions.StateDelta = stateDelta
 	}
-	// When a paused task delegation is still in flight (e.g. a
-	// task sub-agent's confirmation request awaiting the user's
-	// reply), stamp the new user message with that task's
-	// isolation_scope so the task agent's content-build (scoped to
-	// <fc_id>) sees it, and so any FunctionResponse the framework
-	// synthesises for the resume turn inherits the same scope as
-	// its originating FunctionCall — preventing FC/FR scope
-	// mismatches in the contents processor. Mirrors adk-python's
-	// Runner._append_user_event (runners.py:754-757) +
-	// _find_active_task_isolation_scope.
 	if event.IsolationScope == "" {
 		if iso := findActiveTaskIsolationScope(storedSession); iso != "" {
 			event.IsolationScope = iso
@@ -650,27 +640,8 @@ func (r *Runner) appendMessageToSession(ctx agent.Context, storedSession session
 	return ctx, event, nil
 }
 
-// findActiveTaskIsolationScope walks the session backwards and returns
-// the most recent isolation_scope that has not yet been closed by a
-// successful finish_task FunctionResponse. Two flavours of task scope
-// open new scopes today:
-//
-//   - FC delegation (chat coordinator → task sub-agent via FunctionCall):
-//     scope = fc.id, opened by an unresolved task FC.
-//   - Workflow dynamic node (task-mode LlmAgent dispatched as a graph
-//     node): scope = "<node_name>@<run_id>", stamped on every event the
-//     task agent emits.
-//
-// Both close on a successful finish_task FunctionResponse (one whose
-// Response carries {"result": FinishTaskSuccessResult}). An error FR
-// (validation failure) does NOT close the scope: the task agent is
-// still active, will see the error, and retry. Walking backward, the
-// first non-empty scope we encounter that hasn't been closed by a
-// later successful finish_task is the paused task awaiting the user's
-// next reply.
-//
-// Mirrors adk-python's _find_active_task_isolation_scope
-// (runners.py:70-106).
+// findActiveTaskIsolationScope returns the most recent isolation_scope that has
+// not yet been closed by a successful finish_task FunctionResponse.
 func findActiveTaskIsolationScope(sess session.Session) string {
 	if sess == nil {
 		return ""

--- a/runner/runner.go
+++ b/runner/runner.go
@@ -34,6 +34,7 @@ import (
 	imemory "google.golang.org/adk/internal/memory"
 	"google.golang.org/adk/internal/plugininternal"
 	"google.golang.org/adk/internal/utils"
+	"google.golang.org/adk/internal/workflowinternal"
 	"google.golang.org/adk/memory"
 	"google.golang.org/adk/model"
 	"google.golang.org/adk/plugin"
@@ -627,11 +628,78 @@ func (r *Runner) appendMessageToSession(ctx agent.Context, storedSession session
 	if stateDelta != nil {
 		event.Actions.StateDelta = stateDelta
 	}
+	// When a paused task delegation is still in flight (e.g. a
+	// task sub-agent's confirmation request awaiting the user's
+	// reply), stamp the new user message with that task's
+	// isolation_scope so the task agent's content-build (scoped to
+	// <fc_id>) sees it, and so any FunctionResponse the framework
+	// synthesises for the resume turn inherits the same scope as
+	// its originating FunctionCall — preventing FC/FR scope
+	// mismatches in the contents processor. Mirrors adk-python's
+	// Runner._append_user_event (runners.py:754-757) +
+	// _find_active_task_isolation_scope.
+	if event.IsolationScope == "" {
+		if iso := findActiveTaskIsolationScope(storedSession); iso != "" {
+			event.IsolationScope = iso
+		}
+	}
 
 	if err := r.sessionService.AppendEvent(ctx, storedSession, event); err != nil {
 		return ctx, nil, fmt.Errorf("failed to append event to sessionService: %w", err)
 	}
 	return ctx, event, nil
+}
+
+// findActiveTaskIsolationScope walks the session backwards and returns
+// the most recent isolation_scope that has not yet been closed by a
+// successful finish_task FunctionResponse. Two flavours of task scope
+// open new scopes today:
+//
+//   - FC delegation (chat coordinator → task sub-agent via FunctionCall):
+//     scope = fc.id, opened by an unresolved task FC.
+//   - Workflow dynamic node (task-mode LlmAgent dispatched as a graph
+//     node): scope = "<node_name>@<run_id>", stamped on every event the
+//     task agent emits.
+//
+// Both close on a successful finish_task FunctionResponse (one whose
+// Response carries {"result": FinishTaskSuccessResult}). An error FR
+// (validation failure) does NOT close the scope: the task agent is
+// still active, will see the error, and retry. Walking backward, the
+// first non-empty scope we encounter that hasn't been closed by a
+// later successful finish_task is the paused task awaiting the user's
+// next reply.
+//
+// Mirrors adk-python's _find_active_task_isolation_scope
+// (runners.py:70-106).
+func findActiveTaskIsolationScope(sess session.Session) string {
+	if sess == nil {
+		return ""
+	}
+	events := sess.Events()
+	finished := map[string]struct{}{}
+	for i := events.Len() - 1; i >= 0; i-- {
+		ev := events.At(i)
+		if ev == nil || ev.IsolationScope == "" {
+			continue
+		}
+		scope := ev.IsolationScope
+		for _, fr := range utils.FunctionResponses(ev.Content) {
+			if fr == nil || fr.Name != workflowinternal.FinishTaskToolName {
+				continue
+			}
+			if result, ok := fr.Response["result"]; ok {
+				if s, ok := result.(string); ok && s == workflowinternal.FinishTaskSuccessResult {
+					finished[scope] = struct{}{}
+				}
+			}
+			break
+		}
+		if _, done := finished[scope]; done {
+			continue
+		}
+		return scope
+	}
+	return ""
 }
 
 // findAgentToRun returns the agent that should handle the next request based on

--- a/session/inmemory.go
+++ b/session/inmemory.go
@@ -244,7 +244,6 @@ func (s *inMemoryService) AppendEvent(ctx context.Context, curSession Session, e
 		LLMResponse:        event.LLMResponse,
 		Output:             event.Output,
 		NodeInfo:           event.NodeInfo,
-		IsolationScope:     event.IsolationScope,
 	}
 
 	// update the in-memory session service

--- a/session/inmemory.go
+++ b/session/inmemory.go
@@ -229,6 +229,14 @@ func (s *inMemoryService) AppendEvent(ctx context.Context, curSession Session, e
 		Timestamp:    event.Timestamp,
 		Author:       event.Author,
 		Branch:       event.Branch,
+		// IsolationScope MUST be preserved on append: subsequent
+		// LlmAgent runs in the same session rely on it for scope-based
+		// event filtering in the contents processor. Dropping it
+		// orphans a sub-agent's persisted FCs from later FRs the
+		// framework synthesises for the same delegation, producing
+		// "no function call event found for function responses ids"
+		// errors on the next turn.
+		IsolationScope: event.IsolationScope,
 		Actions: EventActions{
 			StateDelta:                 maps.Clone(event.Actions.StateDelta),
 			ArtifactDelta:              maps.Clone(event.Actions.ArtifactDelta),

--- a/session/inmemory.go
+++ b/session/inmemory.go
@@ -224,18 +224,11 @@ func (s *inMemoryService) AppendEvent(ctx context.Context, curSession Session, e
 	}
 
 	eventCopy := &Event{
-		ID:           event.ID,
-		InvocationID: event.InvocationID,
-		Timestamp:    event.Timestamp,
-		Author:       event.Author,
-		Branch:       event.Branch,
-		// IsolationScope MUST be preserved on append: subsequent
-		// LlmAgent runs in the same session rely on it for scope-based
-		// event filtering in the contents processor. Dropping it
-		// orphans a sub-agent's persisted FCs from later FRs the
-		// framework synthesises for the same delegation, producing
-		// "no function call event found for function responses ids"
-		// errors on the next turn.
+		ID:             event.ID,
+		InvocationID:   event.InvocationID,
+		Timestamp:      event.Timestamp,
+		Author:         event.Author,
+		Branch:         event.Branch,
 		IsolationScope: event.IsolationScope,
 		Actions: EventActions{
 			StateDelta:                 maps.Clone(event.Actions.StateDelta),

--- a/session/inmemory_test.go
+++ b/session/inmemory_test.go
@@ -93,13 +93,14 @@ func TestInMemorySession_AppendEvent_WorkflowFieldsRoundTrip(t *testing.T) {
 	}
 	sess := createResp.Session
 
+	const wantScope = "adk-task-isolation-scope"
 	event := &session.Event{
 		ID:             "wf_event",
 		Author:         "agent",
+		IsolationScope: wantScope,
 		NodeInfo:       &session.NodeInfo{Path: "ask_name"},
 		RequestedInput: &session.RequestInput{InterruptID: "ask_name", Message: "What's your name?"},
 		Routes:         []string{"route_a"},
-		IsolationScope: "scope_a",
 	}
 	if err := service.AppendEvent(ctx, sess, event); err != nil {
 		t.Fatalf("AppendEvent: %v", err)
@@ -123,8 +124,8 @@ func TestInMemorySession_AppendEvent_WorkflowFieldsRoundTrip(t *testing.T) {
 	if len(ev.Routes) != 1 || ev.Routes[0] != "route_a" {
 		t.Errorf("Routes not persisted: %#v", ev.Routes)
 	}
-	if ev.IsolationScope != "scope_a" {
-		t.Errorf("IsolationScope not persisted: got %q, want %q", ev.IsolationScope, "scope_a")
+	if ev.IsolationScope != wantScope {
+		t.Errorf("IsolationScope = %q, want %q", ev.IsolationScope, wantScope)
 	}
 }
 

--- a/workflow/agent_node.go
+++ b/workflow/agent_node.go
@@ -114,17 +114,6 @@ func (n *AgentNode) Run(ctx agent.Context, input any) iter.Seq2[*session.Event, 
 			events = n.agent.Run(exCtx)
 		}
 
-		// Task-mode LlmAgents set their output exclusively via
-		// finish_task (handled by llmagent.runTask, which stamps
-		// ev.Output from the FC's args on the successful FR). Plain
-		// model text emitted by a task agent is user-facing chatter
-		// — typically a question to the user mid-conversation — and
-		// must NOT be promoted to the node output. Promoting it
-		// would make the chat coordinator's dispatchTaskFC see a
-		// non-nil output, synthesise a delegation-closing FR, and
-		// route the next user reply to the coordinator instead of
-		// back into the still-open task scope. See
-		// llm_agent_wrapper.go:dispatchAndYield's out==nil branch.
 		skipSynthesize := false
 		if llmA, ok := n.agent.(llminternal.Agent); ok && llmA != nil {
 			if llminternal.Reveal(llmA).Mode == llminternal.ModeTask {

--- a/workflow/agent_node.go
+++ b/workflow/agent_node.go
@@ -24,6 +24,7 @@ import (
 
 	"google.golang.org/adk/agent"
 	internalcontext "google.golang.org/adk/internal/context"
+	"google.golang.org/adk/internal/llminternal"
 	"google.golang.org/adk/session"
 )
 
@@ -113,13 +114,33 @@ func (n *AgentNode) Run(ctx agent.Context, input any) iter.Seq2[*session.Event, 
 			events = n.agent.Run(exCtx)
 		}
 
+		// Task-mode LlmAgents set their output exclusively via
+		// finish_task (handled by llmagent.runTask, which stamps
+		// ev.Output from the FC's args on the successful FR). Plain
+		// model text emitted by a task agent is user-facing chatter
+		// — typically a question to the user mid-conversation — and
+		// must NOT be promoted to the node output. Promoting it
+		// would make the chat coordinator's dispatchTaskFC see a
+		// non-nil output, synthesise a delegation-closing FR, and
+		// route the next user reply to the coordinator instead of
+		// back into the still-open task scope. See
+		// llm_agent_wrapper.go:dispatchAndYield's out==nil branch.
+		skipSynthesize := false
+		if llmA, ok := n.agent.(llminternal.Agent); ok && llmA != nil {
+			if llminternal.Reveal(llmA).Mode == llminternal.ModeTask {
+				skipSynthesize = true
+			}
+		}
+
 		for event, err := range events {
 			if err != nil {
 				yield(nil, err)
 				return
 			}
 
-			synthesizeAgentOutput(event)
+			if !skipSynthesize {
+				synthesizeAgentOutput(event)
+			}
 
 			// Tag the event for scope filtering (mirrors adk-python
 			// NodeRunner._enrich_event). The scheduler stamps delegated
@@ -148,11 +169,24 @@ func (n *AgentNode) Run(ctx agent.Context, input any) iter.Seq2[*session.Event, 
 // resume) know this event's output was derived from the model
 // message, mirroring adk-python's process_llm_agent_output which
 // sets event.output and node_info.message_as_output together.
+//
+// Long-running-tool events (e.g. a tool that called
+// ctx.RequestConfirmation and is awaiting the user's reply) are
+// excluded: IsFinalResponse() returns true for them so the flow
+// loop terminates the round, but they represent a pause, not a
+// completion. Treating them as MessageAsOutput would cache an
+// empty "" as the agent's "output" and, on resume, short-circuit
+// the re-run via collectNodeOutputs / WithRunID-replay — making
+// the chat wrapper synthesise a bogus completion FR for what is
+// still an open delegation.
 func synthesizeAgentOutput(event *session.Event) {
 	if event == nil || event.Output != nil {
 		return
 	}
 	if !event.IsFinalResponse() {
+		return
+	}
+	if len(event.LongRunningToolIDs) > 0 {
 		return
 	}
 	if text, ok := messageText(event); ok {

--- a/workflow/agent_node_modes_test.go
+++ b/workflow/agent_node_modes_test.go
@@ -15,9 +15,18 @@
 package workflow_test
 
 import (
+	"context"
+	"iter"
 	"testing"
 
+	"google.golang.org/genai"
+
+	"google.golang.org/adk/agent"
 	"google.golang.org/adk/agent/llmagent"
+	"google.golang.org/adk/internal/agent/runconfig"
+	icontext "google.golang.org/adk/internal/context"
+	"google.golang.org/adk/model"
+	"google.golang.org/adk/session"
 	"google.golang.org/adk/workflow"
 )
 
@@ -36,3 +45,109 @@ func TestNewAgentNode_NameInheritedFromAgent(t *testing.T) {
 		t.Errorf("node.Name() = %q, want %q (must inherit from wrapped agent)", got, want)
 	}
 }
+
+// Task-mode agents' natural-language text must NOT be promoted to
+// the node Output: their authoritative output is set via finish_task
+// (in llmagent.runTask). Promoting plain text would make the chat
+// coordinator close the delegation prematurely and route the next
+// user reply away from the still-open task scope.
+func TestAgentNode_TaskMode_DoesNotPromoteModelText(t *testing.T) {
+	t.Parallel()
+
+	const userFacingText = "Please tell me what you'd like to order."
+	llm := &scriptedLLM{turns: []*model.LLMResponse{{
+		Content: &genai.Content{
+			Role:  "model",
+			Parts: []*genai.Part{{Text: userFacingText}},
+		},
+	}}}
+
+	taskAgent, err := llmagent.New(llmagent.Config{
+		Name:  "order_collector",
+		Mode:  llmagent.ModeTask,
+		Model: llm,
+	})
+	if err != nil {
+		t.Fatalf("llmagent.New: %v", err)
+	}
+
+	node, err := workflow.NewAgentNode(taskAgent, workflow.NodeConfig{})
+	if err != nil {
+		t.Fatalf("NewAgentNode: %v", err)
+	}
+
+	exCtx := newRunnableNodeContext(t, taskAgent)
+
+	var lastEv *session.Event
+	for ev, runErr := range node.Run(exCtx, nil) {
+		if runErr != nil {
+			t.Fatalf("node.Run yielded err: %v", runErr)
+		}
+		if ev == nil || ev.LLMResponse.Partial {
+			continue
+		}
+		lastEv = ev
+	}
+	if lastEv == nil {
+		t.Fatal("no non-partial events yielded")
+	}
+	if lastEv.Output != nil {
+		t.Errorf("Output = %v, want nil (task-mode text must not be promoted)", lastEv.Output)
+	}
+	if lastEv.NodeInfo != nil && lastEv.NodeInfo.MessageAsOutput {
+		t.Errorf("NodeInfo.MessageAsOutput = true, want false/unset for task-mode text")
+	}
+}
+
+// newRunnableNodeContext builds the minimal NodeContext an LlmAgent
+// flow needs: in-memory Session, Agent, and a RunConfig on the
+// embedded context (the flow reads it via runconfig.FromContext and
+// nil-derefs otherwise).
+func newRunnableNodeContext(t *testing.T, a agent.Agent) agent.Context {
+	t.Helper()
+	svc := session.InMemoryService()
+	resp, err := svc.Create(context.Background(), &session.CreateRequest{
+		AppName: "app",
+		UserID:  "u",
+	})
+	if err != nil {
+		t.Fatalf("create session: %v", err)
+	}
+	stdCtx := runconfig.ToContext(t.Context(), &runconfig.RunConfig{
+		StreamingMode: runconfig.StreamingModeNone,
+	})
+	ic := icontext.NewInvocationContext(stdCtx, icontext.InvocationContextParams{
+		Agent:        a,
+		Session:      resp.Session,
+		InvocationID: "inv-test",
+	})
+	return agent.NewNodeContext(ic, nil)
+}
+
+// scriptedLLM yields one LLMResponse per GenerateContent call,
+// falling back to a terminal "done" event so the flow loop exits.
+type scriptedLLM struct {
+	turns   []*model.LLMResponse
+	callIdx int
+}
+
+func (*scriptedLLM) Name() string { return "scripted-mock" }
+
+func (s *scriptedLLM) GenerateContent(_ context.Context, _ *model.LLMRequest, _ bool) iter.Seq2[*model.LLMResponse, error] {
+	idx := s.callIdx
+	s.callIdx++
+	return func(yield func(*model.LLMResponse, error) bool) {
+		if idx < len(s.turns) {
+			yield(s.turns[idx], nil)
+			return
+		}
+		yield(&model.LLMResponse{
+			Content: &genai.Content{
+				Role:  "model",
+				Parts: []*genai.Part{{Text: "done"}},
+			},
+		}, nil)
+	}
+}
+
+var _ model.LLM = (*scriptedLLM)(nil)

--- a/workflow/dynamic_scheduler.go
+++ b/workflow/dynamic_scheduler.go
@@ -442,14 +442,6 @@ func (s *dynamicSubScheduler) runNode(child Node, input any, opts runNodeOptions
 		}
 	}
 
-	// With WithRaiseOnWait, an unresolved long-running tool (e.g. a
-	// tool that called ctx.RequestConfirmation and is awaiting the
-	// user's reply) counts as an interruption. Without it, the child
-	// would return (nil, nil) and the caller (a chat coordinator
-	// dispatching this task) would synthesise a completion FR that
-	// falsely closes the still-open delegation — orphaning the FR
-	// the request_confirmation processor synthesises on the next
-	// user turn.
 	if opts.raiseOnWait && len(pendingLongRunningIDs) > 0 {
 		interrupted = true
 	}

--- a/workflow/dynamic_scheduler.go
+++ b/workflow/dynamic_scheduler.go
@@ -21,6 +21,7 @@ import (
 	"sync"
 
 	"google.golang.org/adk/agent"
+	"google.golang.org/adk/internal/utils"
 	"google.golang.org/adk/session"
 )
 
@@ -336,6 +337,15 @@ func (s *dynamicSubScheduler) runNode(child Node, input any, opts runNodeOptions
 	var (
 		out         any
 		interrupted bool
+		// pendingLongRunningIDs collects FunctionCall IDs the child
+		// emitted as long-running (listed in the emitting event's
+		// LongRunningToolIDs). Each is removed when we later see a
+		// matching FunctionResponse from the child. Any IDs left
+		// at the end of the child's iteration represent tools the
+		// child is still waiting on — used by WithRaiseOnWait to
+		// distinguish "child paused for HITL" from "child finished
+		// cleanly with no output".
+		pendingLongRunningIDs map[string]struct{}
 	)
 	for ev, evErr := range child.Run(childCtx, input) {
 		if evErr != nil {
@@ -368,6 +378,39 @@ func (s *dynamicSubScheduler) runNode(child Node, input any, opts runNodeOptions
 		if ev.RequestedInput != nil {
 			interrupted = true
 		}
+		// Track LongRunningToolIDs vs FunctionResponses for
+		// WithRaiseOnWait. The check runs unconditionally so this
+		// stays cheap even when the option is off — only one map
+		// lookup per FC / FR and the maps stay empty when there
+		// are no long-running tools at play.
+		if opts.raiseOnWait {
+			if len(ev.LongRunningToolIDs) > 0 {
+				lrtSet := make(map[string]struct{}, len(ev.LongRunningToolIDs))
+				for _, id := range ev.LongRunningToolIDs {
+					lrtSet[id] = struct{}{}
+				}
+				for _, fc := range utils.FunctionCalls(ev.Content) {
+					if fc == nil || fc.ID == "" {
+						continue
+					}
+					if _, isLR := lrtSet[fc.ID]; !isLR {
+						continue
+					}
+					if pendingLongRunningIDs == nil {
+						pendingLongRunningIDs = map[string]struct{}{}
+					}
+					pendingLongRunningIDs[fc.ID] = struct{}{}
+				}
+			}
+			if len(pendingLongRunningIDs) > 0 {
+				for _, fr := range utils.FunctionResponses(ev.Content) {
+					if fr == nil {
+						continue
+					}
+					delete(pendingLongRunningIDs, fr.ID)
+				}
+			}
+		}
 		if childOut, ok := childEventOutput(ev); ok {
 			validated, err := validateAndStampOutput(child, childOut, ev)
 			if err != nil {
@@ -399,6 +442,17 @@ func (s *dynamicSubScheduler) runNode(child Node, input any, opts runNodeOptions
 		}
 	}
 
+	// With WithRaiseOnWait, an unresolved long-running tool (e.g. a
+	// tool that called ctx.RequestConfirmation and is awaiting the
+	// user's reply) counts as an interruption. Without it, the child
+	// would return (nil, nil) and the caller (a chat coordinator
+	// dispatching this task) would synthesise a completion FR that
+	// falsely closes the still-open delegation — orphaning the FR
+	// the request_confirmation processor synthesises on the next
+	// user turn.
+	if opts.raiseOnWait && len(pendingLongRunningIDs) > 0 {
+		interrupted = true
+	}
 	if interrupted {
 		// HITL is not terminal — parent re-runs on resume and is
 		// expected to re-invoke RunNode. Do not cache.

--- a/workflow/run_node.go
+++ b/workflow/run_node.go
@@ -101,22 +101,13 @@ func WithIsolationScopeFromNodePath() RunNodeOption {
 }
 
 // WithRaiseOnWait makes RunNode treat a child that finishes its
-// iteration with an unresolved long-running tool call (a
-// FunctionCall whose ID is listed in the emitting event's
-// LongRunningToolIDs and for which no matching FunctionResponse
-// was emitted by the child) as an interruption rather than a
-// normal completion. The call returns ErrNodeInterrupted instead
-// of (nil, nil).
+// iteration with an unresolved long-running tool call as an interruption rather than a
+// normal completion.
 //
 // Use this when the caller (e.g. a chat-mode coordinator
 // dispatching a task sub-agent via a FunctionCall) MUST distinguish
 // "child paused waiting for HITL" from "child finished cleanly
-// with no output", because synthesising a completion FunctionResponse
-// in the former case would falsely close a still-open delegation.
-//
-// Mirrors adk-python's `ctx.run_node(raise_on_wait=True)` parameter
-// in src/google/adk/workflow/_llm_agent_wrapper.py:159, used by the
-// task-FC dispatch path for the same reason.
+// with no output".
 func WithRaiseOnWait() RunNodeOption {
 	return func(o *runNodeOptions) { o.raiseOnWait = true }
 }

--- a/workflow/run_node.go
+++ b/workflow/run_node.go
@@ -30,6 +30,7 @@ type runNodeOptions struct {
 	useAsOutput            bool
 	overrideIsolationScope string
 	scopeFromNodePath      bool
+	raiseOnWait            bool
 }
 
 // WithRunID overrides the auto-generated counter with a stable
@@ -97,6 +98,27 @@ func WithIsolationScope(scope string) RunNodeOption {
 // LlmAgent case. WithIsolationScope, if also set, takes precedence.
 func WithIsolationScopeFromNodePath() RunNodeOption {
 	return func(o *runNodeOptions) { o.scopeFromNodePath = true }
+}
+
+// WithRaiseOnWait makes RunNode treat a child that finishes its
+// iteration with an unresolved long-running tool call (a
+// FunctionCall whose ID is listed in the emitting event's
+// LongRunningToolIDs and for which no matching FunctionResponse
+// was emitted by the child) as an interruption rather than a
+// normal completion. The call returns ErrNodeInterrupted instead
+// of (nil, nil).
+//
+// Use this when the caller (e.g. a chat-mode coordinator
+// dispatching a task sub-agent via a FunctionCall) MUST distinguish
+// "child paused waiting for HITL" from "child finished cleanly
+// with no output", because synthesising a completion FunctionResponse
+// in the former case would falsely close a still-open delegation.
+//
+// Mirrors adk-python's `ctx.run_node(raise_on_wait=True)` parameter
+// in src/google/adk/workflow/_llm_agent_wrapper.py:159, used by the
+// task-FC dispatch path for the same reason.
+func WithRaiseOnWait() RunNodeOption {
+	return func(o *runNodeOptions) { o.raiseOnWait = true }
 }
 
 // RunNode schedules child as a sub-node of the currently-executing

--- a/workflow/run_node_raise_on_wait_test.go
+++ b/workflow/run_node_raise_on_wait_test.go
@@ -1,0 +1,114 @@
+// Copyright 2026 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package workflow
+
+import (
+	"errors"
+	"iter"
+	"testing"
+
+	"google.golang.org/genai"
+
+	"google.golang.org/adk/agent"
+	"google.golang.org/adk/session"
+)
+
+// longRunningChild emits one FC listed in LongRunningToolIDs, then
+// optionally a matching FR. Drives the WithRaiseOnWait scenarios.
+type longRunningChild struct {
+	BaseNode
+	fcName          string
+	fcID            string
+	yieldMatchingFR bool
+}
+
+func newLongRunningChild(name, fcName, fcID string, yieldMatchingFR bool) *longRunningChild {
+	return &longRunningChild{
+		BaseNode:        NewBaseNode(name, "", NodeConfig{}),
+		fcName:          fcName,
+		fcID:            fcID,
+		yieldMatchingFR: yieldMatchingFR,
+	}
+}
+
+func (n *longRunningChild) Run(agent.Context, any) iter.Seq2[*session.Event, error] {
+	return func(yield func(*session.Event, error) bool) {
+		// FC event: ID in LongRunningToolIDs signals "tool pauses".
+		fcEvent := &session.Event{
+			Author:             n.Name(),
+			LongRunningToolIDs: []string{n.fcID},
+		}
+		fcEvent.LLMResponse.Content = &genai.Content{
+			Role:  "model",
+			Parts: []*genai.Part{{FunctionCall: &genai.FunctionCall{Name: n.fcName, ID: n.fcID}}},
+		}
+		if !yield(fcEvent, nil) {
+			return
+		}
+		if !n.yieldMatchingFR {
+			return
+		}
+		// Matching FR clears the pending-LRT set.
+		frEvent := &session.Event{Author: n.Name()}
+		frEvent.LLMResponse.Content = &genai.Content{
+			Role: "user",
+			Parts: []*genai.Part{{FunctionResponse: &genai.FunctionResponse{
+				Name:     n.fcName,
+				ID:       n.fcID,
+				Response: map[string]any{"result": "ok"},
+			}}},
+		}
+		yield(frEvent, nil)
+	}
+}
+
+// Unresolved LRT + WithRaiseOnWait → ErrNodeInterrupted (so callers
+// can distinguish "task paused" from "task finished with no output").
+func TestRunNode_WithRaiseOnWait_UnresolvedLRT_ReturnsErrNodeInterrupted(t *testing.T) {
+	child := newLongRunningChild("paused_tool_caller", "confirmation", "fc-1", false /* no matching FR */)
+
+	_, err := runInOrchestratorWithErr[string](t, func(ctx NodeContext) (string, error) {
+		return RunNode[string](ctx, child, nil, WithRaiseOnWait())
+	})
+	if !errors.Is(err, ErrNodeInterrupted) {
+		t.Errorf("err = %v, want errors.Is(err, ErrNodeInterrupted)", err)
+	}
+}
+
+// In-iteration matching FR clears the pending LRT — run completes
+// normally even with WithRaiseOnWait set.
+func TestRunNode_WithRaiseOnWait_ResolvedLRT_CompletesNormally(t *testing.T) {
+	child := newLongRunningChild("resolves_in_place", "tool", "fc-1", true /* matching FR yielded */)
+
+	_, err := runInOrchestratorWithErr[string](t, func(ctx NodeContext) (string, error) {
+		return RunNode[string](ctx, child, nil, WithRaiseOnWait())
+	})
+	if err != nil {
+		t.Errorf("err = %v, want nil (in-iteration FR clears the pending LRT)", err)
+	}
+}
+
+// Pins the gating as opt-in: the same unresolved-LRT child completes
+// normally when WithRaiseOnWait is not set.
+func TestRunNode_WithoutRaiseOnWait_UnresolvedLRT_CompletesNormally(t *testing.T) {
+	child := newLongRunningChild("paused_tool_caller", "confirmation", "fc-1", false /* no matching FR */)
+
+	_, err := runInOrchestratorWithErr[string](t, func(ctx NodeContext) (string, error) {
+		return RunNode[string](ctx, child, nil /* no WithRaiseOnWait */)
+	})
+	if err != nil {
+		t.Errorf("err = %v, want nil (LRT tracking must be opt-in via WithRaiseOnWait)", err)
+	}
+}

--- a/workflow/synthesize_agent_output_test.go
+++ b/workflow/synthesize_agent_output_test.go
@@ -1,0 +1,70 @@
+// Copyright 2026 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package workflow
+
+import (
+	"testing"
+
+	"google.golang.org/genai"
+
+	"google.golang.org/adk/session"
+)
+
+// LRT-bearing events are "final" by IsFinalResponse() but represent
+// a pause, not a completion: promoting their text would cache a
+// transient string and short-circuit the re-run on resume.
+func TestSynthesizeAgentOutput_SkipsLongRunningToolEvent(t *testing.T) {
+	t.Parallel()
+
+	// Non-empty text so the assertion catches a regression where the
+	// LRT guard is removed (the text would otherwise be promoted).
+	ev := &session.Event{
+		LongRunningToolIDs: []string{"fc-pending"},
+	}
+	ev.LLMResponse.Content = &genai.Content{
+		Role:  "model",
+		Parts: []*genai.Part{{Text: "Awaiting your approval…"}},
+	}
+
+	synthesizeAgentOutput(ev)
+
+	if ev.Output != nil {
+		t.Errorf("Output = %v, want nil (LRT-bearing events must not be promoted)", ev.Output)
+	}
+	if ev.NodeInfo != nil && ev.NodeInfo.MessageAsOutput {
+		t.Errorf("NodeInfo.MessageAsOutput = true, want false/unset for LRT pauses")
+	}
+}
+
+// Positive control: plain model text without LRT gets promoted.
+// Pins the LRT guard as a targeted skip, not a global behaviour change.
+func TestSynthesizeAgentOutput_PromotesPlainModelText(t *testing.T) {
+	t.Parallel()
+
+	ev := &session.Event{}
+	ev.LLMResponse.Content = &genai.Content{
+		Role:  "model",
+		Parts: []*genai.Part{{Text: "hello"}},
+	}
+
+	synthesizeAgentOutput(ev)
+
+	if got, want := ev.Output, "hello"; got != want {
+		t.Errorf("Output = %v, want %q", ev.Output, want)
+	}
+	if ev.NodeInfo == nil || !ev.NodeInfo.MessageAsOutput {
+		t.Errorf("NodeInfo.MessageAsOutput = %v, want true", ev.NodeInfo)
+	}
+}


### PR DESCRIPTION
This will mark the node as ErrNodeInterrupted if there's unresolved function call and no matching function responses on the node.