### PR TITLE
fix(workflow): synthesize node output only from the node agent's own events

### DIFF
--- a/workflow/agent_node.go
+++ b/workflow/agent_node.go
@@ -127,11 +127,10 @@ func (n *AgentNode) Run(ctx agent.Context, input any) iter.Seq2[*session.Event, 
 			events = n.agent.Run(exCtx)
 		}
 
-		skipSynthesize := false
+		// Task-mode LlmAgents set their output via runTask, not model text.
+		synthesizeMode := true
 		if llmA, ok := n.agent.(llminternal.Agent); ok && llmA != nil {
-			if llminternal.Reveal(llmA).Mode == llminternal.ModeTask {
-				skipSynthesize = true
-			}
+			synthesizeMode = llminternal.Reveal(llmA).Mode != llminternal.ModeTask
 		}
 
 		for event, err := range events {
@@ -140,7 +139,11 @@ func (n *AgentNode) Run(ctx agent.Context, input any) iter.Seq2[*session.Event, 
 				return
 			}
 
-			if !skipSynthesize {
+			// Synthesize output only from the node agent's own reply. A
+			// composite agent streams one final response per sub-agent
+			// (each a distinct author); synthesizing every one would emit
+			// several node outputs and trip the one-output-per-node rule.
+			if synthesizeMode && isOwnAgentEvent(event, n.agent.Name()) {
 				synthesizeAgentOutput(event)
 			}
 
@@ -198,6 +201,17 @@ func synthesizeAgentOutput(event *session.Event) {
 		}
 		event.NodeInfo.MessageAsOutput = true
 	}
+}
+
+// isOwnAgentEvent reports whether ev came from the node's own agent.
+// Empty author counts as own (agent.Run stamps the node agent's name on
+// its un-authored events); composite sub-agent events carry the
+// sub-agent's name.
+func isOwnAgentEvent(ev *session.Event, nodeAgentName string) bool {
+	if ev == nil {
+		return false
+	}
+	return ev.Author == "" || ev.Author == nodeAgentName
 }
 
 // messageText concatenates the non-thought model text of an event. ok

--- a/workflow/agent_node.go
+++ b/workflow/agent_node.go
@@ -139,10 +139,9 @@ func (n *AgentNode) Run(ctx agent.Context, input any) iter.Seq2[*session.Event, 
 				return
 			}
 
-			// Synthesize output only from the node agent's own reply. A
-			// composite agent streams one final response per sub-agent
-			// (each a distinct author); synthesizing every one would emit
-			// several node outputs and trip the one-output-per-node rule.
+			// A composite agent yields one final response per sub-agent
+			// (each a distinct author); synthesizing all of them would
+			// trip the one-output-per-node rule.
 			if synthesizeMode && isOwnAgentEvent(event, n.agent.Name()) {
 				synthesizeAgentOutput(event)
 			}
@@ -204,9 +203,8 @@ func synthesizeAgentOutput(event *session.Event) {
 }
 
 // isOwnAgentEvent reports whether ev came from the node's own agent.
