### PR TITLE
fix: prevent mutation of input event during temporary state delta stripping by creating a shallow copy

### DIFF
--- a/session/database/service_test.go
+++ b/session/database/service_test.go
@@ -158,3 +158,54 @@ func emptyService(t *testing.T) *databaseService {
 
 	return dbservice
 }
+
+func TestDatabaseService_AppendEvent_PreservesInputEventTempState(t *testing.T) {
+	ctx := t.Context()
+	s := emptyService(t)
+
+	createResp, err := s.Create(ctx, &session.CreateRequest{
+		AppName: "testapp",
+		UserID:  "testuser",
+	})
+	if err != nil {
+		t.Fatalf("Create() error = %v", err)
+	}
+
+	event := &session.Event{
+		ID:        "event1",
+		Timestamp: time.Now(),
+		Actions: session.EventActions{
+			StateDelta: map[string]any{
+				"temp:k1": "v1",
+				"sk":      "v2",
+			},
+		},
+	}
+
+	if err := s.AppendEvent(ctx, createResp.Session, event); err != nil {
+		t.Fatalf("AppendEvent failed: %v", err)
+	}
+
+	// Verify that the input event pointer's StateDelta map was not mutated in place.
+	if _, exists := event.Actions.StateDelta["temp:k1"]; !exists {
+		t.Errorf("expected temp:k1 to be preserved on input event after AppendEvent, but it was removed: %v", event.Actions.StateDelta)
+	}
+	if event.Actions.StateDelta["sk"] != "v2" {
+		t.Errorf("expected non-temp key sk to remain in input event, got: %v", event.Actions.StateDelta)
+	}
+
+	// Verify that the stored event in the session has temp keys stripped.
+	var storedEvent *session.Event
+	for ev := range createResp.Session.Events().All() {
+		storedEvent = ev
+	}
+	if storedEvent == nil {
+		t.Fatalf("expected stored event in session, got nil")
+	}
+	if _, exists := storedEvent.Actions.StateDelta["temp:k1"]; exists {
+		t.Errorf("expected temp:k1 to be stripped from stored event, but it still exists: %v", storedEvent.Actions.StateDelta)
+	}
+	if storedEvent.Actions.StateDelta["sk"] != "v2" {
+		t.Errorf("expected non-temp key sk on stored event, got: %v", storedEvent.Actions.StateDelta)
+	}
+}

--- a/session/database/session.go
+++ b/session/database/session.go
@@ -162,10 +162,16 @@ func trimTempDeltaState(event *session.Event) *session.Event {
 		}
 	}
 
-	// Replace the old map with the newly filtered one.
-	event.Actions.StateDelta = filteredStateDelta
+	// If no keys were filtered out, return the original event without copying.
+	if len(filteredStateDelta) == len(event.Actions.StateDelta) {
+		return event
+	}
 
-	return event
+	// Create a copy of the event to avoid mutating the original.
+	eventCopy := *event
+	eventCopy.Actions.StateDelta = filteredStateDelta
+
+	return &eventCopy
 }
 
 // updateSessionState updates the session state based on the event state delta.

--- a/session/inmemory.go
+++ b/session/inmemory.go
@@ -444,10 +444,16 @@ func trimTempDeltaState(event *Event) *Event {
 		}
 	}
 
-	// Replace the old map with the newly filtered one.
-	event.Actions.StateDelta = filteredStateDelta
+	// If no keys were filtered out, return the original event without copying.
+	if len(filteredStateDelta) == len(event.Actions.StateDelta) {
+		return event
+	}
 
-	return event
+	// Create a copy of the event to avoid mutating the original.
+	eventCopy := *event
+	eventCopy.Actions.StateDelta = filteredStateDelta
+
+	return &eventCopy
 }
 
 // updateSessionState updates the session state based on the event state delta.

--- a/session/inmemory_test.go
+++ b/session/inmemory_test.go
@@ -183,3 +183,54 @@ func TestInMemorySession_AppendEvent_Deadlock(t *testing.T) {
 	// If it doesn't hang, the test passes (meaning no deadlock)
 	t.Log("AppendEvent did not deadlock")
 }
