### PR TITLE
test(runner): cover node-runtime behaviors 

### DIFF
--- a/runner/run_node_test.go
+++ b/runner/run_node_test.go
@@ -17,6 +17,7 @@ package runner_test
 import (
 	"context"
 	"iter"
+	"strings"
 	"testing"
 
 	"google.golang.org/genai"
@@ -441,4 +442,433 @@ func TestRunner_LlmAgent_OutputKeySchema_SingleOutput(t *testing.T) {
 	if saved != jsonResp {
 		t.Errorf("state[resp] = %v, want %q", saved, jsonResp)
 	}
+}
+
+// The tests below port runner-level node behaviors from adk-python's
+// tests/unittests/runners/test_runner_node.py. adk-go has no
+// Runner(node=...) constructor, so a node graph is wrapped in a
+// workflowagent (or an LlmAgent root) and driven through the same node
+// runtime.
+
+// newUpperWorkflowAgent wraps a single function node that upper-cases the
+// user's text.
+func newUpperWorkflowAgent(t *testing.T, name string) agent.Agent {
+	t.Helper()
+	upper := workflow.NewFunctionNode(name+"_upper", func(_ agent.Context, in string) (string, error) {
+		return strings.ToUpper(in), nil
+	}, workflow.NodeConfig{})
+	wf, err := workflowagent.New(workflowagent.Config{
+		Name:  name,
+		Edges: workflow.Chain(workflow.Start, upper),
+	})
+	if err != nil {
+		t.Fatalf("workflowagent.New() error = %v", err)
+	}
+	return wf
+}
+
+func TestRunner_WorkflowNode_OutputAndPersistence(t *testing.T) {
+	ctx := t.Context()
+	svc := session.InMemoryService()
+	newNodeTestSession(t, ctx, svc)
+
+	r := newNodeTestRunner(t, newUpperWorkflowAgent(t, "wf"), svc)
+
+	var gotOutputs []any
+	for ev, err := range r.Run(ctx, nodeTestUser, nodeTestSession, userText("hi"), agent.RunConfig{}) {
+		if err != nil {
+			t.Fatalf("Run() error = %v", err)
+		}
+		if ev != nil && ev.Output != nil {
+			gotOutputs = append(gotOutputs, ev.Output)
+		}
+	}
+
+	if len(gotOutputs) != 1 || gotOutputs[0] != "HI" {
+		t.Fatalf("yielded outputs = %v, want [HI]", gotOutputs)
+	}
+
+	// The output event must survive into session history.
+	got, err := svc.Get(ctx, &session.GetRequest{AppName: nodeTestApp, UserID: nodeTestUser, SessionID: nodeTestSession})
+	if err != nil {
+		t.Fatalf("Get() error = %v", err)
+	}
+	if !sessionHasOutput(got.Session, "HI") {
+		t.Errorf("session does not contain the persisted output %q", "HI")
+	}
+}
+
+func TestRunner_WorkflowNode_ErrorPropagates(t *testing.T) {
+	ctx := t.Context()
+	svc := session.InMemoryService()
+	newNodeTestSession(t, ctx, svc)
+
+	boom := workflow.NewFunctionNode("boom", func(_ agent.Context, _ string) (string, error) {
+		return "", errNodeBoom
+	}, workflow.NodeConfig{})
+	wf, err := workflowagent.New(workflowagent.Config{
+		Name:  "wf_err",
+		Edges: workflow.Chain(workflow.Start, boom),
+	})
+	if err != nil {
+		t.Fatalf("workflowagent.New() error = %v", err)
+	}
+	r := newNodeTestRunner(t, wf, svc)
+
+	var gotErr error
+	for _, err := range r.Run(ctx, nodeTestUser, nodeTestSession, userText("hi"), agent.RunConfig{}) {
+		if err != nil {
+			gotErr = err
+		}
+	}
+	if gotErr == nil {
+		t.Fatal("Run() yielded no error, want the node failure to propagate")
+	}
+	if !strings.Contains(gotErr.Error(), "node failure") {
+		t.Errorf("error = %v, want it to contain %q", gotErr, "node failure")
+	}
+}
+
+// TestRunner_WorkflowNode_MultipleInvocationsAccumulate checks that each
+// turn appends to the same session rather than replacing its history.
+func TestRunner_WorkflowNode_MultipleInvocationsAccumulate(t *testing.T) {
+	ctx := t.Context()
+	svc := session.InMemoryService()
+	newNodeTestSession(t, ctx, svc)
+
+	r := newNodeTestRunner(t, newUpperWorkflowAgent(t, "wf"), svc)
+
+	for _, in := range []string{"first", "second", "third"} {
+		for _, err := range r.Run(ctx, nodeTestUser, nodeTestSession, userText(in), agent.RunConfig{}) {
+			if err != nil {
+				t.Fatalf("Run(%q) error = %v", in, err)
+			}
+		}
+	}
+
+	got, err := svc.Get(ctx, &session.GetRequest{AppName: nodeTestApp, UserID: nodeTestUser, SessionID: nodeTestSession})
+	if err != nil {
+		t.Fatalf("Get() error = %v", err)
+	}
+	want := []string{"FIRST", "SECOND", "THIRD"}
+	gotOutputs := sessionOutputs(got.Session)
+	if len(gotOutputs) != len(want) {
+		t.Fatalf("session outputs = %v, want %v", gotOutputs, want)
+	}
+	for i, w := range want {
+		if gotOutputs[i] != w {
+			t.Errorf("session output[%d] = %v, want %q", i, gotOutputs[i], w)
+		}
+	}
+}
+
+// TestRunner_Node_YieldUserMessageFalseByDefault is the negative case for
+// TestRunner_LlmAgent_YieldUserMessage: without the opt-in the user event
+// is persisted but not yielded.
+func TestRunner_Node_YieldUserMessageFalseByDefault(t *testing.T) {
+	ctx := t.Context()
+	svc := session.InMemoryService()
+	newNodeTestSession(t, ctx, svc)
+
+	m := &scriptedModel{responses: []*genai.Content{
+		genai.NewContentFromText("hi back", "model"),
+	}}
+	a, err := llmagent.New(llmagent.Config{Name: "greeter", Model: m})
+	if err != nil {
+		t.Fatalf("llmagent.New() error = %v", err)
+	}
+	r := newNodeTestRunner(t, a, svc)
+
+	for ev, err := range r.Run(ctx, nodeTestUser, nodeTestSession, userText("hi"), agent.RunConfig{}) {
+		if err != nil {
+			t.Fatalf("Run() error = %v", err)
+		}
+		if ev != nil && ev.Author == "user" {
+			t.Errorf("yielded a user message event %v, want none by default", ev)
+		}
+	}
+}
+
+// TestRunner_Node_StateDeltaAppliedBeforeNodeRuns checks that a state
+// delta passed to Run lands in session state before the node body runs.
+func TestRunner_Node_StateDeltaAppliedBeforeNodeRuns(t *testing.T) {
+	ctx := t.Context()
+	svc := session.InMemoryService()
+	newNodeTestSession(t, ctx, svc)
+
+	reader := workflow.NewFunctionNode("reader", func(c agent.Context, _ string) (string, error) {
+		v, err := c.State().Get("test_state")
+		if err != nil {
+			return "", err
+		}
+		s, _ := v.(string)
+		return "state:" + s, nil
+	}, workflow.NodeConfig{})
+	wf, err := workflowagent.New(workflowagent.Config{
+		Name:  "wf_state",
+		Edges: workflow.Chain(workflow.Start, reader),
+	})
+	if err != nil {
+		t.Fatalf("workflowagent.New() error = %v", err)
+	}
+	r := newNodeTestRunner(t, wf, svc)
+
+	var gotOutputs []any
+	for ev, err := range r.Run(ctx, nodeTestUser, nodeTestSession, userText("go"), agent.RunConfig{},
+		runner.WithStateDelta(map[string]any{"test_state": "must_change"})) {
+		if err != nil {
+			t.Fatalf("Run() error = %v", err)
+		}
+		if ev != nil && ev.Output != nil {
+			gotOutputs = append(gotOutputs, ev.Output)
+		}
+	}
+
+	if len(gotOutputs) != 1 || gotOutputs[0] != "state:must_change" {
+		t.Fatalf("outputs = %v, want [state:must_change]", gotOutputs)
+	}
+
+	got, err := svc.Get(ctx, &session.GetRequest{AppName: nodeTestApp, UserID: nodeTestUser, SessionID: nodeTestSession})
+	if err != nil {
+		t.Fatalf("Get() error = %v", err)
+	}
+	v, err := got.Session.State().Get("test_state")
+	if err != nil {
+		t.Fatalf("State().Get(test_state) error = %v", err)
+	}
+	if v != "must_change" {
+		t.Errorf("session state[test_state] = %v, want %q", v, "must_change")
+	}
+}
+
+// TestRunner_Node_YieldsUserEventWithStateDelta checks that the yielded
+// user event carries the run's state delta.
+func TestRunner_Node_YieldsUserEventWithStateDelta(t *testing.T) {
+	ctx := t.Context()
+	svc := session.InMemoryService()
+	newNodeTestSession(t, ctx, svc)
+
+	m := &scriptedModel{responses: []*genai.Content{
+		genai.NewContentFromText("done", "model"),
+	}}
+	a, err := llmagent.New(llmagent.Config{Name: "noop", Model: m})
+	if err != nil {
+		t.Fatalf("llmagent.New() error = %v", err)
+	}
+	r := newNodeTestRunner(t, a, svc)
+
+	var first *session.Event
+	for ev, err := range r.Run(ctx, nodeTestUser, nodeTestSession, userText("go"), agent.RunConfig{},
+		runner.WithStateDelta(map[string]any{"test_state": "must_change"}),
+		runner.WithYieldUserMessage()) {
+		if err != nil {
+			t.Fatalf("Run() error = %v", err)
+		}
+		if ev != nil && first == nil {
+			first = ev
+		}
+	}
+
+	if first == nil {
+		t.Fatal("Run() yielded no events")
+	}
+	if first.Author != "user" {
+		t.Fatalf("first yielded event author = %q, want %q", first.Author, "user")
+	}
+	if got := first.Actions.StateDelta["test_state"]; got != "must_change" {
+		t.Errorf("user event state delta[test_state] = %v, want %q", got, "must_change")
+	}
+}
+
+// TestRunner_Node_StateDeltaAppliedBeforeLlmAgentRuns checks that an
+// LlmAgent's before-agent callback observes the run's state delta before
+// the model is consulted.
+func TestRunner_Node_StateDeltaAppliedBeforeLlmAgentRuns(t *testing.T) {
+	ctx := t.Context()
+	svc := session.InMemoryService()
+	newNodeTestSession(t, ctx, svc)
+
+	var captured any
+	m := &scriptedModel{responses: []*genai.Content{
+		genai.NewContentFromText("unused", "model"),
+	}}
+	a, err := llmagent.New(llmagent.Config{
+		Name:  "state_agent",
+		Model: m,
+		BeforeAgentCallbacks: []agent.BeforeAgentCallback{
+			func(c agent.Context) (*genai.Content, error) {
+				v, err := c.State().Get("test_state")
+				if err != nil {
+					return nil, err
+				}
+				captured = v
+				s, _ := v.(string)
+				return genai.NewContentFromText("state:"+s, genai.RoleModel), nil
+			},
+		},
+	})
+	if err != nil {
+		t.Fatalf("llmagent.New() error = %v", err)
+	}
+	r := newNodeTestRunner(t, a, svc)
+
+	var sawResponse bool
+	for ev, err := range r.Run(ctx, nodeTestUser, nodeTestSession, userText("go"), agent.RunConfig{},
+		runner.WithStateDelta(map[string]any{"test_state": "must_change"})) {
+		if err != nil {
+			t.Fatalf("Run() error = %v", err)
+		}
+		if ev != nil && ev.LLMResponse.Content != nil {
+			for _, p := range ev.LLMResponse.Content.Parts {
+				if p.Text == "state:must_change" {
+					sawResponse = true
+				}
+			}
+		}
+	}
+
+	if captured != "must_change" {
+		t.Errorf("before-agent callback saw state = %v, want %q", captured, "must_change")
+	}
+	if !sawResponse {
+		t.Error("did not observe the before-agent callback response carrying the state value")
+	}
+}
+
+// TestRunner_Node_PlainTextDoesNotTriggerResume checks that a follow-up
+// plain-text turn starts a fresh run instead of resuming.
+func TestRunner_Node_PlainTextDoesNotTriggerResume(t *testing.T) {
+	ctx := t.Context()
+	svc := session.InMemoryService()
+	newNodeTestSession(t, ctx, svc)
+
+	r := newNodeTestRunner(t, newUpperWorkflowAgent(t, "wf"), svc)
+
+	for _, err := range r.Run(ctx, nodeTestUser, nodeTestSession, userText("first"), agent.RunConfig{}) {
+		if err != nil {
+			t.Fatalf("turn 1 Run() error = %v", err)
+		}
+	}
+
+	var gotOutputs []any
+	for ev, err := range r.Run(ctx, nodeTestUser, nodeTestSession, userText("second"), agent.RunConfig{}) {
+		if err != nil {
+			t.Fatalf("turn 2 Run() error = %v", err)
+		}
+		if ev != nil && ev.Output != nil {
+			gotOutputs = append(gotOutputs, ev.Output)
+		}
+	}
+	if len(gotOutputs) != 1 || gotOutputs[0] != "SECOND" {
+		t.Fatalf("turn 2 outputs = %v, want [SECOND]", gotOutputs)
+	}
+}
+
+// adk-python rejects malformed resume messages (test_mixed_fr_and_text_raises,
+// test_resume_raises_on_unmatched_fr): a message must not mix function
+// responses with text, and every response must match a call in history.
+// adk-go is deliberately more permissive — the A2A flow resumes a paused
+// task by sending the human's reply text alongside the approval response
+// in one message (see agent/remoteagent/v2/a2a_e2e_test.go, msg3), and
+// buildResumeResponses ignores responses that answer no pending
+// interrupt. These tests guard that permissive behavior against a future
+// "parity" change that would break A2A.
+
+// newPermissiveAgent's model is consulted because adk-go treats these
+// messages as a fresh run rather than rejecting them.
+func newPermissiveAgent(t *testing.T) agent.Agent {
+	t.Helper()
+	m := &scriptedModel{responses: []*genai.Content{
+		genai.NewContentFromText("handled", "model"),
+	}}
+	a, err := llmagent.New(llmagent.Config{Name: "approver", Model: m})
+	if err != nil {
+		t.Fatalf("llmagent.New() error = %v", err)
+	}
+	return a
+}
+
+func TestRunner_Node_AllowsMixedFunctionResponseAndText(t *testing.T) {
+	ctx := t.Context()
+	svc := session.InMemoryService()
+	newNodeTestSession(t, ctx, svc)
+	r := newNodeTestRunner(t, newPermissiveAgent(t), svc)
+
+	msg := &genai.Content{Role: genai.RoleUser, Parts: []*genai.Part{
+		{Text: "some text"},
+		{FunctionResponse: &genai.FunctionResponse{ID: "fc-1", Name: "tool", Response: map[string]any{"v": 1}}},
+	}}
+
+	if gotErr := collectRunError(r.Run(ctx, nodeTestUser, nodeTestSession, msg, agent.RunConfig{})); gotErr != nil {
+		t.Fatalf("Run() error = %v, want nil (adk-go allows mixed function-response + text)", gotErr)
+	}
+}
+
+func TestRunner_Node_ToleratesUnmatchedFunctionResponse(t *testing.T) {
+	ctx := t.Context()
+	svc := session.InMemoryService()
+	newNodeTestSession(t, ctx, svc)
+	r := newNodeTestRunner(t, newPermissiveAgent(t), svc)
+
+	msg := &genai.Content{Role: genai.RoleUser, Parts: []*genai.Part{
+		{FunctionResponse: &genai.FunctionResponse{ID: "no-such-fc", Name: "unknown", Response: map[string]any{}}},
+	}}
+
+	var sawText bool
+	for ev, err := range r.Run(ctx, nodeTestUser, nodeTestSession, msg, agent.RunConfig{}) {
+		if err != nil {
+			t.Fatalf("Run() error = %v, want nil (adk-go tolerates an unmatched function response)", err)
+		}
+		if ev != nil && ev.LLMResponse.Content != nil {
+			for _, p := range ev.LLMResponse.Content.Parts {
+				if p.Text == "handled" {
+					sawText = true
+				}
+			}
+		}
+	}
+	if !sawText {
+		t.Error("expected a fresh run to consult the model after an unmatched function response")
+	}
+}
+
+// errNodeBoom is the failure returned by TestRunner_WorkflowNode_ErrorPropagates.
+var errNodeBoom = errNode("node failure")
+
+type errNode string
+
+func (e errNode) Error() string { return string(e) }
+
+// collectRunError returns the first error a Run iterator yields, or nil.
+func collectRunError(seq iter.Seq2[*session.Event, error]) error {
+	var gotErr error
+	for _, err := range seq {
+		if err != nil && gotErr == nil {
+			gotErr = err
+		}
+	}
+	return gotErr
+}
+
+// sessionHasOutput reports whether any event carries the given output.
+func sessionHasOutput(sess session.Session, want any) bool {
+	for _, out := range sessionOutputs(sess) {
+		if out == want {
+			return true
+		}
+	}
+	return false
+}
+
+// sessionOutputs returns the terminal outputs of all events, in order.
+func sessionOutputs(sess session.Session) []any {
+	var outs []any
+	events := sess.Events()
+	for i := 0; i < events.Len(); i++ {
+		ev := events.At(i)
+		if ev != nil && ev.Output != nil {
+			outs = append(outs, ev.Output)
+		}
+	}
+	return outs
 }

--- a/runner/run_node_test.go
+++ b/runner/run_node_test.go
@@ -445,14 +445,10 @@ func TestRunner_LlmAgent_OutputKeySchema_SingleOutput(t *testing.T) {
 	}
 }
 
