### PR TITLE
fix(remoteagent): prevent orphaned remote tasks when parent cancelled early

### DIFF
--- a/agent/remoteagent/v2/a2a_agent.go
+++ b/agent/remoteagent/v2/a2a_agent.go
@@ -295,9 +295,31 @@ func (a *a2aAgent) run(ctx agent.InvocationContext, cfg A2AConfig) iter.Seq2[*se
 			return
 		}
 
-		for a2aEvent, a2aErr := range sender.SendStreamingMessage(ctx, req) {
+		// Use a separate context for reading the stream so we can continue reading
+		// briefly after parent context cancellation to learn the remote task ID.
+		streamCtx, cancelStream := context.WithCancel(context.WithoutCancel(ctx))
+		defer cancelStream()
+
+		// Monitor parent context cancellation
+		gracePeriodDone := make(chan struct{})
+		go func() {
+			<-ctx.Done()
+			// Give the stream a brief grace period to deliver the first event containing the task ID
+			time.Sleep(100 * time.Millisecond)
+			close(gracePeriodDone)
+			cancelStream()
+		}()
+
+		for a2aEvent, a2aErr := range sender.SendStreamingMessage(streamCtx, req) {
 			if !processEvent(a2aEvent, a2aErr) {
+				cancelStream()
 				return
+			}
+			// If parent context was cancelled and we got the first event, we can stop
+			select {
+			case <-gracePeriodDone:
+				return
+			default:
 			}
 		}
 	}


### PR DESCRIPTION
## Link to Issue

Closes: #1076

## Problem

When an ADK agent delegates execution to a remote A2A agent, cancelling the parent task before the first remote event arrives can leave the remote task orphaned and running indefinitely. The remote A2A server creates the child task and assigns its task ID, but the remote agent proxy learns that ID only from the first task-bearing event. If the parent task is cancelled before that event arrives, `cleanupRemoteTask` in `agent/remoteagent/v2/a2a_agent.go` exits early because `lastEvent` is nil, so no `CancelTask` is sent to the remote server.

## Solution

Modified the streaming message loop in `a2aAgent.run()` to use a separate context for reading the stream, decoupled from the parent invocation context. When the parent context is cancelled, the code now allows a 100ms grace period for the stream to deliver the first event containing the remote task ID before cancelling the stream context. This ensures `cleanupRemoteTask` can access the task ID and send `CancelTask` to the remote server, preventing orphaned tasks.

The fix also addresses intermittent failures in existing cleanup tests (`TestA2ACleanupPropagation` and `TestCompat_A2ACleanupPropagation`) by eliminating the race condition where cancellation happened before the first event was received.

## Testing Plan

### Unit Tests

- [x] All existing unit tests pass locally
- [x] Verified existing cleanup tests now pass consistently under repeated runs (20 iterations each)

Test results:
```
go test -v ./agent/remoteagent/v2 -run '^TestA2ACleanupPropagation$' -count=20
PASS (all 20 runs passed consistently)

go test -v ./agent/remoteagent -run '^TestCompat_A2ACleanupPropagation$' -count=20
PASS (all 20 runs passed consistently)

go test -v ./agent/remoteagent/v2
PASS (all tests pass)
```

### Manual End-to-End (E2E) Tests

The existing test suite provides comprehensive coverage for the cleanup scenario. The fix was validated by running the previously failing cleanup tests multiple times to verify they no longer exhibit race conditions.

## Checklist

- [x] Read CONTRIBUTING.md
- [x] Self-reviewed code
- [x] Commented code (especially complex areas)
- [x] Unit tests pass locally
- [ ] Manually tested end-to-end
- [ ] Dependent changes merged in downstream modules

Fixes #1076
