### PR TITLE
feat: add a name-based model registry (Register/NewLLM)

### DIFF
--- a/model/registry.go
+++ b/model/registry.go
@@ -1,0 +1,124 @@
+// Copyright 2026 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+// The name-based model registry lets an [LLM] be constructed from just a
+// model-name string via [NewLLM], mirroring Python ADK's
+// LLMRegistry.new_llm(name).
+//
+// Registration is opt-in: provider packages do not register themselves on
+// import. A user who wants name-based Gemini resolution registers it
+// explicitly, using an anchored pattern:
+//
+//	model.Register("^(?i)gemini-.*", func(ctx context.Context, name string) (model.LLM, error) {
+//		return gemini.NewModel(ctx, name, nil)
+//	})
+//
+// [NewLLM] then requires exactly one registered pattern to match a given name:
+// zero matches or two-or-more matches are reported as errors, so resolution
+// never depends on registration or import order.
+package model
+
+import (
+	"context"
+	"fmt"
+	"regexp"
+	"sync"
+)
+
+// Factory constructs an [LLM] for the given model name.
+//
+// The name is the same string that was matched against the registered
+// pattern, allowing a single factory to serve a family of models (for
+// example, all "gemini-*" names).
+type Factory func(ctx context.Context, name string) (LLM, error)
+
+// registration pairs a compiled name pattern with the factory that builds the
+// corresponding [LLM].
+type registration struct {
+	pattern *regexp.Regexp
+	factory Factory
+}
+
+// registry holds all model registrations, guarded by mu.
+var (
+	mu       sync.RWMutex
+	registry []registration
+)
+
+// Register associates a model name pattern with a [Factory].
+//
+// namePattern is a regular expression compiled with [regexp.MustCompile];
+// it is matched against candidate model names using [regexp.Regexp.MatchString]
+// (i.e. an unanchored, partial match). To match a name exactly, anchor the
+// pattern with "^" and "$".
+//
+// Registration order is not significant: [NewLLM] requires exactly one
+// registered pattern to match a name, so patterns must not overlap for names a
+// caller intends to resolve. Register is intended to be called at
+// initialization time. It panics if namePattern is not a valid regular
+// expression, or if namePattern has already been registered — surfacing the
+// programming error at the registration site rather than later in [NewLLM].
+//
+// Register is safe for concurrent use.
+func Register(namePattern string, f Factory) {
+	re := regexp.MustCompile(namePattern)
+	mu.Lock()
+	defer mu.Unlock()
+	for _, reg := range registry {
+		if reg.pattern.String() == namePattern {
+			panic(fmt.Sprintf("model: LLM pattern %q is already registered", namePattern))
+		}
+	}
+	registry = append(registry, registration{pattern: re, factory: f})
+}
+
+// NewLLM builds an [LLM] for the given model name.
+//
+// It scans all registrations and requires exactly one whose pattern matches
+// name:
+//
+//   - If no registered pattern matches, NewLLM returns an error reporting that
+//     name was not found.
+//   - If exactly one matches, NewLLM invokes its [Factory] and returns the
+//     result.
+//   - If two or more match, NewLLM returns an error naming the ambiguous name
+//     and listing the matching patterns, rather than silently picking one.
+//
+// Because a match must be unique, the result never depends on registration or
+// import order.
+//
+// NewLLM is safe for concurrent use.
+func NewLLM(ctx context.Context, name string) (LLM, error) {
+	mu.RLock()
+	// Copy the matching factory out before releasing the lock so we do not hold
+	// the registry lock while the factory (which may do I/O) runs.
+	var f Factory
+	var matched []string
+	for _, reg := range registry {
+		if reg.pattern.MatchString(name) {
+			f = reg.factory
+			matched = append(matched, reg.pattern.String())
+		}
+	}
+	mu.RUnlock()
+
+	switch len(matched) {
+	case 0:
+		return nil, fmt.Errorf("model: no registered LLM matches %q", name)
+	case 1:
+		return f(ctx, name)
+	default:
+		return nil, fmt.Errorf("model: %q matches multiple registered LLM patterns %q; patterns must be unambiguous", name, matched)
+	}
+}

