### PR TITLE
docs(examples/workflow): add per-example READMEs and a workflow index

### DIFF
--- a/examples/workflow/README.md
+++ b/examples/workflow/README.md
@@ -1,0 +1,46 @@
+# Workflow examples
+
+Runnable samples for the adk-go **graph workflow engine** (`google.golang.org/adk/v2/workflow` + `agent/workflowagent`). Each sample is a `main` package that builds a `workflowagent` from a graph of nodes and serves it through the console launcher.
+
+Every example has its own README with a Mermaid diagram, a goal, run instructions, and an example session.
+
+## Running any sample
+
+```bash
+go run ./examples/workflow/<name>/ console
+```
+
+Samples marked **LLM? Yes** call Gemini and need credentials — either a Gemini API key or Vertex AI Application Default Credentials:
+
+```bash
+# Gemini API key
+export GOOGLE_API_KEY=...
+
+# or Vertex AI via gcloud ADC
+gcloud auth application-default login
+export GOOGLE_GENAI_USE_VERTEXAI=true
+export GOOGLE_CLOUD_PROJECT=your-project
+export GOOGLE_CLOUD_LOCATION=your-region
+```
+
+## Examples
+
+| Example | Theme | What it demonstrates | LLM? |
+|---|---|---|---|
+| [`basic`](./basic) | Basics | Sequential chain of `FunctionNode`s with `workflow.Chain` | No |
+| [`complex`](./complex) | Parallel | Fan-out → `JoinNode` fan-in → LLM synthesis (`AddFanOut` + `AddFanIn`) | Yes |
+| [`routing/string`](./routing/string) | Routing | Branch on a string value with `StringRoute` (punctuation classifier) | No |
+| [`routing/int`](./routing/int) | Routing | Branch on a number with `IntRoute` / `MultiRoute[int]` | No |
+| [`routing/llm`](./routing/llm) | Routing | LLM classifies, the engine routes via `StringRoute` | Yes |
+| [`hitl_simple`](./hitl_simple) | Human-in-the-loop | Minimal two-node pause/resume with `RequestInput` | No |
+| [`hitl_rerun`](./hitl_rerun) | Human-in-the-loop | Single-node re-entry HITL with `ResumeOrRequestInput` | No |
+| [`dynamic/basic`](./dynamic/basic) | Dynamic | Orchestrate children imperatively in Go via `NewDynamicNode` + `RunNode` | No |
+| [`dynamic/hitl`](./dynamic/hitl) | Dynamic | Dynamic orchestrator that pauses for human input and resumes | No |
+| [`dynamic/llm`](./dynamic/llm) | Dynamic | Dynamic orchestrator invoking an `LlmAgent` node via `RunNode` | Yes |
+
+## Core concepts at a glance
+
+- **Nodes** — units of work: `FunctionNode` (a Go function), `AgentNode` (wraps an `LlmAgent`), `ToolNode` (wraps a `tool.Tool`), `JoinNode` (fan-in barrier), and `DynamicNode` (imperative orchestrator).
+- **Edges** — declared with `workflow.Chain`, `workflow.Concat`, and `EdgeBuilder` (`Add`, `AddFanOut`, `AddFanIn`).
+- **Routing** — a node sets `Event.Routes`; matching edges use `StringRoute`, `IntRoute`, or `MultiRoute`.
+- **Human-in-the-loop** — a node emits `RequestInput` to pause; the run resumes when the human replies.

--- a/examples/workflow/basic/README.md
+++ b/examples/workflow/basic/README.md
@@ -1,0 +1,42 @@
+# Basic sequential workflow
+
+The smallest possible workflow: two `FunctionNode`s wired into a straight chain with `workflow.Chain`. The first node uppercases the user's message, the second appends a suffix. No LLM, no routing, no HITL — just the sequential happy path.
+
+- **Concept:** Chain nodes in order with `workflow.Chain(Start, nodeA, nodeB)`.
+- **Needs LLM?** No
+
+## Goal
+
+Show the absolute minimum needed to stand up a workflow agent: define plain Go functions, wrap each as a `FunctionNode`, connect them with `Chain`, and hand the result to the launcher. Each node's output becomes the next node's input.
+
+## Workflow
+
+```mermaid
+graph LR
+    User[User]
+    subgraph "ADK Application Workflow"
+        Start((Start)) --> N1[Node: upper]
+        N1 --> N2[Node: suffix]
+        N2 --> End((End))
+    end
+    User -- "hello world" --> Start
+    End -- "HELLO WORLD IS AWESOME!" --> User
+```
+
+1. **upper**: a `FunctionNode` that receives the user message and returns `strings.ToUpper(input)`.
+2. **suffix**: a `FunctionNode` that appends `" IS AWESOME!"` to its input.
+
+Only the final node's output is surfaced to the user; the intermediate `HELLO WORLD` flows on as `suffix`'s input but is not printed on its own. Both nodes use `workflow.DefaultRetryConfig()` so a transient failure is retried with backoff.
+
+## Running the sample
+
+```bash
+go run ./examples/workflow/basic/ console
+```
+
+## Example session
+
+```text
+User -> hello world
+Agent -> HELLO WORLD IS AWESOME!
+```

--- a/examples/workflow/complex/README.md
+++ b/examples/workflow/complex/README.md
@@ -24,18 +24,18 @@ graph LR
     User[User]
     subgraph "ADK Application Workflow"
         Start((Start))
-        Start --> R1[Node: RenewableEnergyResearcher]
-        Start --> R2[Node: EVResearcher]
-        Start --> R3[Node: CarbonCaptureResearcher]
+        Start -->|"2. fan-out (parallel)"| R1[Node: RenewableEnergyResearcher]
+        Start -->|"2. fan-out (parallel)"| R2[Node: EVResearcher]
+        Start -->|"2. fan-out (parallel)"| R3[Node: CarbonCaptureResearcher]
         R1 --> J[Join Node: gather]
         R2 --> J
         R3 --> J
