### PR TITLE
fix(adkrest): round-trip v2 workflow fields through REST event model

### DIFF
--- a/server/adkrest/internal/models/event.go
+++ b/server/adkrest/internal/models/event.go
@@ -21,15 +21,17 @@ import (
 
 	"google.golang.org/adk/model"
 	"google.golang.org/adk/session"
+	"google.golang.org/adk/tool/toolconfirmation"
 )
 
 // EventActions represent a data model for session.EventActions
 type EventActions struct {
-	StateDelta        map[string]any   `json:"stateDelta"`
-	ArtifactDelta     map[string]int64 `json:"artifactDelta"`
-	Escalate          bool             `json:"escalate,omitempty"`
-	SkipSummarization bool             `json:"skipSummarization,omitempty"`
-	TransferToAgent   string           `json:"transferToAgent,omitempty"`
+	StateDelta                 map[string]any                               `json:"stateDelta"`
+	ArtifactDelta              map[string]int64                             `json:"artifactDelta"`
+	Escalate                   bool                                         `json:"escalate,omitempty"`
+	SkipSummarization          bool                                         `json:"skipSummarization,omitempty"`
+	TransferToAgent            string                                       `json:"transferToAgent,omitempty"`
+	RequestedToolConfirmations map[string]toolconfirmation.ToolConfirmation `json:"requestedToolConfirmations,omitempty"`
 }
 
 // Event represents a single event in a session.
@@ -55,6 +57,9 @@ type Event struct {
 	Actions             EventActions                                `json:"actions"`
 	Output              any                                         `json:"output,omitempty"`
 	NodeInfo            *session.NodeInfo                           `json:"nodeInfo,omitempty"`
+	IsolationScope      string                                      `json:"isolationScope,omitempty"`
+	Routes              []string                                    `json:"routes,omitempty"`
+	RequestedInput      *session.RequestInput                       `json:"requestedInput,omitempty"`
 }
 
 // ToSessionEvent maps Event data struct to session.Event
@@ -67,6 +72,9 @@ func ToSessionEvent(event Event) *session.Event {
 		LongRunningToolIDs: event.LongRunningToolIDs,
 		Output:             event.Output,
 		NodeInfo:           event.NodeInfo,
+		IsolationScope:     event.IsolationScope,
+		Routes:             event.Routes,
+		RequestedInput:     event.RequestedInput,
 		LLMResponse: model.LLMResponse{
 			AvgLogprobs:         event.AvgLogprobs,
 			Content:             event.Content,
@@ -83,11 +91,12 @@ func ToSessionEvent(event Event) *session.Event {
 			OutputTranscription: event.OutputTranscription,
 		},
 		Actions: session.EventActions{
-			StateDelta:        event.Actions.StateDelta,
-			ArtifactDelta:     event.Actions.ArtifactDelta,
-			Escalate:          event.Actions.Escalate,
-			SkipSummarization: event.Actions.SkipSummarization,
-			TransferToAgent:   event.Actions.TransferToAgent,
+			StateDelta:                 event.Actions.StateDelta,
+			ArtifactDelta:              event.Actions.ArtifactDelta,
+			Escalate:                   event.Actions.Escalate,
+			SkipSummarization:          event.Actions.SkipSummarization,
+			TransferToAgent:            event.Actions.TransferToAgent,
+			RequestedToolConfirmations: event.Actions.RequestedToolConfirmations,
 		},
 	}
 }
