### PR TITLE
fix(workflow): stop WorkflowNode re-yielding after consumer break

### DIFF
--- a/workflow/workflow_node.go
+++ b/workflow/workflow_node.go
@@ -48,6 +48,10 @@ func (n *WorkflowNode) Run(ctx agent.Context, input any) iter.Seq2[*session.Even
 	return func(yield func(*session.Event, error) bool) {
 		var lastOutput any
 		var pendingErr error
+		// consumerGone becomes true once the parent yield returns false. After
+		// that, calling yield again panics the iterator (Go 1.23 range-over-func
+		// contract), so we only keep draining the sub-workflow to avoid leaks.
+		consumerGone := false
 
 		// Create a cancellable context to signal the sub-workflow to stop on error or break.
 		subCtx, cancel := ctx.WithAgentCancel()
@@ -66,24 +70,29 @@ func (n *WorkflowNode) Run(ctx agent.Context, input any) iter.Seq2[*session.Even
 				continue
 			}
 
+			if consumerGone {
+				// Drain remaining events without yielding.
+				continue
+			}
+
+			out := ev
 			if ev.Output != nil {
 				lastOutput = ev.Output
 				// Create a shallow copy and clear Output so the parent
 				// scheduler doesn't fail on multiple outputs for this node.
 				evCopy := *ev
 				evCopy.Output = nil
-				if !yield(&evCopy, nil) {
-					// Same as above: cancel and drain to avoid leaks and panics.
-					cancel()
-					continue
-				}
-			} else {
-				if !yield(ev, nil) {
-					// Same as above: cancel and drain to avoid leaks and panics.
-					cancel()
-					continue
-				}
+				out = &evCopy
 			}
+			if !yield(out, nil) {
+				consumerGone = true
+				cancel()
+			}
+		}
+
+		// The consumer already broke the range loop; yielding again would panic.
+		if consumerGone {
+			return
 		}
 
 		// Yield the error at the very end if one occurred.

--- a/workflow/workflow_node_test.go
+++ b/workflow/workflow_node_test.go
@@ -296,3 +296,47 @@ func TestNestedWorkflow_ErrorPropagation(t *testing.T) {
 		t.Errorf("expected error containing 'intentional failure', got %v", runErr)
 	}
 }
+
+// TestNestedWorkflow_BreakMidStream checks that breaking the range loop
+// mid-stream does not panic. break makes yield return false; Go forbids
+// calling yield again after that.
+func TestNestedWorkflow_BreakMidStream(t *testing.T) {
+	// Two chained output nodes, so a second event is still pending at break.
+	innerFn1 := func(ctx agent.Context, input string) (string, error) {
+		return input + "-a", nil
+	}
+	innerFn2 := func(ctx agent.Context, input string) (string, error) {
+		return input + "-b", nil
+	}
+	innerNode1 := NewFunctionNode("inner1", innerFn1, defaultNodeConfig)
+	innerNode2 := NewFunctionNode("inner2", innerFn2, defaultNodeConfig)
+	innerEdges := Chain(Start, innerNode1, innerNode2)
+
+	wfNode, err := NewWorkflowNode("nested", innerEdges)
+	if err != nil {
+		t.Fatalf("failed to create workflow node: %v", err)
+	}
+
+	mockCtx := newMockCtx(t)
+	exCtx := agent.NewNodeContext(mockCtx, nil)
+
+	// Turn the regression's panic into a readable failure; no-op once fixed.
+	defer func() {
+		if r := recover(); r != nil {
+			t.Fatalf("WorkflowNode.Run panicked after consumer break: %v", r)
+		}
+	}()
+
+	count := 0
+	for _, err := range wfNode.Run(exCtx, "in") {
+		if err != nil {
+			t.Fatalf("unexpected error: %v", err)
+		}
+		count++
+		break
+	}
+
+	if count != 1 {
+		t.Errorf("expected to consume exactly 1 event before break, got %d", count)
+	}
+}


### PR DESCRIPTION
## Problem
ADK lets you nest workflows: a `WorkflowNode` runs a smaller workflow inside itself and forwards that inner workflow's events up to the parent.
The forwarding works like a **stream**. In Go this uses "range-over-func": `WorkflowNode` calls `yield(event)` for each event, and the return value means `true` = "parent took it, keep going", `false` = "parent stopped listening, stop". **Go's rule (1.23+): once `yield` returns `false`, you must never call it again** — doing so panics with `range function continued iteration after function for loop body returned false`.
A parent can stop listening mid-stream — a sibling node failed, a deadline elapsed, or the caller broke out. When that happens `yield` returns `false`. The old code correctly told the inner workflow to stop and kept looping so it could drain cleanly, but on the next event it **called `yield` again** — exactly what Go forbids. The result:
1. **A panic**, which an inner `recover()` then swallows and reports as a misleading `node "…" panicked` — masking the real cause (it was just a cancellation).
2. **Leaked goroutines** — the panic aborts the clean shutdown of the inner workflow, so its goroutines hang forever. Ironically the very thing the code was trying to prevent.


**When it happens:** any time a nested workflow is cancelled mid-stream (sibling failure / timeout / outer break) while it still has at least one event left to emit.

### Solution
Track a consumerGone flag, mirroring scheduler.run (which already guards this exact case):
- set it when yield returns false, then drain-only — keep ranging over the sub-workflow (so its goroutines finish and don't leak) but skip all further yields;
- after the loop, if consumerGone, return early so the trailing error/output yields don't fire (those would panic too).
cancel() tells the sub-workflow to stop; the drain lets it close cleanly; the post-loop return only skips the final yields.