-        J --> F[Node: format_summaries]
-        F --> S[Node: SynthesisAgent LLM]
+        J -->|"3. gathered map"| F[Node: format_summaries]
+        F -->|"4. prompt"| S[Node: SynthesisAgent LLM]
         S --> End((End))
     end
-    User -- "any message" --> Start
-    End -- "structured report" --> User
+    User -- "1. any message" --> Start
+    End -- "5. structured report" --> User
 ```
 
 `Start` fans out to three researchers that run concurrently; the `gather` join node is the barrier that waits for all three and hands its successor a `map[nodeName]output`; `format_summaries` turns that map into one prompt; and the `SynthesisAgent` merges everything into the final report.

--- a/examples/workflow/complex/README.md
+++ b/examples/workflow/complex/README.md
@@ -5,8 +5,6 @@ A non-trivial graph that fans out to three researchers, gathers their results at
 - **Concept:** Fan-out to concurrent agents, fan-in at a `JoinNode`, then synthesize (`AddFanOut` + `AddFanIn` + `NewJoinNode`).
 - **Needs LLM?** Yes (Gemini with Google Search grounding)
 
-For the fan-out half on its own (no join), see [`../fanout`](../fanout).
-
 ## Goal
 
 Demonstrate the engine's parallel-branch primitives end to end: three researcher agents run concurrently on independent topics, a join barrier waits for all of them, a function node reshapes the gathered results into one prompt, and a single-turn synthesis agent merges everything into one structured report.

--- a/examples/workflow/complex/README.md
+++ b/examples/workflow/complex/README.md
@@ -1,61 +1,63 @@
 # Complex workflow — parallel research → join → synthesize
 
-A non-trivial graph that fans out to three researchers, gathers their
-results at a barrier, and merges them with a final agent. It is the
-graph-native version of the adk-python "parallel web research" sample,
-and the showcase for the graph workflow engine's fan-out / fan-in.
+A non-trivial graph that fans out to three researchers, gathers their results at a barrier, and merges them with a final agent. It is the graph-native version of the adk-python "parallel web research" sample, and the showcase for the graph workflow engine's fan-out / fan-in.
 
-## What it shows
+- **Concept:** Fan-out to concurrent agents, fan-in at a `JoinNode`, then synthesize (`AddFanOut` + `AddFanIn` + `NewJoinNode`).
+- **Needs LLM?** Yes (Gemini with Google Search grounding)
 
-| Concept | Where |
-|---|---|
-| Fan-out — independent nodes run concurrently | `eb.AddFanOut(workflow.Start, renewableNode, evNode, carbonNode)` |
-| Fan-in — a barrier that waits for every predecessor | `workflow.NewJoinNode("gather")` + `eb.AddFanIn(...)` |
-| Consuming the join's `map[nodeName]output` | `formatSummaries` reads the gathered map by node name |
-| A `FunctionNode` transforming data mid-graph | `format_summaries` turns the map into one prompt |
-| A single-turn `AgentNode` after a predecessor (not `Start`) | the `SynthesisAgent` node consumes the formatter's output |
-| Per-node retries with backoff | `llmNodeConfig.RetryConfig` on the LLM nodes |
-| Built-in Google Search grounding | `geminitool.GoogleSearch{}` on each researcher |
-| Default in-memory session | `launcher.Config` sets only `AgentLoader` |
+For the fan-out half on its own (no join), see [`../fanout`](../fanout).
 
-A `JoinNode` is the only node that may have several **unconditional**
-incoming edges; converging plain nodes that way is rejected
-(`ErrUnsupportedFanIn`). Wrapping an `LlmAgent` in an `AgentNode`
-defaults it to single-turn mode, which is what lets the synthesis agent
-sit mid-graph: a chat-mode agent may only be wired directly from `Start`.
+## Goal
 
-## Graph
+Demonstrate the engine's parallel-branch primitives end to end: three researcher agents run concurrently on independent topics, a join barrier waits for all of them, a function node reshapes the gathered results into one prompt, and a single-turn synthesis agent merges everything into one structured report.
 
-```
-START ─┬─> RenewableEnergyResearcher ─┐
-       ├─> EVResearcher ──────────────┼─> gather ─> format_summaries ─> SynthesisAgent
-       └─> CarbonCaptureResearcher ───┘  (Join)        (func)              (LLM)
+## Authentication
+
+The researchers call Gemini with Google Search grounding, so an API key is required:
+
+```bash
+export GOOGLE_API_KEY=...
 ```
 
-## Run it
+## Workflow
 
-Requires `GOOGLE_API_KEY` (the researchers call Gemini with Google
-Search grounding):
+```mermaid
+graph LR
+    User[User]
+    subgraph "ADK Application Workflow"
+        Start((Start))
+        Start --> R1[Node: RenewableEnergyResearcher]
+        Start --> R2[Node: EVResearcher]
+        Start --> R3[Node: CarbonCaptureResearcher]
+        R1 --> J[Join Node: gather]
+        R2 --> J
+        R3 --> J
+        J --> F[Node: format_summaries]
+        F --> S[Node: SynthesisAgent LLM]
+        S --> End((End))
+    end
+    User -- "any message" --> Start
+    End -- "structured report" --> User
+```
 
-```sh
+`Start` fans out to three researchers that run concurrently; the `gather` join node is the barrier that waits for all three and hands its successor a `map[nodeName]output`; `format_summaries` turns that map into one prompt; and the `SynthesisAgent` merges everything into the final report.
+
+## Running the sample
+
+```bash
 export GOOGLE_API_KEY=...
 go run ./examples/workflow/complex/ console
 ```
 
-Send any message to start a run — the research topics are fixed, so the
-message just triggers the pipeline.
+Send any message to start a run — the research topics are fixed, so the message just triggers the pipeline.
 
-Every node emits events, so the console prints **all three researcher
-summaries first, then the synthesized report**. The summaries appear in
-nondeterministic order (the researchers run concurrently), and in an
-interactive terminal the default token streaming interleaves them. For
-clean, block-at-a-time output, disable streaming:
+Every node emits events, so the console prints **all three researcher summaries first, then the synthesized report**. The summaries appear in nondeterministic order (the researchers run concurrently), and in an interactive terminal the default token streaming interleaves them. For clean, block-at-a-time output, disable streaming:
 
-```sh
+```bash
 go run ./examples/workflow/complex/ console -streaming_mode none
 ```
 
