### PR TITLE
refactor(workflow): declare Default sentinel via Route interface

### DIFF
--- a/workflow/workflow.go
+++ b/workflow/workflow.go
@@ -105,8 +105,8 @@ func (r MultiRoute[T]) Matches(event *session.Event) bool {
 	return false
 }
 
-// DefaultRoute is a special route that matches when no other concrete routes match.
-var Default = &defaultRoute{}
+// Default is a special route that matches when no other concrete routes match.
+var Default Route = &defaultRoute{}
 
 type defaultRoute struct{}
 


### PR DESCRIPTION
## Problem

The two graph sentinels in `workflow/workflow.go` are declared inconsistently:

```go
var Default = &defaultRoute{}      // static type: *defaultRoute (unexported, concrete)
var Start   Node = &startNode{...} // static type: Node (exported interface)
```

`Default` infers the unexported concrete type `*defaultRoute`, while `Start` is explicitly declared with its exported interface type `Node`. The two sentinels serve analogous roles (both are matched by identity in the scheduler), yet they are declared with different styles, and the `Default` form has concrete downsides.

## Solution

Declare `Default` with its exported interface type, matching `Start`:

```go
var Default Route = &defaultRoute{}
```

The doc comment is also fixed to start with the symbol name (`Default`).

## Benefits

- **No leak of the unexported type into public godoc.** With the inferred form, godoc renders `var Default *defaultRoute` — exposing a type that callers can see but cannot name or use. The interface form renders `var Default Route`, which is exactly the contract callers need.
- **`Route` conformance asserted at the declaration site.** If `(*defaultRoute).Matches` ever drifts from the `Route` interface, the compiler flags it on the declaration line instead of further away where `Default` is assigned to an `Edge.Route` field.
- **Consistency with the `Start` sentinel.** Both sentinels now follow the same pattern — an exported variable typed by its exported interface — making the pair easier to read and maintain.
- **Smaller, intentional API surface.** Only the `Route` interface methods are visible through `Default`, communicating that it is meant to be used as a `Route` and nothing more.
- **Self-documenting intent.** The explicit type makes it obvious at a glance that `Default` is a `Route`, without having to look up `defaultRoute`.
