### PR TITLE
fix(llmflow): don't end invocation on a thought-only model turn

### DIFF
--- a/agent/llmagent/llmagent_test.go
+++ b/agent/llmagent/llmagent_test.go
@@ -1303,3 +1303,43 @@ func (m *mockInvocationContext) WithContext(ctx context.Context) agent.Invocatio
 	cp.Context = ctx
 	return &cp
 }
+
+// TestThoughtOnlyTurnDoesNotEndInvocation guards against a thought-only model
+// turn ending the run before the answer is produced. Such a turn has no
+// function call/response and is not partial, so IsFinalResponse() reports it as
+// final; the flow must instead call the model again. adk-python parity.
+func TestThoughtOnlyTurnDoesNotEndInvocation(t *testing.T) {
+	m := &testutil.MockModel{Responses: []*genai.Content{
+		// Turn 1: the model is "thinking" — a thought-only part, no answer.
+		{Role: "model", Parts: []*genai.Part{{Thought: true, Text: "let me think"}}},
+		// Turn 2: the real answer.
+		genai.NewContentFromText("the answer", genai.RoleModel),
+	}}
+
+	a, err := llmagent.New(llmagent.Config{Name: "thinker", Model: m})
+	if err != nil {
+		t.Fatalf("llmagent.New: %v", err)
+	}
+	runner := testutil.NewTestAgentRunner(t, a)
+
+	var got strings.Builder
+	for ev, err := range runner.Run(t, "session_id", "hi") {
+		if err != nil {
+			t.Fatalf("run error: %v", err)
+		}
+		if ev.LLMResponse.Content != nil {
+			for _, p := range ev.LLMResponse.Content.Parts {
+				if !p.Thought {
+					got.WriteString(p.Text)
+				}
+			}
+		}
+	}
+
+	if n := len(m.Requests); n != 2 {
+		t.Errorf("model called %d time(s), want 2: a thought-only turn ended the invocation early", n)
+	}
+	if !strings.Contains(got.String(), "the answer") {
+		t.Errorf("surfaced text = %q, want it to contain %q", got.String(), "the answer")
+	}
+}

--- a/internal/llminternal/base_flow.go
+++ b/internal/llminternal/base_flow.go
@@ -115,7 +115,9 @@ func (f *Flow) Run(ctx agent.InvocationContext) iter.Seq2[*session.Event, error]
 				}
 				lastEvent = ev
 			}
-			if lastEvent == nil || lastEvent.IsFinalResponse() {
+			// A thought-only ("thinking") turn reports as final but has no
+			// answer; don't stop on it — call the model again.
+			if lastEvent == nil || (lastEvent.IsFinalResponse() && !isThoughtOnlyTurn(lastEvent)) {
 				return
 			}
 			if lastEvent.LLMResponse.Partial {
@@ -126,6 +128,26 @@ func (f *Flow) Run(ctx agent.InvocationContext) iter.Seq2[*session.Event, error]
 			}
 		}
 	}
+}
+
+// isThoughtOnlyTurn reports whether ev is a completed (non-partial) model turn
+// whose parts are all model "thinking" (Thought) parts — no surfaced answer.
+// Thought signatures ride on substantive parts (text, function calls), which
+// are not Thought, so any such part makes the turn non-thought-only.
+func isThoughtOnlyTurn(ev *session.Event) bool {
+	if ev == nil || ev.LLMResponse.Partial {
+		return false
+	}
+	content := ev.LLMResponse.Content
+	if content == nil || len(content.Parts) == 0 {
+		return false
+	}
+	for _, p := range content.Parts {
+		if p != nil && !p.Thought {
+			return false
+		}
+	}
+	return true
 }
 
 type activeTask struct {

--- a/internal/llminternal/base_flow_test.go
+++ b/internal/llminternal/base_flow_test.go
@@ -737,3 +737,36 @@ func TestMergeParallelFunctionResponseEvents_NilEntries(t *testing.T) {
 		}
 	})
 }
+
+func TestIsThoughtOnlyTurn(t *testing.T) {
+	event := func(partial bool, parts ...*genai.Part) *session.Event {
+		var content *genai.Content
+		if parts != nil {
+			content = &genai.Content{Role: "model", Parts: parts}
+		}
+		return &session.Event{LLMResponse: model.LLMResponse{Content: content, Partial: partial}}
+	}
+
+	tests := []struct {
+		name string
+		ev   *session.Event
+		want bool
+	}{
+		{"thought_text_only", event(false, &genai.Part{Thought: true, Text: "thinking"}), true},
+		{"thought_plus_answer", event(false, &genai.Part{Thought: true, Text: "t"}, &genai.Part{Text: "answer"}), false},
+		{"answer_only", event(false, &genai.Part{Text: "answer"}), false},
+		{"function_call", event(false, &genai.Part{FunctionCall: &genai.FunctionCall{Name: "f"}}), false},
+		{"thought_then_signed_call", event(false, &genai.Part{Thought: true, Text: "t"}, &genai.Part{FunctionCall: &genai.FunctionCall{Name: "f"}, ThoughtSignature: []byte("sig")}), false},
+		{"thought_plus_signature_only_part", event(false, &genai.Part{Thought: true, Text: "t"}, &genai.Part{ThoughtSignature: []byte("sig")}), false},
+		{"partial_thought", event(true, &genai.Part{Thought: true, Text: "t"}), false},
+		{"empty_content", event(false), false},
+		{"nil_event", nil, false},
+	}
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			if got := isThoughtOnlyTurn(tc.ev); got != tc.want {
+				t.Errorf("isThoughtOnlyTurn = %v, want %v", got, tc.want)
+			}
+		})
+	}
+}


### PR DESCRIPTION
## Problem
A model turn whose content carries only thought / thought-signature parts has
no function call or response and is not partial, so `IsFinalResponse()`
classified it as final. The LLM run loop then stopped after that single model
call and never produced the real answer — a parity gap with adk-python that
surfaced intermittently.

## Solution
Treat a thought-only ("thinking") turn as non-final in the run loop
(`base_flow.go`): when the last event is thought-only, the loop calls the model
again instead of returning, so the answer surfaces. A new `isThoughtOnlyTurn`
helper recognizes turns whose parts are all explicit thought or bare
thought-signature parts. Covered by a helper unit test (`base_flow_test.go`)
and an end-to-end run-loop regression test (`llmagent_test.go`).