### PR TITLE
fix(workflow): fix XS-size issues after v2 audit with regression test

### DIFF
--- a/agent/common_context.go
+++ b/agent/common_context.go
@@ -29,12 +29,21 @@ import (
 	"google.golang.org/adk/tool/toolconfirmation"
 )
 
-func NewNodeContext(parent InvocationContext, resumeInputs map[string]any) Context {
+// NewContext returns a full Context backed by parent, with no callback,
+// tool, or node specializations. Use it wherever a plain run context is
+// needed (e.g. running an agent).
+func NewContext(parent InvocationContext) Context {
 	return &commonContext{
 		Context:           parent,
 		invocationContext: parent,
-		resumeInputs:      resumeInputs,
 	}
+}
+
+// NewNodeContext returns a Context carrying per-node resume inputs.
+func NewNodeContext(parent InvocationContext, resumeInputs map[string]any) Context {
+	c := NewContext(parent).(*commonContext)
+	c.resumeInputs = resumeInputs
+	return c
 }
 
 func NewDynamicNodeContext(parent Context, path, runID string, sub DynamicSubScheduler, outputForAncestors []string) Context {

--- a/runner/runner.go
+++ b/runner/runner.go
@@ -597,7 +597,7 @@ func (r *Runner) appendMessageToSession(ctx agent.Context, storedSession session
 				RunConfig:    ctx.RunConfig(),
 				InvocationID: ctx.InvocationID(),
 			})
-			ctx = agent.NewCallbackContext(ic, nil)
+			ctx = agent.NewContext(ic)
 		}
 	}
 

--- a/runner/runner_test.go
+++ b/runner/runner_test.go
@@ -28,6 +28,7 @@ import (
 	"google.golang.org/adk/agent/llmagent"
 	"google.golang.org/adk/artifact"
 	"google.golang.org/adk/model"
+	"google.golang.org/adk/plugin"
 	"google.golang.org/adk/session"
 )
 
@@ -287,6 +288,74 @@ func TestRunner_SaveInputBlobsAsArtifacts(t *testing.T) {
 	expectedText := fmt.Sprintf("Uploaded file: %s. It has been saved to the artifacts", savedFileName)
 	if partWithBlob.Text != expectedText {
 		t.Errorf("unexpected text in placeholder part. got %q, want %q", partWithBlob.Text, expectedText)
+	}
+}
+
+// TestRunner_PluginModifiesUserMessage guards that a plugin modifying the
+// user message still yields a full run context.
+func TestRunner_PluginModifiesUserMessage(t *testing.T) {
+	ctx := context.Background()
+	appName := "testApp"
+	userID := "testUser"
+	sessionID := "testSession"
+
+	var gotMessage *genai.Content
+	testAgent := must(agent.New(agent.Config{
+		Name: "test_agent",
+		Run: func(ctx agent.InvocationContext) iter.Seq2[*session.Event, error] {
+			return func(yield func(*session.Event, error) bool) {
+				// Accessors that nil-deref on a callback-only context.
+				_ = ctx.Agent().Name()
+				_ = ctx.Session().ID()
+				gotMessage = ctx.UserContent()
+			}
+		},
+	}))
+
+	modifierPlugin, err := plugin.New(plugin.Config{
+		Name: "message_modifier",
+		OnUserMessageCallback: func(_ agent.InvocationContext, _ *genai.Content) (*genai.Content, error) {
+			return &genai.Content{
+				Role:  genai.RoleUser,
+				Parts: []*genai.Part{genai.NewPartFromText("modified")},
+			}, nil
+		},
+	})
+	if err != nil {
+		t.Fatalf("plugin.New() error = %v", err)
+	}
+
+	sessionService := session.InMemoryService()
+	r, err := New(Config{
+		AppName:        appName,
+		Agent:          testAgent,
+		SessionService: sessionService,
+		PluginConfig:   PluginConfig{Plugins: []*plugin.Plugin{modifierPlugin}},
+	})
+	if err != nil {
+		t.Fatalf("New() error = %v", err)
+	}
+
+	if _, err := sessionService.Create(ctx, &session.CreateRequest{
+		AppName:   appName,
+		UserID:    userID,
+		SessionID: sessionID,
+	}); err != nil {
+		t.Fatalf("sessionService.Create() error = %v", err)
+	}
+
+	msg := &genai.Content{Role: genai.RoleUser, Parts: []*genai.Part{genai.NewPartFromText("original")}}
+	for _, err := range r.Run(ctx, userID, sessionID, msg, agent.RunConfig{}) {
+		if err != nil {
+			t.Fatalf("r.Run() returned an error: %v", err)
+		}
+	}
+
+	if gotMessage == nil {
+		t.Fatal("agent did not observe a user message")
+	}
+	if len(gotMessage.Parts) != 1 || gotMessage.Parts[0].Text != "modified" {
+		t.Errorf("agent saw %v, want the plugin-modified message", gotMessage)
 	}
 }
 

