### PR TITLE
feat(workflow): enforce at-most-one-terminal-output at run finalize

### DIFF
--- a/workflow/max_concurrency_test.go
+++ b/workflow/max_concurrency_test.go
@@ -38,13 +38,17 @@ func bumpPeak(inFlight, peak *atomic.Int32) func() {
 	return func() { inFlight.Add(-1) }
 }
 
-// fanOutFromStart builds N Edge{Start, nodes[i]} edges.
-func fanOutFromStart(nodes []Node) []Edge {
-	edges := make([]Edge, 0, len(nodes))
+// fanOutToJoin builds a START -> nodes -> join topology: every node
+// fans out from START and feeds a single JoinNode. Returns the edges
+// and the join.
+func fanOutToJoin(nodes []Node) ([]Edge, *JoinNode) {
+	join := NewJoinNode("join")
+	edges := make([]Edge, 0, len(nodes)+1)
 	for _, n := range nodes {
 		edges = append(edges, Edge{From: Start, To: n})
+		edges = append(edges, Edge{From: n, To: join})
 	}
-	return edges
+	return edges, join
 }
 
 // TestMaxConcurrency_Caps verifies that a fan-out wider than the
@@ -68,7 +72,8 @@ func TestMaxConcurrency_Caps(t *testing.T) {
 		})
 	}
 
-	w, err := New("", fanOutFromStart(nodes), WithMaxConcurrency(cap))
+	edges, _ := fanOutToJoin(nodes)
+	w, err := New("", edges, WithMaxConcurrency(cap))
 	if err != nil {
 		t.Fatalf("New: %v", err)
 	}
@@ -120,7 +125,8 @@ func TestMaxConcurrency_PendingDispatchedFIFO(t *testing.T) {
 			defaultNodeConfig,
 		)
 	}
-	w, err := New("", fanOutFromStart(nodes), WithMaxConcurrency(1))
+	edges, _ := fanOutToJoin(nodes)
+	w, err := New("", edges, WithMaxConcurrency(1))
 	if err != nil {
 		t.Fatalf("New: %v", err)
 	}
@@ -173,7 +179,8 @@ func TestMaxConcurrency_RetryRespectsLimit(t *testing.T) {
 		defaultNodeConfig,
 	)
 
-	w, err := New("", fanOutFromStart([]Node{flaky, stable}), WithMaxConcurrency(1))
+	edges, _ := fanOutToJoin([]Node{flaky, stable})
+	w, err := New("", edges, WithMaxConcurrency(1))
 	if err != nil {
 		t.Fatalf("New: %v", err)
 	}

