### PR TITLE
Got rid of context.Background

### DIFF
--- a/session/session.go
+++ b/session/session.go
@@ -21,6 +21,7 @@ import (
 	"time"
 
 	"github.com/google/uuid"
+
 	"google.golang.org/adk/model"
 	"google.golang.org/adk/platform"
 	"google.golang.org/adk/tool/toolconfirmation"

--- a/session/session.go
+++ b/session/session.go
@@ -20,6 +20,7 @@ import (
 	"iter"
 	"time"
 
+	"github.com/google/uuid"
 	"google.golang.org/adk/model"
 	"google.golang.org/adk/platform"
 	"google.golang.org/adk/tool/toolconfirmation"
@@ -136,7 +137,12 @@ func (e *Event) IsFinalResponse() bool {
 // [platform.WithUUIDProvider]) are honored. NewEvent always uses the wall clock
 // and a random UUID.
 func NewEvent(invocationID string) *Event {
-	return NewEventWithContext(context.Background(), invocationID)
+	return &Event{
+		ID:           uuid.NewString(),
+		InvocationID: invocationID,
+		Timestamp:    time.Now(),
+		Actions:      EventActions{StateDelta: make(map[string]any), ArtifactDelta: make(map[string]int64)},
+	}
 }
 
 // NewEventWithContext creates a new event defining now as the timestamp.


### PR DESCRIPTION
Removes the usage of context.Background from the deprecated func. 