-A run then looks like:
+## Example session
 
 ```text
 Agent -> Driven by falling costs, solar PV is projected to overtake ...   (RenewableEnergyResearcher)
@@ -76,5 +78,21 @@ Agent -> ## Recent Sustainable Technology Advancements                    (Synth
          ...
 ```
 
-This fan-out/gather behavior matches adk-python's graph workflow, which
-emits the same per-researcher events before the synthesis.
+## What it shows
+
+| Concept | Where |
+|---|---|
+| Fan-out — independent nodes run concurrently | `eb.AddFanOut(workflow.Start, renewableNode, evNode, carbonNode)` |
+| Fan-in — a barrier that waits for every predecessor | `workflow.NewJoinNode("gather")` + `eb.AddFanIn(...)` |
+| Consuming the join's `map[nodeName]output` | `formatSummaries` reads the gathered map by node name |
+| A `FunctionNode` transforming data mid-graph | `format_summaries` turns the map into one prompt |
+| A single-turn `AgentNode` after a predecessor (not `Start`) | the `SynthesisAgent` node consumes the formatter's output |
+| Per-node retries with backoff | `llmNodeConfig.RetryConfig` on the LLM nodes |
+| Built-in Google Search grounding | `geminitool.GoogleSearch{}` on each researcher |
+| Default in-memory session | `launcher.Config` sets only `AgentLoader` |
+
+## Notes
+
+A `JoinNode` is the only node that may have several **unconditional** incoming edges; converging plain nodes that way is rejected (`ErrUnsupportedFanIn`). Wrapping an `LlmAgent` in an `AgentNode` defaults it to single-turn mode, which is what lets the synthesis agent sit mid-graph: a chat-mode agent may only be wired directly from `Start`.
+
+This fan-out/gather behavior matches adk-python's graph workflow, which emits the same per-researcher events before the synthesis.

--- a/examples/workflow/dynamic/basic/README.md
+++ b/examples/workflow/dynamic/basic/README.md
@@ -1,0 +1,42 @@
+# Dynamic workflow (basic)
+
+A minimal **dynamic** workflow: a parent dynamic node expresses execution order as ordinary Go code and invokes a single child node via `workflow.RunNode`. Mirrors the "Get started" snippet from <https://adk.dev/graphs/dynamic/>.
+
+- **Concept:** Orchestrate children imperatively with `workflow.NewDynamicNode` + `workflow.RunNode`, instead of declaring static edges.
+- **Needs LLM?** No
+
+## Goal
+
+Static graphs (see [`../../basic`](../../basic)) declare every edge up front. A **dynamic node** instead runs a Go function as its body and decides at runtime which child nodes to call, in what order — useful for loops, branching, and data-dependent control flow. This sample is the smallest version: the orchestrator calls one child and returns its output.
+
+## Workflow
+
+```mermaid
+graph LR
+    User[User]
+    subgraph "ADK Application Workflow"
+        Start((Start)) --> D[Dynamic Node: my_workflow]
+        D -.->|"RunNode(hello)"| C[Node: hello_node]
+        C -.->|"returns 'Hello World'"| D
+        D --> End((End))
+    end
+    User -- "any message" --> Start
+    End -- "Hello World" --> User
+```
+
+Solid arrows are static graph edges; dotted arrows are imperative `RunNode` calls made from inside the dynamic node's body. `hello_node` ignores its input and returns the constant `"Hello World"`. Dynamic nodes default to `RerunOnResume = &true`, which is required for the re-entry/resume model (see [`../hitl`](../hitl)).
+
+## Running the sample
+
+```bash
+go run ./examples/workflow/dynamic/basic/ console
+```
+
+## Example session
+
+The orchestrator ignores the message text, so any input triggers the same run.
+
+```text
+User -> hi
+Agent -> Hello World
+```

--- a/examples/workflow/dynamic/basic/README.md
+++ b/examples/workflow/dynamic/basic/README.md
@@ -16,12 +16,12 @@ graph LR
     User[User]
     subgraph "ADK Application Workflow"
         Start((Start)) --> D[Dynamic Node: my_workflow]
-        D -.->|"RunNode(hello)"| C[Node: hello_node]
-        C -.->|"returns 'Hello World'"| D
+        D -.->|"2. RunNode(hello)"| C[Node: hello_node]
+        C -.->|"3. returns 'Hello World'"| D
         D --> End((End))
     end
