### PR TITLE
fix(workflow): don't mark cancelled delegated-child spans as errors

### DIFF
--- a/workflow/dynamic_scheduler.go
+++ b/workflow/dynamic_scheduler.go
@@ -242,15 +242,26 @@ func (s *dynamicSubScheduler) runNode(child Node, input any, opts runNodeOptions
 	defer span.End()
 	childCtx = spanCtx
 
+	// rawErr is the unwrapped child/emit error. The returned err wraps
+	// the cause with "%w: %v", dropping context.Canceled from the chain,
+	// so span status is classified on rawErr rather than err.
+	var rawErr error
+
 	// Record genuine runtime failures on the span. Pauses (HITL
 	// ErrNodeInterrupted, WaitForOutput ErrNodeWaitingForOutput) and
 	// parent cancellation (context.Canceled) are expected control
 	// flow, not span errors — matching the top scheduler's runNode.
 	defer func() {
-		if err != nil &&
-			!errors.Is(err, context.Canceled) &&
-			!errors.Is(err, ErrNodeInterrupted) &&
-			!errors.Is(err, ErrNodeWaitingForOutput) {
+		if err == nil {
+			return
+		}
+		classify := err
+		if rawErr != nil {
+			classify = rawErr
+		}
+		if !errors.Is(classify, context.Canceled) &&
+			!errors.Is(classify, ErrNodeInterrupted) &&
+			!errors.Is(classify, ErrNodeWaitingForOutput) {
 			span.RecordError(err)
 			span.SetStatus(codes.Error, err.Error())
 		}
@@ -298,6 +309,7 @@ func (s *dynamicSubScheduler) runNode(child Node, input any, opts runNodeOptions
 	for ev, evErr := range child.Run(childCtx, input) {
 		if evErr != nil {
 			// Child error wins over any prior interrupt.
+			rawErr = evErr
 			return nil, &NodeRunError{
 				ChildName: name, ChildPath: childPath, RunID: runID,
 				Cause: fmt.Errorf("%w: %v", ErrNodeFailed, evErr),
@@ -383,10 +395,11 @@ func (s *dynamicSubScheduler) runNode(child Node, input any, opts runNodeOptions
 				ev.NodeInfo.OutputFor = outputFor
 			}
 		}
-		if err := s.emitUp(ev); err != nil {
+		if emitErr := s.emitUp(ev); emitErr != nil {
+			rawErr = emitErr
 			return nil, &NodeRunError{
 				ChildName: name, ChildPath: childPath, RunID: runID,
-				Cause: fmt.Errorf("%w: emitUp: %v", ErrNodeFailed, err),
+				Cause: fmt.Errorf("%w: emitUp: %v", ErrNodeFailed, emitErr),
 			}
 		}
 	}

--- a/workflow/dynamic_scheduler_test.go
+++ b/workflow/dynamic_scheduler_test.go
@@ -15,6 +15,7 @@
 package workflow
 
 import (
+	"context"
 	"errors"
 	"iter"
 	"strconv"
@@ -24,9 +25,13 @@ import (
 	"time"
 
 	"github.com/google/jsonschema-go/jsonschema"
+	"go.opentelemetry.io/otel/codes"
+	sdktrace "go.opentelemetry.io/otel/sdk/trace"
+	"go.opentelemetry.io/otel/sdk/trace/tracetest"
 	"google.golang.org/genai"
 
 	"google.golang.org/adk/agent"
+	"google.golang.org/adk/internal/telemetry"
 	"google.golang.org/adk/session"
 )
 
@@ -398,5 +403,70 @@ func (n *interruptThenFailNode) Run(agent.Context, any) iter.Seq2[*session.Event
 			return
 		}
 		yield(nil, errors.New("boom"))
+	}
+}
+
+// errYieldNode yields a fixed error as its run error.
+type errYieldNode struct {
+	BaseNode
+	err error
+}
+
+func newErrYieldNode(name string, err error) *errYieldNode {
+	return &errYieldNode{BaseNode: NewBaseNode(name, "", NodeConfig{}), err: err}
+}
+
+func (n *errYieldNode) Run(agent.Context, any) iter.Seq2[*session.Event, error] {
+	err := n.err
+	return func(yield func(*session.Event, error) bool) {
+		yield(nil, err)
+	}
+}
+
+// TestSubScheduler_RunNode_SpanStatusOnChildError asserts a delegated
+// child's invoke_node span is marked Error on a genuine failure but not
+// on parent cancellation.
+func TestSubScheduler_RunNode_SpanStatusOnChildError(t *testing.T) {
+	tests := []struct {
+		name       string
+		childErr   error
+		wantStatus codes.Code
+	}{
+		{
+			name:       "genuine_failure_marks_error",
+			childErr:   errors.New("boom"),
+			wantStatus: codes.Error,
+		},
+		{
+			name:       "parent_cancellation_not_marked_error",
+			childErr:   context.Canceled,
+			wantStatus: codes.Unset,
+		},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			spanExp := tracetest.NewInMemoryExporter()
+			telemetry.OverrideTracerForTesting(t, sdktrace.NewTracerProvider(sdktrace.WithSyncer(spanExp)))
+
+			child := newErrYieldNode("c", tc.childErr)
+			sub := newDynamicSubScheduler(newTopLevelCtx(t), "wf", noopEmit)
+
+			if _, err := sub.RunNode(child, nil, runNodeOptions{}); err == nil {
+				t.Fatal("RunNode: got nil error, want non-nil")
+			}
+
+			spans := spanExp.GetSpans()
+			if len(spans) != 1 {
+				t.Fatalf("got %d spans, want 1", len(spans))
+			}
+			got := spans[0]
+			if got.Name != "invoke_node c" {
+				t.Errorf("span name = %q, want %q", got.Name, "invoke_node c")
+			}
+			if got.Status.Code != tc.wantStatus {
+				t.Errorf("span status = %v, want %v", got.Status.Code, tc.wantStatus)
+			}
+		})
 	}
 }


### PR DESCRIPTION
## Problem
The `invoke_node` span emitted for a `RunNode`-delegated child (introduced in
#947) marks `context.Canceled` with an **Error** status. The child error is
wrapped via `fmt.Errorf("%w: %v", ErrNodeFailed, evErr)`, and the `%v` flattens
`context.Canceled` out of the error chain — so the span guard's
`errors.Is(err, context.Canceled)` can never match. Parent cancellation is
expected control flow (the top scheduler already skips it), so the dynamic
delegation path diverged and emits spurious **error** spans whenever an
in-flight delegated child is cancelled: client disconnect, context deadline, or
the scheduler's `cancelAll` after a sibling node fails.

## Solution
Classify the span status on the **raw, unwrapped** child/emit error (intact
chain) while still recording the wrapped error (full message) on the span. The
propagated error keeps its `"%w: %v"` shape, so the scheduler's own error
classification (`scheduler.go` → `NodeCancelled`/`NodeWaiting`, `dynamic_node.go`
interrupt swallow) is **unchanged** — this is a span-status-only fix. The same
`emitUp` error path, which had the identical wrapping, is covered too.
