### PR TITLE
fix(examples): keep complex workflow from hanging on flaky Google Search

### DIFF
--- a/examples/workflow/complex/main.go
+++ b/examples/workflow/complex/main.go
@@ -28,7 +28,10 @@
 //     a map[nodeName]output;
 //   - a FunctionNode transforming the join's map into a single prompt;
 //   - a single-turn AgentNode consuming a predecessor's output mid-graph;
-//   - per-node RetryConfig guarding the flaky (model + search) calls;
+//   - a resilientModel wrapper (see resilient_model.go) that bounds each
+//     flaky Google Search call with a per-call timeout, retries it, and —
+//     if it keeps stalling — fails open to a short fallback so the JoinNode
+//     still fires and a report is still produced;
 //   - the default in-memory session service (nothing to configure).
 //
 // Requires GOOGLE_API_KEY in the environment.
@@ -72,6 +75,19 @@ const (
 	carbonResearcher          = "CarbonCaptureResearcher"
 	synthesisAgent            = "SynthesisAgent"
 )
+
+// Resilience budget applied to every agent's model calls: each call is
+// bounded by callTimeout and retried up to callAttempts times before
+// failing open to the agent's fallback.
+const (
+	callTimeout  = 30 * time.Second
+	callAttempts = 3
+)
+
+// synthesisFallback is the minimal report emitted if every synthesis
+// attempt stalls; it keeps the run from ending silently.
+const synthesisFallback = "## Recent Sustainable Technology Advancements\n\n" +
+	"(report unavailable: the synthesis step timed out — please re-run)"
 
 // Each researcher targets one fixed, independent topic — the whole point of
 // fanning out is that no researcher depends on another's result.
