### PR TITLE
feat(agentregistry): add package foundation and REST transport

### DIFF
--- a/agentregistry/doc.go
+++ b/agentregistry/doc.go
@@ -1,0 +1,24 @@
+// Copyright 2026 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+// Package agentregistry provides a client for the Google Cloud Agent Registry
+// (agentregistry.googleapis.com), a governed catalog of A2A agents, MCP
+// servers, and model endpoints.
+//
+// This package provides the client foundation: configuration ([Config]), an
+// authenticated REST transport to the third-party (public) endpoint using
+// Application Default Credentials with mTLS endpoint selection, typed errors
+// ([APIError]), and the wire types returned by the service. Discovery methods
+// and the RemoteAgent/McpToolset factory helpers build on this foundation.
+package agentregistry

--- a/agentregistry/doc.go
+++ b/agentregistry/doc.go
@@ -20,5 +20,5 @@
 // authenticated REST transport to the third-party (public) endpoint using
 // Application Default Credentials with mTLS endpoint selection, typed errors
 // ([APIError]), and the wire types returned by the service. Discovery methods
-// and the RemoteAgent/McpToolset factory helpers build on this foundation.
+// and the RemoteAgent/MCPToolset factory helpers build on this foundation.
 package agentregistry

--- a/agentregistry/registry.go
+++ b/agentregistry/registry.go
@@ -1,0 +1,139 @@
+// Copyright 2026 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package agentregistry
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+	"net/http"
+	"os"
+	"strings"
+
+	"golang.org/x/oauth2/google"
+	"google.golang.org/api/option"
+	"google.golang.org/api/option/internaloption"
+	htransport "google.golang.org/api/transport"
+)
+
+// cloudPlatformScope is the OAuth scope used for Application Default Credentials.
+const cloudPlatformScope = "https://www.googleapis.com/auth/cloud-platform"
+
+// Base URLs for the Agent Registry API (parity with adk-python).
+const (
+	baseURLProd = "https://agentregistry.googleapis.com/v1"
+	baseURLMTLS = "https://agentregistry.mtls.googleapis.com/v1"
+)
+
+// Config configures a [Client].
+type Config struct {
+	// ProjectID is the Google Cloud project ID. Required.
+	ProjectID string
+	// Location is the Google Cloud location (region), e.g. "us-central1".
+	// Required.
+	Location string
+	// HTTPClient is used for registry API calls. If nil, an ADC-authenticated
+	// client is created and the endpoint (incl. mTLS) is resolved from
+	// GOOGLE_API_USE_MTLS_ENDPOINT / GOOGLE_API_USE_CLIENT_CERTIFICATE. A
+	// supplied client manages its own mTLS.
+	HTTPClient *http.Client
+}
+
+// Client is a client for the Google Cloud Agent Registry.
+type Client struct {
+	requester requester
+}
+
+// New creates a [Client]. By default it authenticates to
+// agentregistry.googleapis.com using Application Default Credentials; provide
+// Config.HTTPClient to supply a custom (e.g. pre-authenticated) client.
+func New(ctx context.Context, cfg Config) (*Client, error) {
+	if cfg.ProjectID == "" || cfg.Location == "" {
+		return nil, fmt.Errorf("agentregistry: ProjectID and Location must be set")
+	}
+
+	var creds *google.Credentials
+	var baseURL string
+	httpClient := cfg.HTTPClient
+	if httpClient == nil {
+		c, err := google.FindDefaultCredentials(ctx, cloudPlatformScope)
+		if err != nil {
+			return nil, fmt.Errorf("agentregistry: loading Application Default Credentials: %w", err)
+		}
+		creds = c
+
+		// Resolve the endpoint and client certificate from one source: the
+		// transport honors GOOGLE_API_USE_MTLS_ENDPOINT / _CLIENT_CERTIFICATE and
+		// returns the endpoint it dialed, so endpoint and mTLS can't disagree.
+		client, endpoint, err := htransport.NewHTTPClient(ctx,
+			option.WithCredentials(creds),
+			internaloption.WithDefaultEndpoint(baseURLProd),
+			internaloption.WithDefaultMTLSEndpoint(baseURLMTLS),
+		)
+		if err != nil {
+			return nil, fmt.Errorf("agentregistry: creating authenticated HTTP client: %w", err)
+		}
+		httpClient = client
+		baseURL = endpoint
+	} else {
+		baseURL = customClientBaseURL()
+	}
+
+	// x-goog-user-project: quota project (env or ADC) if set, else ProjectID
+	// (matches adk-python). Resolved even for a caller-supplied client.
+	quotaProject := cfg.ProjectID
+	if qp := quotaProjectID(creds); qp != "" {
+		quotaProject = qp
+	}
+
+	return &Client{
+		requester: &restRequester{
+			httpClient:  httpClient,
+			baseURL:     baseURL,
+			basePath:    fmt.Sprintf("projects/%s/locations/%s", cfg.ProjectID, cfg.Location),
+			userProject: quotaProject,
+		},
+	}, nil
+}
+
+// customClientBaseURL picks the endpoint for a caller-supplied client (which
+// carries no client cert): standard, unless GOOGLE_API_USE_MTLS_ENDPOINT=always.
+func customClientBaseURL() string {
+	if strings.EqualFold(os.Getenv("GOOGLE_API_USE_MTLS_ENDPOINT"), "always") {
+		return baseURLMTLS
+	}
+	return baseURLProd
+}
+
+// quotaProjectID returns the quota project associated with creds, using the same
+// precedence as Google API clients: the GOOGLE_CLOUD_QUOTA_PROJECT environment
+// variable, then the "quota_project_id" field of the credentials JSON. It
+// returns "" when none is configured (e.g. credentials sourced from the GCE
+// metadata server, which carry no JSON).
+func quotaProjectID(creds *google.Credentials) string {
+	if q := os.Getenv("GOOGLE_CLOUD_QUOTA_PROJECT"); q != "" {
+		return q
+	}
+	if creds == nil || len(creds.JSON) == 0 {
+		return ""
+	}
+	var parsed struct {
+		QuotaProjectID string `json:"quota_project_id"`
+	}
+	if err := json.Unmarshal(creds.JSON, &parsed); err != nil {
+		return ""
+	}
+	return parsed.QuotaProjectID
+}

