### PR TITLE
fix(conformance): Align cross-language event attribution and replay m…

### DIFF
--- a/agent/llmagent/llmagent_test.go
+++ b/agent/llmagent/llmagent_test.go
@@ -40,7 +40,10 @@ import (
 	"google.golang.org/adk/workflow"
 )
 
-const modelName = "gemini-2.5-flash"
+const (
+	modelName = "gemini-2.5-flash"
+	message   = "Handle the requests as specified in the System Instruction."
+)
 
 //go:generate go test -httprecord=Test
 
@@ -78,7 +81,7 @@ func TestLLMAgent(t *testing.T) {
 			}
 			// TODO: set tools, planner.
 			runner := testutil.NewTestAgentRunner(t, a)
-			stream := runner.Run(t, "test_session", "")
+			stream := runner.Run(t, "test_session", message)
 			texts, err := testutil.CollectTextParts(stream)
 			if tc.wantErr != nil && !errors.Is(err, tc.wantErr) {
 				t.Fatalf("stream = (%q, %v), want (_, %v)", texts, err, tc.wantErr)

--- a/agent/remoteagent/v2/utils.go
+++ b/agent/remoteagent/v2/utils.go
@@ -109,7 +109,10 @@ func toMissingRemoteSessionParts(ctx agent.InvocationContext, events session.Eve
 	result := make([]*a2a.Part, 0, partCount)
 	for i := lastRemoteResponseIndex + 1; i < events.Len(); i++ {
 		event := events.At(i)
-		if event.Author != "user" && event.Author != ctx.Agent().Name() {
+		// Only wrap foreign agent events as user messages when the current agent has an explicit name.
+		// If Agent().Name() is empty (e.g., in anonymous wrappers or conformance harnesses), event.Author != ""
+		// would falsely match and attribute events as foreign turns.
+		if ctx.Agent().Name() != "" && event.Author != "user" && event.Author != ctx.Agent().Name() {
 			event = presentAsUserMessage(ctx, event)
 		}
 		if event.Content == nil || len(event.Content.Parts) == 0 {

--- a/internal/configurable/conformance/replayplugin/replay_plugin.go
+++ b/internal/configurable/conformance/replayplugin/replay_plugin.go
@@ -468,13 +468,10 @@ This tool hands off control to another agent when it's more suitable to answer t
 	// Compare!
 	// cmp.Diff returns an empty string if they are equal, otherwise a human-readable diff.
 	if diff := cmp.Diff(expectedLLMRequest, actualLLMRequest, opts...); diff != "" {
-		for _, content := range expectedLLMRequest.Contents {
-			for _, part := range content.Parts {
-				if part.Text != "" {
-					part.Text = modifyString(part.Text)
-				}
-			}
-		}
+		// If initial comparison fails due to string formatting (e.g., Python vs Go JSON whitespace or quote styles),
+		// normalize embedded JSON structures across both expected and actual requests before re-comparing.
+		canonicalizeRequestContents(expectedLLMRequest)
+		canonicalizeRequestContents(actualLLMRequest)
 
 		if diff := cmp.Diff(expectedLLMRequest, actualLLMRequest, opts...); diff != "" {
 			return fmt.Errorf("LLM request mismatch for agent '%s' (index %d):\n%s",
@@ -485,9 +482,35 @@ This tool hands off control to another agent when it's more suitable to answer t
 	return nil
 }
 
+// canonicalizeRequestContents normalizes all JSON-like strings within the request's contents and system instructions.
+func canonicalizeRequestContents(req *model.LLMRequest) {
+	if req == nil {
+		return
+	}
+	for _, content := range req.Contents {
+		if content == nil {
+			continue
+		}
+		for _, part := range content.Parts {
+			if part != nil && part.Text != "" {
+				part.Text = canonicalizeJSONSubstrings(part.Text)
+			}
+		}
+	}
+	if req.Config != nil && req.Config.SystemInstruction != nil {
+		for _, part := range req.Config.SystemInstruction.Parts {
+			if part != nil && part.Text != "" {
+				part.Text = canonicalizeJSONSubstrings(part.Text)
+			}
+		}
+	}
+}
+
 var (
 	// Matches either "parameters: " or "result: " followed by a JSON-like object/array
 	dataBlockRegex = regexp.MustCompile(`(?i)(parameters|result):\s*([\{\[].*[\}\]])`)
+	// Matches any standalone or embedded JSON-like object/array
+	jsonCandidateRegex = regexp.MustCompile(`([\{\[].*[\}\]])`)
 	// Matches 'key' or 'value' but ignores apostrophes inside words like O'Malley
 	quoteRegex = regexp.MustCompile(`'([^']*)'`)
 	// Matches Python/Pseudo-JSON constants specifically as values
@@ -531,6 +554,29 @@ func modifyString(input string) string {
 		}
 
 		return fmt.Sprintf("%s: %s", label, string(fixedJSON))
+	})
+}
+
+// canonicalizeJSONSubstrings searches for standalone or embedded JSON candidates within a string and re-marshals
+// them canonically to eliminate key-ordering, whitespace, and quote differences between Python and Go serializers.
+func canonicalizeJSONSubstrings(input string) string {
+	s := modifyString(input)
+	return jsonCandidateRegex.ReplaceAllStringFunc(s, func(rawData string) string {
+		normalized := quoteRegex.ReplaceAllString(rawData, `"$1"`)
+		normalized = nullRegex.ReplaceAllString(normalized, "null")
+		normalized = boolRegex.ReplaceAllStringFunc(normalized, func(m string) string {
+			return strings.ToLower(m)
+		})
+
+		var parsed any
+		if err := json.Unmarshal([]byte(normalized), &parsed); err != nil {
+			return rawData
+		}
+		fixedJSON, err := json.Marshal(parsed)
+		if err != nil {
+			return rawData
+		}
+		return string(fixedJSON)
 	})
 }
 

--- a/internal/llminternal/contents_processor.go
+++ b/internal/llminternal/contents_processor.go
@@ -561,27 +561,6 @@ func ConvertForeignEvent(ev *session.Event) *session.Event {
 		return ev
 	}
 
-	// For nested workflow terminal node outputs (MessageAsOutput=true), bypass synthetic "For context:"
-	// attribution preambles when the event author matches the node name. This promotes sub-workflow
-	// results directly to clean user turns, maintaining parity with Python reference recordings.
-	if ev.NodeInfo != nil && ev.NodeInfo.MessageAsOutput && len(ev.NodeInfo.OutputFor) > 0 {
-		segs := strings.Split(ev.NodeInfo.Path, "/")
-		leaf := segs[len(segs)-1]
-		if idx := strings.IndexByte(leaf, '@'); idx >= 0 {
-			leaf = leaf[:idx]
-		}
-		if ev.Author == "" || ev.Author == leaf {
-			converted := clone(content)
-			converted.Role = "user"
-			return &session.Event{
-				Timestamp:   ev.Timestamp,
-				Author:      "user",
-				LLMResponse: model.LLMResponse{Content: converted},
-				Branch:      ev.Branch,
-			}
-		}
-	}
-
 	converted := &genai.Content{
 		Role:  "user",
 		Parts: []*genai.Part{{Text: "For context:"}},

--- a/internal/llminternal/contents_processor.go
+++ b/internal/llminternal/contents_processor.go
@@ -61,6 +61,13 @@ func ContentsRequestProcessor(ctx agent.InvocationContext, req *model.LLMRequest
 			return
 		}
 		req.Contents = append(req.Contents, contents...)
+		// Gemini API requires role alternation (model turns cannot be consecutive).
+		// If the conversation history concludes on a model turn, inject a synthetic user continuation turn.
+		if len(req.Contents) > 0 {
+			if last := req.Contents[len(req.Contents)-1]; last != nil && last.Role != "user" {
+				req.Contents = append(req.Contents, genai.NewContentFromText("Continue processing previous requests as instructed. Exit or provide a summary if no more outputs are needed.", "user"))
+			}
+		}
 	}
 }
 
@@ -552,6 +559,27 @@ func ConvertForeignEvent(ev *session.Event) *session.Event {
 	content := utils.Content(ev)
 	if content == nil || len(content.Parts) == 0 {
 		return ev
+	}
+
+	// For nested workflow terminal node outputs (MessageAsOutput=true), bypass synthetic "For context:"
+	// attribution preambles when the event author matches the node name. This promotes sub-workflow
+	// results directly to clean user turns, maintaining parity with Python reference recordings.
+	if ev.NodeInfo != nil && ev.NodeInfo.MessageAsOutput && len(ev.NodeInfo.OutputFor) > 0 {
+		segs := strings.Split(ev.NodeInfo.Path, "/")
+		leaf := segs[len(segs)-1]
+		if idx := strings.IndexByte(leaf, '@'); idx >= 0 {
+			leaf = leaf[:idx]
+		}
+		if ev.Author == "" || ev.Author == leaf {
+			converted := clone(content)
+			converted.Role = "user"
+			return &session.Event{
+				Timestamp:   ev.Timestamp,
+				Author:      "user",
+				LLMResponse: model.LLMResponse{Content: converted},
+				Branch:      ev.Branch,
+			}
+		}
 	}
 
 	converted := &genai.Content{

--- a/internal/llminternal/contents_processor_test.go
+++ b/internal/llminternal/contents_processor_test.go
@@ -15,6 +15,7 @@
 package llminternal_test
 
 import (
+	"context"
 	"encoding/json"
 	"iter"
 	"slices"
@@ -241,7 +242,7 @@ func TestContentsRequestProcessor_IncludeContents(t *testing.T) {
 				}
 			}
 			got := req.Contents
-			if diff := cmp.Diff(tc.want, got); diff != "" {
+			if diff := cmp.Diff(wantWithContinuation(tc.want), got); diff != "" {
 				t.Errorf("LLMRequest after contentsRequestProcessor mismatch (-want +got):\n%s", diff)
 			}
 		})
@@ -290,7 +291,7 @@ func TestContentsRequestProcessor_IncludeContentsNone_IsolationScopePivot(t *tes
 		}
 	}
 	want := []*genai.Content{genai.NewContentFromText("unscoped turn", "user")}
-	if diff := cmp.Diff(want, req.Contents); diff != "" {
+	if diff := cmp.Diff(wantWithContinuation(want), req.Contents); diff != "" {
 		t.Errorf("contents mismatch (-want +got):\n%s", diff)
 	}
 }
@@ -336,7 +337,7 @@ func TestContentsRequestProcessor_StrictIsolationFilterExcludesForeignScope(t *t
 		}
 	}
 	want := []*genai.Content{genai.NewContentFromText("my task brief", "user")}
-	if diff := cmp.Diff(want, req.Contents); diff != "" {
+	if diff := cmp.Diff(wantWithContinuation(want), req.Contents); diff != "" {
 		t.Errorf("contents mismatch (-want +got):\n%s", diff)
 	}
 }
@@ -394,7 +395,7 @@ func TestContentsRequestProcessor_TaskInputFromOriginatingFC(t *testing.T) {
 			{Role: genai.RoleUser, Parts: []*genai.Part{{Text: string(argsJSON)}}},
 			genai.NewContentFromText("working on it", "model"),
 		}
-		if diff := cmp.Diff(want, req.Contents); diff != "" {
+		if diff := cmp.Diff(wantWithContinuation(want), req.Contents); diff != "" {
 			t.Errorf("contents mismatch (-want +got):\n%s", diff)
 		}
 	})
@@ -471,7 +472,7 @@ func TestContentsRequestProcessor_TaskInputFromUserContentFallback(t *testing.T)
 		{Role: genai.RoleUser, Parts: userInput.Parts},
 		genai.NewContentFromText("ack", "model"),
 	}
-	if diff := cmp.Diff(want, req.Contents); diff != "" {
+	if diff := cmp.Diff(wantWithContinuation(want), req.Contents); diff != "" {
 		t.Errorf("contents mismatch (-want +got):\n%s", diff)
 	}
 }
@@ -771,7 +772,7 @@ func TestContentsRequestProcessor(t *testing.T) {
 				}
 			}
 			got := req.Contents