--- a/workflow/scheduler.go
+++ b/workflow/scheduler.go
@@ -18,6 +18,8 @@ import (
 	"context"
 	"errors"
 	"fmt"
+	"slices"
+	"strings"
 	"sync"
 	"time"
 
@@ -46,6 +48,11 @@ var (
 	// than one event whose Routes field is set. A node activation
 	// may emit at most one routing decision.
 	ErrMultipleRoutingEvents = errors.New("workflow: node produced multiple events with route tags; only one event per execution can specify routes")
+
+	// ErrMultipleTerminalOutputs is returned when more than one
+	// terminal node produced output in a run, making the workflow's
+	// output ambiguous. See scheduler.finalize for the exact rule.
+	ErrMultipleTerminalOutputs = errors.New("workflow: multiple terminal nodes produced output; a workflow must have at most one terminal output")
 )
 
 // scheduler drives a single Workflow.Run invocation. It owns the
@@ -605,7 +612,47 @@ func (s *scheduler) run(yield func(*session.Event, error) bool) {
 	// panics the iterator.
 	if pendingErr != nil && !consumerGone {
 		yield(nil, pendingErr)
+		return
 	}
+
+	// Skip finalize when draining (cancelled, consumer gone, or a node
+	// errored): the run did not complete normally.
+	if !draining {
+		if err := s.finalize(); err != nil {
+			yield(nil, err)
+		}
+	}
+}
+
+// finalize errors if more than one terminal node (no outgoing edges,
+// excluding START) produced output in this run. It counts actual
+// outputs, not graph shape, so fan-out and conditional-routing graphs
+// with several terminal branches are fine as long as at most one yields
+// output. No-op while a node is interrupted: the run has not finished.
+// Mirrors adk-python's Workflow._finalize.
+func (s *scheduler) finalize() error {
+	for _, ns := range s.state.Nodes {
+		if ns.Status == NodeWaiting {
+			return nil
+		}
+	}
+
+	var producers []string
+	for name := range s.graph.terminalNodeNames() {
+		ns, ok := s.state.Nodes[name]
+		if !ok || ns.Status != NodeCompleted {
+			continue
+		}
+		if ns.Output != nil {
+			producers = append(producers, name)
+		}
+	}
+
+	if len(producers) > 1 {
+		slices.Sort(producers)
+		return fmt.Errorf("%w: %s", ErrMultipleTerminalOutputs, strings.Join(producers, ", "))
+	}
+	return nil
 }
 
 // defaultContentRole picks the role for node Content that left it

--- a/workflow/scheduler_branch_test.go
+++ b/workflow/scheduler_branch_test.go
@@ -74,11 +74,14 @@ func TestScheduler_MultipleSuccessors_AssignsSubBranches(t *testing.T) {
 	b := branchRecorder("b", &mu, &seen)
 	c := branchRecorder("c", &mu, &seen)
 
-	// START fans out to a + b + c.
+	join := NewJoinNode("join")
 	w := mustNew(t, []Edge{
 		{From: Start, To: a},
 		{From: Start, To: b},
 		{From: Start, To: c},
+		{From: a, To: join},
+		{From: b, To: join},
+		{From: c, To: join},
 	})
 
 	drain(t, w.Run(mockCtx))
@@ -109,10 +112,13 @@ func TestScheduler_FanOutChainedDeeperBranches(t *testing.T) {
 	b1 := branchRecorder("b1", &mu, &seen)
 	b2 := branchRecorder("b2", &mu, &seen)
 
+	join := NewJoinNode("join")
 	w := mustNew(t, []Edge{
 		{From: Start, To: a}, // a stays on root (single successor)
 		{From: a, To: b1},    // a fans out: b1 and b2 get sub-branches
 		{From: a, To: b2},
+		{From: b1, To: join},
+		{From: b2, To: join},
 	})
 
 	drain(t, w.Run(mockCtx))
@@ -225,9 +231,12 @@ func TestScheduler_EventsAreBranchStamped(t *testing.T) {
 	a := branchRecorder("a", &mu, &seen)
 	b := branchRecorder("b", &mu, &seen)
 
+	join := NewJoinNode("join")
 	w := mustNew(t, []Edge{
 		{From: Start, To: a},
 		{From: Start, To: b},
+		{From: a, To: join},
+		{From: b, To: join},
 	})
 
 	events := drain(t, w.Run(mockCtx))

--- a/workflow/scheduler_test.go
+++ b/workflow/scheduler_test.go
@@ -115,9 +115,13 @@ func TestScheduler_FanOutConcurrency(t *testing.T) {
 		})
 	}
 
-	edges := make([]Edge, 0, fanOut)
+	// Fan out to a single JoinNode; the N blocking nodes still run
+	// concurrently.
+	join := NewJoinNode("join")
+	edges := make([]Edge, 0, 2*fanOut)
 	for _, n := range nodes {
 		edges = append(edges, Edge{From: Start, To: n})
+		edges = append(edges, Edge{From: n, To: join})
 	}
 	w := mustNew(t, edges)
 
@@ -974,4 +978,132 @@ func (n *progressThenSchemaOutputNode) Run(ctx agent.Context, _ any) iter.Seq2[*
 		ev.Output = n.output
 		yield(ev, nil)
 	}
+}
+
+// outputFnNode returns a FunctionNode that emits the given string as
+// its Event.Output. Used by the finalize tests as an
+// output-producing terminal.
+func outputFnNode(name, out string) *FunctionNode {
+	return NewFunctionNode(name,
+		func(ctx agent.Context, _ any) (string, error) {
+			return out, nil
+		}, defaultNodeConfig)
+}
+
+// noOutputNode records nothing and emits an event without Output. Used
+// by the finalize tests as a terminal that does not produce output.
+type noOutputNode struct {
+	BaseNode
+}
+
+func (n *noOutputNode) Run(ctx agent.Context, _ any) iter.Seq2[*session.Event, error] {
+	return func(yield func(*session.Event, error) bool) {
+		yield(session.NewEvent(ctx.InvocationID()), nil)
+	}
+}
+
+// TestScheduler_Finalize_SingleTerminalOutput verifies the runtime
+// single-terminal-output invariant enforced by scheduler.finalize:
+//
+//   - exactly one terminal node producing output -> success;
+//   - several terminal nodes but at most one producing output (fan-out
+//     where only one leaf yields output) -> success;
+//   - more than one terminal node producing output -> error naming the
+//     offending terminals.
+//
+// Mirrors adk-python's Workflow._finalize, which counts terminal nodes
+// that actually produced output rather than rejecting the topology.
+func TestScheduler_Finalize_SingleTerminalOutput(t *testing.T) {
+	t.Run("single terminal output succeeds", func(t *testing.T) {
+		mockCtx := newMockCtx(t)
+		a := outputFnNode("a", "A")
+		w := mustNew(t, []Edge{{From: Start, To: a}})
+		drain(t, w.Run(mockCtx))
+	})
+
+	t.Run("multiple terminals but only one produces output succeeds", func(t *testing.T) {
+		mockCtx := newMockCtx(t)
+		// a, b, c all terminal; only a yields output.
+		a := outputFnNode("a", "A")
+		b := &noOutputNode{BaseNode: NewBaseNode("b", "", defaultNodeConfig)}
+		c := &noOutputNode{BaseNode: NewBaseNode("c", "", defaultNodeConfig)}
+		w := mustNew(t, []Edge{
+			{From: Start, To: a},
+			{From: Start, To: b},
+			{From: Start, To: c},
+		})
+		drain(t, w.Run(mockCtx))
+	})
+
+	t.Run("zero terminals producing output succeeds", func(t *testing.T) {
+		mockCtx := newMockCtx(t)
+		a := &noOutputNode{BaseNode: NewBaseNode("a", "", defaultNodeConfig)}
+		b := &noOutputNode{BaseNode: NewBaseNode("b", "", defaultNodeConfig)}
+		w := mustNew(t, []Edge{
+			{From: Start, To: a},
+			{From: Start, To: b},
+		})
+		drain(t, w.Run(mockCtx))
+	})
+
+	t.Run("multiple terminals producing output errors", func(t *testing.T) {
+		mockCtx := newMockCtx(t)
+		a := outputFnNode("a", "A")
+		b := outputFnNode("b", "B")
+		c := outputFnNode("c", "C")
+		w := mustNew(t, []Edge{
+			{From: Start, To: a},
+			{From: Start, To: b},
+			{From: Start, To: c},
+		})
+		err := drainErr(t, w.Run(mockCtx))
+		if !errors.Is(err, ErrMultipleTerminalOutputs) {
+			t.Fatalf("got error %v, want ErrMultipleTerminalOutputs", err)
+		}
+		// The error names all offending terminals.
+		for _, name := range []string{"a", "b", "c"} {
+			if !strings.Contains(err.Error(), name) {
+				t.Errorf("error %q does not name terminal %q", err.Error(), name)
+			}
+		}
+	})
+
+	t.Run("conditional routing to one of two output terminals succeeds", func(t *testing.T) {
+		// router conditionally activates a OR b; both are
+		// output-producing terminals, but only the routed branch runs,
+		// so exactly one terminal produces output. Mirrors adk-python's
+		// test_run_async_with_edge_routes.
+		mockCtx := newMockCtx(t)
+		router := &CustomRouteNode{
+			BaseNode: NewBaseNode("router", "", defaultNodeConfig),
+			route:    []string{"branchA"},
+		}
+		a := outputFnNode("a", "A")
+		b := outputFnNode("b", "B")
+		w := mustNew(t, []Edge{
+			{From: Start, To: router},
+			{From: router, To: a, Route: StringRoute("branchA")},
+			{From: router, To: b, Route: StringRoute("branchB")},
+		})
+		drain(t, w.Run(mockCtx))
+	})
+
+	// A terminal that carries Output but is not NodeCompleted (e.g. a
+	// re-entering node that kept its rehydrated Output while parked in
+	// NodePending) must not count as a producer. Without the status
+	// check, a + b would both count and trip ErrMultipleTerminalOutputs.
+	t.Run("non-completed terminal with leftover output is not counted", func(t *testing.T) {
+		a := outputFnNode("a", "A")
+		b := outputFnNode("b", "B")
+		s := &scheduler{
+			state: NewRunState(),
+			graph: newGraph([]Edge{{From: Start, To: a}, {From: Start, To: b}}),
+		}
+		s.state.Nodes["a"] = &NodeState{Status: NodeCompleted, Output: "A"}
+		s.state.Nodes["b"] = &NodeState{Status: NodePending, Output: "B"}
+
+		if err := s.finalize(); err != nil {
+			t.Fatalf("finalize: unexpected error %v", err)
+		}
+	})
 }

--- a/workflow/workflow_node_test.go
+++ b/workflow/workflow_node_test.go
@@ -176,8 +176,10 @@ func TestNestedWorkflow_MultipleTerminals(t *testing.T) {
 			gotErr = err
 		}
 	}
