### PR TITLE
fix: stable ordering of generated tool-confirmation requests

### DIFF
--- a/internal/llminternal/functions.go
+++ b/internal/llminternal/functions.go
@@ -43,16 +43,18 @@ func generateRequestConfirmationEvent(
 
 	parts := []*genai.Part{}
 	longRunningToolIDs := []string{}
-	functionCallParts := make(map[string]*genai.Part, len(functionCallEvent.Content.Parts))
-	for _, part := range functionCallEvent.Content.Parts {
-		if part.FunctionCall != nil {
-			functionCallParts[part.FunctionCall.ID] = part
-		}
-	}
 
-	for funcID, confirmation := range functionResponseEvent.Actions.RequestedToolConfirmations {
-		originalPart, ok := functionCallParts[funcID]
-		if !ok || originalPart.FunctionCall == nil {
+	// Emit confirmations in the order their function calls appear in the model
+	// response, mirroring adk-python. Iterating Content.Parts (an ordered slice)
+	// rather than ranging RequestedToolConfirmations (a map, whose iteration
+	// order Go randomizes) keeps the emitted order deterministic and aligned
+	// with execution flow.
+	for _, originalPart := range functionCallEvent.Content.Parts {
+		if originalPart.FunctionCall == nil {
+			continue
+		}
+		confirmation, ok := functionResponseEvent.Actions.RequestedToolConfirmations[originalPart.FunctionCall.ID]
+		if !ok {
 			continue
 		}
 

--- a/internal/llminternal/functions_test.go
+++ b/internal/llminternal/functions_test.go
@@ -299,6 +299,103 @@ func TestGenerateRequestConfirmationEventPreservesThoughtSignature(t *testing.T)
 	}
 }
 
+// TestGenerateRequestConfirmationEventResponseOrder verifies that the emitted
+// confirmation parts (and the parallel LongRunningToolIDs slice) follow the
+// order of the function calls in the model response (Content.Parts), regardless
+// of the (randomized) Go map iteration order of RequestedToolConfirmations, and
+// that repeated calls produce an identical order.
+func TestGenerateRequestConfirmationEventResponseOrder(t *testing.T) {
+	ctx := &mockInvocationContext{
+		invocationID: "inv_1",
+		agentName:    "agent_1",
+		branch:       "main",
+	}
+
+	// Confirmations are emitted in the order their function calls appear in the
+	// model response (Content.Parts), independent of funcID string order or map
+	// insertion order. responseOrder is deliberately not sorted.
+	responseOrder := []string{"call_c", "call_a", "call_d", "call_b"}
+
+	functionCallParts := make([]*genai.Part, 0, len(responseOrder))
+	requestedConfirmations := make(map[string]toolconfirmation.ToolConfirmation, len(responseOrder))
+	for _, id := range responseOrder {
+		functionCallParts = append(functionCallParts, &genai.Part{
+			FunctionCall: &genai.FunctionCall{
+				ID:   id,
+				Name: "test_tool",
+				Args: map[string]any{"arg": id},
+			},
+		})
+		requestedConfirmations[id] = toolconfirmation.ToolConfirmation{
+			Hint: "confirm " + id,
+		}
+	}
+
+	functionCallEvent := &session.Event{
+		LLMResponse: model.LLMResponse{
+			Content: &genai.Content{
+				Parts: functionCallParts,
+			},
+		},
+	}
+	functionResponseEvent := &session.Event{
+		Actions: session.EventActions{
+			RequestedToolConfirmations: requestedConfirmations,
+		},
+	}
+
+	// orderOf returns the originating funcIDs in the order the parts were
+	// emitted, by reading back the originalFunctionCall arg of each generated
+	// adk_request_confirmation call.
+	orderOf := func(t *testing.T, ev *session.Event) []string {
+		t.Helper()
+		if ev == nil || ev.Content == nil {
+			t.Fatalf("expected non-nil event with content, got %#v", ev)
+		}
+		if got, want := len(ev.Content.Parts), len(responseOrder); got != want {
+			t.Fatalf("got %d parts, want %d", got, want)
+		}
+		if got, want := len(ev.LongRunningToolIDs), len(responseOrder); got != want {
+			t.Fatalf("got %d LongRunningToolIDs, want %d", got, want)
+		}
+		ids := make([]string, 0, len(ev.Content.Parts))
+		for i, part := range ev.Content.Parts {
+			if part.FunctionCall == nil {
+				t.Fatalf("part %d has nil FunctionCall", i)
+			}
+			if got, want := part.FunctionCall.Name, toolconfirmation.FunctionCallName; got != want {
+				t.Fatalf("part %d FunctionCall.Name = %q, want %q", i, got, want)
+			}
+			orig, ok := part.FunctionCall.Args["originalFunctionCall"].(*genai.FunctionCall)
+			if !ok {
+				t.Fatalf("part %d missing originalFunctionCall arg, got %#v", i, part.FunctionCall.Args["originalFunctionCall"])
+			}
+			ids = append(ids, orig.ID)
+
+			// LongRunningToolIDs must be the generated request-confirmation
+			// call ID at the same index (parallel slices).
+			if got, want := ev.LongRunningToolIDs[i], part.FunctionCall.ID; got != want {
+				t.Errorf("LongRunningToolIDs[%d] = %q, want %q (the request-confirmation call ID)", i, got, want)
+			}
+		}
+		return ids
+	}
+
+	first := generateRequestConfirmationEvent(ctx, functionCallEvent, functionResponseEvent)
+	gotOrder := orderOf(t, first)
+	if diff := cmp.Diff(responseOrder, gotOrder); diff != "" {
+		t.Errorf("parts not in model-response order (-want +got):\n%s", diff)
+	}
+
+	// Repeated calls must produce an identical ordering.
+	for i := 0; i < 10; i++ {
+		next := generateRequestConfirmationEvent(ctx, functionCallEvent, functionResponseEvent)
+		if diff := cmp.Diff(gotOrder, orderOf(t, next)); diff != "" {
+			t.Errorf("ordering not stable on call %d (-first +next):\n%s", i, diff)
+		}
+	}
+}
+
 func TestGenerateRequestConfirmationEventNoThoughtSignature(t *testing.T) {
 	ctx := &mockInvocationContext{
 		invocationID: "inv_1",


### PR DESCRIPTION
### Link to Issue

Closes #1052

### Summary

`generateRequestConfirmationEvent` (in `internal/llminternal`) ranged `EventActions.RequestedToolConfirmations` (a Go map) directly, so the order of the emitted `adk_request_confirmation` parts and the parallel `LongRunningToolIDs` slice followed Go's randomized map iteration and varied run-to-run whenever a response requested more than one tool confirmation.

This now iterates the function-call parts of the model response (`functionCallEvent.Content.Parts`) in order — skipping parts with a nil `FunctionCall`, then looking up each confirmation from `RequestedToolConfirmations` by call ID (skipping if absent) — so confirmations are emitted in **model-response order**. That order is deterministic and reproducible for the same input, mirrors adk-python (which emits in the order confirmations were requested), and aligns with execution flow. The intermediate `functionCallParts` map and the `sort` import are no longer needed. No behavior change other than ordering.

### Testing Plan

**Unit Tests:**

- [x] I have added or updated unit tests for my change.
- [x] All unit tests pass locally.

`internal/llminternal/functions_test.go` (`TestGenerateRequestConfirmationEventResponseOrder`): builds a response whose function-call parts are in a deliberately non-sorted order, and asserts the emitted parts and `LongRunningToolIDs` follow that model-response order and are identical across repeated calls.

```
$ go test ./internal/llminternal/...
ok  google.golang.org/adk/v2/internal/llminternal
```

**Manual End-to-End (E2E) Tests:**

N/A - pure output-ordering fix with no ADK Web / Runner UI surface; covered by the unit test above.

### Checklist

- [x] I have read the CONTRIBUTING.md document.
- [x] I have performed a self-review of my own code.
- [x] I have commented my code, particularly in hard-to-understand areas.
- [x] I have added tests that prove my fix is effective.
- [x] New and existing unit tests pass locally with my changes.
- [ ] I have manually tested my changes end-to-end. _(N/A — internal ordering fix; see above.)_
- [ ] Any dependent changes have been merged and published in downstream modules. _(N/A.)_