### PR TITLE
fix(workflow): single-flight RunNode idempotency cache

### DIFF
--- a/workflow/dynamic_scheduler.go
+++ b/workflow/dynamic_scheduler.go
@@ -41,7 +41,8 @@ type dynamicSubScheduler struct {
 	// Context._output_for_ancestors.
 	outputForAncestors []string
 
-	// mu guards everything below. Never held across child.Run.
+	// mu guards everything below. Never held across child.Run, nor
+	// across the wait in awaitOrLead.
 	mu sync.Mutex
 	// runCountByChild seeds the auto-counter per child name; the
 	// n-th invocation gets runID strconv.Itoa(n).
@@ -50,8 +51,36 @@ type dynamicSubScheduler struct {
 	// childPath ("<parentPath>/<name>@<runID>"). Failures and HITL
 	// interrupts are not cached.
 	resultByPath map[string]any
-	delegation   outputDelegation
+	// inflightByPath holds the activation currently running for a
+	// childPath, so concurrent callers with the same WithRunID share its
+	// outcome instead of running the child again.
+	inflightByPath map[string]*inflightRun
+	delegation     outputDelegation
 }
+
+// runResult is one activation's outcome, shared by every caller that
+// overlapped it. Exactly one of out and err is meaningful.
+type runResult struct {
+	out any
+	err error
+}
+
+// inflightRun is a childPath's running activation. The leader stores res
+// and closes done; waiters read res only after done is closed, so the
+// close/receive pair carries the write.
+type inflightRun struct {
+	done chan struct{}
+	res  runResult
+}
+
+// publish hands res to the waiters. Called once, by the leader.
+func (r *inflightRun) publish(res runResult) {
+	r.res = res
+	close(r.done)
+}
+
+// result reports the published outcome; valid only once done is closed.
+func (r *inflightRun) result() runResult { return r.res }
 
 // ResolveByRunID implements [agent.DynamicSubScheduler].
 func (s *dynamicSubScheduler) ResolveByRunID(childName, custom string) (string, error) {
@@ -143,6 +172,7 @@ func newDynamicSubScheduler(parent agent.Context, parentPath string, emitUp func
 		outputForAncestors: ancestors,
 		runCountByChild:    map[string]int{},
 		resultByPath:       map[string]any{},
+		inflightByPath:     map[string]*inflightRun{},
 	}
 	s.rehydrateCache()
 	return s
@@ -191,6 +221,12 @@ func (s *dynamicSubScheduler) rehydrateCache() {
 // call with the same stable WithRunID returns the cached output
 // without re-running the child; auto-counter ids never collide so
 // the cache is effectively bypassed for them.
+//
+// Calls sharing a WithRunID are gated per childPath by awaitOrLead, so
+// overlapping callers share one activation's outcome instead of each
+// running the child. A caller must therefore not invoke RunNode for a
+// childPath its own frame already leads: it would wait on itself until
+// the invocation is cancelled.
 //
 // Session, invocation metadata, and cancellation come from
 // s.parentCtx. opts carries the resolved RunNodeOption arguments.
@@ -271,13 +307,20 @@ func (s *dynamicSubScheduler) runNode(child Node, input any, opts runNodeOptions
 		}
 	}()
 
-	// Cached (WithRunID replay): the child already ran, so publish its
-	// output for the delegation immediately. The span opened above still
-	// records the cache hit.
-	if cached, ok := s.lookupCachedOutput(childPath); ok {
-		s.commitDelegation(childPath, cached)
-		return cached, nil
+	// The child already ran (WithRunID replay), or another caller is
+	// running it right now and we shared its outcome. Either way, publish
+	// the output for the delegation immediately. The span opened above
+	// still records the hit.
+	if res, hasResult := s.awaitOrLead(childPath); hasResult {
+		if res.err != nil {
+			return nil, res.err
+		}
+		s.commitDelegation(childPath, res.out)
+		return res.out, nil
 	}
+	// This caller leads: hand the outcome to every waiter, on every exit
+	// path, so the child runs at most once per activation.
+	defer func() { s.finishRun(childPath, runResult{out: out, err: err}) }()
 
 	var (
 		hasOutput   bool
@@ -407,7 +450,6 @@ func (s *dynamicSubScheduler) runNode(child Node, input any, opts runNodeOptions
 		return nil, s.pause(name, childPath, runID, ErrNodeWaitingForOutput)
 	}
 
-	s.storeCachedOutput(childPath, out)
 	s.commitDelegation(childPath, out) // no-op unless this child claimed the delegation
 	return out, nil
 }
@@ -429,17 +471,59 @@ func waitsForOutput(node Node) bool {
 	return w != nil && *w
 }
 
-func (s *dynamicSubScheduler) lookupCachedOutput(childPath string) (any, bool) {
+// awaitOrLead reports the outcome of childPath's activation when one is
+// already available, and otherwise makes this caller the leader, which
+// must run the child and publish the outcome via finishRun.
+//
+// A caller arriving while a leader runs blocks until the leader publishes
+// and then shares that outcome — including a failure or a HITL interrupt
+// — instead of running the child again. So a childPath executes at most
+// once per activation on every path, not just the successful one.
+// Mirrors adk-python's _check_existing_run, which awaits the in-flight
+// task and hands every concurrent caller the same result.
+//
+// Sharing is confined to callers that overlap one activation: nothing is
+// cached for a failure or an interrupt, so a later sequential call finds
+// no entry and re-runs the child, as before.
+//
+// A blocked caller is released early if s.parentCtx is cancelled, and its
+// outcome is then that cancellation — the leader keeps the slot and
+// finishes on its own.
+func (s *dynamicSubScheduler) awaitOrLead(childPath string) (runResult, bool) {
 	s.mu.Lock()
-	defer s.mu.Unlock()
-	out, ok := s.resultByPath[childPath]
-	return out, ok
+	if out, ok := s.resultByPath[childPath]; ok {
+		s.mu.Unlock()
+		return runResult{out: out}, true
+	}
+	if leader, inflight := s.inflightByPath[childPath]; inflight {
+		s.mu.Unlock()
+		select {
+		case <-leader.done:
+			return leader.result(), true
+		case <-s.parentCtx.Done():
+			return runResult{err: s.parentCtx.Err()}, true
+		}
+	}
+	s.inflightByPath[childPath] = &inflightRun{done: make(chan struct{})}
+	s.mu.Unlock()
+	return runResult{}, false
 }
 
-func (s *dynamicSubScheduler) storeCachedOutput(childPath string, out any) {
+// finishRun publishes res to everyone waiting on childPath and clears the
+// in-flight slot. A successful outcome is also cached so a later call
+// replays it; failures and interrupts are not, matching the pre-existing
+// replay semantics.
+func (s *dynamicSubScheduler) finishRun(childPath string, res runResult) {
 	s.mu.Lock()
-	defer s.mu.Unlock()
-	s.resultByPath[childPath] = out
+	leader := s.inflightByPath[childPath]
+	delete(s.inflightByPath, childPath)
+	if res.err == nil {
+		s.resultByPath[childPath] = res.out
+	}
+	s.mu.Unlock()
+	if leader != nil {
+		leader.publish(res)
+	}
 }
 
 // claimDelegation reserves the at-most-one output delegation when

--- a/workflow/dynamic_scheduler_test.go
+++ b/workflow/dynamic_scheduler_test.go
@@ -236,12 +236,12 @@ func TestSubScheduler_RehydrateCache_InvocationScope(t *testing.T) {
 			ctx.sess = &eventsSession{events: tc.events}
 			sub := newDynamicSubScheduler(agent.NewContext(ctx), "wf", noopEmit).(*dynamicSubScheduler)
 
-			out, ok := sub.lookupCachedOutput(childPath)
+			res, ok := sub.awaitOrLead(childPath)
 			if ok != tc.wantHit {
-				t.Fatalf("lookupCachedOutput(%q) hit = %v, want %v (out=%v)", childPath, ok, tc.wantHit, out)
+				t.Fatalf("awaitOrLead(%q) hit = %v, want %v (res=%+v)", childPath, ok, tc.wantHit, res)
 			}
-			if ok && out != tc.wantValue {
-				t.Errorf("cached output = %v, want %v", out, tc.wantValue)
+			if ok && res.out != tc.wantValue {
+				t.Errorf("cached output = %v, want %v", res.out, tc.wantValue)
 			}
 		})
 	}

--- a/workflow/run_node.go
+++ b/workflow/run_node.go
@@ -40,6 +40,11 @@ type runNodeOptions struct {
 // auto-counter), and exclude the composite-path separators '/' and
 // '@'. Violations surface as ErrInvalidRunID from RunNode.
 //
+// A stable id makes the call idempotent within one invocation: a repeat
+// returns the first run's output without re-running the child, and calls
+// that overlap in time share one execution and its outcome. A failed or
+// interrupted run is not retained, so a later call runs the child again.
+//
 // Mirrors adk-python's run_id kwarg
 // (https://adk.dev/graphs/dynamic/#custom-execution-ids).
 func WithRunID(id string) RunNodeOption {

--- a/workflow/run_node_test.go
+++ b/workflow/run_node_test.go
@@ -15,13 +15,16 @@
 package workflow
 
 import (
+	"context"
 	"errors"
 	"iter"
 	"reflect"
 	"strconv"
 	"strings"
 	"sync"
+	"sync/atomic"
 	"testing"
+	"testing/synctest"
 
 	"google.golang.org/adk/v2/agent"
 	"google.golang.org/adk/v2/session"
@@ -393,6 +396,274 @@ func TestRunNode_WithRunID_IdempotentReplay(t *testing.T) {
 	if got := child.runCount(); got != 1 {
 		t.Errorf("child.Run invocations = %d, want 1", got)
 	}
+}
+
+// gatedRunCountNode counts Run invocations and blocks until release is
+// closed, so a test can hold the leader inside Run while another caller
+// reaches the single-flight gate. outErr fails the activation; out, when
+// non-nil, is emitted as the child's output.
+type gatedRunCountNode struct {
+	BaseNode
+	runs    atomic.Int64
+	release chan struct{}
+	out     any
+	outErr  error
+}
+
+func (n *gatedRunCountNode) Run(ctx agent.Context, _ any) iter.Seq2[*session.Event, error] {
+	return func(yield func(*session.Event, error) bool) {
+		n.runs.Add(1)
+		<-n.release
+		if n.outErr != nil {
+			yield(nil, n.outErr)
+			return
+		}
+		if n.out != nil {
+			ev := session.NewEvent(ctx, ctx.InvocationID())
+			ev.Output = n.out
+			yield(ev, nil)
+		}
+	}
+}
+
+// gatedInterruptNode is gatedRunCountNode's HITL counterpart: it blocks
+// until release is closed, then asks for input.
+type gatedInterruptNode struct {
+	BaseNode
+	runs    atomic.Int64
+	release chan struct{}
+}
+
+func (n *gatedInterruptNode) Run(agent.Context, any) iter.Seq2[*session.Event, error] {
+	return func(yield func(*session.Event, error) bool) {
+		n.runs.Add(1)
+		<-n.release
+		yield(&session.Event{
+			RequestedInput: &session.RequestInput{InterruptID: "iid", Message: "ask"},
+		}, nil)
+	}
+}
+
+// runConcurrentDup issues two RunNode calls sharing one WithRunID against
+// child, holding the leader inside Run until the second caller is durably
+// parked on the gate, then releases both. Results are indexed leader-first.
+// synctest.Wait is what makes the overlap a rendezvous instead of a race
+// against a deadline.
+func runConcurrentDup(t *testing.T, child *gatedRunCountNode) (outs [2]string, errs [2]error) {
+	t.Helper()
+	n := NewDynamicNode[string, string](
+		"orch",
+		func(ctx agent.Context, _ string, _ func(*session.Event) error) (string, error) {
+			var wg sync.WaitGroup
+			wg.Add(1)
+			go func() {
+				defer wg.Done()
+				outs[0], errs[0] = RunNode[string](ctx, child, "x", WithRunID("dup"))
+			}()
+			synctest.Wait() // leader is inside child.Run, parked on release
+
+			wg.Add(1)
+			go func() {
+				defer wg.Done()
+				outs[1], errs[1] = RunNode[string](ctx, child, "x", WithRunID("dup"))
+			}()
+			synctest.Wait() // second caller is parked on the gate, not merely started
+
+			close(child.release)
+			wg.Wait()
+			return "", nil
+		},
+		NodeConfig{},
+	)
+	if _, err := drainDynamicWithErr(t, n, ""); err != nil {
+		t.Fatalf("orchestrator Run error: %v", err)
+	}
+	return outs, errs
+}
+
+// TestRunNode_WithRunID_ConcurrentSingleFlight: two concurrent RunNode
+// calls sharing one WithRunID resolve the same childPath, so the child
+// runs once and both callers receive its output.
+func TestRunNode_WithRunID_ConcurrentSingleFlight(t *testing.T) {
+	synctest.Test(t, func(t *testing.T) {
+		child := &gatedRunCountNode{
+			BaseNode: NewBaseNode("dupchild", "", NodeConfig{}),
+			release:  make(chan struct{}),
+			out:      "shared_value",
+		}
+		outs, errs := runConcurrentDup(t, child)
+
+		if got := child.runs.Load(); got != 1 {
+			t.Errorf("child ran %d times, want exactly 1", got)
+		}
+		for i := range outs {
+			if errs[i] != nil {
+				t.Errorf("caller %d: unexpected error: %v", i, errs[i])
+			}
+			if outs[i] != "shared_value" {
+				t.Errorf("caller %d: output = %q, want %q", i, outs[i], "shared_value")
+			}
+		}
+	})
+}
+
+// TestRunNode_WithRunID_ConcurrentSharesInterrupt: concurrent callers of
+// one HITL child produce a single RequestedInput, so the user is asked to
+// approve once rather than once per caller.
+func TestRunNode_WithRunID_ConcurrentSharesInterrupt(t *testing.T) {
+	synctest.Test(t, func(t *testing.T) {
+		child := &gatedInterruptNode{
+			BaseNode: NewBaseNode("dupchild", "", NodeConfig{}),
+			release:  make(chan struct{}),
+		}
+		var errs [2]error
+		n := NewDynamicNode[string, string](
+			"orch",
+			func(ctx agent.Context, _ string, _ func(*session.Event) error) (string, error) {
+				var wg sync.WaitGroup
+				wg.Add(1)
+				go func() {
+					defer wg.Done()
+					_, errs[0] = RunNode[string](ctx, child, "x", WithRunID("dup"))
+				}()
+				synctest.Wait()
+
+				wg.Add(1)
+				go func() {
+					defer wg.Done()
+					_, errs[1] = RunNode[string](ctx, child, "x", WithRunID("dup"))
+				}()
+				synctest.Wait()
+
+				close(child.release)
+				wg.Wait()
+				return "", nil
+			},
+			NodeConfig{},
+		)
+		events, _ := drainDynamicWithErr(t, n, "")
+
+		if got := child.runs.Load(); got != 1 {
+			t.Errorf("child ran %d times, want exactly 1 (an interrupt is shared, not re-run)", got)
+		}
+		var asks int
+		for _, ev := range events {
+			if ev.RequestedInput != nil {
+				asks++
+			}
+		}
+		if asks != 1 {
+			t.Errorf("emitted %d RequestedInput events, want exactly 1", asks)
+		}
+		for i, err := range errs {
+			if !errors.Is(err, ErrNodeInterrupted) {
+				t.Errorf("caller %d: error = %v, want ErrNodeInterrupted", i, err)
+			}
+		}
+	})
+}
+
+// TestRunNode_WithRunID_ConcurrentSharesFailure: a caller waiting on a
+// leader whose child fails receives the leader's error instead of running
+// the child again, so side effects are not repeated on the failure path.
+func TestRunNode_WithRunID_ConcurrentSharesFailure(t *testing.T) {
+	synctest.Test(t, func(t *testing.T) {
+		child := &gatedRunCountNode{
+			BaseNode: NewBaseNode("dupchild", "", NodeConfig{}),
+			release:  make(chan struct{}),
+			outErr:   errors.New("boom"),
+		}
+		_, errs := runConcurrentDup(t, child)
+
+		if got := child.runs.Load(); got != 1 {
+			t.Errorf("child ran %d times, want exactly 1 (a failure is shared, not re-run)", got)
+		}
+		for i, err := range errs {
+			if !errors.Is(err, ErrNodeFailed) {
+				t.Errorf("caller %d: error = %v, want ErrNodeFailed", i, err)
+			}
+		}
+	})
+}
+
+// TestRunNode_WithRunID_SequentialRerunAfterFailure: sharing is scoped to
+// one activation. A failure is not cached, so a later sequential call with
+// the same WithRunID runs the child again.
+func TestRunNode_WithRunID_SequentialRerunAfterFailure(t *testing.T) {
+	child := &gatedRunCountNode{
+		BaseNode: NewBaseNode("dupchild", "", NodeConfig{}),
+		release:  make(chan struct{}),
+		outErr:   errors.New("boom"),
+	}
+	close(child.release)
+
+	n := NewDynamicNode[string, string](
+		"orch",
+		func(ctx agent.Context, _ string, _ func(*session.Event) error) (string, error) {
+			for range 2 {
+				if _, err := RunNode[string](ctx, child, "x", WithRunID("dup")); !errors.Is(err, ErrNodeFailed) {
+					t.Errorf("error = %v, want ErrNodeFailed", err)
+				}
+			}
+			return "", nil
+		},
+		NodeConfig{},
+	)
+	if _, err := drainDynamicWithErr(t, n, ""); err != nil {
+		t.Fatalf("orchestrator Run error: %v", err)
+	}
+	if got := child.runs.Load(); got != 2 {
+		t.Errorf("child ran %d times, want 2 (a failure must not be cached)", got)
+	}
+}
+
+// TestRunNode_WithRunID_WaiterUnblocksOnCancel: a caller parked on the gate
+// is released when the invocation is cancelled, rather than waiting out a
+// leader whose child is still working.
+func TestRunNode_WithRunID_WaiterUnblocksOnCancel(t *testing.T) {
+	synctest.Test(t, func(t *testing.T) {
+		child := &gatedRunCountNode{
+			BaseNode: NewBaseNode("dupchild", "", NodeConfig{}),
+			release:  make(chan struct{}),
+			out:      "shared_value",
+		}
+		ctx, cancel := context.WithCancel(t.Context())
+		defer cancel()
+
+		var waiterErr error
+		n := NewDynamicNode[string, string](
+			"orch",
+			func(nc agent.Context, _ string, _ func(*session.Event) error) (string, error) {
+				var wg sync.WaitGroup
+				wg.Add(1)
+				go func() {
+					defer wg.Done()
+					_, _ = RunNode[string](nc, child, "x", WithRunID("dup"))
+				}()
+				synctest.Wait()
+
+				wg.Add(1)
+				go func() {
+					defer wg.Done()
+					_, waiterErr = RunNode[string](nc, child, "x", WithRunID("dup"))
+				}()
+				synctest.Wait()
+
+				cancel()
+				synctest.Wait() // the waiter returns without the leader finishing
+
+				if !errors.Is(waiterErr, context.Canceled) {
+					t.Errorf("waiter error = %v, want context.Canceled", waiterErr)
+				}
+				close(child.release)
+				wg.Wait()
+				return "", nil
+			},
+			NodeConfig{},
+		)
+		for range n.Run(agent.NewContext(&MockInvocationContext{Context: ctx}), "") {
+		}
+	})
 }
 
 func TestRunNode_WithRunID_AndUseAsOutput_IdempotentReplay(t *testing.T) {


### PR DESCRIPTION

## Problem

`RunNode`'s idempotency cache was check-then-act: the cache lookup and the store
were each locked, but `child.Run` ran unlocked in between. Two concurrent
`RunNode` calls sharing one explicit `WithRunID` resolve the same `childPath`,
both miss the cache, and both execute the child — defeating idempotent dispatch,
so the child's side effects run twice.

Gating only the successful path is not enough. When the leader's child fails or
pauses for HITL, nothing is cached, so every other caller runs the child anyway:
a failing child still executes once per caller, and a HITL child emits one
`RequestedInput` per caller, prompting the user once for each. adk-python does
not behave this way — `_check_existing_run` awaits the in-flight task, so every
concurrent caller receives the leader's outcome, whether that is a value, an
error, or an interrupt.

## Summary

- Gate execution per `childPath`. The first caller leads and runs the child;
  callers that overlap it wait and then share the leader's outcome instead of
  running the child again.
- Sharing covers failure and HITL interrupt as well as success, so a `childPath`
  executes at most once per activation on every path. This is what closes the
  duplicate-side-effect and duplicate-prompt cases, and it matches adk-python.
- Sharing is scoped to one activation. Only a success is cached, so a later
  sequential call with the same run-id re-runs the child, exactly as before. The
  auto-counter path is untouched: distinct run-ids, distinct paths.
- The wait selects on the parent context, so cancelling the invocation releases a
  waiting caller rather than pinning it to the leader's remaining work.
- `WithRunID`'s godoc now states the idempotency and outcome-sharing contract,
  which it previously left unsaid.
- Tests use a `synctest` rendezvous, so the overlap the assertions depend on is
  deterministic rather than a race against a wall-clock deadline. They cover
  shared success, shared failure, shared interrupt (exactly one `RequestedInput`),
  sequential re-run after failure, and cancellation of a waiting caller.