### PR TITLE
fix(llmagent): stop maybeSaveOutputToState from stamping event.Output

### DIFF
--- a/agent/llmagent/llmagent.go
+++ b/agent/llmagent/llmagent.go
@@ -552,7 +552,6 @@ func (a *llmAgent) maybeSaveOutputToState(event *session.Event) {
 		}
 
 		event.Actions.StateDelta[a.OutputKey] = result
-		event.Output = result
 	}
 }
 

--- a/agent/llmagent/llmagent_saveoutput_test.go
+++ b/agent/llmagent/llmagent_saveoutput_test.go
@@ -133,6 +133,12 @@ func TestLlmAgent_MaybeSaveOutputToState(t *testing.T) {
 			if !reflect.DeepEqual(gotStateDelta, tc.wantStateDelta) {
 				t.Errorf("stateDelta mismatch:\ngot = %v\nwant = %v", gotStateDelta, tc.wantStateDelta)
 			}
+
+			// Output is stamped by the node wrapper, not here (adk-python
+			// __maybe_save_output_to_state parity).
+			if tc.event.Output != nil {
+				t.Errorf("event.Output = %v, want nil (only state_delta may be written here)", tc.event.Output)
+			}
 		})
 	}
 }

--- a/agent/llmagent/llmagent_test.go
+++ b/agent/llmagent/llmagent_test.go
@@ -1260,6 +1260,75 @@ func TestLLMAgent_WorkflowIntegration_OutputPropagatesToSuccessor(t *testing.T) 
 	}
 }
 
+// An OutputKey agent whose model emits a function-call turn then a text
+// turn yields two output-eligible events; only one may carry the node
+// output, else the scheduler raises ErrMultipleOutputs.
+func TestLLMAgent_WorkflowIntegration_OutputKeyDoesNotDuplicateOutput(t *testing.T) {
+	noopTool, err := functiontool.New(functiontool.Config{
+		Name:        "noop",
+		Description: "does nothing",
+	}, func(_ agent.Context, _ struct{}) (struct{}, error) {
+		return struct{}{}, nil
+	})
+	if err != nil {
+		t.Fatalf("functiontool.New: %v", err)
+	}
+
+	// Turn 1: a function call (no text). Turn 2: the final text.
+	testLLM := &testutil.MockModel{
+		Responses: []*genai.Content{
+			{Role: genai.RoleModel, Parts: []*genai.Part{{
+				FunctionCall: &genai.FunctionCall{ID: "fc-1", Name: "noop", Args: map[string]any{}},
+			}}},
+			genai.NewContentFromText("hello world", genai.RoleModel),
+		},
+	}
+
+	a, err := llmagent.New(llmagent.Config{
+		Name:                     "llm_agent",
+		Model:                    testLLM,
+		OutputKey:                "result",
+		Tools:                    []tool.Tool{noopTool},
+		DisallowTransferToParent: true,
+		DisallowTransferToPeers:  true,
+	})
+	if err != nil {
+		t.Fatalf("failed to create llm agent: %v", err)
+	}
+
+	agentNode, err := workflow.NewAgentNode(a, workflow.NodeConfig{})
+	if err != nil {
+		t.Fatalf("failed to create agent node: %v", err)
+	}
+
+	var gotInput any
+	fnNode := workflow.NewFunctionNode("receiver", func(_ agent.Context, in any) (any, error) {
+		gotInput = in
+		return nil, nil
+	}, workflow.NodeConfig{})
+
+	w, err := workflow.New("test_workflow", workflow.Chain(workflow.Start, agentNode, fnNode))
+	if err != nil {
+		t.Fatalf("failed to create workflow: %v", err)
+	}
+
+	runCtx := runconfig.ToContext(t.Context(), &runconfig.RunConfig{})
+	exCtx := agent.NewNodeContext(&mockInvocationContext{
+		Context: runCtx,
+		sess:    &mockSession{id: "test-session-id"},
+	}, nil)
+
+	for _, err := range w.Run(exCtx) {
+		if err != nil {
+			t.Fatalf("workflow run failed: %v", err)
+		}
+	}
+
+	if diff := cmp.Diff("hello world", gotInput); diff != "" {
+		t.Errorf("successor node got unexpected input (-want +got):\n%s", diff)
+	}
+}
+
 type mockEvents struct{}
 
 func (m mockEvents) All() iter.Seq[*session.Event] {

--- a/runner/run_node_test.go
+++ b/runner/run_node_test.go
@@ -391,3 +391,54 @@ func TestRunner_MessageAsOutput_ClearsOutput(t *testing.T) {
 		t.Fatal("expected a non-partial event stamped with NodeInfo.MessageAsOutput")
 	}
 }
