### PR TITLE
docs(v2): document session.NewEvent context.Context requirement

### DIFF
--- a/README-v2.md
+++ b/README-v2.md
@@ -5,6 +5,44 @@
 
 ## Breaking changes
 
+### `session.NewEvent` now requires a `context.Context`
+
+`session.NewEvent` takes a `context.Context` as its first argument:
+
+```go
+func NewEvent(ctx context.Context, invocationID string) *Event
+```
+
+The event ID and timestamp are now obtained through the `platform` package, so a
+time or UUID provider installed on `ctx` (see `platform.WithTimeProvider` and
+`platform.WithUUIDProvider`) controls them. This lets callers such as workflow
+engines produce deterministic, replay-safe events.
+
+The previous parameterless-context form and the temporary `NewEventWithContext`
+helper are gone. Migrate by passing the context that is already in scope:
+
+```go
+// Before
+ev := session.NewEvent(ctx.InvocationID())
+// or
+ev := session.NewEventWithContext(ctx, ctx.InvocationID())
+
+// After
+ev := session.NewEvent(ctx, ctx.InvocationID())
+```
+
+Any `context.Context` works as the first argument: the `ctx` of an agent/tool/
+callback (which embed `context.Context`), the incoming RPC/HTTP request context,
+or — in tests — `t.Context()`. Per
+[go/how-to-use-a-context](http://go/how-to-use-a-context), thread the context
+down the call chain rather than creating one with `context.Background()` in the
+middle of it; reserve `context.Background()` for `main`, `init`, and top-level
+test/setup code.
+
+If you call `NewEvent` from a helper that does not yet receive a context, add a
+`ctx context.Context` parameter to that helper and pass it through from its
+callers.
+
 ### Mocks update required for unified contexts 
 PR https://github.com/google/adk-go/pull/945 merges ToolContext and CallbackContext into single Context. 
 ToolContext and CallbackContext became aliases to Context. 


### PR DESCRIPTION
**Problem:**
The v2 breaking-changes guide (README-v2.md) does not document that
session.NewEvent now takes a context.Context as its first argument. Callers
migrating to v2 have no guidance on how to update their call sites.

**Solution:**
Add a "Breaking changes" section describing the new
NewEvent(ctx, invocationID) signature, why the change was made (event ID and
timestamp flow through the platform package for deterministic, replay-safe
events), removal of the parameterless form and the temporary
NewEventWithContext helper, plus a before/after migration snippet.