-    User -- "any message" --> Start
-    End -- "Hello World" --> User
+    User -- "1. any message" --> Start
+    End -- "4. Hello World" --> User
 ```
 
 Solid arrows are static graph edges; dotted arrows are imperative `RunNode` calls made from inside the dynamic node's body. `hello_node` ignores its input and returns the constant `"Hello World"`. Dynamic nodes default to `RerunOnResume = &true`, which is required for the re-entry/resume model (see [`../hitl`](../hitl)).

--- a/examples/workflow/dynamic/hitl/README.md
+++ b/examples/workflow/dynamic/hitl/README.md
@@ -1,0 +1,47 @@
+# Dynamic workflow + Human-in-the-Loop
+
+A dynamic orchestrator that **pauses for human input** via `workflow.RunNode`, then resumes and greets the user. Demonstrates the dynamic re-entry resume pattern.
+
+- **Concept:** Pause a dynamic node for input, then resume by re-running its body and reading the reply from `agent.Context.ResumedInput`.
+- **Needs LLM?** No
+
+For the static-chain version of the same scenario, see [`../../hitl_simple`](../../hitl_simple).
+
+## Goal
+
+Show how Human-in-the-Loop works inside a *dynamic* node. Dynamic nodes default to `RerunOnResume = &true`: after the human replies, the orchestrator body is re-invoked **from the top**, and the reply is delivered through `ResumedInput(interruptID)`. The body checks for that reply first; if it isn't there yet, it calls the `ask_name` node, which emits a `RequestInput` and interrupts the run.
+
+## Workflow
+
+```mermaid
+graph LR
+    User[User]
+    subgraph "ADK Application Workflow"
+        Start((Start)) --> G[Dynamic Node: hitl_demo]
+        G -.->|"1st pass: RunNode"| A[Node: ask_name]
+        A -.->|"RequestInput, pause"| G
+        G --> End((End))
+    end
+    User -- "start" --> Start
+    A -- "What's your name?" --> User
+    User -- "Alice (resume)" --> G
+    End -- "Hello, Alice!" --> User
+```
+
+- **First pass:** `hitl_demo` finds no resumed input, so it runs `ask_name`, which emits a `RequestInput` event (keyed by an invocation-derived `InterruptID`) and returns `ErrNodeInterrupted` — the run pauses.
+- **Resume:** the console forwards the human's reply; `hitl_demo` re-runs from the top, finds the reply under the same `InterruptID` via `ResumedInput`, emits the greeting as content, and returns.
+
+## Running the sample
+
+```bash
+go run ./examples/workflow/dynamic/hitl/ console
+```
+
+## Example session
+
+```text
+User -> start
+Agent -> What's your name?
+User -> Alice
+Agent -> Hello, Alice!
+```

--- a/examples/workflow/dynamic/hitl/README.md
+++ b/examples/workflow/dynamic/hitl/README.md
@@ -18,14 +18,14 @@ graph LR
     User[User]
     subgraph "ADK Application Workflow"
         Start((Start)) --> G[Dynamic Node: hitl_demo]
-        G -.->|"1st pass: RunNode"| A[Node: ask_name]
-        A -.->|"RequestInput, pause"| G
+        G -.->|"2. 1st pass: RunNode(ask_name)"| A[Node: ask_name]
+        A -.->|"3. RequestInput, pause"| G
         G --> End((End))
     end
-    User -- "start" --> Start
-    A -- "What's your name?" --> User
-    User -- "Alice (resume)" --> G
-    End -- "Hello, Alice!" --> User
+    User -- "1. start" --> Start
+    A -- "4. What's your name?" --> User
+    User -- "5. Alice (resume)" --> G
+    End -- "6. Hello, Alice!" --> User
 ```
 
 - **First pass:** `hitl_demo` finds no resumed input, so it runs `ask_name`, which emits a `RequestInput` event (keyed by an invocation-derived `InterruptID`) and returns `ErrNodeInterrupted` — the run pauses.

--- a/examples/workflow/dynamic/llm/README.md
+++ b/examples/workflow/dynamic/llm/README.md
@@ -1,0 +1,57 @@
+# Dynamic workflow + LLM
+
+A dynamic orchestrator that invokes a single `LlmAgent`-backed node via `workflow.RunNode`. The smallest useful composition of `NewDynamicNode`, `NewAgentNode`, and `RunNode`.
+
+- **Concept:** Call an `LlmAgent` from inside a dynamic node's Go body by wrapping it as an `AgentNode` and invoking it with `RunNode`.
+- **Needs LLM?** Yes (Gemini)
+
+## Goal
+
+Bridge the two building blocks: an `LlmAgent` (the model) and a dynamic node (imperative control flow). The agent is wrapped with `workflow.NewAgentNode` so it can be driven from code, then the dynamic orchestrator calls it once and returns its reply. The same shape scales to multi-step pipelines, branching, and loops — just add more `RunNode` calls to the body.
+
+## Authentication
+
+The model client reads its config from the environment, so set one of:
+
+```bash
+# Option A — Gemini API key
+export GOOGLE_API_KEY=...
+
+# Option B — Vertex AI via gcloud Application Default Credentials
+gcloud auth application-default login
+export GOOGLE_GENAI_USE_VERTEXAI=true
+export GOOGLE_CLOUD_PROJECT=your-project
+export GOOGLE_CLOUD_LOCATION=your-region   # e.g. us-central1
+```
+
+## Workflow
+
+```mermaid
+graph LR
+    User[User]
+    subgraph "ADK Application Workflow"
+        Start((Start)) --> D[Dynamic Node: greeter_workflow]
+        D -.->|"RunNode(input)"| G[Agent Node: greeter LLM]
+        G -.->|"one-sentence greeting"| D
+        D --> End((End))
+    end
+    User -- "hi" --> Start
+    End -- "Hello! How can I help you today?" --> User
+```
+
+Solid arrows are static graph edges; the dotted arrows are the imperative `RunNode` call into the wrapped `LlmAgent`. The `greeter` agent's only instruction is to greet the user in exactly one short sentence.
+
+## Running the sample
+
+```bash
+go run ./examples/workflow/dynamic/llm/ console
+```
+
+## Example session
+
+The exact wording comes from the model, so it varies between runs.
+
+```text
+User -> hi
+Agent -> Hello there! How can I help you today?
+```

--- a/examples/workflow/dynamic/llm/README.md
+++ b/examples/workflow/dynamic/llm/README.md
@@ -31,12 +31,12 @@ graph LR
     User[User]
     subgraph "ADK Application Workflow"
         Start((Start)) --> D[Dynamic Node: greeter_workflow]
-        D -.->|"RunNode(input)"| G[Agent Node: greeter LLM]
-        G -.->|"one-sentence greeting"| D
+        D -.->|"2. RunNode(input)"| G[Agent Node: greeter LLM]
+        G -.->|"3. one-sentence greeting"| D
         D --> End((End))
     end