--- a/agentregistry/registry.go
+++ b/agentregistry/registry.go
@@ -91,8 +91,9 @@ func New(ctx context.Context, cfg Config) (*Client, error) {
 		baseURL = customClientBaseURL()
 	}
 
-	// x-goog-user-project: quota project (env or ADC) if set, else ProjectID
-	// (matches adk-python). Resolved even for a caller-supplied client.
+	// x-goog-user-project quota header, adk-python precedence on the ADC path:
+	// GOOGLE_CLOUD_QUOTA_PROJECT, then creds' quota_project_id, then ProjectID.
+	// A caller-supplied client has no ADC creds, so only env var / ProjectID apply.
 	quotaProject := cfg.ProjectID
 	if qp := quotaProjectID(creds); qp != "" {
 		quotaProject = qp

--- a/agentregistry/registry_test.go
+++ b/agentregistry/registry_test.go
@@ -1,0 +1,161 @@
+// Copyright 2026 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package agentregistry
+
+import (
+	"context"
+	"net/http"
+	"testing"
+
+	"golang.org/x/oauth2/google"
+)
+
+func TestNew_Validation(t *testing.T) {
+	tests := []struct {
+		name string
+		cfg  Config
+	}{
+		{name: "missing project", cfg: Config{Location: "us-central1", HTTPClient: &http.Client{}}},
+		{name: "missing location", cfg: Config{ProjectID: "p", HTTPClient: &http.Client{}}},
+		{name: "missing both", cfg: Config{HTTPClient: &http.Client{}}},
+	}
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			if _, err := New(context.Background(), tc.cfg); err == nil {
+				t.Errorf("New(%+v) error = nil, want an error", tc.cfg)
+			}
+		})
+	}
+}
+
+func TestNew_WiresRestRequester(t *testing.T) {
+	tests := []struct {
+		name            string
+		mtlsEnv         string
+		quotaEnv        string
+		wantBaseURL     string
+		wantUserProject string
+	}{
+		{name: "default endpoint", mtlsEnv: "", wantBaseURL: baseURLProd, wantUserProject: "my-project"},
+		{name: "never keeps standard endpoint", mtlsEnv: "never", wantBaseURL: baseURLProd, wantUserProject: "my-project"},
+		{name: "always targets mTLS endpoint", mtlsEnv: "always", wantBaseURL: baseURLMTLS, wantUserProject: "my-project"},
+		{name: "ALWAYS is case-insensitive", mtlsEnv: "ALWAYS", wantBaseURL: baseURLMTLS, wantUserProject: "my-project"},
+		// Quota env var is honored even with a custom client (adk-python parity).
+		{name: "quota project env honored with custom client", mtlsEnv: "", quotaEnv: "quota-proj", wantBaseURL: baseURLProd, wantUserProject: "quota-proj"},
+	}
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			t.Setenv("GOOGLE_API_USE_MTLS_ENDPOINT", tc.mtlsEnv)
+			t.Setenv("GOOGLE_CLOUD_QUOTA_PROJECT", tc.quotaEnv)
+
+			// Custom HTTPClient avoids ADC/network in tests.
+			c, err := New(context.Background(), Config{
+				ProjectID:  "my-project",
+				Location:   "us-central1",
+				HTTPClient: &http.Client{},
+			})
+			if err != nil {
+				t.Fatalf("New() error = %v", err)
+			}
+
+			rt, ok := c.requester.(*restRequester)
+			if !ok {
+				t.Fatalf("client requester type = %T, want *restRequester", c.requester)
+			}
+			if rt.baseURL != tc.wantBaseURL {
+				t.Errorf("baseURL = %q, want %q", rt.baseURL, tc.wantBaseURL)
+			}
+			if want := "projects/my-project/locations/us-central1"; rt.basePath != want {
+				t.Errorf("basePath = %q, want %q", rt.basePath, want)
+			}
+			if rt.userProject != tc.wantUserProject {
+				t.Errorf("userProject = %q, want %q", rt.userProject, tc.wantUserProject)
+			}
+		})
+	}
+}
+
+func TestCustomClientBaseURL(t *testing.T) {
+	tests := []struct {
+		env  string
+		want string
+	}{
+		{env: "", want: baseURLProd},
+		{env: "never", want: baseURLProd},
+		{env: "auto", want: baseURLProd},
+		{env: "always", want: baseURLMTLS},
+		{env: "ALWAYS", want: baseURLMTLS},
+	}
+	for _, tc := range tests {
+		t.Run(tc.env, func(t *testing.T) {
+			t.Setenv("GOOGLE_API_USE_MTLS_ENDPOINT", tc.env)
+			if got := customClientBaseURL(); got != tc.want {
+				t.Errorf("customClientBaseURL() with %q = %q, want %q", tc.env, got, tc.want)
+			}
+		})
+	}
+}
+
+func TestQuotaProjectID(t *testing.T) {
+	t.Run("env var takes precedence", func(t *testing.T) {
+		t.Setenv("GOOGLE_CLOUD_QUOTA_PROJECT", "env-project")
+		creds := &google.Credentials{JSON: []byte(`{"quota_project_id":"json-project"}`)}
+		if got := quotaProjectID(creds); got != "env-project" {
+			t.Errorf("quotaProjectID() = %q, want env-project", got)
+		}
+	})
+
+	t.Run("from credentials JSON", func(t *testing.T) {
+		t.Setenv("GOOGLE_CLOUD_QUOTA_PROJECT", "")
+		creds := &google.Credentials{JSON: []byte(`{"quota_project_id":"json-project"}`)}
+		if got := quotaProjectID(creds); got != "json-project" {
+			t.Errorf("quotaProjectID() = %q, want json-project", got)
+		}
+	})
+
+	t.Run("JSON without quota project", func(t *testing.T) {
+		t.Setenv("GOOGLE_CLOUD_QUOTA_PROJECT", "")
+		creds := &google.Credentials{JSON: []byte(`{"type":"service_account"}`)}
+		if got := quotaProjectID(creds); got != "" {
+			t.Errorf("quotaProjectID() = %q, want empty", got)
+		}
+	})
+
+	t.Run("nil credentials", func(t *testing.T) {
+		t.Setenv("GOOGLE_CLOUD_QUOTA_PROJECT", "")
+		if got := quotaProjectID(nil); got != "" {
+			t.Errorf("quotaProjectID(nil) = %q, want empty", got)
+		}
+	})
+}
+
+func TestListValues(t *testing.T) {
+	got := listValues(WithFilter("type=A2A"), WithPageSize(25), WithPageToken("tok"))
+	if got.Get("filter") != "type=A2A" {
+		t.Errorf("filter = %q, want type=A2A", got.Get("filter"))
+	}
+	if got.Get("pageSize") != "25" {
+		t.Errorf("pageSize = %q, want 25", got.Get("pageSize"))
+	}
+	if got.Get("pageToken") != "tok" {
+		t.Errorf("pageToken = %q, want tok", got.Get("pageToken"))
+	}
+
+	// Zero/empty options should not set parameters.
+	empty := listValues(WithFilter(""), WithPageSize(0), WithPageToken(""))
+	if len(empty) != 0 {
+		t.Errorf("listValues with empty options = %v, want no parameters", empty)
+	}
+}

