### PR TITLE
feat (codeexecution): support code execution integrations

### DIFF
--- a/agent/llmagent/llmagent.go
+++ b/agent/llmagent/llmagent.go
@@ -22,6 +22,7 @@ import (
 	"google.golang.org/genai"
 
 	"google.golang.org/adk/agent"
+	"google.golang.org/adk/codeexecution"
 	agentinternal "google.golang.org/adk/internal/agent"
 	icontext "google.golang.org/adk/internal/context"
 	"google.golang.org/adk/internal/llminternal"
@@ -90,6 +91,7 @@ func New(cfg Config) (agent.Agent, error) {
 			GlobalInstruction:         cfg.GlobalInstruction,
 			GlobalInstructionProvider: llminternal.InstructionProvider(cfg.GlobalInstructionProvider),
 			OutputKey:                 cfg.OutputKey,
+			CodeExecutor:              cfg.CodeExecutor,
 		},
 	}
 
@@ -280,6 +282,9 @@ type Config struct {
 	// - Extracts agent reply for later use, such as in tools, callbacks, etc.
 	// - Connects agents to coordinate with each other.
 	OutputKey string
+
+	// Allow agent to execute code blocks from model responses using the provided CodeExecutor.
+	CodeExecutor codeexecution.CodeExecutor
 }
 
 // BeforeModelCallback that is called before sending a request to the model.

--- a/codeexecution/builtin_code_executor.go
+++ b/codeexecution/builtin_code_executor.go
@@ -1,0 +1,56 @@
+// Copyright 2025 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package codeexecution
+
+import (
+	"context"
+
+	"google.golang.org/genai"
+
+	"google.golang.org/adk/agent"
+	"google.golang.org/adk/internal/toolinternal"
+	"google.golang.org/adk/model"
+)
+
+// A code executor that uses the Model's built-in code executor.
+// Currently only supports Gemini 2.0+ models.
+type builtInCodeExecutor struct{}
+
+func NewBuiltInCodeExecutor(ctx context.Context) (CodeExecutor, error) {
+	return &builtInCodeExecutor{}, nil
+}
+
+func (e *builtInCodeExecutor) ExecuteCode(ctx agent.InvocationContext, req *CodeExecutionInput) (*CodeExecutionResult, error) {
+	return nil, nil // code execution handled automatically by the model.
+}
+
+func (e *builtInCodeExecutor) Config() *CodeExecutorConfig {
+	return &CodeExecutorConfig{} // any config ignored
+}
+
+func (e *builtInCodeExecutor) ProcessRequest(ctx agent.ToolContext, req *model.LLMRequest) error {
+	if req.Config == nil {
+		req.Config = &genai.GenerateContentConfig{}
+	}
+	req.Config.Tools = append(req.Config.Tools, &genai.Tool{
+		CodeExecution: &genai.ToolCodeExecution{},
+	})
+	return nil
+}
+
+var (
+	_ CodeExecutor                  = (*builtInCodeExecutor)(nil)
+	_ toolinternal.RequestProcessor = (*builtInCodeExecutor)(nil)
+)

--- a/codeexecution/code_execution_context.go
+++ b/codeexecution/code_execution_context.go
@@ -1,0 +1,164 @@
+// Copyright 2025 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package codeexecution
+
+import (
+	"time"
+
+	"google.golang.org/adk/session"
+)
+
+const (
+	contextKey            = "_code_execution_context"
+	sessionIdKey          = "_execution_session_id"
+	processedFileNamesKey = "_processed_input_files"
+	inputFileKey          = "_code_executor_input_files"
+	errorCountKey         = "_code_executor_error_counts"
+	executionResultsKey   = "_code_execution_results"
+)
+
+// CodeExecutorContext manages the persistent context used to configure the code executor.
+type CodeExecutorContext struct {
+	contextState map[string]any
+	sessionState session.State
+}
+
+type executionResult struct {
+	Code      string
+	Stdout    string
+	Stderr    string
+	Timestamp time.Time
+}
+
+// GetStateDelta() gets the state delta to update in the persistent session state.
+func (c *CodeExecutorContext) GetStateDelta() map[string]any {
+	return map[string]any{
+		contextKey: c.contextState,
+	}
+}
+
+// GetExecutionId gets the session ID for the code executor
+func (c *CodeExecutorContext) GetExecutionId() string {
+	if id, ok := c.contextState[sessionIdKey].(string); ok {
+		return id
+	}
+	return ""
+}
+
+// SetExecutionId sets the session ID for the code executor
+func (c *CodeExecutorContext) SetExecutionId(sessionId string) {
+	c.contextState[sessionIdKey] = sessionId
+}
+
+// GetProcessedFileNames gets the processed file names from the session state.
+func (c *CodeExecutorContext) GetProcessedFileNames() []string {
+	if fileNames, ok := c.contextState[processedFileNamesKey].([]string); ok {
+		return fileNames
+	}
+	return nil
+}
+
+// AddProcessedFileNames adds the processed file name to the context state
+func (c *CodeExecutorContext) AddProcessedFileNames(fileNames []string) {
+	currentFiles, _ := c.contextState[processedFileNamesKey].([]string)
+	c.contextState[processedFileNamesKey] = append(currentFiles, fileNames...)
+}
+
+// GetInputFiles gets the code executor input file names from the session state
+func (c *CodeExecutorContext) GetInputFiles() []*File {
+	inputFiles, _ := c.sessionState.Get(inputFileKey)
+	files, _ := inputFiles.([]*File)
+	return files
+}
+
+// AddInputFiles adds the input files to the code executor context.
+func (c *CodeExecutorContext) AddInputFiles(inputFiles []*File) error {
+	files, _ := c.sessionState.Get(inputFileKey)
+	currentFiles, _ := files.([]*File)
+	return c.sessionState.Set(inputFileKey, append(currentFiles, inputFiles...))
+}
+
+// ClearInputFiles removes the input files and processed file names to the code executor context.
+func (c *CodeExecutorContext) ClearInputFiles() error {
+	if err := c.sessionState.Set(inputFileKey, nil); err != nil {
+		return err
+	}
+	if c.contextState != nil {
+		delete(c.contextState, inputFileKey)
+	}
+	return nil
+}
+
+// GetErrorCount gets the error count from the session state.
+func (c *CodeExecutorContext) GetErrorCount(invocationId string) int32 {
+	errCounts, _ := c.sessionState.Get(errorCountKey)
+	errCountMap, _ := errCounts.(map[string]int32)
+	return errCountMap[invocationId]
+}
+
+// ResetErrorCount resets the error count from the session state.
+func (c *CodeExecutorContext) ResetErrorCount(invocationId string) error {
+	errCount, _ := c.sessionState.Get(errorCountKey)
+	errCountMap, _ := errCount.(map[string]int32)
+	if errCountMap == nil {
+		return nil
+	}
+	delete(errCountMap, invocationId)
+	return c.sessionState.Set(errorCountKey, errCountMap)
+}
+
+// IncrementErrorCount increments the error count for a given invocation ID
+func (c *CodeExecutorContext) IncrementErrorCount(invocationId string) error {
+	errCount, _ := c.sessionState.Get(errorCountKey)
+	errCountMap, _ := errCount.(map[string]int32)
+	if errCountMap == nil {
+		errCountMap = make(map[string]int32)
+	}
+	errCountMap[invocationId]++
+	return c.sessionState.Set(errorCountKey, errCountMap)
+}
+
+// UpdateCodeExecutionResult updates the code execution result.
+func (c *CodeExecutorContext) UpdateCodeExecutionResult(invocationId, code, stdout, stderr string) error {
+	val, _ := c.sessionState.Get(executionResultsKey)
+	results, _ := val.(map[string][]executionResult)
+	if results == nil {
+		results = make(map[string][]executionResult)
+	}
+	results[invocationId] = append(results[invocationId], executionResult{
+		Code:      code,
+		Stdout:    stdout,
+		Stderr:    stderr,
+		Timestamp: time.Now().UTC(),
+	})
+	return c.sessionState.Set(executionResultsKey, results)
+}
+
+// getCodeExecutorContext gets the code executor context from the session state.
+func getCodeExecutorContext(state session.State) map[string]any {
+	val, _ := state.Get(contextKey)
+	contextMap, _ := val.(map[string]any)
+	if contextMap == nil {
+		return make(map[string]any)
+	}
+	return contextMap
+}
+
+func NewCodeExecutorContext(state session.State) *CodeExecutorContext {
+	return &CodeExecutorContext{
+		contextState: getCodeExecutorContext(state),
+		sessionState: state,
+	}
+}

