### PR TITLE
fix(llminternal): handle nil entries in parallel function-response merge

### DIFF
--- a/internal/llminternal/base_flow.go
+++ b/internal/llminternal/base_flow.go
@@ -1302,23 +1302,29 @@ func mergeParallelFunctionResponseEvents(events []*session.Event) (*session.Even
 	}
 	var parts []*genai.Part
 	var actions *session.EventActions
+	var result *session.Event // first non-nil event, reused as the merged result
 	for _, ev := range events {
 		if ev == nil || ev.LLMResponse.Content == nil {
 			continue
 		}
+		if result == nil {
+			result = ev
+		}
 		parts = append(parts, ev.LLMResponse.Content.Parts...)
 		actions = mergeEventActions(actions, &ev.Actions)
 	}
-	// reuse events[0]
-	ev := events[0]
-	ev.LLMResponse = model.LLMResponse{
+	// All entries were nil (e.g. every call was long-running/deferred).
+	if result == nil {
+		return nil, nil
+	}
+	result.LLMResponse = model.LLMResponse{
 		Content: &genai.Content{
 			Role:  "user",
 			Parts: parts,
 		},
 	}
-	ev.Actions = *actions
-	return ev, nil
+	result.Actions = *actions
+	return result, nil
 }
 
 func mergeEventActions(base, other *session.EventActions) *session.EventActions {

--- a/internal/llminternal/base_flow_test.go
+++ b/internal/llminternal/base_flow_test.go
@@ -683,3 +683,57 @@ func TestPreprocess_Toolset(t *testing.T) {
 		})
 	}
 }
+
+// fnRespEvent builds a function-response event carrying a single text part,
+// mirroring what the parallel-call producer emits for a normal tool.
+func fnRespEvent(text string) *session.Event {
+	ev := session.NewEvent("inv")
+	ev.LLMResponse = model.LLMResponse{
+		Content: &genai.Content{
+			Role:  "user",
+			Parts: []*genai.Part{{Text: text}},
+		},
+	}
+	return ev
+}
+
+// TestMergeParallelFunctionResponseEvents_NilEntries guards that nil slots
+// (left by long-running/deferred tools that return early) don't panic the
+// merge. Pre-fix, a nil events[0] or an all-nil slice dereferenced nil.
+func TestMergeParallelFunctionResponseEvents_NilEntries(t *testing.T) {
+	t.Run("first entry nil", func(t *testing.T) {
+		got, err := mergeParallelFunctionResponseEvents([]*session.Event{nil, fnRespEvent("b")})
+		if err != nil {
+			t.Fatalf("merge error: %v", err)
+		}
+		if got == nil || got.LLMResponse.Content == nil {
+			t.Fatalf("got nil/empty merged event: %#v", got)
+		}
+		if n := len(got.LLMResponse.Content.Parts); n != 1 {
+			t.Errorf("merged parts = %d, want 1", n)
+		}
+	})
+
+	t.Run("all entries nil", func(t *testing.T) {
+		got, err := mergeParallelFunctionResponseEvents([]*session.Event{nil, nil})
+		if err != nil {
+			t.Fatalf("merge error: %v", err)
+		}
+		if got != nil {
+			t.Errorf("merged event = %#v, want nil", got)
+		}
+	})
+
+	t.Run("mixed nil and non-nil", func(t *testing.T) {
+		got, err := mergeParallelFunctionResponseEvents([]*session.Event{fnRespEvent("a"), nil, fnRespEvent("c")})
+		if err != nil {
+			t.Fatalf("merge error: %v", err)
+		}
+		if got == nil || got.LLMResponse.Content == nil {
+			t.Fatalf("got nil/empty merged event: %#v", got)
+		}
+		if n := len(got.LLMResponse.Content.Parts); n != 2 {
+			t.Errorf("merged parts = %d, want 2", n)
+		}
+	})
+}


### PR DESCRIPTION
## Problem

Parallel function calls execute into a pre-sized slice `fnResponseEvents := make([]*session.Event, len(fnCalls))`. v2 **added** an early `return` for tools that defer (`DefersResponse()`) or are long-running (`IsLongRunning()`) with a nil result — which leaves that index `nil`.

`mergeParallelFunctionResponseEvents` then:
- does `ev := events[0]; ev.LLMResponse = ...` → **panics if index 0 is nil** (first tool is long-running), and
- does `ev.Actions = *actions` → **panics if every entry is nil** (`actions` stays nil).

It's a regression: the early-return is new in v2; in `main` every goroutine reached the event-construction line, so merge never saw nils.

**Trigger:** a model turn with ≥ 2 function calls where the first is a long-running tool (returns nil) — e.g. a long-running HITL tool alongside a normal tool, or two long-running tools in parallel. (Single-call is safe: `len == 1` returns the nil event and the caller handles it.)

## Solution

In `mergeParallelFunctionResponseEvents`, base the merged event on the **first non-nil** entry (instead of `events[0]`), and return `(nil, nil)` when every entry is nil. nil entries were already skipped while accumulating parts/actions; this just stops the post-loop code from dereferencing them.