@@ -139,34 +155,41 @@ func formatSummaries(_ agent.Context, gathered map[string]any) (string, error) {
 // keeps main thin and the graph wiring easy to follow; nothing here calls the
 // model, it only assembles the graph.
 func newResearchPipeline(m model.LLM) (agent.Agent, error) {
-	researcher := func(name, instruction string) (agent.Agent, error) {
+	// Each researcher wraps the shared model in a resilientModel so a
+	// stalled Google Search call degrades to its topic-specific fallback
+	// instead of hanging or failing the whole pipeline. The Search tool
+	// runs inside the Gemini model; no local execution.
+	researcher := func(name, instruction, fallback string) (agent.Agent, error) {
 		return llmagent.New(llmagent.Config{
 			Name:        name,
-			Model:       m,
+			Model:       newResilientModel(m, callTimeout, callAttempts, fallback),
 			Description: "researches one topic and returns a short summary",
 			Instruction: instruction,
-			// Each researcher grounds its summary with Google Search.
-			// The tool runs inside the Gemini model; no local execution.
-			Tools: []tool.Tool{geminitool.GoogleSearch{}},
+			Tools:       []tool.Tool{geminitool.GoogleSearch{}},
 		})
 	}
 
-	renewableAgent, err := researcher(renewableResearcher, renewableInstruction)
+	renewableAgent, err := researcher(renewableResearcher, renewableInstruction,
+		"(no findings: renewable-energy research timed out)")
 	if err != nil {
 		return nil, fmt.Errorf("creating renewable researcher: %w", err)
 	}
-	electricVehicleAgent, err := researcher(electricVehicleResearcher, electricVehicleInstruction)
+	electricVehicleAgent, err := researcher(electricVehicleResearcher, electricVehicleInstruction,
+		"(no findings: electric-vehicle research timed out)")
 	if err != nil {
 		return nil, fmt.Errorf("creating EV researcher: %w", err)
 	}
-	carbonAgent, err := researcher(carbonResearcher, carbonInstruction)
+	carbonAgent, err := researcher(carbonResearcher, carbonInstruction,
+		"(no findings: carbon-capture research timed out)")
 	if err != nil {
 		return nil, fmt.Errorf("creating carbon researcher: %w", err)
 	}
 
+	// Synthesis does no Google Search, but is still wrapped so a stalled
+	// call fails open to a minimal report rather than hanging the run.
 	synthAgent, err := llmagent.New(llmagent.Config{
 		Name:        synthesisAgent,
-		Model:       m,
+		Model:       newResilientModel(m, callTimeout, callAttempts, synthesisFallback),
 		Description: "merges the research summaries into one structured report",
 		Instruction: synthesisInstruction,
 	})
@@ -174,34 +197,27 @@ func newResearchPipeline(m model.LLM) (agent.Agent, error) {
 		return nil, fmt.Errorf("creating synthesis agent: %w", err)
 	}
 
-	// Retry the flaky model + search calls with exponential backoff. The
-	// deterministic formatter needs no retries.
-	llmNodeConfig := workflow.NodeConfig{
-		RetryConfig: &workflow.RetryConfig{
-			MaxAttempts:   3,
-			InitialDelay:  time.Second,
-			MaxDelay:      10 * time.Second,
-			BackoffFactor: 2.0,
-			Jitter:        0.5,
-		},
-	}
-
+	// The resilientModel wrapper already bounds and retries each call (and
+	// fails open), so the nodes themselves need no scheduler-level
+	// RetryConfig or Timeout. NodeConfig still offers both for nodes whose
+	// failures should instead be retried or surfaced by the engine.
+	//
 	// Wrapping an LlmAgent in an AgentNode defaults it to single-turn mode,
 	// so the synthesis node consumes the formatter's output instead of the
 	// chat history — which is why it may sit mid-graph rather than at Start.
-	renewableNode, err := workflow.NewAgentNode(renewableAgent, llmNodeConfig)
+	renewableNode, err := workflow.NewAgentNode(renewableAgent, workflow.NodeConfig{})
 	if err != nil {
 		return nil, fmt.Errorf("creating renewable node: %w", err)
 	}
-	electricVehicleNode, err := workflow.NewAgentNode(electricVehicleAgent, llmNodeConfig)
+	electricVehicleNode, err := workflow.NewAgentNode(electricVehicleAgent, workflow.NodeConfig{})
 	if err != nil {
 		return nil, fmt.Errorf("creating EV node: %w", err)
 	}
-	carbonNode, err := workflow.NewAgentNode(carbonAgent, llmNodeConfig)
+	carbonNode, err := workflow.NewAgentNode(carbonAgent, workflow.NodeConfig{})
 	if err != nil {
 		return nil, fmt.Errorf("creating carbon node: %w", err)
 	}
-	synthNode, err := workflow.NewAgentNode(synthAgent, llmNodeConfig)
+	synthNode, err := workflow.NewAgentNode(synthAgent, workflow.NodeConfig{})
 	if err != nil {
 		return nil, fmt.Errorf("creating synthesis node: %w", err)
 	}

--- a/examples/workflow/complex/main.go
+++ b/examples/workflow/complex/main.go
@@ -28,10 +28,8 @@
 //     a map[nodeName]output;
 //   - a FunctionNode transforming the join's map into a single prompt;
 //   - a single-turn AgentNode consuming a predecessor's output mid-graph;
-//   - a resilientModel wrapper (see resilient_model.go) that bounds each
-//     flaky Google Search call with a per-call timeout, retries it, and —
-//     if it keeps stalling — fails open to a short fallback so the JoinNode
-//     still fires and a report is still produced;
+//   - a resilientModel wrapper (see resilient_model.go) that times out,
+//     retries, and fails open on stalled Google Search calls;
 //   - the default in-memory session service (nothing to configure).
 //
 // Requires GOOGLE_API_KEY in the environment.
@@ -76,16 +74,15 @@ const (
 	synthesisAgent            = "SynthesisAgent"
 )
 
-// Resilience budget applied to every agent's model calls: each call is
-// bounded by callTimeout and retried up to callAttempts times before
-// failing open to the agent's fallback.
+// Resilience budget for every agent's model calls: each is bounded by
+// callTimeout and retried up to callAttempts times before failing open.
 const (
 	callTimeout  = 30 * time.Second
 	callAttempts = 3
 )
 
 // synthesisFallback is the minimal report emitted if every synthesis
-// attempt stalls; it keeps the run from ending silently.
+// attempt stalls.
 const synthesisFallback = "## Recent Sustainable Technology Advancements\n\n" +
 	"(report unavailable: the synthesis step timed out — please re-run)"
 
@@ -156,9 +153,8 @@ func formatSummaries(_ agent.Context, gathered map[string]any) (string, error) {
 // model, it only assembles the graph.
 func newResearchPipeline(m model.LLM) (agent.Agent, error) {
 	// Each researcher wraps the shared model in a resilientModel so a
-	// stalled Google Search call degrades to its topic-specific fallback
-	// instead of hanging or failing the whole pipeline. The Search tool
-	// runs inside the Gemini model; no local execution.
+	// stalled Google Search call degrades to its fallback instead of
+	// hanging the pipeline. Search runs inside the Gemini model.
 	researcher := func(name, instruction, fallback string) (agent.Agent, error) {
 		return llmagent.New(llmagent.Config{
 			Name:        name,
@@ -197,10 +193,8 @@ func newResearchPipeline(m model.LLM) (agent.Agent, error) {
 		return nil, fmt.Errorf("creating synthesis agent: %w", err)
 	}
 
-	// The resilientModel wrapper already bounds and retries each call (and
-	// fails open), so the nodes themselves need no scheduler-level
-	// RetryConfig or Timeout. NodeConfig still offers both for nodes whose
-	// failures should instead be retried or surfaced by the engine.
+	// resilientModel already bounds, retries, and fails open on each call,
+	// so the nodes need no scheduler-level RetryConfig or Timeout.
 	//
 	// Wrapping an LlmAgent in an AgentNode defaults it to single-turn mode,
 	// so the synthesis node consumes the formatter's output instead of the

--- a/examples/workflow/complex/resilient_model.go
+++ b/examples/workflow/complex/resilient_model.go
@@ -25,26 +25,16 @@ import (
 	"google.golang.org/adk/model"
 )
 
-// resilientModel wraps a model.LLM to bound and, as a last resort, paper
-// over flaky calls — specifically Gemini's Google Search grounding, which
-// intermittently stalls with neither a response nor an error.
-//
-// Why it exists: a bare model call has no per-call deadline, so a stalled
-// grounding request hangs forever. A workflow.RetryConfig does not help —
-// it only retries calls that *return* an error, and a hang returns
-// nothing. And because the pipeline fans out to three researchers behind a
-// JoinNode barrier, a single stalled researcher would hang (or, with a
-// plain timeout, fail) the whole run.
-//
-// resilientModel addresses all three:
-//   - timeout: every attempt runs under its own context.WithTimeout, so a
-//     stall becomes a context.DeadlineExceeded instead of an infinite wait;
-//   - retry: timed-out/errored attempts are retried (a fresh deadline
-//     each time) after a short fixed backoff;
-//   - fail-open: if every attempt is exhausted it returns a single
-//     fallback model message instead of an error, so the JoinNode still
-//     fires and the synthesis agent still produces a report from whatever
-//     did succeed (graceful degradation rather than a dead pipeline).
+// resilientModel wraps a model.LLM to guard against Gemini's Google Search
+// grounding, which intermittently stalls with neither a response nor an
+// error. A bare call has no deadline (so a stall hangs forever) and
+// workflow.RetryConfig only retries calls that return an error, so neither
+// helps. resilientModel instead:
+//   - bounds each attempt with context.WithTimeout, turning a stall into a
+//     DeadlineExceeded;
+//   - retries timed-out/errored attempts after a short backoff;
+//   - fails open after the last attempt, returning a fallback message so
+//     the JoinNode still fires and the pipeline still produces a report.
 //
 // It implements model.LLM, so any agent can use it transparently.
 type resilientModel struct {
@@ -54,8 +44,7 @@ type resilientModel struct {
 	fallback string        // model text returned when every attempt fails
 }
 
-// retryBackoff is the fixed pause between attempts. It is deliberately
-// small relative to the per-attempt timeout, which does the real work.
+// retryBackoff is the fixed pause between attempts.
 const retryBackoff = time.Second
 
 // newResilientModel wraps inner. attempts is clamped to a minimum of 1.
@@ -70,8 +59,7 @@ func newResilientModel(inner model.LLM, timeout time.Duration, attempts int, fal
 func (m *resilientModel) Name() string { return m.inner.Name() }
 
 // GenerateContent implements model.LLM. Each attempt is buffered so a
-// half-streamed-then-failed attempt is discarded cleanly before a retry;
-// the caller only ever observes one successful attempt (or the fallback).
+// partially streamed failure is discarded cleanly before a retry.
 func (m *resilientModel) GenerateContent(ctx context.Context, req *model.LLMRequest, stream bool) iter.Seq2[*model.LLMResponse, error] {
 	return func(yield func(*model.LLMResponse, error) bool) {
 		var lastErr error
@@ -87,10 +75,8 @@ func (m *resilientModel) GenerateContent(ctx context.Context, req *model.LLMRequ
 			}
 			lastErr = err
 
-			// A cancelled *parent* context is a real abort (the user quit
-			// or a sibling node failed), not our per-attempt timeout:
-			// propagate it so the node is treated as cancelled, not failed
-			// over to the fallback.
+			// A cancelled parent context is a real abort, not our
+			// per-attempt timeout: propagate it instead of failing open.
 			if ctx.Err() != nil {
 				yield(nil, ctx.Err())
 				return
@@ -127,9 +113,9 @@ func (m *resilientModel) tryOnce(ctx context.Context, req *model.LLMRequest, str
 	return buffered, nil
 }
 
-// fallbackResponse is a plain final model message (no function calls, not
-// partial), so session.Event.IsFinalResponse reports true and the
-// AgentNode adopts m.fallback as the node's output.
+// fallbackResponse is a plain final model message, so
+// session.Event.IsFinalResponse reports true and the AgentNode adopts
+// m.fallback as the node's output.
 func (m *resilientModel) fallbackResponse() *model.LLMResponse {
 	return &model.LLMResponse{
 		Content: &genai.Content{

--- a/examples/workflow/complex/resilient_model.go
+++ b/examples/workflow/complex/resilient_model.go
@@ -1,0 +1,140 @@
+// Copyright 2026 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package main
+
+import (
+	"context"
+	"iter"
+	"log"
+	"time"
+
+	"google.golang.org/genai"
+
+	"google.golang.org/adk/model"
+)
+
+// resilientModel wraps a model.LLM to bound and, as a last resort, paper
+// over flaky calls — specifically Gemini's Google Search grounding, which
+// intermittently stalls with neither a response nor an error.
+//
+// Why it exists: a bare model call has no per-call deadline, so a stalled
+// grounding request hangs forever. A workflow.RetryConfig does not help —
+// it only retries calls that *return* an error, and a hang returns
+// nothing. And because the pipeline fans out to three researchers behind a
+// JoinNode barrier, a single stalled researcher would hang (or, with a
+// plain timeout, fail) the whole run.
+//
+// resilientModel addresses all three:
+//   - timeout: every attempt runs under its own context.WithTimeout, so a
+//     stall becomes a context.DeadlineExceeded instead of an infinite wait;
+//   - retry: timed-out/errored attempts are retried (a fresh deadline
+//     each time) after a short fixed backoff;
+//   - fail-open: if every attempt is exhausted it returns a single
+//     fallback model message instead of an error, so the JoinNode still
+//     fires and the synthesis agent still produces a report from whatever
+//     did succeed (graceful degradation rather than a dead pipeline).
+//
+// It implements model.LLM, so any agent can use it transparently.
+type resilientModel struct {
+	inner    model.LLM
+	timeout  time.Duration // per-attempt deadline
+	attempts int           // total tries, including the first
+	fallback string        // model text returned when every attempt fails
+}
+
+// retryBackoff is the fixed pause between attempts. It is deliberately
+// small relative to the per-attempt timeout, which does the real work.
+const retryBackoff = time.Second
+
+// newResilientModel wraps inner. attempts is clamped to a minimum of 1.
+func newResilientModel(inner model.LLM, timeout time.Duration, attempts int, fallback string) *resilientModel {
+	if attempts < 1 {
+		attempts = 1
+	}
+	return &resilientModel{inner: inner, timeout: timeout, attempts: attempts, fallback: fallback}
+}
+
+// Name implements model.LLM.
+func (m *resilientModel) Name() string { return m.inner.Name() }
+
+// GenerateContent implements model.LLM. Each attempt is buffered so a
+// half-streamed-then-failed attempt is discarded cleanly before a retry;
+// the caller only ever observes one successful attempt (or the fallback).
+func (m *resilientModel) GenerateContent(ctx context.Context, req *model.LLMRequest, stream bool) iter.Seq2[*model.LLMResponse, error] {
+	return func(yield func(*model.LLMResponse, error) bool) {
+		var lastErr error
+		for attempt := 1; attempt <= m.attempts; attempt++ {
+			responses, err := m.tryOnce(ctx, req, stream)
+			if err == nil {
+				for _, r := range responses {
+					if !yield(r, nil) {
+						return
+					}
+				}
+				return
+			}
+			lastErr = err
+
+			// A cancelled *parent* context is a real abort (the user quit
+			// or a sibling node failed), not our per-attempt timeout:
+			// propagate it so the node is treated as cancelled, not failed
+			// over to the fallback.
+			if ctx.Err() != nil {
+				yield(nil, ctx.Err())
+				return
+			}
+			if attempt < m.attempts {
+				select {
+				case <-time.After(retryBackoff):
+				case <-ctx.Done():
+					yield(nil, ctx.Err())
+					return
+				}
+			}
+		}
+
+		log.Printf("resilientModel(%s): all %d attempts failed (%v); returning fallback",
+			m.inner.Name(), m.attempts, lastErr)
+		yield(m.fallbackResponse(), nil)
+	}
+}
+
+// tryOnce runs a single attempt under a fresh timeout, buffering its
+// responses so a mid-stream failure leaves nothing half-emitted.
+func (m *resilientModel) tryOnce(ctx context.Context, req *model.LLMRequest, stream bool) ([]*model.LLMResponse, error) {
+	attemptCtx, cancel := context.WithTimeout(ctx, m.timeout)
+	defer cancel()
+
+	var buffered []*model.LLMResponse
+	for resp, err := range m.inner.GenerateContent(attemptCtx, req, stream) {
+		if err != nil {
+			return nil, err
+		}
+		buffered = append(buffered, resp)
+	}
+	return buffered, nil
+}
+
+// fallbackResponse is a plain final model message (no function calls, not
+// partial), so session.Event.IsFinalResponse reports true and the
+// AgentNode adopts m.fallback as the node's output.
+func (m *resilientModel) fallbackResponse() *model.LLMResponse {
+	return &model.LLMResponse{
+		Content: &genai.Content{
+			Role:  "model",
+			Parts: []*genai.Part{{Text: m.fallback}},
+		},
+	}
+}


### PR DESCRIPTION
## Summary
The `examples/workflow/complex` research pipeline fans three Google
Search-grounded researchers into a `JoinNode` barrier, then formats and
synthesizes their findings. Gemini's Search grounding intermittently
**stalls with neither a response nor an error**, and the example set no
per-call deadline — so a single stalled researcher hung the entire run
**forever**. Observed empirically: ~3/5 single-researcher runs stalled
past 30s; with three in parallel behind a Join barrier the pipeline
almost always hung.
The per-node `RetryConfig` did **not** help: it only retries calls that
*return* an error, and a hang returns nothing, so the retry/backoff
never triggered.

## Fix
Add a `resilientModel` decorator (implements `model.LLM`) that wraps
each agent's model and:
- **bounds** every call with a per-attempt `context.WithTimeout`, turning
  a stall into `context.DeadlineExceeded` instead of an infinite wait;
- **retries** timed-out/errored attempts with exponential backoff (fresh
  deadline each time);
- **fails open** after exhausting attempts, returning a short fallback
  message instead of an error, so the `JoinNode` still fires and the
  synthesis agent still produces a report (graceful degradation rather
  than a dead pipeline);
- distinguishes a cancelled *parent* context (real abort) from its own
  per-attempt timeout, propagating the former instead of failing open.
Wire it into each researcher (30s / 3 attempts, topic-specific fallback)
and synthesis (60s / 2 attempts, minimal-report fallback), drop the
misleading node `RetryConfig`, and refresh the example docs/comments.
The graph wiring is unchanged.