### PR TITLE
Fix artifact version create time format

### DIFF
--- a/artifact/gcsartifact/service.go
+++ b/artifact/gcsartifact/service.go
@@ -400,7 +400,7 @@ func (s *gcsService) GetArtifactVersion(ctx context.Context, req *artifact.GetAr
 			Version:        version,
 			CanonicalURI:   canonicalURI,
 			CustomMetadata: customMeta,
-			CreateTime:     float64(attrs.Created.Unix()),
+			CreateTime:     attrs.Created.Unix(),
 			MimeType:       attrs.ContentType,
 		},
 	}, nil

--- a/artifact/gcsartifact/service.go
+++ b/artifact/gcsartifact/service.go
@@ -400,7 +400,7 @@ func (s *gcsService) GetArtifactVersion(ctx context.Context, req *artifact.GetAr
 			Version:        version,
 			CanonicalURI:   canonicalURI,
 			CustomMetadata: customMeta,
-			CreateTime:     attrs.Created.Unix(),
+			CreateTime:     attrs.Created,
 			MimeType:       attrs.ContentType,
 		},
 	}, nil

--- a/artifact/service.go
+++ b/artifact/service.go
@@ -267,7 +267,7 @@ type ArtifactVersion struct {
 	Version        int64
 	CanonicalURI   string
 	CustomMetadata map[string]any
-	CreateTime     float64
+	CreateTime     int64
 	MimeType       string
 }
 

--- a/artifact/service.go
+++ b/artifact/service.go
@@ -23,6 +23,7 @@ import (
 	"context"
 	"fmt"
 	"strings"
+	"time"
 
 	"google.golang.org/genai"
 )
@@ -267,7 +268,7 @@ type ArtifactVersion struct {
 	Version        int64
 	CanonicalURI   string
 	CustomMetadata map[string]any
-	CreateTime     int64
+	CreateTime     time.Time
 	MimeType       string
 }
 


### PR DESCRIPTION
**Please ensure you have read the [contribution guide](./CONTRIBUTING.md) before creating a pull request.**

### Link to Issue or Description of Change

**1. Link to an existing issue (if applicable):**

- Closes: #685 

**2. Or, if no issue exists, describe the change:**

_If applicable, please follow the issue templates to provide as much detail as
possible._

**Problem:**
`CreateTime` was set using `float64(attrs.Created.Unix())`, which unnecessarily casts the value to `float64`. `time.Time` is more straightforward, making the cast redundant. 

**Solution:**
Drop the cast and use `attrs.Created` directly, which returns `time.Time` as required.

### Testing Plan

_Please describe the tests that you ran to verify your changes. This is required
for all PRs that are not small documentation or typo fixes._

**Unit Tests:**

- [ ] I have added or updated unit tests for my change.
- [ ] All unit tests pass locally.

_Please include a summary of passed go test results._

**Manual End-to-End (E2E) Tests:**

_Please provide instructions on how to manually test your changes, including any
necessary setup or configuration. Please provide logs or screenshots to help
reviewers better understand the fix._

### Checklist

- [x] I have read the [CONTRIBUTING.md](./CONTRIBUTING.md) document.
- [x] I have performed a self-review of my own code.
- [ ] I have commented my code, particularly in hard-to-understand areas.
- [ ] I have added tests that prove my fix is effective or that my feature works.
- [ ] New and existing unit tests pass locally with my changes.
- [ ] I have manually tested my changes end-to-end.
- [ ] Any dependent changes have been merged and published in downstream modules.

### Additional context

_Add any other context or screenshots about the feature request here._