--- a/codeexecution/code_execution_context_test.go
+++ b/codeexecution/code_execution_context_test.go
@@ -1,0 +1,659 @@
+// Copyright 2025 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package codeexecution
+
+import (
+	"testing"
+	"time"
+
+	"github.com/google/go-cmp/cmp"
+	"github.com/google/go-cmp/cmp/cmpopts"
+)
+
+func TestGetStateDelta(t *testing.T) {
+	tests := []struct {
+		name         string
+		initialState *mockState
+		want         map[string]any
+	}{
+		{
+			name: "no error count present",
+			initialState: &mockState{
+				data: map[string]any{
+					contextKey: map[string]any{
+						sessionIdKey:          "session-id-1",
+						processedFileNamesKey: []string{"file.txt"},
+					},
+				},
+			},
+			want: map[string]any{
+				contextKey: map[string]any{
+					sessionIdKey:          "session-id-1",
+					processedFileNamesKey: []string{"file.txt"},
+				},
+			},
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			c := NewCodeExecutorContext(tt.initialState)
+			got := c.GetStateDelta()
+			if diff := cmp.Diff(got, tt.want); diff != "" {
+				t.Errorf("GetStateDelta() mismatch (-want +got):\n%s", diff)
+			}
+		})
+	}
+}
+
+func TestGetExecutionId(t *testing.T) {
+	tests := []struct {
+		name  string
+		state *mockState
+		want  string
+	}{
+		{
+			name: "execution id present",
+			state: &mockState{
+				data: map[string]any{
+					contextKey: map[string]any{
+						sessionIdKey: "session-id-1",
+					},
+				},
+			},
+			want: "session-id-1",
+		},
+		{
+			name: "execution id not present",
+			state: &mockState{
+				data: map[string]any{
+					contextKey: map[string]any{},
+				},
+			},
+			want: "",
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			c := NewCodeExecutorContext(tt.state)
+			got := c.GetExecutionId()
+			if got != tt.want {
+				t.Errorf("expected executionId %s, got %s", tt.want, got)
+			}
+		})
+	}
+}
+
+func TestSetExecutionId(t *testing.T) {
+	tests := []struct {
+		name      string
+		state     *mockState
+		want      map[string]any
+		sessionId string
+	}{
+		{
+			name:      "basic",
+			state:     &mockState{},
+			sessionId: "execution-id-1",
+			want: map[string]any{
+				sessionIdKey: "execution-id-1",
+			},
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			c := NewCodeExecutorContext(tt.state)
+			c.SetExecutionId(tt.sessionId)
+			if diff := cmp.Diff(c.contextState, tt.want); diff != "" {
+				t.Errorf("SetExecutionId() mismatch (-want +got):\n%s", diff)
+			}
+		})
+	}
+}
+
+func TestGetProcessedFileNames(t *testing.T) {
+	tests := []struct {
+		name         string
+		initialState *mockState
+		want         []string
+	}{
+		{
+			name: "files present",
+			initialState: &mockState{
+				data: map[string]any{
+					contextKey: map[string]any{
+						processedFileNamesKey: []string{"file.txt"},
+					},
+				},
+			},
+			want: []string{"file.txt"},
+		},
+		{
+			name: "no files present",
+			initialState: &mockState{
+				data: map[string]any{},
+			},
+			want: nil,
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			c := NewCodeExecutorContext(tt.initialState)
+			got := c.GetProcessedFileNames()
+			if diff := cmp.Diff(got, tt.want); diff != "" {
+				t.Errorf("GetProcessedFileNames() mismatch (-want +got):\n%s", diff)
+			}
+		})
+	}
+}
+
+func TestAddProcessedFileNames(t *testing.T) {
+	tests := []struct {
+		name         string
+		initialState *mockState
+		want         map[string]any
+	}{
+		{
+			name: "add file with none existing",
+			initialState: &mockState{
+				data: map[string]any{},
+			},
+			want: map[string]any{
+				processedFileNamesKey: []string{"newfile.txt"},
+			},
+		},
+		{
+			name: "add file with existing",
+			initialState: &mockState{
+				data: map[string]any{
+					contextKey: map[string]any{
+						processedFileNamesKey: []string{"file.txt"},
+					},
+				},
+			},
+			want: map[string]any{
+				processedFileNamesKey: []string{"file.txt", "newfile.txt"},
+			},
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			c := NewCodeExecutorContext(tt.initialState)
+			c.AddProcessedFileNames([]string{"newfile.txt"})
+			if diff := cmp.Diff(c.contextState, tt.want); diff != "" {
+				t.Errorf("AddProcessedFileNames() mismatch (-want +got):\n%s", diff)
+			}
+		})
+	}
+}
+
+func TestGetInputFiles(t *testing.T) {
+	tests := []struct {
+		name  string
+		state *mockState
+		want  []*File
+	}{
+		{
+			name: "files present",
+			state: &mockState{
+				data: map[string]any{
+					inputFileKey: []*File{
+						{
+							Name:     "file.txt",
+							Content:  []byte("Some content"),
+							MimeType: "text/plain",
+						},
+					},
+				},
+			},
+			want: []*File{
+				{
+					Name:     "file.txt",
+					Content:  []byte("Some content"),
+					MimeType: "text/plain",
+				},
+			},
+		},
+		{
+			name: "no files present",
+			state: &mockState{
+				data: map[string]any{},
+			},
+			want: nil,
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			c := NewCodeExecutorContext(tt.state)
+			got := c.GetInputFiles()
+			if diff := cmp.Diff(got, tt.want); diff != "" {
+				t.Errorf("GetInputFiles() mismatch (-want +got):\n%s", diff)
+			}
+		})
+	}
+}
+
+func TestAddInputFiles(t *testing.T) {
+	tests := []struct {
+		name         string
+		initialState *mockState
+		want         []*File
+	}{
+		{
+			name: "add file with none existing",
+			initialState: &mockState{
+				data: map[string]any{},
+			},
+			want: []*File{
+				{
+					Name:     "file.txt",
+					Content:  []byte("Some content"),
+					MimeType: "text/plain",
+				},
+			},
+		},
+		{
+			name: "add file with existing",
+			initialState: &mockState{
+				data: map[string]any{
+					inputFileKey: []*File{
+						{
+							Name:     "existing.txt",
+							Content:  []byte("Some content"),
+							MimeType: "text/plain",
+						},
+					},
+				},
+			},
+			want: []*File{
+				{
+					Name:     "existing.txt",
+					Content:  []byte("Some content"),
+					MimeType: "text/plain",
+				},
+				{
+					Name:     "file.txt",
+					Content:  []byte("Some content"),
+					MimeType: "text/plain",
+				},
+			},
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			c := NewCodeExecutorContext(tt.initialState)
+			err := c.AddInputFiles([]*File{
+				{
+					Name:     "file.txt",
+					Content:  []byte("Some content"),
+					MimeType: "text/plain",
+				},
+			})
+			if err != nil {
+				t.Errorf("unexpected error = %v", err)
+				return
+			}
+			files, err := c.sessionState.Get(inputFileKey)
+			if err != nil {
+				t.Errorf("unexpected error: %v", err)
+				return
+			}
+
+			if diff := cmp.Diff(files, tt.want); diff != "" {
+				t.Errorf("AddInputFiles() mismatch (-want +got):\n%s", diff)
+			}
+		})
+	}
+}
+
+func TestClearInputFiles(t *testing.T) {
+	tests := []struct {
+		name         string
+		initialState *mockState
+		want         []File
+	}{
+		{
+			name: "clear with existing",
+			initialState: &mockState{
+				data: map[string]any{
+					inputFileKey: []File{
+						{
+							Name:     "existing.txt",
+							Content:  []byte("Some content"),
+							MimeType: "text/plain",
+						},
+					},
+					contextKey: map[string]any{
+						inputFileKey: []File{
+							{
+								Name:     "existing.txt",
+								Content:  []byte("Some content"),
+								MimeType: "text/plain",
+							},
+						},
+					},
+				},
+			},
+			want: nil,
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			c := NewCodeExecutorContext(tt.initialState)
+			err := c.ClearInputFiles()
+			if err != nil {
+				t.Errorf("unexpected error = %v", err)
+				return
+			}
+			sessionStateRaw, err := c.sessionState.Get(inputFileKey)
+			if err != nil {
+				t.Errorf("unexpected error: %v", err)
+				return
+			}
+			sessionStateFiles, _ := sessionStateRaw.([]File)
+			if diff := cmp.Diff(sessionStateFiles, tt.want); diff != "" {
+				t.Errorf("ClearInputFiles() mismatch (-want +got):\n%s", diff)
+				return
+			}
+			contextStateFiles, _ := c.contextState[inputFileKey].([]File)
+			if diff := cmp.Diff(contextStateFiles, tt.want); diff != "" {
+				t.Errorf("ClearInputFiles() mismatch (-want +got):\n%s", diff)
+			}
+		})
+	}
+}
+
+func TestGetErrorCount(t *testing.T) {
+	invocationId := "invocation-1"
+	tests := []struct {
+		name        string
+		state       *mockState
+		expectError bool
+		want        int32
+		validate    func(t *testing.T, got, want int32)
+	}{
+		{
+			name: "error count present",
+			state: &mockState{
+				data: map[string]any{
+					errorCountKey: map[string]int32{
+						invocationId: 1,
+					},
+				},
+			},
+			want: 1,
+		},
+		{
+			name: "error count not present",
+			state: &mockState{
+				data: map[string]any{},
+			},
+			want: 0,
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			c := NewCodeExecutorContext(tt.state)
+			got := c.GetErrorCount(invocationId)
+			if got != tt.want {
+				t.Errorf("expected error count=%d, got %d", tt.want, got)
+			}
+		})
+	}
+}
+
+func TestResetErrorCount(t *testing.T) {
+	tests := []struct {
+		name         string
+		initialState *mockState
+		want         map[string]int32
+	}{
+		{
+			name: "error count present",
+			initialState: &mockState{
+				data: map[string]any{
+					errorCountKey: map[string]int32{
+						"invocation-1": 1,
+					},
+				},
+			},
+			want: map[string]int32{},
+		},
+		{
+			name: "multiple error counts present",
+			initialState: &mockState{
+				data: map[string]any{
+					errorCountKey: map[string]int32{
+						"invocation-1": 1,
+						"invocation-2": 1,
+					},
+				},
+			},
+			want: map[string]int32{
+				"invocation-2": 1,
+			},
+		},
+		{
+			name: "no error counts present",
+			initialState: &mockState{
+				data: map[string]any{},
+			},
+			want: nil,
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			c := NewCodeExecutorContext(tt.initialState)
+			err := c.ResetErrorCount("invocation-1")
+			if err != nil {
+				t.Errorf("unexpected error: %v", err)
+				return
+			}
+			errCount, err := c.sessionState.Get(errorCountKey)
+			if err != nil {
+				t.Errorf("unexpected error: %v", err)
+				return
+			}
+			errCountMap, _ := errCount.(map[string]int32)
+			if diff := cmp.Diff(errCountMap, tt.want); diff != "" {
+				t.Errorf("ResetErrorCount() mismatch (-want +got):\n%s", diff)
+			}
+		})
+	}
+}
+
+func TestIncrementErrorCount(t *testing.T) {
+	tests := []struct {
+		name         string
+		initialState *mockState
+		want         map[string]int32
+	}{
+		{
+			name: "no error count present",
+			initialState: &mockState{
+				data: map[string]any{},
+			},
+			want: map[string]int32{
+				"invocation-1": 1,
+			},
+		},
+		{
+			name: "error counts present",
+			initialState: &mockState{
+				data: map[string]any{
+					errorCountKey: map[string]int32{
+						"invocation-1": 1,
+					},
+				},
+			},
+			want: map[string]int32{
+				"invocation-1": 2,
+			},
+		},
+		{
+			name: "multiple error counts present",
+			initialState: &mockState{
+				data: map[string]any{
+					errorCountKey: map[string]int32{
+						"invocation-1": 1,
+						"invocation-2": 1,
+					},
+				},
+			},
+			want: map[string]int32{
+				"invocation-1": 2,
+				"invocation-2": 1,
+			},
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			c := NewCodeExecutorContext(tt.initialState)
+			err := c.IncrementErrorCount("invocation-1")
+			if err != nil {
+				t.Errorf("unexpected error: %v", err)
+				return
+			}
+
+			x, err := c.sessionState.Get(errorCountKey)
+			if err != nil {
+				t.Errorf("unexpected error: %v", err)
+				return
+			}
+			if diff := cmp.Diff(x, tt.want); diff != "" {
+				t.Errorf("IncrementErrorCount() mismatch (-want +got):\n%s", diff)
+			}
+		})
+	}
+}
+
+func TestUpdateCodeExecutionResult(t *testing.T) {
+	tests := []struct {
+		name         string
+		initialState *mockState
+		invocationId string
+		code         string
+		stdout       string
+		stderr       string
+		want         map[string][]executionResult
+	}{
+		{
+			name: "no existing results",
+			initialState: &mockState{
+				data: map[string]any{},
+			},
+			invocationId: "invocation-1",
+			code:         "fmt.Println(\"Hello\")",
+			stdout:       "Hello\n",
+			stderr:       "",
+			want: map[string][]executionResult{
+				"invocation-1": {
+					{
+						Code:   "fmt.Println(\"Hello\")",
+						Stdout: "Hello\n",
+						Stderr: "",
+					},
+				},
+			},
+		},
+		{
+			name: "existing results",
+			initialState: &mockState{
+				data: map[string]any{
+					executionResultsKey: map[string][]executionResult{
+						"invocation-1": {
+							{
+								Code:      "fmt.Println(\"Hello\")", // 1. Start with Hello
+								Stdout:    "Hello\n",
+								Stderr:    "",
+								Timestamp: time.Now().UTC(),
+							},
+						},
+					},
+				},
+			},
+			invocationId: "invocation-1",
+			code:         "fmt.Println(\"World\")",
+			stdout:       "World\n",
+			stderr:       "",
+			want: map[string][]executionResult{
+				"invocation-1": {
+					{
+						Code:   "fmt.Println(\"Hello\")",
+						Stdout: "Hello\n",
+						Stderr: "",
+					},
+					{
+						Code:   "fmt.Println(\"World\")",
+						Stdout: "World\n",
+						Stderr: "",
+					},
+				},
+			},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			c := NewCodeExecutorContext(tt.initialState)
+			err := c.UpdateCodeExecutionResult(tt.invocationId, tt.code, tt.stdout, tt.stderr)
+			if err != nil {
+				t.Errorf("unexpected error: %v", err)
+				return
+			}
+
+			result, err := c.sessionState.Get(executionResultsKey)
+			if err != nil {
+				t.Errorf("unexpected error: %v", err)
+				return
+			}
+			resultsMap, _ := result.(map[string][]executionResult)
+			if diff := cmp.Diff(resultsMap, tt.want, cmpopts.IgnoreFields(executionResult{}, "Timestamp")); diff != "" {
+				t.Errorf("UpdateCodeExecutionResult() mismatch (-want +got):\n%s", diff)
+			}
+		})
+	}
+}
+
+func TestGetCodeExecutorContext(t *testing.T) {
+	tests := []struct {
+		name         string
+		initialState *mockState
+		want         map[string]any
+	}{
+		{
+			name: "...",
+			initialState: &mockState{
+				data: map[string]any{
+					contextKey: map[string]any{
+						sessionIdKey:          "session-id1",
+						processedFileNamesKey: []string{"file.txt"},
+					},
+				},
+			},
+			want: map[string]any{
+				sessionIdKey:          "session-id1",
+				processedFileNamesKey: []string{"file.txt"},
+			},
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got := getCodeExecutorContext(tt.initialState)
+			if diff := cmp.Diff(got, tt.want); diff != "" {
+				t.Errorf("getCodeExecutorContext() mismatch (-want +got):\n%s", diff)
+			}
+		})
+	}
+}

