### PR TITLE
fix(console): surface terminal node output and trim input newline

### DIFF
--- a/cmd/launcher/console/console.go
+++ b/cmd/launcher/console/console.go
@@ -18,6 +18,7 @@ package console
 import (
 	"bufio"
 	"context"
+	"encoding/json"
 	"errors"
 	"flag"
 	"fmt"
@@ -25,6 +26,7 @@ import (
 	"log"
 	"os"
 	"os/signal"
+	"strings"
 	"time"
 
 	"google.golang.org/genai"
@@ -163,6 +165,9 @@ func (l *consoleLauncher) Run(ctx context.Context, config *launcher.Config) erro
 			}
 			log.Fatal(err)
 		case userInput := <-inputChan:
+			// Drop the line terminator the reader keeps, so the message
+			// matches what the web UI submits (no trailing newline).
+			userInput = strings.TrimRight(userInput, "\r\n")
 
 			var userMsg *genai.Content
 			if len(pendingInterrupts) > 0 {
@@ -198,6 +203,8 @@ func (l *consoleLauncher) Run(ctx context.Context, config *launcher.Config) erro
 
 			fmt.Print("\nAgent -> ")
 			prevText := ""
+			printedContent := false
+			var finalOutput any
 			var collectedEvents []*session.Event
 			for event, err := range r.Run(ctx, userID, sess.ID(), userMsg, agent.RunConfig{
 				StreamingMode: streamingMode,
@@ -207,12 +214,21 @@ func (l *consoleLauncher) Run(ctx context.Context, config *launcher.Config) erro
 				} else {
 					collectedEvents = append(collectedEvents, event)
 					if event.LLMResponse.Content == nil {
+						// Function/terminal nodes carry their result in
+						// Event.Output, not model content; keep the latest
+						// so a content-less turn still surfaces a result.
+						if event.Output != nil {
+							finalOutput = event.Output
+						}
 						continue
 					}
 
 					text := ""
 					for _, p := range event.LLMResponse.Content.Parts {
 						text += p.Text
+					}
+					if text != "" {
+						printedContent = true
 					}
 
 					if streamingMode != agent.StreamingModeSSE {
@@ -245,9 +261,27 @@ func (l *consoleLauncher) Run(ctx context.Context, config *launcher.Config) erro
 				renderInterruptPrompt(pendingInterrupts[0])
 				continue
 			}
+			// A workflow whose terminal node returns a value rather than
+			// model content streams no text; surface that result so the
+			// turn isn't silent.
+			if !printedContent && finalOutput != nil {
+				fmt.Print(renderOutput(finalOutput))
+			}
 			fmt.Print("\nUser -> ")
 		}
 	}
+}
+
+// renderOutput formats a node's Output value for the console: strings
+// as-is, anything else as compact JSON.
+func renderOutput(v any) string {
+	if s, ok := v.(string); ok {
+		return s
+	}
+	if b, err := json.Marshal(v); err == nil {
+		return string(b)
+	}
+	return fmt.Sprint(v)
 }
 
 // Parse implements launcher.SubLauncher. After parsing console-specific

--- a/cmd/launcher/console/hitl_test.go
+++ b/cmd/launcher/console/hitl_test.go
@@ -437,3 +437,25 @@ func TestRenderWorkflowInputPrompt_PayloadFormatting(t *testing.T) {
 		})
 	}
 }
+
+func TestRenderOutput(t *testing.T) {
+	tests := []struct {
+		name string
+		in   any
+		want string
+	}{
+		{"string verbatim", "Hello, Alice!", "Hello, Alice!"},
+		{"empty string", "", ""},
+		{"int", 42, "42"},
+		{"struct as json", struct {
+			Result string `json:"result"`
+		}{Result: "ok"}, `{"result":"ok"}`},
+	}
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			if got := renderOutput(tc.in); got != tc.want {
+				t.Errorf("renderOutput(%#v) = %q, want %q", tc.in, got, tc.want)
+			}
+		})
+	}
+}


### PR DESCRIPTION
## Problem
The console launcher rendered only model content (`Event.LLMResponse.Content`).
A workflow whose terminal node returns its result via `Event.Output` rather than
model content — e.g. a `FunctionNode` — therefore printed an empty `Agent ->`,
so the run looked silent even though it produced a result.
Console input also kept the trailing newline `bufio.Reader.ReadString` returns,
so it leaked into downstream string handling (e.g. a node turning `"hello\n"`
into `"HELLO\n IS AWESOME!"`). The web UI submits the message without a trailing
newline, so the two surfaces disagreed.

Some of our examples with function nodes (e.g. examples/workflow/basic) don't really work while launching with console.

## Solution
- Trim the trailing line terminator from console input, so the message matches
  what the web UI submits (and what adk-python's `input()`-based CLI does).
- When a turn streams no model content, print the terminal `Event.Output`
  (strings as-is, other types as compact JSON). Turns that already streamed
  content are left unchanged, so agent replies are never duplicated.
Content-bearing turns (LLM agents, nodes that emit `Content`) render exactly as
before; function/terminal-node workflows are now visible instead of an empty