-	if !errors.Is(gotErr, ErrMultipleOutputs) {
-		t.Errorf("got error %v, want ErrMultipleOutputs", gotErr)
+	// Two terminals (b, c) each produce output, so the run finalize
+	// invariant fires first with ErrMultipleTerminalOutputs.
+	if !errors.Is(gotErr, ErrMultipleTerminalOutputs) {
+		t.Errorf("got error %v, want ErrMultipleTerminalOutputs", gotErr)
 	}
 }
 

--- a/workflow/workflow_test.go
+++ b/workflow/workflow_test.go
@@ -275,23 +275,26 @@ func TestWorkflowRouting(t *testing.T) {
 	type testCase struct {
 		name         string
 		startRoutes  []string
-		edges        func(nodeStart *CustomRouteNode, nodeA, nodeB *FunctionNode, nodeC *CustomRouteNode, nodeD *FunctionNode) []Edge
+		edges        func(nodeStart, nodeA, nodeB, nodeC, nodeD *CustomRouteNode) []Edge
 		expectedExec []string
 	}
 
-	createNodes := func() (*CustomRouteNode, *FunctionNode, *FunctionNode, *CustomRouteNode, *FunctionNode, *testTracker) {
+	// A, B, and D are leaf nodes whose execution is recorded but which
+	// do not emit Event.Output: this test asserts on which nodes ran
+	// (tracker.executed), not on their output.
+	createNodes := func() (*CustomRouteNode, *CustomRouteNode, *CustomRouteNode, *CustomRouteNode, *CustomRouteNode, *testTracker) {
 		tracker := &testTracker{}
 		nodeX := &CustomRouteNode{
 			BaseNode: NewBaseNode("X", "", defaultNodeConfig),
 		}
-		nodeA := NewFunctionNode("A", func(ctx agent.Context, input any) (string, error) {
-			record(tracker, "A")
-			return "pathA", nil
-		}, defaultNodeConfig)
-		nodeB := NewFunctionNode("B", func(ctx agent.Context, input any) (string, error) {
-			record(tracker, "B")
-			return "pathB", nil
-		}, defaultNodeConfig)
+		nodeA := &CustomRouteNode{
+			BaseNode: NewBaseNode("A", "", defaultNodeConfig),
+			onRun:    func() { record(tracker, "A") },
+		}
+		nodeB := &CustomRouteNode{
+			BaseNode: NewBaseNode("B", "", defaultNodeConfig),
+			onRun:    func() { record(tracker, "B") },
+		}
 		nodeC := &CustomRouteNode{
 			BaseNode: NewBaseNode("C", "", defaultNodeConfig),
 			route:    []string{"branchD"},
@@ -299,10 +302,10 @@ func TestWorkflowRouting(t *testing.T) {
 				record(tracker, "C")
 			},
 		}
-		nodeD := NewFunctionNode("D", func(ctx agent.Context, input any) (string, error) {
-			record(tracker, "D")
-			return "pathD", nil
-		}, defaultNodeConfig)
+		nodeD := &CustomRouteNode{
+			BaseNode: NewBaseNode("D", "", defaultNodeConfig),
+			onRun:    func() { record(tracker, "D") },
+		}
 		return nodeX, nodeA, nodeB, nodeC, nodeD, tracker
 	}
 
@@ -310,7 +313,7 @@ func TestWorkflowRouting(t *testing.T) {
 		{
 			name:        "all edges don't have routing",
 			startRoutes: []string{"branchA", "branchB"},
-			edges: func(x *CustomRouteNode, a, b *FunctionNode, c *CustomRouteNode, d *FunctionNode) []Edge {
+			edges: func(x, a, b, c, d *CustomRouteNode) []Edge {
 				return []Edge{
 					{From: Start, To: x},
 					{From: x, To: a},
@@ -324,7 +327,7 @@ func TestWorkflowRouting(t *testing.T) {
 		{
 			name:        "only one edge has correct routing and the rest have no routing",
 			startRoutes: []string{"branchA"},
-			edges: func(x *CustomRouteNode, a, b *FunctionNode, c *CustomRouteNode, d *FunctionNode) []Edge {
+			edges: func(x, a, b, c, d *CustomRouteNode) []Edge {
 				return []Edge{
 					{From: Start, To: x},
 					{From: x, To: a, Route: StringRoute("branchA")},
@@ -338,7 +341,7 @@ func TestWorkflowRouting(t *testing.T) {
 		{
 			name:        "one edge has no routing and the rest have a correct routing",
 			startRoutes: []string{"branchA", "branchB"},
-			edges: func(x *CustomRouteNode, a, b *FunctionNode, c *CustomRouteNode, d *FunctionNode) []Edge {
+			edges: func(x, a, b, c, d *CustomRouteNode) []Edge {
 				return []Edge{
 					{From: Start, To: x},
 					{From: x, To: a, Route: StringRoute("branchA")},
@@ -352,7 +355,7 @@ func TestWorkflowRouting(t *testing.T) {
 		{
 			name:        "any edge has incorrect routing",
 			startRoutes: []string{"invalid"},
-			edges: func(x *CustomRouteNode, a, b *FunctionNode, c *CustomRouteNode, d *FunctionNode) []Edge {
+			edges: func(x, a, b, c, d *CustomRouteNode) []Edge {
 				return []Edge{
 					{From: Start, To: x},
 					{From: x, To: a, Route: StringRoute("branchA")},
@@ -365,7 +368,7 @@ func TestWorkflowRouting(t *testing.T) {
 		{
 			name:        "fallback to default route when no concrete route matches",
 			startRoutes: []string{"unmatched"},
-			edges: func(x *CustomRouteNode, a, b *FunctionNode, c *CustomRouteNode, d *FunctionNode) []Edge {
+			edges: func(x, a, b, c, d *CustomRouteNode) []Edge {
 				return []Edge{
 					{From: Start, To: x},
 					{From: x, To: a, Route: StringRoute("branchA")},
@@ -377,7 +380,7 @@ func TestWorkflowRouting(t *testing.T) {
 		{
 			name:        "default route is suppressed by concrete route match",
 			startRoutes: []string{"branchA"},
-			edges: func(x *CustomRouteNode, a, b *FunctionNode, c *CustomRouteNode, d *FunctionNode) []Edge {
+			edges: func(x, a, b, c, d *CustomRouteNode) []Edge {
 				return []Edge{
 					{From: Start, To: x},
 					{From: x, To: a, Route: StringRoute("branchA")},
@@ -389,7 +392,7 @@ func TestWorkflowRouting(t *testing.T) {
 		{
 			name:        "unconditional edge does not suppress default route",
 			startRoutes: []string{"unmatched"},
-			edges: func(x *CustomRouteNode, a, b *FunctionNode, c *CustomRouteNode, d *FunctionNode) []Edge {
+			edges: func(x, a, b, c, d *CustomRouteNode) []Edge {
 				return []Edge{
 					{From: Start, To: x},
 					{From: x, To: a},
@@ -401,7 +404,7 @@ func TestWorkflowRouting(t *testing.T) {
 		{
 			name:        "correct MultiRoute",
 			startRoutes: []string{"branchA"},
-			edges: func(x *CustomRouteNode, a, b *FunctionNode, c *CustomRouteNode, d *FunctionNode) []Edge {
+			edges: func(x, a, b, c, d *CustomRouteNode) []Edge {
 				return []Edge{
 					{From: Start, To: x},
 					{From: x, To: a, Route: MultiRoute[string]{"branchX", "branchA"}},
@@ -415,7 +418,7 @@ func TestWorkflowRouting(t *testing.T) {
 		{
 			name:        "no MultiRoute matches event routes",
 			startRoutes: []string{"invalid"},
-			edges: func(x *CustomRouteNode, a, b *FunctionNode, c *CustomRouteNode, d *FunctionNode) []Edge {
+			edges: func(x, a, b, c, d *CustomRouteNode) []Edge {
 				return []Edge{
 					{From: Start, To: x},
 					{From: x, To: a, Route: MultiRoute[string]{"branchX", "branchY"}},
@@ -427,7 +430,7 @@ func TestWorkflowRouting(t *testing.T) {
 		{
 			name:        "MultiRoute with multiple matching routes",
 			startRoutes: []string{"branchA", "branchB"},
-			edges: func(x *CustomRouteNode, a, b *FunctionNode, c *CustomRouteNode, d *FunctionNode) []Edge {
+			edges: func(x, a, b, c, d *CustomRouteNode) []Edge {
 				return []Edge{
 					{From: Start, To: x},
 					{From: x, To: a, Route: MultiRoute[string]{"branchA", "branchB"}},
@@ -520,7 +523,7 @@ func TestWorkflow_StateSchemaConsistency(t *testing.T) {
 
 	for _, tc := range tests {
 		t.Run(tc.name, func(t *testing.T) {
-			edges := fanOutFromStart(tc.nodes)
+			edges, _ := fanOutToJoin(tc.nodes)
 			_, err := New("wf", edges, WithStateSchema(tc.schema))
 			if tc.wantErr != "" {
 				if err == nil {


### PR DESCRIPTION
## Problem
A workflow run could finish with several terminal nodes (nodes with no
outgoing edges) each producing an output, leaving the workflow's overall
output ambiguous — there was no single, well-defined result to hand back to
the caller. adk-python already guards against this in `Workflow._finalize`,
but ADK Go did not.
## Solution
Enforce the at-most-one-terminal-output invariant at run finalize. After the
scheduler loop completes cleanly, `finalize` counts the terminal nodes that
actually produced an output in this run and returns
`ErrMultipleTerminalOutputs` (naming the offending terminals) when more than
one did.
The check is a runtime check on what ran, not a topological constraint on the
graph. Fan-out and conditional-routing graphs with several terminal branches
remain valid as long as at most one terminal yields output per run — so e.g. a
router that picks one of two output-producing terminals is fine. finalize is
skipped while draining (cancelled / consumer gone / a node errored) and is a
no-op while any node is interrupted (the run has not finished). Mirrors
adk-python's `Workflow._finalize`.