### PR TITLE
feat(workflow): emit invoke_node spans for parallel worker items

### DIFF
--- a/workflow/dynamic_scheduler.go
+++ b/workflow/dynamic_scheduler.go
@@ -15,14 +15,10 @@
 package workflow
 
 import (
-	"context"
-	"errors"
 	"fmt"
 	"strconv"
 	"strings"
 	"sync"
-
-	"go.opentelemetry.io/otel/codes"
 
 	"google.golang.org/adk/v2/agent"
 	"google.golang.org/adk/v2/internal/utils"
@@ -243,33 +239,14 @@ func (s *dynamicSubScheduler) runNode(child Node, input any, opts runNodeOptions
 	// cache lookup so a cached (WithRunID replay) hit is still emitted
 	// as its own span. startNodeSpan returns a context carrying the span.
 	span, spanCtx := startNodeSpan(childCtx, child)
-	defer span.End()
+	defer span.end()
 	childCtx = spanCtx
 
 	// rawErr is the unwrapped child/emit error. The returned err wraps
 	// the cause with "%w: %v", dropping context.Canceled from the chain,
 	// so span status is classified on rawErr rather than err.
 	var rawErr error
-
-	// Record genuine runtime failures on the span. Pauses (HITL
-	// ErrNodeInterrupted, WaitForOutput ErrNodeWaitingForOutput) and
-	// parent cancellation (context.Canceled) are expected control
-	// flow, not span errors — matching the top scheduler's runNode.
-	defer func() {
-		if err == nil {
-			return
-		}
-		classify := err
-		if rawErr != nil {
-			classify = rawErr
-		}
-		if !errors.Is(classify, context.Canceled) &&
-			!errors.Is(classify, ErrNodeInterrupted) &&
-			!errors.Is(classify, ErrNodeWaitingForOutput) {
-			span.RecordError(err)
-			span.SetStatus(codes.Error, err.Error())
-		}
-	}()
+	defer func() { span.recordError(err, rawErr) }()
 
 	// Cached (WithRunID replay): the child already ran, so publish its
 	// output for the delegation immediately. The span opened above still

--- a/workflow/node_span.go
+++ b/workflow/node_span.go
@@ -1,0 +1,74 @@
+// Copyright 2026 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package workflow
+
+import (
+	"context"
+	"errors"
+
+	"go.opentelemetry.io/otel/codes"
+	"go.opentelemetry.io/otel/trace"
+	"go.opentelemetry.io/otel/trace/noop"
+
+	"google.golang.org/adk/v2/agent"
+	"google.golang.org/adk/v2/internal/telemetry"
+)
+
+// nodeSpan is the single invoke_node span shared by both schedulers and
+// the parallel worker.
+type nodeSpan struct {
+	span trace.Span
+}
+
+// startNodeSpan begins an invoke_node span for n and returns a context
+// carrying it. It is a noop span for Start and for nodes that emit their
+// own span (EmitsOwnSpan, e.g. an agent node's invoke_agent), so callers
+// can unconditionally defer end / call recordError.
+func startNodeSpan(ctx agent.Context, n Node) (nodeSpan, agent.Context) {
+	if n == Start || n.Config().EmitsOwnSpan {
+		return nodeSpan{span: noop.Span{}}, ctx
+	}
+	spanCtx, span := telemetry.StartNodeSpan(ctx, ctx, telemetry.OperationNode{Node: n})
+	return nodeSpan{span: span}, ctx.WithAgentContext(spanCtx)
+}
+
+// recordError marks the span failed with recordErr, unless the outcome is
+// expected control flow (see isNodeControlFlow). classifyErr picks the
+// error to classify — pass the unwrapped cause when recordErr hides the
+// sentinel (the dynamic scheduler wraps with "%w: %v", dropping
+// context.Canceled); nil classifies on recordErr. Does not end the span.
+func (s nodeSpan) recordError(recordErr, classifyErr error) {
+	if recordErr == nil {
+		return
+	}
+	if classifyErr == nil {
+		classifyErr = recordErr
+	}
+	if isNodeControlFlow(classifyErr) {
+		return
+	}
+	s.span.RecordError(recordErr)
+	s.span.SetStatus(codes.Error, recordErr.Error())
+}
+
+func (s nodeSpan) end() { s.span.End() }
+
+// isNodeControlFlow reports whether err is expected control flow
+// (cancellation or a HITL / wait-for-output pause), not a node failure.
+// ErrNodeWaitingForOutput wraps ErrNodeInterrupted, so one check covers
+// both pauses.
+func isNodeControlFlow(err error) bool {
+	return errors.Is(err, context.Canceled) || errors.Is(err, ErrNodeInterrupted)
+}

--- a/workflow/parallel_worker.go
+++ b/workflow/parallel_worker.go
@@ -178,19 +178,7 @@ func (n *ParallelWorker) runWorker(ctx agent.Context, idx int, item any, sem cha
 	failedAttempts := 0
 
 	for {
-		var workerOutputs []any
-		var runErr error
-
-		for ev, err := range n.wrapped.Run(ctx, item) {
-			if err != nil {
-				runErr = err
-				break
-			}
-
-			if out, ok := extractOutput(ev); ok {
-				workerOutputs = append(workerOutputs, out)
-			}
-		}
+		workerOutputs, runErr := n.runWrappedOnce(ctx, item)
 
 		if runErr == nil {
 			// On success populate the output event.
@@ -216,6 +204,29 @@ func (n *ParallelWorker) runWorker(ctx agent.Context, idx int, item any, sem cha
 		resCh <- workerResult{index: idx, err: runErr}
 		return
 	}
+}
+
+// runWrappedOnce runs the wrapped node once for item under its own
+// invoke_node span, so each item and each retry attempt is a distinct
+// span. Kept a separate function so the deferred span.end() fires per
+// attempt instead of piling up across runWorker's retry loop.
+func (n *ParallelWorker) runWrappedOnce(ctx agent.Context, item any) (outputs []any, err error) {
+	span, ctx := startNodeSpan(ctx, n.wrapped)
+	defer func() {
+		span.recordError(err, nil)
+		span.end()
+	}()
+
+	for ev, runErr := range n.wrapped.Run(ctx, item) {
+		if runErr != nil {
+			err = runErr
+			break
+		}
+		if out, ok := extractOutput(ev); ok {
+			outputs = append(outputs, out)
+		}
+	}
+	return outputs, err
 }
 
 func makeWorkerOutputEvent(outputs []any) *session.Event {

--- a/workflow/parallel_worker_test.go
+++ b/workflow/parallel_worker_test.go
@@ -26,9 +26,13 @@ import (
 	"time"
 
 	"github.com/google/go-cmp/cmp"
+	"go.opentelemetry.io/otel/codes"
+	sdktrace "go.opentelemetry.io/otel/sdk/trace"
+	"go.opentelemetry.io/otel/sdk/trace/tracetest"
 	"google.golang.org/genai"
 
 	"google.golang.org/adk/v2/agent"
+	"google.golang.org/adk/v2/internal/telemetry"
 	"google.golang.org/adk/v2/session"
 )
 
@@ -636,5 +640,135 @@ func TestParallelWorker_SchedulerDoesNotRetryOnFailure(t *testing.T) {
 
 	if atomic.LoadInt32(&wrappedAttempts) != 2 {
 		t.Errorf("expected 2 attempts for wrapped node, got %d (scheduler likely retried the node)", atomic.LoadInt32(&wrappedAttempts))
+	}
+}
+
+// TestParallelWorker_PerItemSpans: each item runs in its own invoke_node
+// span (Error only on a genuine failure); a node that emits its own span
+// is not double-wrapped.
+func TestParallelWorker_PerItemSpans(t *testing.T) {
+	tests := []struct {
+		name         string
+		wrapped      Node
+		input        []any
+		wantSpanName string
+		wantCount    int
+		wantStatus   codes.Code
+	}{
+		{
+			name:         "one_span_per_item_on_success",
+			wrapped:      upperNode,
+			input:        []any{"a", "b", "c"},
+			wantSpanName: "invoke_node upper",
+			wantCount:    3,
+			wantStatus:   codes.Unset,
+		},
+		{
+			name:         "span_marked_error_on_failure",
+			wrapped:      newErrYieldNode("w", errors.New("boom")),
+			input:        []any{"x"},
+			wantSpanName: "invoke_node w",
+			wantCount:    1,
+			wantStatus:   codes.Error,
+		},
+		{
+			// Cancellation is control flow, not a failure: span stays Unset.
+			name:         "control_flow_error_not_marked",
+			wrapped:      newErrYieldNode("c", context.Canceled),
+			input:        []any{"x"},
+			wantSpanName: "invoke_node c",
+			wantCount:    1,
+			wantStatus:   codes.Unset,
+		},
+		{
+			name: "wrapped_emitting_own_span_is_not_double_wrapped",
+			wrapped: NewFunctionNode("agentish", func(ctx agent.Context, in string) (string, error) {
+				return in, nil
+			}, NodeConfig{EmitsOwnSpan: true}),
+			input:     []any{"a", "b"},
+			wantCount: 0,
+		},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			spanExp := tracetest.NewInMemoryExporter()
+			telemetry.OverrideTracerForTesting(t, sdktrace.NewTracerProvider(sdktrace.WithSyncer(spanExp)))
+
+			pw, err := NewParallelWorker("parallel", tc.wrapped, 0, defaultNodeConfig)
+			if err != nil {
+				t.Fatal(err)
+			}
+
+			// Drain; span outcomes asserted below.
+			for range pw.Run(agent.NewContext(newMockCtx(t)), tc.input) {
+			}
+
+			spans := spanExp.GetSpans()
+			if len(spans) != tc.wantCount {
+				t.Fatalf("got %d spans, want %d", len(spans), tc.wantCount)
+			}
+			for _, s := range spans {
+				if s.Name != tc.wantSpanName {
+					t.Errorf("span name = %q, want %q", s.Name, tc.wantSpanName)
+				}
+				if s.Status.Code != tc.wantStatus {
+					t.Errorf("span %q status = %v, want %v", s.Name, s.Status.Code, tc.wantStatus)
+				}
+			}
+		})
+	}
+}
+
+// TestParallelWorker_RetryEmitsSpanPerAttempt verifies each retry attempt
+// gets its own span: a node that fails once then succeeds under
+// RetryConfig produces two spans — the failed attempt marked Error, the
+// successful retry Unset.
+func TestParallelWorker_RetryEmitsSpanPerAttempt(t *testing.T) {
+	spanExp := tracetest.NewInMemoryExporter()
+	telemetry.OverrideTracerForTesting(t, sdktrace.NewTracerProvider(sdktrace.WithSyncer(spanExp)))
+
+	var attempts int32
+	wrapped := NewFunctionNode("flaky", func(ctx agent.Context, in string) (string, error) {
+		if atomic.AddInt32(&attempts, 1) == 1 {
+			return "", errors.New("boom")
+		}
+		return in, nil
+	}, defaultNodeConfig)
+
+	rc := DefaultRetryConfig()
+	rc.MaxAttempts = 2
+	rc.InitialDelay = 0
+	rc.MaxDelay = 0
+	rc.Jitter = 0
+
+	pw, err := NewParallelWorker("parallel", wrapped, 0, NodeConfig{RetryConfig: rc})
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	for range pw.Run(agent.NewContext(newMockCtx(t)), []any{"x"}) {
+	}
+
+	spans := spanExp.GetSpans()
+	if len(spans) != 2 {
+		t.Fatalf("got %d spans, want 2 (one per attempt)", len(spans))
+	}
+	// Same node both attempts; assert the status multiset: one failed
+	// (Error) + one successful retry (Unset).
+	var errCount, unsetCount int
+	for _, s := range spans {
+		if s.Name != "invoke_node flaky" {
+			t.Errorf("span name = %q, want %q", s.Name, "invoke_node flaky")
+		}
+		switch s.Status.Code {
+		case codes.Error:
+			errCount++
+		case codes.Unset:
+			unsetCount++
+		}
+	}
+	if errCount != 1 || unsetCount != 1 {
+		t.Errorf("status multiset = {Error:%d, Unset:%d}, want {Error:1, Unset:1}", errCount, unsetCount)
 	}
 }

--- a/workflow/scheduler.go
+++ b/workflow/scheduler.go
@@ -23,13 +23,9 @@ import (
 	"sync"
 	"time"
 
-	"go.opentelemetry.io/otel/codes"
-	"go.opentelemetry.io/otel/trace"
-	"go.opentelemetry.io/otel/trace/noop"
 	"google.golang.org/genai"
 
 	"google.golang.org/adk/v2/agent"
-	"google.golang.org/adk/v2/internal/telemetry"
 	"google.golang.org/adk/v2/session"
 )
 
@@ -446,7 +442,7 @@ func runNode(
 	defer wg.Done()
 
 	span, ctx := startNodeSpan(ctx, n)
-	defer span.End()
+	defer span.end()
 
 	// completion holds the final completionItem. It is sent in the
 	// outer defer so panic recovery, normal exit, and cancellation
@@ -456,14 +452,7 @@ func runNode(
 		if r := recover(); r != nil {
 			completion.err = fmt.Errorf("node %q panicked: %v", name, r)
 		}
-		// ErrNodeWaitingForOutput is a pause, not a failure: don't mark
-		// the span as errored.
-		if completion.err != nil &&
-			!errors.Is(completion.err, context.Canceled) &&
-			!errors.Is(completion.err, ErrNodeWaitingForOutput) {
-			span.RecordError(completion.err)
-			span.SetStatus(codes.Error, completion.err.Error())
-		}
+		span.recordError(completion.err, nil)
 		out <- completion
 	}()
 
@@ -1059,19 +1048,4 @@ func aggregatePredecessorBranches(g *graph, state *RunState, target Node) []stri
 		branches = append(branches, br)
 	}
 	return branches
-}
-
-func startNodeSpan(ctx agent.Context, n Node) (trace.Span, agent.Context) {
-	if n == Start {
-		// Don't create span for the Start node.
-		return noop.Span{}, ctx
-	}
-	if n.Config().EmitsOwnSpan {
-		// The node body starts its own span (e.g. an LlmAgent node's
-		// wrapped agent emits invoke_agent); don't add an invoke_node
-		// wrapper around it.
-		return noop.Span{}, ctx
-	}
-	spanCtx, span := telemetry.StartNodeSpan(ctx, ctx, telemetry.OperationNode{Node: n})
-	return span, ctx.WithAgentContext(spanCtx)
 }


### PR DESCRIPTION
## Problem
Workflow telemetry emits an `invoke_node` span for every node run through the
top scheduler and the dynamic sub-scheduler, but the **parallel worker** ran its
wrapped node directly via `n.wrapped.Run`, bypassing that span path. So per-item
executions produced **no** `invoke_node` span: only nodes that emit their own
span (e.g. agents) showed up in the trace, and per-item timing/errors for plain
function/tool nodes were invisible — collapsed under the single ParallelWorker
span. The span + error-classification logic was also duplicated across the two
schedulers.

For reference, adk-python has no such gap: every node — static, dynamic
(`ctx.run_node`), and each parallel-worker item — funnels through
`NodeRunner.start_as_current_node_span`, so all get an `invoke_node` span with
consistent error semantics.

## Summary
Centralize the per-node span lifecycle + error classification into a single
`nodeSpan` helper (`workflow/node_span.go`) and use it from all three sites: the
top scheduler, the dynamic sub-scheduler, and the parallel worker.
- Each parallel item — and each retry attempt — now gets its own
  `invoke_node <wrapped>` span, nested under the ParallelWorker's span.
- `startNodeSpan` still skips nodes that emit their own span (`EmitsOwnSpan`), so
  an agent item is not double-wrapped.
- Removes the span/error-classification duplication that lived in both schedulers.

Behavior preserved: the unified control-flow rule (cancellation and
HITL / wait-for-output pauses are not span errors) keeps both schedulers' prior
behavior — `ErrNodeWaitingForOutput` wraps `ErrNodeInterrupted`, so one check
covers both pauses, and a bare `ErrNodeInterrupted` never surfaces to the top
scheduler as a node error.