@@ -103,6 +112,9 @@ func FromSessionEvent(event session.Event) Event {
 		LongRunningToolIDs:  event.LongRunningToolIDs,
 		Output:              event.Output,
 		NodeInfo:            event.NodeInfo,
+		IsolationScope:      event.IsolationScope,
+		Routes:              event.Routes,
+		RequestedInput:      event.RequestedInput,
 		AvgLogprobs:         event.LLMResponse.AvgLogprobs,
 		Content:             event.LLMResponse.Content,
 		GroundingMetadata:   event.LLMResponse.GroundingMetadata,
@@ -116,11 +128,12 @@ func FromSessionEvent(event session.Event) Event {
 		InputTranscription:  event.LLMResponse.InputTranscription,
 		OutputTranscription: event.LLMResponse.OutputTranscription,
 		Actions: EventActions{
-			StateDelta:        event.Actions.StateDelta,
-			ArtifactDelta:     event.Actions.ArtifactDelta,
-			Escalate:          event.Actions.Escalate,
-			SkipSummarization: event.Actions.SkipSummarization,
-			TransferToAgent:   event.Actions.TransferToAgent,
+			StateDelta:                 event.Actions.StateDelta,
+			ArtifactDelta:              event.Actions.ArtifactDelta,
+			Escalate:                   event.Actions.Escalate,
+			SkipSummarization:          event.Actions.SkipSummarization,
+			TransferToAgent:            event.Actions.TransferToAgent,
+			RequestedToolConfirmations: event.Actions.RequestedToolConfirmations,
 		},
 	}
 }

--- a/server/adkrest/internal/models/event_test.go
+++ b/server/adkrest/internal/models/event_test.go
@@ -1,0 +1,61 @@
+// Copyright 2026 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package models_test
+
+import (
+	"testing"
+
+	"google.golang.org/adk/server/adkrest/internal/models"
+	"google.golang.org/adk/session"
+	"google.golang.org/adk/tool/toolconfirmation"
+)
+
+// TestEventRoundTripPreservesWorkflowFields asserts the REST event model
+// round-trips every v2 workflow field added to session.Event so external
+// readers and re-submitted events do not lose them.
+func TestEventRoundTripPreservesWorkflowFields(t *testing.T) {
+	ev := session.Event{
+		ID:             "e1",
+		Author:         "agent",
+		IsolationScope: "scope-1",
+		Routes:         []string{"next-node", "fallback"},
+		RequestedInput: &session.RequestInput{InterruptID: "approve", Message: "ok?"},
+		NodeInfo:       &session.NodeInfo{Path: "root/child", MessageAsOutput: true},
+		Output:         "hello",
+		Actions: session.EventActions{
+			RequestedToolConfirmations: map[string]toolconfirmation.ToolConfirmation{
+				"call-1": {Hint: "please confirm"},
+			},
+		},
+	}
+
+	back := models.ToSessionEvent(models.FromSessionEvent(ev))
+
+	if back.IsolationScope != ev.IsolationScope {
+		t.Errorf("IsolationScope = %q, want %q", back.IsolationScope, ev.IsolationScope)
+	}
+	if len(back.Routes) != len(ev.Routes) || back.Routes[0] != "next-node" {
+		t.Errorf("Routes = %v, want %v", back.Routes, ev.Routes)
+	}
+	if back.RequestedInput == nil || back.RequestedInput.InterruptID != "approve" {
+		t.Errorf("RequestedInput = %+v, want InterruptID=approve", back.RequestedInput)
+	}
+	if back.NodeInfo == nil || back.NodeInfo.Path != "root/child" {
+		t.Errorf("NodeInfo = %+v, want Path=root/child", back.NodeInfo)
+	}
+	if got, ok := back.Actions.RequestedToolConfirmations["call-1"]; !ok || got.Hint != "please confirm" {
+		t.Errorf("RequestedToolConfirmations = %+v, want call-1 hint", back.Actions.RequestedToolConfirmations)
+	}
+}


### PR DESCRIPTION
## Problem
The adkrest REST event wire model did not include several `session.Event`
fields added in v2 — `IsolationScope`, `Routes`, `RequestedInput`, and
`Actions.RequestedToolConfirmations`. Mapping an event to the REST model and
back (when serving or re-submitting events) silently dropped them.

## Solution
Add the missing fields to the REST `Event`/`EventActions` structs and map them
in both `FromSessionEvent` and `ToSessionEvent`, making the round-trip lossless.
Adds a round-trip test asserting all four fields survive.