-    User -- "hi" --> Start
-    End -- "Hello! How can I help you today?" --> User
+    User -- "1. hi" --> Start
+    End -- "4. Hello! How can I help you today?" --> User
 ```
 
 Solid arrows are static graph edges; the dotted arrows are the imperative `RunNode` call into the wrapped `LlmAgent`. The `greeter` agent's only instruction is to greet the user in exactly one short sentence.

--- a/examples/workflow/hitl_rerun/README.md
+++ b/examples/workflow/hitl_rerun/README.md
@@ -1,0 +1,48 @@
+# Human-in-the-Loop (single-node re-entry)
+
+A Human-in-the-Loop workflow where **one** emitting `FunctionNode` both pauses for input and produces the final output. On resume the node is re-run from scratch (`NodeConfig.RerunOnResume = &true`).
+
+- **Concept:** Single-node re-entry HITL with `workflow.ResumeOrRequestInput`.
+- **Needs LLM?** No
+
+For the two-node handoff variant, see [`../hitl_simple`](../hitl_simple).
+
+## Goal
+
+Contrast two ways to do HITL. The two-node *handoff* variant ([`../hitl_simple`](../hitl_simple)) has one node ask and a separate node consume the reply. This sample collapses both phases into a single re-run node:
+
+- `workflow.ResumeOrRequestInput` emits a `RequestInput` and returns `ErrNodeInterrupted` on the **first** pass (pause, no output);
+- after the human replies, the node is **re-run from the top**, and the same call now returns the reply, which the body turns into the terminal output.
+
+## Workflow
+
+```mermaid
+graph LR
+    User[User]
+    subgraph "ADK Application Workflow"
+        Start((Start)) --> G[Node: greet]
+        G -.->|"re-run on resume"| G
+        G --> End((End))
+    end
+    User -- "hello" --> Start
+    G -- "1st pass: What's your name?" --> User
+    User -- "Alice" --> G
+    End -- "Hello, Alice!" --> User
+```
+
+The dotted self-loop is the re-entry: the same `greet` node executes twice — once to ask (and pause), once to answer. The `InterruptID` embeds the invocation ID so the reply still correlates across the re-run within a single run, yet a later run re-prompts.
+
+## Running the sample
+
+```bash
+go run ./examples/workflow/hitl_rerun/ console
+```
+
+## Example session
+
+```text
+User -> hello
+Agent -> What's your name?
+User -> Alice
+Agent -> Hello, Alice!
+```

--- a/examples/workflow/hitl_rerun/README.md
+++ b/examples/workflow/hitl_rerun/README.md
@@ -21,16 +21,15 @@ graph LR
     User[User]
     subgraph "ADK Application Workflow"
         Start((Start)) --> G[Node: greet]
-        G -.->|"re-run on resume"| G
         G --> End((End))
     end
     User -- "1. hello" --> Start
     G -- "2. What's your name? (1st pass)" --> User
-    User -- "3. Alice" --> G
+    User -- "3. Alice (re-run on resume)" --> G
     End -- "4. Hello, Alice!" --> User
 ```
 
-The numbered edges are the user ↔ application exchange, in order. The dotted self-loop is the re-entry that happens *between steps 3 and 4*: the same `greet` node executes twice — first it asks and pauses (step 2), then after the reply (step 3) it is re-run from the top and produces the greeting (step 4). The `InterruptID` embeds the invocation ID so the reply still correlates across the re-run within a single run, yet a later run re-prompts.
+The numbered edges are the user ↔ application exchange, in order. Because `RerunOnResume = &true`, the reply at step 3 re-enters `greet` (instead of flowing on to a successor, as it would in [`../hitl_simple`](../hitl_simple)), so the same node executes twice: first it asks and pauses (step 2), then on resume it is re-run from the top and produces the greeting (step 4). The `InterruptID` embeds the invocation ID so the reply still correlates across the re-run within a single run, yet a later run re-prompts.
 
 ## Running the sample
 

--- a/examples/workflow/hitl_rerun/README.md
+++ b/examples/workflow/hitl_rerun/README.md
@@ -24,13 +24,13 @@ graph LR
         G -.->|"re-run on resume"| G
         G --> End((End))
     end