--- a/agentregistry/registry_test.go
+++ b/agentregistry/registry_test.go
@@ -17,9 +17,13 @@ package agentregistry
 import (
 	"context"
 	"net/http"
+	"strings"
 	"testing"
 
 	"golang.org/x/oauth2/google"
+	"google.golang.org/api/option"
+	"google.golang.org/api/option/internaloption"
+	htransport "google.golang.org/api/transport"
 )
 
 func TestNew_Validation(t *testing.T) {
@@ -82,6 +86,39 @@ func TestNew_WiresRestRequester(t *testing.T) {
 			}
 			if rt.userProject != tc.wantUserProject {
 				t.Errorf("userProject = %q, want %q", rt.userProject, tc.wantUserProject)
+			}
+		})
+	}
+}
+
+// New's ADC path relies on htransport.NewHTTPClient returning the default
+// endpoint verbatim, "/v1" included (restRequester joins baseURL+"/"+path).
+// That branch needs credentials, so exercise the transport directly.
+func TestNewHTTPClientEndpointKeepsVersionPath(t *testing.T) {
+	tests := []struct {
+		name    string
+		mtlsEnv string
+		want    string
+	}{
+		{name: "standard endpoint", mtlsEnv: "", want: baseURLProd},
+		{name: "mTLS endpoint", mtlsEnv: "always", want: baseURLMTLS},
+	}
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			t.Setenv("GOOGLE_API_USE_MTLS_ENDPOINT", tc.mtlsEnv)
+			_, endpoint, err := htransport.NewHTTPClient(context.Background(),
+				option.WithoutAuthentication(),
+				internaloption.WithDefaultEndpoint(baseURLProd),
+				internaloption.WithDefaultMTLSEndpoint(baseURLMTLS),
+			)
+			if err != nil {
+				t.Fatalf("NewHTTPClient() error = %v", err)
+			}
+			if endpoint != tc.want {
+				t.Errorf("endpoint = %q, want %q", endpoint, tc.want)
+			}
+			if !strings.HasSuffix(endpoint, "/v1") {
+				t.Errorf("endpoint = %q, want %q suffix (version path must not be stripped)", endpoint, "/v1")
 			}
 		})
 	}

