### PR TITLE
feat: expose the tool-declaration packer (PackTool) as a public API

### DIFF
--- a/internal/llminternal/handle_function_calls_async_test.go
+++ b/internal/llminternal/handle_function_calls_async_test.go
@@ -24,12 +24,12 @@ import (
 
 	"google.golang.org/adk/v2/agent"
 	"google.golang.org/adk/v2/agent/llmagent"
-	"google.golang.org/adk/v2/internal/toolinternal/toolutils"
 	"google.golang.org/adk/v2/model"
 	"google.golang.org/adk/v2/runner"
 	"google.golang.org/adk/v2/session"
 	"google.golang.org/adk/v2/tool"
 	"google.golang.org/adk/v2/tool/functiontool"
+	"google.golang.org/adk/v2/tool/toolutils"
 )
 
 type SleepArgs struct {

--- a/internal/llminternal/outputschema_processor.go
+++ b/internal/llminternal/outputschema_processor.go
@@ -23,10 +23,10 @@ import (
 
 	"google.golang.org/adk/v2/agent"
 	"google.golang.org/adk/v2/internal/llminternal/googlellm"
-	"google.golang.org/adk/v2/internal/toolinternal/toolutils"
 	"google.golang.org/adk/v2/internal/utils"
 	"google.golang.org/adk/v2/model"
 	"google.golang.org/adk/v2/session"
+	"google.golang.org/adk/v2/tool/toolutils"
 )
 
 const (

--- a/internal/workflowinternal/finish_task_tool.go
+++ b/internal/workflowinternal/finish_task_tool.go
@@ -22,10 +22,10 @@ import (
 
 	"google.golang.org/adk/v2/agent"
 	"google.golang.org/adk/v2/internal/llminternal"
-	"google.golang.org/adk/v2/internal/toolinternal/toolutils"
 	"google.golang.org/adk/v2/internal/utils"
 	"google.golang.org/adk/v2/model"
 	"google.golang.org/adk/v2/tool"
+	"google.golang.org/adk/v2/tool/toolutils"
 )
 
 const (

--- a/internal/workflowinternal/single_turn_tool.go
+++ b/internal/workflowinternal/single_turn_tool.go
@@ -21,10 +21,10 @@ import (
 
 	"google.golang.org/adk/v2/agent"
 	"google.golang.org/adk/v2/internal/llminternal"
-	"google.golang.org/adk/v2/internal/toolinternal/toolutils"
 	"google.golang.org/adk/v2/internal/utils"
 	"google.golang.org/adk/v2/model"
 	"google.golang.org/adk/v2/tool"
+	"google.golang.org/adk/v2/tool/toolutils"
 	"google.golang.org/adk/v2/workflow"
 )
 

--- a/internal/workflowinternal/task_agent_tool.go
+++ b/internal/workflowinternal/task_agent_tool.go
@@ -23,9 +23,9 @@ import (
 	"google.golang.org/adk/v2/agent"
 	"google.golang.org/adk/v2/internal/llminternal"
 	"google.golang.org/adk/v2/internal/llminternal/googlellm"
-	"google.golang.org/adk/v2/internal/toolinternal/toolutils"
 	"google.golang.org/adk/v2/model"
 	"google.golang.org/adk/v2/tool"
+	"google.golang.org/adk/v2/tool/toolutils"
 )
 
 type TaskAgentTool struct {

--- a/tool/agenttool/agent_tool.go
+++ b/tool/agenttool/agent_tool.go
@@ -27,7 +27,6 @@ import (
 	"google.golang.org/adk/v2/agent"
 	"google.golang.org/adk/v2/artifact"
 	"google.golang.org/adk/v2/internal/llminternal"
-	"google.golang.org/adk/v2/internal/toolinternal/toolutils"
 	"google.golang.org/adk/v2/internal/utils"
 	"google.golang.org/adk/v2/internal/workflowinternal"
 	"google.golang.org/adk/v2/memory"
@@ -35,6 +34,7 @@ import (
 	"google.golang.org/adk/v2/runner"
 	"google.golang.org/adk/v2/session"
 	"google.golang.org/adk/v2/tool"
+	"google.golang.org/adk/v2/tool/toolutils"
 )
 
 // agentTool implements a tool that allows an agent to call another agent.

--- a/tool/functiontool/function.go
+++ b/tool/functiontool/function.go
@@ -25,10 +25,10 @@ import (
 	"google.golang.org/genai"
 
 	"google.golang.org/adk/v2/agent"
-	"google.golang.org/adk/v2/internal/toolinternal/toolutils"
 	"google.golang.org/adk/v2/internal/typeutil"
 	"google.golang.org/adk/v2/model"
 	"google.golang.org/adk/v2/tool"
+	"google.golang.org/adk/v2/tool/toolutils"
 )
 
 // FunctionTool: borrow implementation from MCP go.

--- a/tool/functiontool/streaming_function.go
+++ b/tool/functiontool/streaming_function.go
@@ -25,10 +25,10 @@ import (
 	"google.golang.org/genai"
 
 	"google.golang.org/adk/v2/agent"
-	"google.golang.org/adk/v2/internal/toolinternal/toolutils"
 	"google.golang.org/adk/v2/internal/typeutil"
 	"google.golang.org/adk/v2/model"
 	"google.golang.org/adk/v2/tool"
+	"google.golang.org/adk/v2/tool/toolutils"
 )
 
 // StreamingFunc represents a Go function that streams results.

--- a/tool/loadartifactstool/load_artifacts_tool.go
+++ b/tool/loadartifactstool/load_artifacts_tool.go
@@ -26,10 +26,10 @@ import (
 	"google.golang.org/genai"
 
 	"google.golang.org/adk/v2/agent"
-	"google.golang.org/adk/v2/internal/toolinternal/toolutils"
 	"google.golang.org/adk/v2/internal/utils"
 	"google.golang.org/adk/v2/model"
 	"google.golang.org/adk/v2/tool"
+	"google.golang.org/adk/v2/tool/toolutils"
 )
 
 // artifactsTool is a tool that loads artifacts and adds them to the session.

--- a/tool/loadmemorytool/tool.go
+++ b/tool/loadmemorytool/tool.go
@@ -24,10 +24,10 @@ import (
 
 	"google.golang.org/adk/v2/agent"
 	"google.golang.org/adk/v2/internal/toolinternal"
-	"google.golang.org/adk/v2/internal/toolinternal/toolutils"
 	"google.golang.org/adk/v2/internal/utils"
 	"google.golang.org/adk/v2/memory"
 	"google.golang.org/adk/v2/model"
+	"google.golang.org/adk/v2/tool/toolutils"
 )
 
 const memoryInstructions = `You have memory. You can use it to answer questions. If any questions need

--- a/tool/mcptoolset/tool.go
+++ b/tool/mcptoolset/tool.go
@@ -24,9 +24,9 @@ import (
 
 	"google.golang.org/adk/v2/agent"
 	"google.golang.org/adk/v2/internal/toolinternal"
-	"google.golang.org/adk/v2/internal/toolinternal/toolutils"
 	"google.golang.org/adk/v2/model"
 	"google.golang.org/adk/v2/tool"
+	"google.golang.org/adk/v2/tool/toolutils"
 )
 
 func convertTool(t *mcp.Tool, client MCPClient, requireConfirmation bool, requireConfirmationProvider tool.ConfirmationProvider) (tool.Tool, error) {

--- a/tool/tool.go
+++ b/tool/tool.go
@@ -24,8 +24,8 @@ import (
 	"google.golang.org/genai"
 
 	"google.golang.org/adk/v2/agent"
-	"google.golang.org/adk/v2/internal/toolinternal/toolutils"
 	"google.golang.org/adk/v2/model"
+	"google.golang.org/adk/v2/tool/toolutils"
 )
 
 // ErrConfirmationRequired indicates that the tool requires confirmation.

--- a/tool/toolutils/toolutils.go
+++ b/tool/toolutils/toolutils.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.
@@ -12,7 +12,10 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-// Package tool defines internal-only interfaces and logic for tools.
+// Package toolutils provides public helpers for packing tool declarations
+// into a model.LLMRequest. It allows external code to consolidate tool
+// function declarations the same way the built-in ADK tools do, without
+// re-implementing the logic.
 package toolutils
 
 import (
@@ -23,31 +26,33 @@ import (
 	"google.golang.org/adk/v2/model"
 )
 
+// Tool is implemented by any tool that can be packed into a
+// model.LLMRequest via PackTool.
 type Tool interface {
 	Name() string
 	Declaration() *genai.FunctionDeclaration
 }
 
-// The PackTool ensures that in case there is a usage of multiple function tools,
+// PackTool ensures that in case there is a usage of multiple function tools,
 // all of them are consolidated into one genai tool that has all the function declarations
 // provided by the tools. So, if there is already a tool with a function declaration,
 // it appends another to it; otherwise, it creates a new genai tool.
-func PackTool(req *model.LLMRequest, tool Tool) error {
+func PackTool(req *model.LLMRequest, t Tool) error {
 	if req.Tools == nil {
 		req.Tools = make(map[string]any)
 	}
 
-	name := tool.Name()
+	name := t.Name()
 
 	if _, ok := req.Tools[name]; ok {
 		return fmt.Errorf("duplicate tool: %q", name)
 	}
-	req.Tools[name] = tool
+	req.Tools[name] = t
 
 	if req.Config == nil {
 		req.Config = &genai.GenerateContentConfig{}
 	}
-	if decl := tool.Declaration(); decl == nil {
+	if decl := t.Declaration(); decl == nil {
 		return nil
 	}
 	// Find an existing genai.Tool with FunctionDeclarations
@@ -60,10 +65,10 @@ func PackTool(req *model.LLMRequest, tool Tool) error {
 	}
 	if funcTool == nil {
 		req.Config.Tools = append(req.Config.Tools, &genai.Tool{
-			FunctionDeclarations: []*genai.FunctionDeclaration{tool.Declaration()},
+			FunctionDeclarations: []*genai.FunctionDeclaration{t.Declaration()},
 		})
 	} else {
-		funcTool.FunctionDeclarations = append(funcTool.FunctionDeclarations, tool.Declaration())
+		funcTool.FunctionDeclarations = append(funcTool.FunctionDeclarations, t.Declaration())
 	}
 	return nil
 }

--- a/tool/toolutils/toolutils_test.go
+++ b/tool/toolutils/toolutils_test.go
@@ -1,0 +1,106 @@
+// Copyright 2026 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package toolutils_test
+
+import (
+	"testing"
+
+	"google.golang.org/genai"
+
+	"google.golang.org/adk/v2/model"
+	"google.golang.org/adk/v2/tool/toolutils"
+)
+
+// fakeTool is a minimal implementation of toolutils.Tool for tests.
+type fakeTool struct {
+	name string
+	decl *genai.FunctionDeclaration
+}
+
+func (f fakeTool) Name() string                            { return f.name }
+func (f fakeTool) Declaration() *genai.FunctionDeclaration { return f.decl }
+
+var _ toolutils.Tool = fakeTool{}
+
+func TestPackTool_SingleTool(t *testing.T) {
+	req := &model.LLMRequest{}
+	tool := fakeTool{name: "first", decl: &genai.FunctionDeclaration{Name: "first"}}
+
+	if err := toolutils.PackTool(req, tool); err != nil {
+		t.Fatalf("PackTool() returned error: %v", err)
+	}
+
+	if _, ok := req.Tools["first"]; !ok {
+		t.Fatalf("req.Tools missing %q; got %v", "first", req.Tools)
+	}
+	if got := len(req.Config.Tools); got != 1 {
+		t.Fatalf("len(req.Config.Tools) = %d, want 1", got)
+	}
+	if got := len(req.Config.Tools[0].FunctionDeclarations); got != 1 {
+		t.Fatalf("len(FunctionDeclarations) = %d, want 1", got)
+	}
+}
+
+func TestPackTool_SecondToolSharesSameGenaiTool(t *testing.T) {
+	req := &model.LLMRequest{}
+	first := fakeTool{name: "first", decl: &genai.FunctionDeclaration{Name: "first"}}
+	second := fakeTool{name: "second", decl: &genai.FunctionDeclaration{Name: "second"}}
+
+	if err := toolutils.PackTool(req, first); err != nil {
+		t.Fatalf("PackTool(first) returned error: %v", err)
+	}
+	if err := toolutils.PackTool(req, second); err != nil {
+		t.Fatalf("PackTool(second) returned error: %v", err)
+	}
+
+	if _, ok := req.Tools["second"]; !ok {
+		t.Fatalf("req.Tools missing %q; got %v", "second", req.Tools)
+	}
+	// Both declarations must live on a single genai.Tool, not two.
+	if got := len(req.Config.Tools); got != 1 {
+		t.Fatalf("len(req.Config.Tools) = %d, want 1 (second tool should append, not create)", got)
+	}
+	if got := len(req.Config.Tools[0].FunctionDeclarations); got != 2 {
+		t.Fatalf("len(FunctionDeclarations) = %d, want 2", got)
+	}
+}
+
+func TestPackTool_DuplicateName(t *testing.T) {
+	req := &model.LLMRequest{}
+	tool := fakeTool{name: "dup", decl: &genai.FunctionDeclaration{Name: "dup"}}
+
+	if err := toolutils.PackTool(req, tool); err != nil {
+		t.Fatalf("first PackTool() returned error: %v", err)
+	}
+	if err := toolutils.PackTool(req, tool); err == nil {
+		t.Fatalf("second PackTool() with duplicate name = nil error, want error")
+	}
+}
+
+func TestPackTool_NilDeclaration(t *testing.T) {
+	req := &model.LLMRequest{}
+	tool := fakeTool{name: "nodecl", decl: nil}
+
+	if err := toolutils.PackTool(req, tool); err != nil {
+		t.Fatalf("PackTool() returned error: %v", err)
+	}
+
+	if _, ok := req.Tools["nodecl"]; !ok {
+		t.Fatalf("req.Tools missing %q; nil-declaration tool should still register", "nodecl")
+	}
+	if got := len(req.Config.Tools); got != 0 {
+		t.Fatalf("len(req.Config.Tools) = %d, want 0 (nil declaration adds nothing)", got)
+	}
+}


### PR DESCRIPTION
### Link to Issue

Closes #1054

### Summary

Exposes ADK's tool-declaration packer as a public API so external tools / toolsets can consolidate their function declarations onto a `model.LLMRequest` the same way the built-in tools do, instead of re-implementing it.

- New public package `tool/toolutils`: `PackTool(req *model.LLMRequest, t Tool) error` plus a `Tool` interface (`Name()` / `Declaration()`). The packing logic lives here.
- The internal `internal/toolinternal/toolutils` package is **removed**; all of its callers now use the public `tool/toolutils` directly.
- No cyclical imports are created; the public package depends only on `model` and `genai`.

### Testing Plan

**Unit Tests:**

- [x] I have added or updated unit tests for my change.
- [x] All unit tests pass locally.

`tool/toolutils/toolutils_test.go`: packing one tool registers it and creates one `genai.Tool` with one declaration; a second tool appends to the same `genai.Tool`; a duplicate name returns an error; a tool whose `Declaration()` is nil still registers and adds no declaration. The migrated internal callers continue to pass their existing tests.

```
$ go test ./tool/toolutils/... ./internal/...
ok  google.golang.org/adk/v2/tool/toolutils
```

**Manual End-to-End (E2E) Tests:**

N/A (this exposes existing logic via a public package; behavior is unchanged and covered by the unit tests above).

### Checklist

- [x] I have read the CONTRIBUTING.md document.
- [x] I have performed a self-review of my own code.
- [x] I have commented my code, particularly in hard-to-understand areas.
- [x] I have added tests that prove my feature works.
- [x] New and existing unit tests pass locally with my changes.
- [ ] I have manually tested my changes end-to-end. _(N/A — API-exposure refactor; see above.)_
- [ ] Any dependent changes have been merged and published in downstream modules. _(N/A.)_