-    User -- "hello" --> Start
-    G -- "1st pass: What's your name?" --> User
-    User -- "Alice" --> G
-    End -- "Hello, Alice!" --> User
+    User -- "1. hello" --> Start
+    G -- "2. What's your name? (1st pass)" --> User
+    User -- "3. Alice" --> G
+    End -- "4. Hello, Alice!" --> User
 ```
 
-The dotted self-loop is the re-entry: the same `greet` node executes twice — once to ask (and pause), once to answer. The `InterruptID` embeds the invocation ID so the reply still correlates across the re-run within a single run, yet a later run re-prompts.
+The numbered edges are the user ↔ application exchange, in order. The dotted self-loop is the re-entry that happens *between steps 3 and 4*: the same `greet` node executes twice — first it asks and pauses (step 2), then after the reply (step 3) it is re-run from the top and produces the greeting (step 4). The `InterruptID` embeds the invocation ID so the reply still correlates across the re-run within a single run, yet a later run re-prompts.
 
 ## Running the sample
 

--- a/examples/workflow/hitl_simple/README.md
+++ b/examples/workflow/hitl_simple/README.md
@@ -5,7 +5,7 @@ The minimal end-to-end HITL workflow: two nodes where the first pauses for input
 - **Concept:** Two-node HITL handoff — pause with `RequestInput`, resume into the next node.
 - **Needs LLM?** No
 
-Related variants: [`../hitl_rerun`](../hitl_rerun) (single re-entry node) and [`../hitl_llm`](../hitl_llm) (adds an `LlmAgent` and a revise loop).
+Related variant: [`../hitl_rerun`](../hitl_rerun) — the same scenario as a single re-entry node.
 
 ## Goal
 

--- a/examples/workflow/hitl_simple/README.md
+++ b/examples/workflow/hitl_simple/README.md
@@ -1,0 +1,46 @@
+# Human-in-the-Loop (minimal, two nodes)
+
+The minimal end-to-end HITL workflow: two nodes where the first pauses for input and the second consumes the human's reply. No LLM, no API key, no streaming — the smallest thing that exercises the console launcher's pause/resume support.
+
+- **Concept:** Two-node HITL handoff — pause with `RequestInput`, resume into the next node.
+- **Needs LLM?** No
+
+Related variants: [`../hitl_rerun`](../hitl_rerun) (single re-entry node) and [`../hitl_llm`](../hitl_llm) (adds an `LlmAgent` and a revise loop).
+
+## Goal
+
+Demonstrate the simplest possible Human-in-the-Loop pattern. `ask_name` emits a `RequestInput` event and returns `ErrNodeInterrupted`, which pauses the workflow; the console launcher renders the prompt; the user's reply is delivered to `greet` as its typed input.
+
+## Workflow
+
+```mermaid
+graph LR
+    User[User]
+    subgraph "ADK Application Workflow"
+        Start((Start)) --> N1[Node: ask_name]
+        N1 --> N2[Node: greet]
+        N2 --> End((End))
+    end
+    User -- "hello" --> Start
+    N1 -- "What's your name?" --> User
+    User -- "Alice" --> N2
+    End -- "Hello, Alice!" --> User
+```
+
+1. **ask_name**: an emitting `FunctionNode` that yields a `RequestInput` (with a fresh per-request `InterruptID`) and interrupts the run.
+2. **greet**: an ordinary `FunctionNode` that receives the reply string and returns the greeting.
+
+## Running the sample
+
+```bash
+go run ./examples/workflow/hitl_simple/ console
+```
+
+## Example session
+
+```text
+User -> hello
+Agent -> What's your name?
+User -> Alice
+Agent -> Hello, Alice!
+```

--- a/examples/workflow/hitl_simple/README.md
+++ b/examples/workflow/hitl_simple/README.md
@@ -21,10 +21,10 @@ graph LR
         N1 --> N2[Node: greet]
         N2 --> End((End))
     end
-    User -- "hello" --> Start
-    N1 -- "What's your name?" --> User
-    User -- "Alice" --> N2
-    End -- "Hello, Alice!" --> User
+    User -- "1. hello" --> Start
+    N1 -- "2. What's your name?" --> User
+    User -- "3. Alice" --> N2
+    End -- "4. Hello, Alice!" --> User
 ```
 
 1. **ask_name**: an emitting `FunctionNode` that yields a `RequestInput` (with a fresh per-request `InterruptID`) and interrupts the run.

--- a/examples/workflow/routing/int/README.md
+++ b/examples/workflow/routing/int/README.md
@@ -1,8 +1,49 @@
 # Routing sample — random number → 3 branches
 
-The smallest end-to-end demonstration of `workflow.IntRoute` /
-`workflow.MultiRoute` and the `Event.Routes` contract. No LLM, no
-HITL, no persistence — just routing.
+The smallest end-to-end demonstration of `workflow.IntRoute` / `workflow.MultiRoute` and the `Event.Routes` contract. No LLM, no HITL, no persistence — just routing.
+
+- **Concept:** Numeric routing with `IntRoute` / `MultiRoute[int]` over an `Event.Routes` value.
+- **Needs LLM?** No
+
+## Goal
+
+Roll a random integer 1..10 and dispatch to one of three handlers based on which range it falls in. Shows how a node sets `Event.Routes` (and `Event.Output`) so the engine selects the matching downstream edge.
+
+## Workflow
+
+```mermaid
+graph LR
+    User[User]
+    subgraph "ADK Application Workflow"
+        Start((Start)) --> N1[Node: roll_die]
+        N1 --> N2{Node: route_by_value}
+        N2 -- "1, 2, 3" --> L[Node: handle_low]
+        N2 -- "4, 5, 6, 7" --> M[Node: handle_mid]
+        N2 -- "8, 9, 10" --> H[Node: handle_high]
+        L --> End((End))
+        M --> End
+        H --> End
+    end
+    User -- "any message" --> Start
+    End -- "rolled 8 — handling HIGH range" --> User
+```
+
+`roll_die` returns an `int`; `route_by_value` emits an event whose `Routes` is the stringified value and whose `Output` is the value itself, so the matched handler receives a typed `int`. Each `MultiRoute[int]` edge matches a set of values (the LOW / MID / HIGH ranges).
+
+## Running the sample
+
+```bash
+go run ./examples/workflow/routing/int/ console
+```
+
+## Example session
+
+Type any message; the sample ignores it and rolls a fresh number each turn, so the branch changes from run to run (LOW = 1..3, MID = 4..7, HIGH = 8..10):
+
+```text
+User -> hi
+Agent -> rolled 8 — handling HIGH range (8..10)
+```
 
 ## What it shows
 
@@ -13,37 +54,6 @@ HITL, no persistence — just routing.
 | `MultiRoute[int]` matching a set of ints | three downstream edges, one per range |
 | Random behaviour to exercise different paths between runs | `math/rand/v2` in `roll_die` |
 
-In adk-go, `FunctionNode` cannot emit `Event.Routes`: its wrapper
-always builds a single output event from the return value, so the
-routing node drops down to a custom `BaseNode`. (adk-python has no
-such split — a plain function node there can `yield Event(route=...)`
-directly.)
+## Notes
 
-## Run it
-
-```sh
-go run ./examples/workflow/routing/int/ console
-```
-
-Type any message; the sample ignores it. Each turn rolls a fresh
-number. Run a few times in a row to see the route change:
-
-```text
-User -> hi
-Agent -> rolled 7 — handling MID range (4..7)
-
-User -> hi
-Agent -> rolled 2 — handling LOW range (1..3)
-
-User -> hi
-Agent -> rolled 9 — handling HIGH range (8..10)
-```
-
-## Graph
-
-```
-START → roll_die → route_by_value
-                      ├─ {1, 2, 3}    → handle_low
-                      ├─ {4, 5, 6, 7} → handle_mid
-                      └─ {8, 9, 10}   → handle_high
-```
+In adk-go, `FunctionNode` cannot emit `Event.Routes`: its wrapper always builds a single output event from the return value, so the routing node drops down to a custom `BaseNode`. (adk-python has no such split — a plain function node there can `yield Event(route=...)` directly.)

