### PR TITLE
feat(agent): add NewStrictContextMock constructor

### DIFF
--- a/agent/context_mock.go
+++ b/agent/context_mock.go
@@ -44,6 +44,12 @@ type StrictContextMock struct {
 	Ctx context.Context
 }
 
+// NewStrictContextMock returns a StrictContextMock backed by ctx. It keeps test
+// literals concise when the mock is embedded as the only field of a fake.
+func NewStrictContextMock(ctx context.Context) StrictContextMock {
+	return StrictContextMock{Ctx: ctx}
+}
+
 func (m *StrictContextMock) ctx() context.Context {
 	if m.Ctx == nil {
 		panic("agent.StrictContextMock: Ctx is nil")


### PR DESCRIPTION
Add a NewStrictContextMock(ctx) constructor for StrictContextMock so test fakes that embed the mock as their only field can be built from a concise literal instead of StrictContextMock{Ctx: ctx}.
