### PR TITLE
refactor(workflow): move output validation off inline node paths

### DIFF
--- a/workflow/function_node.go
+++ b/workflow/function_node.go
@@ -230,11 +230,6 @@ func NewFunctionNodeFromState[Params, OUT any](
 		if err != nil {
 			return output, err
 		}
-		if oschema != nil {
-			if err := typeutil.ValidateWithJSONSchema(output, oschema); err != nil {
-				return nil, fmt.Errorf("function node %s: validation failed for output %T: %w", name, new(OUT), err)
-			}
-		}
 		return output, nil
 	}
 
@@ -276,13 +271,6 @@ func newFunctionNodeWithResolvedSchemas[IN, OUT any](name string, fn func(ctx ag
 			return output, err
 		}
 
-		if outputSchema != nil {
-			validateErr := typeutil.ValidateWithJSONSchema(output, outputSchema)
-			if validateErr != nil {
-				return nil, fmt.Errorf("function node %s: validation failed for output %T: %w", name, new(OUT), validateErr)
-			}
-		}
-
 		return output, nil
 	}
 
@@ -320,11 +308,6 @@ func newEmittingFunctionNodeWithResolvedSchemas[IN, OUT any](name string, fn Emi
 		output, err := fn(ctx, typedInput, emit)
 		if err != nil {
 			return nil, err
-		}
-		if outputSchema != nil {
-			if validateErr := typeutil.ValidateWithJSONSchema(output, outputSchema); validateErr != nil {
-				return nil, fmt.Errorf("function node %s: validation failed for output %T: %w", name, new(OUT), validateErr)
-			}
 		}
 		return output, nil
 	}

--- a/workflow/function_node_test.go
+++ b/workflow/function_node_test.go
@@ -158,6 +158,17 @@ func TestFunctionNode_ValidateOutput(t *testing.T) {
 	if _, err := node.ValidateOutput(got); err == nil {
 		t.Fatalf("ValidateOutput: expected validation error, got nil")
 	}
+
+	// A schema-conforming output passes ValidateOutput and is returned
+	// unchanged.
+	valid := map[string]any{"result": 1}
+	gotValid, err := node.ValidateOutput(valid)
+	if err != nil {
+		t.Fatalf("ValidateOutput: unexpected error for valid output: %v", err)
+	}
+	if diff := cmp.Diff(valid, gotValid); diff != "" {
+		t.Errorf("ValidateOutput mismatch (-want +got):\n%s", diff)
+	}
 }
 
 func mustSchema[T any](t *testing.T) *jsonschema.Schema {

--- a/workflow/function_node_test.go
+++ b/workflow/function_node_test.go
@@ -37,9 +37,6 @@ func TestNewFunctionNodeWithSchema(t *testing.T) {
 	type Output struct {
 		Result string `json:"result"`
 	}
-	type TargetOutput struct {
-		Result int `json:"result"`
-	}
 
 	tests := []struct {
 		name         string
@@ -79,18 +76,6 @@ func TestNewFunctionNodeWithSchema(t *testing.T) {
 			wantOutput:   map[string]any{"result": "zero"},
 			wantErr:      false,
 		},
-		{
-			name:     "ValidationError",
-			nodeName: "test",
-			fn: func(ctx agent.Context, input Input) (map[string]any, error) {
-				return map[string]any{"result": "not-an-int"}, nil
-			},
-			inputSchema:  mustSchema[Input](t),
-			outputSchema: mustSchema[TargetOutput](t),
-			input:        Input{Value: "hello"},
-			wantErr:      true,
-			errSubstr:    "validation failed for output",
-		},
 	}
 
 	for _, tc := range tests {
@@ -129,6 +114,49 @@ func TestNewFunctionNodeWithSchema(t *testing.T) {
 				t.Errorf("expected 1 event, got %d", count)
 			}
 		})
+	}
+}
+
+// TestFunctionNode_ValidateOutput verifies that output schema validation
+// is enforced through the node-level ValidateOutput contract (invoked
+// scheduler-side), not inline inside Run. Run itself passes the output
+// through unchanged; ValidateOutput surfaces the schema mismatch.
+func TestFunctionNode_ValidateOutput(t *testing.T) {
+	type Input struct {
+		Value string `json:"value"`
+	}
+	type TargetOutput struct {
+		Result int `json:"result"`
+	}
+
+	fn := func(ctx agent.Context, input Input) (map[string]any, error) {
+		return map[string]any{"result": "not-an-int"}, nil
+	}
+	node, err := NewFunctionNodeWithSchema[Input, map[string]any](
+		"test", fn, mustSchema[Input](t), mustSchema[TargetOutput](t), defaultNodeConfig)
+	if err != nil {
+		t.Fatalf("NewFunctionNodeWithSchema failed: %v", err)
+	}
+
+	// Run does not validate: it yields the raw output without error.
+	mockCtx := &MockInvocationContext{sess: nil}
+	exCtx := agent.NewNodeContext(mockCtx, nil)
+	var got any
+	count := 0
+	for ev, err := range node.Run(exCtx, Input{Value: "hello"}) {
+		if err != nil {
+			t.Fatalf("Run returned unexpected error: %v", err)
+		}
+		got = ev.Output
+		count++
+	}
+	if count != 1 {
+		t.Fatalf("expected 1 event from Run, got %d", count)
+	}
+
+	// ValidateOutput (the scheduler-side contract) rejects the mismatch.
+	if _, err := node.ValidateOutput(got); err == nil {
+		t.Fatalf("ValidateOutput: expected validation error, got nil")
 	}
 }
 