+
+func TestInMemoryService_AppendEvent_PreservesInputEventTempState(t *testing.T) {
+	ctx := t.Context()
+	service := session.InMemoryService()
+
+	createResp, err := service.Create(ctx, &session.CreateRequest{
+		AppName: "testapp",
+		UserID:  "testuser",
+	})
+	if err != nil {
+		t.Fatalf("Failed to create session: %v", err)
+	}
+
+	event := &session.Event{
+		ID:        "event1",
+		Timestamp: time.Now(),
+		Actions: session.EventActions{
+			StateDelta: map[string]any{
+				"temp:k1": "v1",
+				"sk":      "v2",
+			},
+		},
+	}
+
+	if err := service.AppendEvent(ctx, createResp.Session, event); err != nil {
+		t.Fatalf("AppendEvent failed: %v", err)
+	}
+
+	// Verify that the input event pointer's StateDelta map was not mutated in place.
+	if _, exists := event.Actions.StateDelta["temp:k1"]; !exists {
+		t.Errorf("expected temp:k1 to be preserved on input event after AppendEvent, but it was removed: %v", event.Actions.StateDelta)
+	}
+	if event.Actions.StateDelta["sk"] != "v2" {
+		t.Errorf("expected non-temp key sk to remain in input event, got: %v", event.Actions.StateDelta)
+	}
+
+	// Verify that the stored event in the session has temp keys stripped.
+	var storedEvent *session.Event
+	for ev := range createResp.Session.Events().All() {
+		storedEvent = ev
+	}
+	if storedEvent == nil {
+		t.Fatalf("expected stored event in session, got nil")
+	}
+	if _, exists := storedEvent.Actions.StateDelta["temp:k1"]; exists {
+		t.Errorf("expected temp:k1 to be stripped from stored event, but it still exists: %v", storedEvent.Actions.StateDelta)
+	}
+	if storedEvent.Actions.StateDelta["sk"] != "v2" {
+		t.Errorf("expected non-temp key sk on stored event, got: %v", storedEvent.Actions.StateDelta)
+	}
+}

--- a/session/vertexai/service_test.go
+++ b/session/vertexai/service_test.go
@@ -224,3 +224,30 @@ func sanitizeFilename(name string) string {
 	safe = strings.ReplaceAll(safe, "/", "-")
 	return safe + ".replay"
 }
+
+func Test_trimTempDeltaState_PreservesInputEvent(t *testing.T) {
+	event := &session.Event{
+		ID: "event1",
+		Actions: session.EventActions{
+			StateDelta: map[string]any{
+				"temp:k1": "v1",
+				"sk":      "v2",
+			},
+		},
+	}
+
+	trimmed := trimTempDeltaState(event)
+
+	if trimmed == event {
+		t.Errorf("expected trimTempDeltaState to return a new event copy when stripping temp keys, got original pointer")
+	}
+	if _, exists := event.Actions.StateDelta["temp:k1"]; !exists {
+		t.Errorf("expected temp:k1 to be preserved on input event, but it was removed: %v", event.Actions.StateDelta)
+	}
+	if _, exists := trimmed.Actions.StateDelta["temp:k1"]; exists {
+		t.Errorf("expected temp:k1 to be stripped from trimmed event copy, but it still exists: %v", trimmed.Actions.StateDelta)
+	}
+	if trimmed.Actions.StateDelta["sk"] != "v2" {
+		t.Errorf("expected non-temp key sk on trimmed event, got: %v", trimmed.Actions.StateDelta)
+	}
+}

--- a/session/vertexai/session.go
+++ b/session/vertexai/session.go
@@ -162,10 +162,16 @@ func trimTempDeltaState(event *session.Event) *session.Event {
 		}
 	}
 
-	// Replace the old map with the newly filtered one.
-	event.Actions.StateDelta = filteredStateDelta
+	// If no keys were filtered out, return the original event without copying.
+	if len(filteredStateDelta) == len(event.Actions.StateDelta) {
+		return event
+	}
 
-	return event
+	// Create a copy of the event to avoid mutating the original.
+	eventCopy := *event
+	eventCopy.Actions.StateDelta = filteredStateDelta
+
+	return &eventCopy
 }
 
 // updateSessionState updates the session state based on the event state delta.


### PR DESCRIPTION
Fixes an issue where `trimTempDeltaState` permanently mutated caller-provided event pointers in-place when filtering out temporary state deltas (keys prefixed with `temp:`).

## Changes
* **Prevent In-Place Mutation**: Updated `trimTempDeltaState` across `inmemory`, `database`, and `vertexai` session service implementations to create a shallow copy of the event object when temporary state delta keys are stripped.
* **Optimize No-Op Case**: Added an early return when no temporary keys are removed (`len(filteredStateDelta) == len(event.Actions.StateDelta)`), avoiding unnecessary struct allocation when the state delta is unchanged.
* **Test Coverage**: Added unit tests across all three session service packages to verify that input events remain immutable during temporary state delta trimming.

## Testing Plan
- [x] Run `go test -race ./session/...` to verify existing session service tests and new immutability test cases pass.
- [x] Verify no regressions in temporary state delta filtering across `inmemory`, `database`, and `vertexai` session backends.