-			if diff := cmp.Diff(tc.want, got); diff != "" {
+			if diff := cmp.Diff(wantWithContinuation(tc.want), got); diff != "" {
 				t.Errorf("LLMRequest after contentRequestProcessor mismatch (-want +got):\n%s", diff)
 			}
 		})
@@ -1382,7 +1383,7 @@ func TestContentsRequestProcessor_Rearrange(t *testing.T) {
 			}
 
 			got := req.Contents
-			if diff := cmp.Diff(tc.want, got); diff != "" {
+			if diff := cmp.Diff(wantWithContinuation(tc.want), got); diff != "" {
 				t.Errorf("LLMRequest.Contents mismatch (-want +got):\n%s", diff)
 			}
 		})
@@ -1415,32 +1416,40 @@ func (s *fakeSession) State() session.State {
 	return nil
 }
 
-func (s *fakeSession) Events() session.Events {
-	return s
-}
-
 func (s *fakeSession) ID() string {
-	return ""
-}
-
-func (s *fakeSession) AppName() string {
-	return ""
+	return "test_session"
 }
 
 func (s *fakeSession) UserID() string {
-	return ""
+	return "test_user"
+}
+
+func (s *fakeSession) AppName() string {
+	return "test_app"
 }
 
 func (s *fakeSession) LastUpdateTime() time.Time {
 	return time.Time{}
 }
 
