### PR TITLE
fix(workflow): reject non-JoinNode fan-in at validation time

### DIFF
--- a/workflow/validation.go
+++ b/workflow/validation.go
@@ -58,6 +58,12 @@ var ErrUnconditionalCycle = errors.New("unconditional cycle detected")
 // ErrSubWorkflowNameCollision is returned when a sub-workflow has the same name as the parent workflow.
 var ErrSubWorkflowNameCollision = errors.New("sub-workflow name collision")
 
+// ErrUnsupportedFanIn is returned when a non-JoinNode has two or more
+// unconditional incoming edges. Such a fan-in target would be activated
+// once per predecessor, which the scheduler does not yet serialize
+// safely. Use a JoinNode to converge multiple branches.
+var ErrUnsupportedFanIn = errors.New("non-JoinNode fan-in is not yet supported")
+
 // validateNodes executes a set of edges validation checks.
 func validateNodes(edges []Edge) error {
 	if err := validateUniqueNames(edges); err != nil {
@@ -156,6 +162,9 @@ func validateWorkflow(workflow *graph, schema *jsonschema.Resolved) error {
 		return err
 	}
 	if err := validateCycles(workflow); err != nil {
+		return err
+	}
+	if err := validateFanIn(workflow); err != nil {
 		return err
 	}
 	if err := validateStaticSchemas(workflow); err != nil {
@@ -318,6 +327,33 @@ func validateCycles(workflow *graph) error {
 		}
 	}
 
+	return nil
+}
+
+// validateFanIn rejects a non-JoinNode target that has two or more
+// unconditional incoming edges. Such a node would be activated once per
+// completed predecessor, colliding the scheduler's per-name bookkeeping
+// (mixed outputs, lost cancel funcs). JoinNode handles fan-in via a
+// barrier; everything else must converge through one. Only unconditional
+// (Route == nil) edges are counted so conditional fan-in and loop-back
+// back-edges — where the predecessors don't all fire together — are not
+// rejected.
+func validateFanIn(workflow *graph) error {
+	for node, edges := range workflow.predecessors {
+		if _, isJoin := node.(*JoinNode); isJoin {
+			continue
+		}
+		unconditional := 0
+		for _, edge := range edges {
+			if edge.Route == nil {
+				unconditional++
+			}
+		}
+		if unconditional > 1 {
+			return fmt.Errorf("%w: node %q has %d unconditional incoming edges; "+
+				"use a JoinNode to converge branches", ErrUnsupportedFanIn, node.Name(), unconditional)
+		}
+	}
 	return nil
 }
 

--- a/workflow/validation_test.go
+++ b/workflow/validation_test.go
@@ -372,6 +372,100 @@ func TestValidateCycles(t *testing.T) {
 	}
 }
 
