### PR TITLE
AgentEngine deployment changes

### DIFF
--- a/cmd/adkgo/internal/deploy/agentengine/agentengine.go
+++ b/cmd/adkgo/internal/deploy/agentengine/agentengine.go
@@ -280,9 +280,6 @@ func (f *deployAgentEngineFlags) gcloudDeployToAgentEngine() error {
 								{Name: "GOOGLE_CLOUD_AGENT_ENGINE_ENABLE_TELEMETRY", Value: "true"},
 								{Name: "OTEL_INSTRUMENTATION_GENAI_CAPTURE_MESSAGE_CONTENT", Value: "true"},
 							},
-							SecretEnv: []*aiplatformpb.SecretEnvVar{
-								{Name: "GOOGLE_API_KEY", SecretRef: &aiplatformpb.SecretRef{Secret: "GOOGLE_API_KEY", Version: "latest"}},
-							},
 						},
 						ClassMethods: methods,
 					},

--- a/examples/agentengine/main.go
+++ b/examples/agentengine/main.go
@@ -82,7 +82,7 @@ func main() {
 	location := os.Getenv("GOOGLE_CLOUD_AGENT_ENGINE_LOCATION")
 	agentEngineID := os.Getenv("GOOGLE_CLOUD_AGENT_ENGINE_ID")
 
-	model, err := gemini.NewModel(ctx, "gemini-flash-latest", &genai.ClientConfig{
+	model, err := gemini.NewModel(ctx, "gemini-3.5-flash", &genai.ClientConfig{
 		Backend:  genai.BackendVertexAI,
 		Project:  projectID,
 		Location: location,


### PR DESCRIPTION
Switched example to gemini-3.5-flash instead of  gemini-flash-latest 
and
removed dependency on GOOGLE_API_KEY secret
