### PR TITLE
chore(workflow): remove dead commented-out debug code

### DIFF
--- a/workflow/dynamic_scheduler.go
+++ b/workflow/dynamic_scheduler.go
@@ -218,7 +218,6 @@ func (s *dynamicSubScheduler) runNode(child Node, input any, opts runNodeOptions
 		childAncestors = append([]string{s.parentPath}, s.outputForAncestors...)
 	}
 	childCtx := agent.NewDynamicNodeContext(s.parentCtx.WithBranch(childBranch), childPath, runID, s, childAncestors)
-	// logContext(childCtx, "childCtx after newDynamicNodeContext", 0)
 
 	// Explicit scope wins over the node-path default; absent both,
 	// inherit. Matches adk-python _compute_isolation_scope_for_node.
@@ -229,9 +228,6 @@ func (s *dynamicSubScheduler) runNode(child Node, input any, opts runNodeOptions
 		childScope = childPath
 	}
 	childCtx = withIsolationScope(childCtx, childScope)
-	///childCtx.SetInvocationContext(iCtx)
-	// logContext(childCtx, "childCtx after withIsolationScope", 0)
-	//	log.Printf("childCtx: %+v branch: %v", childCtx, childCtx.Branch())
 
 	// Emit an "invoke_node <name>" span nested under the dynamic
 	// node's span (carried in s.parentCtx), so RunNode-driven
@@ -263,24 +259,6 @@ func (s *dynamicSubScheduler) runNode(child Node, input any, opts runNodeOptions
 		s.commitDelegation(childPath, cached)
 		return cached, nil
 	}
-
-	// EXPERIMENTAL: stash childCtx (a *nodeContext with non-nil
-	// subScheduler) in the embedded context.Context so tools running
-	// inside an LlmAgent that is itself running as this dynamic
-	// child can recover the NodeContext via
-	// workflow.NodeContextFromGoContext. See
-	// scheduleResumedNode for the static-node equivalent.
-
-	// ctxWithValue := WithNodeContext(childCtx.InvocationContext(), childCtx)
-	// logContext(ctxWithValue, "iCtx3", 0)
-
-	// log.Printf("iCtx3: %+v branch: n/a", ctxWithValue)
-	// iCtx2 := childCtx.WithContext(ctxWithValue)
-	// logContext(iCtx2, "iCtx2", 0)
-	// log.Printf("iCtx2: %+v branch: %v", iCtx2, iCtx2.Branch())
-	// childCtx.SetInvocationContext(iCtx2)
-	// log.Printf("final childCtx: %+v branch: %v", childCtx, childCtx.Branch())
-	// // childCtx= iCtx3
 
 	var (
 		hasOutput   bool

--- a/workflow/scheduler.go
+++ b/workflow/scheduler.go
@@ -397,22 +397,6 @@ func (s *scheduler) startNode(n Node, input any, triggeredBy, branch string, res
 	}
 	perNodeCtx = agent.NewDynamicNodeContext(perNodeCtx, nodePath, "1", nil, s.terminalAncestors(name))
 
-	// EXPERIMENTAL: stash perNodeCtx in the embedded context.Context
-	// so tools running inside an LlmAgent that is itself running as
-	// this node can recover the NodeContext via
-	// workflow.NodeContextFromGoContext. The value rides through
-	// every downstream NewInvocationContext / WithContext call by
-	// virtue of context.Context value-chain propagation.
-	//
-	// See WithNodeContext / NodeContextFromGoContext in
-	// node_context_bridge.go. Top-level static activations have
-	// subScheduler == nil, so RunNode will still reject them; the
-	// // stash is harmless in that case.
-	// perNodeCtxFinal := perNodeCtx.InvocationContext().WithContext(
-	// 	WithNodeContext(perNodeCtx.InvocationContext(), perNodeCtx),
-	// )
-	// perNodeCtx.SetInvocationContext(perNodeCtxFinal)
-
 	ns := s.state.EnsureNode(name)
 	ns.Status = NodeRunning
 	ns.Input = input


### PR DESCRIPTION
Drop leftover commented-out debugging statements (logContext/log.Printf calls referencing a helper that no longer exists) and the disabled NodeContext "stash" experiment in both the dynamic and static schedulers, along with the now-orphaned EXPERIMENTAL comments that only described that removed code.