--- a/codeexecution/code_executor.go
+++ b/codeexecution/code_executor.go
@@ -1,0 +1,150 @@
+// Copyright 2025 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package codeexecution
+
+import (
+	"google.golang.org/adk/agent"
+)
+
+// CodeExecutor implements Code Execution
+//
+// The code executor allows the agent to execute code blocks from model responses
+// and incorporate the execution results into the final response.
+type CodeExecutor interface {
+	// Executes code and return the code execution result
+	ExecuteCode(agent.InvocationContext, *CodeExecutionInput) (*CodeExecutionResult, error)
+	// Access to standard code execution configuration details.
+	Config() *CodeExecutorConfig
+}
+
+// CodeExecutionInput contains the input of code execution.
+type CodeExecutionInput struct {
+	// The code to execute.
+	Code string
+	// The input files available to the code.
+	InputFiles []*File
+	//  The execution ID for the stateful code execution.
+	ExecutionId string
+}
+
+// CodeExecutionResult contains the result of code execution.
+type CodeExecutionResult struct {
+	// The standard output of the code execution.
+	Stdout string
+	// The standard error of the code execution.
+	Stderr string
+	// The output files from the code execution.
+	OutputFiles []*File
+}
+
+// File contains a file name and its content.
+type File struct {
+	// The name of the file with file extension (e.g., "file.csv").
+	Name string
+	//  The base64-encoded bytes of the file content or the original bytes of the file content.
+	Content []byte
+	// The mime type of the file (e.g., "image/png").
+	MimeType string
+}
+
+// Config is the configuration for a CodeExecutor.
+type CodeExecutorConfig struct {
+	// If true, extract and process data files from the model request
+	// and attach them to the code executor.
+	OptimizeDataFile bool
+	// Whether the code executor is stateful.
+	Stateful bool
+	// The number of attempts to retry on consecutive code execution errors.
+	ErrorRetryAttempts int32
+	// The list of the enclosing delimiters to identify the code blocks.
+	//
+	// For example, the delimiter ('```python\\n', '\\n```') can be
+	// used to identify code blocks with the following format:
+	//   ```python
+	//   print("hello")
+	//   ```
+	CodeBlockDelimiters []Delimiter
+	// The delimiters to format the code execution result.
+	ExecutionResultDelimiters []Delimiter
+	// The timeout in seconds for the code execution.
+	TimeoutSeconds int32
+}
+
+// Delimiter is used to identity code execution and result blocks.
+type Delimiter struct {
+	// Code-leading delimiter
+	Leading string
+	// Code-trailing delimiter
+	Trailing string
+}
+
+// ConfigOption is a function that configures the CodeExecutor.
+type ConfigOption func(*CodeExecutorConfig)
+
+// WithCodeBlockDelimiters sets the delimiters on the CodeExecutor.
+func WithCodeBlockDelimiters(delimiters []Delimiter) ConfigOption {
+	return func(c *CodeExecutorConfig) {
+		c.CodeBlockDelimiters = delimiters
+	}
+}
+
+// WithStateful sets the statefulness of the CodeExecutor.
+func WithStateful() ConfigOption {
+	return func(c *CodeExecutorConfig) {
+		c.Stateful = true
+	}
+}
+
+// WithStateful sets the code execution retry attemps count of the CodeExecutor.
+func WithErrorRetryAttempts(count int32) ConfigOption {
+	return func(c *CodeExecutorConfig) {
+		c.ErrorRetryAttempts = count
+	}
+}
+
+// WithTimeoutSeconds sets the execution timeout of the CodeExecutor.
+func WithTimeoutSeconds(seconds int32) ConfigOption {
+	return func(c *CodeExecutorConfig) {
+		c.TimeoutSeconds = seconds
+	}
+}
+
+// NewCodeExecutionConfig configures the CodeExecutorConfig.
+//
+// Also sets default values.
+func newCodeExecutionConfig(opts ...ConfigOption) *CodeExecutorConfig {
+	cfg := &CodeExecutorConfig{
+		OptimizeDataFile:   false,
+		Stateful:           false,
+		ErrorRetryAttempts: 2,
+		CodeBlockDelimiters: []Delimiter{
+			{
+				Leading:  "```python\n",
+				Trailing: "\n```",
+			},
+		},
+		ExecutionResultDelimiters: []Delimiter{
+			{
+				Leading:  "```python\n",
+				Trailing: "\n```",
+			},
+		},
+		TimeoutSeconds: 60,
+	}
+	for _, opt := range opts {
+		opt(cfg)
+	}
+	return cfg
+}

