### PR TITLE
feat(mcptoolset): apply per-request auth via Config.Auth

### DIFF
--- a/tool/mcptoolset/set.go
+++ b/tool/mcptoolset/set.go
@@ -17,10 +17,12 @@ package mcptoolset
 
 import (
 	"fmt"
+	"net/http"
 
 	"github.com/modelcontextprotocol/go-sdk/mcp"
 
 	"google.golang.org/adk/v2/agent"
+	"google.golang.org/adk/v2/auth"
 	"google.golang.org/adk/v2/tool"
 )
 
@@ -47,12 +49,49 @@ import (
 //		},
 //	})
 func New(cfg Config) (tool.Toolset, error) {
+	transport, err := buildTransport(cfg)
+	if err != nil {
+		return nil, err
+	}
 	return &set{
-		mcpClient:                   newConnectionRefresher(cfg.Client, cfg.Transport),
+		mcpClient:                   newConnectionRefresher(cfg.Client, transport),
 		toolFilter:                  cfg.ToolFilter,
 		requireConfirmation:         cfg.RequireConfirmation,
 		requireConfirmationProvider: cfg.RequireConfirmationProvider,
 	}, nil
+}
+
+// buildTransport resolves the MCP transport from cfg. When Transport is nil and
+// Endpoint is set, it builds a streamable HTTP transport to that URL. When
+// Config.Auth is set, it wraps the transport's HTTP client with a per-request
+// auth RoundTripper, which requires a streamable HTTP transport.
+func buildTransport(cfg Config) (mcp.Transport, error) {
+	transport := cfg.Transport
+	if transport == nil && cfg.Endpoint != "" {
+		transport = &mcp.StreamableClientTransport{Endpoint: cfg.Endpoint}
+	}
+	if cfg.Auth == nil {
+		return transport, nil
+	}
+	st, ok := transport.(*mcp.StreamableClientTransport)
+	if !ok {
+		return nil, fmt.Errorf("mcptoolset: Config.Auth requires a streamable HTTP transport; "+
+			"set Config.Endpoint or pass a *mcp.StreamableClientTransport (got %T)", transport)
+	}
+	stCopy := *st
+	stCopy.HTTPClient = authHTTPClient(st.HTTPClient, cfg.Auth)
+	return &stCopy, nil
+}
+
+// authHTTPClient returns a shallow copy of base whose Transport applies provider
+// to every request. base may be nil.
+func authHTTPClient(base *http.Client, provider auth.CredentialProvider) *http.Client {
+	c := &http.Client{}
+	if base != nil {
+		*c = *base
+	}
+	c.Transport = &auth.Transport{Provider: provider, Base: c.Transport}
+	return c
 }
 
 // Config provides initial configuration for the MCP ToolSet.
@@ -61,6 +100,23 @@ type Config struct {
 	Client *mcp.Client
 	// Transport that will be used to connect to MCP server.
 	Transport mcp.Transport
+
+	// Endpoint, when set and Transport is nil, builds a streamable HTTP
+	// transport (mcp.StreamableClientTransport) targeting this URL. Ignored when
+	// Transport is set.
+	Endpoint string
+
+	// Auth, when set, resolves and applies a credential to every outgoing MCP
+	// HTTP request via a context-aware RoundTripper. It requires a streamable
+	// HTTP transport: set Endpoint, or pass a *mcp.StreamableClientTransport.
+	// Combining Auth with a non-HTTP transport (e.g. a stdio command) is a
+	// configuration error. See package google.golang.org/adk/v2/auth.
+	//
+	// Don't also set OAuthHandler on a supplied *mcp.StreamableClientTransport:
+	// Auth is applied last and overwrites the Authorization header, so the two
+	// would fight over the same request.
+	Auth auth.CredentialProvider
+
 	// Deprecated: use tool.FilterToolset instead.
 	// ToolFilter selects tools for which tool.Predicate returns true.
 	// If ToolFilter is nil, then all tools are returned.

--- a/tool/mcptoolset/tool.go
+++ b/tool/mcptoolset/tool.go
@@ -117,7 +117,6 @@ func (t *mcpTool) Run(ctx agent.Context, args any) (map[string]any, error) {
 		}
 	}
 
-	// TODO: add auth
 	res, err := t.mcpClient.CallTool(ctx, &mcp.CallToolParams{
 		Name:      t.name,
 		Arguments: args,

--- a/tool/mcptoolset/transport_config_test.go
+++ b/tool/mcptoolset/transport_config_test.go
@@ -1,0 +1,180 @@
+// Copyright 2026 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package mcptoolset
+
+import (
+	"net/http"
+	"testing"
+	"time"
+
+	"github.com/modelcontextprotocol/go-sdk/mcp"
+
+	"google.golang.org/adk/v2/auth"
+)
+
+const testEndpoint = "https://mcp.example/mcp"
+
+func TestBuildTransport(t *testing.T) {
+	// Shared inputs for the wrap/passthrough cases. buildTransport must never
+	// mutate a caller-supplied transport or client, so sharing these across
+	// cases is safe (and is itself asserted below).
+	base := &http.Client{Timeout: 7 * time.Second}
+	callerStreamable := &mcp.StreamableClientTransport{
+		Endpoint:             testEndpoint,
+		HTTPClient:           base,
+		MaxRetries:           9,
+		DisableStandaloneSSE: true,
+	}
+	callerCommand := &mcp.CommandTransport{}
+	// sentinelRT stands in for a caller's existing HTTP transport, to assert the
+	// auth transport chains onto it rather than replacing it.
+	sentinelRT := &stubRoundTripper{}
+
+	tests := []struct {
+		name    string
+		cfg     Config
+		wantErr bool
+		check   func(t *testing.T, tr mcp.Transport)
+	}{
+		{
+			name: "endpoint with auth builds a streamable client carrying the auth transport",
+			cfg:  Config{Endpoint: testEndpoint, Auth: auth.StaticToken("tok")},
+			check: func(t *testing.T, tr mcp.Transport) {
+				st := mustStreamable(t, tr)
+				if st.Endpoint != testEndpoint {
+					t.Errorf("Endpoint = %q, want %q", st.Endpoint, testEndpoint)
+				}
+				wantsAuthTransport(t, st.HTTPClient)
+			},
+		},
+		{
+			name: "auth wraps a caller streamable transport on a copy, without mutating it",
+			cfg:  Config{Transport: callerStreamable, Auth: auth.StaticToken("tok")},
+			check: func(t *testing.T, tr mcp.Transport) {
+				st := mustStreamable(t, tr)
+				// Non-auth fields and base client settings are preserved on the copy.
+				if st.Endpoint != testEndpoint || st.MaxRetries != 9 || !st.DisableStandaloneSSE {
+					t.Errorf("preserved fields lost: %+v", st)
+				}
+				wantsAuthTransport(t, st.HTTPClient)
+				if st.HTTPClient.Timeout != 7*time.Second {
+					t.Errorf("client Timeout = %v, want 7s (base settings should be copied)", st.HTTPClient.Timeout)
+				}
+				// The caller's transport and client must be untouched.
+				if st == callerStreamable {
+					t.Error("caller transport was not copied")
+				}
+				if st.HTTPClient == base {
+					t.Error("caller HTTPClient was not copied")
+				}
+				if callerStreamable.HTTPClient != base || base.Transport != nil {
+					t.Error("caller's transport/client was mutated")
+				}
+			},
+		},
+		{
+			name: "auth chains onto the caller's existing HTTP transport",
+			cfg: Config{
+				Transport: &mcp.StreamableClientTransport{
+					Endpoint:   testEndpoint,
+					HTTPClient: &http.Client{Transport: sentinelRT},
+				},
+				Auth: auth.StaticToken("tok"),
+			},
+			check: func(t *testing.T, tr mcp.Transport) {
+				st := mustStreamable(t, tr)
+				at, ok := st.HTTPClient.Transport.(*auth.Transport)
+				if !ok {
+					t.Fatalf("HTTPClient.Transport = %T, want *auth.Transport", st.HTTPClient.Transport)
+				}
+				if at.Base != sentinelRT {
+					t.Errorf("auth.Transport.Base = %v, want the caller's original transport", at.Base)
+				}
+			},
+		},
+		{
+			name:    "auth with a non-streamable transport is an error",
+			cfg:     Config{Transport: &mcp.CommandTransport{}, Auth: auth.StaticToken("tok")},
+			wantErr: true,
+		},
+		{
+			name:    "auth without an endpoint or transport is an error",
+			cfg:     Config{Auth: auth.StaticToken("tok")},
+			wantErr: true,
+		},
+		{
+			name: "endpoint without auth builds a streamable client with no HTTP client",
+			cfg:  Config{Endpoint: testEndpoint},
+			check: func(t *testing.T, tr mcp.Transport) {
+				st := mustStreamable(t, tr)
+				if st.Endpoint != testEndpoint {
+					t.Errorf("Endpoint = %q, want %q", st.Endpoint, testEndpoint)
+				}
+				if st.HTTPClient != nil {
+					t.Errorf("HTTPClient = %v, want nil without Auth", st.HTTPClient)
+				}
+			},
+		},
+		{
+			name: "no auth passes the caller transport through unchanged",
+			cfg:  Config{Transport: callerCommand},
+			check: func(t *testing.T, tr mcp.Transport) {
+				if tr != callerCommand {
+					t.Errorf("transport = %v, want the caller's transport unchanged", tr)
+				}
+			},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			tr, err := buildTransport(tt.cfg)
+			if tt.wantErr {
+				if err == nil {
+					t.Fatal("buildTransport() = nil error, want error")
+				}
+				return
+			}
+			if err != nil {
+				t.Fatalf("buildTransport() error = %v", err)
+			}
+			tt.check(t, tr)
+		})
+	}
+}
+
+func mustStreamable(t *testing.T, tr mcp.Transport) *mcp.StreamableClientTransport {
+	t.Helper()
+	st, ok := tr.(*mcp.StreamableClientTransport)
+	if !ok {
+		t.Fatalf("transport = %T, want *mcp.StreamableClientTransport", tr)
+	}
+	return st
+}
+
+func wantsAuthTransport(t *testing.T, c *http.Client) {
+	t.Helper()
+	if c == nil {
+		t.Fatal("HTTPClient = nil, want a client carrying the auth transport")
+	}
+	if _, ok := c.Transport.(*auth.Transport); !ok {
+		t.Errorf("HTTPClient.Transport = %T, want *auth.Transport", c.Transport)
+	}
+}
+
+// stubRoundTripper is a no-op http.RoundTripper used as a sentinel.
+type stubRoundTripper struct{}
+
+func (*stubRoundTripper) RoundTrip(*http.Request) (*http.Response, error) { return nil, nil }


### PR DESCRIPTION
## Problem
`mcptoolset` had no way to authenticate outgoing MCP requests — `tool.go` carried
a `// TODO: add auth`. MCP servers behind bearer / API-key / OAuth (or GCP-bound
endpoints) could not be reached per user, which blocks authenticated MCP servers
in the Agent Registry.

## Summary
Wire the `auth` package into `mcptoolset`:
- **`Config.Auth auth.CredentialProvider`** — when set, `New` builds (or wraps) a
  streamable HTTP transport whose `http.Client` runs a context-aware auth
  RoundTripper, so a credential is resolved and applied to every MCP request.
- **`Config.Endpoint`** — a convenience that builds the streamable transport when
  no `Transport` is supplied.
- Auth requires an HTTP transport; combining it with a non-HTTP transport (e.g. a
  stdio command) is a configuration error. The caller's transport and
  `http.Client` are copied before injection, never mutated (mirrors
  `model/gemini`).
Stacked on the `wolo/auth-core` PR (the core `auth` package): this PR targets
`wolo/auth-core`, so its diff is the single mcptoolset commit.