### PR TITLE
perf(session): reduce allocations in InMemoryService.AppendEvent

### DIFF
--- a/session/inmemory.go
+++ b/session/inmemory.go
@@ -219,32 +219,12 @@ func (s *inMemoryService) AppendEvent(ctx context.Context, curSession Session, e
 	}
 
 	// update the in-memory session
-	if err := sess.appendEvent(event); err != nil {
+	processedEvent, err := sess.appendEvent(event)
+	if err != nil {
 		return fmt.Errorf("fail to set state on appendEvent: %w", err)
 	}
 
-	eventCopy := &Event{
-		ID:             event.ID,
-		InvocationID:   event.InvocationID,
-		Timestamp:      event.Timestamp,
-		Author:         event.Author,
-		Branch:         event.Branch,
-		IsolationScope: event.IsolationScope,
-		Actions: EventActions{
-			StateDelta:                 maps.Clone(event.Actions.StateDelta),
-			ArtifactDelta:              maps.Clone(event.Actions.ArtifactDelta),
-			RequestedToolConfirmations: maps.Clone(event.Actions.RequestedToolConfirmations),
-			TransferToAgent:            event.Actions.TransferToAgent,
-			Escalate:                   event.Actions.Escalate,
-			SkipSummarization:          event.Actions.SkipSummarization,
-		},
-		LongRunningToolIDs: slices.Clone(event.LongRunningToolIDs),
-		Routes:             slices.Clone(event.Routes),
-		RequestedInput:     event.RequestedInput,
-		LLMResponse:        event.LLMResponse,
-		Output:             event.Output,
-		NodeInfo:           event.NodeInfo,
-	}
+	eventCopy := cloneEventForStorage(processedEvent)
 
 	// update the in-memory session service
 	stored_session.events = append(stored_session.events, eventCopy)
@@ -349,22 +329,22 @@ func (s *session) LastUpdateTime() time.Time {
 	return s.updatedAt
 }
 
-func (s *session) appendEvent(event *Event) error {
+func (s *session) appendEvent(event *Event) (*Event, error) {
 	if event.Partial {
-		return nil
+		return nil, nil
 	}
 
 	s.mu.Lock()
 	defer s.mu.Unlock()
 
 	if err := updateSessionState(s, event); err != nil {
-		return fmt.Errorf("error on appendEvent: %w", err)
+		return nil, fmt.Errorf("error on appendEvent: %w", err)
 	}
 	processedEvent := trimTempDeltaState(event)
 
 	s.events = append(s.events, processedEvent)
 	s.updatedAt = event.Timestamp
-	return nil
+	return processedEvent, nil
 }
 
 type events []*Event
@@ -454,6 +434,47 @@ func trimTempDeltaState(event *Event) *Event {
 	eventCopy.Actions.StateDelta = filteredStateDelta
 
 	return &eventCopy
+}
+
+// cloneEventForStorage returns an isolated copy of an event for the session store.
+// Map and slice fields are deep-cloned only when non-empty.
+func cloneEventForStorage(event *Event) *Event {
+	if event == nil {
+		return nil
+	}
+	copied := &Event{
+		ID:             event.ID,
+		InvocationID:   event.InvocationID,
+		Timestamp:      event.Timestamp,
+		Author:         event.Author,
+		Branch:         event.Branch,
+		IsolationScope: event.IsolationScope,
+		Actions: EventActions{
+			TransferToAgent:   event.Actions.TransferToAgent,
+			Escalate:          event.Actions.Escalate,
+			SkipSummarization: event.Actions.SkipSummarization,
+		},
+		RequestedInput: event.RequestedInput,
+		LLMResponse:    event.LLMResponse,
+		Output:         event.Output,
+		NodeInfo:       event.NodeInfo,
+	}
+	if len(event.Actions.StateDelta) > 0 {
+		copied.Actions.StateDelta = maps.Clone(event.Actions.StateDelta)
+	}
+	if len(event.Actions.ArtifactDelta) > 0 {
+		copied.Actions.ArtifactDelta = maps.Clone(event.Actions.ArtifactDelta)
+	}
+	if len(event.Actions.RequestedToolConfirmations) > 0 {
+		copied.Actions.RequestedToolConfirmations = maps.Clone(event.Actions.RequestedToolConfirmations)
+	}
+	if len(event.LongRunningToolIDs) > 0 {
+		copied.LongRunningToolIDs = slices.Clone(event.LongRunningToolIDs)
+	}
+	if len(event.Routes) > 0 {
+		copied.Routes = slices.Clone(event.Routes)
+	}
+	return copied
 }
 
 // updateSessionState updates the session state based on the event state delta.

--- a/session/inmemory_test.go
+++ b/session/inmemory_test.go
@@ -15,12 +15,16 @@
 package session_test
 
 import (
+	"strconv"
 	"strings"
 	"sync"
 	"sync/atomic"
 	"testing"
 	"time"
 
+	"google.golang.org/genai"
+
+	"google.golang.org/adk/v2/model"
 	"google.golang.org/adk/v2/platform"
 	"google.golang.org/adk/v2/session"
 	"google.golang.org/adk/v2/session/sessiontestsuite"
@@ -232,5 +236,47 @@ func TestInMemoryService_AppendEvent_PreservesInputEventTempState(t *testing.T) 
 	}
 	if storedEvent.Actions.StateDelta["sk"] != "v2" {
 		t.Errorf("expected non-temp key sk on stored event, got: %v", storedEvent.Actions.StateDelta)
+	}
+
+	got, err := service.Get(ctx, &session.GetRequest{
+		AppName:   "testapp",
+		UserID:    "testuser",
+		SessionID: createResp.Session.ID(),
+	})
+	if err != nil {
+		t.Fatalf("Get failed: %v", err)
+	}
+	if got.Session.Events().Len() != 1 {
+		t.Fatalf("Get returned %d events, want 1", got.Session.Events().Len())
+	}
+	persisted := got.Session.Events().At(0)
+	if _, exists := persisted.Actions.StateDelta["temp:k1"]; exists {
+		t.Errorf("expected temp:k1 stripped from persisted session event, got: %v", persisted.Actions.StateDelta)
+	}
+}
+
+func BenchmarkInMemoryService_AppendEvent(b *testing.B) {
+	ctx := b.Context()
+	service := session.InMemoryService()
+	createResp, err := service.Create(ctx, &session.CreateRequest{AppName: "bench", UserID: "user"})
+	if err != nil {
+		b.Fatalf("Create: %v", err)
+	}
+	sess := createResp.Session
+	event := &session.Event{
+		ID:        "event",
+		Timestamp: time.Now(),
+		Author:    "agent",
+		LLMResponse: model.LLMResponse{
+			Content: &genai.Content{Parts: []*genai.Part{{Text: "hello"}}},
+		},
+	}
+
+	b.ResetTimer()
+	for i := 0; i < b.N; i++ {
+		event.ID = "event-" + strconv.Itoa(i)
+		if err := service.AppendEvent(ctx, sess, event); err != nil {
+			b.Fatalf("AppendEvent: %v", err)
+		}
 	}
 }


### PR DESCRIPTION
## Summary

- Add `cloneEventForStorage()` to deep-clone event maps and slices only when non-empty
- Trim temporary state keys before persisting events to the canonical in-memory session store

## Motivation

`InMemoryService.AppendEvent` runs on every non-partial LLM/tool event in the default in-memory runner path. It previously called `maps.Clone` / `slices.Clone` on every action field even when empty, causing unnecessary heap allocations on the hot path.

This also ensures events retrieved via `Get` have temporary state keys stripped (matching the runner-held session copy).

## Testing Plan

- [x] `go test -race -count=1 ./session/...`
- [x] Extended `TestInMemoryService_AppendEvent_PreservesInputEventTempState` to verify `Get` returns stripped temp keys
- [x] Added `BenchmarkInMemoryService_AppendEvent`