-// The tests below port runner-level node behaviors from adk-python's
-// tests/unittests/runners/test_runner_node.py. adk-go has no
-// Runner(node=...) constructor, so a node graph is wrapped in a
-// workflowagent (or an LlmAgent root) and driven through the same node
-// runtime.
-
 // newUpperWorkflowAgent wraps a single function node that upper-cases the
-// user's text.
+// user's text. adk-go has no Runner(node=...) constructor, so node graphs
+// are driven through the node runtime by wrapping them in a workflowagent
+// (the LlmAgent cases use an LlmAgent root directly instead).
 func newUpperWorkflowAgent(t *testing.T, name string) agent.Agent {
 	t.Helper()
 	upper := workflow.NewFunctionNode(name+"_upper", func(_ agent.Context, in string) (string, error) {

--- a/runner/run_node_test.go
+++ b/runner/run_node_test.go
@@ -16,6 +16,7 @@ package runner_test
 
 import (
 	"context"
+	"errors"
 	"iter"
 	"strings"
 	"testing"
@@ -587,6 +588,16 @@ func TestRunner_Node_YieldUserMessageFalseByDefault(t *testing.T) {
 			t.Errorf("yielded a user message event %v, want none by default", ev)
 		}
 	}
+
+	// The user message is still recorded in history; only the yielding
+	// is gated by WithYieldUserMessage.
+	got, err := svc.Get(ctx, &session.GetRequest{AppName: nodeTestApp, UserID: nodeTestUser, SessionID: nodeTestSession})
+	if err != nil {
+		t.Fatalf("Get() error = %v", err)
+	}
+	if !sessionHasUserText(got.Session, "hi") {
+		t.Errorf("session does not contain the persisted user message %q", "hi")
+	}
 }
 
 // TestRunner_Node_StateDeltaAppliedBeforeNodeRuns checks that a state
@@ -681,8 +692,9 @@ func TestRunner_Node_YieldsUserEventWithStateDelta(t *testing.T) {
 }
 
 // TestRunner_Node_StateDeltaAppliedBeforeLlmAgentRuns checks that an
-// LlmAgent's before-agent callback observes the run's state delta before
-// the model is consulted.
+// LlmAgent's before-agent callback observes the run's state delta. The
+// callback returns content, which short-circuits the agent, so the model
+// is never consulted.
 func TestRunner_Node_StateDeltaAppliedBeforeLlmAgentRuns(t *testing.T) {
 	ctx := t.Context()
 	svc := session.InMemoryService()
@@ -799,8 +811,21 @@ func TestRunner_Node_AllowsMixedFunctionResponseAndText(t *testing.T) {
 		{FunctionResponse: &genai.FunctionResponse{ID: "fc-1", Name: "tool", Response: map[string]any{"v": 1}}},
 	}}
 
-	if gotErr := collectRunError(r.Run(ctx, nodeTestUser, nodeTestSession, msg, agent.RunConfig{})); gotErr != nil {
-		t.Fatalf("Run() error = %v, want nil (adk-go allows mixed function-response + text)", gotErr)
+	var sawText bool
+	for ev, err := range r.Run(ctx, nodeTestUser, nodeTestSession, msg, agent.RunConfig{}) {
+		if err != nil {
+			t.Fatalf("Run() error = %v, want nil (adk-go allows mixed function-response + text)", err)
+		}
+		if ev != nil && ev.LLMResponse.Content != nil {
+			for _, p := range ev.LLMResponse.Content.Parts {
+				if p.Text == "handled" {
+					sawText = true
+				}
+			}
+		}
+	}
+	if !sawText {
+		t.Error("expected a fresh run to consult the model for a mixed function-response + text message")
 	}
 }
 
@@ -832,22 +857,26 @@ func TestRunner_Node_ToleratesUnmatchedFunctionResponse(t *testing.T) {
 	}
 }
 
-// errNodeBoom is the failure returned by TestRunner_WorkflowNode_ErrorPropagates.
-var errNodeBoom = errNode("node failure")
+// errNodeBoom is the failure the boom node returns in
+// TestRunner_WorkflowNode_ErrorPropagates.
+var errNodeBoom = errors.New("node failure")
 
-type errNode string
-
-func (e errNode) Error() string { return string(e) }
-
-// collectRunError returns the first error a Run iterator yields, or nil.
-func collectRunError(seq iter.Seq2[*session.Event, error]) error {
-	var gotErr error
-	for _, err := range seq {
-		if err != nil && gotErr == nil {
-			gotErr = err
+// sessionHasUserText reports whether session history holds a user event
+// whose content carries the given text.
+func sessionHasUserText(sess session.Session, want string) bool {
+	events := sess.Events()
+	for i := 0; i < events.Len(); i++ {
+		ev := events.At(i)
+		if ev == nil || ev.Author != "user" || ev.LLMResponse.Content == nil {
+			continue
+		}
+		for _, p := range ev.LLMResponse.Content.Parts {
+			if p.Text == want {
+				return true
+			}
 		}
 	}
-	return gotErr
+	return false
 }
 
 // sessionHasOutput reports whether any event carries the given output.


### PR DESCRIPTION
## Summary
Ports the runner-level node behaviors from adk-python's
`tests/unittests/runners/test_runner_node.py` into adk-go's
`runner/run_node_test.go`, to confirm behavioral parity around the
`run_node` path in `runners.py`. adk-go has no `Runner(node=...)`
constructor, so each case drives a node graph wrapped in a
`workflowagent` (or a plain `LlmAgent` root) through the same node
runtime.
Test-only change — no production code is touched.

## What's covered
Behaviors adk-go already implements correctly (now verified at the
runner level):
- terminal node output + persistence to the session
- node error propagation to the caller of `Run`
- event accumulation across multiple turns in one session
- `yield_user_message` defaulting to off
- `WithStateDelta` applied to session state before the node / `LlmAgent`
  runs, and surfaced on the yielded user event
- plain text not triggering the resume path

## Intentional divergence (guarded by characterization tests)
adk-python's `Runner._run_node_async` rejects malformed resume messages
(`test_mixed_fr_and_text_raises`, `test_resume_raises_on_unmatched_fr`,
`test_resume_raises_on_multi_invocation_fr`). adk-go is deliberately more
permissive: the A2A flow resumes a paused task by sending the human's
reply text **alongside** the approval function response in a single
message (`agent/remoteagent/v2/a2a_e2e_test.go`, `msg3`), and
`buildResumeResponses` ignores responses that answer no pending
interrupt.
Two characterization tests (`TestRunner_Node_AllowsMixedFunctionResponseAndText`,
`TestRunner_Node_ToleratesUnmatchedFunctionResponse`) lock in this
permissive behavior so a future "parity" change can't silently break
A2A. Porting the adk-python guards was tried and reverted because it
failed the A2A e2e tests.