--- a/codeexecution/helpers_test.go
+++ b/codeexecution/helpers_test.go
@@ -1,0 +1,54 @@
+// Copyright 2025 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package codeexecution
+
+import (
+	"iter"
+	"time"
+
+	"google.golang.org/adk/session"
+)
+
+type mockState struct {
+	data map[string]any
+}
+
+func (m *mockState) Set(key string, val any) error {
+	m.data[key] = val
+	return nil
+}
+
+func (m *mockState) Get(key string) (any, error) {
+	return m.data[key], nil
+}
+
+func (m *mockState) All() iter.Seq2[string, any] {
+	return nil
+}
+
+var _ session.State = (*mockState)(nil)
+
+type mockSession struct {
+	state *mockState
+}
+
+func (m *mockSession) ID() string                { return "mock-session-id" }
+func (m *mockSession) AppName() string           { return "mock-app" }
+func (m *mockSession) UserID() string            { return "mock-user" }
+func (m *mockSession) State() session.State      { return m.state }
+func (m *mockSession) Events() session.Events    { return nil }
+func (m *mockSession) LastUpdateTime() time.Time { return time.Now() }
+
+var _ session.Session = (*mockSession)(nil)

--- a/codeexecution/unsafe_local_code_executor.go
+++ b/codeexecution/unsafe_local_code_executor.go
@@ -1,0 +1,74 @@
+// Copyright 2025 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package codeexecution
+
+import (
+	"bytes"
+	"context"
+	"errors"
+	"fmt"
+	"os/exec"
+	"strings"
+
+	"google.golang.org/adk/agent"
+)
+
+// A code executor that runs locally.
+//
+// The code executor allows running code using local python installation (if available).
+type unsafeLocalCodeExecutor struct {
+	cfg *CodeExecutorConfig
+}
+
+func NewUnsafeLocalCodeExecutor(ctx context.Context, opts ...ConfigOption) (CodeExecutor, error) {
+	return &unsafeLocalCodeExecutor{newCodeExecutionConfig(opts...)}, nil
+}
+
+func (e *unsafeLocalCodeExecutor) ExecuteCode(ctx agent.InvocationContext, req *CodeExecutionInput) (*CodeExecutionResult, error) {
+	var pythonCmd string
+	for _, py := range []string{"python3", "python"} {
+		if _, err := exec.LookPath(py); err == nil {
+			pythonCmd = py
+			break
+		}
+	}
+	if pythonCmd == "" {
+		return nil, fmt.Errorf("valid python installation not found")
+	}
+	cmd := exec.CommandContext(ctx, pythonCmd)
+	cmd.Stdin = strings.NewReader(req.Code)
+
+	var stdout, stderr bytes.Buffer
+	cmd.Stdout = &stdout
+	cmd.Stderr = &stderr
+
+	if err := cmd.Run(); err != nil {
+		var exitErr *exec.ExitError
+		if !errors.As(err, &exitErr) {
+			return nil, fmt.Errorf("failed to run process: %w", err)
+		}
+	}
+
+	return &CodeExecutionResult{
+		Stdout: stdout.String(),
+		Stderr: stderr.String(),
+	}, nil
+}
+
+func (e *unsafeLocalCodeExecutor) Config() *CodeExecutorConfig {
+	return e.cfg
+}
+
+var _ CodeExecutor = (*unsafeLocalCodeExecutor)(nil)