--- a/session/inmemory.go
+++ b/session/inmemory.go
@@ -243,6 +243,7 @@ func (s *inMemoryService) AppendEvent(ctx context.Context, curSession Session, e
 		LLMResponse:        event.LLMResponse,
 		Output:             event.Output,
 		NodeInfo:           event.NodeInfo,
+		IsolationScope:     event.IsolationScope,
 	}
 
 	// update the in-memory session service

--- a/session/inmemory_test.go
+++ b/session/inmemory_test.go
@@ -80,8 +80,9 @@ func Test_inMemoryService_CreateConcurrentAccess(t *testing.T) {
 
 // TestInMemorySession_AppendEvent_WorkflowFieldsRoundTrip guards that
 // AppendEvent persists the workflow event fields (NodeInfo,
-// RequestedInput, Routes) — workflow resume rehydrates node state from
-// them, and a manual event copy that drops them breaks HITL resume.
+// RequestedInput, Routes, IsolationScope) — workflow resume rehydrates
+// node state from them, and a manual event copy that drops them breaks
+// HITL resume. IsolationScope additionally drives history filtering.
 func TestInMemorySession_AppendEvent_WorkflowFieldsRoundTrip(t *testing.T) {
 	ctx := t.Context()
 	service := session.InMemoryService()
@@ -98,6 +99,7 @@ func TestInMemorySession_AppendEvent_WorkflowFieldsRoundTrip(t *testing.T) {
 		NodeInfo:       &session.NodeInfo{Path: "ask_name"},
 		RequestedInput: &session.RequestInput{InterruptID: "ask_name", Message: "What's your name?"},
 		Routes:         []string{"route_a"},
+		IsolationScope: "scope_a",
 	}
 	if err := service.AppendEvent(ctx, sess, event); err != nil {
 		t.Fatalf("AppendEvent: %v", err)
@@ -120,6 +122,9 @@ func TestInMemorySession_AppendEvent_WorkflowFieldsRoundTrip(t *testing.T) {
 	}
 	if len(ev.Routes) != 1 || ev.Routes[0] != "route_a" {
 		t.Errorf("Routes not persisted: %#v", ev.Routes)
+	}
+	if ev.IsolationScope != "scope_a" {
+		t.Errorf("IsolationScope not persisted: got %q, want %q", ev.IsolationScope, "scope_a")
 	}
 }
 

--- a/workflow/agent_node.go
+++ b/workflow/agent_node.go
@@ -204,6 +204,9 @@ func nodeInputToContent(input any) (*genai.Content, error) {
 	case nil:
 		return nil, nil
 	case *genai.Content:
+		if v == nil {
+			return nil, nil
+		}
 		return &genai.Content{Role: "user", Parts: v.Parts}, nil
 	case string:
 		return &genai.Content{Role: "user", Parts: []*genai.Part{{Text: v}}}, nil

--- a/workflow/agent_node_test.go
+++ b/workflow/agent_node_test.go
@@ -599,6 +599,21 @@ func TestAgentNode_ValidationAndContentConversion(t *testing.T) {
 	}
 }
 
+// TestNodeInputToContent_TypedNilContent guards that a typed-nil
+// *genai.Content is treated as nil input instead of panicking on v.Parts.
+func TestNodeInputToContent_TypedNilContent(t *testing.T) {
+	var typedNil *genai.Content
+	var input any = typedNil // non-nil interface wrapping a nil *genai.Content
+
+	got, err := nodeInputToContent(input)
+	if err != nil {
+		t.Fatalf("nodeInputToContent returned error: %v", err)
+	}
+	if got != nil {
+		t.Errorf("nodeInputToContent(typed-nil) = %#v, want nil", got)
+	}
+}
+
 func TestAgentNode_InputValidation(t *testing.T) {
 	type CustomStruct struct {
 		Val string `json:"val"`

--- a/workflow/retry.go
+++ b/workflow/retry.go
@@ -26,9 +26,15 @@ func CalculateDelay(cfg *RetryConfig, failedAttempts int) time.Duration {
 		return 0
 	}
 
+	// Unset BackoffFactor would collapse the delay to 0; use constant delay.
+	backoffFactor := cfg.BackoffFactor
+	if backoffFactor <= 0 {
+		backoffFactor = 1.0
+	}
+
 	delay := float64(cfg.InitialDelay)
 	for i := 1; i < failedAttempts; i++ {
-		delay *= cfg.BackoffFactor
+		delay *= backoffFactor
 	}
 
 	maxDelay := float64(cfg.MaxDelay)

--- a/workflow/retry_test.go
+++ b/workflow/retry_test.go
@@ -49,6 +49,23 @@ func TestCalculateDelay(t *testing.T) {
 	}
 }
 
+// TestCalculateDelayUnsetBackoffFactor guards that an unset BackoffFactor
+// gives a constant delay instead of collapsing to 0.
+func TestCalculateDelayUnsetBackoffFactor(t *testing.T) {
+	cfg := &RetryConfig{
+		MaxAttempts:  3,
+		InitialDelay: time.Second,
+		// BackoffFactor intentionally unset (zero).
+	}
+
+	for attempt := 1; attempt <= 3; attempt++ {
+		got := CalculateDelay(cfg, attempt)
+		if got != time.Second {
+			t.Errorf("CalculateDelay(unset backoff, %d) = %v, want %v", attempt, got, time.Second)
+		}
+	}
+}
+
 func TestCalculateDelayWithJitter(t *testing.T) {
 	cfg := &RetryConfig{
 		InitialDelay:  time.Second,


### PR DESCRIPTION
## Problem

Four small but high-impact bugs found during the v2 pre-merge review. Each is a one- or few-line defect on a real code path, and none was covered by a test. Severities/IDs match the internal review notes.

- **nil-deref panic when a plugin modifies the user message.** In `appendMessageToSession`, when a plugin's `OnUserMessage` returns a modified message, v2 rebuilt the context and returned `agent.NewCallbackContext(ic, nil)` as the **run** context. That callback-only wrapper's run-critical accessors (`Agent()`, `Session()`, `Memory()`, `WithAgentContext()`, ...) all return `nil`/`""`. The runner then calls `r.rootAgent.Run(ctx)` with it, and the first downstream `ctx.Agent()` / `ctx.Session()` access nil-derefs. Regression vs `main` (which returned a full context here). Triggered by any redaction/normalization/PII plugin on a normal turn.
- **in-memory `AppendEvent` drops `IsolationScope`.** The manual event deep-copy copies the other new v2 fields but omits `IsolationScope`, so the stored copy resets it to `""`. After the per-turn session reload, the contents processor filters history by exact match, so a scoped agent stops seeing its own past events and unscoped agents start seeing them. The SQL backend persists the field correctly, so in-memory (the default service) diverged.
- **typed-nil `*genai.Content` panics `AgentNode`.** A typed-nil `(*genai.Content)(nil)` boxed in `any` does not match `case nil`, falls into the `*genai.Content` case, and dereferences `v.Parts`. Triggered by an upstream node whose `Output` is a nil `*genai.Content`.
- **retry backoff collapses to 0s.** With an unset (zero) `BackoffFactor` in a struct-literal `RetryConfig`, `delay *= cfg.BackoffFactor` makes attempts >= 2 wait 0 -> tight retry hot-loop.

## Solution

- return a full run context. This PR also adds `agent.NewContext(ic)` — a plain run context with no callback/tool/node specializations — and uses it here, instead of borrowing the graph-oriented `NewNodeContext` for a non-graph call site. `NewNodeContext` now builds on `NewContext` (behavior unchanged; it just adds `resumeInputs`).
- add `IsolationScope: event.IsolationScope` to the `eventCopy` literal.
- add `if v == nil { return nil, nil }` at the top of the `*genai.Content` case, mirroring the untyped-`nil` case.
- treat `BackoffFactor <= 0` as `1.0` (constant delay).