### PR TITLE
feat(agentregistry): add RemoteAgent and McpToolset factory helpers

### DIFF
--- a/agentregistry/client_test.go
+++ b/agentregistry/client_test.go
@@ -452,7 +452,7 @@ func TestClientAll(t *testing.T) {
 // newTestClient returns a Client whose requester talks to srv, exercising the
 // full method -> getResource -> restRequester -> HTTP path.
 func newTestClient(srv *httptest.Server) *Client {
-	return &Client{requester: newTestRequester(srv)}
+	return &Client{requester: newTestRequester(srv), httpClient: srv.Client()}
 }
 
 // mapNames projects a display-name-like field out of each element.

--- a/agentregistry/factory.go
+++ b/agentregistry/factory.go
@@ -54,6 +54,18 @@ func applyMCPToolsetOptions(opts []MCPToolsetOption) egressConfig {
 	return ec
 }
 
+func addHeaders(e *egressConfig, h map[string]string) {
+	if len(h) == 0 {
+		return
+	}
+	if e.headers == nil {
+		e.headers = make(map[string]string, len(h))
+	}
+	for k, v := range h {
+		e.headers[k] = v
+	}
+}
+
 // RemoteAgentOption customizes [Client.RemoteAgent].
 type RemoteAgentOption func(*egressConfig)
 
@@ -70,9 +82,9 @@ func WithA2AHTTPClient(c *http.Client) RemoteAgentOption {
 }
 
 // WithA2AHeaders adds static headers to every request sent to the remote A2A
-// agent.
+// agent. Repeated calls accumulate; a later value wins on a key conflict.
 func WithA2AHeaders(h map[string]string) RemoteAgentOption {
-	return func(e *egressConfig) { e.headers = h }
+	return func(e *egressConfig) { addHeaders(e, h) }
 }
 
 // WithMCPHTTPClient sets the HTTP client used to reach the MCP server. It
@@ -86,8 +98,9 @@ func WithMCPHTTPClient(c *http.Client) MCPToolsetOption {
 }
 
 // WithMCPHeaders adds static headers to every request sent to the MCP server.
+// Repeated calls accumulate; a later value wins on a key conflict.
 func WithMCPHeaders(h map[string]string) MCPToolsetOption {
-	return func(e *egressConfig) { e.headers = h }
+	return func(e *egressConfig) { addHeaders(e, h) }
 }
 
 // egressClient selects the HTTP client used to reach an endpoint at rawURL.
@@ -167,7 +180,7 @@ func (c *Client) RemoteAgent(ctx context.Context, name string, opts ...RemoteAge
 		return nil, err
 	}
 
-	card, agentName, description, err := agentCard(info, name)
+	card, agentName, err := agentCard(info, name)
 	if err != nil {
 		return nil, err
 	}
@@ -179,10 +192,15 @@ func (c *Client) RemoteAgent(ctx context.Context, name string, opts ...RemoteAge
 
 	return remoteagent.NewA2A(remoteagent.A2AConfig{
 		Name:           agentName,
-		Description:    description,
+		Description:    card.Description,
 		AgentCard:      card,
 		ClientProvider: remoteagent.NewA2AClientProvider(a2aClientFactory(card, egress)),
 	})
+}
+
+type transportKey struct {
+	binding a2a.TransportProtocol
+	version a2a.ProtocolVersion
 }
 
 // a2aClientFactory builds an A2A client factory for the given card and HTTP
@@ -197,7 +215,7 @@ func a2aClientFactory(card *a2a.AgentCard, httpClient *http.Client) *a2aclient.F
 		a2aclient.WithJSONRPCTransport(httpClient),
 		a2aclient.WithRESTTransport(httpClient),
 	}
-	seen := make(map[string]bool)
+	seen := make(map[transportKey]bool)
 	for _, iface := range card.SupportedInterfaces {
 		// The current-version transports above already cover a2a.Version.
 		if iface == nil || iface.ProtocolVersion == "" || iface.ProtocolVersion == a2a.Version {
@@ -212,7 +230,7 @@ func a2aClientFactory(card *a2a.AgentCard, httpClient *http.Client) *a2aclient.F
 		default:
 			continue
 		}
-		key := string(iface.ProtocolBinding) + "@" + string(iface.ProtocolVersion)
+		key := transportKey{iface.ProtocolBinding, iface.ProtocolVersion}
 		if seen[key] {
 			continue
 		}
@@ -238,30 +256,30 @@ func jsonrpcTransportFactory(httpClient *http.Client) a2aclient.TransportFactory
 	})
 }
 
