### PR TITLE
feat(runner): add NewInMemory convenience constructor

### DIFF
--- a/runner/runner.go
+++ b/runner/runner.go
@@ -121,6 +121,22 @@ func New(cfg Config) (*Runner, error) {
 	}, nil
 }
 
+// NewInMemory creates a [Runner] backed entirely by in-memory session,
+// artifact, and memory services, with session auto-creation enabled. It mirrors
+// adk-python's InMemoryRunner and is intended for local development and tests,
+// not production. Use [New] when you need to supply your own services or
+// plugins.
+func NewInMemory(appName string, a agent.Agent) (*Runner, error) {
+	return New(Config{
+		AppName:           appName,
+		Agent:             a,
+		SessionService:    session.InMemoryService(),
+		ArtifactService:   artifact.InMemoryService(),
+		MemoryService:     memory.InMemoryService(),
+		AutoCreateSession: true,
+	})
+}
+
 // Runner manages the execution of the agent within a session, handling message
 // processing, event generation, and interaction with various services like
 // artifact storage, session management, and memory.

--- a/runner/runner_test.go
+++ b/runner/runner_test.go
@@ -485,6 +485,59 @@ func createSession(t *testing.T, ctx context.Context, sessionID, appName, userID
 	return resp.Session
 }
 
+// TestNewInMemory verifies the convenience constructor wires all three
+// in-memory services, enables session auto-creation, and runs end to end
+// without any manual service or session setup.
+func TestNewInMemory(t *testing.T) {
+	t.Parallel()
+
+	appName := "testApp"
+	userID := "testUser"
+	sessionID := "testSession"
+
+	testAgent := must(agent.New(agent.Config{
+		Name: "test_agent",
+		Run: func(ctx agent.InvocationContext) iter.Seq2[*session.Event, error] {
+			return func(yield func(*session.Event, error) bool) {}
+		},
+	}))
+
+	r, err := NewInMemory(appName, testAgent)
+	if err != nil {
+		t.Fatalf("NewInMemory() error = %v", err)
+	}
+
+	if r.sessionService == nil {
+		t.Error("NewInMemory() sessionService = nil, want in-memory service")
+	}
+	if r.artifactService == nil {
+		t.Error("NewInMemory() artifactService = nil, want in-memory service")
+	}
+	if r.memoryService == nil {
+		t.Error("NewInMemory() memoryService = nil, want in-memory service")
+	}
+	if !r.autoCreateSession {
+		t.Error("NewInMemory() autoCreateSession = false, want true")
+	}
+
+	// A run must succeed without pre-creating the session (auto-create on).
+	ctx := t.Context()
+	msg := &genai.Content{Parts: []*genai.Part{{Text: "hello"}}}
+	for _, err := range r.Run(ctx, userID, sessionID, msg, agent.RunConfig{}) {
+		if err != nil {
+			t.Fatalf("r.Run() error = %v", err)
+		}
+	}
+
+	if _, err := r.sessionService.Get(ctx, &session.GetRequest{
+		AppName:   appName,
+		UserID:    userID,
+		SessionID: sessionID,
+	}); err != nil {
+		t.Errorf("expected auto-created session to exist, got error: %v", err)
+	}
+}
+
 func TestRunner_AutoCreateSession(t *testing.T) {
 	t.Parallel()
 


### PR DESCRIPTION
**Problem:**
`runner.New` requires callers to assemble and pass services explicitly and
fails when `SessionService` is nil (`runner/runner.go:95`). There is no
Python/Java-style `InMemoryRunner` convenience that auto-wires in-memory
services, so every local/dev/test setup must construct the session, artifact,
and memory services (and pre-create a session) by hand.

**Solution:**
Add `runner.NewInMemory(appName, agent)`, mirroring adk-python's
`InMemoryRunner`. It wires the in-memory session, artifact, and memory services
and enables session auto-creation, so a `Runner` can be built and run with zero
manual service/session setup. Auto-creation is required (not merely a default)
because the helper owns its services and `Runner` exposes no service accessor;
without it the first `Run` would always fail with "session not found" and the
caller could not recover. The change is purely additive and
backward-compatible — `runner.New` is unchanged.