--- a/agentregistry/requester.go
+++ b/agentregistry/requester.go
@@ -1,0 +1,105 @@
+// Copyright 2026 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package agentregistry
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+	"io"
+	"net/http"
+	"net/url"
+	"strings"
+)
+
+// requester performs registry API GET requests: base-URL selection,
+// authentication, routing, and JSON decoding. It is an internal seam so an
+// alternative implementation (for example an internal, non-REST transport) can
+// back the same [Client]; the default implementation ([restRequester]) talks to
+// agentregistry.googleapis.com over REST.
+type requester interface {
+	// Get issues a GET for resourcePath — treated as an absolute resource name
+	// when it begins with "projects/", otherwise resolved relative to the
+	// configured parent (projects/<project>/locations/<location>) — applies
+	// params as the query string, and decodes the JSON response body into v.
+	// A non-2xx response is returned as an [*APIError].
+	Get(ctx context.Context, resourcePath string, params url.Values, v any) error
+}
+
+// APIError is returned when the registry API responds with a non-2xx status.
+type APIError struct {
+	// StatusCode is the HTTP status code of the response.
+	StatusCode int
+	// Body is the raw response body, useful for diagnosing the failure.
+	Body string
+}
+
+func (e *APIError) Error() string {
+	return fmt.Sprintf("agentregistry: API request failed with status %d: %s", e.StatusCode, e.Body)
+}
+
+// restRequester is the default requester: it issues authenticated GETs to the
+// third-party (public) Agent Registry REST endpoint.
+type restRequester struct {
+	httpClient  *http.Client
+	baseURL     string
+	basePath    string // projects/<project>/locations/<location>
+	userProject string // value for the x-goog-user-project quota header
+}
+
+var _ requester = (*restRequester)(nil)
+
+func (r *restRequester) Get(ctx context.Context, resourcePath string, params url.Values, v any) error {
+	var fullURL string
+	if strings.HasPrefix(resourcePath, "projects/") {
+		fullURL = r.baseURL + "/" + resourcePath
+	} else {
+		fullURL = r.baseURL + "/" + r.basePath + "/" + resourcePath
+	}
+
+	req, err := http.NewRequestWithContext(ctx, http.MethodGet, fullURL, nil)
+	if err != nil {
+		return fmt.Errorf("agentregistry: building request: %w", err)
+	}
+	if len(params) > 0 {
+		req.URL.RawQuery = params.Encode()
+	}
+	req.Header.Set("Content-Type", "application/json")
+	if r.userProject != "" {
+		req.Header.Set("x-goog-user-project", r.userProject)
+	}
+
+	resp, err := r.httpClient.Do(req)
+	if err != nil {
+		return fmt.Errorf("agentregistry: GET %s: %w", resourcePath, err)
+	}
+	defer func() { _ = resp.Body.Close() }()
+
+	body, err := io.ReadAll(resp.Body)
+	if err != nil {
+		return fmt.Errorf("agentregistry: reading response body: %w", err)
+	}
+
+	if resp.StatusCode < http.StatusOK || resp.StatusCode >= http.StatusMultipleChoices {
+		return &APIError{StatusCode: resp.StatusCode, Body: string(body)}
+	}
+
+	if v != nil {
+		if err := json.Unmarshal(body, v); err != nil {
+			return fmt.Errorf("agentregistry: decoding response: %w", err)
+		}
+	}
+	return nil
+}

--- a/agentregistry/requester_test.go
+++ b/agentregistry/requester_test.go
@@ -46,7 +46,7 @@ func TestRestRequester_Get_RelativePathAndHeaders(t *testing.T) {
 	}))
 	defer srv.Close()
 
-	var page AgentsPage
+	var page ListAgentsResponse
 	params := url.Values{}
 	params.Set("pageSize", "5")
 	if err := newTestRequester(srv).Get(context.Background(), "agents", params, &page); err != nil {
@@ -117,7 +117,7 @@ func TestRestRequester_Get_DecodeError(t *testing.T) {
 	}))
 	defer srv.Close()
 
-	err := newTestRequester(srv).Get(context.Background(), "agents", nil, &AgentsPage{})
+	err := newTestRequester(srv).Get(context.Background(), "agents", nil, &ListAgentsResponse{})
 	if err == nil {
 		t.Fatal("Get() error = nil, want a decode error")
 	}

--- a/agentregistry/requester_test.go
+++ b/agentregistry/requester_test.go
@@ -1,0 +1,156 @@
+// Copyright 2026 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package agentregistry
+
+import (
+	"context"
+	"errors"
+	"net/http"
+	"net/http/httptest"
+	"net/url"
+	"testing"
+)
+
+// newTestRequester returns a restRequester pointing at srv with a fixed parent
+// path and quota project.
+func newTestRequester(srv *httptest.Server) *restRequester {
+	return &restRequester{
+		httpClient:  srv.Client(),
+		baseURL:     srv.URL,
+		basePath:    "projects/p/locations/l",
+		userProject: "p",
+	}
+}
+
+func TestRestRequester_Get_RelativePathAndHeaders(t *testing.T) {
+	var gotPath, gotQuery, gotContentType, gotUserProject string
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		gotPath = r.URL.Path
+		gotQuery = r.URL.RawQuery
+		gotContentType = r.Header.Get("Content-Type")
+		gotUserProject = r.Header.Get("x-goog-user-project")
+		w.Header().Set("Content-Type", "application/json")
+		_, _ = w.Write([]byte(`{"agents":[{"displayName":"Foo"}],"nextPageToken":"next"}`))
+	}))
+	defer srv.Close()
+
+	var page AgentsPage
+	params := url.Values{}
+	params.Set("pageSize", "5")
+	if err := newTestRequester(srv).Get(context.Background(), "agents", params, &page); err != nil {
+		t.Fatalf("Get() error = %v", err)
+	}
+
+	if want := "/projects/p/locations/l/agents"; gotPath != want {
+		t.Errorf("request path = %q, want %q", gotPath, want)
+	}
+	if want := "pageSize=5"; gotQuery != want {
+		t.Errorf("request query = %q, want %q", gotQuery, want)
+	}
+	if gotContentType != "application/json" {
+		t.Errorf("Content-Type = %q, want application/json", gotContentType)
+	}
+	if gotUserProject != "p" {
+		t.Errorf("x-goog-user-project = %q, want p", gotUserProject)
+	}
+	if len(page.Agents) != 1 || page.Agents[0].DisplayName != "Foo" || page.NextPageToken != "next" {
+		t.Errorf("decoded page = %+v, want one agent Foo with nextPageToken", page)
+	}
+}
+
+func TestRestRequester_Get_AbsoluteResourcePath(t *testing.T) {
+	var gotPath string
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		gotPath = r.URL.Path
+		_, _ = w.Write([]byte(`{"displayName":"Bar"}`))
+	}))
+	defer srv.Close()
+
+	var got McpServer
+	name := "projects/p/locations/l/mcpServers/bar"
+	if err := newTestRequester(srv).Get(context.Background(), name, nil, &got); err != nil {
+		t.Fatalf("Get() error = %v", err)
+	}
+	if want := "/" + name; gotPath != want {
+		t.Errorf("request path = %q, want %q (absolute resource name, not prefixed with parent)", gotPath, want)
+	}
+	if got.DisplayName != "Bar" {
+		t.Errorf("decoded DisplayName = %q, want Bar", got.DisplayName)
+	}
+}
+
+func TestRestRequester_Get_APIError(t *testing.T) {
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.WriteHeader(http.StatusNotFound)
+		_, _ = w.Write([]byte(`{"error":"not found"}`))
+	}))
+	defer srv.Close()
+
+	err := newTestRequester(srv).Get(context.Background(), "agents/missing", nil, &Agent{})
+	var apiErr *APIError
+	if !errors.As(err, &apiErr) {
+		t.Fatalf("Get() error = %v, want *APIError", err)
+	}
+	if apiErr.StatusCode != http.StatusNotFound {
+		t.Errorf("APIError.StatusCode = %d, want %d", apiErr.StatusCode, http.StatusNotFound)
+	}
+	if apiErr.Body != `{"error":"not found"}` {
+		t.Errorf("APIError.Body = %q, want the raw response body", apiErr.Body)
+	}
+}
+
+func TestRestRequester_Get_DecodeError(t *testing.T) {
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		_, _ = w.Write([]byte(`{not valid json`))
+	}))
+	defer srv.Close()
+
+	err := newTestRequester(srv).Get(context.Background(), "agents", nil, &AgentsPage{})
+	if err == nil {
+		t.Fatal("Get() error = nil, want a decode error")
+	}
+	var apiErr *APIError
+	if errors.As(err, &apiErr) {
+		t.Errorf("Get() returned *APIError %v, want a decode error", apiErr)
+	}
+}
+
+func TestRestRequester_Get_NilOutSkipsDecode(t *testing.T) {
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		_, _ = w.Write([]byte(`not json but ignored`))
+	}))
+	defer srv.Close()
+
+	if err := newTestRequester(srv).Get(context.Background(), "agents", nil, nil); err != nil {
+		t.Errorf("Get() with nil out error = %v, want nil", err)
+	}
+}
+
+func TestRestRequester_Get_NoUserProjectHeaderWhenEmpty(t *testing.T) {
+	var hadHeader bool
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		_, hadHeader = r.Header["X-Goog-User-Project"]
+		_, _ = w.Write([]byte(`{}`))
+	}))
+	defer srv.Close()
+
+	rt := &restRequester{httpClient: srv.Client(), baseURL: srv.URL, basePath: "projects/p/locations/l"}
+	if err := rt.Get(context.Background(), "agents", nil, nil); err != nil {
+		t.Fatalf("Get() error = %v", err)
+	}
+	if hadHeader {
+		t.Error("x-goog-user-project header set, want it omitted when userProject is empty")
+	}
+}