--- a/examples/workflow/routing/int/README.md
+++ b/examples/workflow/routing/int/README.md
@@ -24,8 +24,8 @@ graph LR
         M --> End
         H --> End
     end
-    User -- "any message" --> Start
-    End -- "rolled 8 — handling HIGH range" --> User
+    User -- "1. any message" --> Start
+    End -- "2. rolled 8 — handling HIGH range" --> User
 ```
 
 `roll_die` returns an `int`; `route_by_value` emits an event whose `Routes` is the stringified value and whose `Output` is the value itself, so the matched handler receives a typed `int`. Each `MultiRoute[int]` edge matches a set of values (the LOW / MID / HIGH ranges).

--- a/examples/workflow/routing/llm/README.md
+++ b/examples/workflow/routing/llm/README.md
@@ -1,26 +1,48 @@
 # LLM-driven routing sample
 
-The smallest sample that uses an actual LLM as the routing brain
-inside a workflow graph. An LLMAgent classifies the user's
-message into one of three categories; a trivial Go function then
-emits the corresponding `Event.Routes` value, dispatching to one
-of three handlers.
+The smallest sample that uses an actual LLM as the routing brain inside a workflow graph. An `LlmAgent` classifies the user's message into one of three categories; a trivial Go function then emits the corresponding `Event.Routes` value, dispatching to one of three handlers.
 
-Same shape as adk-python's
-`contributing/workflow_samples/route/` sample (LLM classifier +
-plain function emitting the routing event).
+- **Concept:** LLM classifies, a plain function emits the route, the engine dispatches (`NewAgentNode` + `StringRoute`).
+- **Needs LLM?** Yes (Gemini)
 
-## Requirements
+Same shape as adk-python's `contributing/workflow_samples/route/` sample (LLM classifier + plain function emitting the routing event). For the non-LLM version, see [`../string`](../string).
 
-```sh
+## Goal
+
+Show the canonical "LLM as the brain, engine does the routing" pattern: keep the LLM stateless about routing and keep the routing logic in plain code. The classifier returns one word; the router turns that into an `Event.Routes` value; three `StringRoute` edges dispatch to the matching handler.
+
+## Authentication
+
+```bash
 export GOOGLE_API_KEY=<your-key>
 ```
 
-## Run it
+## Workflow
 
-```sh
+```mermaid
+graph LR
+    User[User]
+    subgraph "ADK Application Workflow"
+        Start((Start)) --> C[Agent Node: classify LLM]
+        C --> R{Node: route_by_classification}
+        R -- "question" --> Q[Node: answer_question]
+        R -- "statement" --> S[Node: comment_statement]
+        R -- "exclamation" --> E[Node: react_exclamation]
+        Q --> End((End))
+        S --> End
+        E --> End
+    end
+    User -- "What time is it?" --> Start
+    End -- "answering question: What time is it?" --> User
+```
+
+## Running the sample
+
+```bash
 go run ./examples/workflow/routing/llm/ console
 ```
+
+## Example session
 
 ```text
 User -> What time is it?
@@ -36,17 +58,7 @@ Agent -> statement
 commenting on statement: The sky is blue.
 ```
 
-The first line of agent output is the LLM's classification (it
-prints because the console launcher streams every event with
-text content). The second line is the handler's reply.
-
-## Graph
-
-```
-START → classify (LLM) → route_by_classification ─┬─ "question"    → answer_question
-                                                  ├─ "statement"   → comment_statement
-                                                  └─ "exclamation" → react_exclamation
-```
+The first line of agent output is the LLM's classification (it prints because the console launcher streams every event with text content). The second line is the handler's reply.
 
 ## What it shows
 
@@ -54,44 +66,26 @@ START → classify (LLM) → route_by_classification ─┬─ "question"    →
 |---|---|
 | `workflow.NewAgentNode` wrapping an `LLMAgent` | `classifyNode := workflow.NewAgentNode(classifier, ...)` |
 | LLM reply flowing to the next node | `AgentNode` synthesizes the classifier's final reply into `Event.Output`, which the scheduler feeds to the router as input; `LLMAgent.OutputKey = "output"` is optional here and only persists the reply to session state |
-| Custom `BaseNode` translating the LLM's free-form text into a route value | `routeFromClassificationNode` reads the classifier's reply, normalises it, and emits `Event.Routes` |
+| Custom `BaseNode` translating the LLM's free-form text into a route value | `route_by_classification` reads the classifier's reply, normalises it, and emits `Event.Routes` |
 | `StringRoute` matching one of three categories | three downstream edges, one per category |
 | Handler reading the original user message from `ctx.UserContent` | each handler calls `userMessage(ctx)` rather than receiving it as graph input — the routing node only forwards the classification, not the original text |
 
-## Why two nodes (classifier + router)?
+## Notes
 
-Mirrors the canonical adk-python pattern: keep the LLM stateless
-about routing, keep the routing logic in plain code. The
-alternative — one custom node that calls the LLM and emits
-`Routes` from the same Run body — is shorter but mixes
-"LLM-driven decision" with "graph wiring", and reuses none of
-the engine's normal LLMAgent machinery (output_key, telemetry,
-etc.).
+### Why two nodes (classifier + router)?
 
-## Why register the classifier in `Config.SubAgents`?
+Mirrors the canonical adk-python pattern: keep the LLM stateless about routing, keep the routing logic in plain code. The alternative — one custom node that calls the LLM and emits `Routes` from the same Run body — is shorter but mixes "LLM-driven decision" with "graph wiring", and reuses none of the engine's normal LLMAgent machinery (output_key, telemetry, etc.).
 
-`workflow.NewAgentNode` wraps an `agent.Agent` for graph
-execution but does **not** make that agent visible in the
-runner's agent tree (the structure `runner.findAgentToRun`
-walks to resolve `event.Author` to an `agent.Agent`). Without
-the explicit `SubAgents: []agent.Agent{classifier}`
-registration, the runner logs
+### Why register the classifier in `Config.SubAgents`?
+
+`workflow.NewAgentNode` wraps an `agent.Agent` for graph execution but does **not** make that agent visible in the runner's agent tree (the structure `runner.findAgentToRun` walks to resolve `event.Author` to an `agent.Agent`). Without the explicit `SubAgents: []agent.Agent{classifier}` registration, the runner logs
 
 ```
 Event from an unknown agent: classify, event id: ...
 ```
 
-on every turn. The warning is harmless — the runner falls back
-to `rootAgent` (the workflow itself), and
-`isTransferableAcrossAgentTree` blocks any actual re-routing to
-the LLM agent because the chain to root contains a non-LLMAgent
-(the workflow wrapper). But registering the classifier as a
-sub-agent silences the warning and keeps the agent tree
-consistent with the workflow graph. Treat it as required
-boilerplate for any workflow that wraps a sub-agent.
+on every turn. The warning is harmless — the runner falls back to `rootAgent` (the workflow itself), and `isTransferableAcrossAgentTree` blocks any actual re-routing to the LLM agent because the chain to root contains a non-LLMAgent (the workflow wrapper). But registering the classifier as a sub-agent silences the warning and keeps the agent tree consistent with the workflow graph. Treat it as required boilerplate for any workflow that wraps a sub-agent.
 
-## Tunable: pick a different model
+### Tunable: pick a different model
 
-Edit `gemini-flash-latest` in `main.go` to whatever model your
-key has access to. The classifier prompt is very short and any
-modern Gemini model handles it.
+Edit `gemini-flash-latest` in `main.go` to whatever model your key has access to. The classifier prompt is very short and any modern Gemini model handles it.

--- a/examples/workflow/routing/llm/README.md
+++ b/examples/workflow/routing/llm/README.md
@@ -32,8 +32,8 @@ graph LR
         S --> End
         E --> End
     end
-    User -- "What time is it?" --> Start
-    End -- "answering question: What time is it?" --> User
+    User -- "1. What time is it?" --> Start
+    End -- "2. answering question: What time is it?" --> User
 ```
 
 ## Running the sample

