### PR TITLE
feat(guardrail): add ErrGuardrailBlocked sentinel and OnGuardrailBlockedCallback

### DIFF
--- a/agent/llmagent/llmagent.go
+++ b/agent/llmagent/llmagent.go
@@ -22,6 +22,7 @@ import (
 	"google.golang.org/genai"
 
 	"google.golang.org/adk/v2/agent"
+	"google.golang.org/adk/v2/guardrail"
 	agentinternal "google.golang.org/adk/v2/internal/agent"
 	icontext "google.golang.org/adk/v2/internal/context"
 	"google.golang.org/adk/v2/internal/llminternal"
@@ -63,14 +64,20 @@ func New(cfg Config) (agent.Agent, error) {
 		onToolErrorCallback = append(onToolErrorCallback, llminternal.OnToolErrorCallback(c))
 	}
 
+	onGuardrailBlockedCallbacks := make([]llminternal.OnGuardrailBlockedCallback, 0, len(cfg.OnGuardrailBlockedCallbacks))
+	for _, c := range cfg.OnGuardrailBlockedCallbacks {
+		onGuardrailBlockedCallbacks = append(onGuardrailBlockedCallbacks, llminternal.OnGuardrailBlockedCallback(c))
+	}
+
 	a := &llmAgent{
-		model:                 cfg.Model,
-		beforeModelCallbacks:  beforeModelCallbacks,
-		afterModelCallbacks:   afterModelCallbacks,
-		onModelErrorCallbacks: onModelErrorCallbacks,
-		beforeToolCallbacks:   beforeToolCallbacks,
-		afterToolCallbacks:    afterToolCallbacks,
-		onToolErrorCallbacks:  onToolErrorCallback,
+		model:                       cfg.Model,
+		beforeModelCallbacks:        beforeModelCallbacks,
+		afterModelCallbacks:         afterModelCallbacks,
+		onModelErrorCallbacks:       onModelErrorCallbacks,
+		beforeToolCallbacks:         beforeToolCallbacks,
+		afterToolCallbacks:          afterToolCallbacks,
+		onToolErrorCallbacks:        onToolErrorCallback,
+		onGuardrailBlockedCallbacks: onGuardrailBlockedCallbacks,
 		instruction:           cfg.Instruction,
 		inputSchema:           cfg.InputSchema,
 		outputSchema:          cfg.OutputSchema,
@@ -326,6 +333,11 @@ type Config struct {
 
 	OnToolErrorCallbacks []OnToolErrorCallback
 
+	// OnGuardrailBlockedCallbacks are called when a BeforeToolCallback returns
+	// *guardrail.ErrGuardrailBlocked. This allows custom responses for policy
+	// denials, distinct from unexpected runtime errors.
+	OnGuardrailBlockedCallbacks []OnGuardrailBlockedCallback
+
 	// OutputKey is an optional parameter to specify the key in session state for the agent output.
 	//
 	// Typical uses cases are:
@@ -404,6 +416,12 @@ type AfterToolCallback func(ctx agent.Context, tool tool.Tool, args, result map[
 // is replaced with the returned response/error.
 type OnToolErrorCallback func(ctx agent.Context, tool tool.Tool, args map[string]any, err error) (map[string]any, error)
 
+// OnGuardrailBlockedCallback is called when a BeforeToolCallback returns
+// *guardrail.ErrGuardrailBlocked, signalling a policy denial rather than an
+// unexpected runtime error. Returning a non-nil map replaces the default
+// blocked-tool response sent back to the model.
+type OnGuardrailBlockedCallback func(ctx agent.Context, tool tool.Tool, args map[string]any, err *guardrail.ErrGuardrailBlocked) (map[string]any, error)
+
 // IncludeContents controls what parts of prior conversation history is received by llmagent.
 type IncludeContents string
 
@@ -425,9 +443,10 @@ type llmAgent struct {
 	instruction           string
 	onModelErrorCallbacks []llminternal.OnModelErrorCallback
 
-	beforeToolCallbacks  []llminternal.BeforeToolCallback
-	afterToolCallbacks   []llminternal.AfterToolCallback
-	onToolErrorCallbacks []llminternal.OnToolErrorCallback
+	beforeToolCallbacks         []llminternal.BeforeToolCallback
+	afterToolCallbacks          []llminternal.AfterToolCallback
+	onToolErrorCallbacks        []llminternal.OnToolErrorCallback
+	onGuardrailBlockedCallbacks []llminternal.OnGuardrailBlockedCallback
 
 	inputSchema  *genai.Schema
 	outputSchema *genai.Schema
@@ -446,9 +465,10 @@ func (a *llmAgent) run(ctx agent.InvocationContext) iter.Seq2[*session.Event, er
 		BeforeModelCallbacks:  a.beforeModelCallbacks,
 		AfterModelCallbacks:   a.afterModelCallbacks,
 		OnModelErrorCallbacks: a.onModelErrorCallbacks,
-		BeforeToolCallbacks:   a.beforeToolCallbacks,
-		AfterToolCallbacks:    a.afterToolCallbacks,
-		OnToolErrorCallbacks:  a.onToolErrorCallbacks,
+		BeforeToolCallbacks:         a.beforeToolCallbacks,
+		AfterToolCallbacks:          a.afterToolCallbacks,
+		OnToolErrorCallbacks:        a.onToolErrorCallbacks,
+		OnGuardrailBlockedCallbacks: a.onGuardrailBlockedCallbacks,
 	}
 
 	return func(yield func(*session.Event, error) bool) {
@@ -481,9 +501,10 @@ func (a *llmAgent) RunLive(ctx agent.InvocationContext) (agent.LiveSession, iter
 		BeforeModelCallbacks:  a.beforeModelCallbacks,
 		AfterModelCallbacks:   a.afterModelCallbacks,
 		OnModelErrorCallbacks: a.onModelErrorCallbacks,
-		BeforeToolCallbacks:   a.beforeToolCallbacks,
-		AfterToolCallbacks:    a.afterToolCallbacks,
-		OnToolErrorCallbacks:  a.onToolErrorCallbacks,
+		BeforeToolCallbacks:         a.beforeToolCallbacks,
+		AfterToolCallbacks:          a.afterToolCallbacks,
+		OnToolErrorCallbacks:        a.onToolErrorCallbacks,
+		OnGuardrailBlockedCallbacks: a.onGuardrailBlockedCallbacks,
 	}
 
 	sess, innerIter, err := f.RunLive(ctx)

--- a/examples/compliance/main.go
+++ b/examples/compliance/main.go
@@ -1,0 +1,146 @@
+// Copyright 2026 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+// Package main demonstrates the ErrGuardrailBlocked sentinel and
+// OnGuardrailBlockedCallback for policy-aware tool enforcement.
+//
+// Run:
+//
+//	export GOOGLE_API_KEY=<your-api-key>
+//	go run ./examples/compliance -- --console
+package main
+
+import (
+	"context"
+	"fmt"
+	"log"
+	"os"
+	"strings"
+
+	"google.golang.org/genai"
+
+	"google.golang.org/adk/v2/agent"
+	"google.golang.org/adk/v2/agent/llmagent"
+	"google.golang.org/adk/v2/cmd/launcher"
+	"google.golang.org/adk/v2/cmd/launcher/full"
+	"google.golang.org/adk/v2/guardrail"
+	"google.golang.org/adk/v2/model/gemini"
+	"google.golang.org/adk/v2/plugin"
+	"google.golang.org/adk/v2/runner"
+	"google.golang.org/adk/v2/tool"
+	"google.golang.org/adk/v2/tool/functiontool"
+)
+
+// transferFunds simulates a funds transfer tool.
+func transferFunds(ctx agent.Context, args map[string]any) (map[string]any, error) {
+	recipient, _ := args["recipient"].(string)
+	amount, _ := args["amount_minor_units"].(float64)
+	ref := "TXN-XXXX"
+	if len(recipient) >= 4 {
+		ref = "TXN-" + strings.ToUpper(recipient[:4])
+	}
+	return map[string]any{
+		"reference": ref,
+		"status":    "submitted",
+		"amount":    amount,
+	}, nil
+}
+
+// policyGuardrail is a BeforeToolCallback that enforces two simple rules:
+//   - Narrations containing flagged keywords are denied
+//   - Transfers over 1,000,000 minor units are denied
+func policyGuardrail(_ agent.Context, t tool.Tool, args map[string]any) (map[string]any, error) {
+	if t.Name() != "transfer_funds" {
+		return nil, nil // only guard the transfer tool
+	}
+	narration := strings.ToLower(fmt.Sprintf("%v", args["narration"]))
+	for _, kw := range []string{"launder", "evade", "fake"} {
+		if strings.Contains(narration, kw) {
+			return nil, &guardrail.ErrGuardrailBlocked{
+				Policy: "aml-narration",
+				Reason: "narration flagged by AML keyword screening",
+			}
+		}
+	}
+	amount, _ := args["amount_minor_units"].(float64)
+	if amount > 1_000_000 {
+		return nil, &guardrail.ErrGuardrailBlocked{
+			Policy: "high-value-transfer",
+			Reason: fmt.Sprintf("amount %.0f exceeds the single-transfer limit of 1,000,000", amount),
+		}
+	}
+	return nil, nil
+}
+
+// blockedHandler is an OnGuardrailBlockedCallback that converts policy denials
+// into structured tool responses the LLM can reason about.
+func blockedHandler(_ agent.Context, t tool.Tool, _ map[string]any, blocked *guardrail.ErrGuardrailBlocked) (map[string]any, error) {
+	log.Printf("[guardrail] tool=%q policy=%q reason=%q", t.Name(), blocked.Policy, blocked.Reason)
+	return map[string]any{
+		"status":  "blocked",
+		"policy":  blocked.Policy,
+		"message": blocked.Reason,
+	}, nil
+}
+
+func main() {
+	ctx := context.Background()
+
+	mdl, err := gemini.NewModel(ctx, "gemini-2.0-flash-exp", &genai.ClientConfig{
+		APIKey: os.Getenv("GOOGLE_API_KEY"),
+	})
+	if err != nil {
+		log.Fatalf("failed to create model: %v", err)
+	}
+
+	transferTool, err := functiontool.New(functiontool.Config{
+		Name:        "transfer_funds",
+		Description: "Transfer funds. Args: recipient (string), amount_minor_units (integer), narration (string).",
+	}, transferFunds)
+	if err != nil {
+		log.Fatalf("failed to create transfer tool: %v", err)
+	}
+
+	compliancePlugin, err := plugin.New(plugin.Config{
+		Name:                       "compliance-guardrail",
+		BeforeToolCallback:         policyGuardrail,
+		OnGuardrailBlockedCallback: blockedHandler,
+	})
+	if err != nil {
+		log.Fatalf("failed to create plugin: %v", err)
+	}
+
+	complianceAgent, err := llmagent.New(llmagent.Config{
+		Name:  "compliance_agent",
+		Model: mdl,
+		Tools: []tool.Tool{transferTool},
+		Instruction: `You are a payment assistant.
+When a transfer is blocked by policy, explain clearly why it cannot proceed and what the user can do instead.`,
+	})
+	if err != nil {
+		log.Fatalf("failed to create agent: %v", err)
+	}
+
+	cfg := &launcher.Config{
+		AgentLoader: agent.NewSingleLoader(complianceAgent),
+		PluginConfig: runner.PluginConfig{
+			Plugins: []*plugin.Plugin{compliancePlugin},
+		},
+	}
+
+	l := full.NewLauncher()
+	if err = l.Execute(ctx, cfg, os.Args[1:]); err != nil {
+		log.Fatalf("run failed: %v\n\n%s", err, l.CommandLineSyntax())
+	}
+}

--- a/guardrail/guardrail.go
+++ b/guardrail/guardrail.go
@@ -1,0 +1,53 @@
+// Copyright 2026 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+// Package guardrail provides sentinel error types for policy guardrails.
+//
+// Guardrail callbacks signal a policy denial by returning *ErrGuardrailBlocked.
+// Runners detect this via errors.As and route to OnGuardrailBlockedCallbacks
+// rather than OnToolErrorCallbacks, so policy denials are never misreported
+// as unexpected runtime failures.
+package guardrail
+
+import "fmt"
+
+// ErrGuardrailBlocked is returned by a BeforeToolCallback when an agent's
+// tool call has been denied by a policy guardrail.
+//
+// Use errors.As to check for this type and distinguish policy denials from
+// unexpected runtime errors:
+//
+//	var blocked *guardrail.ErrGuardrailBlocked
+//	if errors.As(err, &blocked) {
+//	    // policy denial — blocked.Policy and blocked.Reason are available
+//	}
+type ErrGuardrailBlocked struct {
+	// Policy is the name of the policy or guardrail that blocked the call.
+	// May be empty if the callback does not supply a policy name.
+	Policy string
+
+	// Reason is a human-readable explanation of why the call was blocked.
+	Reason string
+}
+
+// Error implements the error interface.
+func (e *ErrGuardrailBlocked) Error() string {
+	if e.Policy != "" {
+		return fmt.Sprintf("guardrail %q blocked tool call: %s", e.Policy, e.Reason)
+	}
+	if e.Reason != "" {
+		return fmt.Sprintf("guardrail blocked tool call: %s", e.Reason)
+	}
+	return "guardrail blocked tool call"
+}

--- a/guardrail/guardrail_test.go
+++ b/guardrail/guardrail_test.go
@@ -1,0 +1,76 @@
+// Copyright 2026 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package guardrail_test
+
+import (
+	"errors"
+	"testing"
+
+	"google.golang.org/adk/v2/guardrail"
+)
+
+func TestErrGuardrailBlocked_Error(t *testing.T) {
+	tests := []struct {
+		name   string
+		err    *guardrail.ErrGuardrailBlocked
+		want   string
+	}{
+		{
+			name:  "policy and reason",
+			err:   &guardrail.ErrGuardrailBlocked{Policy: "pii-filter", Reason: "request contains PII"},
+			want:  `guardrail "pii-filter" blocked tool call: request contains PII`,
+		},
+		{
+			name:  "reason only",
+			err:   &guardrail.ErrGuardrailBlocked{Reason: "rate limit exceeded"},
+			want:  "guardrail blocked tool call: rate limit exceeded",
+		},
+		{
+			name:  "empty",
+			err:   &guardrail.ErrGuardrailBlocked{},
+			want:  "guardrail blocked tool call",
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			if got := tt.err.Error(); got != tt.want {
+				t.Errorf("Error() = %q, want %q", got, tt.want)
+			}
+		})
+	}
+}
+
+func TestErrGuardrailBlocked_ErrorsAs(t *testing.T) {
+	original := &guardrail.ErrGuardrailBlocked{Policy: "aml", Reason: "suspicious pattern"}
+	wrapped := errors.Join(errors.New("outer"), original)
+
+	var target *guardrail.ErrGuardrailBlocked
+	if !errors.As(wrapped, &target) {
+		t.Fatal("errors.As should find *ErrGuardrailBlocked inside wrapped error")
+	}
+	if target.Policy != "aml" {
+		t.Errorf("Policy = %q, want %q", target.Policy, "aml")
+	}
+	if target.Reason != "suspicious pattern" {
+		t.Errorf("Reason = %q, want %q", target.Reason, "suspicious pattern")
+	}
+}
+
+func TestErrGuardrailBlocked_ImplementsError(t *testing.T) {
+	var err error = &guardrail.ErrGuardrailBlocked{Policy: "test"}
+	if err == nil {
+		t.Fatal("*ErrGuardrailBlocked must implement error")
+	}
+}

--- a/internal/llminternal/base_flow.go
+++ b/internal/llminternal/base_flow.go
@@ -30,6 +30,7 @@ import (
 	"google.golang.org/genai"
 
 	"google.golang.org/adk/v2/agent"
+	"google.golang.org/adk/v2/guardrail"
 	"google.golang.org/adk/v2/internal/agent/parentmap"
 	"google.golang.org/adk/v2/internal/agent/runconfig"
 	icontext "google.golang.org/adk/v2/internal/context"
@@ -60,6 +61,12 @@ type AfterToolCallback func(ctx agent.Context, tool tool.Tool, args, result map[
 
 type OnToolErrorCallback func(ctx agent.Context, tool tool.Tool, args map[string]any, err error) (map[string]any, error)
 
+// OnGuardrailBlockedCallback is called when a BeforeToolCallback returns
+// *guardrail.ErrGuardrailBlocked, signalling a policy denial rather than an
+// unexpected runtime error. Returning a non-nil map replaces the default
+// blocked-tool response sent back to the model.
+type OnGuardrailBlockedCallback func(ctx agent.Context, tool tool.Tool, args map[string]any, err *guardrail.ErrGuardrailBlocked) (map[string]any, error)
+
 // Flow is a base implementation of the agent flow.
 type Flow struct {
 	Model model.LLM
@@ -70,9 +77,10 @@ type Flow struct {
 	BeforeModelCallbacks  []BeforeModelCallback
 	AfterModelCallbacks   []AfterModelCallback
 	OnModelErrorCallbacks []OnModelErrorCallback
-	BeforeToolCallbacks   []BeforeToolCallback
-	AfterToolCallbacks    []AfterToolCallback
-	OnToolErrorCallbacks  []OnToolErrorCallback
+	BeforeToolCallbacks          []BeforeToolCallback
+	AfterToolCallbacks           []AfterToolCallback
+	OnToolErrorCallbacks         []OnToolErrorCallback
+	OnGuardrailBlockedCallbacks  []OnGuardrailBlockedCallback
 }
 
 var (
@@ -1231,6 +1239,17 @@ func (f *Flow) runOnToolErrorCallbacks(toolCtx agent.Context, tool tool.Tool, fA
 	return f.invokeOnToolErrorCallbacks(toolCtx, tool, fArgs, err)
 }
 
+func (f *Flow) runOnGuardrailBlockedCallbacks(toolCtx agent.Context, tool tool.Tool, fArgs map[string]any, blocked *guardrail.ErrGuardrailBlocked) (map[string]any, error) {
+	pluginManager := pluginManagerFromContext(toolCtx)
+	if pluginManager != nil {
+		result, err := pluginManager.RunOnGuardrailBlockedCallback(toolCtx, tool, fArgs, blocked)
+		if result != nil || err != nil {
+			return result, err
+		}
+	}
+	return f.invokeOnGuardrailBlockedCallbacks(toolCtx, tool, fArgs, blocked)
+}
+
 func (f *Flow) callTool(toolCtx agent.Context, tool toolinternal.FunctionTool, fArgs map[string]any) map[string]any {
 	var response map[string]any
 	var err error
@@ -1248,11 +1267,28 @@ func (f *Flow) callTool(toolCtx agent.Context, tool toolinternal.FunctionTool, f
 
 	var errorResponse map[string]any
 	var cbErr error
-	if err != nil && pluginManager != nil {
-		errorResponse, cbErr = pluginManager.RunOnToolErrorCallback(toolCtx, tool, fArgs, err)
-	}
-	if err != nil && errorResponse == nil && cbErr == nil {
-		errorResponse, cbErr = f.invokeOnToolErrorCallbacks(toolCtx, tool, fArgs, err)
+	if err != nil {
+		var blocked *guardrail.ErrGuardrailBlocked
+		if errors.As(err, &blocked) {
+			if pluginManager != nil {
+				errorResponse, cbErr = pluginManager.RunOnGuardrailBlockedCallback(toolCtx, tool, fArgs, blocked)
+			}
+			if errorResponse == nil && cbErr == nil {
+				errorResponse, cbErr = f.invokeOnGuardrailBlockedCallbacks(toolCtx, tool, fArgs, blocked)
+			}
+			if errorResponse == nil && cbErr == nil {
+				// Default: return the policy denial reason as a structured response.
+				errorResponse = map[string]any{"error": err.Error()}
+				err = nil
+			}
+		} else {
+			if pluginManager != nil {
+				errorResponse, cbErr = pluginManager.RunOnToolErrorCallback(toolCtx, tool, fArgs, err)
+			}
+			if errorResponse == nil && cbErr == nil {
+				errorResponse, cbErr = f.invokeOnToolErrorCallbacks(toolCtx, tool, fArgs, err)
+			}
+		}
 	}
 	if errorResponse != nil || cbErr != nil {
 		response = errorResponse
@@ -1323,6 +1359,19 @@ func (f *Flow) invokeOnToolErrorCallbacks(toolCtx agent.Context, tool tool.Tool,
 	}
 	// If no callback returned a result/error, return the original result/error.
 	return nil, fErr
+}
+
+func (f *Flow) invokeOnGuardrailBlockedCallbacks(toolCtx agent.Context, tool tool.Tool, fArgs map[string]any, blocked *guardrail.ErrGuardrailBlocked) (map[string]any, error) {
+	for _, callback := range f.OnGuardrailBlockedCallbacks {
+		result, err := callback(toolCtx, tool, fArgs, blocked)
+		if err != nil {
+			return nil, err
+		}
+		if result != nil {
+			return result, nil
+		}
+	}
+	return nil, nil
 }
 
 func mergeParallelFunctionResponseEvents(events []*session.Event) (*session.Event, error) {
@@ -1420,4 +1469,5 @@ type pluginManager interface {
 	RunBeforeToolCallback(ctx agent.Context, t tool.Tool, args map[string]any) (map[string]any, error)
 	RunAfterToolCallback(ctx agent.Context, t tool.Tool, args, result map[string]any, err error) (map[string]any, error)
 	RunOnToolErrorCallback(ctx agent.Context, t tool.Tool, args map[string]any, err error) (map[string]any, error)
+	RunOnGuardrailBlockedCallback(ctx agent.Context, t tool.Tool, args map[string]any, blocked *guardrail.ErrGuardrailBlocked) (map[string]any, error)
 }

--- a/internal/llminternal/base_flow_test.go
+++ b/internal/llminternal/base_flow_test.go
@@ -22,6 +22,7 @@ import (
 	"google.golang.org/genai"
 
 	"google.golang.org/adk/v2/agent"
+	"google.golang.org/adk/v2/guardrail"
 	icontext "google.golang.org/adk/v2/internal/context"
 	"google.golang.org/adk/v2/internal/toolinternal"
 	"google.golang.org/adk/v2/model"
@@ -95,13 +96,14 @@ func (m *mockRequestProcessorToolset) Tools(ctx agent.ReadonlyContext) ([]tool.T
 }
 
 type testCase struct {
-	name                 string
-	tool                 toolinternal.FunctionTool
-	args                 map[string]any
-	beforeToolCallbacks  []BeforeToolCallback
-	afterToolCallbacks   []AfterToolCallback
-	onToolErrorCallbacks []OnToolErrorCallback
-	want                 map[string]any
+	name                        string
+	tool                        toolinternal.FunctionTool
+	args                        map[string]any
+	beforeToolCallbacks         []BeforeToolCallback
+	afterToolCallbacks          []AfterToolCallback
+	onToolErrorCallbacks        []OnToolErrorCallback
+	onGuardrailBlockedCallbacks []OnGuardrailBlockedCallback
+	want                        map[string]any
 }
 
 func TestCallTool(t *testing.T) {
@@ -379,6 +381,71 @@ func TestCallTool(t *testing.T) {
 			},
 			want: map[string]any{"error": "error_from_after_tool"},
 		},
+		// --- guardrail routing ---
+		{
+			name: "ErrGuardrailBlocked routes to OnGuardrailBlockedCallback, not OnToolErrorCallback",
+			tool: &mockFunctionTool{
+				name: "transfer",
+				runFunc: func(ctx agent.Context, args map[string]any) (map[string]any, error) {
+					t.Error("tool must not run after guardrail block")
+					return nil, nil
+				},
+			},
+			beforeToolCallbacks: []BeforeToolCallback{
+				func(ctx agent.Context, tool tool.Tool, args map[string]any) (map[string]any, error) {
+					return nil, &guardrail.ErrGuardrailBlocked{Policy: "aml", Reason: "suspicious pattern"}
+				},
+			},
+			onToolErrorCallbacks: []OnToolErrorCallback{
+				func(ctx agent.Context, tool tool.Tool, args map[string]any, err error) (map[string]any, error) {
+					t.Error("OnToolErrorCallback must not be called for a guardrail block")
+					return nil, nil
+				},
+			},
+			onGuardrailBlockedCallbacks: []OnGuardrailBlockedCallback{
+				func(ctx agent.Context, tool tool.Tool, args map[string]any, blocked *guardrail.ErrGuardrailBlocked) (map[string]any, error) {
+					return map[string]any{"blocked": true, "policy": blocked.Policy}, nil
+				},
+			},
+			want: map[string]any{"blocked": true, "policy": "aml"},
+		},
+		{
+			name: "ErrGuardrailBlocked default response when no OnGuardrailBlockedCallback registered",
+			tool: &mockFunctionTool{
+				name: "transfer",
+				runFunc: func(ctx agent.Context, args map[string]any) (map[string]any, error) {
+					t.Error("tool must not run after guardrail block")
+					return nil, nil
+				},
+			},
+			beforeToolCallbacks: []BeforeToolCallback{
+				func(ctx agent.Context, tool tool.Tool, args map[string]any) (map[string]any, error) {
+					return nil, &guardrail.ErrGuardrailBlocked{Policy: "pii", Reason: "PII detected"}
+				},
+			},
+			want: map[string]any{"error": `guardrail "pii" blocked tool call: PII detected`},
+		},
+		{
+			name: "non-guardrail error still routes to OnToolErrorCallback",
+			tool: &mockFunctionTool{
+				name: "transfer",
+				runFunc: func(ctx agent.Context, args map[string]any) (map[string]any, error) {
+					return nil, errors.New("network timeout")
+				},
+			},
+			onToolErrorCallbacks: []OnToolErrorCallback{
+				func(ctx agent.Context, tool tool.Tool, args map[string]any, err error) (map[string]any, error) {
+					return map[string]any{"error": "handled: " + err.Error()}, nil
+				},
+			},
+			onGuardrailBlockedCallbacks: []OnGuardrailBlockedCallback{
+				func(ctx agent.Context, tool tool.Tool, args map[string]any, blocked *guardrail.ErrGuardrailBlocked) (map[string]any, error) {
+					t.Error("OnGuardrailBlockedCallback must not be called for a non-guardrail error")
+					return nil, nil
+				},
+			},
+			want: map[string]any{"error": "handled: network timeout"},
+		},
 		{
 			name: "before callback error passed to on tool error callback and passed to after tool called and handled",
 			tool: &mockFunctionTool{
@@ -416,9 +483,10 @@ func TestCallTool(t *testing.T) {
 	for _, tc := range testCases {
 		t.Run(tc.name, func(t *testing.T) {
 			f := &Flow{
-				BeforeToolCallbacks:  tc.beforeToolCallbacks,
-				AfterToolCallbacks:   tc.afterToolCallbacks,
-				OnToolErrorCallbacks: tc.onToolErrorCallbacks,
+				BeforeToolCallbacks:         tc.beforeToolCallbacks,
+				AfterToolCallbacks:          tc.afterToolCallbacks,
+				OnToolErrorCallbacks:        tc.onToolErrorCallbacks,
+				OnGuardrailBlockedCallbacks: tc.onGuardrailBlockedCallbacks,
 			}
 			ctx := icontext.NewInvocationContext(t.Context(), icontext.InvocationContextParams{})
 			got := f.callTool(agent.NewToolContext(ctx, "", nil, nil), tc.tool, tc.args)

--- a/internal/plugininternal/plugin_manager.go
+++ b/internal/plugininternal/plugin_manager.go
@@ -22,6 +22,7 @@ import (
 	"google.golang.org/genai"
 
 	"google.golang.org/adk/v2/agent"
+	"google.golang.org/adk/v2/guardrail"
 	"google.golang.org/adk/v2/internal/plugininternal/plugincontext"
 	"google.golang.org/adk/v2/model"
 	"google.golang.org/adk/v2/plugin"
@@ -207,6 +208,23 @@ func (pm *PluginManager) RunOnToolErrorCallback(ctx agent.Context, tool tool.Too
 		callback := plugin.OnToolErrorCallback()
 		if callback != nil {
 			newResult, err := callback(ctx, tool, args, err)
+			if err != nil {
+				return nil, err
+			}
+			if newResult != nil {
+				return newResult, nil // Early exit
+			}
+		}
+	}
+	return nil, nil
+}
+
+// RunOnGuardrailBlockedCallback runs the OnGuardrailBlockedCallback for all plugins.
+func (pm *PluginManager) RunOnGuardrailBlockedCallback(ctx agent.Context, tool tool.Tool, args map[string]any, blocked *guardrail.ErrGuardrailBlocked) (map[string]any, error) {
+	for _, plugin := range pm.plugins {
+		callback := plugin.OnGuardrailBlockedCallback()
+		if callback != nil {
+			newResult, err := callback(ctx, tool, args, blocked)
 			if err != nil {
 				return nil, err
 			}

--- a/plugin/plugin.go
+++ b/plugin/plugin.go
@@ -40,9 +40,10 @@ type Config struct {
 	AfterModelCallback   llmagent.AfterModelCallback
 	OnModelErrorCallback llmagent.OnModelErrorCallback
 
-	BeforeToolCallback  llmagent.BeforeToolCallback
-	AfterToolCallback   llmagent.AfterToolCallback
-	OnToolErrorCallback llmagent.OnToolErrorCallback
+	BeforeToolCallback          llmagent.BeforeToolCallback
+	AfterToolCallback           llmagent.AfterToolCallback
+	OnToolErrorCallback         llmagent.OnToolErrorCallback
+	OnGuardrailBlockedCallback  llmagent.OnGuardrailBlockedCallback
 
 	CloseFunc func() error
 }
@@ -59,9 +60,10 @@ func New(cfg Config) (*Plugin, error) {
 		beforeModelCallback:   cfg.BeforeModelCallback,
 		afterModelCallback:    cfg.AfterModelCallback,
 		onModelErrorCallback:  cfg.OnModelErrorCallback,
-		beforeToolCallback:    cfg.BeforeToolCallback,
-		afterToolCallback:     cfg.AfterToolCallback,
-		onToolErrorCallback:   cfg.OnToolErrorCallback,
+		beforeToolCallback:         cfg.BeforeToolCallback,
+		afterToolCallback:          cfg.AfterToolCallback,
+		onToolErrorCallback:        cfg.OnToolErrorCallback,
+		onGuardrailBlockedCallback: cfg.OnGuardrailBlockedCallback,
 		closeFunc:             cfg.CloseFunc,
 	}
 
@@ -91,9 +93,10 @@ type Plugin struct {
 	afterModelCallback   llmagent.AfterModelCallback
 	onModelErrorCallback llmagent.OnModelErrorCallback
 
-	beforeToolCallback  llmagent.BeforeToolCallback
-	afterToolCallback   llmagent.AfterToolCallback
-	onToolErrorCallback llmagent.OnToolErrorCallback
+	beforeToolCallback         llmagent.BeforeToolCallback
+	afterToolCallback          llmagent.AfterToolCallback
+	onToolErrorCallback        llmagent.OnToolErrorCallback
+	onGuardrailBlockedCallback llmagent.OnGuardrailBlockedCallback
 
 	closeFunc func() error
 }
@@ -156,6 +159,10 @@ func (p *Plugin) AfterToolCallback() llmagent.AfterToolCallback {
 
 func (p *Plugin) OnToolErrorCallback() llmagent.OnToolErrorCallback {
 	return p.onToolErrorCallback
+}
+
+func (p *Plugin) OnGuardrailBlockedCallback() llmagent.OnGuardrailBlockedCallback {
+	return p.onGuardrailBlockedCallback
 }
 
 type OnUserMessageCallback func(agent.InvocationContext, *genai.Content) (*genai.Content, error)

--- a/plugin/plugin_manager_test.go
+++ b/plugin/plugin_manager_test.go
@@ -26,6 +26,7 @@ import (
 
 	"google.golang.org/adk/v2/agent"
 	"google.golang.org/adk/v2/agent/llmagent"
+	"google.golang.org/adk/v2/guardrail"
 	"google.golang.org/adk/v2/internal/testutil"
 	"google.golang.org/adk/v2/model"
 	"google.golang.org/adk/v2/plugin"
@@ -872,6 +873,92 @@ func TestModelCallbacks(t *testing.T) {
 			}
 			if afterModelCallbacksCalled == false && tc.dontRunAfterCanonicalCallback == false {
 				t.Error("after model should be called")
+			}
+		})
+	}
+}
+
+func TestOnGuardrailBlockedCallbackPlugin(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		name              string
+		blockedCallbackFn llmagent.OnGuardrailBlockedCallback
+		onErrorCallbackFn llmagent.OnToolErrorCallback
+		wantResponse      map[string]any
+	}{
+		{
+			name: "plugin OnGuardrailBlockedCallback called for ErrGuardrailBlocked",
+			blockedCallbackFn: func(ctx agent.Context, t tool.Tool, args map[string]any, blocked *guardrail.ErrGuardrailBlocked) (map[string]any, error) {
+				return map[string]any{"blocked": true, "policy": blocked.Policy}, nil
+			},
+			onErrorCallbackFn: func(ctx agent.Context, t tool.Tool, args map[string]any, err error) (map[string]any, error) {
+				return map[string]any{"error": "should not reach OnToolErrorCallback"}, nil
+			},
+			wantResponse: map[string]any{"blocked": true, "policy": "rate-limit"},
+		},
+		{
+			name:         "default guardrail response when no OnGuardrailBlockedCallback registered",
+			wantResponse: map[string]any{"error": `guardrail "rate-limit" blocked tool call: quota exceeded`},
+		},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			t.Parallel()
+
+			ft, err := functiontool.New(functiontool.Config{Name: "testTool"}, func(ctx agent.Context, args map[string]any) (map[string]any, error) {
+				return map[string]any{"result": "should not run"}, nil
+			})
+			if err != nil {
+				t.Fatalf("failed to create function tool: %v", err)
+			}
+
+			p, err := plugin.New(plugin.Config{
+				Name: "guardrail-plugin",
+				BeforeToolCallback: func(ctx agent.Context, t tool.Tool, args map[string]any) (map[string]any, error) {
+					return nil, &guardrail.ErrGuardrailBlocked{Policy: "rate-limit", Reason: "quota exceeded"}
+				},
+				OnGuardrailBlockedCallback: tc.blockedCallbackFn,
+				OnToolErrorCallback:        tc.onErrorCallbackFn,
+			})
+			if err != nil {
+				t.Fatalf("failed to create plugin: %v", err)
+			}
+
+			mdl := &testutil.MockModel{
+				Responses: []*genai.Content{
+					genai.NewContentFromFunctionCall("testTool", map[string]any{}, genai.RoleModel),
+				},
+			}
+
+			a, err := llmagent.New(llmagent.Config{
+				Name:  "test_agent",
+				Model: mdl,
+				Tools: []tool.Tool{ft},
+			})
+			if err != nil {
+				t.Fatalf("failed to create agent: %v", err)
+			}
+
+			r := testutil.NewTestAgentRunnerWithPluginManager(t, a, runner.PluginConfig{
+				Plugins: []*plugin.Plugin{p},
+			})
+
+			stream := r.Run(t, "session", "user input")
+			parts, err := testutil.CollectParts(stream)
+			if err != nil && err.Error() != "no data" {
+				t.Fatalf("agent stream error: %v", err)
+			}
+
+			var got map[string]any
+			for _, part := range parts {
+				if part.FunctionResponse != nil {
+					got = part.FunctionResponse.Response
+				}
+			}
+			if diff := cmp.Diff(tc.wantResponse, got); diff != "" {
+				t.Errorf("response mismatch (-want +got):\n%s", diff)
 			}
 		})
 	}


### PR DESCRIPTION
Please ensure you have read the contribution guide before creating a pull request.

### Link to Issue or Description of Change

- Closes: #1116

### Testing Plan

**Unit Tests:**

- [x] I have added or updated unit tests for my change.
- [x] All unit tests pass locally.

```
ok  google.golang.org/adk/v2/guardrail                  0.002s
ok  google.golang.org/adk/v2/internal/llminternal       0.579s
ok  google.golang.org/adk/v2/plugin                     0.011s
ok  google.golang.org/adk/v2/agent/llmagent             0.038s
```

New tests added:
- `guardrail/guardrail_test.go` — 4 tests: error message formatting, `errors.As` unwrapping, interface compliance
- `internal/llminternal/base_flow_test.go` — 3 new `TestCallTool` cases: guardrail routes to `OnGuardrailBlockedCallback` not `OnToolErrorCallback`, default fallback response, non-guardrail errors still route to `OnToolErrorCallback`
- `plugin/plugin_manager_test.go` — 2 new `TestOnGuardrailBlockedCallbackPlugin` integration cases via the full plugin/runner stack

**Manual End-to-End (E2E) Tests:**

A runnable example agent is provided at `examples/compliance/`. It demonstrates a payment agent with two policy guardrails (AML narration screening and high-value transfer limit). When a tool call is blocked, `OnGuardrailBlockedCallback` returns a structured `{"status": "blocked", "policy": "...", "message": "..."}` response the LLM reasons about instead of a generic error.

To run:
```bash
export GOOGLE_API_KEY=<your-key>
go run ./examples/compliance -- --console
# Try: "Transfer 2000000 units to ACC123 for payment"
```

### Checklist

- [x] I have read the CONTRIBUTING.md document.
- [x] I have performed a self-review of my own code.
- [x] I have commented my code, particularly in hard-to-understand areas.
- [x] I have added tests that prove my fix is effective or that my feature works.
- [x] New and existing unit tests pass locally with my changes.
- [x] I have manually tested my changes end-to-end.
- [ ] Any dependent changes have been merged and published in downstream modules.

### Additional context

Currently, a `BeforeToolCallback` that returns any error is routed through `OnToolErrorCallback` — the same path as unexpected runtime crashes. This makes it impossible to distinguish a deliberate policy denial from a broken tool.

This PR adds a sentinel type `guardrail.ErrGuardrailBlocked{Policy, Reason}` and a dedicated `OnGuardrailBlockedCallback` chain. The runner uses `errors.As` to detect the sentinel and routes policy blocks separately. Existing behaviour for all other errors is unchanged.