-// Empty author counts as own (agent.Run stamps the node agent's name on
-// its un-authored events); composite sub-agent events carry the
-// sub-agent's name.
+// Un-authored events count as own (agent.Run stamps the node agent's
+// name); composite sub-agents keep their own author.
 func isOwnAgentEvent(ev *session.Event, nodeAgentName string) bool {
 	if ev == nil {
 		return false

--- a/workflow/agent_node_modes_test.go
+++ b/workflow/agent_node_modes_test.go
@@ -101,6 +101,50 @@ func TestAgentNode_TaskMode_DoesNotPromoteModelText(t *testing.T) {
 	}
 }
 
+func TestAgentNode_SequentialAgentAsNode_NoMultipleOutputs(t *testing.T) {
+	t.Parallel()
+
+	seqNode, err := sequentialagent.New(sequentialagent.Config{
+		AgentConfig: agent.Config{
+			Name:      "seq_node",
+			SubAgents: []agent.Agent{fixedTextAgent(t, "seq_a", "SEQ_A"), fixedTextAgent(t, "seq_b", "SEQ_B")},
+		},
+	})
+	if err != nil {
+		t.Fatalf("sequentialagent.New: %v", err)
+	}
+
+	node, err := workflow.NewAgentNode(seqNode, workflow.NodeConfig{})
+	if err != nil {
+		t.Fatalf("NewAgentNode: %v", err)
+	}
+
+	ctx := newRunnableNodeContext(t, seqNode)
+	assertSubAgentOutputsNotSynthesized(t, node, "seq_node", ctx, "seq_a", "seq_b")
+}
+
+func TestAgentNode_ParallelAgentAsNode_NoMultipleOutputs(t *testing.T) {
+	t.Parallel()
+
+	parNode, err := parallelagent.New(parallelagent.Config{
+		AgentConfig: agent.Config{
+			Name:      "par_node",
+			SubAgents: []agent.Agent{fixedTextAgent(t, "par_a", "PAR_A"), fixedTextAgent(t, "par_b", "PAR_B")},
+		},
+	})
+	if err != nil {
+		t.Fatalf("parallelagent.New: %v", err)
+	}
+
+	node, err := workflow.NewAgentNode(parNode, workflow.NodeConfig{})
+	if err != nil {
+		t.Fatalf("NewAgentNode: %v", err)
+	}
+
+	ctx := newRunnableNodeContext(t, parNode)
+	assertSubAgentOutputsNotSynthesized(t, node, "par_node", ctx, "par_a", "par_b")
+}
+
 // newRunnableNodeContext builds the minimal NodeContext an LlmAgent
 // flow needs: in-memory Session, Agent, and a RunConfig on the
 // embedded context (the flow reads it via runconfig.FromContext and
@@ -198,48 +242,4 @@ func assertSubAgentOutputsNotSynthesized(t *testing.T, node workflow.Node, nodeN
 			t.Errorf("missing final event from sub-agent %q", a)
 		}
 	}
-}
-
-func TestAgentNode_SequentialAgentAsNode_NoMultipleOutputs(t *testing.T) {
-	t.Parallel()
-
-	seqNode, err := sequentialagent.New(sequentialagent.Config{
-		AgentConfig: agent.Config{
-			Name:      "seq_node",
-			SubAgents: []agent.Agent{fixedTextAgent(t, "seq_a", "SEQ_A"), fixedTextAgent(t, "seq_b", "SEQ_B")},
-		},
-	})
-	if err != nil {
-		t.Fatalf("sequentialagent.New: %v", err)
-	}
-
-	node, err := workflow.NewAgentNode(seqNode, workflow.NodeConfig{})
-	if err != nil {
-		t.Fatalf("NewAgentNode: %v", err)
-	}
-
-	ctx := newRunnableNodeContext(t, seqNode)
-	assertSubAgentOutputsNotSynthesized(t, node, "seq_node", ctx, "seq_a", "seq_b")
-}
-
-func TestAgentNode_ParallelAgentAsNode_NoMultipleOutputs(t *testing.T) {
-	t.Parallel()
-
-	parNode, err := parallelagent.New(parallelagent.Config{
-		AgentConfig: agent.Config{
-			Name:      "par_node",
-			SubAgents: []agent.Agent{fixedTextAgent(t, "par_a", "PAR_A"), fixedTextAgent(t, "par_b", "PAR_B")},
-		},
-	})
-	if err != nil {
-		t.Fatalf("parallelagent.New: %v", err)
-	}
-
-	node, err := workflow.NewAgentNode(parNode, workflow.NodeConfig{})
-	if err != nil {
-		t.Fatalf("NewAgentNode: %v", err)
-	}
-
-	ctx := newRunnableNodeContext(t, parNode)
-	assertSubAgentOutputsNotSynthesized(t, node, "par_node", ctx, "par_a", "par_b")
 }