-// agentCard resolves an [a2a.AgentCard] plus the cleaned agent name and
-// description for a registered agent, using the embedded card when available and
-// otherwise synthesizing one. resourceName is used as a fallback name.
-func agentCard(info *Agent, resourceName string) (card *a2a.AgentCard, name, description string, err error) {
+// agentCard resolves an [a2a.AgentCard] plus the cleaned agent name for a
+// registered agent, using the embedded card when available and otherwise
+// synthesizing one. resourceName is used as a fallback name.
+func agentCard(info *Agent, resourceName string) (card *a2a.AgentCard, name string, err error) {
 	if info.Card != nil && info.Card.Type == cardTypeA2AAgentCard && len(info.Card.Content) > 0 {
 		var embedded a2a.AgentCard
 		if err := json.Unmarshal(info.Card.Content, &embedded); err != nil {
-			return nil, "", "", fmt.Errorf("agentregistry: decoding embedded agent card for %q: %w", resourceName, err)
+			return nil, "", fmt.Errorf("agentregistry: decoding embedded agent card for %q: %w", resourceName, err)
 		}
 		// Fail fast: an interface-less card would otherwise only error at the
 		// first invocation, deep in the a2a client, without the resource name.
 		if len(embedded.SupportedInterfaces) == 0 {
-			return nil, "", "", fmt.Errorf("agentregistry: embedded agent card for %q has no supported interfaces", resourceName)
+			return nil, "", fmt.Errorf("agentregistry: embedded agent card for %q has no supported interfaces", resourceName)
 		}
 		agentName := cleanName(embedded.Name)
 		if agentName == "" {
-			agentName = cleanName(resourceName)
+			return nil, "", fmt.Errorf("agentregistry: embedded agent card for %q has an empty name", resourceName)
 		}
-		return &embedded, agentName, embedded.Description, nil
+		return &embedded, agentName, nil
 	}
 
 	url, version, transport, ok := connectionURI(info.Protocols, nil, protocolTypeA2AAgent, "")
 	if !ok {
-		return nil, "", "", fmt.Errorf("agentregistry: A2A connection URI not found for agent %q", resourceName)
+		return nil, "", fmt.Errorf("agentregistry: A2A connection URI not found for agent %q", resourceName)
 	}
 
 	displayName := info.DisplayName
@@ -269,6 +287,9 @@ func agentCard(info *Agent, resourceName string) (card *a2a.AgentCard, name, des
 		displayName = resourceName
 	}
 	agentName := cleanName(displayName)
+	if agentName == "" {
+		return nil, "", fmt.Errorf("agentregistry: cannot derive a non-empty agent name for %q", resourceName)
+	}
 
 	// Default to HTTP+JSON for an unrecognized binding (as adk-python does).
 	if transport == "" {
@@ -289,11 +310,10 @@ func agentCard(info *Agent, resourceName string) (card *a2a.AgentCard, name, des
 			ProtocolVersion: a2a.ProtocolVersion(protocolVersion),
 		}},
 		Skills:             toA2ASkills(info.Skills),
-		Capabilities:       a2a.AgentCapabilities{Streaming: false},
 		DefaultInputModes:  []string{"text"},
 		DefaultOutputModes: []string{"text"},
 	}
-	return card, agentName, info.Description, nil
+	return card, agentName, nil
 }
 
 func toA2ASkills(skills []Skill) []a2a.AgentSkill {

--- a/agentregistry/factory.go
+++ b/agentregistry/factory.go
@@ -1,0 +1,352 @@
+// Copyright 2026 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package agentregistry
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+	"net/http"
+	"net/url"
+	"strings"
+
+	"github.com/a2aproject/a2a-go/v2/a2a"
+	"github.com/a2aproject/a2a-go/v2/a2aclient"
+	"github.com/modelcontextprotocol/go-sdk/mcp"
+
+	"google.golang.org/adk/v2/agent"
+	remoteagent "google.golang.org/adk/v2/agent/remoteagent/v2"
+	"google.golang.org/adk/v2/tool"
+	"google.golang.org/adk/v2/tool/mcptoolset"
+)
+
+// egressConfig holds the resolved options shared by the factory helpers.
+type egressConfig struct {
+	httpClient *http.Client
+	headers    map[string]string
+}
+
+func applyRemoteAgentOptions(opts []RemoteAgentOption) egressConfig {
+	var ec egressConfig
+	for _, opt := range opts {
+		opt(&ec)
+	}
+	return ec
+}
+
+func applyMcpToolsetOptions(opts []McpToolsetOption) egressConfig {
+	var ec egressConfig
+	for _, opt := range opts {
+		opt(&ec)
+	}
+	return ec
+}
+
+// RemoteAgentOption customizes [Client.RemoteAgent].
+type RemoteAgentOption func(*egressConfig)
+
+// McpToolsetOption customizes [Client.McpToolset].
+type McpToolsetOption func(*egressConfig)
+
+// WithA2AHTTPClient sets the HTTP client used to reach the remote A2A agent.
+func WithA2AHTTPClient(c *http.Client) RemoteAgentOption {
+	return func(e *egressConfig) { e.httpClient = c }
+}
+
+// WithA2AHeaders adds static headers to every request sent to the remote A2A
+// agent.
+func WithA2AHeaders(h map[string]string) RemoteAgentOption {
+	return func(e *egressConfig) { e.headers = h }
+}
+
+// WithMcpHTTPClient sets the HTTP client used to reach the MCP server. It
+// overrides the default (an Application Default Credentials client for
+// *.googleapis.com endpoints).
+func WithMcpHTTPClient(c *http.Client) McpToolsetOption {
+	return func(e *egressConfig) { e.httpClient = c }
+}
+
+// WithMcpHeaders adds static headers to every request sent to the MCP server.
+func WithMcpHeaders(h map[string]string) McpToolsetOption {
+	return func(e *egressConfig) { e.headers = h }
+}
+
+// egressClient selects the HTTP client used to reach an endpoint at rawURL.
+// Precedence: an explicit override, then (only when autoADC is set and the
+// endpoint is a Google API) the registry's authenticated client, then a default
+// client. Static headers, if any, are layered on via a cloned client so shared
+// clients are never mutated.
+func (c *Client) egressClient(rawURL string, ec egressConfig, autoADC bool) *http.Client {
+	base := ec.httpClient
+	if base == nil {
+		if autoADC && isGoogleAPI(rawURL) {
+			base = c.httpClient
+		} else {
+			base = http.DefaultClient
+		}
+	}
+	return clientWithHeaders(base, ec.headers)
+}
+
+// isGoogleAPI reports whether rawURL points at a Google API endpoint. It mirrors
+// adk-python's _is_google_api.
+func isGoogleAPI(rawURL string) bool {
+	u, err := url.Parse(rawURL)
+	if err != nil {
+		return false
+	}
+	host := u.Hostname()
+	return host == "googleapis.com" || strings.HasSuffix(host, ".googleapis.com")
+}
+
+// clientWithHeaders returns a client that adds the given static headers to every
+// request. If there are no headers, base is returned unchanged. Otherwise base
+// is shallow-copied so the caller's client is not mutated.
+func clientWithHeaders(base *http.Client, headers map[string]string) *http.Client {
+	if len(headers) == 0 {
+		return base
+	}
+	clone := *base
+	clone.Transport = &headerRoundTripper{base: base.Transport, headers: headers}
+	return &clone
+}
+
+// headerRoundTripper adds a fixed set of headers to each request.
+type headerRoundTripper struct {
+	base    http.RoundTripper
+	headers map[string]string
+}
+
+func (h *headerRoundTripper) RoundTrip(req *http.Request) (*http.Response, error) {
+	rt := h.base
+	if rt == nil {
+		rt = http.DefaultTransport
+	}
+	req = req.Clone(req.Context())
+	for k, v := range h.headers {
+		req.Header.Set(k, v)
+	}
+	return rt.RoundTrip(req)
+}
+
+// cardTypeA2AAgentCard is the Card.Type value for an embedded A2A agent card.
+const cardTypeA2AAgentCard = "A2A_AGENT_CARD"
+
+// defaultA2AProtocolVersion is used when the registry does not report one.
+const defaultA2AProtocolVersion = "0.3.0"
+
+// RemoteAgent resolves a registered A2A agent into an [agent.Agent] usable as a
+// sub-agent. name is the full agent resource name.
+//
+// The agent card is taken from the registry's embedded card when present, and
+// otherwise synthesized from the agent's discrete fields. Egress auth is left to
+// the caller: pass [WithA2AHTTPClient] (and/or [WithA2AHeaders]) to authenticate
+// requests to the remote agent.
+func (c *Client) RemoteAgent(ctx context.Context, name string, opts ...RemoteAgentOption) (agent.Agent, error) {
+	info, err := c.GetAgent(ctx, name)
+	if err != nil {
+		return nil, err
+	}
+
+	card, agentName, description, err := agentCard(info, name)
+	if err != nil {
+		return nil, err
+	}
+
+	ec := applyRemoteAgentOptions(opts)
+	egress := c.egressClient(cardURL(card), ec, false)
+
+	return remoteagent.NewA2A(remoteagent.A2AConfig{
+		Name:           agentName,
+		Description:    description,
+		AgentCard:      card,
+		ClientProvider: remoteagent.NewA2AClientProvider(a2aClientFactory(card, egress)),
+	})
+}
+
+// a2aClientFactory builds an A2A client factory for the given card and HTTP
+// client. Besides the SDK's current-version transports, it registers a
+// compatibility transport for each (binding, protocolVersion) the card
+// advertises. Agent Registry commonly reports an older A2A protocol version
+// (e.g. 0.3.0) than the SDK's current one, and the a2a-go factory matches
+// transports by (protocol, version); without a matching compat transport,
+// client creation fails with "no compatible transports found".
+func a2aClientFactory(card *a2a.AgentCard, httpClient *http.Client) *a2aclient.Factory {
+	opts := []a2aclient.FactoryOption{
+		a2aclient.WithJSONRPCTransport(httpClient),
+		a2aclient.WithRESTTransport(httpClient),
+	}
+	seen := make(map[string]bool)
+	for _, iface := range card.SupportedInterfaces {
+		// The current-version transports above already cover a2a.Version.
+		if iface == nil || iface.ProtocolVersion == "" || iface.ProtocolVersion == a2a.Version {
+			continue
+		}
+		var factory a2aclient.TransportFactory
+		switch iface.ProtocolBinding {
+		case a2a.TransportProtocolJSONRPC:
+			factory = jsonrpcTransportFactory(httpClient)
+		case a2a.TransportProtocolHTTPJSON:
+			factory = restTransportFactory(httpClient)
+		default:
+			continue
+		}
+		key := string(iface.ProtocolBinding) + "@" + string(iface.ProtocolVersion)
+		if seen[key] {
+			continue
+		}
+		seen[key] = true
+		opts = append(opts, a2aclient.WithCompatTransport(iface.ProtocolVersion, iface.ProtocolBinding, factory))
+	}
+	return a2aclient.NewFactory(opts...)
+}
+
+func restTransportFactory(httpClient *http.Client) a2aclient.TransportFactory {
+	return a2aclient.TransportFactoryFn(func(_ context.Context, _ *a2a.AgentCard, iface *a2a.AgentInterface) (a2aclient.Transport, error) {
+		u, err := url.Parse(iface.URL)
+		if err != nil {
+			return nil, fmt.Errorf("agentregistry: parsing endpoint URL %q: %w", iface.URL, err)
+		}
+		return a2aclient.NewRESTTransport(u, httpClient), nil
+	})
+}
+
+func jsonrpcTransportFactory(httpClient *http.Client) a2aclient.TransportFactory {
+	return a2aclient.TransportFactoryFn(func(_ context.Context, _ *a2a.AgentCard, iface *a2a.AgentInterface) (a2aclient.Transport, error) {
+		return a2aclient.NewJSONRPCTransport(iface.URL, httpClient), nil
+	})
+}
+
+// agentCard resolves an [a2a.AgentCard] plus the cleaned agent name and
+// description for a registered agent, using the embedded card when available and
+// otherwise synthesizing one. resourceName is used as a fallback name.
+func agentCard(info *Agent, resourceName string) (card *a2a.AgentCard, name, description string, err error) {
+	if info.Card != nil && info.Card.Type == cardTypeA2AAgentCard && len(info.Card.Content) > 0 {
+		var embedded a2a.AgentCard
+		if err := json.Unmarshal(info.Card.Content, &embedded); err != nil {
+			return nil, "", "", fmt.Errorf("agentregistry: decoding embedded agent card for %q: %w", resourceName, err)
+		}
+		agentName := cleanName(embedded.Name)
+		if agentName == "" {
+			agentName = cleanName(resourceName)
+		}
+		return &embedded, agentName, embedded.Description, nil
+	}
+
+	url, version, transport, ok := connectionURI(info.Protocols, nil, protocolTypeA2AAgent, "")
+	if !ok {
+		return nil, "", "", fmt.Errorf("agentregistry: A2A connection URI not found for agent %q", resourceName)
+	}
+
+	displayName := info.DisplayName
+	if displayName == "" {
+		displayName = resourceName
+	}
+	agentName := cleanName(displayName)
+
+	// Default to HTTP+JSON for an unrecognized binding (as adk-python does).
+	if transport == "" {
+		transport = a2a.TransportProtocolHTTPJSON
+	}
+	protocolVersion := version
+	if protocolVersion == "" {
+		protocolVersion = defaultA2AProtocolVersion
+	}
+
+	card = &a2a.AgentCard{
+		Name:        agentName,
+		Description: info.Description,
+		Version:     info.Version,
+		SupportedInterfaces: []*a2a.AgentInterface{{
+			URL:             url,
+			ProtocolBinding: transport,
+			ProtocolVersion: a2a.ProtocolVersion(protocolVersion),
+		}},
+		Skills:             toA2ASkills(info.Skills),
+		Capabilities:       a2a.AgentCapabilities{Streaming: false},
+		DefaultInputModes:  []string{"text"},
+		DefaultOutputModes: []string{"text"},
+	}
+	return card, agentName, info.Description, nil
+}
+
+// cardURL returns the first supported-interface URL of a card, or "".
+func cardURL(card *a2a.AgentCard) string {
+	for _, iface := range card.SupportedInterfaces {
+		if iface != nil && iface.URL != "" {
+			return iface.URL
+		}
+	}
+	return ""
+}
+
+// toA2ASkills converts registry skills to A2A skills.
+func toA2ASkills(skills []Skill) []a2a.AgentSkill {
+	if len(skills) == 0 {
+		return nil
+	}
+	out := make([]a2a.AgentSkill, 0, len(skills))
+	for _, s := range skills {
+		out = append(out, a2a.AgentSkill{
+			ID:          s.ID,
+			Name:        s.Name,
+			Description: s.Description,
+			Tags:        s.Tags,
+			Examples:    s.Examples,
+		})
+	}
+	return out
+}
+
+// McpToolset resolves a registered MCP server into a [tool.Toolset] backed by a
+// streamable-HTTP MCP connection. name is the full MCP server resource name.
+//
+// The endpoint is resolved preferring the JSONRPC binding, then HTTP_JSON. By
+// default, requests to *.googleapis.com endpoints are authenticated with the
+// registry's Application Default Credentials; use [WithMcpHTTPClient] and/or
+// [WithMcpHeaders] to override or augment egress.
+func (c *Client) McpToolset(ctx context.Context, name string, opts ...McpToolsetOption) (tool.Toolset, error) {
+	server, err := c.GetMcpServer(ctx, name)
+	if err != nil {
+		return nil, err
+	}
+
+	uri, ok := mcpEndpointURI(server)
+	if !ok {
+		return nil, fmt.Errorf("agentregistry: MCP server endpoint URI not found for %q", name)
+	}
+
+	ec := applyMcpToolsetOptions(opts)
+	egress := c.egressClient(uri, ec, true)
+
+	return mcptoolset.New(mcptoolset.Config{
+		Transport: &mcp.StreamableClientTransport{
+			Endpoint:   uri,
+			HTTPClient: egress,
+		},
+	})
+}
+
+// mcpEndpointURI returns the MCP server's connection URI, preferring the JSONRPC
+// binding and falling back to HTTP_JSON (parity with adk-python).
+func mcpEndpointURI(server *McpServer) (string, bool) {
+	if uri, _, _, ok := connectionURI(server.Protocols, server.Interfaces, "", a2a.TransportProtocolJSONRPC); ok {
+		return uri, true
+	}
+	if uri, _, _, ok := connectionURI(server.Protocols, server.Interfaces, "", a2a.TransportProtocolHTTPJSON); ok {
+		return uri, true
+	}
+	return "", false
+}