--- a/examples/workflow/routing/string/README.md
+++ b/examples/workflow/routing/string/README.md
@@ -25,8 +25,8 @@ graph LR
         S --> End
         E --> End
     end
-    User -- "What time is it?" --> Start
-    End -- "answering question: What time is it?" --> User
+    User -- "1. What time is it?" --> Start
+    End -- "2. answering question: What time is it?" --> User
 ```
 
 ## Running the sample

--- a/examples/workflow/routing/string/README.md
+++ b/examples/workflow/routing/string/README.md
@@ -1,15 +1,43 @@
 # String routing sample — message classification → 3 branches
 
-The smallest end-to-end demonstration of `workflow.StringRoute`
-and the `Event.Routes` contract. No LLM, no HITL, no random — a
-trivial classifier picks the route based on the message's
-terminal punctuation.
+The smallest end-to-end demonstration of `workflow.StringRoute` and the `Event.Routes` contract. No LLM, no HITL, no random — a trivial classifier picks the route based on the message's terminal punctuation.
 
-## Run it
+- **Concept:** String routing with `StringRoute` over an `Event.Routes` value.
+- **Needs LLM?** No
 
-```sh
+For the version where an LLM does the classification, see [`../llm`](../llm).
+
+## Goal
+
+Classify a message by its terminal punctuation (`?` / `!` / otherwise) and dispatch to one of three handlers. The single `classify` node emits both the route and the original message as output, so each handler receives the message as a typed `string`.
+
+## Workflow
+
+```mermaid
+graph LR
+    User[User]
+    subgraph "ADK Application Workflow"
+        Start((Start)) --> C{Node: classify}
+        C -- "question" --> Q[Node: answer_question]
+        C -- "statement" --> S[Node: comment_statement]
+        C -- "exclamation" --> E[Node: react_exclamation]
+        Q --> End((End))
+        S --> End
+        E --> End
+    end
+    User -- "What time is it?" --> Start
+    End -- "answering question: What time is it?" --> User
+```
+
+## Running the sample
+
+```bash
 go run ./examples/workflow/routing/string/ console
 ```
+
+## Example session
+
+The route is chosen by the message's terminal punctuation, so it is fully deterministic:
 
 ```text
 User -> What time is it?
@@ -22,18 +50,10 @@ User -> Hello world!
 Agent -> reacting to exclamation: Hello world!
 ```
 
-## Graph
-
-```
-START → classify ─┬─ "question"    → answer_question
-                  ├─ "statement"   → comment_statement
-                  └─ "exclamation" → react_exclamation
-```
-
 ## What it shows
 
 | Concept | Where |
 |---|---|
-| Custom `BaseNode` emitting a routing event | `classifyNode` sets `Event.Routes = []string{category}` and `Event.Output = msg` so downstream `FunctionNode`s get the original message as a typed `string` input |
+| Custom `BaseNode` emitting a routing event | `classify` sets `Event.Routes = []string{category}` and `Event.Output = msg` so downstream `FunctionNode`s get the original message as a typed `string` input |
 | `StringRoute` matching a single value | three downstream edges, one per category |
 | Direct port of adk-python's `route/` sample, minus the LLM | classifier is a plain Go function instead of an `Agent` with `output_schema` |


### PR DESCRIPTION
Add README files for the workflow examples that lacked them and normalize the existing ones to a shared section order with `graph LR` Mermaid diagrams. Each example README covers the goal, an annotated workflow diagram, how to run it, and an example session.

Also add a top-level examples/workflow/README.md that indexes the examples in a table (theme, what it demonstrates, whether it needs an LLM) with shared run/auth instructions.

Covers the examples tracked in this repo: basic, complex, routing/{string,int,llm}, hitl_simple, hitl_rerun, and dynamic/{basic,hitl,llm}.