+func TestValidateFanIn(t *testing.T) {
+	tests := []struct {
+		name      string
+		edges     func() []Edge
+		expectErr bool
+	}{
+		{
+			name: "non-Join diamond fan-in rejected",
+			edges: func() []Edge {
+				a, b, c, d := newDummyNode("A"), newDummyNode("B"), newDummyNode("C"), newDummyNode("D")
+				return []Edge{
+					{From: Start, To: a},
+					{From: a, To: b},
+					{From: a, To: c},
+					{From: b, To: d},
+					{From: c, To: d},
+				}
+			},
+			expectErr: true,
+		},
+		{
+			name: "JoinNode diamond fan-in allowed",
+			edges: func() []Edge {
+				a, b, c := newDummyNode("A"), newDummyNode("B"), newDummyNode("C")
+				j := NewJoinNode("J")
+				return []Edge{
+					{From: Start, To: a},
+					{From: a, To: b},
+					{From: a, To: c},
+					{From: b, To: j},
+					{From: c, To: j},
+				}
+			},
+			expectErr: false,
+		},
+		{
+			name: "conditional loop-back not rejected",
+			edges: func() []Edge {
+				a, b := newDummyNode("A"), newDummyNode("B")
+				// A has two incoming edges (Start + back-edge from B), but
+				// the back-edge is conditional, so they don't fire together.
+				return []Edge{
+					{From: Start, To: a},
+					{From: a, To: b},
+					{From: b, To: a, Route: StringRoute("retry")},
+				}
+			},
+			expectErr: false,
+		},
+		{
+			name: "conditional fan-in not rejected",
+			edges: func() []Edge {
+				a, b, c, d := newDummyNode("A"), newDummyNode("B"), newDummyNode("C"), newDummyNode("D")
+				// Only one of B/C routes into D at a time.
+				return []Edge{
+					{From: Start, To: a},
+					{From: a, To: b},
+					{From: a, To: c},
+					{From: b, To: d, Route: StringRoute("x")},
+					{From: c, To: d, Route: StringRoute("y")},
+				}
+			},
+			expectErr: false,
+		},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			err := validateFanIn(newGraph(tc.edges()))
+			if tc.expectErr && !errors.Is(err, ErrUnsupportedFanIn) {
+				t.Errorf("got %v, want ErrUnsupportedFanIn", err)
+			} else if !tc.expectErr && err != nil {
+				t.Errorf("expected no error, got %v", err)
+			}
+		})
+	}
+}
+
+// TestNew_NonJoinFanIn_Rejected confirms the fan-in check is wired into
+// the public New constructor.
+func TestNew_NonJoinFanIn_Rejected(t *testing.T) {
+	a, b, c, d := newDummyNode("A"), newDummyNode("B"), newDummyNode("C"), newDummyNode("D")
+	_, err := New("wf", []Edge{
+		{From: Start, To: a},
+		{From: a, To: b},
+		{From: a, To: c},
+		{From: b, To: d},
+		{From: c, To: d},
+	})
+	if !errors.Is(err, ErrUnsupportedFanIn) {
+		t.Errorf("New() error = %v, want ErrUnsupportedFanIn", err)
+	}
+}
+
 func TestValidateSubWorkflowNames(t *testing.T) {
 	// Create a valid sub-workflow
 	subWf, err := New("inner_wf", []Edge{{From: Start, To: newDummyNode("A")}})


### PR DESCRIPTION
### Problem
In a diamond like Start → A, A → B, A → C, B → D, C → D where D is a plain node (not a JoinNode), D has two predecessors. When B and C each complete, the scheduler schedules D twice.
The scheduler keys its per-node bookkeeping (runsByName / runCancels) by node name and has no "already running" guard, so the second activation of D overwrites the first while it's still running:
- the first activation's cancel func is lost (leak / uncancellable),
- both activations accumulate into the same per-name run, mixing outputs → ErrMultipleOutputs / wrong output.
JoinNode fan-in is safe (it's barrier-gated — it waits for all predecessors and gets the aggregated input), but nothing stopped a plain node from being used as a fan-in target, so the corruption happened silently.

### How adk-python handles it (for context)
adk-python's v2 graph engine allows plain fan-in: it buffers a trigger per predecessor and serializes per-node execution (_schedule_ready_nodes skips a node already RUNNING), so a plain fan-in node runs once per trigger, never concurrently. adk-go has no such per-node serialization yet.

### Solution
Rather than serialization, reject the unsupported graph at construction with a clear, honest error (ErrUnsupportedFanIn: "non-JoinNode fan-in is not yet supported ... use a JoinNode to converge branches"). This turns silent state corruption into a fail-fast build error, and the message signals it's a temporary limitation. When per-node serialization lands later, the check can be removed.

The check counts only unconditional (Route == nil) incoming edges, so it rejects exactly the diamond case while leaving legitimate graphs alone:
- loop-back (a conditional back-edge gives a node a 2nd predecessor, but they don't fire together) — allowed,
- conditional fan-in (only one branch routes in at a time) — allowed,
- JoinNode fan-in — exempt (barrier-gated).