### PR TITLE
fix: keep position of the seed event

### DIFF
--- a/agent/llmagent/llm_agent_wrapper.go
+++ b/agent/llmagent/llm_agent_wrapper.go
@@ -105,7 +105,7 @@ func RunLLMAgentAsNode(a agent.Agent, ctx agent.Context, nodeInput any) iter.Seq
 			}
 			sess := ctx.Session()
 			if seed := PrepareLLMAgentInput(a, ctx, nodeInput); seed != nil {
-				sess = &wrappedSession{Session: sess, appended: seed}
+				sess = newWrappedSession(sess, seed)
 			}
 			ic := icontext.NewInvocationContext(ctx, icontext.InvocationContextParams{
 				Artifacts:      ctx.Artifacts(),
@@ -661,33 +661,66 @@ func runTask(a agent.Agent, ic agent.InvocationContext, yield func(*session.Even
 type wrappedSession struct {
 	session.Session
 	appended *session.Event
+	// insertAt is the index in the underlying session events at which
+	// the synthetic ``appended`` event must appear. It is snapshotted at
+	// wrappedSession-creation time so the seed always sits BETWEEN the
+	// events that already existed in the session (the parent's
+	// invocation that produced the delegation FC) and any events the
+	// agent appends to the underlying session during its own run (its
+	// FC/FR rounds). Putting the seed at the tail instead would let the
+	// backward-scan in buildContentsCurrentTurnContextOnly pivot on the
+	// seed and drop the agent's own tool history between rounds; see
+	// adk-python's behaviour (which appends to session.events before
+	// run_async, achieving the same ordering for free).
+	insertAt int
+}
+
+func newWrappedSession(orig session.Session, seed *session.Event) *wrappedSession {
+	w := &wrappedSession{Session: orig, appended: seed}
+	if orig != nil {
+		if ev := orig.Events(); ev != nil {
+			w.insertAt = ev.Len()
+		}
+	}
+	return w
 }
 
 func (w *wrappedSession) Events() session.Events {
 	if w.Session == nil {
-		return &wrappedEvents{app: w.appended}
+		return &wrappedEvents{app: w.appended, insertAt: 0}
 	}
 	return &wrappedEvents{
-		orig: w.Session.Events(),
-		app:  w.appended,
+		orig:     w.Session.Events(),
+		app:      w.appended,
+		insertAt: w.insertAt,
 	}
 }
 
 type wrappedEvents struct {
-	orig session.Events
-	app  *session.Event
+	orig     session.Events
+	app      *session.Event
+	insertAt int
 }
 
 func (w *wrappedEvents) All() iter.Seq[*session.Event] {
 	return func(yield func(*session.Event) bool) {
+		i := 0
 		if w.orig != nil {
 			for e := range w.orig.All() {
+				if i == w.insertAt && w.app != nil {
+					if !yield(w.app) {
+						return
+					}
+				}
 				if !yield(e) {
 					return
 				}
+				i++
 			}
 		}
-		if w.app != nil {
+		// Seed at very end of underlying events (or when there are no
+		// orig events at all).
+		if w.app != nil && i <= w.insertAt {
 			yield(w.app)
 		}
 	}
@@ -709,8 +742,17 @@ func (w *wrappedEvents) At(i int) *session.Event {
 	if w.orig != nil {
 		n = w.orig.Len()
 	}
-	if i < n {
+	if w.app == nil {
 		return w.orig.At(i)
 	}
-	return w.app
+	switch {
+	case i < w.insertAt:
+		return w.orig.At(i)
+	case i == w.insertAt:
+		return w.app
+	case i <= n: // i > insertAt, still within orig range (orig has grown since snapshot)
+		return w.orig.At(i - 1)
+	default:
+		return nil
+	}
 }

--- a/agent/llmagent/llmagent_delegation_test.go
+++ b/agent/llmagent/llmagent_delegation_test.go
@@ -1838,6 +1838,212 @@ func TestDelegation_10_TaskAgentRejectedAsStaticGraphNode(t *testing.T) {
 }
 
 // =============================================================================
+// Scenario 11: chat coordinator → single_turn sub-agent that chains 2 tools.
+// =============================================================================
+
+// TestDelegation_11_ChatToSingleTurnChainedTools covers a single_turn
+// sub-agent that chains two tools where the second tool's argument
+// depends on the first tool's result. The chat coordinator delegates
+// once; the sub-agent calls tool_one, sees its FR, then calls
+// tool_two with the token tool_one returned, and emits a final
+// structured reply.
+//
+// Pins:
+//  1. The sub-agent's own tool history (its FC/FR events) is visible
+//     to its model on subsequent LLM rounds — captured directly via
+//     a BeforeModelCallback.
+//  2. The sub-agent emits FCs for BOTH tool_one and tool_two.
+//  3. The sub-agent's model is called a bounded number of times.
+func TestDelegation_11_ChatToSingleTurnChainedTools(t *testing.T) {
+	type token struct {
+		Token string `json:"token"`
+	}
+	type echo struct {
+		Result string `json:"result"`
+	}
+
+	// tool_one returns a fixed token; tool_two needs that exact
+	// token. The model can only call tool_two correctly after
+	// seeing tool_one's FR, so the single_turn agent's own tool
+	// history must survive across rounds.
+	t1, err := functiontool.New(functiontool.Config{
+		Name:        "tool_one",
+		Description: "Returns a fixed token string. Call this first.",
+	}, func(_ agent.Context, _ struct{}) (token, error) {
+		return token{Token: "alpha-42"}, nil
+	})
+	if err != nil {
+		t.Fatalf("tool_one: %v", err)
+	}
+	t2, err := functiontool.New(functiontool.Config{
+		Name:        "tool_two",
+		Description: "Echoes the token returned by tool_one.",
+	}, func(_ agent.Context, in token) (echo, error) {
+		return echo{Result: "got " + in.Token}, nil
+	})
+	if err != nil {
+		t.Fatalf("tool_two: %v", err)
+	}
+
+	// Capture the contents the sub-agent's model sees on each round.
+	// BeforeModelCallback runs after all request processors, so the
+	// snapshot is exactly what the model receives.
+	var (
+		mu       sync.Mutex
+		requests [][]*genai.Content
+	)
+	capture := func(_ agent.Context, req *model.LLMRequest) (*model.LLMResponse, error) {
+		mu.Lock()
+		defer mu.Unlock()
+		snap := make([]*genai.Content, len(req.Contents))
+		copy(snap, req.Contents)
+		requests = append(requests, snap)
+		return nil, nil
+	}
+
+	sub, err := llmagent.New(llmagent.Config{
+		Name:        "sub",
+		Description: "Chains tool_one then tool_two.",
+		Model:       newDelegationModel(t),
+		Mode:        llmagent.ModeSingleTurn,
+		Tools:       []tool.Tool{t1, t2},
+		Instruction: `Call tool_one to obtain a token, then call tool_two with
+that exact token, then report the result string. Call each tool at most once.`,
+		BeforeModelCallbacks: []llmagent.BeforeModelCallback{capture},
+	})
+	if err != nil {
+		t.Fatalf("sub: %v", err)
+	}
+
+	coordinator, err := llmagent.New(llmagent.Config{
+		Name:        "coordinator",
+		Description: "Delegates to sub and reports the answer.",
+		Model:       newDelegationModel(t),
+		Mode:        llmagent.ModeChat,
+		SubAgents:   []agent.Agent{sub},
+		Instruction: `Call the sub agent exactly once with a brief description
+of what to do, then report its answer in one sentence.`,
+	})
+	if err != nil {
+		t.Fatalf("coordinator: %v", err)
+	}
+
+	events := newDelegationRunner(t, coordinator).turn("Run the chained tools.")
+
+	mu.Lock()
+	defer mu.Unlock()
+
+	// (1) Bounded rounds: ~3 in the healthy path (tool_one, tool_two,
+	// final reply).
+	if n := len(requests); n == 0 || n > 8 {
+		t.Fatalf("sub-agent model rounds = %d (want 1..8); requests: %s",
+			n, summarizeAllRounds(requests))
+	}
+
+	// (2) Both tools were called; tool_one at most a few times.
+	if n := len(collectFCsByName(events, "tool_one")); n == 0 || n > 3 {
+		t.Errorf("tool_one FCs = %d, want 1..3", n)
+	}
+	if len(collectFCsByName(events, "tool_two")) == 0 {
+		t.Errorf("tool_two never called; model could not proceed past tool_one")
+	}
+
+	// (3) Some round's contents must contain BOTH tool_one's FC and
+	// FR — direct evidence the agent's own tool history survived
+	// between LLM rounds.
+	var historySurvived bool
+	for _, c := range requests {
+		if hasFunctionCall(c, "tool_one") && hasFunctionResponse(c, "tool_one") {
+			historySurvived = true
+			break
+		}
+	}
+	if !historySurvived {
+		t.Errorf("no captured round contained both tool_one FC and FR; tool history did not survive across rounds. requests: %s",
+			summarizeAllRounds(requests))
+	}
+}
+
+// hasFunctionCall reports whether any content part across the slice
+// is a FunctionCall with the given name. Used by chained-tool tests
+// to assert prior-round tool history survives across LLM rounds.
+func hasFunctionCall(contents []*genai.Content, name string) bool {
+	for _, c := range contents {
+		if c == nil {
+			continue
+		}
+		for _, p := range c.Parts {
+			if p != nil && p.FunctionCall != nil && p.FunctionCall.Name == name {
+				return true
+			}
+		}
+	}
+	return false
+}
+
+// hasFunctionResponse reports whether any content part across the
+// slice is a FunctionResponse with the given name.
+func hasFunctionResponse(contents []*genai.Content, name string) bool {
+	for _, c := range contents {
+		if c == nil {
+			continue
+		}
+		for _, p := range c.Parts {
+			if p != nil && p.FunctionResponse != nil && p.FunctionResponse.Name == name {
+				return true
+			}
+		}
+	}
+	return false
+}
+
+// summarizeContents returns a compact one-line description of an
+// LLMRequest.Contents slice for use in t.Logf / t.Errorf diagnostics.
+func summarizeContents(contents []*genai.Content) string {
+	var b strings.Builder
+	for i, c := range contents {
+		if i > 0 {
+			b.WriteString(" / ")
+		}
+		if c == nil {
+			b.WriteString("<nil>")
+			continue
+		}
+		b.WriteString(c.Role)
+		b.WriteString(":[")
+		for j, p := range c.Parts {
+			if j > 0 {
+				b.WriteString(",")
+			}
+			switch {
+			case p == nil:
+				b.WriteString("<nil>")
+			case p.FunctionCall != nil:
+				b.WriteString("FC(" + p.FunctionCall.Name + ")")
+			case p.FunctionResponse != nil:
+				b.WriteString("FR(" + p.FunctionResponse.Name + ")")
+			case p.Text != "":
+				b.WriteString("text")
+			default:
+				b.WriteString("?")
+			}
+		}
+		b.WriteString("]")
+	}
+	return b.String()
+}
+
+// summarizeAllRounds formats every captured round's contents on a
+// single labelled line for use in failure diagnostics.
+func summarizeAllRounds(rounds [][]*genai.Content) string {
+	parts := make([]string, len(rounds))
+	for i, c := range rounds {
+		parts[i] = fmt.Sprintf("round %d: %s", i+1, summarizeContents(c))
+	}
+	return strings.Join(parts, " | ")
+}
+
+// =============================================================================
 // Diagnostic helpers
 // =============================================================================
 

--- a/agent/llmagent/llmagent_saveoutput_test.go
+++ b/agent/llmagent/llmagent_saveoutput_test.go
@@ -185,7 +185,7 @@ func TestWrappedSession_SeedNotPersisted(t *testing.T) {
 	base := newSessionWithEvent(t, "existing turn")
 	baseLen := base.Events().Len()
 	seed := seedEvent("transient node input")
-	wrapped := &wrappedSession{Session: base, appended: seed}
+	wrapped := newWrappedSession(base, seed)
 
 	if got, want := wrapped.Events().Len(), baseLen+1; got != want {
 		t.Errorf("wrapped.Events().Len() = %d, want %d", got, want)

--- a/agent/llmagent/testdata/TestDelegation_11_ChatToSingleTurnChainedTools.events.yaml
+++ b/agent/llmagent/testdata/TestDelegation_11_ChatToSingleTurnChainedTools.events.yaml
@@ -1,0 +1,82 @@
+- author: user
+  role: user
+  parts:
+    - text: Run the chained tools.
+- author: coordinator
+  role: model
+  parts:
+    - function_call:
+        name: sub
+        id: axn9agj2
+        args:
+            request: Execute the chained tools.
+  node_info:
+    path: coordinator
+- author: sub
+  branch: sub@1
+  role: model
+  parts:
+    - function_call:
+        name: tool_one
+        id: bjqewbip
+  node_info:
+    path: coordinator/sub@1
+- author: sub
+  branch: sub@1
+  role: user
+  parts:
+    - function_response:
+        name: tool_one
+        id: bjqewbip
+        response:
+            token: alpha-42
+  node_info:
+    path: coordinator/sub@1
+- author: sub
+  branch: sub@1
+  role: model
+  parts:
+    - function_call:
+        name: tool_two
+        id: 8t7zjdck
+        args:
+            token: alpha-42
+  node_info:
+    path: coordinator/sub@1
+- author: sub
+  branch: sub@1
+  role: user
+  parts:
+    - function_response:
+        name: tool_two
+        id: 8t7zjdck
+        response:
+            result: got alpha-42
+  node_info:
+    path: coordinator/sub@1
+- author: sub
+  branch: sub@1
+  role: model
+  parts:
+    - text: 'The execution of the chained tools is complete. The result string returned by tool_two is: "got alpha-42".'
+  node_info:
+    path: coordinator/sub@1
+    message_as_output: true
+    output_for:
+        - coordinator/sub@1
+- author: coordinator
+  role: user
+  parts:
+    - function_response:
+        name: sub
+        id: axn9agj2
+        response:
+            result: 'The execution of the chained tools is complete. The result string returned by tool_two is: "got alpha-42".'
+  node_info:
+    path: coordinator
+- author: coordinator
+  role: model
+  parts:
+    - text: The sub agent successfully executed the chained tools, returning the final result "got alpha-42".
+  node_info:
+    path: coordinator

--- a/agent/llmagent/testdata/TestDelegation_11_ChatToSingleTurnChainedTools.httprr
+++ b/agent/llmagent/testdata/TestDelegation_11_ChatToSingleTurnChainedTools.httprr
@@ -1,0 +1,280 @@
+httprr trace v1
+829 2197
+POST https://generativelanguage.googleapis.com/v1beta/models/gemini-3.5-flash:generateContent HTTP/1.1
+Host: generativelanguage.googleapis.com
+User-Agent: Go-http-client/1.1
+Content-Length: 597
+Content-Type: application/json
+
+{"contents":[{"parts":[{"text":"Run the chained tools."}],"role":"user"}],"generationConfig":{},"systemInstruction":{"parts":[{"text":"Call the sub agent exactly once with a brief description\nof what to do, then report its answer in one sentence.\n\nYou are an agent. Your internal name is \"coordinator\". The description about you is \"Delegates to sub and reports the answer.\"."}],"role":"user"},"tools":[{"functionDeclarations":[{"description":"Chains tool_one then tool_two.","name":"sub","parameters":{"properties":{"request":{"type":"STRING"}},"required":["request"],"type":"OBJECT"}}]}]}HTTP/2.0 200 OK
+Content-Type: application/json; charset=UTF-8
+Date: Wed, 24 Jun 2026 09:08:04 GMT
+Server: scaffolding on HTTPServer2
+Server-Timing: gfet4t7; dur=6956
+Vary: Origin
+Vary: X-Origin
+Vary: Referer
+X-Content-Type-Options: nosniff
+X-Frame-Options: SAMEORIGIN
+X-Gemini-Service-Tier: standard
+X-Xss-Protection: 0
+
+{
+  "candidates": [
+    {
+      "content": {
+        "parts": [
+          {
+            "functionCall": {
+              "name": "sub",
+              "args": {
+                "request": "Execute the chained tools."
+              },
+              "id": "axn9agj2"
+            },
+            "thoughtSignature": "EvIFCu8FAQw51sceP5YPkC6Qp/GcPbjSYLPaV6Qf4AKaYqY+VBsrTOom9Tb1GcY9vJ/8I+xHg8xZnOcS4uJqu3vKaYHq4vqqU8L0MdVQWcncaUbWDZhu9acZ0c4++/DBwxQvBUpEv2ZtycQp0ap14jtbomTsCq//eiB/3wJZGrfkWkkrCL6aN2ISX4HzCpkKFgFKROkZe2bertFV/DV2xC5y+D2O33Qzjt5ZwQZIdPKbes4K7WoB+4ko5+j2EpdUPURsSLW6jSXaDXI1CbzwT8kikvAIvBVc0He79EGTsj+uWWA4+mHVMuNmJ25nrAEVm8HHV1ZxjQn6yB1J2Bl6AKMGsBCERipo6NOrYZ8xZZzubPtxR69xn/DQGQ8dhYFAvflo/BhIgH2IE27+Uj82ASDXe8LSA5C1uNKGh2QCQk2OzgRpHxpLz0rCEYjozb7Q7baMACTAsjoadrmqD0Fce+7KbcM2NbOBKp4LtORseUX8FuRsqNrO5ZnlsUa8cUwvy0oCzLFBpijH/ybRo86z2ONvxdDjycC1HZQ4bTH4fChYUlN91qEr1QFu8utLbdWuJ4ZX+3gd13VQ0u5GjbOyWeRf93GFKX8HnzBog6WBbrK7IjbTrHblVlPKK477D/63s1fTthBSr4KMfMfrHLB1VWO0s2r/4YWv5EozIdO2QsuDlKXZoNZFi1dge7x4j5SPiOphxpap/Jj6OveQS80Rp1p8+wfSq7XvrEy6G9MSQ87N4N2aZzIWNIYomaY2g6OVooPusR2aqyww7GPBwKvaBmyUufXtKHEmmOuGSJJhCdVQGyq57ucDAYu+goldPWMYMD4DzoXnB3ZYkBVc+SHN/U2zcDdNt07zWx5FwcZni2NpfT5ZSqVeT8zUGIwxCpJBgFAHyCEpts5zPhH3/CCNGSl1KipPscGnlfuXdqXUPEVU6eEPaHq+NwECkFgTpYgtVnGO9iqLjKKVVCc/ZdWhnbjcPCa2+cS7o4qE04sZeoWgr9i55w=="
+          }
+        ],
+        "role": "model"
+      },
+      "finishReason": "STOP",
+      "index": 0,
+      "finishMessage": "Model generated function call(s)."
+    }
+  ],
+  "usageMetadata": {
+    "promptTokenCount": 104,
+    "candidatesTokenCount": 18,
+    "totalTokenCount": 297,
+    "promptTokensDetails": [
+      {
+        "modality": "TEXT",
+        "tokenCount": 104
+      }
+    ],
+    "thoughtsTokenCount": 175,
+    "serviceTier": "standard"
+  },
+  "modelVersion": "gemini-3.5-flash",
+  "responseId": "bZ47arDsLPTqkdUPsNvO8A8"
+}
+1602 1554
+POST https://generativelanguage.googleapis.com/v1beta/models/gemini-3.5-flash:generateContent HTTP/1.1
+Host: generativelanguage.googleapis.com
+User-Agent: Go-http-client/1.1
+Content-Length: 1369
+Content-Type: application/json
+
+{"contents":[{"parts":[{"text":"{\"request\":\"Execute the chained tools.\"}"}],"role":"user"}],"generationConfig":{},"systemInstruction":{"parts":[{"text":"Call tool_one to obtain a token, then call tool_two with\nthat exact token, then report the result string. Call each tool at most once.\n\n"}],"role":"user"},"tools":[{"functionDeclarations":[{"description":"Transfer the question to another agent.\nThis tool hands off control to another agent when it's more suitable to answer the user's question according to the agent's description.","name":"transfer_to_agent","parameters":{"properties":{"agent_name":{"description":"the agent name to transfer to","enum":["coordinator"],"type":"STRING"}},"required":["agent_name"],"type":"OBJECT"}},{"description":"Returns a fixed token string. Call this first.","name":"tool_one","parametersJsonSchema":{"additionalProperties":false,"type":"object"},"responseJsonSchema":{"additionalProperties":false,"properties":{"token":{"type":"string"}},"required":["token"],"type":"object"}},{"description":"Echoes the token returned by tool_one.","name":"tool_two","parametersJsonSchema":{"additionalProperties":false,"properties":{"token":{"type":"string"}},"required":["token"],"type":"object"},"responseJsonSchema":{"additionalProperties":false,"properties":{"result":{"type":"string"}},"required":["result"],"type":"object"}}]}]}HTTP/2.0 200 OK
+Content-Type: application/json; charset=UTF-8
+Date: Wed, 24 Jun 2026 09:08:13 GMT
+Server: scaffolding on HTTPServer2
+Server-Timing: gfet4t7; dur=9207
+Vary: Origin
+Vary: X-Origin
+Vary: Referer
+X-Content-Type-Options: nosniff
+X-Frame-Options: SAMEORIGIN
+X-Gemini-Service-Tier: standard
+X-Xss-Protection: 0
+
+{
+  "candidates": [
+    {
+      "content": {
+        "parts": [
+          {
+            "functionCall": {
+              "name": "tool_one",
+              "args": {},
+              "id": "bjqewbip"
+            },
+            "thoughtSignature": "EsMCCsACAQw51sdHSo0GnWh304cgbKiISOjA/Qf0kGutWLExt6Qidi1QQpUeYfX5GTrlEo65YeEDVk7AFg8GDjFfRS5UIdYJJbtpqStY840Tuy2Z8bb10aby7qsVit3ST+TluKa/gUDWxl9/GRXQrOzocKAF2mSiVH/RBl3XU8be0LQ0bo0Sv+AnBRC6eU1s5XlQqz2v98kuei1zVvLiJZUhc4PAxlJCmgOoSsJeLz/HZWBwgnbWM/mKOEOzrnMJ0ToaUD1YpMUtlpKiRXOzKelGNyo3GHfxN0cBX+eXwW4q/RhvZsNrVwOsykGQ68yiHGy2ZY8wrtpi8zfZa1qv9NymcxoxpAjNz1EveP8sm6Lg5YfOuk5q1oOhFJlTyTCUrMLcAiwag4Zg1niwcEdn8a3TPJvPADeTWsrVzpPq+8mmmy947F8="
+          }
+        ],
+        "role": "model"
+      },
+      "finishReason": "STOP",
+      "index": 0,
+      "finishMessage": "Model generated function call(s)."
+    }
+  ],
+  "usageMetadata": {
+    "promptTokenCount": 268,
+    "candidatesTokenCount": 10,
+    "totalTokenCount": 346,
+    "promptTokensDetails": [
+      {
+        "modality": "TEXT",
+        "tokenCount": 268
+      }
+    ],
+    "thoughtsTokenCount": 68,
+    "serviceTier": "standard"
+  },
+  "modelVersion": "gemini-3.5-flash",
+  "responseId": "dJ47avb8K5LinsEPubfw-AQ"
+}
+2255 1372
+POST https://generativelanguage.googleapis.com/v1beta/models/gemini-3.5-flash:generateContent HTTP/1.1
+Host: generativelanguage.googleapis.com
+User-Agent: Go-http-client/1.1
+Content-Length: 2022
+Content-Type: application/json
+
+{"contents":[{"parts":[{"text":"{\"request\":\"Execute the chained tools.\"}"}],"role":"user"},{"parts":[{"functionCall":{"id":"bjqewbip","name":"tool_one"},"thoughtSignature":"EsMCCsACAQw51sdHSo0GnWh304cgbKiISOjA/Qf0kGutWLExt6Qidi1QQpUeYfX5GTrlEo65YeEDVk7AFg8GDjFfRS5UIdYJJbtpqStY840Tuy2Z8bb10aby7qsVit3ST+TluKa/gUDWxl9/GRXQrOzocKAF2mSiVH/RBl3XU8be0LQ0bo0Sv+AnBRC6eU1s5XlQqz2v98kuei1zVvLiJZUhc4PAxlJCmgOoSsJeLz/HZWBwgnbWM/mKOEOzrnMJ0ToaUD1YpMUtlpKiRXOzKelGNyo3GHfxN0cBX+eXwW4q/RhvZsNrVwOsykGQ68yiHGy2ZY8wrtpi8zfZa1qv9NymcxoxpAjNz1EveP8sm6Lg5YfOuk5q1oOhFJlTyTCUrMLcAiwag4Zg1niwcEdn8a3TPJvPADeTWsrVzpPq+8mmmy947F8="}],"role":"model"},{"parts":[{"functionResponse":{"id":"bjqewbip","name":"tool_one","response":{"token":"alpha-42"}}}],"role":"user"}],"generationConfig":{},"systemInstruction":{"parts":[{"text":"Call tool_one to obtain a token, then call tool_two with\nthat exact token, then report the result string. Call each tool at most once.\n\n"}],"role":"user"},"tools":[{"functionDeclarations":[{"description":"Transfer the question to another agent.\nThis tool hands off control to another agent when it's more suitable to answer the user's question according to the agent's description.","name":"transfer_to_agent","parameters":{"properties":{"agent_name":{"description":"the agent name to transfer to","enum":["coordinator"],"type":"STRING"}},"required":["agent_name"],"type":"OBJECT"}},{"description":"Returns a fixed token string. Call this first.","name":"tool_one","parametersJsonSchema":{"additionalProperties":false,"type":"object"},"responseJsonSchema":{"additionalProperties":false,"properties":{"token":{"type":"string"}},"required":["token"],"type":"object"}},{"description":"Echoes the token returned by tool_one.","name":"tool_two","parametersJsonSchema":{"additionalProperties":false,"properties":{"token":{"type":"string"}},"required":["token"],"type":"object"},"responseJsonSchema":{"additionalProperties":false,"properties":{"result":{"type":"string"}},"required":["result"],"type":"object"}}]}]}HTTP/2.0 200 OK
+Content-Type: application/json; charset=UTF-8
+Date: Wed, 24 Jun 2026 09:08:16 GMT
+Server: scaffolding on HTTPServer2
+Server-Timing: gfet4t7; dur=2578
+Vary: Origin
+Vary: X-Origin
+Vary: Referer
+X-Content-Type-Options: nosniff
+X-Frame-Options: SAMEORIGIN
+X-Gemini-Service-Tier: standard
+X-Xss-Protection: 0
+
+{
+  "candidates": [
+    {
+      "content": {
+        "parts": [
+          {
+            "functionCall": {
+              "name": "tool_two",
+              "args": {
+                "token": "alpha-42"
+              },
+              "id": "8t7zjdck"
+            },
+            "thoughtSignature": "EpYBCpMBAQw51se4RqRA8/ZZcDvoBMxjamPbFyEC93pAU2vWrkwsruoLP3i8TjetqOLvfLU7VZc41eUTFntppbzMq/HeA0YB3E9r/dq6edF+mHi6Q81j1RF72XPo5vbksWLeKZpBgIOVbpC1cIHEYKMmEhkHaV6MeD0xszepUVrkePkoyoACUxv4lMJ2Kj99gn3a5evKK0jx"
+          }
+        ],
+        "role": "model"
+      },
+      "finishReason": "STOP",
+      "index": 0,
+      "finishMessage": "Model generated function call(s)."
+    }
+  ],
+  "usageMetadata": {
+    "promptTokenCount": 363,
+    "candidatesTokenCount": 19,
+    "totalTokenCount": 414,
+    "promptTokensDetails": [
+      {
+        "modality": "TEXT",
+        "tokenCount": 363
+      }
+    ],
+    "thoughtsTokenCount": 32,
+    "serviceTier": "standard"
+  },
+  "modelVersion": "gemini-3.5-flash",
+  "responseId": "fZ47apqiN9fjnsEP-MnRaA"
+}
+2709 1242
+POST https://generativelanguage.googleapis.com/v1beta/models/gemini-3.5-flash:generateContent HTTP/1.1
+Host: generativelanguage.googleapis.com
+User-Agent: Go-http-client/1.1
+Content-Length: 2476
+Content-Type: application/json
+
+{"contents":[{"parts":[{"text":"{\"request\":\"Execute the chained tools.\"}"}],"role":"user"},{"parts":[{"functionCall":{"id":"bjqewbip","name":"tool_one"},"thoughtSignature":"EsMCCsACAQw51sdHSo0GnWh304cgbKiISOjA/Qf0kGutWLExt6Qidi1QQpUeYfX5GTrlEo65YeEDVk7AFg8GDjFfRS5UIdYJJbtpqStY840Tuy2Z8bb10aby7qsVit3ST+TluKa/gUDWxl9/GRXQrOzocKAF2mSiVH/RBl3XU8be0LQ0bo0Sv+AnBRC6eU1s5XlQqz2v98kuei1zVvLiJZUhc4PAxlJCmgOoSsJeLz/HZWBwgnbWM/mKOEOzrnMJ0ToaUD1YpMUtlpKiRXOzKelGNyo3GHfxN0cBX+eXwW4q/RhvZsNrVwOsykGQ68yiHGy2ZY8wrtpi8zfZa1qv9NymcxoxpAjNz1EveP8sm6Lg5YfOuk5q1oOhFJlTyTCUrMLcAiwag4Zg1niwcEdn8a3TPJvPADeTWsrVzpPq+8mmmy947F8="}],"role":"model"},{"parts":[{"functionResponse":{"id":"bjqewbip","name":"tool_one","response":{"token":"alpha-42"}}}],"role":"user"},{"parts":[{"functionCall":{"args":{"token":"alpha-42"},"id":"8t7zjdck","name":"tool_two"},"thoughtSignature":"EpYBCpMBAQw51se4RqRA8/ZZcDvoBMxjamPbFyEC93pAU2vWrkwsruoLP3i8TjetqOLvfLU7VZc41eUTFntppbzMq/HeA0YB3E9r/dq6edF+mHi6Q81j1RF72XPo5vbksWLeKZpBgIOVbpC1cIHEYKMmEhkHaV6MeD0xszepUVrkePkoyoACUxv4lMJ2Kj99gn3a5evKK0jx"}],"role":"model"},{"parts":[{"functionResponse":{"id":"8t7zjdck","name":"tool_two","response":{"result":"got alpha-42"}}}],"role":"user"}],"generationConfig":{},"systemInstruction":{"parts":[{"text":"Call tool_one to obtain a token, then call tool_two with\nthat exact token, then report the result string. Call each tool at most once.\n\n"}],"role":"user"},"tools":[{"functionDeclarations":[{"description":"Transfer the question to another agent.\nThis tool hands off control to another agent when it's more suitable to answer the user's question according to the agent's description.","name":"transfer_to_agent","parameters":{"properties":{"agent_name":{"description":"the agent name to transfer to","enum":["coordinator"],"type":"STRING"}},"required":["agent_name"],"type":"OBJECT"}},{"description":"Returns a fixed token string. Call this first.","name":"tool_one","parametersJsonSchema":{"additionalProperties":false,"type":"object"},"responseJsonSchema":{"additionalProperties":false,"properties":{"token":{"type":"string"}},"required":["token"],"type":"object"}},{"description":"Echoes the token returned by tool_one.","name":"tool_two","parametersJsonSchema":{"additionalProperties":false,"properties":{"token":{"type":"string"}},"required":["token"],"type":"object"},"responseJsonSchema":{"additionalProperties":false,"properties":{"result":{"type":"string"}},"required":["result"],"type":"object"}}]}]}HTTP/2.0 200 OK
+Content-Type: application/json; charset=UTF-8
+Date: Wed, 24 Jun 2026 09:08:23 GMT
+Server: scaffolding on HTTPServer2
+Server-Timing: gfet4t7; dur=6566
+Vary: Origin
+Vary: X-Origin
+Vary: Referer
+X-Content-Type-Options: nosniff
+X-Frame-Options: SAMEORIGIN
+X-Gemini-Service-Tier: standard
+X-Xss-Protection: 0
+
+{
+  "candidates": [
+    {
+      "content": {
+        "parts": [
+          {
+            "text": "The execution of the chained tools is complete. The result string returned by tool_two is: \"got alpha-42\".",
+            "thoughtSignature": "EokBCoYBAQw51sfxzCd/f1yMCVUp9tcG+18UhIPbbn5PEOG0WXGvpqm5aO2u8XGKeIc/VJ9F3FzrFnWV40AeQfMiPFujIgfFA+ZP/92go5uf0lLnhMH9cQPk0VacTzNAeeTabeSLw3G3aPvUpvljF4A7r9n4Ajyv4sgS4hddzuO1c032yrRcsvIPx7o="
+          }
+        ],
+        "role": "model"
+      },
+      "finishReason": "STOP",
+      "index": 0
+    }
+  ],
+  "usageMetadata": {
+    "promptTokenCount": 432,
+    "candidatesTokenCount": 26,
+    "totalTokenCount": 480,
+    "promptTokensDetails": [
+      {
+        "modality": "TEXT",
+        "tokenCount": 432
+      }
+    ],
+    "thoughtsTokenCount": 22,
+    "serviceTier": "standard"
+  },
+  "modelVersion": "gemini-3.5-flash",
+  "responseId": "gJ47ao-wHtmN7M8Pwv3VuQM"
+}
+2198 1509
+POST https://generativelanguage.googleapis.com/v1beta/models/gemini-3.5-flash:generateContent HTTP/1.1
+Host: generativelanguage.googleapis.com
+User-Agent: Go-http-client/1.1
+Content-Length: 1965
+Content-Type: application/json
+
+{"contents":[{"parts":[{"text":"Run the chained tools."}],"role":"user"},{"parts":[{"functionCall":{"args":{"request":"Execute the chained tools."},"id":"axn9agj2","name":"sub"},"thoughtSignature":"EvIFCu8FAQw51sceP5YPkC6Qp/GcPbjSYLPaV6Qf4AKaYqY+VBsrTOom9Tb1GcY9vJ/8I+xHg8xZnOcS4uJqu3vKaYHq4vqqU8L0MdVQWcncaUbWDZhu9acZ0c4++/DBwxQvBUpEv2ZtycQp0ap14jtbomTsCq//eiB/3wJZGrfkWkkrCL6aN2ISX4HzCpkKFgFKROkZe2bertFV/DV2xC5y+D2O33Qzjt5ZwQZIdPKbes4K7WoB+4ko5+j2EpdUPURsSLW6jSXaDXI1CbzwT8kikvAIvBVc0He79EGTsj+uWWA4+mHVMuNmJ25nrAEVm8HHV1ZxjQn6yB1J2Bl6AKMGsBCERipo6NOrYZ8xZZzubPtxR69xn/DQGQ8dhYFAvflo/BhIgH2IE27+Uj82ASDXe8LSA5C1uNKGh2QCQk2OzgRpHxpLz0rCEYjozb7Q7baMACTAsjoadrmqD0Fce+7KbcM2NbOBKp4LtORseUX8FuRsqNrO5ZnlsUa8cUwvy0oCzLFBpijH/ybRo86z2ONvxdDjycC1HZQ4bTH4fChYUlN91qEr1QFu8utLbdWuJ4ZX+3gd13VQ0u5GjbOyWeRf93GFKX8HnzBog6WBbrK7IjbTrHblVlPKK477D/63s1fTthBSr4KMfMfrHLB1VWO0s2r/4YWv5EozIdO2QsuDlKXZoNZFi1dge7x4j5SPiOphxpap/Jj6OveQS80Rp1p8+wfSq7XvrEy6G9MSQ87N4N2aZzIWNIYomaY2g6OVooPusR2aqyww7GPBwKvaBmyUufXtKHEmmOuGSJJhCdVQGyq57ucDAYu+goldPWMYMD4DzoXnB3ZYkBVc+SHN/U2zcDdNt07zWx5FwcZni2NpfT5ZSqVeT8zUGIwxCpJBgFAHyCEpts5zPhH3/CCNGSl1KipPscGnlfuXdqXUPEVU6eEPaHq+NwECkFgTpYgtVnGO9iqLjKKVVCc/ZdWhnbjcPCa2+cS7o4qE04sZeoWgr9i55w=="}],"role":"model"},{"parts":[{"functionResponse":{"id":"axn9agj2","name":"sub","response":{"result":"The execution of the chained tools is complete. The result string returned by tool_two is: \"got alpha-42\"."}}}],"role":"user"}],"generationConfig":{},"systemInstruction":{"parts":[{"text":"Call the sub agent exactly once with a brief description\nof what to do, then report its answer in one sentence.\n\nYou are an agent. Your internal name is \"coordinator\". The description about you is \"Delegates to sub and reports the answer.\"."}],"role":"user"},"tools":[{"functionDeclarations":[{"description":"Chains tool_one then tool_two.","name":"sub","parameters":{"properties":{"request":{"type":"STRING"}},"required":["request"],"type":"OBJECT"}}]}]}HTTP/2.0 200 OK
+Content-Type: application/json; charset=UTF-8
+Date: Wed, 24 Jun 2026 09:08:34 GMT
+Server: scaffolding on HTTPServer2
+Server-Timing: gfet4t7; dur=11166
+Vary: Origin
+Vary: X-Origin
+Vary: Referer
+X-Content-Type-Options: nosniff
+X-Frame-Options: SAMEORIGIN
+X-Gemini-Service-Tier: standard
+X-Xss-Protection: 0
+
+{
+  "candidates": [
+    {
+      "content": {
+        "parts": [
+          {
+            "text": "The sub agent successfully executed the chained tools, returning the final result \"got alpha-42\".",
+            "thoughtSignature": "EtgCCtUCAQw51sczgXmHnynZ9mI95S597m/E8dRk87doM4w20DviP3Or63rFBx8lFfsoj8DjtkDHZAUiwSwG4JE5F+342iOSQRSQkKTv+s6v9cOk16c4yrR/p14pD/kvoDuztYGXRxXHKilUsaCuxo+79GAOk1iJrncXmXQw4/GqGtie3l1VhbD40ENRP5o7LPb5gjkxRWsrZAhFWRVUCW+B1Ufe/9O/kqBHHg0QyvqrnPH+U0/dbwmVssoS6NJiAzTPUwu8je8zZspbeV0VllSNM2WOkFO5poi7KsjRGY1XrlOKVDbp4Tc7coYQzcbZOgqRV7KNxkmlyiH3xr329G8dsqeTASmZvHc6w99f2BEoe8KyhNudWgp5pONediq2JJ1krJ4JmeRHYCD6yFavMRTG8BIbQYUwHuHuljFN29uUBguBvJOLcUH+jvW2LnUI0Us68fj+eHAyrAQ="
+          }
+        ],
+        "role": "model"
+      },
+      "finishReason": "STOP",
+      "index": 0
+    }
+  ],
+  "usageMetadata": {
+    "promptTokenCount": 334,
+    "candidatesTokenCount": 20,
+    "totalTokenCount": 423,
+    "promptTokensDetails": [
+      {
+        "modality": "TEXT",
+        "tokenCount": 334
+      }
+    ],
+    "thoughtsTokenCount": 69,
+    "serviceTier": "standard"
+  },
+  "modelVersion": "gemini-3.5-flash",
+  "responseId": "h547aq_yA-Pi7M8Pu4u0CQ"
+}


### PR DESCRIPTION
This is only needed for single_turn agents. Before this commit, the seed event in the wrappedSession was always appended at the end, which hid any subsequent events if for example single_turn agent produces multiple function calls.

Now the seed event is injected at the wrappedSession creation time and has a fixed position.

I've also added a regression test for this case.