--- a/agentregistry/factory.go
+++ b/agentregistry/factory.go
@@ -46,7 +46,7 @@ func applyRemoteAgentOptions(opts []RemoteAgentOption) egressConfig {
 	return ec
 }
 
-func applyMcpToolsetOptions(opts []McpToolsetOption) egressConfig {
+func applyMCPToolsetOptions(opts []MCPToolsetOption) egressConfig {
 	var ec egressConfig
 	for _, opt := range opts {
 		opt(&ec)
@@ -57,10 +57,14 @@ func applyMcpToolsetOptions(opts []McpToolsetOption) egressConfig {
 // RemoteAgentOption customizes [Client.RemoteAgent].
 type RemoteAgentOption func(*egressConfig)
 
-// McpToolsetOption customizes [Client.McpToolset].
-type McpToolsetOption func(*egressConfig)
+// MCPToolsetOption customizes [Client.MCPToolset].
+type MCPToolsetOption func(*egressConfig)
 
 // WithA2AHTTPClient sets the HTTP client used to reach the remote A2A agent.
+// A2A egress is not auto-authenticated, so set this to authenticate requests to
+// the remote agent. The default ([http.DefaultClient]) has no timeout; bound
+// egress on the client's Transport rather than via http.Client.Timeout, which
+// is a deadline over the whole request and would truncate streaming responses.
 func WithA2AHTTPClient(c *http.Client) RemoteAgentOption {
 	return func(e *egressConfig) { e.httpClient = c }
 }
@@ -71,15 +75,18 @@ func WithA2AHeaders(h map[string]string) RemoteAgentOption {
 	return func(e *egressConfig) { e.headers = h }
 }
 
-// WithMcpHTTPClient sets the HTTP client used to reach the MCP server. It
+// WithMCPHTTPClient sets the HTTP client used to reach the MCP server. It
 // overrides the default (an Application Default Credentials client for
-// *.googleapis.com endpoints).
-func WithMcpHTTPClient(c *http.Client) McpToolsetOption {
+// *.googleapis.com endpoints, else [http.DefaultClient]). The default has no
+// timeout; bound egress on the client's Transport rather than via
+// http.Client.Timeout, which is a deadline over the whole request and would
+// truncate streaming responses.
+func WithMCPHTTPClient(c *http.Client) MCPToolsetOption {
 	return func(e *egressConfig) { e.httpClient = c }
 }
 
-// WithMcpHeaders adds static headers to every request sent to the MCP server.
-func WithMcpHeaders(h map[string]string) McpToolsetOption {
+// WithMCPHeaders adds static headers to every request sent to the MCP server.
+func WithMCPHeaders(h map[string]string) MCPToolsetOption {
 	return func(e *egressConfig) { e.headers = h }
 }
 
@@ -166,7 +173,9 @@ func (c *Client) RemoteAgent(ctx context.Context, name string, opts ...RemoteAge
 	}
 
 	ec := applyRemoteAgentOptions(opts)
-	egress := c.egressClient(cardURL(card), ec, false)
+	// A2A egress is not auto-authenticated (parity with adk-python), so the
+	// endpoint URL is irrelevant to client selection here.
+	egress := c.egressClient("", ec, false)
 
 	return remoteagent.NewA2A(remoteagent.A2AConfig{
 		Name:           agentName,
@@ -238,6 +247,11 @@ func agentCard(info *Agent, resourceName string) (card *a2a.AgentCard, name, des
 		if err := json.Unmarshal(info.Card.Content, &embedded); err != nil {
 			return nil, "", "", fmt.Errorf("agentregistry: decoding embedded agent card for %q: %w", resourceName, err)
 		}
+		// Fail fast: an interface-less card would otherwise only error at the
+		// first invocation, deep in the a2a client, without the resource name.
+		if len(embedded.SupportedInterfaces) == 0 {
+			return nil, "", "", fmt.Errorf("agentregistry: embedded agent card for %q has no supported interfaces", resourceName)
+		}
 		agentName := cleanName(embedded.Name)
 		if agentName == "" {
 			agentName = cleanName(resourceName)
@@ -282,17 +296,6 @@ func agentCard(info *Agent, resourceName string) (card *a2a.AgentCard, name, des
 	return card, agentName, info.Description, nil
 }
 
-// cardURL returns the first supported-interface URL of a card, or "".
-func cardURL(card *a2a.AgentCard) string {
-	for _, iface := range card.SupportedInterfaces {
-		if iface != nil && iface.URL != "" {
-			return iface.URL
-		}
-	}
-	return ""
-}
-
-// toA2ASkills converts registry skills to A2A skills.
 func toA2ASkills(skills []Skill) []a2a.AgentSkill {
 	if len(skills) == 0 {
 		return nil
@@ -310,15 +313,15 @@ func toA2ASkills(skills []Skill) []a2a.AgentSkill {
 	return out
 }
 
-// McpToolset resolves a registered MCP server into a [tool.Toolset] backed by a
+// MCPToolset resolves a registered MCP server into a [tool.Toolset] backed by a
 // streamable-HTTP MCP connection. name is the full MCP server resource name.
 //
 // The endpoint is resolved preferring the JSONRPC binding, then HTTP_JSON. By
 // default, requests to *.googleapis.com endpoints are authenticated with the
-// registry's Application Default Credentials; use [WithMcpHTTPClient] and/or
-// [WithMcpHeaders] to override or augment egress.
-func (c *Client) McpToolset(ctx context.Context, name string, opts ...McpToolsetOption) (tool.Toolset, error) {
-	server, err := c.GetMcpServer(ctx, name)
+// registry's Application Default Credentials; use [WithMCPHTTPClient] and/or
+// [WithMCPHeaders] to override or augment egress.
+func (c *Client) MCPToolset(ctx context.Context, name string, opts ...MCPToolsetOption) (tool.Toolset, error) {
+	server, err := c.GetMCPServer(ctx, name)
 	if err != nil {
 		return nil, err
 	}
@@ -328,7 +331,7 @@ func (c *Client) McpToolset(ctx context.Context, name string, opts ...McpToolset
 		return nil, fmt.Errorf("agentregistry: MCP server endpoint URI not found for %q", name)
 	}
 
-	ec := applyMcpToolsetOptions(opts)
+	ec := applyMCPToolsetOptions(opts)
 	egress := c.egressClient(uri, ec, true)
 
 	return mcptoolset.New(mcptoolset.Config{
@@ -341,7 +344,7 @@ func (c *Client) McpToolset(ctx context.Context, name string, opts ...McpToolset
 
 // mcpEndpointURI returns the MCP server's connection URI, preferring the JSONRPC
 // binding and falling back to HTTP_JSON (parity with adk-python).
-func mcpEndpointURI(server *McpServer) (string, bool) {
+func mcpEndpointURI(server *MCPServer) (string, bool) {
 	if uri, _, _, ok := connectionURI(server.Protocols, server.Interfaces, "", a2a.TransportProtocolJSONRPC); ok {
 		return uri, true
 	}

--- a/agentregistry/factory.go
+++ b/agentregistry/factory.go
@@ -15,9 +15,11 @@
 package agentregistry
 
 import (
+	"cmp"
 	"context"
 	"encoding/json"
 	"fmt"
+	"maps"
 	"net/http"
 	"net/url"
 	"strings"
@@ -54,6 +56,8 @@ func applyMCPToolsetOptions(opts []MCPToolsetOption) egressConfig {
 	return ec
 }
 
+// addHeaders merges h into e.headers: it adds new keys and overwrites existing
+// ones, and never removes a key.
 func addHeaders(e *egressConfig, h map[string]string) {
 	if len(h) == 0 {
 		return
@@ -61,9 +65,7 @@ func addHeaders(e *egressConfig, h map[string]string) {
 	if e.headers == nil {
 		e.headers = make(map[string]string, len(h))
 	}
-	for k, v := range h {
-		e.headers[k] = v
-	}
+	maps.Copy(e.headers, h)
 }
 
 // RemoteAgentOption customizes [Client.RemoteAgent].
@@ -81,8 +83,8 @@ func WithA2AHTTPClient(c *http.Client) RemoteAgentOption {
 	return func(e *egressConfig) { e.httpClient = c }
 }
 
-// WithA2AHeaders adds static headers to every request sent to the remote A2A
-// agent. Repeated calls accumulate; a later value wins on a key conflict.
+// WithA2AHeaders adds or overwrites static headers on every request sent to the
+// remote A2A agent. Repeated calls accumulate; a later value wins on a key conflict.
 func WithA2AHeaders(h map[string]string) RemoteAgentOption {
 	return func(e *egressConfig) { addHeaders(e, h) }
 }
@@ -97,21 +99,20 @@ func WithMCPHTTPClient(c *http.Client) MCPToolsetOption {
 	return func(e *egressConfig) { e.httpClient = c }
 }
 
-// WithMCPHeaders adds static headers to every request sent to the MCP server.
-// Repeated calls accumulate; a later value wins on a key conflict.
+// WithMCPHeaders adds or overwrites static headers on every request sent to the
+// MCP server. Repeated calls accumulate; a later value wins on a key conflict.
 func WithMCPHeaders(h map[string]string) MCPToolsetOption {
 	return func(e *egressConfig) { addHeaders(e, h) }
 }
 
-// egressClient selects the HTTP client used to reach an endpoint at rawURL.
-// Precedence: an explicit override, then (only when autoADC is set and the
-// endpoint is a Google API) the registry's authenticated client, then a default
-// client. Static headers, if any, are layered on via a cloned client so shared
-// clients are never mutated.
-func (c *Client) egressClient(rawURL string, ec egressConfig, autoADC bool) *http.Client {
+// egressClient selects the HTTP client used to reach an MCP endpoint at rawURL.
+// Precedence: an explicit override, then (for a Google API endpoint) the
+// registry's authenticated client, then a default client. Static headers, if
+// any, are layered on via a cloned client so shared clients are never mutated.
+func (c *Client) egressClient(rawURL string, ec egressConfig) *http.Client {
 	base := ec.httpClient
 	if base == nil {
-		if autoADC && isGoogleAPI(rawURL) {
+		if isGoogleAPI(rawURL) {
 			base = c.httpClient
 		} else {
 			base = http.DefaultClient
@@ -131,9 +132,9 @@ func isGoogleAPI(rawURL string) bool {
 	return host == "googleapis.com" || strings.HasSuffix(host, ".googleapis.com")
 }
 
-// clientWithHeaders returns a client that adds the given static headers to every
-// request. If there are no headers, base is returned unchanged. Otherwise base
-// is shallow-copied so the caller's client is not mutated.
+// clientWithHeaders returns a client that adds or overwrites the given static
+// headers on every request. If there are no headers, base is returned unchanged.
+// Otherwise base is shallow-copied so the caller's client is not mutated.
 func clientWithHeaders(base *http.Client, headers map[string]string) *http.Client {
 	if len(headers) == 0 {
 		return base
@@ -148,6 +149,8 @@ type headerRoundTripper struct {
 	base    http.RoundTripper
 	headers map[string]string
 }
+
+var _ http.RoundTripper = (*headerRoundTripper)(nil)
 
 func (h *headerRoundTripper) RoundTrip(req *http.Request) (*http.Response, error) {
 	rt := h.base
@@ -186,9 +189,9 @@ func (c *Client) RemoteAgent(ctx context.Context, name string, opts ...RemoteAge
 	}
 
 	ec := applyRemoteAgentOptions(opts)
-	// A2A egress is not auto-authenticated (parity with adk-python), so the
-	// endpoint URL is irrelevant to client selection here.
-	egress := c.egressClient("", ec, false)
+	// A2A egress is not auto-authenticated (parity with adk-python): use the
+	// caller's client or the default, never the registry's ADC client.
+	egress := clientWithHeaders(cmp.Or(ec.httpClient, http.DefaultClient), ec.headers)
 
 	return remoteagent.NewA2A(remoteagent.A2AConfig{
 		Name:           agentName,
@@ -352,7 +355,7 @@ func (c *Client) MCPToolset(ctx context.Context, name string, opts ...MCPToolset
 	}
 
 	ec := applyMCPToolsetOptions(opts)
-	egress := c.egressClient(uri, ec, true)
+	egress := c.egressClient(uri, ec)
 
 	return mcptoolset.New(mcptoolset.Config{
 		Transport: &mcp.StreamableClientTransport{

--- a/agentregistry/factory_test.go
+++ b/agentregistry/factory_test.go
@@ -136,31 +136,33 @@ func TestClientWithHeaders_AppliesAndDoesNotMutateBase(t *testing.T) {
 
 func TestRemoteAgentOptions(t *testing.T) {
 	client := &http.Client{}
-	headers := map[string]string{"X": "y"}
 	ec := applyRemoteAgentOptions([]RemoteAgentOption{
 		WithA2AHTTPClient(client),
-		WithA2AHeaders(headers),
+		WithA2AHeaders(map[string]string{"X": "y"}),
+		WithA2AHeaders(map[string]string{"Z": "w"}),
 	})
 	if ec.httpClient != client {
 		t.Errorf("httpClient = %p, want %p", ec.httpClient, client)
 	}
-	if ec.headers["X"] != "y" {
-		t.Errorf(`headers["X"] = %q, want "y"`, ec.headers["X"])
+	// Repeated WithA2AHeaders calls accumulate rather than replacing the set.
+	if ec.headers["X"] != "y" || ec.headers["Z"] != "w" {
+		t.Errorf("headers = %v, want X=y and Z=w", ec.headers)
 	}
 }
 
 func TestMCPToolsetOptions(t *testing.T) {
 	client := &http.Client{}
-	headers := map[string]string{"X": "y"}
 	ec := applyMCPToolsetOptions([]MCPToolsetOption{
 		WithMCPHTTPClient(client),
-		WithMCPHeaders(headers),
+		WithMCPHeaders(map[string]string{"X": "y"}),
+		WithMCPHeaders(map[string]string{"Z": "w"}),
 	})
 	if ec.httpClient != client {
 		t.Errorf("httpClient = %p, want %p", ec.httpClient, client)
 	}
-	if ec.headers["X"] != "y" {
-		t.Errorf(`headers["X"] = %q, want "y"`, ec.headers["X"])
+	// Repeated WithMCPHeaders calls accumulate rather than replacing the set.
+	if ec.headers["X"] != "y" || ec.headers["Z"] != "w" {
+		t.Errorf("headers = %v, want X=y and Z=w", ec.headers)
 	}
 }
 
@@ -177,15 +179,15 @@ func TestAgentCard_EmbeddedFastPath(t *testing.T) {
 	}
 	info := &Agent{Card: &Card{Type: "A2A_AGENT_CARD", Content: content}}
 
-	card, name, desc, err := agentCard(info, "projects/p/locations/l/agents/a")
+	card, name, err := agentCard(info, "projects/p/locations/l/agents/a")
 	if err != nil {
 		t.Fatalf("agentCard() error = %v", err)
 	}
 	if name != "My_Agent" {
 		t.Errorf("name = %q, want My_Agent (cleaned)", name)
 	}
-	if desc != "embedded desc" {
-		t.Errorf("description = %q, want embedded desc", desc)
+	if card.Description != "embedded desc" {
+		t.Errorf("description = %q, want embedded desc", card.Description)
 	}
 	// The embedded card itself is used verbatim (its name is not rewritten).
 	if card.Name != "My Agent" || card.Version != "9" {
@@ -202,8 +204,24 @@ func TestAgentCard_EmbeddedNoInterfaces(t *testing.T) {
 	}
 	info := &Agent{Card: &Card{Type: "A2A_AGENT_CARD", Content: content}}
 
-	if _, _, _, err := agentCard(info, "projects/p/locations/l/agents/a"); err == nil {
+	if _, _, err := agentCard(info, "projects/p/locations/l/agents/a"); err == nil {
 		t.Error("agentCard() error = nil, want an error for an embedded card with no supported interfaces")
+	}
+}
+
+func TestAgentCard_EmbeddedEmptyName(t *testing.T) {
+	// An embedded card must carry a usable name; the embedded path does not fall
+	// back to the resource name (parity with adk-python), so an empty name fails.
+	content, err := json.Marshal(a2a.AgentCard{
+		SupportedInterfaces: []*a2a.AgentInterface{a2a.NewAgentInterface("https://a.example", a2a.TransportProtocolJSONRPC)},
+	})
+	if err != nil {
+		t.Fatalf("marshal embedded card: %v", err)
+	}
+	info := &Agent{Card: &Card{Type: "A2A_AGENT_CARD", Content: content}}
+
+	if _, _, err := agentCard(info, "projects/p/locations/l/agents/a"); err == nil {
+		t.Error("agentCard() error = nil, want an error for an embedded card with an empty name")
 	}
 }
 
@@ -222,15 +240,15 @@ func TestAgentCard_Synthesized(t *testing.T) {
 		Skills: []Skill{{ID: "s1", Name: "Skill One", Tags: []string{"t"}}},
 	}
 
-	card, name, desc, err := agentCard(info, "projects/p/locations/l/agents/cool")
+	card, name, err := agentCard(info, "projects/p/locations/l/agents/cool")
 	if err != nil {
 		t.Fatalf("agentCard() error = %v", err)
 	}
 	if name != "Cool_Agent" {
 		t.Errorf("name = %q, want Cool_Agent", name)
 	}
-	if desc != "does cool things" {
-		t.Errorf("description = %q, want does cool things", desc)
+	if card.Description != "does cool things" {
+		t.Errorf("description = %q, want does cool things", card.Description)
 	}
 	if card.Name != "Cool_Agent" || card.Version != "2.0" {
 		t.Errorf("card name/version = %q/%q, want Cool_Agent/2.0", card.Name, card.Version)
@@ -262,7 +280,7 @@ func TestAgentCard_SynthesizedDefaultsAndNameFallback(t *testing.T) {
 			Interfaces: []Interface{{URL: "https://a.example", ProtocolBinding: "SOMETHING_ELSE"}},
 		}},
 	}
-	card, name, _, err := agentCard(info, "projects/p/locations/l/agents/fallback-id")
+	card, name, err := agentCard(info, "projects/p/locations/l/agents/fallback-id")
 	if err != nil {
 		t.Fatalf("agentCard() error = %v", err)
 	}
@@ -280,8 +298,23 @@ func TestAgentCard_SynthesizedDefaultsAndNameFallback(t *testing.T) {
 
 func TestAgentCard_NoConnectionURI(t *testing.T) {
 	info := &Agent{DisplayName: "no interfaces"}
-	if _, _, _, err := agentCard(info, "projects/p/locations/l/agents/x"); err == nil {
+	if _, _, err := agentCard(info, "projects/p/locations/l/agents/x"); err == nil {
 		t.Error("agentCard() error = nil, want an error when no A2A connection URI is present")
+	}
+}
+
+func TestAgentCard_EmptyNameError(t *testing.T) {
+	// No display name and an empty resource name leave nothing to derive a
+	// non-empty agent name from, so agentCard must fail rather than build an
+	// agent with an empty (invalid) name.
+	info := &Agent{
+		Protocols: []Protocol{{
+			Type:       "A2A_AGENT",
+			Interfaces: []Interface{{URL: "https://a.example", ProtocolBinding: "JSONRPC"}},
+		}},
+	}
+	if _, _, err := agentCard(info, ""); err == nil {
+		t.Error("agentCard() error = nil, want an error when no non-empty name can be derived")
 	}
 }
 

--- a/agentregistry/factory_test.go
+++ b/agentregistry/factory_test.go
@@ -51,41 +51,31 @@ func TestEgressClient(t *testing.T) {
 	c := &Client{httpClient: registryClient}
 
 	tests := []struct {
-		name    string
-		url     string
-		ec      egressConfig
-		autoADC bool
-		want    *http.Client
+		name string
+		url  string
+		ec   egressConfig
+		want *http.Client
 	}{
 		{
-			name:    "explicit override wins",
-			url:     "https://x.googleapis.com",
-			ec:      egressConfig{httpClient: override},
-			autoADC: true,
-			want:    override,
+			name: "explicit override wins",
+			url:  "https://x.googleapis.com",
+			ec:   egressConfig{httpClient: override},
+			want: override,
 		},
 		{
-			name:    "google api with autoADC reuses registry client",
-			url:     "https://x.googleapis.com/mcp",
-			autoADC: true,
-			want:    registryClient,
+			name: "google api reuses registry client",
+			url:  "https://x.googleapis.com/mcp",
+			want: registryClient,
 		},
 		{
-			name:    "google api without autoADC uses default",
-			url:     "https://x.googleapis.com/mcp",
-			autoADC: false,
-			want:    http.DefaultClient,
-		},
-		{
-			name:    "non-google uses default",
-			url:     "https://third-party.example/mcp",
-			autoADC: true,
-			want:    http.DefaultClient,
+			name: "non-google uses default",
+			url:  "https://third-party.example/mcp",
+			want: http.DefaultClient,
 		},
 	}
 	for _, tc := range tests {
 		t.Run(tc.name, func(t *testing.T) {
-			if got := c.egressClient(tc.url, tc.ec, tc.autoADC); got != tc.want {
+			if got := c.egressClient(tc.url, tc.ec); got != tc.want {
 				t.Errorf("egressClient() = %p, want %p", got, tc.want)
 			}
 		})
@@ -95,7 +85,7 @@ func TestEgressClient(t *testing.T) {
 func TestEgressClient_HeadersProduceDistinctClient(t *testing.T) {
 	registryClient := &http.Client{}
 	c := &Client{httpClient: registryClient}
-	got := c.egressClient("https://x.googleapis.com", egressConfig{headers: map[string]string{"X": "y"}}, true)
+	got := c.egressClient("https://x.googleapis.com", egressConfig{headers: map[string]string{"X": "y"}})
 	if got == registryClient {
 		t.Error("egressClient() with headers returned the shared registry client; want a distinct clone")
 	}

--- a/agentregistry/factory_test.go
+++ b/agentregistry/factory_test.go
@@ -1,0 +1,383 @@
+// Copyright 2026 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package agentregistry
+
+import (
+	"encoding/json"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+
+	"github.com/a2aproject/a2a-go/v2/a2a"
+)
+
+func TestIsGoogleAPI(t *testing.T) {
+	tests := []struct {
+		url  string
+		want bool
+	}{
+		{url: "https://googleapis.com/v1", want: true},
+		{url: "https://agentregistry.googleapis.com/v1", want: true},
+		{url: "https://agentregistry.mtls.googleapis.com/v1", want: true},
+		{url: "https://evil.com/googleapis.com", want: false},
+		{url: "https://notgoogleapis.com", want: false},
+		{url: "https://example.com", want: false},
+		{url: "://bad", want: false},
+	}
+	for _, tc := range tests {
+		t.Run(tc.url, func(t *testing.T) {
+			if got := isGoogleAPI(tc.url); got != tc.want {
+				t.Errorf("isGoogleAPI(%q) = %t, want %t", tc.url, got, tc.want)
+			}
+		})
+	}
+}
+
+func TestEgressClient(t *testing.T) {
+	registryClient := &http.Client{}
+	override := &http.Client{}
+	c := &Client{httpClient: registryClient}
+
+	tests := []struct {
+		name    string
+		url     string
+		ec      egressConfig
+		autoADC bool
+		want    *http.Client
+	}{
+		{
+			name:    "explicit override wins",
+			url:     "https://x.googleapis.com",
+			ec:      egressConfig{httpClient: override},
+			autoADC: true,
+			want:    override,
+		},
+		{
+			name:    "google api with autoADC reuses registry client",
+			url:     "https://x.googleapis.com/mcp",
+			autoADC: true,
+			want:    registryClient,
+		},
+		{
+			name:    "google api without autoADC uses default",
+			url:     "https://x.googleapis.com/mcp",
+			autoADC: false,
+			want:    http.DefaultClient,
+		},
+		{
+			name:    "non-google uses default",
+			url:     "https://third-party.example/mcp",
+			autoADC: true,
+			want:    http.DefaultClient,
+		},
+	}
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			if got := c.egressClient(tc.url, tc.ec, tc.autoADC); got != tc.want {
+				t.Errorf("egressClient() = %p, want %p", got, tc.want)
+			}
+		})
+	}
+}
+
+func TestEgressClient_HeadersProduceDistinctClient(t *testing.T) {
+	registryClient := &http.Client{}
+	c := &Client{httpClient: registryClient}
+	got := c.egressClient("https://x.googleapis.com", egressConfig{headers: map[string]string{"X": "y"}}, true)
+	if got == registryClient {
+		t.Error("egressClient() with headers returned the shared registry client; want a distinct clone")
+	}
+}
+
+func TestClientWithHeaders_NoHeadersReturnsBase(t *testing.T) {
+	base := &http.Client{}
+	if got := clientWithHeaders(base, nil); got != base {
+		t.Errorf("clientWithHeaders(base, nil) = %p, want base %p", got, base)
+	}
+}
+
+func TestClientWithHeaders_AppliesAndDoesNotMutateBase(t *testing.T) {
+	var gotHeader string
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		gotHeader = r.Header.Get("X-Test")
+	}))
+	defer srv.Close()
+
+	base := &http.Client{}
+	wrapped := clientWithHeaders(base, map[string]string{"X-Test": "v"})
+	if wrapped == base {
+		t.Fatal("clientWithHeaders returned base; want a clone")
+	}
+	if base.Transport != nil {
+		t.Error("base client Transport was mutated; want it left nil")
+	}
+
+	resp, err := wrapped.Get(srv.URL)
+	if err != nil {
+		t.Fatalf("wrapped.Get() error = %v", err)
+	}
+	_ = resp.Body.Close()
+	if gotHeader != "v" {
+		t.Errorf("server saw X-Test = %q, want v", gotHeader)
+	}
+}
+
+func TestAgentCard_EmbeddedFastPath(t *testing.T) {
+	embedded := a2a.AgentCard{Name: "My Agent", Description: "embedded desc", Version: "9"}
+	content, err := json.Marshal(embedded)
+	if err != nil {
+		t.Fatalf("marshal embedded card: %v", err)
+	}
+	info := &Agent{Card: &Card{Type: "A2A_AGENT_CARD", Content: content}}
+
+	card, name, desc, err := agentCard(info, "projects/p/locations/l/agents/a")
+	if err != nil {
+		t.Fatalf("agentCard() error = %v", err)
+	}
+	if name != "My_Agent" {
+		t.Errorf("name = %q, want My_Agent (cleaned)", name)
+	}
+	if desc != "embedded desc" {
+		t.Errorf("description = %q, want embedded desc", desc)
+	}
+	// The embedded card itself is used verbatim (its name is not rewritten).
+	if card.Name != "My Agent" || card.Version != "9" {
+		t.Errorf("card = %+v, want the embedded card unchanged", card)
+	}
+}
+
+func TestAgentCard_Synthesized(t *testing.T) {
+	info := &Agent{
+		DisplayName: "Cool Agent",
+		Description: "does cool things",
+		Version:     "2.0",
+		Protocols: []Protocol{{
+			Type:            "A2A_AGENT",
+			ProtocolVersion: "0.3.0",
+			Interfaces: []Interface{
+				{URL: "https://a.example/jsonrpc", ProtocolBinding: "JSONRPC"},
+			},
+		}},
+		Skills: []Skill{{ID: "s1", Name: "Skill One", Tags: []string{"t"}}},
+	}
+
+	card, name, desc, err := agentCard(info, "projects/p/locations/l/agents/cool")
+	if err != nil {
+		t.Fatalf("agentCard() error = %v", err)
+	}
+	if name != "Cool_Agent" {
+		t.Errorf("name = %q, want Cool_Agent", name)
+	}
+	if desc != "does cool things" {
+		t.Errorf("description = %q, want does cool things", desc)
+	}
+	if card.Name != "Cool_Agent" || card.Version != "2.0" {
+		t.Errorf("card name/version = %q/%q, want Cool_Agent/2.0", card.Name, card.Version)
+	}
+	if len(card.SupportedInterfaces) != 1 {
+		t.Fatalf("supported interfaces = %d, want 1", len(card.SupportedInterfaces))
+	}
+	iface := card.SupportedInterfaces[0]
+	if iface.URL != "https://a.example/jsonrpc" {
+		t.Errorf("interface URL = %q, want the jsonrpc URL", iface.URL)
+	}
+	if iface.ProtocolBinding != a2a.TransportProtocolJSONRPC {
+		t.Errorf("interface binding = %q, want JSONRPC", iface.ProtocolBinding)
+	}
+	if iface.ProtocolVersion != a2a.ProtocolVersion("0.3.0") {
+		t.Errorf("interface protocol version = %q, want 0.3.0", iface.ProtocolVersion)
+	}
+	if len(card.Skills) != 1 || card.Skills[0].ID != "s1" || card.Skills[0].Name != "Skill One" {
+		t.Errorf("skills = %+v, want one mapped skill s1", card.Skills)
+	}
+}
+
+func TestAgentCard_SynthesizedDefaultsAndNameFallback(t *testing.T) {
+	// No display name -> fall back to the resource name; no binding -> HTTP+JSON;
+	// no protocol version -> default.
+	info := &Agent{
+		Protocols: []Protocol{{
+			Type:       "A2A_AGENT",
+			Interfaces: []Interface{{URL: "https://a.example", ProtocolBinding: "SOMETHING_ELSE"}},
+		}},
+	}
+	card, name, _, err := agentCard(info, "projects/p/locations/l/agents/fallback-id")
+	if err != nil {
+		t.Fatalf("agentCard() error = %v", err)
+	}
+	if name != "projects_p_locations_l_agents_fallback_id" {
+		t.Errorf("name = %q, want cleaned resource name", name)
+	}
+	iface := card.SupportedInterfaces[0]
+	if iface.ProtocolBinding != a2a.TransportProtocolHTTPJSON {
+		t.Errorf("binding = %q, want default HTTP+JSON for unknown binding", iface.ProtocolBinding)
+	}
+	if iface.ProtocolVersion != a2a.ProtocolVersion(defaultA2AProtocolVersion) {
+		t.Errorf("protocol version = %q, want default %q", iface.ProtocolVersion, defaultA2AProtocolVersion)
+	}
+}
+
+func TestAgentCard_NoConnectionURI(t *testing.T) {
+	info := &Agent{DisplayName: "no interfaces"}
+	if _, _, _, err := agentCard(info, "projects/p/locations/l/agents/x"); err == nil {
+		t.Error("agentCard() error = nil, want an error when no A2A connection URI is present")
+	}
+}
+
+func TestRemoteAgent_Integration(t *testing.T) {
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		_, _ = w.Write([]byte(`{
+			"displayName": "Doc Summarizer",
+			"description": "summarizes documents",
+			"protocols": [{"type": "A2A_AGENT", "protocolVersion": "0.3.0",
+				"interfaces": [{"url": "https://a.example/jsonrpc", "protocolBinding": "JSONRPC"}]}]
+		}`))
+	}))
+	defer srv.Close()
+
+	got, err := newTestClient(srv).RemoteAgent(t.Context(), "projects/p/locations/l/agents/doc")
+	if err != nil {
+		t.Fatalf("RemoteAgent() error = %v", err)
+	}
+	if got == nil {
+		t.Fatal("RemoteAgent() = nil, want an agent")
+	}
+	if got.Name() != "Doc_Summarizer" {
+		t.Errorf("agent Name() = %q, want Doc_Summarizer", got.Name())
+	}
+	if got.Description() != "summarizes documents" {
+		t.Errorf("agent Description() = %q, want summarizes documents", got.Description())
+	}
+}
+
+func TestA2AClientFactory_CompatProtocolVersion(t *testing.T) {
+	// Registry cards commonly advertise an older A2A protocol version than the
+	// SDK's current one. The factory must register a compatible transport so the
+	// client can be created (this failed with "no compatible transports found"
+	// before the compat transports were added).
+	tests := []struct {
+		name    string
+		binding a2a.TransportProtocol
+		version a2a.ProtocolVersion
+	}{
+		{name: "http+json old version", binding: a2a.TransportProtocolHTTPJSON, version: "0.3.0"},
+		{name: "jsonrpc old version", binding: a2a.TransportProtocolJSONRPC, version: "0.3.0"},
+		{name: "http+json current version", binding: a2a.TransportProtocolHTTPJSON, version: a2a.Version},
+	}
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			card := &a2a.AgentCard{
+				Name: "x",
+				SupportedInterfaces: []*a2a.AgentInterface{{
+					URL:             "https://x.example/a2a",
+					ProtocolBinding: tc.binding,
+					ProtocolVersion: tc.version,
+				}},
+			}
+			factory := a2aClientFactory(card, http.DefaultClient)
+			client, err := factory.CreateFromCard(t.Context(), card)
+			if err != nil {
+				t.Fatalf("CreateFromCard(%s@%s) error = %v, want a client", tc.binding, tc.version, err)
+			}
+			if client == nil {
+				t.Fatal("CreateFromCard() = nil client")
+			}
+			_ = client.Destroy()
+		})
+	}
+}
+
+func TestMcpEndpointURI(t *testing.T) {
+	tests := []struct {
+		name    string
+		server  *McpServer
+		wantURI string
+		wantOK  bool
+	}{
+		{
+			name: "prefers jsonrpc over http_json",
+			server: &McpServer{Interfaces: []Interface{
+				{URL: "https://s/http", ProtocolBinding: "HTTP_JSON"},
+				{URL: "https://s/jsonrpc", ProtocolBinding: "JSONRPC"},
+			}},
+			wantURI: "https://s/jsonrpc",
+			wantOK:  true,
+		},
+		{
+			name: "falls back to http_json",
+			server: &McpServer{Interfaces: []Interface{
+				{URL: "https://s/http", ProtocolBinding: "HTTP_JSON"},
+			}},
+			wantURI: "https://s/http",
+			wantOK:  true,
+		},
+		{
+			name: "reads from protocols too",
+			server: &McpServer{Protocols: []Protocol{{
+				Interfaces: []Interface{{URL: "https://s/jsonrpc", ProtocolBinding: "JSONRPC"}},
+			}}},
+			wantURI: "https://s/jsonrpc",
+			wantOK:  true,
+		},
+		{
+			name:   "no supported binding",
+			server: &McpServer{Interfaces: []Interface{{URL: "https://s/grpc", ProtocolBinding: "GRPC"}}},
+			wantOK: false,
+		},
+		{
+			name:   "empty",
+			server: &McpServer{},
+			wantOK: false,
+		},
+	}
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			uri, ok := mcpEndpointURI(tc.server)
+			if ok != tc.wantOK || uri != tc.wantURI {
+				t.Errorf("mcpEndpointURI() = (%q, %t), want (%q, %t)", uri, ok, tc.wantURI, tc.wantOK)
+			}
+		})
+	}
+}
+
+func TestMcpToolset_Integration(t *testing.T) {
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		_, _ = w.Write([]byte(`{
+			"displayName": "Data MCP",
+			"mcpServerId": "data-mcp",
+			"interfaces": [{"url": "https://data.example/mcp", "protocolBinding": "JSONRPC"}]
+		}`))
+	}))
+	defer srv.Close()
+
+	ts, err := newTestClient(srv).McpToolset(t.Context(), "projects/p/locations/l/mcpServers/data")
+	if err != nil {
+		t.Fatalf("McpToolset() error = %v", err)
+	}
+	if ts == nil {
+		t.Fatal("McpToolset() = nil, want a toolset")
+	}
+}
+
+func TestMcpToolset_NoEndpoint(t *testing.T) {
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		_, _ = w.Write([]byte(`{"displayName": "Data MCP"}`)) // no interfaces
+	}))
+	defer srv.Close()
+
+	if _, err := newTestClient(srv).McpToolset(t.Context(), "projects/p/locations/l/mcpServers/data"); err == nil {
+		t.Error("McpToolset() error = nil, want an error when no endpoint URI is present")
+	}
+}

--- a/agentregistry/factory_test.go
+++ b/agentregistry/factory_test.go
@@ -134,8 +134,43 @@ func TestClientWithHeaders_AppliesAndDoesNotMutateBase(t *testing.T) {
 	}
 }
 
+func TestRemoteAgentOptions(t *testing.T) {
+	client := &http.Client{}
+	headers := map[string]string{"X": "y"}
+	ec := applyRemoteAgentOptions([]RemoteAgentOption{
+		WithA2AHTTPClient(client),
+		WithA2AHeaders(headers),
+	})
+	if ec.httpClient != client {
+		t.Errorf("httpClient = %p, want %p", ec.httpClient, client)
+	}
+	if ec.headers["X"] != "y" {
+		t.Errorf(`headers["X"] = %q, want "y"`, ec.headers["X"])
+	}
+}
+
+func TestMCPToolsetOptions(t *testing.T) {
+	client := &http.Client{}
+	headers := map[string]string{"X": "y"}
+	ec := applyMCPToolsetOptions([]MCPToolsetOption{
+		WithMCPHTTPClient(client),
+		WithMCPHeaders(headers),
+	})
+	if ec.httpClient != client {
+		t.Errorf("httpClient = %p, want %p", ec.httpClient, client)
+	}
+	if ec.headers["X"] != "y" {
+		t.Errorf(`headers["X"] = %q, want "y"`, ec.headers["X"])
+	}
+}
+
 func TestAgentCard_EmbeddedFastPath(t *testing.T) {
-	embedded := a2a.AgentCard{Name: "My Agent", Description: "embedded desc", Version: "9"}
+	embedded := a2a.AgentCard{
+		Name:                "My Agent",
+		Description:         "embedded desc",
+		Version:             "9",
+		SupportedInterfaces: []*a2a.AgentInterface{a2a.NewAgentInterface("https://a.example", a2a.TransportProtocolJSONRPC)},
+	}
 	content, err := json.Marshal(embedded)
 	if err != nil {
 		t.Fatalf("marshal embedded card: %v", err)
@@ -155,6 +190,20 @@ func TestAgentCard_EmbeddedFastPath(t *testing.T) {
 	// The embedded card itself is used verbatim (its name is not rewritten).
 	if card.Name != "My Agent" || card.Version != "9" {
 		t.Errorf("card = %+v, want the embedded card unchanged", card)
+	}
+}
+
+func TestAgentCard_EmbeddedNoInterfaces(t *testing.T) {
+	// An embedded card without supported interfaces must fail fast (with the
+	// resource name) rather than only at the first invocation.
+	content, err := json.Marshal(a2a.AgentCard{Name: "My Agent"})
+	if err != nil {
+		t.Fatalf("marshal embedded card: %v", err)
+	}
+	info := &Agent{Card: &Card{Type: "A2A_AGENT_CARD", Content: content}}
+
+	if _, _, _, err := agentCard(info, "projects/p/locations/l/agents/a"); err == nil {
+		t.Error("agentCard() error = nil, want an error for an embedded card with no supported interfaces")
 	}
 }
 
@@ -299,16 +348,16 @@ func TestA2AClientFactory_CompatProtocolVersion(t *testing.T) {
 	}
 }
 
-func TestMcpEndpointURI(t *testing.T) {
+func TestMCPEndpointURI(t *testing.T) {
 	tests := []struct {
 		name    string
-		server  *McpServer
+		server  *MCPServer
 		wantURI string
 		wantOK  bool
 	}{
 		{
 			name: "prefers jsonrpc over http_json",
-			server: &McpServer{Interfaces: []Interface{
+			server: &MCPServer{Interfaces: []Interface{
 				{URL: "https://s/http", ProtocolBinding: "HTTP_JSON"},
 				{URL: "https://s/jsonrpc", ProtocolBinding: "JSONRPC"},
 			}},
@@ -317,7 +366,7 @@ func TestMcpEndpointURI(t *testing.T) {
 		},
 		{
 			name: "falls back to http_json",
-			server: &McpServer{Interfaces: []Interface{
+			server: &MCPServer{Interfaces: []Interface{
 				{URL: "https://s/http", ProtocolBinding: "HTTP_JSON"},
 			}},
 			wantURI: "https://s/http",
@@ -325,7 +374,7 @@ func TestMcpEndpointURI(t *testing.T) {
 		},
 		{
 			name: "reads from protocols too",
-			server: &McpServer{Protocols: []Protocol{{
+			server: &MCPServer{Protocols: []Protocol{{
 				Interfaces: []Interface{{URL: "https://s/jsonrpc", ProtocolBinding: "JSONRPC"}},
 			}}},
 			wantURI: "https://s/jsonrpc",
@@ -333,12 +382,12 @@ func TestMcpEndpointURI(t *testing.T) {
 		},
 		{
 			name:   "no supported binding",
-			server: &McpServer{Interfaces: []Interface{{URL: "https://s/grpc", ProtocolBinding: "GRPC"}}},
+			server: &MCPServer{Interfaces: []Interface{{URL: "https://s/grpc", ProtocolBinding: "GRPC"}}},
 			wantOK: false,
 		},
 		{
 			name:   "empty",
-			server: &McpServer{},
+			server: &MCPServer{},
 			wantOK: false,
 		},
 	}
@@ -352,7 +401,7 @@ func TestMcpEndpointURI(t *testing.T) {
 	}
 }
 
-func TestMcpToolset_Integration(t *testing.T) {
+func TestMCPToolset_Integration(t *testing.T) {
 	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		_, _ = w.Write([]byte(`{
 			"displayName": "Data MCP",
@@ -362,22 +411,22 @@ func TestMcpToolset_Integration(t *testing.T) {
 	}))
 	defer srv.Close()
 
-	ts, err := newTestClient(srv).McpToolset(t.Context(), "projects/p/locations/l/mcpServers/data")
+	ts, err := newTestClient(srv).MCPToolset(t.Context(), "projects/p/locations/l/mcpServers/data")
 	if err != nil {
-		t.Fatalf("McpToolset() error = %v", err)
+		t.Fatalf("MCPToolset() error = %v", err)
 	}
 	if ts == nil {
-		t.Fatal("McpToolset() = nil, want a toolset")
+		t.Fatal("MCPToolset() = nil, want a toolset")
 	}
 }
 
-func TestMcpToolset_NoEndpoint(t *testing.T) {
+func TestMCPToolset_NoEndpoint(t *testing.T) {
 	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		_, _ = w.Write([]byte(`{"displayName": "Data MCP"}`)) // no interfaces
 	}))
 	defer srv.Close()
 
-	if _, err := newTestClient(srv).McpToolset(t.Context(), "projects/p/locations/l/mcpServers/data"); err == nil {
-		t.Error("McpToolset() error = nil, want an error when no endpoint URI is present")
+	if _, err := newTestClient(srv).MCPToolset(t.Context(), "projects/p/locations/l/mcpServers/data"); err == nil {
+		t.Error("MCPToolset() error = nil, want an error when no endpoint URI is present")
 	}
 }

--- a/agentregistry/mcptoolset_e2e_test.go
+++ b/agentregistry/mcptoolset_e2e_test.go
@@ -1,0 +1,87 @@
+// Copyright 2026 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package agentregistry
+
+import (
+	"context"
+	"encoding/json"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+
+	"github.com/modelcontextprotocol/go-sdk/mcp"
+
+	icontext "google.golang.org/adk/v2/internal/context"
+)
+
+// TestMCPToolset_E2E is an end-to-end round trip: a real in-process MCP server
+// over streamable HTTP is fronted by a faked registry record, and MCPToolset
+// resolves that record, connects over the resolved endpoint, and lists the
+// server's tools. It exercises endpoint resolution, the streamable-HTTP
+// transport wiring, and egress-client selection.
+func TestMCPToolset_E2E(t *testing.T) {
+	const toolName = "get_data"
+
+	mcpServer := mcp.NewServer(&mcp.Implementation{Name: "data_mcp", Version: "v1.0.0"}, nil)
+	mcp.AddTool(mcpServer, &mcp.Tool{Name: toolName, Description: "returns data"},
+		func(context.Context, *mcp.CallToolRequest, struct{}) (*mcp.CallToolResult, struct{}, error) {
+			return &mcp.CallToolResult{}, struct{}{}, nil
+		})
+
+	mcpSrv := httptest.NewServer(mcp.NewStreamableHTTPHandler(
+		func(*http.Request) *mcp.Server { return mcpServer }, nil))
+	defer mcpSrv.Close()
+	// The toolset holds a persistent streamable-HTTP connection with no public
+	// close; force-close it (runs before Close) so the server can shut down.
+	defer mcpSrv.CloseClientConnections()
+
+	regSrv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		rec := MCPServer{
+			DisplayName: "Data MCP",
+			MCPServerID: "data-mcp",
+			Interfaces:  []Interface{{URL: mcpSrv.URL, ProtocolBinding: bindingJSONRPC}},
+		}
+		if err := json.NewEncoder(w).Encode(rec); err != nil {
+			t.Errorf("encoding registry record: %v", err)
+		}
+	}))
+	defer regSrv.Close()
+
+	ts, err := newTestClient(regSrv).MCPToolset(t.Context(), "projects/p/locations/l/mcpServers/data")
+	if err != nil {
+		t.Fatalf("MCPToolset() error = %v", err)
+	}
+
+	rctx := icontext.NewReadonlyContext(icontext.NewInvocationContext(t.Context(), icontext.InvocationContextParams{}))
+	tools, err := ts.Tools(rctx)
+	if err != nil {
+		t.Fatalf("Tools() error = %v", err)
+	}
+
+	var names []string
+	for _, tl := range tools {
+		names = append(names, tl.Name())
+	}
+	found := false
+	for _, n := range names {
+		if n == toolName {
+			found = true
+			break
+		}
+	}
+	if !found {
+		t.Errorf("Tools() = %v, want it to contain %q", names, toolName)
+	}
+}

--- a/agentregistry/registry.go
+++ b/agentregistry/registry.go
@@ -54,6 +54,9 @@ type Config struct {
 // Client is a client for the Google Cloud Agent Registry.
 type Client struct {
 	requester requester
+	// httpClient is the client used for registry calls; the factory helpers
+	// reuse it for egress to *.googleapis.com endpoints (parity with adk-python).
+	httpClient *http.Client
 }
 
 // New creates a [Client]. By default it authenticates to
@@ -106,6 +109,7 @@ func New(ctx context.Context, cfg Config) (*Client, error) {
 			basePath:    fmt.Sprintf("projects/%s/locations/%s", cfg.ProjectID, cfg.Location),
 			userProject: quotaProject,
 		},
+		httpClient: httpClient,
 	}, nil
 }
 

--- a/agentregistry/remoteagent_e2e_test.go
+++ b/agentregistry/remoteagent_e2e_test.go
@@ -1,0 +1,183 @@
+// Copyright 2026 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package agentregistry
+
+import (
+	"encoding/json"
+	"iter"
+	"net/http"
+	"net/http/httptest"
+	"strings"
+	"testing"
+
+	"github.com/a2aproject/a2a-go/v2/a2a"
+	"github.com/a2aproject/a2a-go/v2/a2asrv"
+	"google.golang.org/genai"
+
+	"google.golang.org/adk/v2/agent"
+	"google.golang.org/adk/v2/model"
+	"google.golang.org/adk/v2/runner"
+	adka2a "google.golang.org/adk/v2/server/adka2a/v2"
+	"google.golang.org/adk/v2/session"
+)
+
+// TestRemoteAgent_E2E is an end-to-end round trip: a real in-process A2A server
+// (adka2a over an offline canned agent) is fronted by a faked registry record,
+// and RemoteAgent resolves that record, connects over A2A, and exchanges a
+// message. It exercises both agentCard shapes — an embedded A2A_AGENT_CARD and
+// discrete protocols — and both transports (JSONRPC, HTTP+JSON), which also
+// covers the HTTP_JSON->HTTP+JSON binding mapping and the 0.3.0 compat transport.
+func TestRemoteAgent_E2E(t *testing.T) {
+	const reply = "hello from the remote agent"
+
+	tests := []struct {
+		name    string
+		binding a2a.TransportProtocol // selects the A2A server transport
+		record  func(serverURL string) Agent
+	}{
+		{
+			name:    "embedded A2A_AGENT_CARD over JSONRPC",
+			binding: a2a.TransportProtocolJSONRPC,
+			record: func(serverURL string) Agent {
+				card, err := json.Marshal(a2a.AgentCard{
+					Name:                "Echo",
+					Description:         "echoes a canned reply",
+					SupportedInterfaces: []*a2a.AgentInterface{a2a.NewAgentInterface(serverURL, a2a.TransportProtocolJSONRPC)},
+					Capabilities:        a2a.AgentCapabilities{Streaming: true},
+				})
+				if err != nil {
+					t.Fatalf("marshaling embedded card: %v", err)
+				}
+				return Agent{
+					DisplayName: "Echo",
+					Description: "echoes a canned reply",
+					Card:        &Card{Type: cardTypeA2AAgentCard, Content: card},
+				}
+			},
+		},
+		{
+			// Registry wire binding HTTP_JSON maps to a2a HTTP+JSON; the missing
+			// protocolVersion falls back to 0.3.0, for which the factory registers
+			// a compat transport.
+			name:    "discrete protocols over HTTP+JSON",
+			binding: a2a.TransportProtocolHTTPJSON,
+			record: func(serverURL string) Agent {
+				return Agent{
+					DisplayName: "Echo",
+					Description: "echoes a canned reply",
+					Protocols: []Protocol{{
+						Type:       protocolTypeA2AAgent,
+						Interfaces: []Interface{{URL: serverURL, ProtocolBinding: bindingHTTPJSON}},
+					}},
+				}
+			},
+		},
+	}
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			a2aURL := startCannedA2AServer(t, tc.binding, reply)
+
+			regSrv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+				if err := json.NewEncoder(w).Encode(tc.record(a2aURL)); err != nil {
+					t.Errorf("encoding registry record: %v", err)
+				}
+			}))
+			defer regSrv.Close()
+
+			remote, err := newTestClient(regSrv).RemoteAgent(t.Context(), "projects/p/locations/l/agents/echo")
+			if err != nil {
+				t.Fatalf("RemoteAgent() error = %v", err)
+			}
+
+			if got := runAndCollectText(t, remote, "ping"); !strings.Contains(got, reply) {
+				t.Errorf("remote agent response = %q, want it to contain %q", got, reply)
+			}
+		})
+	}
+}
+
+// startCannedA2AServer runs an in-process A2A server, backed by an offline agent
+// that always replies with reply, over the given transport. It returns the
+// server URL and registers cleanup.
+func startCannedA2AServer(t *testing.T, binding a2a.TransportProtocol, reply string) string {
+	t.Helper()
+
+	canned, err := agent.New(agent.Config{
+		Name: "echo_agent",
+		Run: func(agent.InvocationContext) iter.Seq2[*session.Event, error] {
+			return func(yield func(*session.Event, error) bool) {
+				yield(&session.Event{LLMResponse: model.LLMResponse{
+					Content: genai.NewContentFromText(reply, genai.RoleModel),
+				}}, nil)
+			}
+		},
+	})
+	if err != nil {
+		t.Fatalf("agent.New() error = %v", err)
+	}
+
+	handler := a2asrv.NewHandler(adka2a.NewExecutor(adka2a.ExecutorConfig{
+		RunnerConfig: runner.Config{
+			AppName:        canned.Name(),
+			Agent:          canned,
+			SessionService: session.InMemoryService(),
+		},
+	}))
+
+	var h http.Handler
+	switch binding {
+	case a2a.TransportProtocolJSONRPC:
+		h = a2asrv.NewJSONRPCHandler(handler)
+	case a2a.TransportProtocolHTTPJSON:
+		h = a2asrv.NewRESTHandler(handler)
+	default:
+		t.Fatalf("unsupported binding %q", binding)
+	}
+
+	srv := httptest.NewServer(h)
+	t.Cleanup(srv.Close)
+	return srv.URL
+}
+
+// runAndCollectText drives ag with a single user message and returns the
+// concatenated text across all model responses.
+func runAndCollectText(t *testing.T, ag agent.Agent, prompt string) string {
+	t.Helper()
+
+	r, err := runner.New(runner.Config{
+		AppName:           ag.Name(),
+		Agent:             ag,
+		SessionService:    session.InMemoryService(),
+		AutoCreateSession: true,
+	})
+	if err != nil {
+		t.Fatalf("runner.New() error = %v", err)
+	}
+
+	var sb strings.Builder
+	msg := genai.NewContentFromText(prompt, genai.RoleUser)
+	for ev, err := range r.Run(t.Context(), "user", "session", msg, agent.RunConfig{}) {
+		if err != nil {
+			t.Fatalf("runner.Run() yielded error = %v", err)
+		}
+		if ev.LLMResponse.Content == nil {
+			continue
+		}
+		for _, p := range ev.LLMResponse.Content.Parts {
+			sb.WriteString(p.Text)
+		}
+	}
+	return sb.String()
+}

--- a/agentregistry/resolve.go
+++ b/agentregistry/resolve.go
@@ -21,6 +21,9 @@ import (
 	"github.com/a2aproject/a2a-go/v2/a2a"
 )
 
+// Registry protocol type for A2A agents.
+const protocolTypeA2AAgent = "A2A_AGENT"
+
 // Registry protocol-binding wire values.
 const (
 	bindingJSONRPC  = "JSONRPC"


### PR DESCRIPTION
**Problem:**
The `agentregistry` package can already _discover_ registry resources (list/get
agents, MCP servers, endpoints), but the returned metadata isn't usable at
runtime as-is. Callers still have to resolve connection endpoints, parse or
synthesize A2A agent cards, reconcile A2A protocol-version compatibility, and
wire up egress auth before a registered agent or MCP server can be plugged into
ADK.

adk-python already exposes this via `AgentRegistry.get_remote_a2a_agent`
and `get_mcp_toolset`; the Go client had no equivalent.

**Solution:**
Add two factory helpers on `Client` that turn registry metadata into
ready-to-use ADK objects (parity with adk-python 2.3.0
`integrations/agent_registry`):
- `Client.RemoteAgent(ctx, name, ...RemoteAgentOption) (agent.Agent, error)` —
  resolves a registered A2A agent into an `agent.Agent` via
  `remoteagent.NewA2A`. Uses the embedded `A2A_AGENT_CARD` when present,
  otherwise synthesizes a card from discrete fields (cleaned display name,
  default HTTP+JSON binding, default protocol version `0.3.0`, text I/O modes).
  It registers a2a **compatibility transports** for each (binding,
  protocolVersion) the card advertises: Agent Registry commonly reports a
  different-major protocol version (e.g. `0.3.0`) than the a2a-go SDK's current
  `1.0`, and the SDK's same-major fallback can't bridge it — without a matching
  compat transport, client creation fails with "no compatible transports found".
- `Client.McpToolset(ctx, name, ...McpToolsetOption) (tool.Toolset, error)` —
  resolves a registered MCP server into a `tool.Toolset` via `mcptoolset.New`
  over a streamable-HTTP transport. Endpoint resolution prefers the JSONRPC
  binding, falling back to HTTP_JSON.
Egress model (mirrors adk-python's `_is_google_api`):
- `McpToolset` auto-authenticates `*.googleapis.com` endpoints with the
  registry's ADC client; `RemoteAgent` does **not** auto-authenticate (egress is
  left to the caller).
- Both accept caller-supplied HTTP clients and static headers via options:
  `WithA2AHTTPClient`/`WithA2AHeaders`, `WithMcpHTTPClient`/`WithMcpHeaders`.
  Headers are layered onto a cloned client so shared clients are never mutated.
Deferred (out of scope, to be tracked separately): bindings-based
`GcpAuthProvider` resolution, the MCP tool-name prefix, and the
`gcp.mcp.server.destination.id` telemetry key — they depend on the auth
subsystem and on tool-level metadata support respectively.