--- a/model/registry_test.go
+++ b/model/registry_test.go
@@ -1,0 +1,144 @@
+// Copyright 2026 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package model
+
+import (
+	"context"
+	"iter"
+	"strconv"
+	"strings"
+	"sync"
+	"testing"
+)
+
+// stubLLM is a minimal [LLM] implementation used by the registry tests. It
+// carries the name it was constructed with so tests can assert which factory
+// produced it.
+type stubLLM struct {
+	name string
+}
+
+func (s *stubLLM) Name() string { return s.name }
+
+func (s *stubLLM) GenerateContent(ctx context.Context, req *LLMRequest, stream bool) iter.Seq2[*LLMResponse, error] {
+	return func(yield func(*LLMResponse, error) bool) {}
+}
+
+// The registry is a global shared across every test in this package, so each
+// test registers its own uniquely prefixed patterns and never relies on
+// provider packages (e.g. gemini) self-registering.
+
+func TestNewLLMSingleMatch(t *testing.T) {
+	const pattern = "^registry-test-single-.*$"
+	Register(pattern, func(_ context.Context, name string) (LLM, error) {
+		return &stubLLM{name: name}, nil
+	})
+
+	llm, err := NewLLM(context.Background(), "registry-test-single-001")
+	if err != nil {
+		t.Fatalf("NewLLM returned unexpected error: %v", err)
+	}
+	stub, ok := llm.(*stubLLM)
+	if !ok {
+		t.Fatalf("NewLLM returned %T, want *stubLLM", llm)
+	}
+	if got, want := stub.Name(), "registry-test-single-001"; got != want {
+		t.Errorf("stub.Name() = %q, want %q (factory should receive the matched name)", got, want)
+	}
+}
+
+func TestRegisterDuplicatePatternPanics(t *testing.T) {
+	// Registering the same pattern twice is a programming error and must panic
+	// at the registration site rather than surfacing later in NewLLM.
+	const pattern = "^registry-test-dup-.*$"
+	Register(pattern, func(_ context.Context, name string) (LLM, error) {
+		return &stubLLM{name: name}, nil
+	})
+	defer func() {
+		if r := recover(); r == nil {
+			t.Fatal("Register did not panic when the same pattern was registered twice")
+		}
+	}()
+	Register(pattern, func(_ context.Context, name string) (LLM, error) {
+		return &stubLLM{name: name}, nil
+	})
+}
+
+func TestNewLLMNoMatch(t *testing.T) {
+	// A name that no registered pattern can match.
+	const name = "registry-test-no-such-provider-xyzzy-0000"
+	_, err := NewLLM(context.Background(), name)
+	if err == nil {
+		t.Fatalf("NewLLM(%q) returned nil error, want no-match error", name)
+	}
+	if !strings.Contains(err.Error(), name) {
+		t.Errorf("NewLLM error = %q, want it to mention the unmatched name %q", err.Error(), name)
+	}
+}
+
+func TestNewLLMMultipleMatchesError(t *testing.T) {
+	// Two patterns that both match the same name. NewLLM must refuse to guess
+	// and instead return an error, regardless of registration order.
+	const (
+		name     = "registry-test-ambiguous-001"
+		broad    = "^registry-test-ambiguous-.*$"
+		specific = "^registry-test-ambiguous-001$"
+	)
+	Register(broad, func(_ context.Context, _ string) (LLM, error) {
+		return &stubLLM{name: "broad"}, nil
+	})
+	Register(specific, func(_ context.Context, _ string) (LLM, error) {
+		return &stubLLM{name: "specific"}, nil
+	})
+
+	llm, err := NewLLM(context.Background(), name)
+	if err == nil {
+		t.Fatalf("NewLLM(%q) returned %v, want ambiguous-match error", name, llm)
+	}
+	// The error must name the ambiguous input and list the matching patterns.
+	for _, want := range []string{name, broad, specific} {
+		if !strings.Contains(err.Error(), want) {
+			t.Errorf("NewLLM error = %q, want it to mention %q", err.Error(), want)
+		}
+	}
+}
+
+func TestRegistryConcurrentAccess(t *testing.T) {
+	// Exercise Register and NewLLM concurrently so `go test -race` can detect
+	// data races on the package-level registry. Each goroutine uses a distinct
+	// pattern so no name matches more than one of them.
+	const goroutines = 16
+	var wg sync.WaitGroup
+	wg.Add(goroutines * 2)
+
+	for i := 0; i < goroutines; i++ {
+		suffix := strconv.Itoa(i)
+		// Writer: register a unique pattern.
+		go func() {
+			defer wg.Done()
+			Register("^registry-test-concurrent-"+suffix+"-.*$", func(_ context.Context, name string) (LLM, error) {
+				return &stubLLM{name: name}, nil
+			})
+		}()
+		// Reader: look up a name. It may or may not match depending on
+		// scheduling; either outcome is fine, we only care about race safety.
+		go func() {
+			defer wg.Done()
+			_, _ = NewLLM(context.Background(), "registry-test-concurrent-"+suffix+"-x")
+		}()
+	}
+
+	wg.Wait()
+}


### PR DESCRIPTION
### Link to Issue

Closes #1056

### Summary

Adds a public, name-based model registry _mirroring adk-python's `LLMRegistry`_  so an `LLM` can be constructed from just a model-name string.

- `model.Register(namePattern string, Factory)` and `model.NewLLM(ctx, name) (LLM, error)`. Registrations are matched by regular expression in registration order (first match wins), guarded by a `sync.RWMutex`; the matching factory is copied out before the lock is released so construction never runs under the lock.
- `model/gemini` self-registers `"(?i)gemini-.*"` in an `init()`, constructing via `gemini.NewModel(ctx, name, nil)` (application-default credentials; callers needing custom config continue to call `NewModel` directly).
- Purely additive, no existing behavior changes.

### Testing Plan

**Unit Tests:**

- [x] I have added or updated unit tests for my change.
- [x] All unit tests pass locally.

`model/registry_test.go`: register + lookup, no-match error, first-match-wins precedence, and concurrent `Register`/`NewLLM` access (so it is meaningful under `-race`).

```
$ go test -race ./model/...
ok  google.golang.org/adk/model
ok  google.golang.org/adk/model/apigee
ok  google.golang.org/adk/model/gemini
```

**Manual End-to-End (E2E) Tests:**

N/A; additive registry with no ADK Web / Runner UI surface; covered by the unit tests above.

### Checklist

- [x] I have read the CONTRIBUTING.md document.
- [x] I have performed a self-review of my own code.
- [x] I have commented my code, particularly in hard-to-understand areas.
- [x] I have added tests that prove my feature works.
- [x] New and existing unit tests pass locally with my changes.
- [ ] I have manually tested my changes end-to-end. _(N/A — additive registry; see above.)_
- [ ] Any dependent changes have been merged and published in downstream modules. _(N/A.)_