### PR TITLE
fix(workflow): scope HITL resume rehydration to the run's invocation

### DIFF
--- a/agent/workflowagent/workflow.go
+++ b/agent/workflowagent/workflow.go
@@ -139,7 +139,10 @@ func (a *workflowAgent) detectResume(ctx agent.InvocationContext) (map[string]an
 		return nil, nil, false, nil
 	}
 
-	state, err := a.workflow.ReconstructRunState(ctx.Session())
+	// Scope rehydration to this run's invocation (the runner reuses the
+	// paused run's ID on resume) so a prior completed run in the same
+	// session does not leak in.
+	state, err := a.workflow.ReconstructRunState(ctx.Session(), ctx.InvocationID())
 	if err != nil {
 		// A bad resume (e.g. failed schema validation) must fail,
 		// not silently fall through to a fresh Run.

--- a/examples/workflow/dynamic/hitl/main.go
+++ b/examples/workflow/dynamic/hitl/main.go
@@ -52,8 +52,11 @@ func main() {
 
 	ask := workflow.NewEmittingFunctionNode[any, any]("ask_name",
 		func(ctx agent.Context, _ any, emit func(*session.Event) error) (any, error) {
+			// InterruptID embeds the invocation ID: stable within a run
+			// (the greeter resolves by the same key) yet unique per run
+			// for the Dev UI.
 			if err := emit(workflow.NewRequestInputEvent(ctx, session.RequestInput{
-				InterruptID: "ask_name",
+				InterruptID: "ask_name-" + ctx.InvocationID(),
 				Message:     "What's your name?",
 			})); err != nil {
 				return nil, err
@@ -65,8 +68,9 @@ func main() {
 
 	greeter := workflow.NewDynamicNode[string, string]("hitl_demo",
 		func(nc workflow.NodeContext, _ string, emit func(*session.Event) error) (string, error) {
-			// Resume re-entry: the reply is in ResumedInput.
-			if reply, ok := nc.ResumedInput("ask_name"); ok {
+			// Resume re-entry: the reply is in ResumedInput, keyed by
+			// the same invocation-derived ID the ask node emitted.
+			if reply, ok := nc.ResumedInput("ask_name-" + nc.InvocationID()); ok {
 				name, _ := reply.(string)
 				if name == "" {
 					name = "stranger"

--- a/examples/workflow/hitl_rerun/main.go
+++ b/examples/workflow/hitl_rerun/main.go
@@ -53,8 +53,11 @@ func main() {
 			// ResumeOrRequestInput pauses (asks and returns
 			// ErrNodeInterrupted) on the first pass, and returns the
 			// human's reply once the node is re-run after the answer.
+			// InterruptID embeds the invocation ID: stable across this
+			// run's re-entry so the reply still correlates, yet unique
+			// per run so the Dev UI re-prompts on a later run.
 			reply, err := workflow.ResumeOrRequestInput(nc, emit, session.RequestInput{
-				InterruptID: "ask_name",
+				InterruptID: "ask_name-" + nc.InvocationID(),
 				Message:     "What's your name?",
 			})
 			if err != nil {

--- a/examples/workflow/hitl_simple/main.go
+++ b/examples/workflow/hitl_simple/main.go
@@ -37,6 +37,8 @@ import (
 	"log"
 	"os"
 
+	"github.com/google/uuid"
+
 	"google.golang.org/adk/agent"
 	"google.golang.org/adk/agent/workflowagent"
 	"google.golang.org/adk/cmd/launcher"
@@ -50,8 +52,12 @@ func main() {
 
 	ask := workflow.NewEmittingFunctionNode[any, any]("ask_name",
 		func(ctx agent.Context, _ any, emit func(*session.Event) error) (any, error) {
+			// Unique InterruptID per request: a reused ID would let the
+			// Dev UI treat a later run's prompt as already answered.
+			// Mirrors adk-python (RequestInput.interrupt_id defaults to
+			// a fresh UUID).
 			if err := emit(workflow.NewRequestInputEvent(ctx, session.RequestInput{
-				InterruptID: "ask_name",
+				InterruptID: "ask_name-" + uuid.NewString(),
 				Message:     "What's your name?",
 			})); err != nil {
 				return nil, err

--- a/runner/hitl_integration_test.go
+++ b/runner/hitl_integration_test.go
@@ -256,6 +256,43 @@ func TestRunner_WorkflowHITL_DynamicOrchestrator_Resume(t *testing.T) {
 	}
 }
 
+// TestRunner_WorkflowHITL_TwoFullCycles_SameSession guards the re-run
+// case behind the hitl_simple bug: two complete pause/resume cycles in
+// one session must not collide. Each pause gets a fresh auto-generated
+// interrupt ID and rehydration is scoped to the resumed run's
+// invocation (adk-python parity), so the second resume still routes its
+// response to the handler instead of failing with ErrNothingToResume.
+func TestRunner_WorkflowHITL_TwoFullCycles_SameSession(t *testing.T) {
+	ctx := t.Context()
+
+	asker := newHitlAsker("asker", "", false /*rerunOnResume*/)
+	var handlerInput atomic.Value
+	handler := workflow.NewFunctionNode(
+		"handler",
+		func(ctx agent.Context, input string) (string, error) {
+			handlerInput.Store(input)
+			return "handled:" + input, nil
+		},
+		workflow.NodeConfig{},
+	)
+	r := newWorkflowRunner(t, workflow.Chain(workflow.Start, asker, handler))
+
+	runCycle := func(answer string) {
+		turn1 := drainRunner(t, r.Run(ctx, nodeTestUser, nodeTestSession, userText("draft"), agent.RunConfig{}))
+		callID, callName := findLongRunningInterrupt(turn1)
+		if callID == "" {
+			t.Fatalf("fresh turn produced no interrupt; events:\n%s", debugEvents(turn1))
+		}
+		drainRunner(t, r.Run(ctx, nodeTestUser, nodeTestSession, resumeContent(callID, callName, answer), agent.RunConfig{}))
+		if got, want := handlerInput.Load(), answer; got != want {
+			t.Fatalf("handler input = %v, want %q", got, want)
+		}
+	}
+
+	runCycle("first")
+	runCycle("second")
+}
+
 // newWorkflowRunner builds a runner driving a workflow agent over the
 // given edges, with its session pre-created.
 func newWorkflowRunner(t *testing.T, edges []workflow.Edge) *runner.Runner {

--- a/runner/run_node.go
+++ b/runner/run_node.go
@@ -129,7 +129,7 @@ func (r *Runner) runNode(
 	// Resume (HITL continuation) vs Run (fresh): a resume is a turn whose
 	// function response answers a node waiting on an open interrupt. The
 	// paused state comes from session history, not a persisted blob.
-	state, err := wf.ReconstructRunState(storedSession)
+	state, err := wf.ReconstructRunState(storedSession, ictx.InvocationID())
 	if err != nil {
 		yield(nil, fmt.Errorf("failed to reconstruct workflow run state: %w", err))
 		return
@@ -238,12 +238,13 @@ func (r *Runner) newNodeInvocationContext(
 	}
 
 	ic := icontext.NewInvocationContext(ctx, icontext.InvocationContextParams{
-		Artifacts:   artifacts,
-		Memory:      memoryImpl,
-		Session:     storedSession,
-		Agent:       agentToRun,
-		UserContent: msg,
-		RunConfig:   &cfg,
+		Artifacts:    artifacts,
+		Memory:       memoryImpl,
+		Session:      storedSession,
+		Agent:        agentToRun,
+		UserContent:  msg,
+		RunConfig:    &cfg,
+		InvocationID: resolveInvocationID(storedSession, msg),
 	})
 	resCtx := agent.NewNodeContext(ic, nil)
 	return resCtx
@@ -358,4 +359,47 @@ func waitingInterruptIDs(state *workflow.RunState) map[string]struct{} {
 		}
 	}
 	return ids
+}
+
+// resolveInvocationID reuses the paused run's invocation ID when msg is a
+// HITL resume (carries a function response), so the resume turn and the
+// pause it answers share one ID and rehydration can scope to a single
+// run. Returns "" for a fresh turn or when the answered call is not in
+// history, letting the caller mint a fresh ID. Go analog of adk-python
+// Runner._resolve_invocation_id.
+func resolveInvocationID(sess session.Session, msg *genai.Content) string {
+	if sess == nil || msg == nil {
+		return ""
+	}
+	for _, fr := range utils.FunctionResponses(msg) {
+		if fr == nil || fr.ID == "" {
+			continue
+		}
+		if ev := findEventByFunctionCallID(sess, fr.ID); ev != nil {
+			return ev.InvocationID
+		}
+	}
+	return ""
+}
+
+// findEventByFunctionCallID returns the most recent event whose content
+// carries a FunctionCall with the given id, or nil. Go analog of
+// adk-python functions.find_event_by_function_call_id (reverse scan).
+func findEventByFunctionCallID(sess session.Session, id string) *session.Event {
+	if sess == nil || id == "" {
+		return nil
+	}
+	events := sess.Events()
+	for i := events.Len() - 1; i >= 0; i-- {
+		ev := events.At(i)
+		if ev == nil {
+			continue
+		}
+		for _, fc := range utils.FunctionCalls(utils.Content(ev)) {
+			if fc != nil && fc.ID == id {
+				return ev
+			}
+		}
+	}
+	return nil
 }

--- a/runner/run_node_test.go
+++ b/runner/run_node_test.go
@@ -301,7 +301,7 @@ func runStateForAgent(t *testing.T, ctx context.Context, svc session.Service, a 
 	if err != nil {
 		t.Fatalf("workflow.New() error = %v", err)
 	}
-	state, err := wf.ReconstructRunState(got.Session)
+	state, err := wf.ReconstructRunState(got.Session, "")
 	if err != nil {
 		t.Fatalf("ReconstructRunState() error = %v", err)
 	}

--- a/runner/runner.go
+++ b/runner/runner.go
@@ -260,12 +260,13 @@ func (r *Runner) Run(ctx context.Context, userID, sessionID string, msg *genai.C
 		}
 
 		ic := icontext.NewInvocationContext(ctx, icontext.InvocationContextParams{
-			Artifacts:   artifacts,
-			Memory:      memoryImpl,
-			Session:     storedSession,
-			Agent:       r.rootAgent,
-			UserContent: msg,
-			RunConfig:   &cfg,
+			Artifacts:    artifacts,
+			Memory:       memoryImpl,
+			Session:      storedSession,
+			Agent:        r.rootAgent,
+			UserContent:  msg,
+			RunConfig:    &cfg,
+			InvocationID: resolveInvocationID(storedSession, msg),
 		})
 		ctx := agent.NewNodeContext(ic, nil)
 		ctx, _, err = r.appendMessageToSession(ctx, storedSession, msg, cfg.SaveInputBlobsAsArtifacts, r.pluginManager, options.stateDelta)

--- a/session/session.go
+++ b/session/session.go
@@ -177,11 +177,19 @@ type NodeInfo struct {
 // binary data, stash the bytes via agent.Artifacts and put a URI
 // string in Payload.
 type RequestInput struct {
-	// InterruptID is the stable correlation key for this request.
-	// It identifies the intent of the prompt (e.g. "manager_approval",
-	// "human_review"). If empty when the node yields the event, the
-	// engine fills in a UUID so the downstream contract is always a
-	// non-empty string.
+	// InterruptID correlates this request with the response that
+	// resumes it; the reply is routed back by matching this ID.
+	// Prefer a value that is unique per request: leave it empty and
+	// the engine fills in a fresh UUID (the recommended default), or
+	// build your own from a readable prefix plus a UUID
+	// (e.g. "manager_approval-"+uuid).
+	//
+	// Avoid reusing one fixed literal across separate runs in the same
+	// session. ADK clients — notably the Dev UI — track answered
+	// requests by this ID and will not re-prompt for an ID already
+	// resolved earlier in the session, so a later run that reuses it
+	// shows no input box. Mirrors adk-python RequestInput.interrupt_id,
+	// which defaults to a fresh UUID.
 	InterruptID string `json:"interruptId"`
 
 	// Message is the human-readable description of what is being

--- a/workflow/persistence.go
+++ b/workflow/persistence.go
@@ -68,7 +68,16 @@ func (s *nodeScanState) addInterrupt(id string) {
 // response schema. inferNodeState then maps that scan to a NodeState
 // (WAITING / PENDING+ResumedInputs / COMPLETED+Output). Returns
 // (nil, nil) when no node has interrupt history.
-func (w *Workflow) ReconstructRunState(sess session.Session) (*RunState, error) {
+//
+// invocationID scopes the scan to a single logical run: events from
+// other invocations are skipped, so a fresh run started in a session
+// that already holds a completed run does not collide with it (a stable
+// InterruptID reused across runs would otherwise rehydrate against the
+// prior, already-resolved interrupt). The runner reuses the paused
+// run's invocation ID for the resume turn, so the pause and its reply
+// share it. Empty invocationID disables the filter (scan all history).
+// Mirrors adk-python _reconstruct_node_states' invocation_id gate.
+func (w *Workflow) ReconstructRunState(sess session.Session, invocationID string) (*RunState, error) {
 	if sess == nil {
 		return nil, nil
 	}
@@ -77,13 +86,13 @@ func (w *Workflow) ReconstructRunState(sess session.Session) (*RunState, error) 
 
 	// Stage 1: scan history into a per-node view of the pause
 	// (interrupts raised, responses that resolved them, schemas).
-	scans := scanHistory(events, nodesByName)
+	scans := scanHistory(events, nodesByName, invocationID)
 
 	// Stage 2: gather the inputs inferNodeState needs to rebuild a
 	// re-entry node's input: every node's cached output, the set of
 	// nodes that ran, and the workflow's seed input.
-	nodeOutputs, completed := collectNodeOutputs(events, nodesByName)
-	workflowInput := firstUserInput(events)
+	nodeOutputs, completed := collectNodeOutputs(events, nodesByName, invocationID)
+	workflowInput := firstUserInput(events, invocationID)
 
 	// Stage 3: turn each interrupted node's scan into a NodeState.
 	state, err := w.buildRunState(scans, nodesByName, nodeOutputs, workflowInput)
@@ -110,8 +119,9 @@ func (w *Workflow) ReconstructRunState(sess session.Session) (*RunState, error) 
 // node, what history says about a paused run: the long-running
 // interrupts it raised, the user responses that resolved them, and
 // each interrupt's declared response schema. Only nodes with
-// interrupt history are returned.
-func scanHistory(events session.Events, nodesByName map[string]Node) map[string]*nodeScanState {
+// interrupt history are returned. invocationID, when non-empty,
+// restricts the scan to that invocation's events.
+func scanHistory(events session.Events, nodesByName map[string]Node, invocationID string) map[string]*nodeScanState {
 	scans := map[string]*nodeScanState{}
 	interruptOwner := map[string]string{} // interrupt ID -> node name
 	scanFor := func(name string) *nodeScanState {
@@ -126,6 +136,9 @@ func scanHistory(events session.Events, nodesByName map[string]Node) map[string]
 	for i := 0; i < events.Len(); i++ {
 		ev := events.At(i)
 		if ev == nil {
+			continue
+		}
+		if invocationID != "" && ev.InvocationID != invocationID {
 			continue
 		}
 
@@ -182,13 +195,18 @@ func scanHistory(events session.Events, nodesByName map[string]Node) map[string]
 // collectNodeOutputs walks history once and returns each graph node's
 // last cached output plus the set of nodes that emitted any event.
 // The outputs feed predecessor-input reconstruction for re-entry
-// nodes; completed lets Resume skip already-run successors.
-func collectNodeOutputs(events session.Events, nodesByName map[string]Node) (outputs map[string]any, completed map[string]bool) {
+// nodes; completed lets Resume skip already-run successors. When
+// invocationID is non-empty, events from other invocations are skipped
+// so a prior run's completed nodes do not suppress the current run.
+func collectNodeOutputs(events session.Events, nodesByName map[string]Node, invocationID string) (outputs map[string]any, completed map[string]bool) {
 	outputs = map[string]any{}
 	completed = map[string]bool{}
 	for i := 0; i < events.Len(); i++ {
 		ev := events.At(i)
 		if ev == nil {
+			continue
+		}
+		if invocationID != "" && ev.InvocationID != invocationID {
 			continue
 		}
 		name := eventNodeName(ev, nodesByName)
@@ -382,11 +400,16 @@ func (w *Workflow) predecessorInput(node Node, nodeOutputs map[string]any, workf
 // firstUserInput returns the seed workflow input: the text of the
 // first user event in history (the original prompt), used as the
 // START successor's input on re-entry. Resume turns (user
-// FunctionResponses) are skipped.
-func firstUserInput(events session.Events) any {
+// FunctionResponses) are skipped. When invocationID is non-empty, only
+// that invocation's user events are considered, so the seed is the
+// current run's prompt rather than an earlier run's.
+func firstUserInput(events session.Events, invocationID string) any {
 	for i := 0; i < events.Len(); i++ {
 		ev := events.At(i)
 		if ev == nil || ev.Author != "user" || ev.Content == nil {
+			continue
+		}
+		if invocationID != "" && ev.InvocationID != invocationID {
 			continue
 		}
 		var text string

--- a/workflow/persistence_test.go
+++ b/workflow/persistence_test.go
@@ -17,6 +17,7 @@ package workflow
 import (
 	"iter"
 	"testing"
+	"time"
 
 	"google.golang.org/genai"
 
@@ -37,6 +38,19 @@ func (e sliceEvents) All() iter.Seq[*session.Event] {
 		}
 	}
 }
+
+// fakeSession backs ReconstructRunState, which reads only Events(); the
+// rest are stubs.
+type fakeSession struct {
+	events session.Events
+}
+
+func (s fakeSession) ID() string                { return "test-session" }
+func (s fakeSession) AppName() string           { return "test-app" }
+func (s fakeSession) UserID() string            { return "test-user" }
+func (s fakeSession) State() session.State      { return nil }
+func (s fakeSession) Events() session.Events    { return s.events }
+func (s fakeSession) LastUpdateTime() time.Time { return time.Time{} }
 
 func modelEvent(path, text string, messageAsOutput bool) *session.Event {
 	ev := &session.Event{
@@ -178,12 +192,18 @@ func TestEventNodeName(t *testing.T) {
 	}
 }
 
-// TestScanHistory_InvocationScope verifies rehydration is scoped to one
-// logical run: a stable interrupt ID resolved in an earlier invocation
-// must not shadow the same ID freshly raised in the current invocation
-// (the examples/workflow/hitl_simple re-run bug).
-func TestScanHistory_InvocationScope(t *testing.T) {
-	nodes := map[string]Node{"ask": newDummyNode("ask")}
+// TestReconstructRunState_InvocationScope verifies rehydration is scoped
+// to one logical run: a stable interrupt ID resolved in an earlier
+// invocation must not shadow the same ID freshly raised in the current
+// invocation (the examples/workflow/hitl_simple re-run bug). It drives
+// the public ReconstructRunState so the production resume path is
+// exercised end to end, not just the internal scan helper.
+func TestReconstructRunState_InvocationScope(t *testing.T) {
+	ask := newDummyNode("ask")
+	wf, err := New("hitl-rerun", []Edge{{From: Start, To: ask}})
+	if err != nil {
+		t.Fatalf("New() error = %v", err)
+	}
 
 	raise := func(invID string) *session.Event {
 		return &session.Event{
@@ -203,18 +223,40 @@ func TestScanHistory_InvocationScope(t *testing.T) {
 		return ev
 	}
 
-	// Run 1 (inv1) fully resolved; run 2 (inv2) freshly raised, unresolved.
-	events := sliceEvents{raise("inv1"), resolve("inv1"), raise("inv2")}
+	// Both runs reuse interrupt ID "iid": run 1 (inv1) raised and
+	// resolved, run 2 (inv2) freshly raised.
+	sess := fakeSession{events: sliceEvents{raise("inv1"), resolve("inv1"), raise("inv2")}}
 
-	// Scoped to the current run: the prior run's resolution is invisible,
-	// so the interrupt is still pending.
-	if s := scanHistory(events, nodes, "inv2")["ask"]; s == nil || len(unresolvedInterrupts(s)) != 1 {
-		t.Fatalf("inv2 scope: want 1 unresolved interrupt, got %+v", s)
+	// Scanning inv2, the prior run's resolution is out of scope, so the
+	// reused ID counts as unresolved and "ask" rehydrates as still waiting.
+	state, err := wf.ReconstructRunState(sess, "inv2")
+	if err != nil {
+		t.Fatalf("ReconstructRunState(inv2) error = %v", err)
+	}
+	if ns := nodeState(t, state, "ask"); ns.Status != NodeWaiting ||
+		len(ns.Interrupts) != 1 || ns.Interrupts[0] != "iid" {
+		t.Errorf("inv2 ask = %+v, want NodeWaiting on interrupt [iid]", ns)
 	}
 
-	// Unscoped: the prior run's resolution leaks in and wrongly marks the
-	// interrupt resolved — the leak the invocation scope prevents.
-	if s := scanHistory(events, nodes, "")["ask"]; s == nil || len(unresolvedInterrupts(s)) != 0 {
-		t.Fatalf("no scope: want 0 unresolved (demonstrates the leak), got %+v", s)
+	// inv1's own resolution is in scope, so the same node resolves —
+	// proving the scope isolates runs rather than merely hiding history.
+	state, err = wf.ReconstructRunState(sess, "inv1")
+	if err != nil {
+		t.Fatalf("ReconstructRunState(inv1) error = %v", err)
 	}
+	if ns := nodeState(t, state, "ask"); ns.Status != NodeCompleted || len(ns.Interrupts) != 0 {
+		t.Errorf("inv1 ask = %+v, want NodeCompleted with no pending interrupts", ns)
+	}
+}
+
+func nodeState(t *testing.T, state *RunState, name string) *NodeState {
+	t.Helper()
+	if state == nil {
+		t.Fatalf("ReconstructRunState returned nil state, want node %q", name)
+	}
+	ns := state.Nodes[name]
+	if ns == nil {
+		t.Fatalf("no NodeState for %q; nodes = %+v", name, state.Nodes)
+	}
+	return ns
 }

--- a/workflow/persistence_test.go
+++ b/workflow/persistence_test.go
@@ -56,7 +56,7 @@ func TestCollectNodeOutputs_MessageAsOutput(t *testing.T) {
 
 	events := sliceEvents{modelEvent("talky", "Hello, world!", true)}
 
-	outputs, completed := collectNodeOutputs(events, nodes)
+	outputs, completed := collectNodeOutputs(events, nodes, "")
 
 	if got, want := outputs["talky"], "Hello, world!"; got != want {
 		t.Errorf("outputs[talky] = %#v, want %q", got, want)
@@ -71,7 +71,7 @@ func TestCollectNodeOutputs_MessageNotFlagged(t *testing.T) {
 
 	events := sliceEvents{modelEvent("talky", "Hello, world!", false)}
 
-	outputs, _ := collectNodeOutputs(events, nodes)
+	outputs, _ := collectNodeOutputs(events, nodes, "")
 
 	if _, ok := outputs["talky"]; ok {
 		t.Errorf("outputs[talky] = %#v, want absent", outputs["talky"])
@@ -85,7 +85,7 @@ func TestCollectNodeOutputs_ExplicitOutputWins(t *testing.T) {
 	ev.Output = "explicit"
 	events := sliceEvents{ev}
 
-	outputs, _ := collectNodeOutputs(events, nodes)
+	outputs, _ := collectNodeOutputs(events, nodes, "")
 
 	if got, want := outputs["talky"], "explicit"; got != want {
 		t.Errorf("outputs[talky] = %#v, want %q", got, want)
@@ -109,7 +109,7 @@ func TestCollectNodeOutputs_OutputForAttributesAncestors(t *testing.T) {
 		},
 	}
 
-	outputs, _ := collectNodeOutputs(sliceEvents{ev}, nodes)
+	outputs, _ := collectNodeOutputs(sliceEvents{ev}, nodes, "")
 
 	if got, want := outputs["child"], "delegated"; got != want {
 		t.Errorf("outputs[child] = %#v, want %q", got, want)
@@ -175,5 +175,46 @@ func TestEventNodeName(t *testing.T) {
 				t.Errorf("eventNodeName() = %q, want %q", got, tc.want)
 			}
 		})
+	}
+}
+
+// TestScanHistory_InvocationScope verifies rehydration is scoped to one
+// logical run: a stable interrupt ID resolved in an earlier invocation
+// must not shadow the same ID freshly raised in the current invocation
+// (the examples/workflow/hitl_simple re-run bug).
+func TestScanHistory_InvocationScope(t *testing.T) {
+	nodes := map[string]Node{"ask": newDummyNode("ask")}
+
+	raise := func(invID string) *session.Event {
+		return &session.Event{
+			Author:             "ask",
+			InvocationID:       invID,
+			LongRunningToolIDs: []string{"iid"},
+		}
+	}
+	resolve := func(invID string) *session.Event {
+		ev := &session.Event{Author: "user", InvocationID: invID}
+		ev.Content = &genai.Content{Parts: []*genai.Part{{
+			FunctionResponse: &genai.FunctionResponse{
+				ID:       "iid",
+				Response: map[string]any{"payload": "first"},
+			},
+		}}}
+		return ev
+	}
+
+	// Run 1 (inv1) fully resolved; run 2 (inv2) freshly raised, unresolved.
+	events := sliceEvents{raise("inv1"), resolve("inv1"), raise("inv2")}
+
+	// Scoped to the current run: the prior run's resolution is invisible,
+	// so the interrupt is still pending.
+	if s := scanHistory(events, nodes, "inv2")["ask"]; s == nil || len(unresolvedInterrupts(s)) != 1 {
+		t.Fatalf("inv2 scope: want 1 unresolved interrupt, got %+v", s)
+	}
+
+	// Unscoped: the prior run's resolution leaks in and wrongly marks the
+	// interrupt resolved — the leak the invocation scope prevents.
+	if s := scanHistory(events, nodes, "")["ask"]; s == nil || len(unresolvedInterrupts(s)) != 0 {
+		t.Fatalf("no scope: want 0 unresolved (demonstrates the leak), got %+v", s)
 	}
 }

--- a/workflow/request_input.go
+++ b/workflow/request_input.go
@@ -49,18 +49,21 @@ const WorkflowInputFunctionCallName = "adk_request_input"
 // generic FunctionResponse-by-ID dispatch route the human's reply
 // back to the workflow agent that issued the request.
 //
-// If req.InterruptID is empty, a UUID is generated so the
-// downstream contract (a non-empty correlation key on
-// NodeState.PendingRequest) is always satisfied. Pass an explicit
-// InterruptID when the prompt has a stable, author-defined intent
-// that the UI or a multi-prompt node needs to recognise.
+// Prefer a unique InterruptID per request. If req.InterruptID is
+// empty, a UUID is generated so the downstream contract (a non-empty
+// correlation key on NodeState.PendingRequest) is always satisfied.
+// You may also build a readable-but-unique ID (a stable prefix plus a
+// UUID). Avoid a fixed literal that recurs across separate runs in the
+// same session: clients such as the Dev UI track answered requests by
+// this ID and will not re-prompt for one already resolved earlier in
+// the session (see session.RequestInput.InterruptID).
 //
 // Example:
 //
 //	func (n *MyNode) Run(ctx agent.InvocationContext, in any) iter.Seq2[*session.Event, error] {
 //	    return func(yield func(*session.Event, error) bool) {
 //	        yield(workflow.NewRequestInputEvent(ctx, session.RequestInput{
-//	            InterruptID: "human_review",
+//	            InterruptID: "human_review-" + uuid.NewString(),
 //	            Message:     "Please review this draft.",
 //	            Payload:     draft,
 //	        }), nil)


### PR DESCRIPTION
## Problem
A workflow human-in-the-loop (HITL) agent that pauses for input
(`RequestInput`) could not be re-run in the same session. After one full
pause→resume cycle, starting a second run and answering the prompt failed with:
AGENT_ERROR: workflow: no waiting node matched the supplied responses

**Root cause:** rehydration (`ReconstructRunState` → `scanHistory` /
`collectNodeOutputs` / `firstUserInput`) scanned the entire accumulated session
history with no run boundary. Because the console and Dev UI reuse one session
across turns, a second run that reused a stable `InterruptID` (as the examples
did) collided with the first run's already-resolved interrupt: the node was
reconstructed as completed and its successor skipped, so the resume scheduled
nothing.

This diverged from adk-python, where rehydration is scoped to a single
invocation and `RequestInput.interrupt_id` defaults to a fresh UUID. The console
masked the bug because it doesn't depend on interrupt-ID uniqueness; the Dev UI
(which keys its reply box on the ID) did not re-prompt on the second run.

## Solution
- **Scope rehydration to one logical run.** `ReconstructRunState` and its scans
  skip events from other invocations (empty invocation ID = scan all history,
  backward-compatible).
- **Reuse the paused run's invocation ID on resume.** The runner resolves the
  invocation ID from the inbound `FunctionResponse` by matching it to the
  originating `FunctionCall` event, so a pause and its reply share one
  invocation ID. Mirrors adk-python `Runner._resolve_invocation_id`; applied on
  both the node and legacy paths.
- **Examples use a unique `InterruptID` per request** — `hitl_simple` (handoff):
  fresh UUID; `hitl_rerun` / `dynamic/hitl` (re-entry): invocation-derived
  (stable within a run, unique across runs). Matches adk-python and what the Dev
  UI needs to re-prompt on a later run.
- **Document the contract** on `session.RequestInput.InterruptID` and
  `workflow.NewRequestInputEvent`: prefer a unique ID per request; a reused ID
  is not re-prompted by the Dev UI.