--- a/workflow/function_node_test.go
+++ b/workflow/function_node_test.go
@@ -117,10 +117,47 @@ func TestNewFunctionNodeWithSchema(t *testing.T) {
 	}
 }
 
-// TestFunctionNode_ValidateOutput verifies that output schema validation
-// is enforced through the node-level ValidateOutput contract (invoked
-// scheduler-side), not inline inside Run. Run itself passes the output
-// through unchanged; ValidateOutput surfaces the schema mismatch.
+// TestFunctionNode_RunDoesNotValidate verifies Run yields the raw output
+// unchanged even when it violates the output schema: validation is the
+// scheduler's job (ValidateOutput), not Run's.
+func TestFunctionNode_RunDoesNotValidate(t *testing.T) {
+	type Input struct {
+		Value string `json:"value"`
+	}
+	type TargetOutput struct {
+		Result int `json:"result"`
+	}
+
+	raw := map[string]any{"result": "not-an-int"} // violates TargetOutput
+	fn := func(ctx agent.Context, input Input) (map[string]any, error) {
+		return raw, nil
+	}
+	node, err := NewFunctionNodeWithSchema[Input, map[string]any](
+		"test", fn, mustSchema[Input](t), mustSchema[TargetOutput](t), defaultNodeConfig)
+	if err != nil {
+		t.Fatalf("NewFunctionNodeWithSchema failed: %v", err)
+	}
+
+	mockCtx := &MockInvocationContext{sess: nil}
+	exCtx := agent.NewNodeContext(mockCtx, nil)
+	count := 0
+	for ev, err := range node.Run(exCtx, Input{Value: "hello"}) {
+		if err != nil {
+			t.Fatalf("Run returned unexpected error: %v", err)
+		}
+		if diff := cmp.Diff(raw, ev.Output); diff != "" {
+			t.Errorf("Run output mismatch (-want +got):\n%s", diff)
+		}
+		count++
+	}
+	if count != 1 {
+		t.Fatalf("expected 1 event from Run, got %d", count)
+	}
+}
+
+// TestFunctionNode_ValidateOutput covers the scheduler-side output
+// validation contract: a schema-conforming value passes through, a
+// schema mismatch errors, and a nil schema accepts anything.
 func TestFunctionNode_ValidateOutput(t *testing.T) {
 	type Input struct {
 		Value string `json:"value"`
@@ -130,44 +167,58 @@ func TestFunctionNode_ValidateOutput(t *testing.T) {
 	}
 
 	fn := func(ctx agent.Context, input Input) (map[string]any, error) {
-		return map[string]any{"result": "not-an-int"}, nil
+		return nil, nil // body unused: ValidateOutput is exercised directly
 	}
-	node, err := NewFunctionNodeWithSchema[Input, map[string]any](
+	schemaNode, err := NewFunctionNodeWithSchema[Input, map[string]any](
 		"test", fn, mustSchema[Input](t), mustSchema[TargetOutput](t), defaultNodeConfig)
 	if err != nil {
 		t.Fatalf("NewFunctionNodeWithSchema failed: %v", err)
 	}
+	nilSchemaNode := NewFunctionNode[Input, map[string]any]("test_nil", fn, defaultNodeConfig)
 
-	// Run does not validate: it yields the raw output without error.
-	mockCtx := &MockInvocationContext{sess: nil}
-	exCtx := agent.NewNodeContext(mockCtx, nil)
-	var got any
-	count := 0
-	for ev, err := range node.Run(exCtx, Input{Value: "hello"}) {
-		if err != nil {
-			t.Fatalf("Run returned unexpected error: %v", err)
-		}
-		got = ev.Output
-		count++
-	}
-	if count != 1 {
-		t.Fatalf("expected 1 event from Run, got %d", count)
+	tests := []struct {
+		name    string
+		node    *FunctionNode
+		output  any
+		want    any
+		wantErr bool
+	}{
+		{
+			name:   "direct_valid_passes_through",
+			node:   schemaNode,
+			output: map[string]any{"result": 1},
+			want:   map[string]any{"result": 1},
+		},
+		{
+			name:    "schema_mismatch_fails",
+			node:    schemaNode,
+			output:  map[string]any{"result": "not-an-int"},
+			wantErr: true,
+		},
+		{
+			name:   "nil_schema_passes_through",
+			node:   nilSchemaNode,
+			output: map[string]any{"anything": 1},
+			want:   map[string]any{"anything": 1},
+		},
 	}
 
-	// ValidateOutput (the scheduler-side contract) rejects the mismatch.
-	if _, err := node.ValidateOutput(got); err == nil {
-		t.Fatalf("ValidateOutput: expected validation error, got nil")
-	}
-
-	// A schema-conforming output passes ValidateOutput and is returned
-	// unchanged.
-	valid := map[string]any{"result": 1}
-	gotValid, err := node.ValidateOutput(valid)
-	if err != nil {
-		t.Fatalf("ValidateOutput: unexpected error for valid output: %v", err)
-	}
-	if diff := cmp.Diff(valid, gotValid); diff != "" {
-		t.Errorf("ValidateOutput mismatch (-want +got):\n%s", diff)
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			got, err := tc.node.ValidateOutput(tc.output)
+			if tc.wantErr {
+				if err == nil {
+					t.Fatalf("ValidateOutput: expected error, got nil (out=%v)", got)
+				}
+				return
+			}
+			if err != nil {
+				t.Fatalf("ValidateOutput: unexpected error: %v", err)
+			}
+			if diff := cmp.Diff(tc.want, got); diff != "" {
+				t.Errorf("ValidateOutput mismatch (-want +got):\n%s", diff)
+			}
+		})
 	}
 }
 

--- a/workflow/tool_node.go
+++ b/workflow/tool_node.go
@@ -112,23 +112,39 @@ func (n *ToolNode) runTool(toolCtx agent.Context, input any) (any, error) {
 		return nil, fmt.Errorf("tool %q execution failed: %w", n.tool.Name(), err)
 	}
 
-	var toolOutput any = output
+	return output, nil
+}
 
