### PR TITLE
chore(examples): use gemini-flash-latest alias for standard text models

### DIFF
--- a/examples/a2a/main.go
+++ b/examples/a2a/main.go
@@ -42,7 +42,7 @@ import (
 
 // newWeatherAgent creates a simple LLM-agent as in the quickstart example.
 func newWeatherAgent(ctx context.Context) agent.Agent {
-	model, err := gemini.NewModel(ctx, "gemini-3.1-flash-lite", &genai.ClientConfig{
+	model, err := gemini.NewModel(ctx, "gemini-flash-latest", &genai.ClientConfig{
 		APIKey: os.Getenv("GOOGLE_API_KEY"),
 	})
 	if err != nil {

--- a/examples/agentengine/main.go
+++ b/examples/agentengine/main.go
@@ -82,7 +82,7 @@ func main() {
 	location := os.Getenv("GOOGLE_CLOUD_AGENT_ENGINE_LOCATION")
 	agentEngineID := os.Getenv("GOOGLE_CLOUD_AGENT_ENGINE_ID")
 
-	model, err := gemini.NewModel(ctx, "gemini-2.5-flash", &genai.ClientConfig{
+	model, err := gemini.NewModel(ctx, "gemini-flash-latest", &genai.ClientConfig{
 		Backend:  genai.BackendVertexAI,
 		Project:  projectID,
 		Location: location,

--- a/examples/mcp/main.go
+++ b/examples/mcp/main.go
@@ -90,7 +90,7 @@ func main() {
 	ctx, stop := signal.NotifyContext(context.Background(), os.Interrupt)
 	defer stop()
 
-	model, err := gemini.NewModel(ctx, "gemini-3.1-flash-lite", &genai.ClientConfig{
+	model, err := gemini.NewModel(ctx, "gemini-flash-latest", &genai.ClientConfig{
 		APIKey: os.Getenv("GOOGLE_API_KEY"),
 	})
 	if err != nil {

--- a/examples/multiagent/single_turn/main.go
+++ b/examples/multiagent/single_turn/main.go
@@ -79,7 +79,7 @@ func checkPhonePrice(_ agent.Context, in CheckPhonePriceInput) (CheckPhonePriceO
 func main() {
 	ctx := context.Background()
 
-	model, err := gemini.NewModel(ctx, "gemini-3.1-flash-lite", &genai.ClientConfig{
+	model, err := gemini.NewModel(ctx, "gemini-flash-latest", &genai.ClientConfig{
 		APIKey: os.Getenv("GOOGLE_API_KEY"),
 	})
 	if err != nil {

--- a/examples/multiagent/task_sub_agent/main.go
+++ b/examples/multiagent/task_sub_agent/main.go
@@ -94,7 +94,7 @@ func confirmation(_ agent.Context, _ ConfirmationInput) (ConfirmationOutput, err
 func main() {
 	ctx := context.Background()
 
-	model, err := gemini.NewModel(ctx, "gemini-3.5-flash", &genai.ClientConfig{
+	model, err := gemini.NewModel(ctx, "gemini-flash-latest", &genai.ClientConfig{
 		APIKey: os.Getenv("GOOGLE_API_KEY"),
 	})
 	if err != nil {

--- a/examples/quickstart/main.go
+++ b/examples/quickstart/main.go
@@ -34,7 +34,7 @@ import (
 func main() {
 	ctx := context.Background()
 
-	model, err := gemini.NewModel(ctx, "gemini-3.1-flash-lite", &genai.ClientConfig{
+	model, err := gemini.NewModel(ctx, "gemini-flash-latest", &genai.ClientConfig{
 		APIKey: os.Getenv("GOOGLE_API_KEY"),
 	})
 	if err != nil {

--- a/examples/rest/main.go
+++ b/examples/rest/main.go
@@ -37,7 +37,7 @@ func main() {
 	ctx := context.Background()
 
 	// Create a Gemini model
-	model, err := gemini.NewModel(ctx, "gemini-3.1-flash-lite", &genai.ClientConfig{
+	model, err := gemini.NewModel(ctx, "gemini-flash-latest", &genai.ClientConfig{
 		APIKey: os.Getenv("GOOGLE_API_KEY"),
 	})
 	if err != nil {

--- a/examples/skills/main.go
+++ b/examples/skills/main.go
@@ -47,7 +47,7 @@ import (
 func main() {
 	ctx := context.Background()
 
-	model, err := gemini.NewModel(ctx, "gemini-3.1-flash-lite", &genai.ClientConfig{
+	model, err := gemini.NewModel(ctx, "gemini-flash-latest", &genai.ClientConfig{
 		APIKey: os.Getenv("GOOGLE_API_KEY"),
 	})
 	if err != nil {

--- a/examples/telemetry/main.go
+++ b/examples/telemetry/main.go
@@ -44,7 +44,7 @@ func main() {
 func run() error {
 	ctx := context.Background()
 
-	model, err := gemini.NewModel(ctx, "gemini-3.1-flash-lite", &genai.ClientConfig{
+	model, err := gemini.NewModel(ctx, "gemini-flash-latest", &genai.ClientConfig{
 		APIKey: os.Getenv("GOOGLE_API_KEY"),
 	})
 	if err != nil {

--- a/examples/toolconfirmation/main.go
+++ b/examples/toolconfirmation/main.go
@@ -79,7 +79,7 @@ var (
 func main() {
 	ctx := context.Background()
 
-	model, err := gemini.NewModel(ctx, "gemini-3.1-flash-lite", &genai.ClientConfig{})
+	model, err := gemini.NewModel(ctx, "gemini-flash-latest", &genai.ClientConfig{})
 	if err != nil {
 		log.Fatalf("Failed to create model: %v", err)
 	}

--- a/examples/tools/loadartifacts/main.go
+++ b/examples/tools/loadartifacts/main.go
@@ -39,7 +39,7 @@ import (
 func main() {
 	ctx := context.Background()
 
-	model, err := gemini.NewModel(ctx, "gemini-3.1-flash-lite", &genai.ClientConfig{
+	model, err := gemini.NewModel(ctx, "gemini-flash-latest", &genai.ClientConfig{
 		APIKey: os.Getenv("GOOGLE_API_KEY"),
 	})
 	if err != nil {

--- a/examples/tools/loadmemory/main.go
+++ b/examples/tools/loadmemory/main.go
@@ -40,7 +40,7 @@ import (
 func main() {
 	ctx := context.Background()
 
-	model, err := gemini.NewModel(ctx, "gemini-3.1-flash-lite", &genai.ClientConfig{
+	model, err := gemini.NewModel(ctx, "gemini-flash-latest", &genai.ClientConfig{
 		APIKey: os.Getenv("GOOGLE_API_KEY"),
 	})
 	if err != nil {

--- a/examples/tools/multipletools/main.go
+++ b/examples/tools/multipletools/main.go
@@ -41,7 +41,7 @@ import (
 func main() {
 	ctx := context.Background()
 
-	model, err := gemini.NewModel(ctx, "gemini-3.1-flash-lite", &genai.ClientConfig{
+	model, err := gemini.NewModel(ctx, "gemini-flash-latest", &genai.ClientConfig{
 		APIKey: os.Getenv("GOOGLE_API_KEY"),
 	})
 	if err != nil {

--- a/examples/vertexai/agent.go
+++ b/examples/vertexai/agent.go
@@ -32,7 +32,7 @@ import (
 )
 
 const (
-	modelName = "gemini-2.5-flash"
+	modelName = "gemini-flash-latest"
 )
 
 func main() {

--- a/examples/web/main.go
+++ b/examples/web/main.go
@@ -64,7 +64,7 @@ func main() {
 	ctx := context.Background()
 	apiKey := os.Getenv("GOOGLE_API_KEY")
 
-	model, err := gemini.NewModel(ctx, "gemini-3.1-flash-lite", &genai.ClientConfig{
+	model, err := gemini.NewModel(ctx, "gemini-flash-latest", &genai.ClientConfig{
 		APIKey: apiKey,
 	})
 	if err != nil {

--- a/examples/workflow/dynamic/llm/main.go
+++ b/examples/workflow/dynamic/llm/main.go
@@ -37,7 +37,7 @@ import (
 func main() {
 	ctx := context.Background()
 
-	model, err := gemini.NewModel(ctx, "gemini-3.1-flash-lite", &genai.ClientConfig{})
+	model, err := gemini.NewModel(ctx, "gemini-flash-latest", &genai.ClientConfig{})
 	if err != nil {
 		log.Fatalf("gemini.NewModel: %v", err)
 	}

--- a/examples/workflowagents/sequentialCode/main.go
+++ b/examples/workflowagents/sequentialCode/main.go
@@ -33,7 +33,7 @@ import (
 func main() {
 	ctx := context.Background()
 
-	model, err := gemini.NewModel(ctx, "gemini-3.1-flash-lite", &genai.ClientConfig{})
+	model, err := gemini.NewModel(ctx, "gemini-flash-latest", &genai.ClientConfig{})
 	if err != nil {
 		log.Fatalf("failed to create model: %s", err)
 	}


### PR DESCRIPTION
## Summary
Replaces pinned Gemini model versions in the `examples/` with the
`gemini-flash-latest` alias for all standard text-generation samples, so the
examples automatically track the latest standard Flash model and we don't have
to bump versions by hand over time.
Changed models (17 files):
- `gemini-3.1-flash-lite` → `gemini-flash-latest` (14 files)
- `gemini-3.5-flash` → `gemini-flash-latest` (multiagent/task_sub_agent)
- `gemini-2.5-flash` → `gemini-flash-latest` (agentengine, vertexai/agent.go)

## Why some models are intentionally NOT changed
`gemini-flash-latest` is **not** a universal "everything" model. The alias only
ever points to the newest version of the *standard* Flash family — it means
"latest version of that one model line", not "one model with every capability".
Google ships separate model families for different runtime contracts, and they
expose different API surfaces. Pointing the following examples at
`gemini-flash-latest` would break them at runtime, so they keep their
specialized models:

| Example | Model kept | Reason |
| --- | --- | --- |
| `bidi/`, `bidi/streamingtool/` | `gemini-3.1-flash-live-preview` | Only the Live family speaks the **Live API** (bidirectional audio over WebSockets). Standard Flash does not expose that endpoint. |
| `bidi/sequential/` | `gemini-2.5-flash-native-audio-preview-12-2025` | Native audio. Google's own migration note routes this to `gemini-3.1-flash-live-preview`, **not** standard Flash. |
| `vertexai/imagegenerator/` | `gemini-3.1-flash-image-preview` | Dedicated image-**output** variant; the generic alias does not reliably produce image output. |
