### PR TITLE
test(remotagent) deflake a2a cleanup propagation

### DIFF
--- a/agent/remoteagent/v2/a2a_e2e_test.go
+++ b/agent/remoteagent/v2/a2a_e2e_test.go
@@ -26,6 +26,7 @@ import (
 	"net/http"
 	"path/filepath"
 	"strings"
+	"sync"
 	"testing"
 	"time"
 
@@ -377,9 +378,11 @@ func TestA2AMultiHopInputRequired(t *testing.T) {
 }
 
 func TestA2ACleanupPropagation(t *testing.T) {
+	remoteTaskIDChan, remoteCleanupCalledChan := make(chan a2a.TaskID, 1), make(chan struct{}, 2)
+	// Artifact text the mock subagent streams; the cancel step keys off it.
+	const remoteArtifactText = "remote-subagent-working"
 	// Remote A2A server publishes a submitted task and start generating artifact updates
 	// until it detects a context cancelation
-	remoteTaskIDChan, remoteCleanupCalledChan := make(chan a2a.TaskID, 1), make(chan struct{}, 2)
 	serverB := startA2AServer(&mockA2AExecutor{
 		cancelFn: func(ctx context.Context, reqCtx *a2asrv.ExecutorContext) iter.Seq2[a2a.Event, error] {
 			return func(yield func(a2a.Event, error) bool) {
@@ -393,7 +396,7 @@ func TestA2ACleanupPropagation(t *testing.T) {
 					return
 				}
 				for ctx.Err() == nil {
-					if !yield(a2a.NewArtifactEvent(reqCtx, a2a.NewTextPart("foo")), nil) {
+					if !yield(a2a.NewArtifactEvent(reqCtx, a2a.NewTextPart(remoteArtifactText)), nil) {
 						return
 					}
 					time.Sleep(1 * time.Millisecond)
@@ -427,27 +430,44 @@ func TestA2ACleanupPropagation(t *testing.T) {
 
 	client := newA2AClient(t, serverA)
 
-	// Send a streaming message in a detached goroutine, passing status update through chan
+	// Join the detached streaming/cancel goroutines before teardown; a late
+	// t.Errorf from an in-flight RPC on a finished test would panic.
+	var wg sync.WaitGroup
+	t.Cleanup(wg.Wait)
+
+	// remoteStreamingChan closes when the subagent's own output first reaches the client.
 	statusUpdateEventChan := make(chan a2a.Event, 10)
+	remoteStreamingChan := make(chan struct{})
+	wg.Add(1)
 	go func() {
+		defer wg.Done()
 		defer close(statusUpdateEventChan)
+		remoteStreaming := false
 		msg := a2a.NewMessage(a2a.MessageRoleUser, a2a.NewTextPart("work"))
 		for event, err := range client.SendStreamingMessage(t.Context(), &a2a.SendMessageRequest{Message: msg}) {
 			if err != nil {
 				t.Errorf("client.SendStreamingMessage() error = %v", err)
 				return
 			}
-			if _, ok := event.(*a2a.TaskArtifactUpdateEvent); ok {
+			if tau, ok := event.(*a2a.TaskArtifactUpdateEvent); ok {
+				if !remoteStreaming && artifactContainsText(tau, remoteArtifactText) {
+					remoteStreaming = true
+					close(remoteStreamingChan)
+				}
 				continue
 			}
 			statusUpdateEventChan <- event
 		}
 	}()
 
-	// Issue a task cancellation request
+	// Cancel only after the subagent's output reaches the client: before that the
+	// parent doesn't know the subagent task ID, so cancellation can't propagate.
 	taskID := (<-statusUpdateEventChan).TaskInfo().TaskID
+	awaitN(t, remoteStreamingChan, 1, "remote subagent streaming")
 	cancelResultChan := make(chan *a2a.Task, 1)
+	wg.Add(1)
 	go func() {
+		defer wg.Done()
 		defer close(cancelResultChan)
 		task, err := client.CancelTask(t.Context(), &a2a.CancelTaskRequest{ID: taskID})
 		if err != nil {
@@ -470,25 +490,12 @@ func TestA2ACleanupPropagation(t *testing.T) {
 		t.Fatalf("type(lastStreamingUpdate) = %T, want *a2a.TaskStatusUpdateEvent", lastStreamingUpdate)
 	}
 
-	// Check subagent task got cancelled when the parent task was cancelled.
-	// Reads from channel twice because cleanup gets called both for cancelation and execution.
-	timeout := time.After(5 * time.Second)
-	for range 2 {
-		select {
-		case <-remoteCleanupCalledChan:
-		case <-timeout:
-			t.Fatalf("remote cleanup was not called")
-		}
-	}
+	// Subagent cleanup fires twice: once for cancelation, once for execution.
+	// A generous per-wait deadline avoids flaking under CPU contention.
+	awaitN(t, remoteCleanupCalledChan, 2, "remote cleanup")
 	remoteTaskID := <-remoteTaskIDChan
+	awaitN(t, executorCleanupCalledChan, 2, "executor cleanup")
 
-	for range 2 {
-		select {
-		case <-executorCleanupCalledChan:
-		case <-timeout:
-			t.Fatalf("executor cleanup was not called")
-		}
-	}
 	remoteClient := newA2AClient(t, serverB)
 	remoteTask, err := remoteClient.GetTask(t.Context(), &a2a.GetTaskRequest{ID: remoteTaskID})
 	if err != nil {
@@ -497,6 +504,35 @@ func TestA2ACleanupPropagation(t *testing.T) {
 	if remoteTask.Status.State != a2a.TaskStateCanceled {
 		t.Errorf("remoteTask.Status.State = %q, want %q", remoteTask.Status.State, a2a.TaskStateCanceled)
 	}
+
+	// Join the cancel RPC so it can't log on t after the test returns.
+	awaitN(t, cancelResultChan, 1, "cancel task")
+}
+
+// awaitN receives n values from ch or fails the test after a generous, contention-
+// tolerant deadline. A closed channel counts as a receive, so it also joins a
+// goroutine that closed ch without sending.
+func awaitN[T any](t *testing.T, ch <-chan T, n int, what string) {
+	t.Helper()
+	const deadline = 30 * time.Second
+	timer := time.NewTimer(deadline)
+	defer timer.Stop()
+	for i := range n {
+		select {
+		case <-ch:
+		case <-timer.C:
+			t.Fatalf("%s: got %d of %d within %v", what, i, n, deadline)
+		}
+	}
+}
+
+func artifactContainsText(tau *a2a.TaskArtifactUpdateEvent, substr string) bool {
+	for _, p := range tau.Artifact.Parts {
+		if strings.Contains(p.Text(), substr) {
+			return true
+		}
+	}
+	return false
 }
 
 func TestA2ASingleHopFinalResponse(t *testing.T) {


### PR DESCRIPTION
## Summary
- Fix the panic + flakiness in `TestA2ACleanupPropagation` (`agent/remoteagent/v2/a2a_e2e_test.go`)
- Join the detached streaming/cancel goroutines so neither logs on `t` after the test completes.
- Make cancellation-propagation deterministic by cancelling only once the remote subagent's output has round-tripped to the client (i.e. once the remote agent actually knows the subagent task ID).
Test-only change; no production code is modified.

## Background / root cause
The test exercised two failure modes:
1. **Panic — `Log in goroutine after test has completed`.** The `CancelTask`
   goroutine was never joined (`cancelResultChan` was created but never read),
   so under load it could still be mid-RPC when the test returned, fail on the
   cancelled `t.Context()`, and call `t.Errorf` on a finished test.
2. **`remote cleanup was not called`.** This was *not* merely a too-tight
   timeout. Via goroutine dumps + tracing I confirmed the test cancelled the
   parent task right after the first status event — i.e. **before the remote
   agent had received any event from the subagent**. In that window the remote
   agent doesn't yet know the subagent's (server-assigned) task ID, so
   `cleanupRemoteTask` returns early (`lastEvent == nil`) and cannot propagate
   the cancellation. Under `GOMAXPROCS=1` / CPU contention this race was lost
   deterministically, so the subagent task kept running and its cleanup never
   fired.

## What changed
- `sync.WaitGroup` + `t.Cleanup(wg.Wait)` join both detached goroutines before the test tears down (fixes the panic in all exit paths).
- Replaced the single fixed `time.After(5s)` shared across all cleanup-channel reads with a per-wait, contention-tolerant helper `awaitN`.
- The test now waits until the subagent's own artifact reaches the client before issuing the cancel. That is the precondition for propagation to be possible, so the (unchanged) propagation assertions become deterministic. Only the moment of cancellation is corrected — the test still exercises the full path.

## Note on scope (best-effort propagation)
adk-go's remote-task cancellation propagation (`cleanupRemoteTask`) is an
additive, **best-effort** feature; adk-python's remote A2A agent **does not cancel**
remote tasks at all. Cancelling in the window *before* the remote agent has
received its first subagent event genuinely cannot propagate (the remote task
ID is unknown to the caller). This PR fixes the flaky test to respect that
contract; making propagation robust in that early-cancel window would be a
separate, behaviour-changing effort (client-assigned task IDs and/or a2a-go
support) and is intentionally out of scope here.