### PR TITLE
refactor(session)!: NewEvent takes a context.Context

### DIFF
--- a/agent/agent.go
+++ b/agent/agent.go
@@ -272,7 +272,7 @@ func runBeforeAgentCallbacks(ctx InvocationContext) (*session.Event, error) {
 			return nil, fmt.Errorf("failed to run plugin before agent callback: %w", err)
 		}
 		if content != nil {
-			event := session.NewEventWithContext(ctx, ctx.InvocationID())
+			event := session.NewEvent(ctx, ctx.InvocationID())
 			event.LLMResponse = model.LLMResponse{
 				Content: content,
 			}
@@ -293,7 +293,7 @@ func runBeforeAgentCallbacks(ctx InvocationContext) (*session.Event, error) {
 			continue
 		}
 
-		event := session.NewEventWithContext(ctx, ctx.InvocationID())
+		event := session.NewEvent(ctx, ctx.InvocationID())
 		event.LLMResponse = model.LLMResponse{
 			Content: content,
 		}
@@ -306,7 +306,7 @@ func runBeforeAgentCallbacks(ctx InvocationContext) (*session.Event, error) {
 
 	// check if has delta create event with it
 	if len(actions.StateDelta) > 0 {
-		event := session.NewEventWithContext(ctx, ctx.InvocationID())
+		event := session.NewEvent(ctx, ctx.InvocationID())
 		event.Author = agent.Name()
 		event.Branch = ctx.Branch()
 		event.Actions = *actions
@@ -331,7 +331,7 @@ func runAfterAgentCallbacks(ctx InvocationContext) (*session.Event, error) {
 			return nil, fmt.Errorf("failed to run plugin after agent callback: %w", err)
 		}
 		if content != nil {
-			event := session.NewEventWithContext(ctx, ctx.InvocationID())
+			event := session.NewEvent(ctx, ctx.InvocationID())
 			event.LLMResponse = model.LLMResponse{
 				Content: content,
 			}
@@ -351,7 +351,7 @@ func runAfterAgentCallbacks(ctx InvocationContext) (*session.Event, error) {
 			continue
 		}
 
-		event := session.NewEventWithContext(ctx, ctx.InvocationID())
+		event := session.NewEvent(ctx, ctx.InvocationID())
 		event.LLMResponse = model.LLMResponse{
 			Content: newContent,
 		}
@@ -365,7 +365,7 @@ func runAfterAgentCallbacks(ctx InvocationContext) (*session.Event, error) {
 
 	// check if has delta create event with it
 	if len(actions.StateDelta) > 0 {
-		event := session.NewEventWithContext(ctx, ctx.InvocationID())
+		event := session.NewEvent(ctx, ctx.InvocationID())
 		event.Author = agent.Name()
 		event.Branch = ctx.Branch()
 		event.Actions = *actions

--- a/agent/llmagent/dynamic_events_test.go
+++ b/agent/llmagent/dynamic_events_test.go
@@ -33,7 +33,7 @@ func TestSessionEvents_YieldedPresence(t *testing.T) {
 		Run: func(ctx agent.InvocationContext) iter.Seq2[*session.Event, error] {
 			return func(yield func(*session.Event, error) bool) {
 				// 1. Yield a test event
-				testEvent := session.NewEventWithContext(ctx, ctx.InvocationID())
+				testEvent := session.NewEvent(ctx, ctx.InvocationID())
 				testEvent.Content = genai.NewContentFromText("Initial test event", genai.RoleModel)
 				if !yield(testEvent, nil) {
 					return
@@ -53,7 +53,7 @@ func TestSessionEvents_YieldedPresence(t *testing.T) {
 				}
 
 				// 3. Yield the result of the check
-				resultEvent := session.NewEventWithContext(ctx, ctx.InvocationID())
+				resultEvent := session.NewEvent(ctx, ctx.InvocationID())
 				if found {
 					resultEvent.Content = genai.NewContentFromText("Found initial event in session", genai.RoleModel)
 				} else {

--- a/agent/llmagent/llm_agent_wrapper.go
+++ b/agent/llmagent/llm_agent_wrapper.go
@@ -145,7 +145,7 @@ func PrepareLLMAgentInput(a agent.Agent, ctx agent.InvocationContext, nodeInput 
 	if content == nil {
 		return nil
 	}
-	ev := session.NewEventWithContext(ctx, ctx.InvocationID())
+	ev := session.NewEvent(ctx, ctx.InvocationID())
 	ev.Author = "user"
 	ev.LLMResponse = model.LLMResponse{Content: content}
 	if iso := ctx.IsolationScope(); iso != "" {
@@ -415,7 +415,7 @@ func synthesizeTaskFREvent(ctx context.Context, invocationID string, fc *genai.F
 	} else {
 		response = map[string]any{"output": output}
 	}
-	ev := session.NewEventWithContext(ctx, invocationID)
+	ev := session.NewEvent(ctx, invocationID)
 	ev.Author = "user"
 	ev.LLMResponse = model.LLMResponse{
 		Content: &genai.Content{

--- a/agent/llmagent/llm_agent_wrapper_test.go
+++ b/agent/llmagent/llm_agent_wrapper_test.go
@@ -1088,7 +1088,7 @@ func TestChatCoordinator_ResumesUnresolvedTaskFC(t *testing.T) {
 	if err != nil {
 		t.Fatal(err)
 	}
-	pendingFCEvent := session.NewEventWithContext(t.Context(), "inv-prior")
+	pendingFCEvent := session.NewEvent(t.Context(), "inv-prior")
 	pendingFCEvent.Author = coordName
 	pendingFCEvent.LLMResponse = model.LLMResponse{
 		Content: fcContent(fcID, taskName, map[string]any{"q": "leftover"}),

--- a/agent/llmagent/llmagent_saveoutput_test.go
+++ b/agent/llmagent/llmagent_saveoutput_test.go
@@ -154,7 +154,7 @@ func newSessionWithEvent(t *testing.T, text string) session.Session {
 	if err != nil {
 		t.Fatalf("session.Create: %v", err)
 	}
-	ev := session.NewEvent("inv-existing")
+	ev := session.NewEvent(t.Context(), "inv-existing")
 	ev.Author = "user"
 	ev.LLMResponse = model.LLMResponse{Content: &genai.Content{
 		Role:  genai.RoleUser,
@@ -172,8 +172,9 @@ func newSessionWithEvent(t *testing.T, text string) session.Session {
 	return getResp.Session
 }
 
-func seedEvent(text string) *session.Event {
-	ev := session.NewEvent("inv-seed")
+func seedEvent(t *testing.T, text string) *session.Event {
+	t.Helper()
+	ev := session.NewEvent(t.Context(), "inv-seed")
 	ev.Author = "user"
 	ev.LLMResponse = model.LLMResponse{Content: &genai.Content{
 		Role:  genai.RoleUser,
@@ -190,7 +191,7 @@ func TestWrappedSession_SeedNotPersisted(t *testing.T) {
 
 	base := newSessionWithEvent(t, "existing turn")
 	baseLen := base.Events().Len()
-	seed := seedEvent("transient node input")
+	seed := seedEvent(t, "transient node input")
 	wrapped := newWrappedSession(base, seed)
 
 	if got, want := wrapped.Events().Len(), baseLen+1; got != want {

--- a/agent/remoteagent/a2a_agent_compat_test.go
+++ b/agent/remoteagent/a2a_agent_compat_test.go
@@ -181,7 +181,7 @@ func TestCompat_RemoteAgent(t *testing.T) {
 			},
 			updateConfig: func(config *A2AConfig) {
 				config.Converter = func(ctx agent.InvocationContext, req *legacyA2A.MessageSendParams, event legacyA2A.Event, err error) (*session.Event, error) {
-					ev := session.NewEventWithContext(ctx, "custom")
+					ev := session.NewEvent(ctx, "custom")
 					ev.Author = ctx.Agent().Name()
 					ev.LLMResponse = model.LLMResponse{
 						Content:      genai.NewContentFromText("converted", genai.RoleModel),
@@ -563,7 +563,7 @@ func newInvocationContext(t *testing.T, events []*session.Event) agent.Invocatio
 }
 
 func newUserHello() *session.Event {
-	event := session.NewEventWithContext(context.Background(), "invocation")
+	event := session.NewEvent(context.Background(), "invocation")
 	event.Author = "user"
 	event.LLMResponse = model.LLMResponse{
 		Content: genai.NewContentFromText("hello", genai.RoleUser),

--- a/agent/remoteagent/v2/a2a_agent_test.go
+++ b/agent/remoteagent/v2/a2a_agent_test.go
@@ -206,7 +206,7 @@ func newA2AEventReplay(t *testing.T, events []a2a.Event) a2asrv.AgentExecutor {
 }
 
 func newUserHello() *session.Event {
-	event := session.NewEventWithContext(context.Background(), "invocation")
+	event := session.NewEvent(context.Background(), "invocation")
 	event.Author = "user"
 	event.Content = genai.NewContentFromText("hello", genai.RoleUser)
 	return event

--- a/agent/remoteagent/v2/utils.go
+++ b/agent/remoteagent/v2/utils.go
@@ -129,7 +129,7 @@ func toMissingRemoteSessionParts(ctx agent.InvocationContext, events session.Eve
 }
 
 func presentAsUserMessage(ctx agent.InvocationContext, agentEvent *session.Event) *session.Event {
-	event := session.NewEventWithContext(ctx, ctx.InvocationID())
+	event := session.NewEvent(ctx, ctx.InvocationID())
 	event.Author = "user"
 
 	if agentEvent.Content == nil {

--- a/agent/workflowagent/hitl_test.go
+++ b/agent/workflowagent/hitl_test.go
@@ -277,7 +277,7 @@ func TestWorkflowAgent_RunThenResume_DynamicNodeOrchestrator(t *testing.T) {
 
 	asker := newHitlNode("ask_name", func(ctx agent.Context, _ any, yield func(*session.Event, error) bool) {
 		if resp, ok := ctx.ResumedInput(interruptID); ok {
-			ev := session.NewEventWithContext(ctx, ctx.InvocationID())
+			ev := session.NewEvent(ctx, ctx.InvocationID())
 			ev.Output = resp
 			yield(ev, nil)
 			return
@@ -389,7 +389,7 @@ func (s *fakeSession) appendUserMessage(msg *genai.Content) {
 	if msg == nil {
 		return
 	}
-	ev := session.NewEventWithContext(context.Background(), "test-invocation-id")
+	ev := session.NewEvent(context.Background(), "test-invocation-id")
 	ev.Author = "user"
 	ev.LLMResponse = model.LLMResponse{Content: msg}
 	s.appendEvent(ev)

--- a/agent/workflowagent/reentry_test.go
+++ b/agent/workflowagent/reentry_test.go
@@ -296,7 +296,7 @@ func askerForSequence(name string, ids []string, finalOutput any) (*reentryNode,
 			}
 
 			// All answered: emit the terminal output.
-			ev := session.NewEventWithContext(ctx, ctx.InvocationID())
+			ev := session.NewEvent(ctx, ctx.InvocationID())
 			ev.Output = finalOutput
 			yield(ev, nil)
 		}

--- a/agent/workflowagents/sequentialagent/agent_test.go
+++ b/agent/workflowagents/sequentialagent/agent_test.go
@@ -465,7 +465,7 @@ func TestSequentialAgent_RunLive_SequentialOrchestration(t *testing.T) {
 		Agent: agent1,
 		runLiveFn: func(ctx agent.InvocationContext) (agent.LiveSession, iter.Seq2[*session.Event, error], error) {
 			iterFn := func(yield func(*session.Event, error) bool) {
-				ev := session.NewEventWithContext(ctx, ctx.InvocationID())
+				ev := session.NewEvent(ctx, ctx.InvocationID())
 				ev.Author = "sub_agent_1"
 				yield(ev, nil)
 			}
@@ -478,7 +478,7 @@ func TestSequentialAgent_RunLive_SequentialOrchestration(t *testing.T) {
 		Agent: agent2,
 		runLiveFn: func(ctx agent.InvocationContext) (agent.LiveSession, iter.Seq2[*session.Event, error], error) {
 			iterFn := func(yield func(*session.Event, error) bool) {
-				ev := session.NewEventWithContext(ctx, ctx.InvocationID())
+				ev := session.NewEvent(ctx, ctx.InvocationID())
 				ev.Author = "sub_agent_2"
 				yield(ev, nil)
 			}

--- a/cmd/launcher/web/a2a/a2a_test.go
+++ b/cmd/launcher/web/a2a/a2a_test.go
@@ -75,7 +75,7 @@ func TestWebLauncher_ServesA2A(t *testing.T) {
 		Name: "HelloWorldAgent",
 		Run: func(ic agent.InvocationContext) iter.Seq2[*session.Event, error] {
 			return func(yield func(*session.Event, error) bool) {
-				event := session.NewEventWithContext(ic, ic.InvocationID())
+				event := session.NewEvent(ic, ic.InvocationID())
 				event.Content = genai.NewContentFromText(wantMessage, genai.RoleModel)
 				yield(event, nil)
 			}

--- a/examples/tools/loadmemory/main.go
+++ b/examples/tools/loadmemory/main.go
@@ -170,7 +170,7 @@ func createPreviousSessionWithHistory(
 	}
 
 	for _, e := range events {
-		event := session.NewEventWithContext(ctx, "previous-session")
+		event := session.NewEvent(ctx, "previous-session")
 		event.Author = e.author
 		event.LLMResponse = model.LLMResponse{
 			Content: genai.NewContentFromText(e.content, genai.Role(e.author)),

--- a/examples/workflow/dynamic/hitl/main.go
+++ b/examples/workflow/dynamic/hitl/main.go
@@ -74,7 +74,7 @@ func main() {
 				greeting := fmt.Sprintf("Hello, %s!", name)
 				// Emit Content so the console renders the greeting; the
 				// terminal Output below is for downstream nodes / state.
-				ev := session.NewEventWithContext(nc, nc.InvocationID())
+				ev := session.NewEvent(nc, nc.InvocationID())
 				ev.Content = &genai.Content{Parts: []*genai.Part{{Text: greeting}}}
 				if err := emit(ev); err != nil {
 					return "", err

--- a/examples/workflow/routing/int/main.go
+++ b/examples/workflow/routing/int/main.go
@@ -46,7 +46,7 @@ func rollDie(_ agent.Context, _ string) (int, error) {
 // terminal event so this single emit carries both the route and the
 // output.
 func routeByValue(ctx agent.Context, value int, emit func(*session.Event) error) (any, error) {
-	ev := session.NewEventWithContext(ctx, ctx.InvocationID())
+	ev := session.NewEvent(ctx, ctx.InvocationID())
 	// IntRoute and MultiRoute[int] both compare against the
 	// stringified value, so emit it that way.
 	ev.Routes = []string{fmt.Sprint(value)}

--- a/examples/workflow/routing/llm/main.go
+++ b/examples/workflow/routing/llm/main.go
@@ -63,7 +63,7 @@ func routeByClassification(ctx agent.Context, input any, emit func(*session.Even
 	if category != "question" && category != "exclamation" && category != "statement" {
 		category = "statement"
 	}
-	ev := session.NewEventWithContext(ctx, ctx.InvocationID())
+	ev := session.NewEvent(ctx, ctx.InvocationID())
 	ev.Routes = []string{category}
 	if err := emit(ev); err != nil {
 		return nil, err

--- a/examples/workflow/routing/string/main.go
+++ b/examples/workflow/routing/string/main.go
@@ -36,7 +36,7 @@ import (
 // classifyAndRoute emits a routing event keyed on the message
 // category; returning nil suppresses the default terminal event.
 func classifyAndRoute(ctx agent.Context, msg string, emit func(*session.Event) error) (any, error) {
-	ev := session.NewEventWithContext(ctx, ctx.InvocationID())
+	ev := session.NewEvent(ctx, ctx.InvocationID())
 	ev.Routes = []string{classify(msg)}
 	ev.Output = msg // feeds the successor's typed input
 	if err := emit(ev); err != nil {

--- a/internal/configurable/configurable_workflow_test.go
+++ b/internal/configurable/configurable_workflow_test.go
@@ -59,7 +59,7 @@ func upperFn(ctx agent.Context, input any) (any, error) {
 	}
 	val := stringsToUpper(s)
 	if val == "ALPHA" || val == "BETA" {
-		ev := session.NewEventWithContext(ctx, ctx.InvocationID())
+		ev := session.NewEvent(ctx, ctx.InvocationID())
 		ev.Output = val
 		ev.Routes = []string{val}
 		return ev, nil

--- a/internal/llminternal/audio_cache_manager.go
+++ b/internal/llminternal/audio_cache_manager.go
@@ -152,7 +152,7 @@ func (m *AudioCacheManager) flushCache(ctx agent.InvocationContext, cache [][]by
 		role = "user"
 	}
 
-	ev := session.NewEventWithContext(ctx, ctx.InvocationID())
+	ev := session.NewEvent(ctx, ctx.InvocationID())
 	ev.Author = author
 	ev.Timestamp = startTime
 	ev.Content = &genai.Content{

--- a/internal/llminternal/base_flow.go
+++ b/internal/llminternal/base_flow.go
@@ -403,7 +403,7 @@ func (f *Flow) RunLive(ctx agent.InvocationContext) (agent.LiveSession, iter.Seq
 								}
 							}
 						}
-						ev := session.NewEventWithContext(ctx, ctx.InvocationID())
+						ev := session.NewEvent(ctx, ctx.InvocationID())
 						ev.Author = ctx.Agent().Name()
 						ev.LLMResponse = *resp
 						select {
@@ -961,7 +961,7 @@ func (f *Flow) finalizeModelResponseEvent(ctx agent.InvocationContext, resp *res
 	// Generate function call ids. (see functions.populate_client_function_call_id in python SDK)
 	utils.PopulateClientFunctionCallID(ctx, resp.Content)
 
-	ev := session.NewEventWithContext(ctx, ctx.InvocationID())
+	ev := session.NewEvent(ctx, ctx.InvocationID())
 	ev.ID = resp.eventID // TODO change NewEvent to accept event id
 	ev.Author = ctx.Agent().Name()
 	ev.Branch = ctx.Branch()
@@ -1171,7 +1171,7 @@ func (f *Flow) handleFunctionCalls(ctx agent.InvocationContext, toolsDict map[st
 				}
 			}
 
-			ev := session.NewEventWithContext(ctx, ctx.InvocationID())
+			ev := session.NewEvent(ctx, ctx.InvocationID())
 			ev.LLMResponse = model.LLMResponse{
 				Content: &genai.Content{
 					Role: "user",

--- a/internal/llminternal/base_flow_test.go
+++ b/internal/llminternal/base_flow_test.go
@@ -688,7 +688,7 @@ func TestPreprocess_Toolset(t *testing.T) {
 // mirroring what the parallel-call producer emits for a normal tool.
 func fnRespEvent(t *testing.T, text string) *session.Event {
 	t.Helper()
-	ev := session.NewEventWithContext(t.Context(), "inv")
+	ev := session.NewEvent(t.Context(), "inv")
 	ev.LLMResponse = model.LLMResponse{
 		Content: &genai.Content{
 			Role:  "user",

--- a/internal/llminternal/functions.go
+++ b/internal/llminternal/functions.go
@@ -79,7 +79,7 @@ func generateRequestConfirmationEvent(
 		return nil
 	}
 
-	ev := session.NewEventWithContext(invocationContext, invocationContext.InvocationID())
+	ev := session.NewEvent(invocationContext, invocationContext.InvocationID())
 	ev.Author = invocationContext.Agent().Name()
 	ev.Branch = invocationContext.Branch()
 	ev.LLMResponse = model.LLMResponse{

--- a/internal/llminternal/functions_test.go
+++ b/internal/llminternal/functions_test.go
@@ -210,7 +210,7 @@ func TestGenerateRequestConfirmationEvent(t *testing.T) {
 //	    if not self.id:
 //	        self.id = Event.new_id()   # str(uuid.uuid4())
 //
-// In Go ADK, events must be created with session.NewEventWithContext() to get an ID.
+// In Go ADK, events must be created with session.NewEvent() to get an ID.
 // A raw &session.Event{} literal leaves ID as "" which breaks features
 // that rely on event IDs (e.g. time-travel restart_from_event_id).
 func TestGenerateRequestConfirmationEventHasID(t *testing.T) {

--- a/internal/llminternal/outputschema_processor.go
+++ b/internal/llminternal/outputschema_processor.go
@@ -66,7 +66,7 @@ func outputSchemaRequestProcessor(ctx agent.InvocationContext, req *model.LLMReq
 // createFinalModelResponseEvent creates a final model response event from set_model_response JSON.
 func createFinalModelResponseEvent(invocationContext agent.InvocationContext, response string) *session.Event {
 	// Create a proper model response event
-	finalEvent := session.NewEventWithContext(invocationContext, invocationContext.InvocationID())
+	finalEvent := session.NewEvent(invocationContext, invocationContext.InvocationID())
 	finalEvent.Author = invocationContext.Agent().Name()
 	finalEvent.Branch = invocationContext.Branch()
 	finalEvent.Content = &genai.Content{

--- a/internal/telemetry/telemetry_test.go
+++ b/internal/telemetry/telemetry_test.go
@@ -167,7 +167,7 @@ func TestInvokeAgent(t *testing.T) {
 		{
 			name: "Success",
 			resultParams: TraceAgentResultParams{
-				ResponseEvent: session.NewEventWithContext(context.Background(), "test-invocation-id"),
+				ResponseEvent: session.NewEvent(t.Context(), "test-invocation-id"),
 			},
 			wantName:   "invoke_agent test-agent",
 			wantStatus: codes.Unset,

--- a/runner/hitl_integration_test.go
+++ b/runner/hitl_integration_test.go
@@ -297,7 +297,7 @@ func (n *hitlAskerNode) Run(ctx agent.Context, input any) iter.Seq2[*session.Eve
 	return func(yield func(*session.Event, error) bool) {
 		// On re-entry, hand the response to the successor as output.
 		if response, ok := ctx.ResumedInput(n.interruptID); ok {
-			ev := session.NewEvent(ctx.InvocationID())
+			ev := session.NewEvent(ctx, ctx.InvocationID())
 			ev.Output = response
 			yield(ev, nil)
 			return

--- a/runner/live_runner_test.go
+++ b/runner/live_runner_test.go
@@ -76,7 +76,7 @@ func TestRunner_RunLive_Callbacks(t *testing.T) {
 		Agent: testAgent,
 		runLiveFn: func(ctx agent.InvocationContext) (agent.LiveSession, iter.Seq2[*session.Event, error], error) {
 			return &dummyLiveSession{}, func(yield func(*session.Event, error) bool) {
-				yield(session.NewEventWithContext(ctx, ctx.InvocationID()), nil)
+				yield(session.NewEvent(ctx, ctx.InvocationID()), nil)
 			}, nil
 		},
 	}
@@ -221,7 +221,7 @@ func TestRunner_RunLive_ChronologicalBuffering(t *testing.T) {
 		runLiveFn: func(ctx agent.InvocationContext) (agent.LiveSession, iter.Seq2[*session.Event, error], error) {
 			return &dummyLiveSession{}, func(yield func(*session.Event, error) bool) {
 				// 1. Partial Transcription
-				ev1 := session.NewEventWithContext(ctx, ctx.InvocationID())
+				ev1 := session.NewEvent(ctx, ctx.InvocationID())
 				ev1.LLMResponse.Partial = true
 				ev1.LLMResponse.OutputTranscription = &genai.Transcription{Text: "Hello"}
 				if !yield(ev1, nil) {
@@ -229,7 +229,7 @@ func TestRunner_RunLive_ChronologicalBuffering(t *testing.T) {
 				}
 
 				// 2. Function Call (happening during transcription)
-				ev2 := session.NewEventWithContext(ctx, ctx.InvocationID())
+				ev2 := session.NewEvent(ctx, ctx.InvocationID())
 				ev2.LLMResponse.Content = &genai.Content{
 					Parts: []*genai.Part{{FunctionCall: &genai.FunctionCall{Name: "test_func"}}},
 				}
@@ -238,7 +238,7 @@ func TestRunner_RunLive_ChronologicalBuffering(t *testing.T) {
 				}
 
 				// 3. Final Transcription
-				ev3 := session.NewEventWithContext(ctx, ctx.InvocationID())
+				ev3 := session.NewEvent(ctx, ctx.InvocationID())
 				ev3.LLMResponse.OutputTranscription = &genai.Transcription{Text: "Hello there."}
 				if !yield(ev3, nil) {
 					return

--- a/runner/run_node.go
+++ b/runner/run_node.go
@@ -112,7 +112,7 @@ func (r *Runner) runNode(
 
 		earlyExitResult, err := pluginManager.RunBeforeRunCallback(ictx)
 		if earlyExitResult != nil || err != nil {
-			earlyExitEvent := session.NewEventWithContext(ictx, ictx.InvocationID())
+			earlyExitEvent := session.NewEvent(ictx, ictx.InvocationID())
 			earlyExitEvent.Author = "user"
 			earlyExitEvent.LLMResponse = model.LLMResponse{
 				Content: msg,

--- a/runner/runner.go
+++ b/runner/runner.go
@@ -282,7 +282,7 @@ func (r *Runner) Run(ctx context.Context, userID, sessionID string, msg *genai.C
 
 			earlyExitResult, err := pluginManager.RunBeforeRunCallback(ctx)
 			if earlyExitResult != nil || err != nil {
-				earlyExitEvent := session.NewEventWithContext(ctx, ctx.InvocationID())
+				earlyExitEvent := session.NewEvent(ctx, ctx.InvocationID())
 				earlyExitEvent.Author = "user"
 				earlyExitEvent.LLMResponse = model.LLMResponse{
 					Content: msg,
@@ -370,7 +370,7 @@ func (s *runnerLiveSession) Send(req agent.LiveRequest) error {
 		}
 
 		if !isFunctionResponse {
-			event := session.NewEventWithContext(s.iCtx, s.iCtx.InvocationID())
+			event := session.NewEvent(s.iCtx, s.iCtx.InvocationID())
 			event.Author = "user"
 			event.LLMResponse = model.LLMResponse{
 				Content: req.Content,
@@ -461,7 +461,7 @@ func (r *Runner) RunLive(ctx context.Context, userID, sessionID string, cfg agen
 			return nil, nil, err
 		}
 		if earlyExitResult != nil {
-			earlyExitEvent := session.NewEventWithContext(iCtx, iCtx.InvocationID())
+			earlyExitEvent := session.NewEvent(iCtx, iCtx.InvocationID())
 			earlyExitEvent.Author = agentToRun.Name()
 			earlyExitEvent.LLMResponse = model.LLMResponse{
 				Content: earlyExitResult,
@@ -635,7 +635,7 @@ func (r *Runner) appendMessageToSession(ctx agent.Context, storedSession session
 		}
 	}
 
-	event := session.NewEventWithContext(ctx, ctx.InvocationID())
+	event := session.NewEvent(ctx, ctx.InvocationID())
 
 	event.Author = "user"
 	event.LLMResponse = model.LLMResponse{

--- a/server/adka2a/v2/events.go
+++ b/server/adka2a/v2/events.go
@@ -28,7 +28,7 @@ import (
 
 // NewRemoteAgentEvent create a new Event authored by the agent running in the provided invocation context.
 func NewRemoteAgentEvent(ctx agent.InvocationContext) *session.Event {
-	event := session.NewEventWithContext(ctx, ctx.InvocationID())
+	event := session.NewEvent(ctx, ctx.InvocationID())
 	event.Author = ctx.Agent().Name()
 	event.Branch = ctx.Branch()
 	return event

--- a/server/adkrest/controllers/runtime_test.go
+++ b/server/adkrest/controllers/runtime_test.go
@@ -117,7 +117,7 @@ func testAgent(results []testAgentResult) func(ctx agent.InvocationContext) iter
 }
 
 func makeEvent(id, author, text string) *session.Event {
-	e := session.NewEventWithContext(context.Background(), id)
+	e := session.NewEvent(context.Background(), id)
 	e.Author = author
 	e.LLMResponse.Content = &genai.Content{
 		Parts: []*genai.Part{{Text: text}},

--- a/session/event_test.go
+++ b/session/event_test.go
@@ -29,7 +29,7 @@ import (
 // original signature and use the wall clock and a random UUID.
 func TestNewEventDefaults(t *testing.T) {
 	before := time.Now()
-	ev := session.NewEvent("inv-1")
+	ev := session.NewEvent(t.Context(), "inv-1")
 	after := time.Now()
 
 	if ev.InvocationID != "inv-1" {
@@ -48,7 +48,7 @@ func TestNewEventUsesProviders(t *testing.T) {
 	ctx := platform.WithTimeProvider(context.Background(), func() time.Time { return fixedTime })
 	ctx = platform.WithUUIDProvider(ctx, func() string { return "fixed-event-id" })
 
-	ev := session.NewEventWithContext(ctx, "inv-1")
+	ev := session.NewEvent(ctx, "inv-1")
 
 	if ev.ID != "fixed-event-id" {
 		t.Errorf("ID = %q, want %q", ev.ID, "fixed-event-id")
@@ -80,8 +80,8 @@ func TestNewEventDeterministicReplay(t *testing.T) {
 
 	run := func(ctx context.Context) []*session.Event {
 		return []*session.Event{
-			session.NewEventWithContext(ctx, "inv"),
-			session.NewEventWithContext(ctx, "inv"),
+			session.NewEvent(ctx, "inv"),
+			session.NewEvent(ctx, "inv"),
 		}
 	}
 

--- a/session/session.go
+++ b/session/session.go
@@ -21,7 +21,6 @@ import (
 	"time"
 
 	"github.com/google/jsonschema-go/jsonschema"
-	"github.com/google/uuid"
 
 	"google.golang.org/adk/model"
 	"google.golang.org/adk/platform"
@@ -212,26 +211,11 @@ func (e *Event) IsFinalResponse() bool {
 
 // NewEvent creates a new event defining now as the timestamp.
 //
-// Deprecated: Use [NewEventWithContext] instead so that platform-installed time
-// and UUID providers (see [platform.WithTimeProvider] and
-// [platform.WithUUIDProvider]) are honored. NewEvent always uses the wall clock
-// and a random UUID.
-func NewEvent(invocationID string) *Event {
-	return &Event{
-		ID:           uuid.NewString(),
-		InvocationID: invocationID,
-		Timestamp:    time.Now(),
-		Actions:      EventActions{StateDelta: make(map[string]any), ArtifactDelta: make(map[string]int64)},
-	}
-}
-
-// NewEventWithContext creates a new event defining now as the timestamp.
-//
 // The event ID and timestamp are obtained through the platform package, so a
 // time or UUID provider installed on ctx (see [platform.WithTimeProvider] and
 // [platform.WithUUIDProvider]) controls them. This lets callers such as
 // workflow engines produce deterministic, replay-safe events.
-func NewEventWithContext(ctx context.Context, invocationID string) *Event {
+func NewEvent(ctx context.Context, invocationID string) *Event {
 	return &Event{
 		ID:           platform.NewUUID(ctx),
 		InvocationID: invocationID,

--- a/workflow/agent_node_test.go
+++ b/workflow/agent_node_test.go
@@ -54,7 +54,7 @@ func TestAgentNode_New(t *testing.T) {
 		Description: "a test agent",
 		Run: func(ctx agent.InvocationContext) iter.Seq2[*session.Event, error] {
 			return func(yield func(*session.Event, error) bool) {
-				event := session.NewEventWithContext(ctx, ctx.InvocationID())
+				event := session.NewEvent(ctx, ctx.InvocationID())
 				event.Output = map[string]any{"result": "success"}
 				yield(event, nil)
 			}
@@ -157,7 +157,7 @@ func TestAgentNode_Run(t *testing.T) {
 							if uc != nil && len(uc.Parts) > 0 {
 								val = uc.Parts[0].Text
 							}
-							event := session.NewEventWithContext(ctx, ctx.InvocationID())
+							event := session.NewEvent(ctx, ctx.InvocationID())
 							event.Output = map[string]any{"result": val}
 							yield(event, nil)
 						}
@@ -193,7 +193,7 @@ func TestAgentNode_Run(t *testing.T) {
 							if uc != nil && len(uc.Parts) > 0 {
 								val = uc.Parts[0].Text
 							}
-							event := session.NewEventWithContext(ctx, ctx.InvocationID())
+							event := session.NewEvent(ctx, ctx.InvocationID())
 							event.Output = val
 							yield(event, nil)
 						}
@@ -327,7 +327,7 @@ func TestAgentNode_WorkflowIntegration(t *testing.T) {
 							val = parsed.Val
 						}
 
-						event := session.NewEventWithContext(ctx, ctx.InvocationID())
+						event := session.NewEvent(ctx, ctx.InvocationID())
 						event.Output = map[string]any{"result": val * 2}
 						yield(event, nil)
 					}
@@ -387,7 +387,7 @@ func TestAgentNode_SynthesizesOutputFromModelText(t *testing.T) {
 		Run: func(ctx agent.InvocationContext) iter.Seq2[*session.Event, error] {
 			return func(yield func(*session.Event, error) bool) {
 				// Partial must not be promoted to Output.
-				partial := session.NewEventWithContext(ctx, ctx.InvocationID())
+				partial := session.NewEvent(ctx, ctx.InvocationID())
 				partial.LLMResponse.Partial = true
 				partial.LLMResponse.Content = &genai.Content{
 					Role:  "model",
@@ -397,7 +397,7 @@ func TestAgentNode_SynthesizesOutputFromModelText(t *testing.T) {
 					return
 				}
 				// Thought parts are skipped; text parts concatenate.
-				final := session.NewEventWithContext(ctx, ctx.InvocationID())
+				final := session.NewEvent(ctx, ctx.InvocationID())
 				final.LLMResponse.Content = &genai.Content{
 					Role: "model",
 					Parts: []*genai.Part{
@@ -460,11 +460,11 @@ func TestAgentNode_StampsIsolationScopeOnEvents(t *testing.T) {
 		Run: func(ctx agent.InvocationContext) iter.Seq2[*session.Event, error] {
 			gotAgentScope = ctx.IsolationScope()
 			return func(yield func(*session.Event, error) bool) {
-				ev := session.NewEventWithContext(ctx, ctx.InvocationID())
+				ev := session.NewEvent(ctx, ctx.InvocationID())
 				ev.Output = "v"
 				yield(ev, nil)
 				// An event that already carries a scope is left untouched.
-				pre := session.NewEventWithContext(ctx, ctx.InvocationID())
+				pre := session.NewEvent(ctx, ctx.InvocationID())
 				pre.IsolationScope = "preset"
 				yield(pre, nil)
 			}
@@ -552,7 +552,7 @@ func TestAgentNode_ValidationAndContentConversion(t *testing.T) {
 					return func(yield func(*session.Event, error) bool) {
 						agentInvoked = true
 						gotContent = ctx.UserContent()
-						event := session.NewEventWithContext(ctx, ctx.InvocationID())
+						event := session.NewEvent(ctx, ctx.InvocationID())
 						event.Output = "ok"
 						yield(event, nil)
 					}
@@ -658,7 +658,7 @@ func TestAgentNode_InputValidation(t *testing.T) {
 					return func(yield func(*session.Event, error) bool) {
 						agentInvoked = true
 						gotContent = ctx.UserContent()
-						event := session.NewEventWithContext(ctx, ctx.InvocationID())
+						event := session.NewEvent(ctx, ctx.InvocationID())
 						event.Output = "ok"
 						yield(event, nil)
 					}
@@ -733,7 +733,7 @@ func TestAgentNode_StructuredOutputProjectedViaValidation(t *testing.T) {
 		Name: "json-talky",
 		Run: func(ctx agent.InvocationContext) iter.Seq2[*session.Event, error] {
 			return func(yield func(*session.Event, error) bool) {
-				final := session.NewEventWithContext(ctx, ctx.InvocationID())
+				final := session.NewEvent(ctx, ctx.InvocationID())
 				final.LLMResponse.Content = &genai.Content{
 					Role:  "model",
 					Parts: []*genai.Part{{Text: `{"value":"hello"}`}},
@@ -790,7 +790,7 @@ func TestAgentNode_AutomaticOutputExtraction(t *testing.T) {
 		Name: "text_only_agent",
 		Run: func(ctx agent.InvocationContext) iter.Seq2[*session.Event, error] {
 			return func(yield func(*session.Event, error) bool) {
-				event := session.NewEventWithContext(ctx, ctx.InvocationID())
+				event := session.NewEvent(ctx, ctx.InvocationID())
 				// Model response with plain text, but no Output set
 				event.Content = &genai.Content{
 					Parts: []*genai.Part{

--- a/workflow/dynamic_node.go
+++ b/workflow/dynamic_node.go
@@ -139,7 +139,7 @@ func (n *dynamicNode[IN, OUT]) Run(ctx agent.Context, input any) iter.Seq2[*sess
 		if any(out) == nil {
 			return
 		}
-		ev := session.NewEventWithContext(ctx, ctx.InvocationID())
+		ev := session.NewEvent(ctx, ctx.InvocationID())
 		ev.Output = out
 		ev.NodeInfo = &session.NodeInfo{Path: sub.ParentPath()}
 		// TODO(wolo): validate ev.Output against n.outputSchema,

--- a/workflow/function_node.go
+++ b/workflow/function_node.go
@@ -342,7 +342,7 @@ func (n *FunctionNode) Run(ctx agent.Context, input any) iter.Seq2[*session.Even
 			return
 		}
 
-		event := session.NewEventWithContext(ctx, ctx.InvocationID())
+		event := session.NewEvent(ctx, ctx.InvocationID())
 		if c, ok := output.(*genai.Content); ok {
 			event.Content = c
 		} else if c, ok := output.(genai.Content); ok {
@@ -371,7 +371,7 @@ func (n *FunctionNode) runEmitting(ctx agent.Context, input any, yield func(*ses
 	if output == nil {
 		return
 	}
-	event := session.NewEventWithContext(ctx, ctx.InvocationID())
+	event := session.NewEvent(ctx, ctx.InvocationID())
 	event.Output = output
 	if s, ok := output.(string); ok {
 		event.Content = &genai.Content{

--- a/workflow/function_node_test.go
+++ b/workflow/function_node_test.go
@@ -233,7 +233,7 @@ func mustSchema[T any](t *testing.T) *jsonschema.Schema {
 
 func TestFunctionNodeDirectEventPropagation(t *testing.T) {
 	fn := func(ctx agent.Context, input string) (*session.Event, error) {
-		ev := session.NewEventWithContext(ctx, ctx.InvocationID())
+		ev := session.NewEvent(ctx, ctx.InvocationID())
 		ev.Output = input + " processed"
 		ev.Routes = []string{"CUSTOM_ROUTE"}
 		return ev, nil
@@ -597,7 +597,7 @@ func TestEmittingFunctionNode_EmitProgressBeforeOutput(t *testing.T) {
 
 	var downstreamRan atomic.Bool
 	worker := NewEmittingFunctionNode("worker", func(ctx agent.Context, _ any, emit func(*session.Event) error) (string, error) {
-		progress := session.NewEventWithContext(ctx, ctx.InvocationID())
+		progress := session.NewEvent(ctx, ctx.InvocationID())
 		progress.Content = &genai.Content{Parts: []*genai.Part{{Text: "tick"}}}
 		if err := emit(progress); err != nil {
 			return "", err

--- a/workflow/hitl_test.go
+++ b/workflow/hitl_test.go
@@ -227,7 +227,7 @@ func TestScheduler_HitlNode_ConcurrentBranches_PausesOnlyWhenAllNonRunning(t *te
 		hitlDownstreamRan.Store(true)
 	})
 	plainNode := newHitlNode("plain", func(ctx agent.Context, _ any, yield func(*session.Event, error) bool) {
-		ev := session.NewEventWithContext(ctx, ctx.InvocationID())
+		ev := session.NewEvent(ctx, ctx.InvocationID())
 		ev.Output = "done"
 		yield(ev, nil)
 	})

--- a/workflow/join_node.go
+++ b/workflow/join_node.go
@@ -59,7 +59,7 @@ func NewJoinNodeWithSchema(name string, schema *jsonschema.Resolved) *JoinNode {
 // aggregation contract.
 func (n *JoinNode) Run(ctx agent.Context, input any) iter.Seq2[*session.Event, error] {
 	return func(yield func(*session.Event, error) bool) {
-		event := session.NewEventWithContext(ctx, ctx.InvocationID())
+		event := session.NewEvent(ctx, ctx.InvocationID())
 		event.Output = input
 		yield(event, nil)
 	}

--- a/workflow/parallel_worker.go
+++ b/workflow/parallel_worker.go
@@ -82,7 +82,7 @@ func (n *ParallelWorker) Run(ctx agent.Context, input any) iter.Seq2[*session.Ev
 		nItems := v.Len()
 		if nItems == 0 {
 			// Yield an empty list as output
-			event := session.NewEventWithContext(ctx, ctx.InvocationID())
+			event := session.NewEvent(ctx, ctx.InvocationID())
 			event.Output = []any{}
 			yield(event, nil)
 			return
@@ -153,7 +153,7 @@ func (n *ParallelWorker) Run(ctx agent.Context, input any) iter.Seq2[*session.Ev
 		}
 
 		// Yield the aggregated output
-		event := session.NewEventWithContext(ctx, ctx.InvocationID())
+		event := session.NewEvent(ctx, ctx.InvocationID())
 		event.Output = outputs
 		yield(event, nil)
 	}

--- a/workflow/parallel_worker_test.go
+++ b/workflow/parallel_worker_test.go
@@ -567,13 +567,13 @@ func (n *delayedMultiOutputTestNode) Run(ctx agent.Context, input any) iter.Seq2
 			<-ch
 		}
 
-		ev1 := session.NewEventWithContext(ctx, ctx.InvocationID())
+		ev1 := session.NewEvent(ctx, ctx.InvocationID())
 		ev1.Output = s
 		if !yield(ev1, nil) {
 			return
 		}
 
-		ev2 := session.NewEventWithContext(ctx, ctx.InvocationID())
+		ev2 := session.NewEvent(ctx, ctx.InvocationID())
 		ev2.Output = fmt.Sprintf("%v_2", s)
 		yield(ev2, nil)
 	}

--- a/workflow/request_input.go
+++ b/workflow/request_input.go
@@ -71,7 +71,7 @@ func NewRequestInputEvent(ctx agent.InvocationContext, req session.RequestInput)
 		req.InterruptID = uuid.NewString()
 	}
 
-	ev := session.NewEventWithContext(ctx, ctx.InvocationID())
+	ev := session.NewEvent(ctx, ctx.InvocationID())
 	ev.RequestedInput = &req
 
 	// Synthesise the FunctionCall part so generic

--- a/workflow/retry_loop_test.go
+++ b/workflow/retry_loop_test.go
@@ -43,7 +43,7 @@ func (n *retryLoopTestNode) Run(ctx agent.Context, input any) iter.Seq2[*session
 			return
 		}
 
-		ev := session.NewEventWithContext(ctx, ctx.InvocationID())
+		ev := session.NewEvent(ctx, ctx.InvocationID())
 		// Finish after 2 loop executions.
 		if calls >= 6 {
 			ev.Routes = []string{"finish"}

--- a/workflow/scheduler_test.go
+++ b/workflow/scheduler_test.go
@@ -351,7 +351,7 @@ func (n *recordingNode) release() { close(n.released) }
 func (n *recordingNode) Run(ctx agent.Context, input any) iter.Seq2[*session.Event, error] {
 	return func(yield func(*session.Event, error) bool) {
 		<-n.released
-		ev := session.NewEventWithContext(ctx, ctx.InvocationID())
+		ev := session.NewEvent(ctx, ctx.InvocationID())
 		out := fmt.Sprintf("%v:%s", input, n.Name())
 		ev.Output = out
 		yield(ev, nil)
@@ -377,7 +377,7 @@ func newBlockingNode(name string, work func()) *blockingNode {
 func (n *blockingNode) Run(ctx agent.Context, _ any) iter.Seq2[*session.Event, error] {
 	return func(yield func(*session.Event, error) bool) {
 		n.work()
-		ev := session.NewEventWithContext(ctx, ctx.InvocationID())
+		ev := session.NewEvent(ctx, ctx.InvocationID())
 		ev.Output = n.Name()
 		yield(ev, nil)
 	}
@@ -439,7 +439,7 @@ func newMultiOutputNode(name string, outputs []string) *multiOutputNode {
 func (n *multiOutputNode) Run(ctx agent.Context, _ any) iter.Seq2[*session.Event, error] {
 	return func(yield func(*session.Event, error) bool) {
 		for _, out := range n.outputs {
-			ev := session.NewEventWithContext(ctx, ctx.InvocationID())
+			ev := session.NewEvent(ctx, ctx.InvocationID())
 			ev.Output = out
 			if !yield(ev, nil) {
 				return
@@ -468,12 +468,12 @@ func newProgressThenOutputNode(name string, progressCount int, finalOutput strin
 func (n *progressThenOutputNode) Run(ctx agent.Context, _ any) iter.Seq2[*session.Event, error] {
 	return func(yield func(*session.Event, error) bool) {
 		for range n.progressCount {
-			ev := session.NewEventWithContext(ctx, ctx.InvocationID())
+			ev := session.NewEvent(ctx, ctx.InvocationID())
 			if !yield(ev, nil) {
 				return
 			}
 		}
-		final := session.NewEventWithContext(ctx, ctx.InvocationID())
+		final := session.NewEvent(ctx, ctx.InvocationID())
 		final.Output = n.finalOutput
 		yield(final, nil)
 	}
@@ -563,7 +563,7 @@ func (n *retryTestNode) Run(ctx agent.Context, input any) iter.Seq2[*session.Eve
 			yield(nil, fmt.Errorf("fail attempt %d", calls))
 			return
 		}
-		ev := session.NewEventWithContext(ctx, ctx.InvocationID())
+		ev := session.NewEvent(ctx, ctx.InvocationID())
 		out := fmt.Sprintf("%v:%s", input, n.Name())
 		ev.Output = out
 		yield(ev, nil)
@@ -749,7 +749,7 @@ func (n *validationTestNode) Run(ctx agent.Context, input any) iter.Seq2[*sessio
 	return func(yield func(*session.Event, error) bool) {
 		n.calls.Add(1)
 		n.runInput = input
-		ev := session.NewEventWithContext(ctx, ctx.InvocationID())
+		ev := session.NewEvent(ctx, ctx.InvocationID())
 		ev.Output = "ok"
 		yield(ev, nil)
 	}
@@ -763,7 +763,7 @@ type roleTestNode struct {
 
 func (n *roleTestNode) Run(ctx agent.Context, input any) iter.Seq2[*session.Event, error] {
 	return func(yield func(*session.Event, error) bool) {
-		ev := session.NewEventWithContext(ctx, ctx.InvocationID())
+		ev := session.NewEvent(ctx, ctx.InvocationID())
 		ev.Output = "hi"
 		// Content with Parts but deliberately no Role.
 		ev.Content = &genai.Content{Parts: []*genai.Part{{Text: "hi"}}}
@@ -860,7 +860,7 @@ func newSchemaValidatedNode(name string, schema *jsonschema.Resolved, output any
 
 func (n *schemaValidatedNode) Run(ctx agent.Context, _ any) iter.Seq2[*session.Event, error] {
 	return func(yield func(*session.Event, error) bool) {
-		ev := session.NewEventWithContext(ctx, ctx.InvocationID())
+		ev := session.NewEvent(ctx, ctx.InvocationID())
 		ev.Output = n.output
 		yield(ev, nil)
 	}
@@ -898,7 +898,7 @@ type preRoledNode struct {
 
 func (n *preRoledNode) Run(ctx agent.Context, input any) iter.Seq2[*session.Event, error] {
 	return func(yield func(*session.Event, error) bool) {
-		ev := session.NewEventWithContext(ctx, ctx.InvocationID())
+		ev := session.NewEvent(ctx, ctx.InvocationID())
 		ev.Content = &genai.Content{Role: "user", Parts: []*genai.Part{{Text: "x"}}}
 		yield(ev, nil)
 	}
@@ -926,7 +926,7 @@ type funcResponseNode struct {
 
 func (n *funcResponseNode) Run(ctx agent.Context, input any) iter.Seq2[*session.Event, error] {
 	return func(yield func(*session.Event, error) bool) {
-		ev := session.NewEventWithContext(ctx, ctx.InvocationID())
+		ev := session.NewEvent(ctx, ctx.InvocationID())
 		ev.Content = &genai.Content{Parts: []*genai.Part{{
 			FunctionResponse: &genai.FunctionResponse{Name: "f", Response: map[string]any{"ok": true}},
 		}}}
@@ -970,11 +970,11 @@ type progressThenSchemaOutputNode struct {
 func (n *progressThenSchemaOutputNode) Run(ctx agent.Context, _ any) iter.Seq2[*session.Event, error] {
 	return func(yield func(*session.Event, error) bool) {
 		for i := 0; i < n.progress; i++ {
-			if !yield(session.NewEventWithContext(ctx, ctx.InvocationID()), nil) {
+			if !yield(session.NewEvent(ctx, ctx.InvocationID()), nil) {
 				return
 			}
 		}
-		ev := session.NewEventWithContext(ctx, ctx.InvocationID())
+		ev := session.NewEvent(ctx, ctx.InvocationID())
 		ev.Output = n.output
 		yield(ev, nil)
 	}
@@ -998,7 +998,7 @@ type noOutputNode struct {
 
 func (n *noOutputNode) Run(ctx agent.Context, _ any) iter.Seq2[*session.Event, error] {
 	return func(yield func(*session.Event, error) bool) {
-		yield(session.NewEventWithContext(ctx, ctx.InvocationID()), nil)
+		yield(session.NewEvent(ctx, ctx.InvocationID()), nil)
 	}
 }
 

--- a/workflow/tool_node.go
+++ b/workflow/tool_node.go
@@ -167,7 +167,7 @@ func (n *ToolNode) Run(ctx agent.Context, input any) iter.Seq2[*session.Event, e
 			return
 		}
 
-		event := session.NewEventWithContext(ctx, ctx.InvocationID())
+		event := session.NewEvent(ctx, ctx.InvocationID())
 		event.Actions = *eventActions
 		event.Output = toolOutput
 

--- a/workflow/workflow_node.go
+++ b/workflow/workflow_node.go
@@ -135,7 +135,7 @@ func (n *WorkflowNode) Run(ctx agent.Context, input any) iter.Seq2[*session.Even
 
 		// Yield the terminal output at the end if one was produced.
 		for _, out := range terminalOutputs {
-			event := session.NewEventWithContext(ctx, ctx.InvocationID())
+			event := session.NewEvent(ctx, ctx.InvocationID())
 			event.Output = out
 			if !yield(event, nil) {
 				return

--- a/workflow/workflow_test.go
+++ b/workflow/workflow_test.go
@@ -252,7 +252,7 @@ func (n *CustomRouteNode) Run(ctx agent.Context, input any) iter.Seq2[*session.E
 		n.onRun()
 	}
 	return func(yield func(*session.Event, error) bool) {
-		ev := session.NewEventWithContext(ctx, ctx.InvocationID())
+		ev := session.NewEvent(ctx, ctx.InvocationID())
 		ev.Routes = n.route
 		yield(ev, nil)
 	}
@@ -587,7 +587,7 @@ func TestEndToEndInputValidationFlow(t *testing.T) {
 				if ctx.UserContent() != nil && len(ctx.UserContent().Parts) > 0 {
 					receivedInput = ctx.UserContent().Parts[0].Text
 				}
-				ev := session.NewEventWithContext(ctx, ctx.InvocationID())
+				ev := session.NewEvent(ctx, ctx.InvocationID())
 				ev.Output = "ok"
 				yield(ev, nil)
 			}


### PR DESCRIPTION
**Problem:**
`session.NewEvent(invocationID)` always used the wall clock (`time.Now()`) and a
random UUID, so it couldn't honor the time/UUID providers installed on a context
(`platform.WithTimeProvider` / `platform.WithUUIDProvider`). The temporary
`session.NewEventWithContext(ctx, invocationID)` helper was introduced as a
migration step, leaving two overlapping constructors and a deprecated `NewEvent`.

**Solution:**
Make `NewEvent` context-aware and delete the temporary helper, completing the v2
migration. `NewEvent` now reads the event ID and timestamp through the `platform`
package, so context-installed providers control them — enabling deterministic,
replay-safe events (used by the workflow engine).
- `func NewEvent(invocationID string)` → `func NewEvent(ctx context.Context, invocationID string)`
- `session.NewEventWithContext` is removed; all call sites now use `NewEvent`.
- Call sites that lacked a context thread the in-scope one (agent/tool/callback
  ctx, request ctx, or `t.Context()` in tests).
- Migration guidance documented in `README-v2.md`.
> **BREAKING CHANGE:** `session.NewEvent(invocationID)` becomes
> `session.NewEvent(ctx, invocationID)` and `session.NewEventWithContext` is
> removed.
>
> ```go
> // Before
> ev := session.NewEvent(ctx.InvocationID())
> ev := session.NewEventWithContext(ctx, ctx.InvocationID())
> // After
> ev := session.NewEvent(ctx, ctx.InvocationID())

README-v2.md already reflects this change.