--- a/agentregistry/requester_test.go
+++ b/agentregistry/requester_test.go
@@ -78,7 +78,7 @@ func TestRestRequester_Get_AbsoluteResourcePath(t *testing.T) {
 	}))
 	defer srv.Close()
 
-	var got McpServer
+	var got MCPServer
 	name := "projects/p/locations/l/mcpServers/bar"
 	if err := newTestRequester(srv).Get(context.Background(), name, nil, &got); err != nil {
 		t.Fatalf("Get() error = %v", err)

--- a/agentregistry/resolve.go
+++ b/agentregistry/resolve.go
@@ -1,0 +1,95 @@
+// Copyright 2026 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package agentregistry
+
+import (
+	"regexp"
+	"strings"
+
+	"github.com/a2aproject/a2a-go/v2/a2a"
+)
+
+// Registry protocol-binding wire values.
+const (
+	bindingJSONRPC  = "JSONRPC"
+	bindingHTTPJSON = "HTTP_JSON"
+	bindingGRPC     = "GRPC"
+)
+
+var (
+	reNonIdentifier = regexp.MustCompile(`[^a-zA-Z0-9_]`)
+	reUnderscores   = regexp.MustCompile(`_+`)
+)
+
+// cleanName converts an arbitrary display name into a valid identifier suitable
+// for use as an agent or tool name. It mirrors adk-python's _clean_name:
+// non-identifier characters become underscores, runs of underscores collapse,
+// leading/trailing underscores are trimmed, and a leading digit is prefixed
+// with an underscore.
+func cleanName(name string) string {
+	s := reNonIdentifier.ReplaceAllString(name, "_")
+	s = reUnderscores.ReplaceAllString(s, "_")
+	s = strings.Trim(s, "_")
+	// A valid identifier cannot start with a digit; prefix one with "_".
+	// (After trimming, s can never start with "_".)
+	if s != "" && s[0] >= '0' && s[0] <= '9' {
+		s = "_" + s
+	}
+	return s
+}
+
+// connectionURI returns the first interface URL matching the optional type and
+// transport filters (empty filters match anything), plus the protocol version
+// and the interface's A2A transport (mapped from its registry binding via
+// [transportBinding]; empty if unrecognized).
+//
+// Like adk-python's _get_connection_uri, top-level interfaces are treated as a
+// trailing type-less protocol.
+func connectionURI(protocols []Protocol, ifaces []Interface, protocolType string, transport a2a.TransportProtocol) (uri, version string, binding a2a.TransportProtocol, ok bool) {
+	all := protocols
+	if len(ifaces) > 0 {
+		all = append(append([]Protocol(nil), protocols...), Protocol{Interfaces: ifaces})
+	}
+	for _, p := range all {
+		if protocolType != "" && p.Type != protocolType {
+			continue
+		}
+		for _, i := range p.Interfaces {
+			mapped, _ := transportBinding(i.ProtocolBinding)
+			if transport != "" && mapped != transport {
+				continue
+			}
+			if i.URL != "" {
+				return i.URL, p.ProtocolVersion, mapped, true
+			}
+		}
+	}
+	return "", "", "", false
+}
+
+// transportBinding maps a registry protocol-binding wire value to the
+// corresponding A2A transport protocol.
+func transportBinding(wire string) (a2a.TransportProtocol, bool) {
+	switch wire {
+	case bindingJSONRPC:
+		return a2a.TransportProtocolJSONRPC, true
+	case bindingHTTPJSON:
+		return a2a.TransportProtocolHTTPJSON, true
+	case bindingGRPC:
+		return a2a.TransportProtocolGRPC, true
+	default:
+		return "", false
+	}
+}

--- a/agentregistry/resolve_test.go
+++ b/agentregistry/resolve_test.go
@@ -1,0 +1,177 @@
+// Copyright 2026 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package agentregistry
+
+import (
+	"testing"
+
+	"github.com/a2aproject/a2a-go/v2/a2a"
+)
+
+func TestCleanName(t *testing.T) {
+	tests := []struct {
+		name string
+		in   string
+		want string
+	}{
+		{name: "already valid", in: "my_agent", want: "my_agent"},
+		{name: "spaces and dashes", in: "My Cool-Agent", want: "My_Cool_Agent"},
+		{name: "collapse underscores", in: "a  b--c", want: "a_b_c"},
+		{name: "trim underscores", in: "__agent__", want: "agent"},
+		{name: "leading digit", in: "123agent", want: "_123agent"},
+		{name: "resource path", in: "projects/p/locations/l/agents/foo", want: "projects_p_locations_l_agents_foo"},
+		{name: "empty", in: "", want: ""},
+		{name: "only specials", in: "!!!", want: ""},
+	}
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			if got := cleanName(tc.in); got != tc.want {
+				t.Errorf("cleanName(%q) = %q, want %q", tc.in, got, tc.want)
+			}
+		})
+	}
+}
+
+func TestConnectionURI(t *testing.T) {
+	agentProtocols := []Protocol{
+		{
+			Type:            "A2A_AGENT",
+			ProtocolVersion: "0.3.0",
+			Interfaces: []Interface{
+				{URL: "https://a.example/jsonrpc", ProtocolBinding: bindingJSONRPC},
+				{URL: "https://a.example/http", ProtocolBinding: bindingHTTPJSON},
+			},
+		},
+		{
+			Type:       "CUSTOM",
+			Interfaces: []Interface{{URL: "https://custom.example", ProtocolBinding: bindingGRPC}},
+		},
+	}
+
+	tests := []struct {
+		name         string
+		protocols    []Protocol
+		ifaces       []Interface
+		protocolType string
+		transport    a2a.TransportProtocol
+		wantURL      string
+		wantVersion  string
+		wantBinding  a2a.TransportProtocol
+		wantOK       bool
+	}{
+		{
+			name:         "type filter picks first interface",
+			protocols:    agentProtocols,
+			protocolType: "A2A_AGENT",
+			wantURL:      "https://a.example/jsonrpc",
+			wantVersion:  "0.3.0",
+			wantBinding:  a2a.TransportProtocolJSONRPC,
+			wantOK:       true,
+		},
+		{
+			// Filter and result are A2A transports: wire HTTP_JSON -> a2a HTTP+JSON.
+			name:        "transport filter picks matching interface (wire->a2a mapping)",
+			protocols:   agentProtocols,
+			transport:   a2a.TransportProtocolHTTPJSON,
+			wantURL:     "https://a.example/http",
+			wantVersion: "0.3.0",
+			wantBinding: a2a.TransportProtocolHTTPJSON,
+			wantOK:      true,
+		},
+		{
+			name:         "type and transport filter",
+			protocols:    agentProtocols,
+			protocolType: "A2A_AGENT",
+			transport:    a2a.TransportProtocolHTTPJSON,
+			wantURL:      "https://a.example/http",
+			wantVersion:  "0.3.0",
+			wantBinding:  a2a.TransportProtocolHTTPJSON,
+			wantOK:       true,
+		},
+		{
+			name:        "no filters returns first",
+			protocols:   agentProtocols,
+			wantURL:     "https://a.example/jsonrpc",
+			wantVersion: "0.3.0",
+			wantBinding: a2a.TransportProtocolJSONRPC,
+			wantOK:      true,
+		},
+		{
+			name:        "top-level interfaces treated as typeless protocol",
+			ifaces:      []Interface{{URL: "https://top.example", ProtocolBinding: bindingJSONRPC}},
+			transport:   a2a.TransportProtocolJSONRPC,
+			wantURL:     "https://top.example",
+			wantBinding: a2a.TransportProtocolJSONRPC,
+			wantOK:      true,
+		},
+		{
+			name:         "type filter excludes typeless top-level interfaces",
+			ifaces:       []Interface{{URL: "https://top.example", ProtocolBinding: bindingJSONRPC}},
+			protocolType: "A2A_AGENT",
+			wantOK:       false,
+		},
+		{
+			// Unrecognized binding -> empty transport (Python's None), still returned unfiltered.
+			name:        "unknown binding returns empty transport",
+			protocols:   []Protocol{{ProtocolVersion: "1.0", Interfaces: []Interface{{URL: "https://x.example", ProtocolBinding: "WEIRD"}}}},
+			wantURL:     "https://x.example",
+			wantVersion: "1.0",
+			wantBinding: "",
+			wantOK:      true,
+		},
+		{
+			name:      "no match returns not ok",
+			protocols: agentProtocols,
+			transport: a2a.TransportProtocol("UNKNOWN"),
+			wantOK:    false,
+		},
+		{
+			name:      "empty returns not ok",
+			protocols: nil,
+			wantOK:    false,
+		},
+	}
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			gotURL, gotVer, gotBind, gotOK := connectionURI(tc.protocols, tc.ifaces, tc.protocolType, tc.transport)
+			if gotOK != tc.wantOK || gotURL != tc.wantURL || gotVer != tc.wantVersion || gotBind != tc.wantBinding {
+				t.Errorf("connectionURI() = (%q, %q, %q, %t), want (%q, %q, %q, %t)",
+					gotURL, gotVer, gotBind, gotOK, tc.wantURL, tc.wantVersion, tc.wantBinding, tc.wantOK)
+			}
+		})
+	}
+}
+
+func TestTransportBinding(t *testing.T) {
+	tests := []struct {
+		in     string
+		want   a2a.TransportProtocol
+		wantOK bool
+	}{
+		{in: "JSONRPC", want: a2a.TransportProtocolJSONRPC, wantOK: true},
+		{in: "HTTP_JSON", want: a2a.TransportProtocolHTTPJSON, wantOK: true},
+		{in: "GRPC", want: a2a.TransportProtocolGRPC, wantOK: true},
+		{in: "http+json", wantOK: false},
+		{in: "", wantOK: false},
+	}
+	for _, tc := range tests {
+		t.Run(tc.in, func(t *testing.T) {
+			got, ok := transportBinding(tc.in)
+			if ok != tc.wantOK || got != tc.want {
+				t.Errorf("transportBinding(%q) = (%q, %t), want (%q, %t)", tc.in, got, ok, tc.want, tc.wantOK)
+			}
+		})
+	}
+}