+
+// OutputKey + OutputSchema agent run through the Runner must yield one
+// output-carrying event, else the scheduler raises ErrMultipleOutputs.
+func TestRunner_LlmAgent_OutputKeySchema_SingleOutput(t *testing.T) {
+	ctx := t.Context()
+	svc := session.InMemoryService()
+	newNodeTestSession(t, ctx, svc)
+
+	const jsonResp = `{"text":"ok"}`
+	m := &scriptedModel{responses: []*genai.Content{
+		genai.NewContentFromText(jsonResp, "model"),
+	}}
+	a, err := llmagent.New(llmagent.Config{
+		Name:      "structured",
+		Model:     m,
+		OutputKey: "resp",
+		OutputSchema: &genai.Schema{
+			Type:       genai.TypeObject,
+			Properties: map[string]*genai.Schema{"text": {Type: genai.TypeString}},
+		},
+	})
+	if err != nil {
+		t.Fatalf("llmagent.New() error = %v", err)
+	}
+	r := newNodeTestRunner(t, a, svc)
+
+	events := 0
+	for ev, err := range r.Run(ctx, nodeTestUser, nodeTestSession, userText("hi"), agent.RunConfig{}) {
+		if err != nil {
+			t.Fatalf("Run() error = %v", err)
+		}
+		if ev != nil {
+			events++
+		}
+	}
+	if events != 1 {
+		t.Fatalf("yielded %d events, want 1", events)
+	}
+
+	got, err := svc.Get(ctx, &session.GetRequest{AppName: nodeTestApp, UserID: nodeTestUser, SessionID: nodeTestSession})
+	if err != nil {
+		t.Fatalf("Get() error = %v", err)
+	}
+	saved, err := got.Session.State().Get("resp")
+	if err != nil {
+		t.Fatalf("State().Get(resp) error = %v", err)
+	}
+	if saved != jsonResp {
+		t.Errorf("state[resp] = %v, want %q", saved, jsonResp)
+	}
+}


### PR DESCRIPTION
## Problem
An `LlmAgent` configured with `OutputKey` and run as a workflow node could
fail with the scheduler's one-output-per-node error:
workflow: node produced multiple events with output values; only one event
per execution can carry output: node "<name>"
`maybeSaveOutputToState` wrote **both** `event.Actions.StateDelta[OutputKey]`
**and** `event.Output` on every non-partial, agent-authored content event.
When the model emitted a function-call turn before its final text, two events
ended up carrying output:
- the function-call event — empty text projected to `""`, which is non-nil and
  is counted as an output value, and
- the final text event — the real reply.
The node wrapper already stamps the single node output
(`synthesizeAgentOutput` in the graph path, `ProcessLLMAgentOutput` in the
runner path), so the extra stamp in `maybeSaveOutputToState` was both
redundant and incorrect. adk-python (source of truth) does not do this — its
`__maybe_save_output_to_state` writes only `state_delta`.

## Solution
Write only the `state_delta` in `maybeSaveOutputToState`; let the node wrapper
remain the single source of `event.Output`. This aligns Go with adk-python and
keeps exactly one output-carrying event per node execution.