--- a/workflow/agent_node_modes_test.go
+++ b/workflow/agent_node_modes_test.go
@@ -23,6 +23,8 @@ import (
 
 	"google.golang.org/adk/agent"
 	"google.golang.org/adk/agent/llmagent"
+	"google.golang.org/adk/agent/workflowagents/parallelagent"
+	"google.golang.org/adk/agent/workflowagents/sequentialagent"
 	"google.golang.org/adk/internal/agent/runconfig"
 	icontext "google.golang.org/adk/internal/context"
 	"google.golang.org/adk/model"
@@ -151,3 +153,93 @@ func (s *scriptedLLM) GenerateContent(_ context.Context, _ *model.LLMRequest, _ 
 }
 
 var _ model.LLM = (*scriptedLLM)(nil)
+
+func fixedTextAgent(t *testing.T, name, text string) agent.Agent {
+	t.Helper()
+	llm := &scriptedLLM{turns: []*model.LLMResponse{{
+		Content: &genai.Content{
+			Role:  "model",
+			Parts: []*genai.Part{{Text: text}},
+		},
+	}}}
+	a, err := llmagent.New(llmagent.Config{Name: name, Model: llm})
+	if err != nil {
+		t.Fatalf("llmagent.New(%q): %v", name, err)
+	}
+	return a
+}
+
+// assertSubAgentOutputsNotSynthesized fails if a composite's sub-agent events
+// were promoted to node outputs (each would trip the one-output-per-node rule).
+func assertSubAgentOutputsNotSynthesized(t *testing.T, node workflow.Node, nodeName string, ctx agent.Context, wantAuthors ...string) {
+	t.Helper()
+
+	seen := map[string]bool{}
+	for ev, err := range node.Run(ctx, nil) {
+		if err != nil {
+			t.Fatalf("node.Run yielded err: %v", err)
+		}
+		if ev == nil || ev.LLMResponse.Partial {
+			continue
+		}
+		if ev.Author != "" && ev.Author != nodeName {
+			seen[ev.Author] = true
+			if ev.Output != nil {
+				t.Errorf("sub-agent %q event Output = %v, want nil", ev.Author, ev.Output)
+			}
+			if ev.NodeInfo != nil && ev.NodeInfo.MessageAsOutput {
+				t.Errorf("sub-agent %q event MessageAsOutput = true, want false", ev.Author)
+			}
+		}
+	}
+
+	for _, a := range wantAuthors {
+		if !seen[a] {
+			t.Errorf("missing final event from sub-agent %q", a)
+		}
+	}
+}
+
+func TestAgentNode_SequentialAgentAsNode_NoMultipleOutputs(t *testing.T) {
+	t.Parallel()
+
+	seqNode, err := sequentialagent.New(sequentialagent.Config{
+		AgentConfig: agent.Config{
+			Name:      "seq_node",
+			SubAgents: []agent.Agent{fixedTextAgent(t, "seq_a", "SEQ_A"), fixedTextAgent(t, "seq_b", "SEQ_B")},
+		},
+	})
+	if err != nil {
+		t.Fatalf("sequentialagent.New: %v", err)
+	}
+
+	node, err := workflow.NewAgentNode(seqNode, workflow.NodeConfig{})
+	if err != nil {
+		t.Fatalf("NewAgentNode: %v", err)
+	}
+
+	ctx := newRunnableNodeContext(t, seqNode)
+	assertSubAgentOutputsNotSynthesized(t, node, "seq_node", ctx, "seq_a", "seq_b")
+}
+
+func TestAgentNode_ParallelAgentAsNode_NoMultipleOutputs(t *testing.T) {
+	t.Parallel()
+
+	parNode, err := parallelagent.New(parallelagent.Config{
+		AgentConfig: agent.Config{
+			Name:      "par_node",
+			SubAgents: []agent.Agent{fixedTextAgent(t, "par_a", "PAR_A"), fixedTextAgent(t, "par_b", "PAR_B")},
+		},
+	})
+	if err != nil {
+		t.Fatalf("parallelagent.New: %v", err)
+	}
+
+	node, err := workflow.NewAgentNode(parNode, workflow.NodeConfig{})
+	if err != nil {
+		t.Fatalf("NewAgentNode: %v", err)
+	}
+
+	ctx := newRunnableNodeContext(t, parNode)
+	assertSubAgentOutputsNotSynthesized(t, node, "par_node", ctx, "par_a", "par_b")
+}


### PR DESCRIPTION
## Problem

A classic composite agent (`SequentialAgent` / `ParallelAgent` / `LoopAgent`)
wrapped as a single graph node fails:

" workflow: node produced multiple events with output values;"

`AgentNode` synthesized `Event.Output` (and `NodeInfo.MessageAsOutput`) on every
final-response event. A composite node streams one final response **per
sub-agent**, so each sub-agent reply became a node output and tripped the
scheduler's one-output-per-node rule. 

adk-python doesn't do this — a node's output is derived only from the node agent itself 
(`run_llm_agent_as_node`), not its sub-agents.

## Solution
Gate output synthesis to the node agent's **own** events (empty author, or
author == the node agent's name). Sub-agent events carry the sub-agent's name
and now pass through untouched. The task-mode exclusion and single-agent output
extraction are preserved.