### PR TITLE
fix(llminternal): drop thought parts in ConvertForeignEvent

### DIFF
--- a/internal/llminternal/contents_processor.go
+++ b/internal/llminternal/contents_processor.go
@@ -87,7 +87,9 @@ func buildContentsDefault(agentName, invocationBranch string, events []*session.
 			continue
 		}
 		if isOtherAgentReply(agentName, ev) {
-			filtered = append(filtered, ConvertForeignEvent(ev))
+			if converted := ConvertForeignEvent(ev); converted != nil {
+				filtered = append(filtered, converted)
+			}
 		} else {
 			filtered = append(filtered, ev)
 		}
@@ -531,6 +533,9 @@ func ConvertForeignEvent(ev *session.Event) *session.Event {
 		Parts: []*genai.Part{{Text: "For context:"}},
 	}
 	for _, p := range content.Parts {
+		if p.Thought {
+			continue
+		}
 		switch {
 		case p.Text != "":
 			converted.Parts = append(converted.Parts, &genai.Part{
@@ -547,6 +552,11 @@ func ConvertForeignEvent(ev *session.Event) *session.Event {
 		default: // fallback to the original part for non-text and non-functionCall parts.
 			converted.Parts = append(converted.Parts, p)
 		}
+	}
+
+	// If all parts were thoughts, nothing meaningful remains after the header.
+	if len(converted.Parts) == 1 {
+		return nil
 	}
 
 	return &session.Event{ // made-up event. Don't go through types.NewEvent.

--- a/internal/llminternal/contents_processor_test.go
+++ b/internal/llminternal/contents_processor_test.go
@@ -586,6 +586,55 @@ func TestConvertForeignEvent(t *testing.T) {
 				Branch: "b",
 			},
 		},
+		{
+			name: "ThoughtOnlyEvent",
+			event: &session.Event{
+				Timestamp: now,
+				Author:    "foreign",
+				LLMResponse: model.LLMResponse{
+					Content: &genai.Content{
+						Role: "model",
+						Parts: []*genai.Part{
+							{Text: "internal reasoning", Thought: true},
+							{Text: "more thoughts", Thought: true},
+						},
+					},
+				},
+				Branch: "b",
+			},
+			want: nil, // thought-only event produces no useful context
+		},
+		{
+			name: "MixedThoughtAndTextEvent",
+			event: &session.Event{
+				Timestamp: now,
+				Author:    "foreign",
+				LLMResponse: model.LLMResponse{
+					Content: &genai.Content{
+						Role: "model",
+						Parts: []*genai.Part{
+							{Text: "internal reasoning", Thought: true},
+							{Text: "actual response"},
+						},
+					},
+				},
+				Branch: "b",
+			},
+			want: &session.Event{
+				Timestamp: now,
+				Author:    "user",
+				LLMResponse: model.LLMResponse{
+					Content: &genai.Content{
+						Role: "user",
+						Parts: []*genai.Part{
+							{Text: "For context:"},
+							{Text: "[foreign] said: actual response"},
+						},
+					},
+				},
+				Branch: "b",
+			},
+		},
 	}
 
 	for _, tc := range testCases {


### PR DESCRIPTION
### Link to Issue or Description of Change
- Closes: #1096

**Problem:** `ConvertForeignEvent` includes thought parts (`Part.Thought == true`) when building foreign-agent context, diverging from adk-python's `_present_other_agent_message` which skips parts where `thought=True`. This leaks internal reasoning into the context passed to other agents.

**Solution:** Skip thought parts in `ConvertForeignEvent`'s parts loop. If the event contains only thought parts (nothing meaningful remains after stripping), return `nil` so the call site can omit it entirely. Nil-check the return at the call site.

### Testing Plan
**Unit Tests:**
- [x] Added test case: thought-only event returns nil
- [x] Added test case: mixed event strips thought parts, retains regular parts
- [x] All unit tests pass locally

**Manual End-to-End (E2E) Tests:**
This is a pure logic fix with full unit test coverage; no E2E harness needed for this change.

### Checklist
- [x] Read CONTRIBUTING.md
- [x] Self-reviewed code
- [x] Commented hard-to-understand areas
- [x] Tests prove fix/feature works
- [x] Unit tests pass locally
- [x] Dependent changes merged