### PR TITLE
docs: update AGENTS.md repository layout for current packages

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -36,8 +36,9 @@ A change is complete only when all of these pass locally:
 
 ## Repository layout
 
-- `agent/`     Agent interface + types (`llmagent`, `workflowagents`, `remoteagent`)
+- `agent/`     Agent interface + types (`llmagent`, `workflowagent(s)`, `remoteagent`)
 - `runner/`    Execution engine that drives the run loop
+- `workflow/`  Node/graph-based workflow engine for multi-agent apps
 - `model/`     LLM abstraction (`gemini`, `apigee`)
 - `tool/`      Tool/Toolset interface + built-in tools (incl. `skilltoolset/`, `mcptoolset/`)
 - `session/`   Conversation state + events
@@ -46,6 +47,7 @@ A change is complete only when all of these pass locally:
 - `server/`    HTTP servers (`adkrest` is primary; `adka2a`, `agentengine`)
 - `cmd/`       CLI (`adkgo`) and server launchers
 - `telemetry/`, `util/`   Public helper packages
+- `platform/`  Overridable seams for time & UUID generation (deterministic tests)
 - `internal/`  Private packages — NOT public API; `internal/httprr` is vendored
 - `examples/`  Runnable example agents (quickstart, tools, a2a, skills, …)
 


### PR DESCRIPTION
## Summary

Re-verified `AGENTS.md` against the current tree. The rest of the file (setup/core commands, definition of done, minimal example, extension snippets, testing workflow) still matches the code — only the **Repository layout** section had drifted, missing packages added since the file was introduced.

- Add `workflow/` — node/graph-based workflow engine for multi-agent apps.
- Add `platform/` — overridable seams for time & UUID generation (deterministic tests).
- Update the `agent/` entry to `workflowagent(s)` so it covers both the base workflow agent and the loop/parallel/sequential workflow agents.

## Testing Plan

Docs-only change; no code affected. Verified the updated layout entries against the actual top-level packages in the repo and confirmed the Markdown renders correctly.