-	// Validate
-	if schema := n.OutputSchema(); schema != nil {
-		if err := schema.Validate(output); err != nil {
-			if val, ok := output["result"]; ok {
-				if err := schema.Validate(val); err != nil {
-					return nil, fmt.Errorf("converting tool %q output: validation failed for result key: %w", n.tool.Name(), err)
-				}
-				toolOutput = val
-			} else {
-				return nil, fmt.Errorf("converting tool %q output: validation failed: %w", n.tool.Name(), err)
+// ValidateOutput validates the tool output against the node's output
+// schema, adding a FunctionTool-specific fallback on top of the default
+// behavior: when the output is a map of shape {"result": X} that fails
+// direct schema validation, it retries against the unwrapped "result"
+// value and, on success, returns that unwrapped value.
+//
+// This override is the home for the {"result": X} convention because it
+// is tool-specific; making it a general default could mask genuine
+// validation errors in other node types.
+func (n *ToolNode) ValidateOutput(out any) (any, error) {
+	schema := n.OutputSchema()
+	if schema == nil {
+		return out, nil
+	}
+	// Try standard validation first.
+	if validated, err := defaultValidateOutput(out, schema); err == nil {
+		return validated, nil
+	}
+	// Fallback: unwrap {"result": X} (FunctionTool convention).
+	if m, ok := out.(map[string]any); ok {
+		if val, ok := m["result"]; ok {
+			if validated, err := defaultValidateOutput(val, schema); err == nil {
+				return validated, nil
 			}
 		}
 	}
-
-	return toolOutput, nil
+	// Both attempts failed: return the error from validating the
+	// original output, not the one from the {"result": X} fallback,
+	// so the caller sees the actual schema mismatch.
+	return defaultValidateOutput(out, schema)
 }
 
 // Run implements the Node interface and executes the tool.

--- a/workflow/tool_node_test.go
+++ b/workflow/tool_node_test.go
@@ -110,9 +110,6 @@ func TestToolNode_Run(t *testing.T) {
 	type Output struct {
 		Greeting string `json:"greeting"`
 	}
-	type ErrorOutput struct {
-		Result int `json:"result"`
-	}
 
 	tests := []struct {
 		name      string
@@ -162,25 +159,13 @@ func TestToolNode_Run(t *testing.T) {
 			node: func(t tool.Tool) (Node, error) {
 				return NewToolNodeTyped[Input, string](t, defaultNodeConfig)
 			},
+			// Run yields the raw FunctionTool map output; the
+			// {"result": X} unwrap happens scheduler-side in
+			// ToolNode.ValidateOutput.
 			extract: func(t *testing.T, out any) string {
-				return out.(string)
+				return out.(map[string]any)["result"].(string)
 			},
 			want: "HELLO WORLD",
-		},
-		{
-			name: "schema_validation_error",
-			tool: func() (tool.Tool, error) {
-				return functiontool.New(functiontool.Config{
-					Name: "test_tool",
-				}, func(ctx agent.Context, in map[string]any) (map[string]any, error) {
-					return map[string]any{"result": "not-an-int"}, nil
-				})
-			},
-			nodeInput: map[string]any{},
-			node: func(t tool.Tool) (Node, error) {
-				return NewToolNodeTyped[map[string]any, ErrorOutput](t, defaultNodeConfig)
-			},
-			wantErr: "converting tool \"test_tool\" output",
 		},
 		{
 			name: "tool_execution_error",
@@ -271,6 +256,78 @@ func TestToolNode_Run(t *testing.T) {
 			}
 			if diff := cmp.Diff(tc.want, got); diff != "" {
 				t.Errorf("output mismatch (-want +got):\n%s", diff)
+			}
+		})
+	}
+}
+
+// TestToolNode_ValidateOutput exercises the FunctionTool-specific
+// {"result": X} unwrap fallback that ToolNode layers on top of the
+// default schema validation.
+func TestToolNode_ValidateOutput(t *testing.T) {
+	type Result struct {
+		Greeting string `json:"greeting"`
+	}
+
+	// Node carrying a Result output schema.
+	schemaNode := &ToolNode{
+		BaseNode: NewBaseNodeWithSchemas(
+			"greet", "", defaultNodeConfig, nil, resolveTestSchema[Result](t)),
+	}
+	// Node with no output schema.
+	nilSchemaNode := &ToolNode{
+		BaseNode: NewBaseNode("greet", "", defaultNodeConfig),
+	}
+
+	valid := map[string]any{"greeting": "Hello World"}
+
+	tests := []struct {
+		name    string
+		node    *ToolNode
+		output  any
+		want    any
+		wantErr bool
+	}{
+		{
+			name:   "direct_valid_passes_through",
+			node:   schemaNode,
+			output: valid,
+			want:   valid,
+		},
+		{
+			name:   "result_wrapped_is_unwrapped",
+			node:   schemaNode,
+			output: map[string]any{"result": valid},
+			want:   valid,
+		},
+		{
+			name:    "fails_direct_and_fallback",
+			node:    schemaNode,
+			output:  map[string]any{"result": map[string]any{"unexpected": 1}},
+			wantErr: true,
+		},
+		{
+			name:   "nil_schema_passes_through",
+			node:   nilSchemaNode,
+			output: map[string]any{"anything": 1},
+			want:   map[string]any{"anything": 1},
+		},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			got, err := tc.node.ValidateOutput(tc.output)
+			if tc.wantErr {
+				if err == nil {
+					t.Fatalf("ValidateOutput: expected error, got nil (out=%v)", got)
+				}
+				return
+			}
+			if err != nil {
+				t.Fatalf("ValidateOutput: unexpected error: %v", err)
+			}
+			if diff := cmp.Diff(tc.want, got); diff != "" {
+				t.Errorf("ValidateOutput mismatch (-want +got):\n%s", diff)
 			}
 		})
 	}


### PR DESCRIPTION
## Problem
Output validation for `FunctionNode` and `ToolNode` was duplicated. Each node
validated its output inline (inside `wrappedFn` / `runTool`) **and** the
scheduler validated it again scheduler-side via `BaseNode.ValidateOutput`
(introduced in #970). The same `OutputSchema` was therefore checked twice on
every activation.
Beyond the redundancy, the two copies are a drift hazard: as the
scheduler-side helper evolves (e.g. #970 added the `*genai.Content` text
fallback and passthrough for framework control values), the inline copies fall
behind and the two paths diverge. The validation behaviour also stopped being
uniform across node types — custom `Node` implementations only ever went through
the scheduler, while `FunctionNode`/`ToolNode` carried their own logic.
The FunctionTool `{"result": X}` unwrap convention was buried inline inside
`ToolNode.runTool`, mixing a tool-specific quirk into the execution path instead
of expressing it as part of the validation contract.

## Solution
Make the scheduler the single, authoritative output-validation point and remove
the inline validation from the node run paths:
- **`FunctionNode`**: drop the inline `OutputSchema` check from all three
  constructors (`newFunctionNodeWithResolvedSchemas`, `NewFunctionNodeFromState`,
  and the emitting variant). The schema still flows through `BaseNode`, so the
  scheduler enforces it via `BaseNode.ValidateOutput`. `wrappedFn` is back to
  doing one thing: materialise the typed parameter and call the user function.
- **`ToolNode`**: remove the inline validation from `runTool` and move the
  FunctionTool `{"result": X}` unwrap into a dedicated `ToolNode.ValidateOutput`
  override. The override tries standard validation first, falls back to
  unwrapping `{"result": X}`, and re-runs standard validation on total failure
  so the caller still sees the original schema-mismatch error. This is the right
  home for the convention because it is tool-specific — making it a general
  default could mask genuine validation errors in other node types.

## Behaviour note
Validation errors now surface scheduler-side rather than inside `Run`. For real
workflows this is unobservable (every activation goes through the scheduler).
Callers that invoke `node.Run()` directly (mostly tests) now receive the raw
output and must call `ValidateOutput` themselves. Tests are split accordingly:
`Run`-level tests assert raw passthrough; validation is asserted via
`ValidateOutput` (`TestFunctionNode_ValidateOutput`,
`TestToolNode_ValidateOutput` covering direct-valid, `{"result": X}` unwrap,
fail-both-paths, and nil-schema cases).