--- a/agentregistry/types.go
+++ b/agentregistry/types.go
@@ -83,20 +83,20 @@ type Endpoint struct {
 	Attributes  map[string]any `json:"attributes,omitempty"`
 }
 
-// AgentsPage is one page of a ListAgents response.
-type AgentsPage struct {
+// ListAgentsResponse is one page of a [Client.ListAgents] response.
+type ListAgentsResponse struct {
 	Agents        []Agent `json:"agents,omitempty"`
 	NextPageToken string  `json:"nextPageToken,omitempty"`
 }
 
-// McpServersPage is one page of a ListMcpServers response.
-type McpServersPage struct {
+// ListMcpServersResponse is one page of a [Client.ListMcpServers] response.
+type ListMcpServersResponse struct {
 	McpServers    []McpServer `json:"mcpServers,omitempty"`
 	NextPageToken string      `json:"nextPageToken,omitempty"`
 }
 
-// EndpointsPage is one page of a ListEndpoints response.
-type EndpointsPage struct {
+// ListEndpointsResponse is one page of a [Client.ListEndpoints] response.
+type ListEndpointsResponse struct {
 	Endpoints     []Endpoint `json:"endpoints,omitempty"`
 	NextPageToken string     `json:"nextPageToken,omitempty"`
 }

--- a/agentregistry/types.go
+++ b/agentregistry/types.go
@@ -1,0 +1,141 @@
+// Copyright 2026 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package agentregistry
+
+import (
+	"encoding/json"
+	"net/url"
+	"strconv"
+)
+
+// Interface describes a single connection interface (endpoint URL + binding)
+// for a protocol.
+type Interface struct {
+	URL             string `json:"url,omitempty"`
+	ProtocolBinding string `json:"protocolBinding,omitempty"`
+}
+
+// Protocol describes a protocol a resource speaks together with its interfaces.
+type Protocol struct {
+	Type            string      `json:"type,omitempty"`
+	ProtocolVersion string      `json:"protocolVersion,omitempty"`
+	Interfaces      []Interface `json:"interfaces,omitempty"`
+}
+
+// Skill describes an A2A agent skill.
+type Skill struct {
+	ID          string   `json:"id,omitempty"`
+	Name        string   `json:"name,omitempty"`
+	Description string   `json:"description,omitempty"`
+	Tags        []string `json:"tags,omitempty"`
+	Examples    []string `json:"examples,omitempty"`
+}
+
+// Card carries an embedded agent card returned by the registry. Content holds
+// the raw card JSON (e.g. an A2A AgentCard) when Type is "A2A_AGENT_CARD".
+type Card struct {
+	Type    string          `json:"type,omitempty"`
+	Content json.RawMessage `json:"content,omitempty"`
+}
+
+// Agent is a registered A2A agent.
+type Agent struct {
+	Name        string     `json:"name,omitempty"`
+	DisplayName string     `json:"displayName,omitempty"`
+	Description string     `json:"description,omitempty"`
+	Version     string     `json:"version,omitempty"`
+	Protocols   []Protocol `json:"protocols,omitempty"`
+	Skills      []Skill    `json:"skills,omitempty"`
+	Card        *Card      `json:"card,omitempty"`
+}
+
+// McpServer is a registered MCP server.
+type McpServer struct {
+	Name        string      `json:"name,omitempty"`
+	McpServerID string      `json:"mcpServerId,omitempty"`
+	DisplayName string      `json:"displayName,omitempty"`
+	Description string      `json:"description,omitempty"`
+	Protocols   []Protocol  `json:"protocols,omitempty"`
+	Interfaces  []Interface `json:"interfaces,omitempty"`
+}
+
+// Endpoint is a registered model endpoint.
+type Endpoint struct {
+	Name        string         `json:"name,omitempty"`
+	EndpointID  string         `json:"endpointId,omitempty"`
+	DisplayName string         `json:"displayName,omitempty"`
+	Description string         `json:"description,omitempty"`
+	Interfaces  []Interface    `json:"interfaces,omitempty"`
+	CreateTime  string         `json:"createTime,omitempty"`
+	UpdateTime  string         `json:"updateTime,omitempty"`
+	Attributes  map[string]any `json:"attributes,omitempty"`
+}
+
+// AgentsPage is one page of a ListAgents response.
+type AgentsPage struct {
+	Agents        []Agent `json:"agents,omitempty"`
+	NextPageToken string  `json:"nextPageToken,omitempty"`
+}
+
+// McpServersPage is one page of a ListMcpServers response.
+type McpServersPage struct {
+	McpServers    []McpServer `json:"mcpServers,omitempty"`
+	NextPageToken string      `json:"nextPageToken,omitempty"`
+}
+
+// EndpointsPage is one page of a ListEndpoints response.
+type EndpointsPage struct {
+	Endpoints     []Endpoint `json:"endpoints,omitempty"`
+	NextPageToken string     `json:"nextPageToken,omitempty"`
+}
+
+// ListOption customizes a list request (filter and pagination).
+type ListOption func(url.Values)
+
+// WithFilter sets the list filter expression.
+func WithFilter(filter string) ListOption {
+	return func(v url.Values) {
+		if filter != "" {
+			v.Set("filter", filter)
+		}
+	}
+}
+
+// WithPageSize sets the maximum number of results per page.
+func WithPageSize(size int) ListOption {
+	return func(v url.Values) {
+		if size > 0 {
+			v.Set("pageSize", strconv.Itoa(size))
+		}
+	}
+}
+
+// WithPageToken sets the page token used to continue a previous list call.
+func WithPageToken(token string) ListOption {
+	return func(v url.Values) {
+		if token != "" {
+			v.Set("pageToken", token)
+		}
+	}
+}
+
+// listValues collapses list options into url.Values.
+func listValues(opts ...ListOption) url.Values {
+	v := url.Values{}
+	for _, opt := range opts {
+		opt(v)
+	}
+	return v
+}

--- a/agentregistry/types.go
+++ b/agentregistry/types.go
@@ -61,10 +61,10 @@ type Agent struct {
 	Card        *Card      `json:"card,omitempty"`
 }
 
-// McpServer is a registered MCP server.
-type McpServer struct {
+// MCPServer is a registered MCP server.
+type MCPServer struct {
 	Name        string      `json:"name,omitempty"`
-	McpServerID string      `json:"mcpServerId,omitempty"`
+	MCPServerID string      `json:"mcpServerId,omitempty"`
 	DisplayName string      `json:"displayName,omitempty"`
 	Description string      `json:"description,omitempty"`
 	Protocols   []Protocol  `json:"protocols,omitempty"`
@@ -89,9 +89,9 @@ type ListAgentsResponse struct {
 	NextPageToken string  `json:"nextPageToken,omitempty"`
 }
 
-// ListMcpServersResponse is one page of a [Client.ListMcpServers] response.
-type ListMcpServersResponse struct {
-	McpServers    []McpServer `json:"mcpServers,omitempty"`
+// ListMCPServersResponse is one page of a [Client.ListMCPServers] response.
+type ListMCPServersResponse struct {
+	MCPServers    []MCPServer `json:"mcpServers,omitempty"`
 	NextPageToken string      `json:"nextPageToken,omitempty"`
 }
 


### PR DESCRIPTION
**Problem:**
adk-go has no client for the Google Cloud Agent Registry
(`agentregistry.googleapis.com`) — the governed catalog of A2A agents, MCP
servers, and model endpoints. adk-python already ships one, so we need a Go
equivalent with matching behavior to discover and construct agents/toolsets from
the registry.

**Solution:**
Add the `agentregistry` package **foundation** — everything the discovery
methods and the RemoteAgent/McpToolset factory helpers (follow-up PRs in this
stack) build on. This PR is additive: a new package, no changes to existing
public APIs.
- **Client surface:** `Config`, `Client`, and `New` — ADC-authenticated by
  default, or a caller-supplied `*http.Client`.
- **REST transport:** an authenticated GET path to `agentregistry.googleapis.com`
  that resolves resource paths (absolute `projects/...` vs. parent-relative),
  sets the `x-goog-user-project` quota header, and returns non-2xx responses as a
  typed `*APIError`. The transport sits behind an internal `requester` interface
  seam (default impl `restRequester`) so an alternative transport can back the
  same `Client`.
- **Endpoint & mTLS selection (single source of truth):** when `New` builds the
  client, endpoint and client-certificate selection are delegated to the Google
  API transport (`internaloption.WithDefaultEndpoint` /
  `WithDefaultMTLSEndpoint`). It honors `GOOGLE_API_USE_MTLS_ENDPOINT` and
  `GOOGLE_API_USE_CLIENT_CERTIFICATE` and, when a default client-certificate
  source is present, both targets the mTLS endpoint **and** configures mTLS on
  the transport from the same source — so endpoint and transport can never
  disagree (parity with adk-python / google-auth). A caller-supplied
  `*http.Client` owns its own transport/mTLS config; we only honor an explicit
  `GOOGLE_API_USE_MTLS_ENDPOINT=always` for it. (No programmatic mTLS knob — this
  is env-driven, like adk-python.)
- **Quota project:** `x-goog-user-project` follows adk-python's
  `credentials.quota_project_id or project_id`: prefer
  `GOOGLE_CLOUD_QUOTA_PROJECT`, then the ADC credentials' `quota_project_id`,
  then the configured `ProjectID` — resolved regardless of whether the HTTP
  client is caller-supplied.
- **Wire types & options:** `Agent`, `McpServer`, `Endpoint`, `Protocol`,
  `Interface`, `Skill`, `Card`, the `List{Agents,McpServers,Endpoints}Response`
  list responses, and `ListOption`s (`WithFilter` / `WithPageSize` /
  `WithPageToken`).
- **Resolution helpers (parity with adk-python):** `cleanName` (`_clean_name`),
  the protocol-binding → A2A transport map (`_TRANSPORT_MAPPING`, via
  `transportBinding`), and `connectionURI` (`_get_connection_uri`) — which maps
  each interface's registry binding to an A2A transport (e.g. `HTTP_JSON` →
  `HTTP+JSON`) and returns that mapped transport, matching Python.