--- a/internal/llminternal/agent.go
+++ b/internal/llminternal/agent.go
@@ -18,6 +18,7 @@ import (
 	"google.golang.org/genai"
 
 	"google.golang.org/adk/agent"
+	"google.golang.org/adk/codeexecution"
 	"google.golang.org/adk/model"
 	"google.golang.org/adk/tool"
 )
@@ -49,6 +50,8 @@ type State struct {
 	OutputSchema *genai.Schema
 
 	OutputKey string
+
+	CodeExecutor codeexecution.CodeExecutor
 }
 
 type InstructionProvider func(ctx agent.ReadonlyContext) (string, error)

--- a/internal/llminternal/base_flow.go
+++ b/internal/llminternal/base_flow.go
@@ -64,7 +64,7 @@ type Flow struct {
 
 	Tools                 []tool.Tool
 	RequestProcessors     []func(ctx agent.InvocationContext, req *model.LLMRequest, f *Flow) iter.Seq2[*session.Event, error]
-	ResponseProcessors    []func(ctx agent.InvocationContext, req *model.LLMRequest, resp *model.LLMResponse) error
+	ResponseProcessors    []func(ctx agent.InvocationContext, req *model.LLMRequest, resp *model.LLMResponse) iter.Seq2[*session.Event, error]
 	BeforeModelCallbacks  []BeforeModelCallback
 	AfterModelCallbacks   []AfterModelCallback
 	OnModelErrorCallbacks []OnModelErrorCallback
@@ -92,7 +92,7 @@ var (
 		AgentTransferRequestProcessor,
 		removeDisplayNameIfExists,
 	}
-	DefaultResponseProcessors = []func(ctx agent.InvocationContext, req *model.LLMRequest, resp *model.LLMResponse) error{
+	DefaultResponseProcessors = []func(ctx agent.InvocationContext, req *model.LLMRequest, resp *model.LLMResponse) iter.Seq2[*session.Event, error]{
 		nlPlanningResponseProcessor,
 		codeExecutionResponseProcessor,
 	}
@@ -560,9 +560,16 @@ func (f *Flow) runOneStep(ctx agent.InvocationContext) iter.Seq2[*session.Event,
 				yield(nil, err)
 				return
 			}
-			if err := f.postprocess(ctx, req, resp); err != nil {
-				yield(nil, err)
-				return
+			for ev, err := range f.postprocess(ctx, req, resp) {
+				if err != nil {
+					yield(nil, err)
+					return
+				}
+				if ev != nil {
+					if !yield(ev, nil) {
+						return
+					}
+				}
 			}
 			// Skip the model response event if there is no content and no error code.
 			// This is needed for the code executor to trigger another loop according to
@@ -898,14 +905,24 @@ func (f *Flow) runOnModelErrorCallbacks(ctx agent.InvocationContext, llmReq *mod
 	return nil, nil
 }
 
-func (f *Flow) postprocess(ctx agent.InvocationContext, req *model.LLMRequest, resp *responseWithEventID) error {
-	// apply response processor functions to the response in the configured order.
-	for _, processor := range f.ResponseProcessors {
-		if err := processor(ctx, req, resp.LLMResponse); err != nil {
-			return err
+func (f *Flow) postprocess(ctx agent.InvocationContext, req *model.LLMRequest, resp *responseWithEventID) iter.Seq2[*session.Event, error] {
+	return func(yield func(*session.Event, error) bool) {
+		// apply response processor functions to the response in the configured order.
+
+		// Skip the model response event if there is no content and no error code.
+		// This is needed for the code executor to trigger another loop.
+		for _, processor := range f.ResponseProcessors {
+			for ev, err := range processor(ctx, req, resp.LLMResponse) {
+				if err != nil {
+					yield(nil, err)
+					return
+				}
+				if ev != nil {
+					yield(ev, nil)
+				}
+			}
 		}
 	}
-	return nil
 }
 
 func (f *Flow) agentToRun(ctx agent.InvocationContext, agentName string) agent.Agent {
@@ -1130,7 +1147,7 @@ func (f *Flow) handleFunctionCalls(ctx agent.InvocationContext, toolsDict map[st
 			}
 
 			// TODO: handle long-running tool.
-			ev := session.NewEventWithContext(ctx, ctx.InvocationID())
+			ev := session.NewEvent(ctx.InvocationID())
 			ev.LLMResponse = model.LLMResponse{
 				Content: &genai.Content{
 					Role: "user",

--- a/internal/llminternal/code_execution_processor.go
+++ b/internal/llminternal/code_execution_processor.go
@@ -1,0 +1,236 @@
+// Copyright 2025 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package llminternal
+
+import (
+	"fmt"
+	"iter"
+	"regexp"
+	"strings"
+
+	"google.golang.org/genai"
+
+	"google.golang.org/adk/agent"
+	"google.golang.org/adk/codeexecution"
+	"google.golang.org/adk/internal/toolinternal"
+	"google.golang.org/adk/model"
+	"google.golang.org/adk/session"
+)
+
+func codeExecutionRequestProcessor(ctx agent.InvocationContext, req *model.LLMRequest, f *Flow) iter.Seq2[*session.Event, error] {
+	return func(yield func(*session.Event, error) bool) {
+		llmAgent := asLLMAgent(ctx.Agent())
+		if llmAgent == nil {
+			return
+		}
+		codeExecutor := Reveal(llmAgent).CodeExecutor
+		if codeExecutor == nil {
+			return
+		}
+
+		// For the BuiltInCodeExecutor only, code execution is handled by the model itself.
+		if codeExecutorProcessor, ok := codeExecutor.(toolinternal.RequestProcessor); ok {
+			toolCtx := agent.NewToolContext(ctx, "", &session.EventActions{}, nil)
+			if err := codeExecutorProcessor.ProcessRequest(toolCtx, req); err != nil {
+				yield(nil, err)
+				return
+			}
+		}
+
+		// TODO: consider input file processing implementation (see adk-python src/google/adk/flows/llm_flows/_code_execution.py)
+		// This involves extracting any data files from the session history, executing analysis code and storing them in memory.
+	}
+}
+
+func codeExecutionResponseProcessor(ctx agent.InvocationContext, req *model.LLMRequest, resp *model.LLMResponse) iter.Seq2[*session.Event, error] {
+	return func(yield func(*session.Event, error) bool) {
+		llmAgent := asLLMAgent(ctx.Agent())
+		if llmAgent == nil {
+			return
+		}
+		if resp == nil || resp.Content == nil || resp.Partial {
+			return // Skip if the response is empty or partial
+		}
+		codeExecutor := Reveal(llmAgent).CodeExecutor
+		if codeExecutor == nil {
+			return // Skip if no configured CodeExecutor
+		}
+
+		// TODO: consider generated image handling (see adk-python src/google/adk/flows/llm_flows/_code_execution.py)
+
+		codeExecutorContext := codeexecution.NewCodeExecutorContext(ctx.Session().State())
+
+		// Skip if the error count exceeds the max retry attempts.
+		if codeExecutorContext.GetErrorCount(ctx.InvocationID()) > codeExecutor.Config().ErrorRetryAttempts {
+			return
+		}
+
+		// Extract the code from model response and truncate the content
+		// to the part with the first code block. Do nothing if no code to execute.
+		codeStr := extractCodeAndTruncateContent(resp.Content, codeExecutor.Config().CodeBlockDelimiters)
+		if codeStr == "" {
+			return
+		}
+
+		// Emit code execution event
+		ev := session.NewEventWithContext(ctx, ctx.InvocationID())
+		ev.LLMResponse = model.LLMResponse{
+			Content: resp.Content,
+		}
+		ev.Author = ctx.Agent().Name()
+		ev.Branch = ctx.Branch()
+		if !yield(ev, nil) {
+			return
+		}
+
+		// Execute the code
+		executionResult, err := codeExecutor.ExecuteCode(ctx, &codeexecution.CodeExecutionInput{
+			Code:        codeStr,
+			ExecutionId: getOrSetExecutionId(ctx, codeExecutorContext),
+			InputFiles:  codeExecutorContext.GetInputFiles(),
+		})
+		if err != nil {
+			yield(nil, err)
+			return
+		}
+		if err = codeExecutorContext.UpdateCodeExecutionResult(ctx.InvocationID(), codeStr, executionResult.Stdout, executionResult.Stderr); err != nil {
+			yield(nil, err)
+			return
+		}
+
+		// Emit code execution result event
+		ev, err = generateCodeExecutionResultEvent(ctx, codeExecutorContext, executionResult)
+		if !yield(ev, err) {
+			return
+		}
+
+		// Skip processing the original model response to continue generation loop.
+		resp.Content = nil
+	}
+}
+
+// generateCodeExecutionResultEvent constructs a code execution result event.
+func generateCodeExecutionResultEvent(ctx agent.InvocationContext, codeExecutionContext *codeexecution.CodeExecutorContext, codeExecutionResult *codeexecution.CodeExecutionResult) (*session.Event, error) {
+	ev := session.NewEventWithContext(ctx, ctx.InvocationID())
+	ev.LLMResponse = model.LLMResponse{
+		Content: &genai.Content{
+			Role: genai.RoleModel,
+			Parts: []*genai.Part{
+				buildCodeExecutionResultPart(codeExecutionResult),
+			},
+		},
+	}
+	ev.Author = ctx.Agent().Name()
+	ev.Branch = ctx.Branch()
+	ev.Actions.StateDelta = codeExecutionContext.GetStateDelta()
+
+	// Handle code execution error retry.
+	if codeExecutionResult.Stderr != "" {
+		if err := codeExecutionContext.IncrementErrorCount(ctx.InvocationID()); err != nil {
+			return nil, err
+		}
+	} else {
+		if err := codeExecutionContext.ResetErrorCount(ctx.InvocationID()); err != nil {
+			return nil, err
+		}
+	}
+
+	// Handle output files.
+	for _, outputFile := range codeExecutionResult.OutputFiles {
+		saveResp, err := ctx.Artifacts().Save(ctx, outputFile.Name, genai.NewPartFromBytes(outputFile.Content, outputFile.MimeType))
+		if err != nil {
+			return nil, err
+		}
+		ev.Actions.ArtifactDelta[outputFile.Name] = saveResp.Version
+	}
+	return ev, nil
+}
+
+func buildExecutableCodePart(code string) *genai.Part {
+	return genai.NewPartFromExecutableCode(code, genai.LanguagePython)
+}
+
+func buildCodeExecutionResultPart(code *codeexecution.CodeExecutionResult) *genai.Part {
+	if code.Stderr != "" {
+		return genai.NewPartFromCodeExecutionResult(
+			genai.OutcomeFailed, code.Stderr,
+		)
+	}
+	return genai.NewPartFromCodeExecutionResult(
+		genai.OutcomeOK, code.Stdout,
+	)
+}
+
+// extractCodeAndTruncateContent extracts the first code block from the content and truncate everything after it.
+func extractCodeAndTruncateContent(content *genai.Content, delimiters []codeexecution.Delimiter) string {
+	if content == nil || len(content.Parts) == 0 {
+		return ""
+	}
+
+	// TODO: Extract the code from the executable code parts if there are no associated
+	// code execution result parts.
+
+	// Extract from text parts
+	var textParts []*genai.Part
+	for _, part := range content.Parts {
+		if part.Text != "" {
+			textParts = append(textParts, part)
+		}
+	}
+	if len(textParts) == 0 {
+		return ""
+	}
+	var responseTexts []string
+	for _, part := range textParts {
+		responseTexts = append(responseTexts, part.Text)
+	}
+	responseText := strings.Join(responseTexts, "\n")
+
+	var leadingPatterns []string
+	var trailingPatterns []string
+	for _, d := range delimiters {
+		leadingPatterns = append(leadingPatterns, d.Leading)
+		trailingPatterns = append(trailingPatterns, d.Trailing)
+	}
+	leadingDelimiterPattern := strings.Join(leadingPatterns, "|")
+	trailingDelimiterPattern := strings.Join(trailingPatterns, "|")
+
+	patternStr := fmt.Sprintf("(?s)%s(.*?)%s",
+		regexp.QuoteMeta(leadingDelimiterPattern), regexp.QuoteMeta(trailingDelimiterPattern))
+	pattern := regexp.MustCompile(patternStr)
+	match := pattern.FindStringSubmatch(responseText)
+	if len(match) < 2 {
+		return "" // No match found
+	}
+	codeStr := match[1]
+	if codeStr == "" {
+		return ""
+	}
+	content.Parts = []*genai.Part{}
+	content.Parts = append(
+		content.Parts,
+		buildExecutableCodePart(codeStr),
+	)
+	return codeStr
+}
+
+func getOrSetExecutionId(ctx agent.InvocationContext, codeExecutorContext *codeexecution.CodeExecutorContext) string {
+	executionId := codeExecutorContext.GetExecutionId()
+	if executionId == "" {
+		executionId = ctx.Session().ID()
+	}
+	codeExecutorContext.SetExecutionId(executionId)
+	return executionId
+}

--- a/internal/llminternal/code_execution_processor_test.go
+++ b/internal/llminternal/code_execution_processor_test.go
@@ -1,0 +1,126 @@
+// Copyright 2025 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package llminternal
+
+import (
+	"testing"
+
+	"google.golang.org/genai"
+
+	"google.golang.org/adk/agent"
+	"google.golang.org/adk/codeexecution"
+	icontext "google.golang.org/adk/internal/context"
+	"google.golang.org/adk/internal/utils"
+	"google.golang.org/adk/model"
+	"google.golang.org/adk/session"
+)
+
+func TestCodeExecutionResponseProcessor(t *testing.T) {
+	tests := []struct {
+		name    string
+		agent   agent.Agent
+		session session.Session
+		req     *model.LLMRequest
+		resp    *model.LLMResponse
+	}{
+		{
+			name: "simple",
+			agent: &mockLLMAgent{
+				Agent: utils.Must(agent.New(agent.Config{
+					Name: "test_agent",
+				})),
+				s: &State{
+					CodeExecutor: &mockCodeExecutor{
+						stdout: "Hello world!",
+					},
+				},
+			},
+			session: &mockSession{
+				state: &mockState{
+					data: make(map[string]any),
+				},
+			},
+			req: &model.LLMRequest{
+				Contents: []*genai.Content{
+					{
+						Parts: []*genai.Part{
+							genai.NewPartFromText("Print 'Hello World!'"),
+						},
+						Role: genai.RoleUser,
+					},
+				},
+			},
+			resp: &model.LLMResponse{
+				Content: &genai.Content{
+					Parts: []*genai.Part{
+						genai.NewPartFromText("Some text before code."),
+						genai.NewPartFromText("```python\nprint(\"Hello World!\")\n```"),
+						genai.NewPartFromText("Some text after code."),
+					},
+					Role: genai.RoleModel,
+				},
+			},
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			ctx := icontext.NewInvocationContext(t.Context(), icontext.InvocationContextParams{
+				Agent:   tt.agent,
+				Session: tt.session,
+			})
+			iter := codeExecutionResponseProcessor(ctx, tt.req, tt.resp)
+			for _, err := range iter {
+				if err != nil {
+					t.Fatalf("codeExecutionResponseProcessor() unexpected error: %v", err)
+				}
+			}
+		})
+	}
+}
+
+func TestExtractCodeAndTruncateContent(t *testing.T) {
+	tests := []struct {
+		name       string
+		content    *genai.Content
+		delimiters []codeexecution.Delimiter
+		want       string
+	}{
+		{
+			name: "simple python code extraction",
+			content: &genai.Content{
+				Parts: []*genai.Part{
+					genai.NewPartFromText("Here is some python code to execute."),
+					genai.NewPartFromText("```python\nprint(\"Hello World!\")\n```"),
+				},
+				Role: genai.RoleModel,
+			},
+			delimiters: []codeexecution.Delimiter{
+				{
+					Leading:  "```python\n",
+					Trailing: "\n```",
+				},
+			},
+			want: "print(\"Hello World!\")",
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got := extractCodeAndTruncateContent(tt.content, tt.delimiters)
+			if got != tt.want {
+				t.Errorf("incorrect code extraction: got %s, expected %s", got, tt.want)
+			}
+		})
+	}
+}

--- a/internal/llminternal/helpers_test.go
+++ b/internal/llminternal/helpers_test.go
@@ -15,7 +15,12 @@
 package llminternal
 
 import (
+	"iter"
+	"time"
+
 	"google.golang.org/adk/agent"
+	"google.golang.org/adk/codeexecution"
+	"google.golang.org/adk/session"
 )
 
 // mockLLMAgent satisfies both agent.Agent (via embedding) and llminternal.Agent (via internal() implementation)
@@ -29,3 +34,87 @@ var _ Agent = (*mockLLMAgent)(nil)
 func (m *mockLLMAgent) internal() *State {
 	return m.s
 }
+
+type mockCodeExecutor struct {
+	stdout string
+	stderr string
+}
+
+func (m *mockCodeExecutor) ExecuteCode(agent.InvocationContext, *codeexecution.CodeExecutionInput) (*codeexecution.CodeExecutionResult, error) {
+	return &codeexecution.CodeExecutionResult{
+		Stdout: m.stdout,
+		Stderr: m.stderr,
+	}, nil
+}
+
+func (m *mockCodeExecutor) Config() *codeexecution.CodeExecutorConfig {
+	return &codeexecution.CodeExecutorConfig{
+		OptimizeDataFile:   false,
+		Stateful:           false,
+		ErrorRetryAttempts: 2,
+		CodeBlockDelimiters: []codeexecution.Delimiter{
+			{
+				Leading:  "```python\n",
+				Trailing: "\n```",
+			},
+		},
+		ExecutionResultDelimiters: []codeexecution.Delimiter{
+			{
+				Leading:  "```python\n",
+				Trailing: "\n```",
+			},
+		},
+		TimeoutSeconds: 60,
+	}
+}
+
+var _ codeexecution.CodeExecutor = (*mockCodeExecutor)(nil)
+
+type mockState struct {
+	data map[string]any
+}
+
+func (m *mockState) Set(key string, val any) error {
+	m.data[key] = val
+	return nil
+}
+
+func (m *mockState) Get(key string) (any, error) {
+	return m.data[key], nil
+}
+
+func (m *mockState) All() iter.Seq2[string, any] {
+	return nil
+}
+
+var _ session.State = (*mockState)(nil)
+
+type mockSession struct {
+	state *mockState
+}
+
+func (m *mockSession) ID() string {
+	return "mock-session-id"
+}
+
+func (m *mockSession) AppName() string {
+	return "mock-app"
+}
+
+func (m *mockSession) UserID() string {
+	return "mock-user"
+}
+
+func (m *mockSession) State() session.State {
+	return m.state
+}
+
+func (m *mockSession) Events() session.Events {
+	return nil
+}
+
+func (m *mockSession) LastUpdateTime() time.Time {
+	return time.Now()
+}
+
+var _ session.Session = (*mockSession)(nil)

--- a/internal/llminternal/other_processors.go
+++ b/internal/llminternal/other_processors.go
@@ -27,22 +27,12 @@ func nlPlanningRequestProcessor(ctx agent.InvocationContext, req *model.LLMReque
 	return func(yield func(*session.Event, error) bool) {}
 }
 
-func codeExecutionRequestProcessor(ctx agent.InvocationContext, req *model.LLMRequest, f *Flow) iter.Seq2[*session.Event, error] {
-	// TODO: implement (adk-python src/google/adk/flows/llm_flows/_code_execution.py)
-	return func(yield func(*session.Event, error) bool) {}
-}
-
 func authPreprocessor(ctx agent.InvocationContext, req *model.LLMRequest, f *Flow) iter.Seq2[*session.Event, error] {
 	// TODO: implement (adk-python src/google/adk/auth/auth_preprocessor.py)
 	return func(yield func(*session.Event, error) bool) {}
 }
 
-func nlPlanningResponseProcessor(ctx agent.InvocationContext, req *model.LLMRequest, resp *model.LLMResponse) error {
+func nlPlanningResponseProcessor(ctx agent.InvocationContext, req *model.LLMRequest, resp *model.LLMResponse) iter.Seq2[*session.Event, error] {
 	// TODO: implement (adk-python src/google/adk/_nl_planning.py)
-	return nil
-}
-
-func codeExecutionResponseProcessor(ctx agent.InvocationContext, req *model.LLMRequest, resp *model.LLMResponse) error {
-	// TODO: implement (adk-python src/google/adk_code_execution.py)
-	return nil
+	return func(yield func(*session.Event, error) bool) {}
 }


### PR DESCRIPTION
### Link to Issue or Description of Change

- Closes: #319 
- Closes: #1066 

**Problem:**
ADK Go missing unified CodeExecutor API to support extended code execution integrations, currently available in [Python ADK SDK](https://github.com/google/adk-python/tree/main/src/google/adk/code_executors).

**Solution:**
Details can be found in linked issues. Brief outline of main solution points:

- Introduce CodeExecutor API (in line with Python ADK) as the unified code execution interface.
- Provide initial out-of-the-box code execution implementations (`BuiltInCodeExecutor` and `UnSafeLocalCodeExecutor`)
- LLMAgent configuration extension (`llmAgent.Config` and `llminternal.State`) to allow configuring selected CodeExecutor implementation on an agent.
- Modify post-request processor function interface definition to be iterabl (in line with Python ADK)
- Pre- and post-request processor implementations (migrated from `other_processors.go` to dedicated `code_execution_processer.go`) for handling code execution, `genai.ExecutableCode` and `genai.CodeExecutionResult` part types.


### Testing Plan

Introduced new set of tests covering core functionality additions:

`./codeexecution/code_execution_context_test.go`
`./codeexecution/helpers_test.go`
`./internal/llminternal/code_execution_processor_test.go`
`./internal/llminternal/helpers_test.go`

See unit tests and manual E2E tests below for details.

**Unit Tests:**

- [x] I have added or updated unit tests for my change.
- [x] All unit tests pass locally.

Summary of go test results:

```bash
go test ./codeexecution
ok      google.golang.org/adk/codeexecution     0.419s

go test ./internal/llminternal
ok      google.golang.org/adk/internal/llminternal      1.020s
```

**Manual End-to-End (E2E) Tests:**

Manually tested complete agent loop flows using `BuiltInCodeExecutor` and `UnsafeLocalCodeExecutor` (requires local python installation) implementations.

Relevant code snippet:

```go

import (
    ...
	"google.golang.org/adk/codeexecution"
)
codeExecutor, err := codeexecution.NewUnsafeLocalCodeExecutor(ctx)
if err != nil {
    log.Fatalf("Failed to create CodeExecutor: %v", err)
}

// Create new agent
adkAgent, err := llmagent.New(llmagent.Config{
    ...
    CodeExecutor: codeExecutor,
})
```

Example ADK web UI interaction:

<img width="1192" height="715" alt="Screenshot 2026-06-19 at 10 02 01" src="https://github.com/user-attachments/assets/0c034ffc-b884-48c1-91e8-bf99e263278e" />


### Checklist

- [x] I have read the [CONTRIBUTING.md](./CONTRIBUTING.md) document.
- [x] I have performed a self-review of my own code.
- [x] I have commented my code, particularly in hard-to-understand areas.
- [x] I have added tests that prove my fix is effective or that my feature works.
- [x] New and existing unit tests pass locally with my changes.
- [x] I have manually tested my changes end-to-end.
- [x] Any dependent changes have been merged and published in downstream modules.