-func (s *fakeSession) All() iter.Seq[*session.Event] {
-	return slices.Values(s.events)
+func (s *fakeSession) Events() session.Events {
+	return s
 }
 
 func (s *fakeSession) Len() int {
 	return len(s.events)
+}
+
+func (s *fakeSession) All() iter.Seq[*session.Event] {
+	return slices.Values(s.events)
+}
+
+func (s *fakeSession) AllBackward() iter.Seq[*session.Event] {
+	return nil
+}
+
+func (s *fakeSession) Append(ctx context.Context, e ...*session.Event) error {
+	return nil
 }
 
 func (s *fakeSession) At(i int) *session.Event {
@@ -1451,3 +1460,15 @@ var (
 	_ session.Session = (*fakeSession)(nil)
 	_ session.Events  = (*fakeSession)(nil)
 )
+
+func wantWithContinuation(want []*genai.Content) []*genai.Content {
+	if len(want) > 0 {
+		if last := want[len(want)-1]; last != nil && last.Role != "user" {
+			res := make([]*genai.Content, len(want), len(want)+1)
+			copy(res, want)
+			res = append(res, genai.NewContentFromText("Continue processing previous requests as instructed. Exit or provide a summary if no more outputs are needed.", "user"))
+			return res
+		}
+	}
+	return want
+}

--- a/model/gemini/gemini.go
+++ b/model/gemini/gemini.go
@@ -161,12 +161,12 @@ func (m *geminiModel) generateStream(ctx context.Context, req *model.LLMRequest)
 
 // maybeAppendUserContent appends a user content, so that model can continue to output.
 func (m *geminiModel) maybeAppendUserContent(req *model.LLMRequest) {
-	if len(req.Contents) == 0 {
-		req.Contents = append(req.Contents, genai.NewContentFromText("Handle the requests as specified in the System Instruction.", "user"))
-	}
-
-	if last := req.Contents[len(req.Contents)-1]; last != nil && last.Role != "user" {
-		req.Contents = append(req.Contents, genai.NewContentFromText("Continue processing previous requests as instructed. Exit or provide a summary if no more outputs are needed.", "user"))
+	// Ensure turn alternation if the request history ends on a non-user turn.
+	// Note: We omit placeholder user prompts when req.Contents is empty to match Python ADK behavior.
+	if len(req.Contents) > 0 {
+		if last := req.Contents[len(req.Contents)-1]; last != nil && last.Role != "user" {
+			req.Contents = append(req.Contents, genai.NewContentFromText("Continue processing previous requests as instructed. Exit or provide a summary if no more outputs are needed.", "user"))
+		}
 	}
 }
 


### PR DESCRIPTION
When replaying Python-recorded conformance sessions in Go, structural and prompt formatting differences caused replay verification failures:
- JSON serialization discrepancies between Python and Go (key sorting, whitespace, quotes) caused false-positive prompt history mismatches during replay verification.
- Consecutive model turns lacked synthetic user continuation nudges during prompt construction, violating API turn alternation rules.

Normalized embedded JSON substrings during replay matching, added safety guards for empty histories, and updated unit test assertions.
