### PR TITLE
feat(auth): add CredentialStore and cache GCP credentials

### DIFF
--- a/auth/doc.go
+++ b/auth/doc.go
@@ -23,6 +23,12 @@
 // Default Credentials ([ADC]), and service accounts ([ServiceAccount]) — and a
 // context-aware [Transport] applies a provider per outgoing request.
 //
+// A provider that has to reach the network to resolve a credential can cache
+// what it resolved in a [CredentialStore], keyed per app, per end user, and per
+// whatever else decides which credential comes back; [InMemoryCredentialStore]
+// is the process-local implementation. Providers backed by a token source
+// refresh themselves and need none.
+//
 // Token exchange and refresh are delegated to golang.org/x/oauth2 rather than
 // reimplemented here. Heavier, provider-specific integrations (for example GCP
 // agent identity) live in subpackages so this package stays dependency-light.

--- a/auth/gcp/agentidentity.go
+++ b/auth/gcp/agentidentity.go
@@ -38,7 +38,7 @@ type consentDetail struct {
 func (r agentIdentityResponse) result(resource string) (outcome, error) {
 	switch {
 	case r.Success != nil:
-		return credOutcome{header: r.Success.Header, token: r.Success.Token}, nil
+		return credOutcome{header: r.Success.Header, token: r.Success.Token, expiresAt: parseExpireTime(r.Success.ExpireTime)}, nil
 	case r.URIConsentRequired != nil:
 		return consentOutcome{authURI: r.URIConsentRequired.AuthorizationURI, nonce: r.URIConsentRequired.ConsentNonce}, nil
 	case r.ConsentRejected != nil:

--- a/auth/gcp/agentidentity.go
+++ b/auth/gcp/agentidentity.go
@@ -46,7 +46,7 @@ type consentDetail struct {
 func (r agentIdentityResponse) result(_ Request) (outcome, error) {
 	switch {
 	case r.Success != nil:
-		return credOutcome{header: r.Success.Header, token: r.Success.Token}, nil
+		return credOutcome{header: r.Success.Header, token: r.Success.Token, expiresAt: parseExpireTime(r.Success.ExpireTime)}, nil
 	case r.URIConsentRequired != nil:
 		return consentOutcome{authURI: r.URIConsentRequired.AuthorizationURI, nonce: r.URIConsentRequired.ConsentNonce}, nil
 	case r.ConsentRejected != nil:

--- a/auth/gcp/client.go
+++ b/auth/gcp/client.go
@@ -182,10 +182,18 @@ type Request struct {
 	ContinueURI string
 }
 
+// Retrieval is the result of [Client.RetrieveCredential].
+type Retrieval struct {
+	Credential auth.Credential
+	// ExpiresAt is the credential's expiry, or the zero time when the service
+	// reports no lifetime.
+	ExpiresAt time.Time
+}
+
 // RetrieveCredential retrieves a credential for req, polling while the service
 // reports a non-interactive pending state (up to the configured poll timeout).
 // If interactive consent is required it returns an [auth.ConsentRequiredError].
-func (c *Client) RetrieveCredential(ctx context.Context, req Request) (auth.Credential, error) {
+func (c *Client) RetrieveCredential(ctx context.Context, req Request) (*Retrieval, error) {
 	if req.Resource == "" {
 		return nil, errors.New("gcp: RetrieveCredential requires a Resource")
 	}
@@ -210,7 +218,11 @@ func (c *Client) RetrieveCredential(ctx context.Context, req Request) (auth.Cred
 		}
 		switch o := res.(type) {
 		case credOutcome:
-			return mapCredential(o.header, o.token)
+			cred, err := mapCredential(o.header, o.token)
+			if err != nil {
+				return nil, err
+			}
+			return &Retrieval{Credential: cred, ExpiresAt: o.expiresAt}, nil
 		case consentOutcome:
 			return nil, &auth.ConsentRequiredError{AuthURI: o.authURI, Nonce: o.nonce}
 		case rejectedOutcome:
@@ -238,8 +250,12 @@ func (c *Client) RetrieveCredential(ctx context.Context, req Request) (auth.Cred
 type outcome interface{ isOutcome() }
 
 type (
-	// credOutcome carries a successfully retrieved {header, token} credential.
-	credOutcome struct{ header, token string }
+	// credOutcome carries a successfully retrieved {header, token} credential and
+	// its expiry (zero when the service does not report one).
+	credOutcome struct {
+		header, token string
+		expiresAt     time.Time
+	}
 	// pendingOutcome means retrieval is still pending; poll again.
 	pendingOutcome struct{}
 	// consentOutcome means interactive consent is required at authURI.
@@ -256,11 +272,28 @@ func (pendingOutcome) isOutcome()  {}
 func (consentOutcome) isOutcome()  {}
 func (rejectedOutcome) isOutcome() {}
 
-// credentialPayload is the {header, token} success shape shared by both services
-// (under "success" for Agent Identity, "response" for the IAM Connector operation).
+// credentialPayload is the success shape shared by both services (under
+// "success" for Agent Identity, "response" for the IAM Connector operation): the
+// {header, token} pair plus the token's expiry. An empty expireTime means the
+// service can't say when the token expires (possibly permanent), so callers must
+// not treat it as "expires now".
 type credentialPayload struct {
-	Token  string `json:"token"`
-	Header string `json:"header"`
+	Token      string `json:"token"`
+	Header     string `json:"header"`
+	ExpireTime string `json:"expireTime"` // RFC 3339; empty when the service reports no expiry
+}
+
+// parseExpireTime parses a proto Timestamp (RFC 3339) into a time.Time, or
+// returns the zero time when empty or malformed.
+func parseExpireTime(s string) time.Time {
+	if s == "" {
+		return time.Time{}
+	}
+	t, err := time.Parse(time.RFC3339, s)
+	if err != nil {
+		return time.Time{}
+	}
+	return t
 }
 
 // retrieveRequest is the JSON body for both services' credentials:retrieve RPC

--- a/auth/gcp/client.go
+++ b/auth/gcp/client.go
@@ -17,6 +17,8 @@ package gcp
 import (
 	"bytes"
 	"context"
+	"crypto/rand"
+	"encoding/hex"
 	"encoding/json"
 	"errors"
 	"fmt"
@@ -170,20 +172,40 @@ type Client struct {
 	connectorURL     string
 	pollTimeout      time.Duration
 	initialBackoff   time.Duration
-	// cacheSlot separates clients that can mint different credentials, so the
-	// provider's cache key can include it. What the services return depends on
-	// the endpoint asked and on the identity the request is authenticated as, and
-	// a caller can supply both — so two providers sharing one store must not
-	// share an entry unless their clients agree on both.
+	// cacheSlot names this Client for the credential cache. What the services
+	// return depends on the endpoint asked and on the identity the ask is
+	// authenticated as, so two providers sharing one store must not share an
+	// entry unless their Clients agree on both.
 	//
-	// A caller-supplied HTTPClient is opaque, so its slot is unique per client.
-	// Clients left to Application Default Credentials all authenticate as the one
-	// process principal, so they share a slot and keep sharing cache entries.
+	// It is one value per Client, not one per identity, because this package
+	// cannot observe the identity a Client authenticates as. A caller-supplied
+	// HTTPClient is opaque by construction. So is Application Default
+	// Credentials: NewClient resolves it afresh on every call, so two ADC clients
+	// in one process need not be the same principal — the credentials file can be
+	// rewritten between them, and oauth2.HTTPClient in the context supplies the
+	// transport underneath the ADC one, which this package's own PollTimeout doc
+	// invites a caller to use. Erring towards a false miss costs a round trip;
+	// erring the other way discloses one principal's token to another.
+	//
+	// The value is unique per process as well as within one, so a store that
+	// outlives the process — or is shared by two — misses rather than serving an
+	// entry written by a Client that no longer exists and cannot be identified.
 	cacheSlot string
 }
 
-// callerSeq numbers clients whose identity this package cannot inspect.
-var callerSeq atomic.Uint64
+// clientSeq numbers Clients within this process, and clientNonce separates one
+// process's numbering from another's. See the cacheSlot field.
+var (
+	clientSeq   atomic.Uint64
+	clientNonce = newClientNonce()
+)
+
+func newClientNonce() string {
+	var b [16]byte
+	// Documented never to fail, and it panics rather than returning short.
+	_, _ = rand.Read(b[:])
+	return hex.EncodeToString(b[:])
+}
 
 // Config configures a [Client]. A nil *Config, or any zero-valued field, uses
 // the corresponding default.
@@ -192,6 +214,10 @@ type Config struct {
 	// from Application Default Credentials (cloud-platform scope). If set, it is
 	// used verbatim and ADC is not applied, so it must carry its own credentials
 	// and should refuse redirects for the reason [NewClient] describes.
+	//
+	// Two Clients are two cache dimensions even when built from one HTTPClient,
+	// so build a Client once and share it. One per request resolves nothing from
+	// cache and leaves an entry behind per request.
 	HTTPClient *http.Client
 	// AgentIdentityEndpoint overrides the Agent Identity base URL (scheme+host).
 	// It is used as given, not parsed: an http:// value would send the ADC token
@@ -259,11 +285,20 @@ func NewClient(ctx context.Context, cfg *Config) (*Client, error) {
 		}
 		c.httpClient = hc
 	}
-	c.cacheSlot = joinFields("adc", c.agentIdentityURL, c.connectorURL)
-	if cfg.HTTPClient != nil {
-		c.cacheSlot = joinFields("caller", strconv.FormatUint(callerSeq.Add(1), 10))
-	}
+	c.cacheSlot = joinFields(clientNonce, strconv.FormatUint(clientSeq.Add(1), 10))
 	return c, nil
+}
+
+// CacheKey returns the key a credential for scheme, retrieved through c on
+// behalf of userID under appName, is cached under — the key to hand
+// [auth.CredentialStore.Delete] to invalidate that credential ahead of its
+// expiry, on a consent revocation or a logout.
+//
+// It is meaningful only to the process that produced c, and only for as long as
+// c is alive: a Client is one cache dimension, so rebuilding it strands whatever
+// the old one cached.
+func (c *Client) CacheKey(scheme ProviderScheme, appName, userID string) auth.CredentialKey {
+	return auth.CredentialKey{AppName: appName, UserID: userID, Key: cacheSlot(c, scheme)}
 }
 
 // joinFields encodes fields as one unambiguous string, each prefixed with its
@@ -314,9 +349,12 @@ type Request struct {
 
 // Retrieval is the result of [Client.RetrieveCredential].
 type Retrieval struct {
+	// Credential authenticates outbound requests as the end user.
 	Credential auth.Credential
 	// ExpiresAt is the credential's expiry, or the zero time when the service
-	// reports no lifetime.
+	// reports no lifetime — which it does when the token may be permanent, or
+	// when it cannot say. Either way the lifetime is unknown, so a caller must
+	// not treat the zero value as "expires now" and must not cache it.
 	ExpiresAt time.Time
 }
 
@@ -455,9 +493,14 @@ func (rejectedOutcome) isOutcome() {}
 // service can't say when the token expires (possibly permanent), so callers must
 // not treat it as "expires now".
 type credentialPayload struct {
-	Token      string `json:"token"`
-	Header     string `json:"header"`
-	ExpireTime string `json:"expireTime"` // RFC 3339; empty when the service reports no expiry
+	Token  string `json:"token"`
+	Header string `json:"header"`
+	// ExpireTime is RFC 3339, and empty when the service reports no expiry. The
+	// name is the one in the published API surface
+	// (https://agentidentitycredentials.googleapis.com/$discovery/rest?version=v1,
+	// Success.expireTime), which also warns that the token may be revoked, or
+	// expire slightly early through clock skew, before the time it names.
+	ExpireTime string `json:"expireTime"`
 }
 
 // parseExpireTime parses a proto Timestamp (RFC 3339) into a time.Time, or

--- a/auth/gcp/client.go
+++ b/auth/gcp/client.go
@@ -503,8 +503,11 @@ type credentialPayload struct {
 	ExpireTime string `json:"expireTime"`
 }
 
-// parseExpireTime parses a proto Timestamp (RFC 3339) into a time.Time, or
-// returns the zero time when empty or malformed.
+// parseExpireTime parses the service's expiry into a time.Time, collapsing an
+// absent one and an unparseable one to the same zero time. Callers read that as
+// "lifetime unknown" and decline to cache, which is the safe reading of both:
+// the service omits the field when the token may be permanent or when it cannot
+// say, and a value it sent but we cannot read tells us no more than silence.
 func parseExpireTime(s string) time.Time {
 	if s == "" {
 		return time.Time{}

--- a/auth/gcp/client.go
+++ b/auth/gcp/client.go
@@ -23,7 +23,9 @@ import (
 	"io"
 	"net/http"
 	"regexp"
+	"strconv"
 	"strings"
+	"sync/atomic"
 	"time"
 
 	"golang.org/x/oauth2"
@@ -168,7 +170,20 @@ type Client struct {
 	connectorURL     string
 	pollTimeout      time.Duration
 	initialBackoff   time.Duration
+	// cacheSlot separates clients that can mint different credentials, so the
+	// provider's cache key can include it. What the services return depends on
+	// the endpoint asked and on the identity the request is authenticated as, and
+	// a caller can supply both — so two providers sharing one store must not
+	// share an entry unless their clients agree on both.
+	//
+	// A caller-supplied HTTPClient is opaque, so its slot is unique per client.
+	// Clients left to Application Default Credentials all authenticate as the one
+	// process principal, so they share a slot and keep sharing cache entries.
+	cacheSlot string
 }
+
+// callerSeq numbers clients whose identity this package cannot inspect.
+var callerSeq atomic.Uint64
 
 // Config configures a [Client]. A nil *Config, or any zero-valued field, uses
 // the corresponding default.
@@ -244,7 +259,24 @@ func NewClient(ctx context.Context, cfg *Config) (*Client, error) {
 		}
 		c.httpClient = hc
 	}
+	c.cacheSlot = joinFields("adc", c.agentIdentityURL, c.connectorURL)
+	if cfg.HTTPClient != nil {
+		c.cacheSlot = joinFields("caller", strconv.FormatUint(callerSeq.Add(1), 10))
+	}
 	return c, nil
+}
+
+// joinFields encodes fields as one unambiguous string, each prefixed with its
+// byte length. No delimiter occurring inside a field can then make two different
+// field lists encode alike, which joining on a separator alone allowed.
+func joinFields(fields ...string) string {
+	var b strings.Builder
+	for _, f := range fields {
+		b.WriteString(strconv.Itoa(len(f)))
+		b.WriteByte(':')
+		b.WriteString(f)
+	}
+	return b.String()
 }
 
 // Request identifies the resource and acting user for a credential retrieval.

--- a/auth/gcp/client.go
+++ b/auth/gcp/client.go
@@ -280,6 +280,14 @@ type Request struct {
 	ContinueURI string
 }
 
+// Retrieval is the result of [Client.RetrieveCredential].
+type Retrieval struct {
+	Credential auth.Credential
+	// ExpiresAt is the credential's expiry, or the zero time when the service
+	// reports no lifetime.
+	ExpiresAt time.Time
+}
+
 // RetrieveCredential retrieves a credential for req, polling while the service
 // reports a non-interactive pending state (up to the configured poll timeout).
 // If interactive consent is required it returns an [auth.ConsentRequiredError].
@@ -296,7 +304,7 @@ type Request struct {
 // was true in v2.3.0. A decode failure is now [ErrMalformedResponse] and no
 // longer carries the [encoding/json] error behind it, so [errors.As] against
 // *json.SyntaxError stops finding one.
-func (c *Client) RetrieveCredential(ctx context.Context, req Request) (_ auth.Credential, err error) {
+func (c *Client) RetrieveCredential(ctx context.Context, req Request) (_ *Retrieval, err error) {
 	if req.Resource == "" {
 		return nil, errors.New("gcp: RetrieveCredential requires a Resource")
 	}
@@ -351,7 +359,11 @@ func (c *Client) RetrieveCredential(ctx context.Context, req Request) (_ auth.Cr
 		}
 		switch o := res.(type) {
 		case credOutcome:
-			return mapCredential(o.header, o.token, req.UserID, req.ContinueURI)
+			cred, err := mapCredential(o.header, o.token, req.UserID, req.ContinueURI)
+			if err != nil {
+				return nil, err
+			}
+			return &Retrieval{Credential: cred, ExpiresAt: o.expiresAt}, nil
 		case consentOutcome:
 			return nil, &auth.ConsentRequiredError{AuthURI: o.authURI, Nonce: o.nonce}
 		case rejectedOutcome:
@@ -383,8 +395,12 @@ func (c *Client) RetrieveCredential(ctx context.Context, req Request) (_ auth.Cr
 type outcome interface{ isOutcome() }
 
 type (
-	// credOutcome carries a successfully retrieved {header, token} credential.
-	credOutcome struct{ header, token string }
+	// credOutcome carries a successfully retrieved {header, token} credential and
+	// its expiry (zero when the service does not report one).
+	credOutcome struct {
+		header, token string
+		expiresAt     time.Time
+	}
 	// pendingOutcome means retrieval is still pending; poll again.
 	pendingOutcome struct{}
 	// consentOutcome means interactive consent is required at authURI.
@@ -401,11 +417,28 @@ func (pendingOutcome) isOutcome()  {}
 func (consentOutcome) isOutcome()  {}
 func (rejectedOutcome) isOutcome() {}
 
-// credentialPayload is the {header, token} success shape shared by both services
-// (under "success" for Agent Identity, "response" for the IAM Connector operation).
+// credentialPayload is the success shape shared by both services (under
+// "success" for Agent Identity, "response" for the IAM Connector operation): the
+// {header, token} pair plus the token's expiry. An empty expireTime means the
+// service can't say when the token expires (possibly permanent), so callers must
+// not treat it as "expires now".
 type credentialPayload struct {
-	Token  string `json:"token"`
-	Header string `json:"header"`
+	Token      string `json:"token"`
+	Header     string `json:"header"`
+	ExpireTime string `json:"expireTime"` // RFC 3339; empty when the service reports no expiry
+}
+
+// parseExpireTime parses a proto Timestamp (RFC 3339) into a time.Time, or
+// returns the zero time when empty or malformed.
+func parseExpireTime(s string) time.Time {
+	if s == "" {
+		return time.Time{}
+	}
+	t, err := time.Parse(time.RFC3339, s)
+	if err != nil {
+		return time.Time{}
+	}
+	return t
 }
 
 // retrieveRequest is the JSON body for both services' credentials:retrieve RPC

--- a/auth/gcp/client.go
+++ b/auth/gcp/client.go
@@ -521,9 +521,23 @@ type credentialPayload struct {
 	// Success.expireTime), which also warns that the token may be revoked, or
 	// expire slightly early through clock skew, before the time it names. The IAM
 	// Connector service publishes no discovery document to anonymous callers, so
-	// its field is taken to be the same name; if it is not, a connector
-	// credential simply reports no lifetime and is never cached.
-	ExpireTime string `json:"expireTime"`
+	// its field is assumed to be the same name and shape; if it is not, a
+	// connector credential reports no lifetime and is never cached.
+	ExpireTime lenientTime `json:"expireTime"`
+}
+
+// lenientTime is a JSON string that declines to fail. Only the cache reads this
+// field, and the IAM Connector's shape for it is an assumption, so a value of an
+// unexpected type must cost a cache entry rather than the whole retrieval — the
+// credential itself is perfectly usable without an expiry.
+type lenientTime string
+
+func (t *lenientTime) UnmarshalJSON(b []byte) error {
+	var s string
+	if json.Unmarshal(b, &s) == nil {
+		*t = lenientTime(s)
+	}
+	return nil
 }
 
 // parseExpireTime parses the service's expiry into a time.Time, collapsing an
@@ -531,11 +545,11 @@ type credentialPayload struct {
 // "lifetime unknown" and decline to cache, which is the safe reading of both:
 // the service omits the field when the token may be permanent or when it cannot
 // say, and a value it sent but we cannot read tells us no more than silence.
-func parseExpireTime(s string) time.Time {
-	if s == "" {
+func parseExpireTime(v lenientTime) time.Time {
+	if v == "" {
 		return time.Time{}
 	}
-	t, err := time.Parse(time.RFC3339, s)
+	t, err := time.Parse(time.RFC3339, string(v))
 	if err != nil {
 		return time.Time{}
 	}

--- a/auth/gcp/client.go
+++ b/auth/gcp/client.go
@@ -187,6 +187,9 @@ type Client struct {
 	// invites a caller to use. Erring towards a false miss costs a round trip;
 	// erring the other way discloses one principal's token to another.
 	//
+	// The converse is a precondition this package cannot enforce and states on
+	// Config.HTTPClient: one Client must not authenticate as several identities.
+	//
 	// The value is unique per process as well as within one, so a store that
 	// outlives the process — or is shared by two — misses rather than serving an
 	// entry written by a Client that no longer exists and cannot be identified.
@@ -219,9 +222,16 @@ type Config struct {
 	// used verbatim and ADC is not applied, so it must carry its own credentials
 	// and should refuse redirects for the reason [NewClient] describes.
 	//
+	// It must authenticate as one identity for the Client's whole life. A Client
+	// is a credential-cache dimension precisely because it is assumed to fix who
+	// the credential service mints on behalf of, and a transport that picks its
+	// credentials out of the request context breaks that assumption without this
+	// package being able to see it: every tenant would share one cache entry.
+	// Build a Client per identity instead.
+	//
 	// Two Clients are two cache dimensions even when built from one HTTPClient,
-	// so build a Client once and share it. One per request resolves nothing from
-	// cache and leaves an entry behind per request.
+	// so build a Client once per identity and share it. One per request resolves
+	// nothing from cache and leaves an entry behind per request.
 	HTTPClient *http.Client
 	// AgentIdentityEndpoint overrides the Agent Identity base URL (scheme+host).
 	// It is used as given, not parsed: an http:// value would send the ADC token

--- a/auth/gcp/client.go
+++ b/auth/gcp/client.go
@@ -200,8 +200,12 @@ var (
 	clientNonce = newClientNonce()
 )
 
+// nonceBytes is the width of clientNonce. 128 bits makes a collision between two
+// processes not worth reasoning about.
+const nonceBytes = 16
+
 func newClientNonce() string {
-	var b [16]byte
+	var b [nonceBytes]byte
 	// Documented never to fail, and it panics rather than returning short.
 	_, _ = rand.Read(b[:])
 	return hex.EncodeToString(b[:])
@@ -294,6 +298,10 @@ func NewClient(ctx context.Context, cfg *Config) (*Client, error) {
 // [auth.CredentialStore.Delete] to invalidate that credential ahead of its
 // expiry, on a consent revocation or a logout.
 //
+// Pass the same [ProviderScheme] value the provider was built with. A scheme
+// differing in any field names a different entry, and Delete of a key nothing
+// is filed under succeeds silently, so a mistake here reads as "already gone".
+//
 // It is meaningful only to the process that produced c, and only for as long as
 // c is alive: a Client is one cache dimension, so rebuilding it strands whatever
 // the old one cached.
@@ -351,10 +359,11 @@ type Request struct {
 type Retrieval struct {
 	// Credential authenticates outbound requests as the end user.
 	Credential auth.Credential
-	// ExpiresAt is the credential's expiry, or the zero time when the service
-	// reports no lifetime — which it does when the token may be permanent, or
-	// when it cannot say. Either way the lifetime is unknown, so a caller must
-	// not treat the zero value as "expires now" and must not cache it.
+	// ExpiresAt is the credential's expiry, or the zero time when the lifetime is
+	// unknown: the service reports none when the token may be permanent or when
+	// it cannot say, and one it reports that cannot be parsed arrives here the
+	// same way. A caller must not read the zero value as "expires now", and must
+	// not cache a credential carrying it.
 	ExpiresAt time.Time
 }
 
@@ -495,11 +504,15 @@ func (rejectedOutcome) isOutcome() {}
 type credentialPayload struct {
 	Token  string `json:"token"`
 	Header string `json:"header"`
-	// ExpireTime is RFC 3339, and empty when the service reports no expiry. The
-	// name is the one in the published API surface
+	// ExpireTime is RFC 3339, and empty when the service reports no expiry.
+	//
+	// For Agent Identity the name is the one in the published API surface
 	// (https://agentidentitycredentials.googleapis.com/$discovery/rest?version=v1,
 	// Success.expireTime), which also warns that the token may be revoked, or
-	// expire slightly early through clock skew, before the time it names.
+	// expire slightly early through clock skew, before the time it names. The IAM
+	// Connector service publishes no discovery document to anonymous callers, so
+	// its field is taken to be the same name; if it is not, a connector
+	// credential simply reports no lifetime and is never cached.
 	ExpireTime string `json:"expireTime"`
 }
 

--- a/auth/gcp/client_test.go
+++ b/auth/gcp/client_test.go
@@ -69,6 +69,14 @@ func TestRetrieveCredential(t *testing.T) {
 			wantExpiry: "2999-01-01T00:00:00Z",
 		},
 		{
+			// An unparseable expiry leaves ExpiresAt zero, which the provider
+			// reads as "don't cache"; the credential itself is still usable.
+			name:       "agent identity bearer with unparseable expiry",
+			resource:   authProviderResource,
+			bodies:     []string{`{"success":{"token":"tok","header":"Authorization: Bearer","expireTime":"not-a-time"}}`},
+			wantBearer: "tok",
+		},
+		{
 			name:       "agent identity custom header",
 			resource:   authProviderResource,
 			bodies:     []string{`{"success":{"token":"KEY","header":"X-Goog-Api-Key"}}`},

--- a/auth/gcp/client_test.go
+++ b/auth/gcp/client_test.go
@@ -47,6 +47,7 @@ func TestRetrieveCredential(t *testing.T) {
 		bodies      []string
 		wantCalls   int       // >0 => assert the number of service calls
 		wantBearer  string    // expect a bearer credential carrying this token
+		wantExpiry  string    // non-empty => expect this timestamp as ExpiresAt
 		wantAPIKey  [2]string // expect an API-key credential {name, value}
 		wantConsent [2]string // expect *auth.ConsentRequiredError {authURI, nonce}
 		wantErrIs   error     // expect errors.Is(err, target)
@@ -59,6 +60,13 @@ func TestRetrieveCredential(t *testing.T) {
 			resource:   authProviderResource,
 			bodies:     []string{`{"success":{"token":"tok","header":"Authorization: Bearer"}}`},
 			wantBearer: "tok",
+		},
+		{
+			name:       "agent identity bearer with expiry",
+			resource:   authProviderResource,
+			bodies:     []string{`{"success":{"token":"tok","header":"Authorization: Bearer","expireTime":"2999-01-01T00:00:00Z"}}`},
+			wantBearer: "tok",
+			wantExpiry: "2999-01-01T00:00:00Z",
 		},
 		{
 			name:       "agent identity custom header",
@@ -154,7 +162,7 @@ func TestRetrieveCredential(t *testing.T) {
 			if tc.pollTimeout > 0 {
 				c.pollTimeout = tc.pollTimeout
 			}
-			cred, err := c.RetrieveCredential(t.Context(),
+			got, err := c.RetrieveCredential(t.Context(),
 				Request{Resource: tc.resource, UserID: "u"})
 
 			switch {
@@ -162,12 +170,20 @@ func TestRetrieveCredential(t *testing.T) {
 				if err != nil {
 					t.Fatalf("RetrieveCredential() error = %v", err)
 				}
-				wantBearer(t, cred, tc.wantBearer)
+				wantBearer(t, got.Credential, tc.wantBearer)
+				if tc.wantExpiry != "" {
+					want, _ := time.Parse(time.RFC3339, tc.wantExpiry)
+					if !got.ExpiresAt.Equal(want) {
+						t.Errorf("ExpiresAt = %v, want %v", got.ExpiresAt, want)
+					}
+				} else if !got.ExpiresAt.IsZero() {
+					t.Errorf("ExpiresAt = %v, want zero", got.ExpiresAt)
+				}
 			case tc.wantAPIKey[0] != "":
 				if err != nil {
 					t.Fatalf("RetrieveCredential() error = %v", err)
 				}
-				wantAPIKey(t, cred, tc.wantAPIKey[0], tc.wantAPIKey[1])
+				wantAPIKey(t, got.Credential, tc.wantAPIKey[0], tc.wantAPIKey[1])
 			case tc.wantConsent[0] != "":
 				var consent *auth.ConsentRequiredError
 				if !errors.As(err, &consent) {
@@ -573,11 +589,11 @@ func TestNewClientOutlivesConstructionCtx(t *testing.T) {
 	}
 	cancel()
 
-	cred, err := c.RetrieveCredential(t.Context(), Request{Resource: authProviderResource, UserID: "u"})
+	got, err := c.RetrieveCredential(t.Context(), Request{Resource: authProviderResource, UserID: "u"})
 	if err != nil {
 		t.Fatalf("RetrieveCredential() error = %v", err)
 	}
-	wantBearer(t, cred, "tok")
+	wantBearer(t, got.Credential, "tok")
 }
 
 // fakeADC points Application Default Credentials at a local token server so the

--- a/auth/gcp/client_test.go
+++ b/auth/gcp/client_test.go
@@ -70,6 +70,14 @@ func TestRetrieveCredential(t *testing.T) {
 			wantExpiry: "2999-01-01T00:00:00Z",
 		},
 		{
+			// An unparseable expiry leaves ExpiresAt zero, which the provider
+			// reads as "don't cache"; the credential itself is still usable.
+			name:       "agent identity bearer with unparseable expiry",
+			resource:   authProviderResource,
+			bodies:     []string{`{"success":{"token":"tok","header":"Authorization: Bearer","expireTime":"not-a-time"}}`},
+			wantBearer: "tok",
+		},
+		{
 			name:       "agent identity custom header",
 			resource:   authProviderResource,
 			bodies:     []string{`{"success":{"token":"KEY","header":"X-Goog-Api-Key"}}`},

--- a/auth/gcp/client_test.go
+++ b/auth/gcp/client_test.go
@@ -202,7 +202,12 @@ func TestRetrieveCredential(t *testing.T) {
 				}
 				wantBearer(t, got.Credential, tc.wantBearer)
 				if tc.wantExpiry != "" {
-					want, _ := time.Parse(time.RFC3339, tc.wantExpiry)
+					want, err := time.Parse(time.RFC3339, tc.wantExpiry)
+					if err != nil {
+						// Otherwise a mistyped want parses to the zero time, which is exactly
+						// what a dropped expiry produces, and the case asserts its own inverse.
+						t.Fatalf("parse wantExpiry %q: %v", tc.wantExpiry, err)
+					}
 					if !got.ExpiresAt.Equal(want) {
 						t.Errorf("ExpiresAt = %v, want %v", got.ExpiresAt, want)
 					}

--- a/auth/gcp/client_test.go
+++ b/auth/gcp/client_test.go
@@ -48,6 +48,7 @@ func TestRetrieveCredential(t *testing.T) {
 		bodies      []string
 		wantCalls   int       // >0 => assert the number of service calls
 		wantBearer  string    // expect a bearer credential carrying this token
+		wantExpiry  string    // non-empty => expect this timestamp as ExpiresAt
 		wantAPIKey  [2]string // expect an API-key credential {name, value}
 		wantConsent [2]string // expect *auth.ConsentRequiredError {authURI, nonce}
 		wantErrIs   error     // expect errors.Is(err, target)
@@ -60,6 +61,13 @@ func TestRetrieveCredential(t *testing.T) {
 			resource:   authProviderResource,
 			bodies:     []string{`{"success":{"token":"tok","header":"Authorization: Bearer"}}`},
 			wantBearer: "tok",
+		},
+		{
+			name:       "agent identity bearer with expiry",
+			resource:   authProviderResource,
+			bodies:     []string{`{"success":{"token":"tok","header":"Authorization: Bearer","expireTime":"2999-01-01T00:00:00Z"}}`},
+			wantBearer: "tok",
+			wantExpiry: "2999-01-01T00:00:00Z",
 		},
 		{
 			name:       "agent identity custom header",
@@ -155,7 +163,7 @@ func TestRetrieveCredential(t *testing.T) {
 			if tc.pollTimeout > 0 {
 				c.pollTimeout = tc.pollTimeout
 			}
-			cred, err := c.RetrieveCredential(t.Context(),
+			got, err := c.RetrieveCredential(t.Context(),
 				Request{Resource: tc.resource, UserID: "u"})
 
 			switch {
@@ -163,12 +171,20 @@ func TestRetrieveCredential(t *testing.T) {
 				if err != nil {
 					t.Fatalf("RetrieveCredential() error = %v", err)
 				}
-				wantBearer(t, cred, tc.wantBearer)
+				wantBearer(t, got.Credential, tc.wantBearer)
+				if tc.wantExpiry != "" {
+					want, _ := time.Parse(time.RFC3339, tc.wantExpiry)
+					if !got.ExpiresAt.Equal(want) {
+						t.Errorf("ExpiresAt = %v, want %v", got.ExpiresAt, want)
+					}
+				} else if !got.ExpiresAt.IsZero() {
+					t.Errorf("ExpiresAt = %v, want zero", got.ExpiresAt)
+				}
 			case tc.wantAPIKey[0] != "":
 				if err != nil {
 					t.Fatalf("RetrieveCredential() error = %v", err)
 				}
-				wantAPIKey(t, cred, tc.wantAPIKey[0], tc.wantAPIKey[1])
+				wantAPIKey(t, got.Credential, tc.wantAPIKey[0], tc.wantAPIKey[1])
 			case tc.wantConsent[0] != "":
 				var consent *auth.ConsentRequiredError
 				if !errors.As(err, &consent) {
@@ -652,11 +668,11 @@ func TestNewClientOutlivesConstructionCtx(t *testing.T) {
 	}
 	cancel()
 
-	cred, err := c.RetrieveCredential(t.Context(), Request{Resource: authProviderResource, UserID: "u"})
+	got, err := c.RetrieveCredential(t.Context(), Request{Resource: authProviderResource, UserID: "u"})
 	if err != nil {
 		t.Fatalf("RetrieveCredential() error = %v", err)
 	}
-	wantBearer(t, cred, "tok")
+	wantBearer(t, got.Credential, "tok")
 }
 
 // fakeADC points Application Default Credentials at a local token server so the

--- a/auth/gcp/client_test.go
+++ b/auth/gcp/client_test.go
@@ -110,6 +110,17 @@ func TestRetrieveCredential(t *testing.T) {
 			wantBearer: "tok",
 		},
 		{
+			// The connector reads its expiry from the operation's response, a
+			// different path from Agent Identity's. Without this case, dropping the
+			// expiry there leaves the suite green and a connector-backed provider
+			// silently never caches.
+			name:       "connector bearer with expiry",
+			resource:   connectorResource,
+			bodies:     []string{`{"done":true,"response":{"token":"tok","header":"Authorization: Bearer","expireTime":"2999-01-01T00:00:00Z"}}`},
+			wantBearer: "tok",
+			wantExpiry: "2999-01-01T00:00:00Z",
+		},
+		{
 			name:       "connector polls consent pending then succeeds",
 			resource:   connectorResource,
 			bodies:     []string{`{"metadata":{"@type":"x","consentPending":{}}}`, `{"done":true,"response":{"token":"tok","header":"Authorization: Bearer"}}`},

--- a/auth/gcp/client_test.go
+++ b/auth/gcp/client_test.go
@@ -110,6 +110,16 @@ func TestRetrieveCredential(t *testing.T) {
 			wantBearer: "tok",
 		},
 		{
+			// The connector's expireTime shape is an assumption — the service
+			// publishes no discovery document — so a value of another JSON type must
+			// cost the cache entry, not the credential. Decoding it strictly would
+			// fail the whole retrieval and take auth down with it.
+			name:       "connector expireTime of an unexpected JSON type",
+			resource:   connectorResource,
+			bodies:     []string{`{"done":true,"response":{"token":"tok","header":"Authorization: Bearer","expireTime":{"seconds":1798761600}}}`},
+			wantBearer: "tok",
+		},
+		{
 			// The connector reads its expiry from the operation's response, a
 			// different path from Agent Identity's. Without this case, dropping the
 			// expiry there leaves the suite green and a connector-backed provider

--- a/auth/gcp/connector.go
+++ b/auth/gcp/connector.go
@@ -53,7 +53,7 @@ func (o connectorOperation) result(resource string) (outcome, error) {
 		if o.Response == nil {
 			return nil, fmt.Errorf("gcp: connector operation done but returned no credential for %q", resource)
 		}
-		return credOutcome{header: o.Response.Header, token: o.Response.Token}, nil
+		return credOutcome{header: o.Response.Header, token: o.Response.Token, expiresAt: parseExpireTime(o.Response.ExpireTime)}, nil
 	}
 	if md := o.Metadata; md != nil {
 		switch {

--- a/auth/gcp/connector.go
+++ b/auth/gcp/connector.go
@@ -54,7 +54,7 @@ func (o connectorOperation) result(req Request) (outcome, error) {
 		if o.Response == nil {
 			return nil, errors.New("gcp: connector operation done but returned no credential")
 		}
-		return credOutcome{header: o.Response.Header, token: o.Response.Token}, nil
+		return credOutcome{header: o.Response.Header, token: o.Response.Token, expiresAt: parseExpireTime(o.Response.ExpireTime)}, nil
 	}
 	if md := o.Metadata; md != nil {
 		switch {

--- a/auth/gcp/provider.go
+++ b/auth/gcp/provider.go
@@ -47,6 +47,11 @@ type ProviderConfig struct {
 	// Client reaches the credential services. When nil, a default client (backed
 	// by Application Default Credentials) is created lazily on first use.
 	Client *Client
+	// Store caches resolved credentials across requests (keyed by app, user, and
+	// resource). When nil, an in-memory store is used. Caching matters here
+	// because each miss is a network round-trip (and up to a ~10s pending poll)
+	// to the credential service.
+	Store auth.CredentialStore
 }
 
 // ErrNoActingUser means the provider could not determine the acting end user,
@@ -73,13 +78,19 @@ func NewProvider(scheme Scheme, cfg *ProviderConfig) (auth.CredentialProvider, e
 	if cfg.Client != nil && cfg.Client.httpClient == nil {
 		return nil, errors.New("gcp: ProviderConfig.Client must come from NewClient")
 	}
-	// Defensive copy: the provider outlives this call and re-reads Scopes per request, so it must not alias a caller-mutable slice.
+	// Defensive copy: the provider outlives this call and reads Scopes on every
+	// request, so it must not alias a slice the caller can mutate later.
 	scheme.Scopes = slices.Clone(scheme.Scopes)
-	return &provider{scheme: scheme, client: cfg.Client}, nil
+	store := cfg.Store
+	if store == nil {
+		store = auth.NewInMemoryCredentialStore()
+	}
+	return &provider{scheme: scheme, store: store, client: cfg.Client}, nil
 }
 
 type provider struct {
 	scheme Scheme
+	store  auth.CredentialStore
 
 	mu         sync.Mutex
 	client     *Client
@@ -98,16 +109,33 @@ func (p *provider) Credential(ctx context.Context) (auth.Credential, error) {
 		return nil, fmt.Errorf("%w: invocation for app %q session %q has an empty UserID", ErrNoActingUser, id.AppName, id.SessionID)
 	}
 
+	key := auth.CredentialKey{AppName: id.AppName, UserID: id.UserID, Key: p.scheme.Name}
+	// A store read error is non-fatal: fall through and fetch a fresh credential.
+	if cred, ok, err := p.store.Get(ctx, key); err == nil && ok {
+		return cred, nil
+	}
+
 	client, err := p.resolveClient(ctx)
 	if err != nil {
 		return nil, err
 	}
-	return client.RetrieveCredential(ctx, Request{
+	r, err := client.RetrieveCredential(ctx, Request{
 		Resource:    p.scheme.Name,
 		UserID:      id.UserID,
 		Scopes:      p.scheme.Scopes,
 		ContinueURI: p.scheme.ContinueURI,
 	})
+	if err != nil {
+		return nil, err
+	}
+	// Cache only when the service reported an expiry: a zero time means "never
+	// expires" to the store, and the GCP services omit it only when the lifetime
+	// is unknown — caching that would risk serving a stale credential forever.
+	// Best-effort: a store write failure must not fail auth.
+	if !r.ExpiresAt.IsZero() {
+		_ = p.store.Set(ctx, key, r.Credential, r.ExpiresAt)
+	}
+	return r.Credential, nil
 }
 
 // resolveClient returns the configured client, creating a default one (backed by

--- a/auth/gcp/provider.go
+++ b/auth/gcp/provider.go
@@ -19,12 +19,15 @@ import (
 	"errors"
 	"fmt"
 	"slices"
+	"strings"
 	"sync"
+	"time"
 
 	"golang.org/x/sync/singleflight"
 
 	"google.golang.org/adk/v2/agent"
 	"google.golang.org/adk/v2/auth"
+	"google.golang.org/adk/v2/platform"
 )
 
 // Scheme identifies a GCP auth resource and the access it requests. It mirrors
@@ -85,11 +88,25 @@ func NewProvider(scheme Scheme, cfg *ProviderConfig) (auth.CredentialProvider, e
 	if store == nil {
 		store = auth.NewInMemoryCredentialStore()
 	}
-	return &provider{scheme: scheme, store: store, client: cfg.Client}, nil
+	return &provider{scheme: scheme, slot: schemeSlot(scheme), store: store, client: cfg.Client}, nil
+}
+
+// maxCachedLifetime caps how long a credential is cached, whatever expiry the
+// service reports, so a bad or injected expireTime cannot pin one indefinitely.
+const maxCachedLifetime = time.Hour
+
+// schemeSlot is the store slot for a scheme. Scopes and the continue URI shape
+// what the minted token authorizes, so credentials that differ in them must not
+// share an entry; the sort makes the slot independent of the caller's ordering.
+func schemeSlot(s Scheme) string {
+	scopes := slices.Clone(s.Scopes)
+	slices.Sort(scopes)
+	return s.Name + "|" + strings.Join(scopes, ",") + "|" + s.ContinueURI
 }
 
 type provider struct {
 	scheme Scheme
+	slot   string
 	store  auth.CredentialStore
 
 	mu         sync.Mutex
@@ -109,9 +126,13 @@ func (p *provider) Credential(ctx context.Context) (auth.Credential, error) {
 		return nil, fmt.Errorf("%w: invocation for app %q session %q has an empty UserID", ErrNoActingUser, id.AppName, id.SessionID)
 	}
 
-	key := auth.CredentialKey{AppName: id.AppName, UserID: id.UserID, Key: p.scheme.Name}
+	// The slot covers everything that shapes the minted token, not just the
+	// resource: a store shared by a broad and a narrow provider would otherwise
+	// serve the broad token to the narrow one.
+	key := auth.CredentialKey{AppName: id.AppName, UserID: id.UserID, Key: p.slot}
 	// A store read error is non-fatal: fall through and fetch a fresh credential.
-	if cred, ok, err := p.store.Get(ctx, key); err == nil && ok {
+	// A hit carrying no credential is treated as a miss; the interface allows it.
+	if cred, ok, err := p.store.Get(ctx, key); err == nil && ok && cred != nil {
 		return cred, nil
 	}
 
@@ -128,12 +149,15 @@ func (p *provider) Credential(ctx context.Context) (auth.Credential, error) {
 	if err != nil {
 		return nil, err
 	}
-	// Cache only when the service reported an expiry: a zero time means "never
-	// expires" to the store, and the GCP services omit it only when the lifetime
-	// is unknown — caching that would risk serving a stale credential forever.
-	// Best-effort: a store write failure must not fail auth.
+	// Cache only when the service reported an expiry; it omits one when the
+	// lifetime is unknown, and a credential with no known lifetime cannot be
+	// vouched for later. Best-effort: a store write failure must not fail auth.
 	if !r.ExpiresAt.IsZero() {
-		_ = p.store.Set(ctx, key, r.Credential, r.ExpiresAt)
+		expiresAt := r.ExpiresAt
+		if capped := platform.Now(ctx).Add(maxCachedLifetime); expiresAt.After(capped) {
+			expiresAt = capped
+		}
+		_ = p.store.Set(ctx, key, r.Credential, expiresAt)
 	}
 	return r.Credential, nil
 }

--- a/auth/gcp/provider.go
+++ b/auth/gcp/provider.go
@@ -70,13 +70,15 @@ type ProviderConfig struct {
 	//
 	// One store can safely back several providers: entries are keyed by the app,
 	// the end user, and everything that decides what the service returns — the
-	// resource, the scopes, the continue URI, and the Client. Providers whose
-	// Clients authenticate as different identities do not share entries.
+	// resource, the scopes, the continue URI, and the Client. Two providers share
+	// an entry when they share a Client and agree on all of that, and not
+	// otherwise. Building a Client per provider is therefore a way to get no
+	// sharing at all; see [Config.HTTPClient].
 	//
 	// The cost of caching is staleness. A credential revoked before it expires
 	// keeps being served until the cached entry does, which is the service's
-	// expiry or an hour, whichever comes first. Call
-	// [auth.CredentialStore.Delete] to invalidate one sooner.
+	// expiry or an hour, whichever comes first. To invalidate one sooner, pass
+	// [Client.CacheKey] to [auth.CredentialStore.Delete].
 	Store auth.CredentialStore
 }
 
@@ -188,6 +190,8 @@ func NewProvider(ctx context.Context, cfg ProviderConfig) (auth.CredentialProvid
 
 // maxCachedLifetime caps how long a credential is cached, whatever expiry the
 // service reports, so a bad or injected expireTime cannot pin one indefinitely.
+// It also bounds how long a credential revoked before its expiry keeps being
+// served, which the service warns can happen at any time.
 const maxCachedLifetime = time.Hour
 
 // cacheSlot is the store slot a credential for s, minted through c, is cached
@@ -200,9 +204,14 @@ const maxCachedLifetime = time.Hour
 //
 // The components are length-prefixed before hashing, so no combination of
 // delimiters inside a scope or a URI can collide two different schemes. Sorting
-// the scopes makes the slot independent of the caller's ordering. adk-python
-// keys its credential service the same way, on a SHA-256 digest of a canonical
-// encoding of the whole scheme plus the credential used to obtain it.
+// the scopes makes the slot independent of the caller's ordering.
+//
+// adk-python's credential key is also a digest rather than a joined string —
+// two SHA-256s truncated to 16 hex characters, over canonical JSON of the auth
+// scheme and of the credential used to obtain it (auth_tool.py,
+// _stable_model_digest). This one covers the same ground by a different route:
+// Go cannot digest the credential, since a Client's own credentials are opaque
+// to this package, so it names the Client instead.
 func cacheSlot(c *Client, s ProviderScheme) string {
 	scopes := slices.Clone(s.Scopes)
 	slices.Sort(scopes)
@@ -266,9 +275,10 @@ func (p *provider) Credential(ctx context.Context) (auth.Credential, error) {
 		return nil, fmt.Errorf("%w: the invocation's session carries no user", ErrNoActingUser)
 	}
 
-	// Before the cache read, because the client is part of the cache key. Costs a
-	// mutex on the hot path: the client is built at most once, and a provider
-	// that has never built one has nothing cached under its slot either.
+	// Before the cache read, because the Client is part of the cache key and a
+	// provider that has not built one yet has no slot, so nothing can be cached
+	// under it. Costs one mutex on the hot path; the client is built at most
+	// once.
 	client, err := p.resolveClient(ctx)
 	if err != nil {
 		// Deliberately not qualified by resource: a client-init failure is about
@@ -305,18 +315,20 @@ func (p *provider) Credential(ctx context.Context) (auth.Credential, error) {
 // cache stores r under key, best-effort: a store write failure must not fail
 // auth.
 //
-// Nothing is stored unless the service gave a lifetime that is still running.
-// That single test covers three cases: the service reported no expiry, meaning
-// it cannot say when the token dies, so the credential cannot be vouched for
-// later; it reported an unparseable one, which reaches here as the same zero
-// time; or it reported one already spent, which a store deriving a TTL from it
-// would turn into a negative one.
+// Nothing is stored unless the service gave a lifetime with enough left to be
+// worth reading back. That single test covers four cases: the service reported
+// no expiry, meaning it cannot say when the token dies, so the credential cannot
+// be vouched for later; it reported an unparseable one, which reaches here as
+// the same zero time; it reported one already spent, which a store deriving a
+// TTL from it would turn into a negative one; or it reported one so close that
+// a store applying the standard margin would refuse to serve the entry the
+// moment it was written.
 //
 // The far end is clamped rather than rejected, so a wildly distant expiry —
 // wrong, or injected — shortens to the cap instead of pinning the entry.
 func (p *provider) cache(ctx context.Context, key auth.CredentialKey, r *Retrieval) {
 	now := platform.Now(ctx)
-	if !r.ExpiresAt.After(now) {
+	if !r.ExpiresAt.After(now.Add(auth.ExpirySkew)) {
 		return
 	}
 	expiresAt := r.ExpiresAt

--- a/auth/gcp/provider.go
+++ b/auth/gcp/provider.go
@@ -19,11 +19,13 @@ import (
 	"errors"
 	"fmt"
 	"slices"
+	"strings"
 	"sync"
 	"time"
 
 	"google.golang.org/adk/v2/agent"
 	"google.golang.org/adk/v2/auth"
+	"google.golang.org/adk/v2/platform"
 )
 
 // ProviderScheme identifies a GCP auth resource and the access it requests. It
@@ -158,6 +160,7 @@ func NewProvider(ctx context.Context, cfg ProviderConfig) (auth.CredentialProvid
 		scheme:      cfg.Scheme,
 		client:      cfg.Client,
 		store:       store,
+		slot:        schemeSlot(cfg.Scheme),
 		newClient:   func(ctx context.Context) (*Client, error) { return NewClient(ctx, nil) },
 		initTimeout: defaultInitTimeout,
 	}
@@ -172,8 +175,22 @@ func NewProvider(ctx context.Context, cfg ProviderConfig) (auth.CredentialProvid
 	return p, nil
 }
 
+// maxCachedLifetime caps how long a credential is cached, whatever expiry the
+// service reports, so a bad or injected expireTime cannot pin one indefinitely.
+const maxCachedLifetime = time.Hour
+
+// schemeSlot is the store slot for a scheme. Scopes and the continue URI shape
+// what the minted token authorizes, so credentials that differ in them must not
+// share an entry; the sort makes the slot independent of the caller's ordering.
+func schemeSlot(s ProviderScheme) string {
+	scopes := slices.Clone(s.Scopes)
+	slices.Sort(scopes)
+	return s.Name + "|" + strings.Join(scopes, ",") + "|" + s.ContinueURI
+}
+
 type provider struct {
 	scheme ProviderScheme
+	slot   string
 	store  auth.CredentialStore
 	// initCtx roots the lazily built default client, which is why NewProvider
 	// asks for a process-scoped context. Nil when a Client was supplied.
@@ -225,9 +242,13 @@ func (p *provider) Credential(ctx context.Context) (auth.Credential, error) {
 		return nil, fmt.Errorf("%w: the invocation's session carries no user", ErrNoActingUser)
 	}
 
-	key := auth.CredentialKey{AppName: id.AppName, UserID: id.UserID, Key: p.scheme.Name}
+	// The slot covers everything that shapes the minted token, not just the
+	// resource: a store shared by a broad and a narrow provider would otherwise
+	// serve the broad token to the narrow one.
+	key := auth.CredentialKey{AppName: id.AppName, UserID: id.UserID, Key: p.slot}
 	// A store read error is non-fatal: fall through and fetch a fresh credential.
-	if cred, ok, err := p.store.Get(ctx, key); err == nil && ok {
+	// A hit carrying no credential is treated as a miss; the interface allows it.
+	if cred, ok, err := p.store.Get(ctx, key); err == nil && ok && cred != nil {
 		return cred, nil
 	}
 
@@ -250,12 +271,15 @@ func (p *provider) Credential(ctx context.Context) (auth.Credential, error) {
 	if err != nil {
 		return nil, err
 	}
-	// Cache only when the service reported an expiry: a zero time means "never
-	// expires" to the store, and the GCP services omit it only when the lifetime
-	// is unknown — caching that would risk serving a stale credential forever.
-	// Best-effort: a store write failure must not fail auth.
+	// Cache only when the service reported an expiry; it omits one when the
+	// lifetime is unknown, and a credential with no known lifetime cannot be
+	// vouched for later. Best-effort: a store write failure must not fail auth.
 	if !r.ExpiresAt.IsZero() {
-		_ = p.store.Set(ctx, key, r.Credential, r.ExpiresAt)
+		expiresAt := r.ExpiresAt
+		if capped := platform.Now(ctx).Add(maxCachedLifetime); expiresAt.After(capped) {
+			expiresAt = capped
+		}
+		_ = p.store.Set(ctx, key, r.Credential, expiresAt)
 	}
 	return r.Credential, nil
 }

--- a/auth/gcp/provider.go
+++ b/auth/gcp/provider.go
@@ -59,6 +59,11 @@ type ProviderConfig struct {
 	// synchronously, so the cost and any failure move to startup, where they can
 	// at least be reported.
 	Client *Client
+	// Store caches resolved credentials across requests (keyed by app, user, and
+	// resource). When nil, an in-memory store is used. Caching matters here
+	// because each miss is a network round-trip (and up to a ~10s pending poll)
+	// to the credential service.
+	Store auth.CredentialStore
 }
 
 // ErrClientUnavailable means the default Application Default Credentials client
@@ -145,9 +150,14 @@ func NewProvider(ctx context.Context, cfg ProviderConfig) (auth.CredentialProvid
 	if cfg.Client != nil && cfg.Client.httpClient == nil {
 		return nil, errors.New("gcp: ProviderConfig.Client must come from NewClient")
 	}
+	store := cfg.Store
+	if store == nil {
+		store = auth.NewInMemoryCredentialStore()
+	}
 	p := &provider{
 		scheme:      cfg.Scheme,
 		client:      cfg.Client,
+		store:       store,
 		newClient:   func(ctx context.Context) (*Client, error) { return NewClient(ctx, nil) },
 		initTimeout: defaultInitTimeout,
 	}
@@ -164,6 +174,7 @@ func NewProvider(ctx context.Context, cfg ProviderConfig) (auth.CredentialProvid
 
 type provider struct {
 	scheme ProviderScheme
+	store  auth.CredentialStore
 	// initCtx roots the lazily built default client, which is why NewProvider
 	// asks for a process-scoped context. Nil when a Client was supplied.
 	initCtx context.Context
@@ -214,6 +225,12 @@ func (p *provider) Credential(ctx context.Context) (auth.Credential, error) {
 		return nil, fmt.Errorf("%w: the invocation's session carries no user", ErrNoActingUser)
 	}
 
+	key := auth.CredentialKey{AppName: id.AppName, UserID: id.UserID, Key: p.scheme.Name}
+	// A store read error is non-fatal: fall through and fetch a fresh credential.
+	if cred, ok, err := p.store.Get(ctx, key); err == nil && ok {
+		return cred, nil
+	}
+
 	client, err := p.resolveClient(ctx)
 	if err != nil {
 		// Deliberately not qualified by resource: a client-init failure is about
@@ -224,7 +241,7 @@ func (p *provider) Credential(ctx context.Context) (auth.Credential, error) {
 		// provider to do it for them.
 		return nil, err
 	}
-	cred, err := client.RetrieveCredential(ctx, Request{
+	r, err := client.RetrieveCredential(ctx, Request{
 		Resource:    p.scheme.Name,
 		UserID:      id.UserID,
 		Scopes:      p.scheme.Scopes,
@@ -233,7 +250,14 @@ func (p *provider) Credential(ctx context.Context) (auth.Credential, error) {
 	if err != nil {
 		return nil, err
 	}
-	return cred, nil
+	// Cache only when the service reported an expiry: a zero time means "never
+	// expires" to the store, and the GCP services omit it only when the lifetime
+	// is unknown — caching that would risk serving a stale credential forever.
+	// Best-effort: a store write failure must not fail auth.
+	if !r.ExpiresAt.IsZero() {
+		_ = p.store.Set(ctx, key, r.Credential, r.ExpiresAt)
+	}
+	return r.Credential, nil
 }
 
 // resolveClient returns the configured client, building a default one (backed by

--- a/auth/gcp/provider.go
+++ b/auth/gcp/provider.go
@@ -78,7 +78,10 @@ type ProviderConfig struct {
 	// The cost of caching is staleness. A credential revoked before it expires
 	// keeps being served until the cached entry does, which is the service's
 	// expiry or an hour, whichever comes first. To invalidate one sooner, pass
-	// [Client.CacheKey] to [auth.CredentialStore.Delete].
+	// [Client.CacheKey] to [auth.CredentialStore.Delete] — which needs a Client,
+	// so set one here rather than leaving it to the lazy default if you intend to
+	// invalidate at all. The provider does not expose the Client it builds for
+	// itself.
 	Store auth.CredentialStore
 }
 
@@ -101,8 +104,8 @@ var ErrClientUnavailable = errors.New("gcp: default credentials client unavailab
 
 // ErrNoActingUser means the provider could not determine the acting end user,
 // either because the context is not an ADK context or because the invocation
-// carries no user. Unlike adk-python, which degrades such a turn into an auth
-// request, the Go provider fails the request: no user, no credential.
+// carries no user. No user, no credential — the same call adk-python makes,
+// which raises on a missing user id rather than degrading the turn.
 var ErrNoActingUser = errors.New("gcp: no acting user")
 
 // defaultInitTimeout bounds how long a caller waits for the default client. The
@@ -206,12 +209,15 @@ const maxCachedLifetime = time.Hour
 // delimiters inside a scope or a URI can collide two different schemes. Sorting
 // the scopes makes the slot independent of the caller's ordering.
 //
-// adk-python's credential key is also a digest rather than a joined string —
-// two SHA-256s truncated to 16 hex characters, over canonical JSON of the auth
-// scheme and of the credential used to obtain it (auth_tool.py,
-// _stable_model_digest). This one covers the same ground by a different route:
-// Go cannot digest the credential, since a Client's own credentials are opaque
-// to this package, so it names the Client instead.
+// There is no adk-python original to match. Python's credential service is not
+// on this provider's path at all: GcpAuthProviderScheme is a CustomAuthScheme,
+// and CredentialManager returns the provider's credential directly without ever
+// loading or saving one (credential_manager.py). Caching GCP credentials is a Go
+// addition, and this slot is its own design. The nearest analogue is
+// _stable_model_digest (auth_tool.py), which hashes canonical JSON of the auth
+// scheme and of the credential used to obtain it — the second of which Go cannot
+// do, a Client's credentials being opaque to this package, hence naming the
+// Client instead.
 func cacheSlot(c *Client, s ProviderScheme) string {
 	scopes := slices.Clone(s.Scopes)
 	slices.Sort(scopes)

--- a/auth/gcp/provider.go
+++ b/auth/gcp/provider.go
@@ -16,10 +16,12 @@ package gcp
 
 import (
 	"context"
+	"crypto/sha256"
+	"encoding/hex"
 	"errors"
 	"fmt"
 	"slices"
-	"strings"
+	"strconv"
 	"sync"
 	"time"
 
@@ -61,10 +63,20 @@ type ProviderConfig struct {
 	// synchronously, so the cost and any failure move to startup, where they can
 	// at least be reported.
 	Client *Client
-	// Store caches resolved credentials across requests (keyed by app, user, and
-	// resource). When nil, an in-memory store is used. Caching matters here
-	// because each miss is a network round-trip (and up to a ~10s pending poll)
-	// to the credential service.
+	// Store caches resolved credentials across requests. When nil, a private
+	// in-memory store is used. Caching matters here because each miss is a
+	// network round-trip (and up to a ~10s pending poll) to the credential
+	// service.
+	//
+	// One store can safely back several providers: entries are keyed by the app,
+	// the end user, and everything that decides what the service returns — the
+	// resource, the scopes, the continue URI, and the Client. Providers whose
+	// Clients authenticate as different identities do not share entries.
+	//
+	// The cost of caching is staleness. A credential revoked before it expires
+	// keeps being served until the cached entry does, which is the service's
+	// expiry or an hour, whichever comes first. Call
+	// [auth.CredentialStore.Delete] to invalidate one sooner.
 	Store auth.CredentialStore
 }
 
@@ -160,7 +172,6 @@ func NewProvider(ctx context.Context, cfg ProviderConfig) (auth.CredentialProvid
 		scheme:      cfg.Scheme,
 		client:      cfg.Client,
 		store:       store,
-		slot:        schemeSlot(cfg.Scheme),
 		newClient:   func(ctx context.Context) (*Client, error) { return NewClient(ctx, nil) },
 		initTimeout: defaultInitTimeout,
 	}
@@ -179,18 +190,31 @@ func NewProvider(ctx context.Context, cfg ProviderConfig) (auth.CredentialProvid
 // service reports, so a bad or injected expireTime cannot pin one indefinitely.
 const maxCachedLifetime = time.Hour
 
-// schemeSlot is the store slot for a scheme. Scopes and the continue URI shape
-// what the minted token authorizes, so credentials that differ in them must not
-// share an entry; the sort makes the slot independent of the caller's ordering.
-func schemeSlot(s ProviderScheme) string {
+// cacheSlot is the store slot a credential for s, minted through c, is cached
+// under. It covers everything that decides what comes back: the client (which
+// fixes both the service asked and the identity the ask is authenticated as),
+// the resource, the scopes, and the continue URI. A store shared by several
+// providers would otherwise serve one provider's credential to another —
+// the broad token to a read-only provider, or one caller identity's token to a
+// second identity's provider.
+//
+// The components are length-prefixed before hashing, so no combination of
+// delimiters inside a scope or a URI can collide two different schemes. Sorting
+// the scopes makes the slot independent of the caller's ordering. adk-python
+// keys its credential service the same way, on a SHA-256 digest of a canonical
+// encoding of the whole scheme plus the credential used to obtain it.
+func cacheSlot(c *Client, s ProviderScheme) string {
 	scopes := slices.Clone(s.Scopes)
 	slices.Sort(scopes)
-	return s.Name + "|" + strings.Join(scopes, ",") + "|" + s.ContinueURI
+	fields := []string{c.cacheSlot, s.Name, strconv.Itoa(len(scopes))}
+	fields = append(fields, scopes...)
+	fields = append(fields, s.ContinueURI)
+	sum := sha256.Sum256([]byte(joinFields(fields...)))
+	return hex.EncodeToString(sum[:])
 }
 
 type provider struct {
 	scheme ProviderScheme
-	slot   string
 	store  auth.CredentialStore
 	// initCtx roots the lazily built default client, which is why NewProvider
 	// asks for a process-scoped context. Nil when a Client was supplied.
@@ -242,16 +266,9 @@ func (p *provider) Credential(ctx context.Context) (auth.Credential, error) {
 		return nil, fmt.Errorf("%w: the invocation's session carries no user", ErrNoActingUser)
 	}
 
-	// The slot covers everything that shapes the minted token, not just the
-	// resource: a store shared by a broad and a narrow provider would otherwise
-	// serve the broad token to the narrow one.
-	key := auth.CredentialKey{AppName: id.AppName, UserID: id.UserID, Key: p.slot}
-	// A store read error is non-fatal: fall through and fetch a fresh credential.
-	// A hit carrying no credential is treated as a miss; the interface allows it.
-	if cred, ok, err := p.store.Get(ctx, key); err == nil && ok && cred != nil {
-		return cred, nil
-	}
-
+	// Before the cache read, because the client is part of the cache key. Costs a
+	// mutex on the hot path: the client is built at most once, and a provider
+	// that has never built one has nothing cached under its slot either.
 	client, err := p.resolveClient(ctx)
 	if err != nil {
 		// Deliberately not qualified by resource: a client-init failure is about
@@ -262,6 +279,16 @@ func (p *provider) Credential(ctx context.Context) (auth.Credential, error) {
 		// provider to do it for them.
 		return nil, err
 	}
+
+	key := auth.CredentialKey{AppName: id.AppName, UserID: id.UserID, Key: cacheSlot(client, p.scheme)}
+	// A store read error is non-fatal: fall through and fetch a fresh credential.
+	// A hit carrying no credential is a miss, though the interface forbids one:
+	// a third-party store is not worth failing closed over, and returning a nil
+	// credential to auth.Transport would fail the request anyway.
+	if cred, ok, err := p.store.Get(ctx, key); err == nil && ok && cred != nil {
+		return cred, nil
+	}
+
 	r, err := client.RetrieveCredential(ctx, Request{
 		Resource:    p.scheme.Name,
 		UserID:      id.UserID,
@@ -271,17 +298,45 @@ func (p *provider) Credential(ctx context.Context) (auth.Credential, error) {
 	if err != nil {
 		return nil, err
 	}
-	// Cache only when the service reported an expiry; it omits one when the
-	// lifetime is unknown, and a credential with no known lifetime cannot be
-	// vouched for later. Best-effort: a store write failure must not fail auth.
-	if !r.ExpiresAt.IsZero() {
-		expiresAt := r.ExpiresAt
-		if capped := platform.Now(ctx).Add(maxCachedLifetime); expiresAt.After(capped) {
-			expiresAt = capped
-		}
-		_ = p.store.Set(ctx, key, r.Credential, expiresAt)
-	}
+	p.cache(ctx, key, r)
 	return r.Credential, nil
+}
+
+// cache stores r under key, best-effort: a store write failure must not fail
+// auth.
+//
+// Nothing is stored unless the service gave a lifetime that is still running.
+// That single test covers three cases: the service reported no expiry, meaning
+// it cannot say when the token dies, so the credential cannot be vouched for
+// later; it reported an unparseable one, which reaches here as the same zero
+// time; or it reported one already spent, which a store deriving a TTL from it
+// would turn into a negative one.
+//
+// The far end is clamped rather than rejected, so a wildly distant expiry —
+// wrong, or injected — shortens to the cap instead of pinning the entry.
+func (p *provider) cache(ctx context.Context, key auth.CredentialKey, r *Retrieval) {
+	now := platform.Now(ctx)
+	if !r.ExpiresAt.After(now) {
+		return
+	}
+	expiresAt := r.ExpiresAt
+	if capped := now.Add(maxCachedLifetime); expiresAt.After(capped) {
+		expiresAt = capped
+	}
+	_ = p.store.Set(ctx, key, r.Credential, expiresAt)
+}
+
+// attribute names the resource a retrieval failure belongs to: several providers
+// can be wired into one process, and an unattributed error says nothing about
+// which.
+//
+// It names nothing else. This error becomes the tool's error, which is fed to
+// the model and persisted in the session, and every id available here is
+// supplied by the caller — a user id is commonly an email, and a session id
+// arrives unvalidated from the request path. The invocation is already
+// identified by the trace and the session the error is stored in.
+func (p *provider) attribute(err error) error {
+	return fmt.Errorf("gcp: resource %q: %w", p.scheme.Name, err)
 }
 
 // resolveClient returns the configured client, building a default one (backed by

--- a/auth/gcp/provider.go
+++ b/auth/gcp/provider.go
@@ -347,19 +347,6 @@ func (p *provider) cache(ctx context.Context, key auth.CredentialKey, r *Retriev
 	_ = p.store.Set(ctx, key, r.Credential, expiresAt)
 }
 
-// attribute names the resource a retrieval failure belongs to: several providers
-// can be wired into one process, and an unattributed error says nothing about
-// which.
-//
-// It names nothing else. This error becomes the tool's error, which is fed to
-// the model and persisted in the session, and every id available here is
-// supplied by the caller — a user id is commonly an email, and a session id
-// arrives unvalidated from the request path. The invocation is already
-// identified by the trace and the session the error is stored in.
-func (p *provider) attribute(err error) error {
-	return fmt.Errorf("gcp: resource %q: %w", p.scheme.Name, err)
-}
-
 // resolveClient returns the configured client, building a default one (backed by
 // Application Default Credentials) on first use.
 //

--- a/auth/gcp/provider.go
+++ b/auth/gcp/provider.go
@@ -27,7 +27,6 @@ import (
 
 	"google.golang.org/adk/v2/agent"
 	"google.golang.org/adk/v2/auth"
-	"google.golang.org/adk/v2/platform"
 )
 
 // ProviderScheme identifies a GCP auth resource and the access it requests. It
@@ -332,8 +331,12 @@ func (p *provider) Credential(ctx context.Context) (auth.Credential, error) {
 //
 // The far end is clamped rather than rejected, so a wildly distant expiry —
 // wrong, or injected — shortens to the cap instead of pinning the entry.
+//
+// Wall clock, not platform.Now: what is being decided is when a real credential
+// stops working, which no simulated clock changes. [auth.CredentialStore.Set]
+// says the same of the value written here.
 func (p *provider) cache(ctx context.Context, key auth.CredentialKey, r *Retrieval) {
-	now := platform.Now(ctx)
+	now := time.Now()
 	if !r.ExpiresAt.After(now.Add(auth.ExpirySkew)) {
 		return
 	}

--- a/auth/gcp/provider.go
+++ b/auth/gcp/provider.go
@@ -213,10 +213,10 @@ const maxCachedLifetime = time.Hour
 // and CredentialManager returns the provider's credential directly without ever
 // loading or saving one (credential_manager.py). Caching GCP credentials is a Go
 // addition, and this slot is its own design. The nearest analogue is
-// _stable_model_digest (auth_tool.py), which hashes canonical JSON of the auth
-// scheme and of the credential used to obtain it — the second of which Go cannot
-// do, a Client's credentials being opaque to this package, hence naming the
-// Client instead.
+// AuthConfig.get_credential_key (auth_tool.py), which joins two digests of
+// canonical JSON — one of the auth scheme, one of the credential used to obtain
+// it. Go cannot produce the second, a Client's credentials being opaque to this
+// package, so it names the Client instead.
 func cacheSlot(c *Client, s ProviderScheme) string {
 	scopes := slices.Clone(s.Scopes)
 	slices.Sort(scopes)

--- a/auth/gcp/provider_internal_test.go
+++ b/auth/gcp/provider_internal_test.go
@@ -19,6 +19,7 @@ import (
 	"errors"
 	"net/http"
 	"runtime"
+	"slices"
 	"strings"
 	"sync"
 	"sync/atomic"
@@ -476,6 +477,13 @@ func TestADCClientsDoNotShareACacheSlot(t *testing.T) {
 // the process that wrote to it, or be shared by two, and an entry written by a
 // Client that no longer exists names an identity nothing can check.
 func TestClientCacheSlotIsProcessUnique(t *testing.T) {
+	// The width is spelled out rather than derived from nonceBytes: a test that
+	// measures the constant against itself moves with it, and a nonce narrowed to
+	// a byte would collide between two processes once in 256 while still passing
+	// an inequality check almost every run. 128 bits, hex-encoded.
+	if len(clientNonce) < 32 {
+		t.Fatalf("clientNonce is %d hex characters, want at least 32 (128 bits)", len(clientNonce))
+	}
 	if clientNonce == newClientNonce() {
 		t.Fatal("clientNonce is fixed; two processes constructing Clients in the same order would collide")
 	}
@@ -485,5 +493,73 @@ func TestClientCacheSlotIsProcessUnique(t *testing.T) {
 	}
 	if !strings.Contains(c.cacheSlot, clientNonce) {
 		t.Errorf("cache slot %q does not carry the per-process nonce", c.cacheSlot)
+	}
+}
+
+// joinFields must be injective: no two distinct field lists may encode alike,
+// whatever characters the fields contain. This is what stands between a scope
+// holding a delimiter and a cross-provider cache hit, and the cache-dimension
+// tests above cannot pin it on their own — every pair they compare also differs
+// in the scope count, so an encoding that merely joined on a separator would
+// still tell them apart.
+func TestJoinFieldsIsInjective(t *testing.T) {
+	// Every field list that can be built from a small alphabet of delimiters, at
+	// every length up to 3. A separator-joining encoding collides inside this set
+	// whatever separator it picks, because each separator is itself a field value.
+	alphabet := []string{"", "a", ",", "|", ":", "0", "1:", "a,b", "a|b"}
+	var lists [][]string
+	var build func(prefix []string, depth int)
+	build = func(prefix []string, depth int) {
+		lists = append(lists, slices.Clone(prefix))
+		if depth == 0 {
+			return
+		}
+		for _, f := range alphabet {
+			build(append(prefix, f), depth-1)
+		}
+	}
+	build(nil, 3)
+
+	seen := make(map[string][]string, len(lists))
+	for _, l := range lists {
+		enc := joinFields(l...)
+		if prev, ok := seen[enc]; ok {
+			t.Fatalf("joinFields(%q) and joinFields(%q) both encode to %q", prev, l, enc)
+		}
+		seen[enc] = l
+	}
+	t.Logf("%d distinct field lists, %d distinct encodings", len(lists), len(seen))
+}
+
+// NewClient is called concurrently in production — two providers on the lazy
+// path build their default clients on goroutines they own — and a slot handed
+// out twice is a cross-principal cache hit.
+func TestNewClientSlotsAreUniqueUnderConcurrency(t *testing.T) {
+	const n = 32
+	slots := make([]string, n)
+	var wg sync.WaitGroup
+	for i := range n {
+		wg.Add(1)
+		go func() {
+			defer wg.Done()
+			c, err := NewClient(t.Context(), &Config{HTTPClient: &http.Client{}})
+			if err != nil {
+				t.Errorf("NewClient() error = %v", err)
+				return
+			}
+			slots[i] = c.cacheSlot
+		}()
+	}
+	wg.Wait()
+
+	seen := make(map[string]bool, n)
+	for _, s := range slots {
+		if s == "" {
+			t.Fatal("a Client was built with an empty cache slot")
+		}
+		if seen[s] {
+			t.Fatalf("cache slot %q was handed to two Clients", s)
+		}
+		seen[s] = true
 	}
 }

--- a/auth/gcp/provider_internal_test.go
+++ b/auth/gcp/provider_internal_test.go
@@ -450,3 +450,40 @@ func TestResolveClientBoundIsPerAttemptNotPerWaiter(t *testing.T) {
 		t.Errorf("a caller arriving halfway through the bound waited %v, a full bound being %v: the bound must be the attempt's, not the waiter's", late, p.initTimeout)
 	}
 }
+
+// Two Clients left to Application Default Credentials are still two cache
+// dimensions. NewClient resolves ADC afresh on every call and the transport
+// underneath it can come from the context, so this package cannot know that two
+// of them authenticate as the same principal — and a false miss costs a round
+// trip where a false hit discloses one principal's token to another.
+func TestADCClientsDoNotShareACacheSlot(t *testing.T) {
+	fakeADC(t)
+	newADCClient := func() *Client {
+		t.Helper()
+		c, err := NewClient(t.Context(), nil)
+		if err != nil {
+			t.Fatalf("NewClient() error = %v", err)
+		}
+		return c
+	}
+	first, second := newADCClient(), newADCClient()
+	if first.cacheSlot == second.cacheSlot {
+		t.Error("two ADC-built Clients share a cache slot, so one would be served the other's credential")
+	}
+}
+
+// A Client's cache slot must not repeat in another process. A store can outlive
+// the process that wrote to it, or be shared by two, and an entry written by a
+// Client that no longer exists names an identity nothing can check.
+func TestClientCacheSlotIsProcessUnique(t *testing.T) {
+	if clientNonce == newClientNonce() {
+		t.Fatal("clientNonce is fixed; two processes constructing Clients in the same order would collide")
+	}
+	c, err := NewClient(t.Context(), &Config{HTTPClient: &http.Client{}})
+	if err != nil {
+		t.Fatalf("NewClient() error = %v", err)
+	}
+	if !strings.Contains(c.cacheSlot, clientNonce) {
+		t.Errorf("cache slot %q does not carry the per-process nonce", c.cacheSlot)
+	}
+}

--- a/auth/gcp/provider_internal_test.go
+++ b/auth/gcp/provider_internal_test.go
@@ -499,14 +499,16 @@ func TestClientCacheSlotIsProcessUnique(t *testing.T) {
 // joinFields must be injective: no two distinct field lists may encode alike,
 // whatever characters the fields contain. This is what stands between a scope
 // holding a delimiter and a cross-provider cache hit, and the cache-dimension
-// tests above cannot pin it on their own — every pair they compare also differs
-// in the scope count, so an encoding that merely joined on a separator would
-// still tell them apart.
+// cases in provider_test.go do not pin it on their own — none of the pairs they
+// compare uses ":" as a field value, so a ":"-separated join tells them apart.
 func TestJoinFieldsIsInjective(t *testing.T) {
-	// Every field list that can be built from a small alphabet of delimiters, at
-	// every length up to 3. A separator-joining encoding collides inside this set
-	// whatever separator it picks, because each separator is itself a field value.
-	alphabet := []string{"", "a", ",", "|", ":", "0", "1:", "a,b", "a|b"}
+	// Every field list that can be built from this alphabet, at every length up to
+	// 3. A separator-joining encoding collides inside the set whatever separator
+	// it picks, because each separator is itself a field value. The long entries
+	// are load-bearing too: with every field under ten bytes the length prefix is
+	// a single digit and is self-punctuating, so dropping the ":" would survive.
+	long := strings.Repeat("a", 19)
+	alphabet := []string{"", "a", ",", "|", ":", "0", "1:", "a,b", "a|b", "23", long, "319" + long}
 	var lists [][]string
 	var build func(prefix []string, depth int)
 	build = func(prefix []string, depth int) {

--- a/auth/gcp/provider_test.go
+++ b/auth/gcp/provider_test.go
@@ -22,12 +22,15 @@ import (
 	"net/http"
 	"net/http/httptest"
 	"slices"
+	"strings"
 	"sync/atomic"
 	"testing"
+	"time"
 
 	"google.golang.org/adk/v2/auth"
 	"google.golang.org/adk/v2/auth/gcp"
 	icontext "google.golang.org/adk/v2/internal/context"
+	"google.golang.org/adk/v2/platform"
 	"google.golang.org/adk/v2/session"
 )
 
@@ -207,4 +210,183 @@ func adkContext(t *testing.T, userID string) context.Context {
 		t.Fatalf("session Create() error = %v", err)
 	}
 	return icontext.NewInvocationContext(t.Context(), icontext.InvocationContextParams{Session: resp.Session})
+}
+
+// TestProviderCacheIsolatesPrincipals is the guard on the cache's headline
+// property: a long-lived provider must never serve one principal's credential
+// to another. Collapsing the cache key leaves every other test green.
+func TestProviderCacheIsolatesPrincipals(t *testing.T) {
+	var calls int32
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		atomic.AddInt32(&calls, 1)
+		var body struct {
+			UserID string `json:"userId"`
+		}
+		_ = json.NewDecoder(r.Body).Decode(&body)
+		// Echo the caller, so a credential served to the wrong principal shows up.
+		_, _ = io.WriteString(w, `{"success":{"token":"tok-`+body.UserID+`","header":"Authorization: Bearer","expireTime":"2999-01-01T00:00:00Z"}}`)
+	}))
+	defer srv.Close()
+
+	client, err := gcp.NewClient(t.Context(), &gcp.Config{HTTPClient: srv.Client(), AgentIdentityEndpoint: srv.URL})
+	if err != nil {
+		t.Fatalf("NewClient() error = %v", err)
+	}
+	p, err := gcp.NewProvider(gcp.Scheme{Name: "projects/p/locations/l/authProviders/ap"}, &gcp.ProviderConfig{Client: client})
+	if err != nil {
+		t.Fatalf("NewProvider() error = %v", err)
+	}
+
+	// Twice each, so the second pass reads through the cache.
+	for range 2 {
+		for _, user := range []string{"user-1", "user-2"} {
+			cred, err := p.Credential(adkContext(t, user))
+			if err != nil {
+				t.Fatalf("Credential(%q) error = %v", user, err)
+			}
+			if bc, ok := cred.(auth.BearerCredential); !ok || bc.Token != "tok-"+user {
+				t.Fatalf("%q was served %+v, want bearer %q", user, cred, "tok-"+user)
+			}
+		}
+	}
+	if got := atomic.LoadInt32(&calls); got != 2 {
+		t.Errorf("service calls = %d, want 2 (one cold read per principal)", got)
+	}
+}
+
+// A store shared by providers that differ only in scopes must not serve the
+// broad credential to the narrow one.
+func TestProviderCacheSeparatesScopes(t *testing.T) {
+	var gotScopes [][]string
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		var body struct {
+			Scopes []string `json:"scopes"`
+		}
+		_ = json.NewDecoder(r.Body).Decode(&body)
+		gotScopes = append(gotScopes, body.Scopes)
+		_, _ = io.WriteString(w, `{"success":{"token":"tok-`+strings.Join(body.Scopes, ",")+`","header":"Authorization: Bearer","expireTime":"2999-01-01T00:00:00Z"}}`)
+	}))
+	defer srv.Close()
+
+	client, err := gcp.NewClient(t.Context(), &gcp.Config{HTTPClient: srv.Client(), AgentIdentityEndpoint: srv.URL})
+	if err != nil {
+		t.Fatalf("NewClient() error = %v", err)
+	}
+	store := auth.NewInMemoryCredentialStore()
+	newProvider := func(scope string) auth.CredentialProvider {
+		t.Helper()
+		p, err := gcp.NewProvider(
+			gcp.Scheme{Name: "projects/p/locations/l/authProviders/ap", Scopes: []string{scope}},
+			&gcp.ProviderConfig{Client: client, Store: store},
+		)
+		if err != nil {
+			t.Fatalf("NewProvider() error = %v", err)
+		}
+		return p
+	}
+
+	for _, scope := range []string{"drive", "drive.readonly"} {
+		cred, err := newProvider(scope).Credential(adkContext(t, "user-1"))
+		if err != nil {
+			t.Fatalf("Credential(%q) error = %v", scope, err)
+		}
+		if bc, ok := cred.(auth.BearerCredential); !ok || bc.Token != "tok-"+scope {
+			t.Errorf("scope %q was served %+v, want bearer %q", scope, cred, "tok-"+scope)
+		}
+	}
+	if len(gotScopes) != 2 {
+		t.Errorf("service calls = %d, want 2 (the narrow provider must not reuse the broad entry)", len(gotScopes))
+	}
+}
+
+// recordingStore reports every call, and can fail writes.
+type recordingStore struct {
+	inner   auth.CredentialStore
+	sets    int
+	gets    int
+	setErr  error
+	nilOnce bool // return a hit carrying no credential on the first Get
+}
+
+func (s *recordingStore) Get(ctx context.Context, key auth.CredentialKey) (auth.Credential, bool, error) {
+	s.gets++
+	if s.nilOnce {
+		s.nilOnce = false
+		return nil, true, nil
+	}
+	return s.inner.Get(ctx, key)
+}
+
+func (s *recordingStore) Set(ctx context.Context, key auth.CredentialKey, cred auth.Credential, expiresAt time.Time) error {
+	s.sets++
+	if s.setErr != nil {
+		return s.setErr
+	}
+	return s.inner.Set(ctx, key, cred, expiresAt)
+}
+
+func (s *recordingStore) Delete(ctx context.Context, key auth.CredentialKey) error {
+	return s.inner.Delete(ctx, key)
+}
+
+// A configured store is actually used, a write failure does not fail auth, and
+// a hit carrying no credential is treated as a miss rather than returned.
+func TestProviderStorePlumbing(t *testing.T) {
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		_, _ = io.WriteString(w, `{"success":{"token":"tok","header":"Authorization: Bearer","expireTime":"2999-01-01T00:00:00Z"}}`)
+	}))
+	defer srv.Close()
+	client, err := gcp.NewClient(t.Context(), &gcp.Config{HTTPClient: srv.Client(), AgentIdentityEndpoint: srv.URL})
+	if err != nil {
+		t.Fatalf("NewClient() error = %v", err)
+	}
+
+	store := &recordingStore{inner: auth.NewInMemoryCredentialStore(), setErr: errors.New("disk on fire"), nilOnce: true}
+	p, err := gcp.NewProvider(
+		gcp.Scheme{Name: "projects/p/locations/l/authProviders/ap"},
+		&gcp.ProviderConfig{Client: client, Store: store},
+	)
+	if err != nil {
+		t.Fatalf("NewProvider() error = %v", err)
+	}
+	cred, err := p.Credential(adkContext(t, "user-1"))
+	if err != nil {
+		t.Fatalf("Credential() error = %v; a store write failure must not fail auth", err)
+	}
+	if cred == nil {
+		t.Fatal("Credential() = nil credential; a hit with no credential must be treated as a miss")
+	}
+	if store.gets != 1 || store.sets != 1 {
+		t.Errorf("store gets/sets = %d/%d, want 1/1 (the configured store must be used)", store.gets, store.sets)
+	}
+}
+
+// The service's expiry is honoured only up to a bound, so a bad or injected
+// expireTime cannot pin a credential in the cache.
+func TestProviderClampsServiceExpiry(t *testing.T) {
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		_, _ = io.WriteString(w, `{"success":{"token":"tok","header":"Authorization: Bearer","expireTime":"9999-12-31T23:59:59Z"}}`)
+	}))
+	defer srv.Close()
+	client, err := gcp.NewClient(t.Context(), &gcp.Config{HTTPClient: srv.Client(), AgentIdentityEndpoint: srv.URL})
+	if err != nil {
+		t.Fatalf("NewClient() error = %v", err)
+	}
+	store := &recordingStore{inner: auth.NewInMemoryCredentialStore()}
+	p, err := gcp.NewProvider(
+		gcp.Scheme{Name: "projects/p/locations/l/authProviders/ap"},
+		&gcp.ProviderConfig{Client: client, Store: store},
+	)
+	if err != nil {
+		t.Fatalf("NewProvider() error = %v", err)
+	}
+	if _, err := p.Credential(adkContext(t, "user-1")); err != nil {
+		t.Fatalf("Credential() error = %v", err)
+	}
+	// Far past the cap: the entry must already be gone a day later.
+	future := platform.WithTimeProvider(t.Context(), func() time.Time { return time.Now().Add(24 * time.Hour) })
+	key := auth.CredentialKey{AppName: "app", UserID: "user-1", Key: "projects/p/locations/l/authProviders/ap||"}
+	if _, ok, _ := store.inner.Get(future, key); ok {
+		t.Error("credential still cached a day later, want the service expiry clamped")
+	}
 }

--- a/auth/gcp/provider_test.go
+++ b/auth/gcp/provider_test.go
@@ -22,6 +22,7 @@ import (
 	"net/http"
 	"net/http/httptest"
 	"slices"
+	"sync/atomic"
 	"testing"
 
 	"google.golang.org/adk/v2/auth"
@@ -131,6 +132,68 @@ func TestNewProviderRejectsUnconstructedClient(t *testing.T) {
 func TestNewProviderValidatesScheme(t *testing.T) {
 	if _, err := gcp.NewProvider(gcp.Scheme{}, nil); err == nil {
 		t.Fatal("NewProvider() = nil error, want error for empty scheme Name")
+	}
+}
+
+func TestProviderCachesCredential(t *testing.T) {
+	var calls int32
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		atomic.AddInt32(&calls, 1)
+		_, _ = io.WriteString(w, `{"success":{"token":"tok","header":"Authorization: Bearer","expireTime":"2999-01-01T00:00:00Z"}}`)
+	}))
+	defer srv.Close()
+
+	client, err := gcp.NewClient(t.Context(), &gcp.Config{
+		HTTPClient:            srv.Client(),
+		AgentIdentityEndpoint: srv.URL,
+	})
+	if err != nil {
+		t.Fatalf("NewClient() error = %v", err)
+	}
+	// Default (in-memory) store; two resolves for the same app+user+resource.
+	p, err := gcp.NewProvider(gcp.Scheme{Name: "projects/p/locations/l/authProviders/ap"}, &gcp.ProviderConfig{Client: client})
+	if err != nil {
+		t.Fatalf("NewProvider() error = %v", err)
+	}
+
+	for i := range 2 {
+		if _, err := p.Credential(adkContext(t, "user-1")); err != nil {
+			t.Fatalf("call %d: Credential() error = %v", i, err)
+		}
+	}
+	if got := atomic.LoadInt32(&calls); got != 1 {
+		t.Errorf("service calls = %d, want 1 (second resolve should hit the cache)", got)
+	}
+}
+
+func TestProviderSkipsCacheWithoutExpiry(t *testing.T) {
+	var calls int32
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		atomic.AddInt32(&calls, 1)
+		// No expireTime: lifetime unknown, so the provider must not cache.
+		_, _ = io.WriteString(w, `{"success":{"token":"tok","header":"Authorization: Bearer"}}`)
+	}))
+	defer srv.Close()
+
+	client, err := gcp.NewClient(t.Context(), &gcp.Config{
+		HTTPClient:            srv.Client(),
+		AgentIdentityEndpoint: srv.URL,
+	})
+	if err != nil {
+		t.Fatalf("NewClient() error = %v", err)
+	}
+	p, err := gcp.NewProvider(gcp.Scheme{Name: "projects/p/locations/l/authProviders/ap"}, &gcp.ProviderConfig{Client: client})
+	if err != nil {
+		t.Fatalf("NewProvider() error = %v", err)
+	}
+
+	for i := range 2 {
+		if _, err := p.Credential(adkContext(t, "user-1")); err != nil {
+			t.Fatalf("call %d: Credential() error = %v", i, err)
+		}
+	}
+	if got := atomic.LoadInt32(&calls); got != 2 {
+		t.Errorf("service calls = %d, want 2 (unknown expiry must not be cached)", got)
 	}
 }
 

--- a/auth/gcp/provider_test.go
+++ b/auth/gcp/provider_test.go
@@ -33,7 +33,6 @@ import (
 	"google.golang.org/adk/v2/auth"
 	"google.golang.org/adk/v2/auth/gcp"
 	icontext "google.golang.org/adk/v2/internal/context"
-	"google.golang.org/adk/v2/platform"
 	"google.golang.org/adk/v2/session"
 )
 
@@ -1139,48 +1138,82 @@ func TestProviderCacheSeparatesClientInstances(t *testing.T) {
 }
 
 // TestProviderCachedExpiry pins what lifetime the provider is willing to cache
-// for. The store is asked directly rather than inferred from a call count, so
-// each case fails loudly if the provider stops calling Set at all.
+// for. The store is asked what it was handed rather than inferring from a call
+// count, so each case fails loudly if the provider stops calling Set at all.
+//
+// Expiries are relative to the wall clock, because that is the clock the whole
+// path now uses: a credential dies when the issuer says it does, not when a
+// simulated clock says so.
 func TestProviderCachedExpiry(t *testing.T) {
-	now := time.Date(2030, 1, 1, 0, 0, 0, 0, time.UTC)
+	const noCache = time.Duration(0)
 	tests := []struct {
-		name       string
-		expireTime string    // what the service reports
-		want       time.Time // zero means: must not be cached
+		name string
+		// left is how much life the service reports, from now. The zero value
+		// means the service reports no expiry at all.
+		left string
+		// want is the lifetime the store should be handed, or noCache. When clamped
+		// is set it is measured from the provider's clock; otherwise the service's
+		// own expiry must be passed through untouched.
+		want    time.Duration
+		clamped bool
 	}{
-		{"honored as reported", "2030-01-01T00:05:00Z", now.Add(5 * time.Minute)},
-		// A short-lived credential is still worth caching. Together with the
-		// boundary cases below this pins auth.ExpirySkew to something under a
-		// minute: widen it and this stops being cached at all.
-		{"a minute of life left", "2030-01-01T00:01:00Z", now.Add(time.Minute)},
-		// Inside the margin the store applies, so the entry would be written and
+		{name: "honored as reported", left: "5m", want: 5 * time.Minute},
+		// A short-lived credential is still worth caching. With the boundary cases
+		// below this pins auth.ExpirySkew under a minute: widen it and this stops
+		// being cached at all.
+		{name: "a minute of life left", left: "1m", want: time.Minute},
+		{name: "clamped to the cap", left: "8760h", want: maxCachedLifetimeForTest, clamped: true},
+		// At or inside the margin the store applies, the entry would be written and
 		// then refused on the very next read: a guaranteed-dead write.
-		{"less left than the store's margin", "2030-01-01T00:00:05Z", time.Time{}},
-		{"exactly the store's margin", "2030-01-01T00:00:10Z", time.Time{}},
-		{"clamped to the cap", "9999-12-31T23:59:59Z", now.Add(maxCachedLifetimeForTest)},
-		{"absent", "", time.Time{}},
-		{"already past", "2029-12-31T23:00:00Z", time.Time{}},
-		{"unparseable", "not-a-time", time.Time{}},
+		{name: "less left than the store's margin", left: "5s", want: noCache},
+		{name: "exactly the store's margin", left: "10s", want: noCache},
+		{name: "already past", left: "-1h", want: noCache},
+		{name: "absent", left: "", want: noCache},
+		{name: "unparseable", left: "garbage", want: noCache},
 	}
 	for _, tc := range tests {
 		t.Run(tc.name, func(t *testing.T) {
-			e := newEchoServer(t, tc.expireTime)
+			issued := time.Now()
+			expireTime := tc.left
+			if d, err := time.ParseDuration(tc.left); err == nil {
+				expireTime = issued.Add(d).Format(time.RFC3339Nano)
+			}
+			e := newEchoServer(t, expireTime)
 			store := &recordingStore{inner: auth.NewInMemoryCredentialStore()}
 			p := newStoreProvider(t, e, store)
 
-			ctx := platform.WithTimeProvider(adkContext(t, "user-1"), func() time.Time { return now })
-			if _, err := p.Credential(ctx); err != nil {
+			before := time.Now()
+			if _, err := p.Credential(adkContext(t, "user-1")); err != nil {
 				t.Fatalf("Credential() error = %v", err)
 			}
-			switch {
-			case tc.want.IsZero():
+			after := time.Now()
+
+			if tc.want == noCache {
 				if store.sets != 0 {
-					t.Errorf("store Set called with expiry %s, want no cache write for expireTime %q", store.lastExpires, tc.expireTime)
+					t.Errorf("store Set called with expiry %s, want no cache write for expireTime %q", store.lastExpires, expireTime)
 				}
-			case store.sets != 1:
-				t.Errorf("store Set calls = %d, want 1", store.sets)
-			case !store.lastExpires.Equal(tc.want):
-				t.Errorf("cached until %s, want %s", store.lastExpires, tc.want)
+				return
+			}
+			if store.sets != 1 {
+				t.Fatalf("store Set calls = %d, want 1", store.sets)
+			}
+			if !tc.clamped {
+				// Passed through untouched, so this is exact.
+				want, err := time.Parse(time.RFC3339Nano, expireTime)
+				if err != nil {
+					t.Fatalf("parse %q: %v", expireTime, err)
+				}
+				if !store.lastExpires.Equal(want) {
+					t.Errorf("cached until %s, want the service's own %s", store.lastExpires, want)
+				}
+				return
+			}
+			// Clamped to the cap measured from the provider's own clock read, which
+			// happens somewhere between these two. The window is the test's
+			// scheduling jitter, not a tolerance on the arithmetic.
+			lo, hi := before.Add(tc.want), after.Add(tc.want)
+			if store.lastExpires.Before(lo) || store.lastExpires.After(hi) {
+				t.Errorf("cached until %s, want %s from now (between %s and %s)", store.lastExpires, tc.want, lo, hi)
 			}
 		})
 	}

--- a/auth/gcp/provider_test.go
+++ b/auth/gcp/provider_test.go
@@ -33,6 +33,7 @@ import (
 	"google.golang.org/adk/v2/auth"
 	"google.golang.org/adk/v2/auth/gcp"
 	icontext "google.golang.org/adk/v2/internal/context"
+	"google.golang.org/adk/v2/platform"
 	"google.golang.org/adk/v2/session"
 )
 
@@ -729,5 +730,187 @@ func TestRedactionCoversTheWholeSecretSurface(t *testing.T) {
 				t.Errorf("APIError.Body is %d bytes, want it capped near %d", len(apiErr.Body), cap)
 			}
 		})
+	}
+}
+
+// TestProviderCacheIsolatesPrincipals is the guard on the cache's headline
+// property: a long-lived provider must never serve one principal's credential
+// to another. Collapsing the cache key leaves every other test green.
+func TestProviderCacheIsolatesPrincipals(t *testing.T) {
+	var calls int32
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		atomic.AddInt32(&calls, 1)
+		var body struct {
+			UserID string `json:"userId"`
+		}
+		_ = json.NewDecoder(r.Body).Decode(&body)
+		// Echo the caller, so a credential served to the wrong principal shows up.
+		_, _ = io.WriteString(w, `{"success":{"token":"tok-`+body.UserID+`","header":"Authorization: Bearer","expireTime":"2999-01-01T00:00:00Z"}}`)
+	}))
+	defer srv.Close()
+
+	client, err := gcp.NewClient(t.Context(), &gcp.Config{HTTPClient: srv.Client(), AgentIdentityEndpoint: srv.URL})
+	if err != nil {
+		t.Fatalf("NewClient() error = %v", err)
+	}
+	p, err := gcp.NewProvider(t.Context(), gcp.ProviderConfig{Scheme: gcp.ProviderScheme{Name: testResource}, Client: client})
+	if err != nil {
+		t.Fatalf("NewProvider() error = %v", err)
+	}
+
+	// Twice each, so the second pass reads through the cache.
+	for range 2 {
+		for _, user := range []string{"user-1", "user-2"} {
+			cred, err := p.Credential(adkContext(t, user))
+			if err != nil {
+				t.Fatalf("Credential(%q) error = %v", user, err)
+			}
+			if bc, ok := cred.(auth.BearerCredential); !ok || bc.Token != "tok-"+user {
+				t.Fatalf("%q was served %+v, want bearer %q", user, cred, "tok-"+user)
+			}
+		}
+	}
+	if got := atomic.LoadInt32(&calls); got != 2 {
+		t.Errorf("service calls = %d, want 2 (one cold read per principal)", got)
+	}
+}
+
+// A store shared by providers that differ only in scopes must not serve the
+// broad credential to the narrow one.
+func TestProviderCacheSeparatesScopes(t *testing.T) {
+	var gotScopes [][]string
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		var body struct {
+			Scopes []string `json:"scopes"`
+		}
+		_ = json.NewDecoder(r.Body).Decode(&body)
+		gotScopes = append(gotScopes, body.Scopes)
+		_, _ = io.WriteString(w, `{"success":{"token":"tok-`+strings.Join(body.Scopes, ",")+`","header":"Authorization: Bearer","expireTime":"2999-01-01T00:00:00Z"}}`)
+	}))
+	defer srv.Close()
+
+	client, err := gcp.NewClient(t.Context(), &gcp.Config{HTTPClient: srv.Client(), AgentIdentityEndpoint: srv.URL})
+	if err != nil {
+		t.Fatalf("NewClient() error = %v", err)
+	}
+	store := auth.NewInMemoryCredentialStore()
+	newProvider := func(scope string) auth.CredentialProvider {
+		t.Helper()
+		p, err := gcp.NewProvider(t.Context(), gcp.ProviderConfig{
+			Scheme: gcp.ProviderScheme{Name: testResource, Scopes: []string{scope}},
+			Client: client,
+			Store:  store,
+		})
+		if err != nil {
+			t.Fatalf("NewProvider() error = %v", err)
+		}
+		return p
+	}
+
+	for _, scope := range []string{"drive", "drive.readonly"} {
+		cred, err := newProvider(scope).Credential(adkContext(t, "user-1"))
+		if err != nil {
+			t.Fatalf("Credential(%q) error = %v", scope, err)
+		}
+		if bc, ok := cred.(auth.BearerCredential); !ok || bc.Token != "tok-"+scope {
+			t.Errorf("scope %q was served %+v, want bearer %q", scope, cred, "tok-"+scope)
+		}
+	}
+	if len(gotScopes) != 2 {
+		t.Errorf("service calls = %d, want 2 (the narrow provider must not reuse the broad entry)", len(gotScopes))
+	}
+}
+
+// recordingStore reports every call, and can fail writes.
+type recordingStore struct {
+	inner   auth.CredentialStore
+	sets    int
+	gets    int
+	setErr  error
+	nilOnce bool // return a hit carrying no credential on the first Get
+}
+
+func (s *recordingStore) Get(ctx context.Context, key auth.CredentialKey) (auth.Credential, bool, error) {
+	s.gets++
+	if s.nilOnce {
+		s.nilOnce = false
+		return nil, true, nil
+	}
+	return s.inner.Get(ctx, key)
+}
+
+func (s *recordingStore) Set(ctx context.Context, key auth.CredentialKey, cred auth.Credential, expiresAt time.Time) error {
+	s.sets++
+	if s.setErr != nil {
+		return s.setErr
+	}
+	return s.inner.Set(ctx, key, cred, expiresAt)
+}
+
+func (s *recordingStore) Delete(ctx context.Context, key auth.CredentialKey) error {
+	return s.inner.Delete(ctx, key)
+}
+
+// A configured store is actually used, a write failure does not fail auth, and
+// a hit carrying no credential is treated as a miss rather than returned.
+func TestProviderStorePlumbing(t *testing.T) {
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		_, _ = io.WriteString(w, `{"success":{"token":"tok","header":"Authorization: Bearer","expireTime":"2999-01-01T00:00:00Z"}}`)
+	}))
+	defer srv.Close()
+	client, err := gcp.NewClient(t.Context(), &gcp.Config{HTTPClient: srv.Client(), AgentIdentityEndpoint: srv.URL})
+	if err != nil {
+		t.Fatalf("NewClient() error = %v", err)
+	}
+
+	store := &recordingStore{inner: auth.NewInMemoryCredentialStore(), setErr: errors.New("disk on fire"), nilOnce: true}
+	p, err := gcp.NewProvider(t.Context(), gcp.ProviderConfig{
+		Scheme: gcp.ProviderScheme{Name: testResource},
+		Client: client,
+		Store:  store,
+	})
+	if err != nil {
+		t.Fatalf("NewProvider() error = %v", err)
+	}
+	cred, err := p.Credential(adkContext(t, "user-1"))
+	if err != nil {
+		t.Fatalf("Credential() error = %v; a store write failure must not fail auth", err)
+	}
+	if cred == nil {
+		t.Fatal("Credential() = nil credential; a hit with no credential must be treated as a miss")
+	}
+	if store.gets != 1 || store.sets != 1 {
+		t.Errorf("store gets/sets = %d/%d, want 1/1 (the configured store must be used)", store.gets, store.sets)
+	}
+}
+
+// The service's expiry is honoured only up to a bound, so a bad or injected
+// expireTime cannot pin a credential in the cache.
+func TestProviderClampsServiceExpiry(t *testing.T) {
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		_, _ = io.WriteString(w, `{"success":{"token":"tok","header":"Authorization: Bearer","expireTime":"9999-12-31T23:59:59Z"}}`)
+	}))
+	defer srv.Close()
+	client, err := gcp.NewClient(t.Context(), &gcp.Config{HTTPClient: srv.Client(), AgentIdentityEndpoint: srv.URL})
+	if err != nil {
+		t.Fatalf("NewClient() error = %v", err)
+	}
+	store := &recordingStore{inner: auth.NewInMemoryCredentialStore()}
+	p, err := gcp.NewProvider(t.Context(), gcp.ProviderConfig{
+		Scheme: gcp.ProviderScheme{Name: testResource},
+		Client: client,
+		Store:  store,
+	})
+	if err != nil {
+		t.Fatalf("NewProvider() error = %v", err)
+	}
+	if _, err := p.Credential(adkContext(t, "user-1")); err != nil {
+		t.Fatalf("Credential() error = %v", err)
+	}
+	// Far past the cap: the entry must already be gone a day later.
+	future := platform.WithTimeProvider(t.Context(), func() time.Time { return time.Now().Add(24 * time.Hour) })
+	key := auth.CredentialKey{AppName: "app", UserID: "user-1", Key: testResource + "||"}
+	if _, ok, _ := store.inner.Get(future, key); ok {
+		t.Error("credential still cached a day later, want the service expiry clamped")
 	}
 }

--- a/auth/gcp/provider_test.go
+++ b/auth/gcp/provider_test.go
@@ -24,7 +24,6 @@ import (
 	"slices"
 	"strings"
 	"sync"
-	"sync/atomic"
 	"testing"
 	"time"
 	"unicode/utf8"
@@ -470,52 +469,19 @@ func newProvider(t *testing.T, srv *httptest.Server, scheme gcp.ProviderScheme) 
 	return p
 }
 
-func TestProviderCachesCredential(t *testing.T) {
-	var calls int32
-	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
-		atomic.AddInt32(&calls, 1)
-		_, _ = io.WriteString(w, `{"success":{"token":"tok","header":"Authorization: Bearer","expireTime":"2999-01-01T00:00:00Z"}}`)
-	}))
-	defer srv.Close()
-
-	// Default (in-memory) store; two resolves for the same app+user+resource.
-	p := newProvider(t, srv, gcp.ProviderScheme{Name: testResource})
-	for i := range 2 {
-		if _, err := p.Credential(adkContext(t, "user-1")); err != nil {
-			t.Fatalf("call %d: Credential() error = %v", i, err)
-		}
-	}
-	if got := atomic.LoadInt32(&calls); got != 1 {
-		t.Errorf("service calls = %d, want 1 (second resolve should hit the cache)", got)
-	}
-}
-
-func TestProviderSkipsCacheWithoutExpiry(t *testing.T) {
-	var calls int32
-	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
-		atomic.AddInt32(&calls, 1)
-		// No expireTime: lifetime unknown, so the provider must not cache.
-		_, _ = io.WriteString(w, `{"success":{"token":"tok","header":"Authorization: Bearer"}}`)
-	}))
-	defer srv.Close()
-
-	p := newProvider(t, srv, gcp.ProviderScheme{Name: testResource})
-	for i := range 2 {
-		if _, err := p.Credential(adkContext(t, "user-1")); err != nil {
-			t.Fatalf("call %d: Credential() error = %v", i, err)
-		}
-	}
-	if got := atomic.LoadInt32(&calls); got != 2 {
-		t.Errorf("service calls = %d, want 2 (unknown expiry must not be cached)", got)
-	}
-}
-
 // adkContext returns an ADK invocation context (recoverable via
-// agent.IdentityFromContext) for the given user.
+// agent.IdentityFromContext) for the given user, under the app name "app".
 func adkContext(t *testing.T, userID string) context.Context {
 	t.Helper()
+	return adkContextIn(t, "app", userID)
+}
+
+// adkContextIn is adkContext with the app name spelled out, for the tests that
+// vary it.
+func adkContextIn(t *testing.T, appName, userID string) context.Context {
+	t.Helper()
 	svc := session.InMemoryService()
-	resp, err := svc.Create(t.Context(), &session.CreateRequest{AppName: "app", UserID: userID})
+	resp, err := svc.Create(t.Context(), &session.CreateRequest{AppName: appName, UserID: userID})
 	if err != nil {
 		t.Fatalf("session Create() error = %v", err)
 	}
@@ -733,101 +699,242 @@ func TestRedactionCoversTheWholeSecretSurface(t *testing.T) {
 	}
 }
 
-// TestProviderCacheIsolatesPrincipals is the guard on the cache's headline
-// property: a long-lived provider must never serve one principal's credential
-// to another. Collapsing the cache key leaves every other test green.
-func TestProviderCacheIsolatesPrincipals(t *testing.T) {
-	var calls int32
-	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
-		atomic.AddInt32(&calls, 1)
+// echoServer answers every retrieval with a token naming what the request asked
+// for, so a credential served from the wrong cache entry is visible in the token
+// rather than only in a call count. It records each request.
+type echoServer struct {
+	*httptest.Server
+	mu       sync.Mutex
+	requests []echoRequest
+}
+
+type echoRequest struct {
+	userID      string
+	scopes      []string
+	continueURI string
+	caller      string // X-Caller-Identity, set by the identity transports below
+}
+
+// newEchoServer starts an echoServer whose tokens expire at expireTime (RFC
+// 3339; empty for a response that reports no expiry).
+func newEchoServer(t *testing.T, expireTime string) *echoServer {
+	t.Helper()
+	e := &echoServer{}
+	e.Server = httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		var body struct {
-			UserID string `json:"userId"`
+			UserID      string   `json:"userId"`
+			Scopes      []string `json:"scopes"`
+			ContinueURI string   `json:"continueUri"`
 		}
 		_ = json.NewDecoder(r.Body).Decode(&body)
-		// Echo the caller, so a credential served to the wrong principal shows up.
-		_, _ = io.WriteString(w, `{"success":{"token":"tok-`+body.UserID+`","header":"Authorization: Bearer","expireTime":"2999-01-01T00:00:00Z"}}`)
-	}))
-	defer srv.Close()
+		req := echoRequest{
+			userID:      body.UserID,
+			scopes:      body.Scopes,
+			continueURI: body.ContinueURI,
+			caller:      r.Header.Get("X-Caller-Identity"),
+		}
+		e.mu.Lock()
+		e.requests = append(e.requests, req)
+		e.mu.Unlock()
 
-	client, err := gcp.NewClient(t.Context(), &gcp.Config{HTTPClient: srv.Client(), AgentIdentityEndpoint: srv.URL})
-	if err != nil {
-		t.Fatalf("NewClient() error = %v", err)
+		resp := map[string]any{"token": req.token(), "header": "Authorization: Bearer"}
+		if expireTime != "" {
+			resp["expireTime"] = expireTime
+		}
+		_ = json.NewEncoder(w).Encode(map[string]any{"success": resp})
+	}))
+	t.Cleanup(e.Close)
+	return e
+}
+
+// token is the token this request is answered with: everything the service was
+// told, so any two requests that should not share a cache entry get different
+// tokens.
+func (r echoRequest) token() string {
+	return "tok|" + r.caller + "|" + r.userID + "|" + strings.Join(r.scopes, "+") + "|" + r.continueURI
+}
+
+func (e *echoServer) calls() int {
+	e.mu.Lock()
+	defer e.mu.Unlock()
+	return len(e.requests)
+}
+
+// identityTransport stamps a caller identity on every request, standing in for
+// the distinct service-account credentials a caller-supplied HTTPClient carries.
+type identityTransport struct {
+	base http.RoundTripper
+	who  string
+}
+
+func (t identityTransport) RoundTrip(r *http.Request) (*http.Response, error) {
+	r = r.Clone(r.Context())
+	r.Header.Set("X-Caller-Identity", t.who)
+	return t.base.RoundTrip(r)
+}
+
+// newSharingProvider builds a provider against e that shares store with every
+// other provider built the same way. who names the caller identity its client
+// authenticates as; two providers given the same who share one *Client.
+func newSharingProvider(t *testing.T, e *echoServer, store auth.CredentialStore, clients map[string]*gcp.Client, who string, scheme gcp.ProviderScheme) auth.CredentialProvider {
+	t.Helper()
+	client, ok := clients[who]
+	if !ok {
+		var err error
+		client, err = gcp.NewClient(t.Context(), &gcp.Config{
+			HTTPClient:            &http.Client{Transport: identityTransport{base: e.Client().Transport, who: who}},
+			AgentIdentityEndpoint: e.URL,
+		})
+		if err != nil {
+			t.Fatalf("NewClient() error = %v", err)
+		}
+		clients[who] = client
 	}
-	p, err := gcp.NewProvider(t.Context(), gcp.ProviderConfig{Scheme: gcp.ProviderScheme{Name: testResource}, Client: client})
+	p, err := gcp.NewProvider(t.Context(), gcp.ProviderConfig{Scheme: scheme, Client: client, Store: store})
 	if err != nil {
 		t.Fatalf("NewProvider() error = %v", err)
 	}
+	return p
+}
 
-	// Twice each, so the second pass reads through the cache.
-	for range 2 {
-		for _, user := range []string{"user-1", "user-2"} {
-			cred, err := p.Credential(adkContext(t, user))
-			if err != nil {
-				t.Fatalf("Credential(%q) error = %v", user, err)
-			}
-			if bc, ok := cred.(auth.BearerCredential); !ok || bc.Token != "tok-"+user {
-				t.Fatalf("%q was served %+v, want bearer %q", user, cred, "tok-"+user)
-			}
+func TestProviderCachesCredential(t *testing.T) {
+	e := newEchoServer(t, "2999-01-01T00:00:00Z")
+
+	// Default (in-memory) store; two resolves for the same app+user+resource.
+	p := newProvider(t, e.Server, gcp.ProviderScheme{Name: testResource})
+	for i := range 2 {
+		if _, err := p.Credential(adkContext(t, "user-1")); err != nil {
+			t.Fatalf("call %d: Credential() error = %v", i, err)
 		}
 	}
-	if got := atomic.LoadInt32(&calls); got != 2 {
-		t.Errorf("service calls = %d, want 2 (one cold read per principal)", got)
+	if got := e.calls(); got != 1 {
+		t.Errorf("service calls = %d, want 1 (second resolve should hit the cache)", got)
 	}
 }
 
-// A store shared by providers that differ only in scopes must not serve the
-// broad credential to the narrow one.
-func TestProviderCacheSeparatesScopes(t *testing.T) {
-	var gotScopes [][]string
-	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
-		var body struct {
-			Scopes []string `json:"scopes"`
-		}
-		_ = json.NewDecoder(r.Body).Decode(&body)
-		gotScopes = append(gotScopes, body.Scopes)
-		_, _ = io.WriteString(w, `{"success":{"token":"tok-`+strings.Join(body.Scopes, ",")+`","header":"Authorization: Bearer","expireTime":"2999-01-01T00:00:00Z"}}`)
-	}))
-	defer srv.Close()
-
-	client, err := gcp.NewClient(t.Context(), &gcp.Config{HTTPClient: srv.Client(), AgentIdentityEndpoint: srv.URL})
-	if err != nil {
-		t.Fatalf("NewClient() error = %v", err)
+// TestProviderCacheDimensions is the guard on the cache's headline property: a
+// credential must never be served to a request that would not have been minted
+// the same one. Each case runs two resolves that differ in exactly one thing,
+// through one shared store, and requires that both reach the service and each
+// gets its own token. Collapsing any single dimension of the cache key leaves
+// every other test in the package green.
+func TestProviderCacheDimensions(t *testing.T) {
+	const res2 = "projects/p/locations/l/authProviders/other"
+	// resolve names one call: which caller identity mints, for which end user,
+	// under which app, for which scheme.
+	type resolve struct {
+		who, app, user string
+		scheme         gcp.ProviderScheme
 	}
-	store := auth.NewInMemoryCredentialStore()
-	newProvider := func(scope string) auth.CredentialProvider {
-		t.Helper()
-		p, err := gcp.NewProvider(t.Context(), gcp.ProviderConfig{
-			Scheme: gcp.ProviderScheme{Name: testResource, Scopes: []string{scope}},
-			Client: client,
-			Store:  store,
+	base := resolve{who: "sa-alpha", app: "app", user: "user-1", scheme: gcp.ProviderScheme{Name: testResource, Scopes: []string{"drive"}}}
+	with := func(f func(*resolve)) resolve {
+		r := base
+		r.scheme.Scopes = slices.Clone(base.scheme.Scopes)
+		f(&r)
+		return r
+	}
+
+	tests := []struct {
+		name          string
+		first, second resolve
+	}{
+		{name: "end user", second: with(func(r *resolve) { r.user = "user-2" })},
+		{name: "app", second: with(func(r *resolve) { r.app = "other-app" })},
+		{name: "caller identity", second: with(func(r *resolve) { r.who = "sa-beta" })},
+		{name: "resource", second: with(func(r *resolve) { r.scheme.Name = res2 })},
+		{name: "scopes", second: with(func(r *resolve) { r.scheme.Scopes = []string{"drive.readonly"} })},
+		{name: "continue URI", second: with(func(r *resolve) { r.scheme.ContinueURI = "https://example.com/finish" })},
+		// The two pairs below are what an encoding that joins the components on a
+		// delimiter collides, since neither "," nor "|" is escaped or barred from a
+		// scope or a URI: both members slot alike under
+		// name + "|" + join(scopes, ",") + "|" + continueURI.
+		{
+			name:   "one scope holding the scope separator",
+			first:  with(func(r *resolve) { r.scheme.Scopes = []string{"a,b"} }),
+			second: with(func(r *resolve) { r.scheme.Scopes = []string{"a", "b"} }),
+		},
+		{
+			name:   "field separator shifted between scope and continue URI",
+			first:  with(func(r *resolve) { r.scheme.Scopes, r.scheme.ContinueURI = []string{"x"}, "y|z" }),
+			second: with(func(r *resolve) { r.scheme.Scopes, r.scheme.ContinueURI = []string{"x|y"}, "z" }),
+		},
+	}
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			first := tc.first
+			if first.who == "" {
+				first = base
+			}
+			// The pair is symmetric, so also run it reversed: broad-then-narrow hands
+			// out more authority than was asked for, narrow-then-broad only produces a
+			// confusing failure, and one pass checks only one of the two orders.
+			for _, order := range [][2]resolve{{first, tc.second}, {tc.second, first}} {
+				e := newEchoServer(t, "2999-01-01T00:00:00Z")
+				store := auth.NewInMemoryCredentialStore()
+				clients := map[string]*gcp.Client{}
+				for _, r := range order {
+					p := newSharingProvider(t, e, store, clients, r.who, r.scheme)
+					cred, err := p.Credential(adkContextIn(t, r.app, r.user))
+					if err != nil {
+						t.Fatalf("Credential() error = %v", err)
+					}
+					want := echoRequest{userID: r.user, scopes: r.scheme.Scopes, continueURI: r.scheme.ContinueURI, caller: r.who}.token()
+					if bc, ok := cred.(auth.BearerCredential); !ok || bc.Token != want {
+						t.Errorf("%+v was served %+v, want bearer %q", r, cred, want)
+					}
+				}
+				if got := e.calls(); got != 2 {
+					t.Errorf("service calls = %d, want 2 (the second resolve must not reuse the first entry)", got)
+				}
+			}
 		})
-		if err != nil {
-			t.Fatalf("NewProvider() error = %v", err)
-		}
-		return p
-	}
-
-	for _, scope := range []string{"drive", "drive.readonly"} {
-		cred, err := newProvider(scope).Credential(adkContext(t, "user-1"))
-		if err != nil {
-			t.Fatalf("Credential(%q) error = %v", scope, err)
-		}
-		if bc, ok := cred.(auth.BearerCredential); !ok || bc.Token != "tok-"+scope {
-			t.Errorf("scope %q was served %+v, want bearer %q", scope, cred, "tok-"+scope)
-		}
-	}
-	if len(gotScopes) != 2 {
-		t.Errorf("service calls = %d, want 2 (the narrow provider must not reuse the broad entry)", len(gotScopes))
 	}
 }
 
-// recordingStore reports every call, and can fail writes.
+// The same resolve twice through a shared store is one call, so the isolation
+// above is not just the cache never hitting at all.
+func TestProviderCacheHitsAcrossProviders(t *testing.T) {
+	e := newEchoServer(t, "2999-01-01T00:00:00Z")
+	store := auth.NewInMemoryCredentialStore()
+	clients := map[string]*gcp.Client{}
+	scheme := gcp.ProviderScheme{Name: testResource, Scopes: []string{"drive"}}
+	for range 2 {
+		p := newSharingProvider(t, e, store, clients, "sa-alpha", scheme)
+		if _, err := p.Credential(adkContext(t, "user-1")); err != nil {
+			t.Fatalf("Credential() error = %v", err)
+		}
+	}
+	if got := e.calls(); got != 1 {
+		t.Errorf("service calls = %d, want 1 (a second provider with the same client and scheme should hit the entry)", got)
+	}
+}
+
+// Scope order is the caller's, not a cache dimension.
+func TestProviderCacheIgnoresScopeOrder(t *testing.T) {
+	e := newEchoServer(t, "2999-01-01T00:00:00Z")
+	store := auth.NewInMemoryCredentialStore()
+	clients := map[string]*gcp.Client{}
+	for _, scopes := range [][]string{{"a", "b"}, {"b", "a"}} {
+		p := newSharingProvider(t, e, store, clients, "sa-alpha", gcp.ProviderScheme{Name: testResource, Scopes: scopes})
+		if _, err := p.Credential(adkContext(t, "user-1")); err != nil {
+			t.Fatalf("Credential() error = %v", err)
+		}
+	}
+	if got := e.calls(); got != 1 {
+		t.Errorf("service calls = %d, want 1 (reordered scopes are the same credential)", got)
+	}
+}
+
+// recordingStore reports every call and what it was handed, and can fail writes.
 type recordingStore struct {
 	inner   auth.CredentialStore
 	sets    int
 	gets    int
 	setErr  error
 	nilOnce bool // return a hit carrying no credential on the first Get
+
+	lastKey     auth.CredentialKey
+	lastExpires time.Time
 }
 
 func (s *recordingStore) Get(ctx context.Context, key auth.CredentialKey) (auth.Credential, bool, error) {
@@ -841,6 +948,7 @@ func (s *recordingStore) Get(ctx context.Context, key auth.CredentialKey) (auth.
 
 func (s *recordingStore) Set(ctx context.Context, key auth.CredentialKey, cred auth.Credential, expiresAt time.Time) error {
 	s.sets++
+	s.lastKey, s.lastExpires = key, expiresAt
 	if s.setErr != nil {
 		return s.setErr
 	}
@@ -851,19 +959,13 @@ func (s *recordingStore) Delete(ctx context.Context, key auth.CredentialKey) err
 	return s.inner.Delete(ctx, key)
 }
 
-// A configured store is actually used, a write failure does not fail auth, and
-// a hit carrying no credential is treated as a miss rather than returned.
-func TestProviderStorePlumbing(t *testing.T) {
-	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
-		_, _ = io.WriteString(w, `{"success":{"token":"tok","header":"Authorization: Bearer","expireTime":"2999-01-01T00:00:00Z"}}`)
-	}))
-	defer srv.Close()
-	client, err := gcp.NewClient(t.Context(), &gcp.Config{HTTPClient: srv.Client(), AgentIdentityEndpoint: srv.URL})
+// newStoreProvider builds a provider against e backed by a recordingStore.
+func newStoreProvider(t *testing.T, e *echoServer, store auth.CredentialStore) auth.CredentialProvider {
+	t.Helper()
+	client, err := gcp.NewClient(t.Context(), &gcp.Config{HTTPClient: e.Client(), AgentIdentityEndpoint: e.URL})
 	if err != nil {
 		t.Fatalf("NewClient() error = %v", err)
 	}
-
-	store := &recordingStore{inner: auth.NewInMemoryCredentialStore(), setErr: errors.New("disk on fire"), nilOnce: true}
 	p, err := gcp.NewProvider(t.Context(), gcp.ProviderConfig{
 		Scheme: gcp.ProviderScheme{Name: testResource},
 		Client: client,
@@ -872,6 +974,16 @@ func TestProviderStorePlumbing(t *testing.T) {
 	if err != nil {
 		t.Fatalf("NewProvider() error = %v", err)
 	}
+	return p
+}
+
+// A configured store is actually used, a write failure does not fail auth, and
+// a hit carrying no credential is treated as a miss rather than returned.
+func TestProviderStorePlumbing(t *testing.T) {
+	e := newEchoServer(t, "2999-01-01T00:00:00Z")
+	store := &recordingStore{inner: auth.NewInMemoryCredentialStore(), setErr: errors.New("disk on fire"), nilOnce: true}
+	p := newStoreProvider(t, e, store)
+
 	cred, err := p.Credential(adkContext(t, "user-1"))
 	if err != nil {
 		t.Fatalf("Credential() error = %v; a store write failure must not fail auth", err)
@@ -884,33 +996,46 @@ func TestProviderStorePlumbing(t *testing.T) {
 	}
 }
 
-// The service's expiry is honoured only up to a bound, so a bad or injected
-// expireTime cannot pin a credential in the cache.
-func TestProviderClampsServiceExpiry(t *testing.T) {
-	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
-		_, _ = io.WriteString(w, `{"success":{"token":"tok","header":"Authorization: Bearer","expireTime":"9999-12-31T23:59:59Z"}}`)
-	}))
-	defer srv.Close()
-	client, err := gcp.NewClient(t.Context(), &gcp.Config{HTTPClient: srv.Client(), AgentIdentityEndpoint: srv.URL})
-	if err != nil {
-		t.Fatalf("NewClient() error = %v", err)
+// TestProviderCachedExpiry pins what lifetime the provider is willing to cache
+// for. The store is asked directly rather than inferred from a call count, so
+// each case fails loudly if the provider stops calling Set at all.
+func TestProviderCachedExpiry(t *testing.T) {
+	now := time.Date(2030, 1, 1, 0, 0, 0, 0, time.UTC)
+	tests := []struct {
+		name       string
+		expireTime string    // what the service reports
+		want       time.Time // zero means: must not be cached
+	}{
+		{"honored as reported", "2030-01-01T00:05:00Z", now.Add(5 * time.Minute)},
+		{"clamped to the cap", "9999-12-31T23:59:59Z", now.Add(maxCachedLifetimeForTest)},
+		{"absent", "", time.Time{}},
+		{"already past", "2029-12-31T23:00:00Z", time.Time{}},
+		{"unparseable", "not-a-time", time.Time{}},
 	}
-	store := &recordingStore{inner: auth.NewInMemoryCredentialStore()}
-	p, err := gcp.NewProvider(t.Context(), gcp.ProviderConfig{
-		Scheme: gcp.ProviderScheme{Name: testResource},
-		Client: client,
-		Store:  store,
-	})
-	if err != nil {
-		t.Fatalf("NewProvider() error = %v", err)
-	}
-	if _, err := p.Credential(adkContext(t, "user-1")); err != nil {
-		t.Fatalf("Credential() error = %v", err)
-	}
-	// Far past the cap: the entry must already be gone a day later.
-	future := platform.WithTimeProvider(t.Context(), func() time.Time { return time.Now().Add(24 * time.Hour) })
-	key := auth.CredentialKey{AppName: "app", UserID: "user-1", Key: testResource + "||"}
-	if _, ok, _ := store.inner.Get(future, key); ok {
-		t.Error("credential still cached a day later, want the service expiry clamped")
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			e := newEchoServer(t, tc.expireTime)
+			store := &recordingStore{inner: auth.NewInMemoryCredentialStore()}
+			p := newStoreProvider(t, e, store)
+
+			ctx := platform.WithTimeProvider(adkContext(t, "user-1"), func() time.Time { return now })
+			if _, err := p.Credential(ctx); err != nil {
+				t.Fatalf("Credential() error = %v", err)
+			}
+			switch {
+			case tc.want.IsZero():
+				if store.sets != 0 {
+					t.Errorf("store Set called with expiry %s, want no cache write for expireTime %q", store.lastExpires, tc.expireTime)
+				}
+			case store.sets != 1:
+				t.Errorf("store Set calls = %d, want 1", store.sets)
+			case !store.lastExpires.Equal(tc.want):
+				t.Errorf("cached until %s, want %s", store.lastExpires, tc.want)
+			}
+		})
 	}
 }
+
+// maxCachedLifetimeForTest mirrors the provider's cap. Duplicated rather than
+// exported: the cap is a policy the test should notice changing.
+const maxCachedLifetimeForTest = time.Hour

--- a/auth/gcp/provider_test.go
+++ b/auth/gcp/provider_test.go
@@ -1162,6 +1162,10 @@ func TestProviderCachedExpiry(t *testing.T) {
 		// below this pins auth.ExpirySkew under a minute: widen it and this stops
 		// being cached at all.
 		{name: "a minute of life left", left: "1m", want: time.Minute},
+		// Twice the margin, so widening the floor to any multiple of it stops
+		// caching this. The floor is what keeps a guaranteed-dead entry out; it is
+		// not a licence to refuse short-lived credentials.
+		{name: "twice the store's margin", left: "20s", want: 20 * time.Second},
 		{name: "clamped to the cap", left: "8760h", want: maxCachedLifetimeForTest, clamped: true},
 		// At or inside the margin the store applies, the entry would be written and
 		// then refused on the very next read: a guaranteed-dead write.

--- a/auth/gcp/provider_test.go
+++ b/auth/gcp/provider_test.go
@@ -22,6 +22,7 @@ import (
 	"net/http"
 	"net/http/httptest"
 	"slices"
+	"strconv"
 	"strings"
 	"sync"
 	"testing"
@@ -105,11 +106,18 @@ func TestProviderCredentialConcurrent(t *testing.T) {
 			UserID string `json:"userId"`
 		}
 		_ = json.NewDecoder(r.Body).Decode(&body)
-		_, _ = io.WriteString(w, `{"success":{"token":"tok-`+body.UserID+`","header":"Authorization: Bearer"}}`)
+		// With an expiry, so these goroutines drive the cache write and the cache
+		// read, not only the retrieval. Without one the provider declines to cache
+		// and store.Set is never reached under concurrency at all.
+		_, _ = io.WriteString(w, `{"success":{"token":"tok-`+body.UserID+`","header":"Authorization: Bearer","expireTime":"2999-01-01T00:00:00Z"}}`)
 	}))
 	defer srv.Close()
 
-	p := newProvider(t, srv, gcp.ProviderScheme{Name: testResource})
+	// Several scopes, so the clone-before-sort in the slot derivation is exercised
+	// concurrently: sorting p.scheme.Scopes in place instead would write a shared
+	// backing array from every one of these goroutines, and a nil Scopes makes
+	// that mutant a no-op.
+	p := newProvider(t, srv, gcp.ProviderScheme{Name: testResource, Scopes: []string{"b", "a", "c"}})
 	users := []string{"alice", "bob", "carol", "dave"}
 	ctxs := make([]context.Context, len(users))
 	for i, u := range users {
@@ -709,6 +717,7 @@ type echoServer struct {
 }
 
 type echoRequest struct {
+	path        string // carries the resource name, which is not in the body
 	userID      string
 	scopes      []string
 	continueURI string
@@ -728,6 +737,7 @@ func newEchoServer(t *testing.T, expireTime string) *echoServer {
 		}
 		_ = json.NewDecoder(r.Body).Decode(&body)
 		req := echoRequest{
+			path:        r.URL.Path,
 			userID:      body.UserID,
 			scopes:      body.Scopes,
 			continueURI: body.ContinueURI,
@@ -750,8 +760,23 @@ func newEchoServer(t *testing.T, expireTime string) *echoServer {
 // token is the token this request is answered with: everything the service was
 // told, so any two requests that should not share a cache entry get different
 // tokens.
+//
+// Length-prefixed for the same reason the cache slot is. Joining on a delimiter
+// made the token for {scopes:["x"], continueURI:"y|z"} byte-identical to the one
+// for {scopes:["x|y"], continueURI:"z"} — so the two cases written to catch
+// exactly that collision in the cache key could not see it in the token, and
+// rested on the call count alone.
 func (r echoRequest) token() string {
-	return "tok|" + r.caller + "|" + r.userID + "|" + strings.Join(r.scopes, "+") + "|" + r.continueURI
+	fields := []string{"tok", r.path, r.caller, r.userID, strconv.Itoa(len(r.scopes))}
+	fields = append(fields, r.scopes...)
+	fields = append(fields, r.continueURI)
+	var b strings.Builder
+	for _, f := range fields {
+		b.WriteString(strconv.Itoa(len(f)))
+		b.WriteByte(':')
+		b.WriteString(f)
+	}
+	return b.String()
 }
 
 func (e *echoServer) calls() int {
@@ -878,7 +903,13 @@ func TestProviderCacheDimensions(t *testing.T) {
 					if err != nil {
 						t.Fatalf("Credential() error = %v", err)
 					}
-					want := echoRequest{userID: r.user, scopes: r.scheme.Scopes, continueURI: r.scheme.ContinueURI, caller: r.who}.token()
+					want := echoRequest{
+						path:        "/v1/" + r.scheme.Name + "/credentials:retrieve",
+						userID:      r.user,
+						scopes:      r.scheme.Scopes,
+						continueURI: r.scheme.ContinueURI,
+						caller:      r.who,
+					}.token()
 					if bc, ok := cred.(auth.BearerCredential); !ok || bc.Token != want {
 						t.Errorf("%+v was served %+v, want bearer %q", r, cred, want)
 					}
@@ -925,11 +956,13 @@ func TestProviderCacheIgnoresScopeOrder(t *testing.T) {
 	}
 }
 
-// recordingStore reports every call and what it was handed, and can fail writes.
+// recordingStore reports every call and what it was handed, and can fail either
+// direction.
 type recordingStore struct {
 	inner   auth.CredentialStore
 	sets    int
 	gets    int
+	getErr  error
 	setErr  error
 	nilOnce bool // return a hit carrying no credential on the first Get
 
@@ -939,6 +972,9 @@ type recordingStore struct {
 
 func (s *recordingStore) Get(ctx context.Context, key auth.CredentialKey) (auth.Credential, bool, error) {
 	s.gets++
+	if s.getErr != nil {
+		return nil, false, s.getErr
+	}
 	if s.nilOnce {
 		s.nilOnce = false
 		return nil, true, nil
@@ -977,22 +1013,119 @@ func newStoreProvider(t *testing.T, e *echoServer, store auth.CredentialStore) a
 	return p
 }
 
-// A configured store is actually used, a write failure does not fail auth, and
-// a hit carrying no credential is treated as a miss rather than returned.
-func TestProviderStorePlumbing(t *testing.T) {
+// TestProviderStoreDegradesRatherThanFails pins that a store which misbehaves
+// costs a round trip and nothing else. Each case breaks the store a different
+// way and requires a usable credential back.
+func TestProviderStoreDegradesRatherThanFails(t *testing.T) {
+	tests := []struct {
+		name    string
+		breakIt func(*recordingStore)
+	}{
+		{"the read fails", func(s *recordingStore) { s.getErr = errors.New("backend unreachable") }},
+		{"the write fails", func(s *recordingStore) { s.setErr = errors.New("disk on fire") }},
+		{"a hit carries no credential", func(s *recordingStore) { s.nilOnce = true }},
+	}
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			e := newEchoServer(t, "2999-01-01T00:00:00Z")
+			store := &recordingStore{inner: auth.NewInMemoryCredentialStore()}
+			tc.breakIt(store)
+			p := newStoreProvider(t, e, store)
+
+			cred, err := p.Credential(adkContext(t, "user-1"))
+			if err != nil {
+				t.Fatalf("Credential() error = %v; a broken store must not fail auth", err)
+			}
+			if cred == nil {
+				t.Fatal("Credential() = nil credential")
+			}
+			if store.gets != 1 {
+				t.Errorf("store gets = %d, want 1 (the configured store must be consulted)", store.gets)
+			}
+		})
+	}
+}
+
+// The configured store is written to, under a key whose app and user land in
+// their own fields.
+func TestProviderStoreWritesTheKeyItRead(t *testing.T) {
 	e := newEchoServer(t, "2999-01-01T00:00:00Z")
-	store := &recordingStore{inner: auth.NewInMemoryCredentialStore(), setErr: errors.New("disk on fire"), nilOnce: true}
+	store := &recordingStore{inner: auth.NewInMemoryCredentialStore()}
 	p := newStoreProvider(t, e, store)
 
-	cred, err := p.Credential(adkContext(t, "user-1"))
-	if err != nil {
-		t.Fatalf("Credential() error = %v; a store write failure must not fail auth", err)
-	}
-	if cred == nil {
-		t.Fatal("Credential() = nil credential; a hit with no credential must be treated as a miss")
+	if _, err := p.Credential(adkContext(t, "user-1")); err != nil {
+		t.Fatalf("Credential() error = %v", err)
 	}
 	if store.gets != 1 || store.sets != 1 {
 		t.Errorf("store gets/sets = %d/%d, want 1/1 (the configured store must be used)", store.gets, store.sets)
+	}
+	// The app and the user must land in their own fields, not merely in some
+	// distinct pair: a store that buckets by app and then by user — the shape
+	// auth.CredentialStore is documented for — files them separately, so swapping
+	// the two would file alice's credential under an app named "alice".
+	if store.lastKey.AppName != "app" || store.lastKey.UserID != "user-1" {
+		t.Errorf("store key = %+v, want AppName \"app\" and UserID \"user-1\"", store.lastKey)
+	}
+	if store.lastKey.Key == "" {
+		t.Error("store key has an empty slot")
+	}
+}
+
+// The key the provider writes under is the one Client.CacheKey names, so a
+// caller told to invalidate a credential with it can actually reach the entry.
+func TestClientCacheKeyMatchesWhatTheProviderWrote(t *testing.T) {
+	e := newEchoServer(t, "2999-01-01T00:00:00Z")
+	client, err := gcp.NewClient(t.Context(), &gcp.Config{HTTPClient: e.Client(), AgentIdentityEndpoint: e.URL})
+	if err != nil {
+		t.Fatalf("NewClient() error = %v", err)
+	}
+	scheme := gcp.ProviderScheme{Name: testResource, Scopes: []string{"drive"}}
+	store := auth.NewInMemoryCredentialStore()
+	p, err := gcp.NewProvider(t.Context(), gcp.ProviderConfig{Scheme: scheme, Client: client, Store: store})
+	if err != nil {
+		t.Fatalf("NewProvider() error = %v", err)
+	}
+	if _, err := p.Credential(adkContext(t, "user-1")); err != nil {
+		t.Fatalf("Credential() error = %v", err)
+	}
+
+	key := client.CacheKey(scheme, "app", "user-1")
+	if _, ok, _ := store.Get(t.Context(), key); !ok {
+		t.Fatal("Client.CacheKey() names no cached entry, so a caller cannot invalidate one")
+	}
+	if err := store.Delete(t.Context(), key); err != nil {
+		t.Fatalf("Delete() error = %v", err)
+	}
+	if _, err := p.Credential(adkContext(t, "user-1")); err != nil {
+		t.Fatalf("Credential() after Delete error = %v", err)
+	}
+	if got := e.calls(); got != 2 {
+		t.Errorf("service calls = %d, want 2 (Delete must actually invalidate)", got)
+	}
+}
+
+// Two Clients are two cache dimensions even when built from one config: this
+// package cannot see what identity a Client authenticates as, so it never
+// assumes two of them agree.
+func TestProviderCacheSeparatesClientInstances(t *testing.T) {
+	e := newEchoServer(t, "2999-01-01T00:00:00Z")
+	store := auth.NewInMemoryCredentialStore()
+	scheme := gcp.ProviderScheme{Name: testResource}
+	for range 2 {
+		client, err := gcp.NewClient(t.Context(), &gcp.Config{HTTPClient: e.Client(), AgentIdentityEndpoint: e.URL})
+		if err != nil {
+			t.Fatalf("NewClient() error = %v", err)
+		}
+		p, err := gcp.NewProvider(t.Context(), gcp.ProviderConfig{Scheme: scheme, Client: client, Store: store})
+		if err != nil {
+			t.Fatalf("NewProvider() error = %v", err)
+		}
+		if _, err := p.Credential(adkContext(t, "user-1")); err != nil {
+			t.Fatalf("Credential() error = %v", err)
+		}
+	}
+	if got := e.calls(); got != 2 {
+		t.Errorf("service calls = %d, want 2 (a second Client must not read the first one's entries)", got)
 	}
 }
 
@@ -1007,6 +1140,10 @@ func TestProviderCachedExpiry(t *testing.T) {
 		want       time.Time // zero means: must not be cached
 	}{
 		{"honored as reported", "2030-01-01T00:05:00Z", now.Add(5 * time.Minute)},
+		// Inside the margin the store applies, so the entry would be written and
+		// then refused on the very next read: a guaranteed-dead write.
+		{"less left than the store's margin", "2030-01-01T00:00:05Z", time.Time{}},
+		{"exactly the store's margin", "2030-01-01T00:00:10Z", time.Time{}},
 		{"clamped to the cap", "9999-12-31T23:59:59Z", now.Add(maxCachedLifetimeForTest)},
 		{"absent", "", time.Time{}},
 		{"already past", "2029-12-31T23:00:00Z", time.Time{}},

--- a/auth/gcp/provider_test.go
+++ b/auth/gcp/provider_test.go
@@ -959,11 +959,16 @@ func TestProviderCacheIgnoresScopeOrder(t *testing.T) {
 // recordingStore reports every call and what it was handed, and can fail either
 // direction.
 type recordingStore struct {
-	inner   auth.CredentialStore
+	inner  auth.CredentialStore
+	getErr error
+	setErr error
+
+	// CredentialStore is documented safe for concurrent use, so the double is too
+	// — otherwise the first test to drive one from two goroutines reports a race
+	// in the harness rather than a finding about the code.
+	mu      sync.Mutex
 	sets    int
 	gets    int
-	getErr  error
-	setErr  error
 	nilOnce bool // return a hit carrying no credential on the first Get
 
 	lastKey     auth.CredentialKey
@@ -971,6 +976,8 @@ type recordingStore struct {
 }
 
 func (s *recordingStore) Get(ctx context.Context, key auth.CredentialKey) (auth.Credential, bool, error) {
+	s.mu.Lock()
+	defer s.mu.Unlock()
 	s.gets++
 	if s.getErr != nil {
 		return nil, false, s.getErr
@@ -983,6 +990,8 @@ func (s *recordingStore) Get(ctx context.Context, key auth.CredentialKey) (auth.
 }
 
 func (s *recordingStore) Set(ctx context.Context, key auth.CredentialKey, cred auth.Credential, expiresAt time.Time) error {
+	s.mu.Lock()
+	defer s.mu.Unlock()
 	s.sets++
 	s.lastKey, s.lastExpires = key, expiresAt
 	if s.setErr != nil {
@@ -1140,6 +1149,10 @@ func TestProviderCachedExpiry(t *testing.T) {
 		want       time.Time // zero means: must not be cached
 	}{
 		{"honored as reported", "2030-01-01T00:05:00Z", now.Add(5 * time.Minute)},
+		// A short-lived credential is still worth caching. Together with the
+		// boundary cases below this pins auth.ExpirySkew to something under a
+		// minute: widen it and this stops being cached at all.
+		{"a minute of life left", "2030-01-01T00:01:00Z", now.Add(time.Minute)},
 		// Inside the margin the store applies, so the entry would be written and
 		// then refused on the very next read: a guaranteed-dead write.
 		{"less left than the store's margin", "2030-01-01T00:00:05Z", time.Time{}},

--- a/auth/gcp/provider_test.go
+++ b/auth/gcp/provider_test.go
@@ -24,6 +24,7 @@ import (
 	"slices"
 	"strings"
 	"sync"
+	"sync/atomic"
 	"testing"
 	"time"
 	"unicode/utf8"
@@ -466,6 +467,46 @@ func newProvider(t *testing.T, srv *httptest.Server, scheme gcp.ProviderScheme) 
 		t.Fatalf("NewProvider() error = %v", err)
 	}
 	return p
+}
+
+func TestProviderCachesCredential(t *testing.T) {
+	var calls int32
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		atomic.AddInt32(&calls, 1)
+		_, _ = io.WriteString(w, `{"success":{"token":"tok","header":"Authorization: Bearer","expireTime":"2999-01-01T00:00:00Z"}}`)
+	}))
+	defer srv.Close()
+
+	// Default (in-memory) store; two resolves for the same app+user+resource.
+	p := newProvider(t, srv, gcp.ProviderScheme{Name: testResource})
+	for i := range 2 {
+		if _, err := p.Credential(adkContext(t, "user-1")); err != nil {
+			t.Fatalf("call %d: Credential() error = %v", i, err)
+		}
+	}
+	if got := atomic.LoadInt32(&calls); got != 1 {
+		t.Errorf("service calls = %d, want 1 (second resolve should hit the cache)", got)
+	}
+}
+
+func TestProviderSkipsCacheWithoutExpiry(t *testing.T) {
+	var calls int32
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		atomic.AddInt32(&calls, 1)
+		// No expireTime: lifetime unknown, so the provider must not cache.
+		_, _ = io.WriteString(w, `{"success":{"token":"tok","header":"Authorization: Bearer"}}`)
+	}))
+	defer srv.Close()
+
+	p := newProvider(t, srv, gcp.ProviderScheme{Name: testResource})
+	for i := range 2 {
+		if _, err := p.Credential(adkContext(t, "user-1")); err != nil {
+			t.Fatalf("call %d: Credential() error = %v", i, err)
+		}
+	}
+	if got := atomic.LoadInt32(&calls); got != 2 {
+		t.Errorf("service calls = %d, want 2 (unknown expiry must not be cached)", got)
+	}
 }
 
 // adkContext returns an ADK invocation context (recoverable via

--- a/auth/providers.go
+++ b/auth/providers.go
@@ -70,7 +70,9 @@ type ConsentRequiredError struct {
 	// Nonce is an opaque value echoed back to correlate the consent response.
 	// Sensitive on the same terms as AuthURI, which embeds it.
 	Nonce string
-	// Key is the credential-store key to resume the flow under.
+	// Key is an opaque, caller-defined identifier for the credential this flow
+	// will produce, for a consumer that has to resume the flow later. It is not a
+	// [CredentialKey], which identifies a [CredentialStore] entry.
 	Key string
 }
 

--- a/auth/providers.go
+++ b/auth/providers.go
@@ -167,8 +167,11 @@ func ServiceAccount(cfg ServiceAccountConfig) CredentialProvider {
 			return ts, nil
 		}
 		if len(cfg.JSONKey) > 0 {
-			// Stricter than adk-python (scopes optional there): an explicit-key
-			// access token is scope-bound, so no scopes = unusable — fail fast.
+			// An explicit-key access token is scope-bound, so no scopes = unusable.
+			// Fail at wiring time rather than at request time, which is also where
+			// adk-python fails it (service_account_exchanger.py raises for an
+			// explicit key with no scopes; only the default-credential branch
+			// defaults them, as this one does above).
 			if len(cfg.Scopes) == 0 {
 				return nil, fmt.Errorf("auth: scopes are required for a service-account access token")
 			}

--- a/auth/store.go
+++ b/auth/store.go
@@ -16,6 +16,7 @@ package auth
 
 import (
 	"context"
+	"fmt"
 	"sync"
 	"time"
 
@@ -45,15 +46,28 @@ type CredentialKey struct {
 type CredentialStore interface {
 	// Get returns the cached, unexpired credential for key, if present.
 	Get(ctx context.Context, key CredentialKey) (Credential, bool, error)
-	// Set stores cred for key. A zero expiresAt means the entry does not expire.
+	// Set stores cred for key until expiresAt. Both cred and expiresAt are
+	// required: a caller that cannot establish a lifetime must not cache, rather
+	// than cache forever.
 	Set(ctx context.Context, key CredentialKey, cred Credential, expiresAt time.Time) error
+	// Delete removes any entry for key, so a credential can be invalidated ahead
+	// of its expiry — on consent revocation, logout, or a downstream 401.
+	// Removing an absent key is not an error.
+	Delete(ctx context.Context, key CredentialKey) error
 }
 
+// sweepEvery is how many Set calls pass between sweeps of expired entries.
+// Nothing else evicts a principal that resolves once and never returns.
+const sweepEvery = 256
+
 // InMemoryCredentialStore is a concurrency-safe, process-local [CredentialStore]
-// (per app+user+key, across sessions). It mirrors adk-python's
-// InMemoryCredentialService.
+// (per app+user+key, across sessions). It serves the same role as adk-python's
+// InMemoryCredentialService, which buckets the same way, and adds per-entry
+// expiry. The zero value is ready to use.
 type InMemoryCredentialStore struct {
+	// mu guards entries. Not an RWMutex: Get evicts on expiry, so readers write.
 	mu      sync.Mutex
+	sets    uint64
 	entries map[CredentialKey]cacheEntry
 }
 
@@ -70,13 +84,17 @@ func NewInMemoryCredentialStore() *InMemoryCredentialStore {
 // Get implements [CredentialStore]. Expiry is evaluated against the context's
 // clock ([platform.Now]), so tests can drive it deterministically.
 func (s *InMemoryCredentialStore) Get(ctx context.Context, key CredentialKey) (Credential, bool, error) {
+	// Resolved before the lock: platform.Now is caller-supplied, and a clock that
+	// reaches back into the store would deadlock on this non-reentrant mutex.
+	now := platform.Now(ctx)
+
 	s.mu.Lock()
 	defer s.mu.Unlock()
 	e, ok := s.entries[key]
 	if !ok {
 		return nil, false, nil
 	}
-	if !e.expiresAt.IsZero() && platform.Now(ctx).Add(expirySkew).After(e.expiresAt) {
+	if now.Add(expirySkew).After(e.expiresAt) {
 		delete(s.entries, key)
 		return nil, false, nil
 	}
@@ -84,10 +102,37 @@ func (s *InMemoryCredentialStore) Get(ctx context.Context, key CredentialKey) (C
 }
 
 // Set implements [CredentialStore].
-func (s *InMemoryCredentialStore) Set(_ context.Context, key CredentialKey, cred Credential, expiresAt time.Time) error {
+func (s *InMemoryCredentialStore) Set(ctx context.Context, key CredentialKey, cred Credential, expiresAt time.Time) error {
+	if cred == nil {
+		return fmt.Errorf("auth: Set requires a credential")
+	}
+	if expiresAt.IsZero() {
+		return fmt.Errorf("auth: Set requires an expiry for %+v", key)
+	}
+	now := platform.Now(ctx)
+
 	s.mu.Lock()
 	defer s.mu.Unlock()
+	if s.entries == nil {
+		s.entries = make(map[CredentialKey]cacheEntry)
+	}
+	s.sets++
+	if s.sets%sweepEvery == 0 {
+		for k, e := range s.entries {
+			if now.Add(expirySkew).After(e.expiresAt) {
+				delete(s.entries, k)
+			}
+		}
+	}
 	s.entries[key] = cacheEntry{cred: cred, expiresAt: expiresAt}
+	return nil
+}
+
+// Delete implements [CredentialStore].
+func (s *InMemoryCredentialStore) Delete(_ context.Context, key CredentialKey) error {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	delete(s.entries, key)
 	return nil
 }
 

--- a/auth/store.go
+++ b/auth/store.go
@@ -1,0 +1,94 @@
+// Copyright 2026 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package auth
+
+import (
+	"context"
+	"sync"
+	"time"
+
+	"google.golang.org/adk/v2/platform"
+)
+
+// expirySkew is how long before its stated expiry a cached credential is treated
+// as expired, to absorb clock skew and in-flight latency.
+const expirySkew = 10 * time.Second
+
+// CredentialKey identifies a cached credential: the app, the acting user, and a
+// caller-chosen slot (typically the target resource or scheme name).
+type CredentialKey struct {
+	// AppName is the ADK application name.
+	AppName string
+	// UserID is the acting end user's identity.
+	UserID string
+	// Key is a caller-chosen slot, typically the target resource or scheme name.
+	Key string
+}
+
+// CredentialStore caches resolved credentials across calls, keyed by
+// [CredentialKey]. It exists so network-backed providers (e.g. auth/gcp) avoid a
+// credential-service round-trip on every request; self-caching providers
+// (oauth2.TokenSource) do not need it. Implementations must be safe for
+// concurrent use.
+type CredentialStore interface {
+	// Get returns the cached, unexpired credential for key, if present.
+	Get(ctx context.Context, key CredentialKey) (Credential, bool, error)
+	// Set stores cred for key. A zero expiresAt means the entry does not expire.
+	Set(ctx context.Context, key CredentialKey, cred Credential, expiresAt time.Time) error
+}
+
+// InMemoryCredentialStore is a concurrency-safe, process-local [CredentialStore]
+// (per app+user+key, across sessions). It mirrors adk-python's
+// InMemoryCredentialService.
+type InMemoryCredentialStore struct {
+	mu      sync.Mutex
+	entries map[CredentialKey]cacheEntry
+}
+
+type cacheEntry struct {
+	cred      Credential
+	expiresAt time.Time
+}
+
+// NewInMemoryCredentialStore returns an empty [InMemoryCredentialStore].
+func NewInMemoryCredentialStore() *InMemoryCredentialStore {
+	return &InMemoryCredentialStore{entries: make(map[CredentialKey]cacheEntry)}
+}
+
+// Get implements [CredentialStore]. Expiry is evaluated against the context's
+// clock ([platform.Now]), so tests can drive it deterministically.
+func (s *InMemoryCredentialStore) Get(ctx context.Context, key CredentialKey) (Credential, bool, error) {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	e, ok := s.entries[key]
+	if !ok {
+		return nil, false, nil
+	}
+	if !e.expiresAt.IsZero() && platform.Now(ctx).Add(expirySkew).After(e.expiresAt) {
+		delete(s.entries, key)
+		return nil, false, nil
+	}
+	return e.cred, true, nil
+}
+
+// Set implements [CredentialStore].
+func (s *InMemoryCredentialStore) Set(_ context.Context, key CredentialKey, cred Credential, expiresAt time.Time) error {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	s.entries[key] = cacheEntry{cred: cred, expiresAt: expiresAt}
+	return nil
+}
+
+var _ CredentialStore = (*InMemoryCredentialStore)(nil)

--- a/auth/store.go
+++ b/auth/store.go
@@ -23,18 +23,39 @@ import (
 	"google.golang.org/adk/v2/platform"
 )
 
-// expirySkew is how long before its stated expiry a cached credential is treated
-// as expired, to absorb clock skew and in-flight latency.
-const expirySkew = 10 * time.Second
+// ExpirySkew is how long before its stated expiry [InMemoryCredentialStore]
+// treats a cached credential as expired, so a credential is never handed out
+// with too little lifetime left to complete the request it was fetched for.
+//
+// It absorbs two things. Time passes between the store read and the outbound
+// request the credential authenticates. And the issuer's clock is not the
+// caller's: Google's credential services warn that a token "may expire slightly
+// earlier" than the expiry they report, for exactly that reason
+// (https://agentidentitycredentials.googleapis.com/$discovery/rest?version=v1,
+// the Success.expireTime field).
+//
+// It is exported so another [CredentialStore] can apply the same margin, and so
+// a producer can decline to cache a credential with less than this left.
+const ExpirySkew = 10 * time.Second
 
 // CredentialKey identifies a cached credential: the app, the acting user, and a
-// caller-chosen slot (typically the target resource or scheme name).
+// slot chosen by whatever produced the credential.
 type CredentialKey struct {
 	// AppName is the ADK application name.
 	AppName string
 	// UserID is the acting end user's identity.
 	UserID string
-	// Key is a caller-chosen slot, typically the target resource or scheme name.
+	// Key is the producer's slot. It must distinguish every input that changes
+	// which credential comes back — the endpoint, the identity the request for it
+	// is authenticated as, the resource, the scopes, any redirect URI — and it
+	// must distinguish the producer itself, since one store can back several. A
+	// bare resource name does none of that: two providers for one resource that
+	// differ only in scope would share an entry, and the narrower one would be
+	// served the broader token.
+	//
+	// Derive it from a collision-resistant digest of those inputs rather than by
+	// joining them, so that no delimiter appearing inside one of them can make
+	// two different sets encode alike. auth/gcp is the reference construction.
 	Key string
 }
 
@@ -52,23 +73,33 @@ type CredentialStore interface {
 	// credential whenever the error is non-nil, so a store reporting a degraded
 	// backend that way would have its result silently dropped.
 	//
-	// An entry should be treated as expired shortly before its stated expiry, so
-	// a credential is never handed out with too little lifetime left to complete
-	// the request it was fetched for. [InMemoryCredentialStore] uses a 10s
-	// margin.
+	// An entry should be treated as expired shortly before its stated expiry;
+	// [ExpirySkew] is the margin [InMemoryCredentialStore] applies.
 	Get(ctx context.Context, key CredentialKey) (Credential, bool, error)
-	// Set stores cred for key until expiresAt. Both cred and expiresAt are
-	// required: a caller that cannot establish a lifetime must not cache, rather
-	// than cache forever.
+	// Set stores cred for key until expiresAt, an absolute time on the context's
+	// clock ([platform.Now]). Both arguments are required: a caller that cannot
+	// establish a lifetime must not cache, rather than cache forever.
+	//
+	// cred must be safe for concurrent [Credential.Apply] and must not be mutated
+	// after Set returns, since every hit for key hands the same value to a
+	// different request. A store that persists entries outside the process must
+	// cope with a cred it cannot encode — several of this package's credentials
+	// are opaque, and one wraps a live token source — by rejecting it, which
+	// costs a round trip rather than correctness.
 	Set(ctx context.Context, key CredentialKey, cred Credential, expiresAt time.Time) error
 	// Delete removes any entry for key. Removing an absent key is not an error.
 	//
-	// It is the invalidation hook for callers that learn a credential is no
+	// It is the invalidation hook for a caller that learns a credential is no
 	// longer good before it expires — on consent revocation or logout. ADK does
 	// not call it: a credential rejected downstream is refreshed by the provider
 	// that issued it, not deleted from the store, and until a provider implements
-	// that refresh a revoked credential is served until its cached expiry. The
-	// auth/gcp provider bounds that window to an hour.
+	// that refresh a revoked credential is served until its cached entry expires.
+	// The auth/gcp provider bounds that to an hour and exposes the key to delete
+	// as gcp.Client.CacheKey.
+	//
+	// Delete does not cancel a retrieval already in flight. One that began before
+	// the Delete will still write its result afterwards, so a caller invalidating
+	// a credential it has just seen rejected should expect a fresh one, not none.
 	Delete(ctx context.Context, key CredentialKey) error
 }
 
@@ -148,20 +179,28 @@ func (s *InMemoryCredentialStore) Set(ctx context.Context, key CredentialKey, cr
 		s.entries = make(map[CredentialKey]cacheEntry)
 	}
 	s.sweep(now)
-	s.entries[key] = cacheEntry{cred: cred, expiresAt: expiresAt}
+	// Round(0) strips the monotonic reading a caller derived expiresAt from its
+	// own clock would carry. Comparing two entries in different clock domains
+	// diverges across a suspend, when the monotonic clock stops but the wall
+	// clock does not.
+	s.entries[key] = cacheEntry{cred: cred, expiresAt: expiresAt.Round(0)}
 	return nil
 }
 
 // expired reports whether an entry expiring at expiresAt is spent as of now,
 // counting the skew margin.
 func expired(now, expiresAt time.Time) bool {
-	return now.Add(expirySkew).After(expiresAt)
+	return now.Add(ExpirySkew).After(expiresAt)
 }
 
 // sweep drops every expired entry, at most once per [sweepInterval]. The caller
 // holds s.mu.
 func (s *InMemoryCredentialStore) sweep(now time.Time) {
-	if now.Sub(s.lastSweep) < sweepInterval {
+	// A clock that went backwards makes a sweep due rather than suppressing one.
+	// The clock is caller-supplied and need not be monotonic, and one call
+	// arriving with a far-future reading would otherwise park lastSweep there and
+	// switch eviction off until real time caught up.
+	if d := now.Sub(s.lastSweep); d >= 0 && d < sweepInterval {
 		return
 	}
 	s.lastSweep = now

--- a/auth/store.go
+++ b/auth/store.go
@@ -19,8 +19,6 @@ import (
 	"errors"
 	"sync"
 	"time"
-
-	"google.golang.org/adk/v2/platform"
 )
 
 // ExpirySkew is how long before its stated expiry [InMemoryCredentialStore]
@@ -79,8 +77,8 @@ type CredentialStore interface {
 	// backend that way would have its result silently dropped.
 	//
 	// An entry should be treated as expired shortly before its stated expiry, by
-	// no more than [ExpirySkew]. Producers decline to cache anything with less
-	// than that left, so a store applying a wider margin would be handed
+	// no more than [ExpirySkew]. Producers decline to cache anything with that
+	// much left or less, so a store applying a wider margin would be handed
 	// credentials it then refuses to serve, and the cache would do nothing.
 	//
 	// The returned credential must be safe for concurrent [Credential.Apply] and
@@ -88,9 +86,17 @@ type CredentialStore interface {
 	// value handed in — a store that materializes credentials on read owes it
 	// too, since one value is handed to every request that hits.
 	Get(ctx context.Context, key CredentialKey) (Credential, bool, error)
-	// Set stores cred for key until expiresAt, an absolute time on the context's
-	// clock ([platform.Now]). Both arguments are required: a caller that cannot
-	// establish a lifetime must not cache, rather than cache forever.
+	// Set stores cred for key until expiresAt, an absolute wall-clock time. Both
+	// arguments are required: a caller that cannot establish a lifetime must not
+	// cache, rather than cache forever.
+	//
+	// Wall clock, and not platform.Now, deliberately. That seam is scoped to one
+	// call tree so concurrent runs can hold independent clocks, and a credential's
+	// expiry is not that kind of quantity: the token dies when its issuer says it
+	// does, on everybody's clock at once. Judging it on a simulated clock would
+	// serve a dead credential to a real request, or drop a live one — and the
+	// sweep, which judges entries the caller does not own, would let one call tree
+	// empty another's.
 	//
 	// cred must be safe for concurrent [Credential.Apply] and must not be mutated
 	// after Set returns, since every hit for key hands the same value to a
@@ -171,16 +177,13 @@ func NewInMemoryCredentialStore() *InMemoryCredentialStore {
 	return &InMemoryCredentialStore{entries: make(map[CredentialKey]cacheEntry)}
 }
 
-// Get implements [CredentialStore]. Expiry is evaluated against the context's
-// clock ([platform.Now]), so tests can drive it deterministically.
-func (s *InMemoryCredentialStore) Get(ctx context.Context, key CredentialKey) (Credential, bool, error) {
-	// Resolved before the lock: platform.Now is caller-supplied, and a clock that
-	// reaches back into the store would deadlock on this non-reentrant mutex.
-	now := platform.Now(ctx)
+// Get implements [CredentialStore].
+func (s *InMemoryCredentialStore) Get(_ context.Context, key CredentialKey) (Credential, bool, error) {
+	now := time.Now()
 
 	s.mu.Lock()
 	defer s.mu.Unlock()
-	s.sweep()
+	s.sweep(now)
 	e, ok := s.entries[key]
 	if !ok {
 		return nil, false, nil
@@ -193,7 +196,7 @@ func (s *InMemoryCredentialStore) Get(ctx context.Context, key CredentialKey) (C
 }
 
 // Set implements [CredentialStore].
-func (s *InMemoryCredentialStore) Set(ctx context.Context, key CredentialKey, cred Credential, expiresAt time.Time) error {
+func (s *InMemoryCredentialStore) Set(_ context.Context, key CredentialKey, cred Credential, expiresAt time.Time) error {
 	if cred == nil {
 		return errors.New("auth: Set requires a credential")
 	}
@@ -208,7 +211,7 @@ func (s *InMemoryCredentialStore) Set(ctx context.Context, key CredentialKey, cr
 	if s.entries == nil {
 		s.entries = make(map[CredentialKey]cacheEntry)
 	}
-	s.sweep()
+	s.sweep(time.Now())
 	// Round(0) strips the monotonic reading a caller derived expiresAt from its
 	// own clock would carry. Comparing two entries in different clock domains
 	// diverges across a suspend, when the monotonic clock stops but the wall
@@ -227,21 +230,13 @@ func expired(now, expiresAt time.Time) bool {
 }
 
 // sweep drops every expired entry, at most once per [sweepInterval]. The caller
-// holds s.mu.
-//
-// It reads the wall clock itself rather than taking the caller's
-// ([platform.Now]). The caller's clock is scoped to one call tree by design, and
-// this decision is not: it deletes other callers' entries. One request arriving
-// with a clock pinned to next year would otherwise empty a shared store, and two
-// call trees whose clocks differ by more than the interval would make every call
-// sweep. time.Now also always carries a monotonic reading, so the interval
-// cannot be defeated by a clock that steps.
-func (s *InMemoryCredentialStore) sweep() {
+// holds s.mu and supplies now, which is always the wall clock — see Set on why
+// this type reads no other.
+func (s *InMemoryCredentialStore) sweep(now time.Time) {
 	every := s.sweepEvery
 	if every == 0 {
 		every = sweepInterval
 	}
-	now := time.Now()
 	if !s.lastSweep.IsZero() && now.Sub(s.lastSweep) < every {
 		return
 	}
@@ -257,7 +252,7 @@ func (s *InMemoryCredentialStore) sweep() {
 func (s *InMemoryCredentialStore) Delete(_ context.Context, key CredentialKey) error {
 	s.mu.Lock()
 	defer s.mu.Unlock()
-	s.sweep()
+	s.sweep(time.Now())
 	delete(s.entries, key)
 	return nil
 }

--- a/auth/store.go
+++ b/auth/store.go
@@ -16,7 +16,7 @@ package auth
 
 import (
 	"context"
-	"fmt"
+	"errors"
 	"sync"
 	"time"
 
@@ -44,31 +44,59 @@ type CredentialKey struct {
 // (oauth2.TokenSource) do not need it. Implementations must be safe for
 // concurrent use.
 type CredentialStore interface {
-	// Get returns the cached, unexpired credential for key, if present.
+	// Get returns the cached, unexpired credential for key.
+	//
+	// The bool reports a usable hit, so a miss is (nil, false, nil). An
+	// implementation must not report a hit carrying a nil credential, and must
+	// not return a credential alongside a non-nil error: callers discard the
+	// credential whenever the error is non-nil, so a store reporting a degraded
+	// backend that way would have its result silently dropped.
+	//
+	// An entry should be treated as expired shortly before its stated expiry, so
+	// a credential is never handed out with too little lifetime left to complete
+	// the request it was fetched for. [InMemoryCredentialStore] uses a 10s
+	// margin.
 	Get(ctx context.Context, key CredentialKey) (Credential, bool, error)
 	// Set stores cred for key until expiresAt. Both cred and expiresAt are
 	// required: a caller that cannot establish a lifetime must not cache, rather
 	// than cache forever.
 	Set(ctx context.Context, key CredentialKey, cred Credential, expiresAt time.Time) error
-	// Delete removes any entry for key, so a credential can be invalidated ahead
-	// of its expiry — on consent revocation, logout, or a downstream 401.
-	// Removing an absent key is not an error.
+	// Delete removes any entry for key. Removing an absent key is not an error.
+	//
+	// It is the invalidation hook for callers that learn a credential is no
+	// longer good before it expires — on consent revocation or logout. ADK does
+	// not call it: a credential rejected downstream is refreshed by the provider
+	// that issued it, not deleted from the store, and until a provider implements
+	// that refresh a revoked credential is served until its cached expiry. The
+	// auth/gcp provider bounds that window to an hour.
 	Delete(ctx context.Context, key CredentialKey) error
 }
 
-// sweepEvery is how many Set calls pass between sweeps of expired entries.
-// Nothing else evicts a principal that resolves once and never returns.
-const sweepEvery = 256
+// sweepInterval is the shortest time between sweeps of expired entries. Nothing
+// else evicts a principal that resolves once and never returns, and the sweep is
+// O(entries), so it is paced by wall clock rather than by call count: a large
+// store under heavy traffic would otherwise pay for a scan on a fixed fraction
+// of its calls.
+const sweepInterval = time.Minute
 
 // InMemoryCredentialStore is a concurrency-safe, process-local [CredentialStore]
 // (per app+user+key, across sessions). It serves the same role as adk-python's
 // InMemoryCredentialService, which buckets the same way, and adds per-entry
 // expiry. The zero value is ready to use.
+//
+// It holds one entry per key seen, and it is unbounded: an expired entry is
+// dropped when its key is read, and otherwise by a sweep that any call at least
+// [sweepInterval] after the last one performs. Steady-state size is therefore
+// the number of distinct keys active within one credential lifetime. A process
+// that stops calling the store entirely retains whatever it last held, so a
+// caller that must not keep credential material past its use should
+// [InMemoryCredentialStore.Delete] it.
 type InMemoryCredentialStore struct {
-	// mu guards entries. Not an RWMutex: Get evicts on expiry, so readers write.
-	mu      sync.Mutex
-	sets    uint64
-	entries map[CredentialKey]cacheEntry
+	// mu guards every field below. Not an RWMutex: Get evicts on expiry and can
+	// sweep, so readers write.
+	mu        sync.Mutex
+	lastSweep time.Time
+	entries   map[CredentialKey]cacheEntry
 }
 
 type cacheEntry struct {
@@ -90,11 +118,12 @@ func (s *InMemoryCredentialStore) Get(ctx context.Context, key CredentialKey) (C
 
 	s.mu.Lock()
 	defer s.mu.Unlock()
+	s.sweep(now)
 	e, ok := s.entries[key]
 	if !ok {
 		return nil, false, nil
 	}
-	if now.Add(expirySkew).After(e.expiresAt) {
+	if expired(now, e.expiresAt) {
 		delete(s.entries, key)
 		return nil, false, nil
 	}
@@ -104,10 +133,12 @@ func (s *InMemoryCredentialStore) Get(ctx context.Context, key CredentialKey) (C
 // Set implements [CredentialStore].
 func (s *InMemoryCredentialStore) Set(ctx context.Context, key CredentialKey, cred Credential, expiresAt time.Time) error {
 	if cred == nil {
-		return fmt.Errorf("auth: Set requires a credential")
+		return errors.New("auth: Set requires a credential")
 	}
+	// The key names the app and the end user, so it stays out of the message: an
+	// error text is logged far more freely than the store's contents.
 	if expiresAt.IsZero() {
-		return fmt.Errorf("auth: Set requires an expiry for %+v", key)
+		return errors.New("auth: Set requires an expiry")
 	}
 	now := platform.Now(ctx)
 
@@ -116,16 +147,29 @@ func (s *InMemoryCredentialStore) Set(ctx context.Context, key CredentialKey, cr
 	if s.entries == nil {
 		s.entries = make(map[CredentialKey]cacheEntry)
 	}
-	s.sets++
-	if s.sets%sweepEvery == 0 {
-		for k, e := range s.entries {
-			if now.Add(expirySkew).After(e.expiresAt) {
-				delete(s.entries, k)
-			}
-		}
-	}
+	s.sweep(now)
 	s.entries[key] = cacheEntry{cred: cred, expiresAt: expiresAt}
 	return nil
+}
+
+// expired reports whether an entry expiring at expiresAt is spent as of now,
+// counting the skew margin.
+func expired(now, expiresAt time.Time) bool {
+	return now.Add(expirySkew).After(expiresAt)
+}
+
+// sweep drops every expired entry, at most once per [sweepInterval]. The caller
+// holds s.mu.
+func (s *InMemoryCredentialStore) sweep(now time.Time) {
+	if now.Sub(s.lastSweep) < sweepInterval {
+		return
+	}
+	s.lastSweep = now
+	for k, e := range s.entries {
+		if expired(now, e.expiresAt) {
+			delete(s.entries, k)
+		}
+	}
 }
 
 // Delete implements [CredentialStore].

--- a/auth/store.go
+++ b/auth/store.go
@@ -59,6 +59,14 @@ type CredentialKey struct {
 	Key string
 }
 
+// The same warning applies to a store that flattens a CredentialKey into one
+// identifier of its own — a row key, a filename, a cache line. AppName and
+// UserID come off the request and ADK does not authenticate either, so joining
+// the three fields on a separator lets {app "acme", user "bob|X"} and
+// {app "acme|bob", user "X"} name one entry, and one end user is then served
+// another's credential. Length-prefix or digest them, as auth/gcp does for the
+// slot itself.
+
 // CredentialStore caches resolved credentials across calls, keyed by
 // [CredentialKey]. It exists so network-backed providers (e.g. auth/gcp) avoid a
 // credential-service round-trip on every request; self-caching providers

--- a/auth/store.go
+++ b/auth/store.go
@@ -33,7 +33,9 @@ import (
 // the Success.expireTime field).
 //
 // It is exported so another [CredentialStore] can apply the same margin, and so
-// a producer can decline to cache a credential with less than this left.
+// a producer can decline to cache a credential with this much left or less —
+// which is the boundary the reference producer and this store both use, so that
+// the store serves exactly what a producer will write.
 const ExpirySkew = 10 * time.Second
 
 // CredentialKey identifies a cached credential: the app, the acting user, and a
@@ -162,7 +164,8 @@ type InMemoryCredentialStore struct {
 	mu sync.Mutex
 	// lastSweep is on the store's own clock, never a caller's. See sweep.
 	lastSweep time.Time
-	// sweepEvery overrides sweepInterval; only tests set it.
+	// sweepEvery overrides sweepInterval; only tests set it. Zero means the
+	// default, so it cannot be used to ask for a sweep on every call.
 	sweepEvery time.Duration
 	entries    map[CredentialKey]cacheEntry
 }

--- a/auth/store.go
+++ b/auth/store.go
@@ -78,8 +78,15 @@ type CredentialStore interface {
 	// credential whenever the error is non-nil, so a store reporting a degraded
 	// backend that way would have its result silently dropped.
 	//
-	// An entry should be treated as expired shortly before its stated expiry;
-	// [ExpirySkew] is the margin [InMemoryCredentialStore] applies.
+	// An entry should be treated as expired shortly before its stated expiry, by
+	// no more than [ExpirySkew]. Producers decline to cache anything with less
+	// than that left, so a store applying a wider margin would be handed
+	// credentials it then refuses to serve, and the cache would do nothing.
+	//
+	// The returned credential must be safe for concurrent [Credential.Apply] and
+	// must not be mutated afterwards, the same requirement Set places on the
+	// value handed in — a store that materializes credentials on read owes it
+	// too, since one value is handed to every request that hits.
 	Get(ctx context.Context, key CredentialKey) (Credential, bool, error)
 	// Set stores cred for key until expiresAt, an absolute time on the context's
 	// clock ([platform.Now]). Both arguments are required: a caller that cannot
@@ -91,6 +98,11 @@ type CredentialStore interface {
 	// cope with a cred it cannot encode — several of this package's credentials
 	// are opaque, and one wraps a live token source — by rejecting it, which
 	// costs a round trip rather than correctness.
+	//
+	// Both arguments are secret. cred is bearer material, and key names the
+	// application and the acting end user, so neither belongs in a log line or an
+	// error string, and a store that persists them owes them the protection the
+	// credentials themselves get.
 	Set(ctx context.Context, key CredentialKey, cred Credential, expiresAt time.Time) error
 	// Delete removes any entry for key. Removing an absent key is not an error.
 	//
@@ -102,15 +114,18 @@ type CredentialStore interface {
 	// The auth/gcp provider bounds that to an hour and exposes the key to delete
 	// as gcp.Client.CacheKey.
 	//
-	// Delete does not cancel a retrieval already in flight. One that began before
-	// the Delete will still write its result afterwards, so a caller invalidating
-	// a credential it has just seen rejected should expect a fresh one, not none.
+	// Delete does not cancel a retrieval already in flight, and it reports success
+	// whether or not an entry was there. A retrieval that began before the Delete
+	// writes its result afterwards, so if it began before the revocation it
+	// restores exactly the credential the caller was removing, for the full
+	// cached lifetime, and the nil return said nothing about it. Invalidate again
+	// once the request that failed has returned.
 	Delete(ctx context.Context, key CredentialKey) error
 }
 
 // sweepInterval is the shortest time between sweeps of expired entries. Nothing
 // else evicts a principal that resolves once and never returns, and the sweep is
-// O(entries), so it is paced by wall clock rather than by call count: a large
+// O(entries), so it is paced by elapsed time rather than by call count: a large
 // store under heavy traffic would otherwise pay for a scan on a fixed fraction
 // of its calls.
 const sweepInterval = time.Minute
@@ -120,19 +135,30 @@ const sweepInterval = time.Minute
 // InMemoryCredentialService, which buckets the same way, and adds per-entry
 // expiry. The zero value is ready to use.
 //
-// It holds one entry per key seen, and it is unbounded: an expired entry is
-// dropped when its key is read, and otherwise by a sweep that any call at least
-// [sweepInterval] after the last one performs. Steady-state size is therefore
-// the number of distinct keys active within one credential lifetime. A process
-// that stops calling the store entirely retains whatever it last held, so a
-// caller that must not keep credential material past its use should
-// [InMemoryCredentialStore.Delete] it.
+// It holds one entry per key ever written and has no size limit. An expired
+// entry is dropped when its key is read, and otherwise by a sweep that any call
+// at least [sweepInterval] after the last one performs, so the resident count is
+// the number of distinct keys written within one credential lifetime.
+//
+// That is a count of keys, not of requests — unless the producer makes it one.
+// The auth/gcp provider keys on the Client among other things, so a program that
+// builds a Client per request writes an entry per request that nothing will ever
+// read again, and the store then grows with request rate until the sweep catches
+// up. Build long-lived Clients, or supply a store of your own that bounds
+// itself.
+//
+// A process that stops calling the store entirely retains whatever it last held:
+// nothing here runs on its own. A caller that must not keep credential material
+// past its use should [InMemoryCredentialStore.Delete] it.
 type InMemoryCredentialStore struct {
 	// mu guards every field below. Not an RWMutex: Get evicts on expiry and can
 	// sweep, so readers write.
-	mu        sync.Mutex
+	mu sync.Mutex
+	// lastSweep is on the store's own clock, never a caller's. See sweep.
 	lastSweep time.Time
-	entries   map[CredentialKey]cacheEntry
+	// sweepEvery overrides sweepInterval; only tests set it.
+	sweepEvery time.Duration
+	entries    map[CredentialKey]cacheEntry
 }
 
 type cacheEntry struct {
@@ -154,7 +180,7 @@ func (s *InMemoryCredentialStore) Get(ctx context.Context, key CredentialKey) (C
 
 	s.mu.Lock()
 	defer s.mu.Unlock()
-	s.sweep(now)
+	s.sweep()
 	e, ok := s.entries[key]
 	if !ok {
 		return nil, false, nil
@@ -176,14 +202,13 @@ func (s *InMemoryCredentialStore) Set(ctx context.Context, key CredentialKey, cr
 	if expiresAt.IsZero() {
 		return errors.New("auth: Set requires an expiry")
 	}
-	now := platform.Now(ctx)
 
 	s.mu.Lock()
 	defer s.mu.Unlock()
 	if s.entries == nil {
 		s.entries = make(map[CredentialKey]cacheEntry)
 	}
-	s.sweep(now)
+	s.sweep()
 	// Round(0) strips the monotonic reading a caller derived expiresAt from its
 	// own clock would carry. Comparing two entries in different clock domains
 	// diverges across a suspend, when the monotonic clock stops but the wall
@@ -193,19 +218,31 @@ func (s *InMemoryCredentialStore) Set(ctx context.Context, key CredentialKey, cr
 }
 
 // expired reports whether an entry expiring at expiresAt is spent as of now,
-// counting the skew margin.
+// counting the skew margin. Exactly [ExpirySkew] left counts as spent, so this
+// is the precise complement of the test a producer applies before caching — the
+// auth/gcp provider stores exactly what this will serve, and nothing that it
+// won't.
 func expired(now, expiresAt time.Time) bool {
-	return now.Add(ExpirySkew).After(expiresAt)
+	return !expiresAt.After(now.Add(ExpirySkew))
 }
 
 // sweep drops every expired entry, at most once per [sweepInterval]. The caller
 // holds s.mu.
-func (s *InMemoryCredentialStore) sweep(now time.Time) {
-	// A clock that went backwards makes a sweep due rather than suppressing one.
-	// The clock is caller-supplied and need not be monotonic, and one call
-	// arriving with a far-future reading would otherwise park lastSweep there and
-	// switch eviction off until real time caught up.
-	if d := now.Sub(s.lastSweep); d >= 0 && d < sweepInterval {
+//
+// It reads the wall clock itself rather than taking the caller's
+// ([platform.Now]). The caller's clock is scoped to one call tree by design, and
+// this decision is not: it deletes other callers' entries. One request arriving
+// with a clock pinned to next year would otherwise empty a shared store, and two
+// call trees whose clocks differ by more than the interval would make every call
+// sweep. time.Now also always carries a monotonic reading, so the interval
+// cannot be defeated by a clock that steps.
+func (s *InMemoryCredentialStore) sweep() {
+	every := s.sweepEvery
+	if every == 0 {
+		every = sweepInterval
+	}
+	now := time.Now()
+	if !s.lastSweep.IsZero() && now.Sub(s.lastSweep) < every {
 		return
 	}
 	s.lastSweep = now
@@ -220,6 +257,7 @@ func (s *InMemoryCredentialStore) sweep(now time.Time) {
 func (s *InMemoryCredentialStore) Delete(_ context.Context, key CredentialKey) error {
 	s.mu.Lock()
 	defer s.mu.Unlock()
+	s.sweep()
 	delete(s.entries, key)
 	return nil
 }

--- a/auth/store.go
+++ b/auth/store.go
@@ -64,6 +64,11 @@ type CredentialKey struct {
 // credential-service round-trip on every request; self-caching providers
 // (oauth2.TokenSource) do not need it. Implementations must be safe for
 // concurrent use.
+//
+// It carries no unexported method, so anyone can implement it and its method set
+// is frozen: a method added later breaks every implementation outside this
+// module. That is the price of the seam, and it is why Delete is here from the
+// start rather than added when something first needs it.
 type CredentialStore interface {
 	// Get returns the cached, unexpired credential for key.
 	//

--- a/auth/store_internal_test.go
+++ b/auth/store_internal_test.go
@@ -1,0 +1,52 @@
+// Copyright 2026 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package auth
+
+import (
+	"strconv"
+	"testing"
+	"time"
+
+	"google.golang.org/adk/v2/platform"
+)
+
+// Expired entries for principals that never come back must not accumulate:
+// nothing but the sweep evicts them.
+func TestInMemoryCredentialStoreSweepsExpired(t *testing.T) {
+	clock := time.Date(2030, 1, 1, 0, 0, 0, 0, time.UTC)
+	ctx := platform.WithTimeProvider(t.Context(), func() time.Time { return clock })
+	s := NewInMemoryCredentialStore()
+	cred := BearerCredential{Token: "t"}
+
+	fill := func(prefix string, n int) {
+		t.Helper()
+		for i := range n {
+			key := CredentialKey{UserID: prefix + strconv.Itoa(i), Key: "res"}
+			if err := s.Set(ctx, key, cred, clock.Add(time.Minute)); err != nil {
+				t.Fatalf("Set() error = %v", err)
+			}
+		}
+	}
+	fill("early-", 300)
+	clock = clock.Add(time.Hour) // every entry above is now expired
+	fill("late-", 300)
+
+	s.mu.Lock()
+	got := len(s.entries)
+	s.mu.Unlock()
+	if got > 300 {
+		t.Errorf("store holds %d entries, want the 300 expired ones swept", got)
+	}
+}

--- a/auth/store_internal_test.go
+++ b/auth/store_internal_test.go
@@ -16,6 +16,7 @@ package auth
 
 import (
 	"strconv"
+	"sync"
 	"testing"
 	"time"
 
@@ -26,23 +27,20 @@ import (
 // nothing but the sweep evicts them, and a read of some other key is enough to
 // trigger one.
 func TestInMemoryCredentialStoreSweepsExpired(t *testing.T) {
-	clock := time.Date(2030, 1, 1, 0, 0, 0, 0, time.UTC)
-	ctx := platform.WithTimeProvider(t.Context(), func() time.Time { return clock })
 	s := NewInMemoryCredentialStore()
 	cred := BearerCredential{Token: "t"}
-
 	for i := range 300 {
 		key := CredentialKey{UserID: "gone-" + strconv.Itoa(i), Key: "res"}
-		if err := s.Set(ctx, key, cred, clock.Add(time.Minute)); err != nil {
+		if err := s.Set(t.Context(), key, cred, time.Now().Add(-time.Hour)); err != nil {
 			t.Fatalf("Set() error = %v", err)
 		}
 	}
 	if got := s.size(); got != 300 {
-		t.Fatalf("store holds %d entries before expiry, want 300", got)
+		t.Fatalf("store holds %d entries before any sweep is due, want 300", got)
 	}
 
-	clock = clock.Add(time.Hour) // every entry above is now expired
-	if _, _, err := s.Get(ctx, CredentialKey{UserID: "someone-else", Key: "res"}); err != nil {
+	s.arm()
+	if _, _, err := s.Get(t.Context(), CredentialKey{UserID: "someone-else", Key: "res"}); err != nil {
 		t.Fatalf("Get() error = %v", err)
 	}
 	if got := s.size(); got != 0 {
@@ -52,19 +50,16 @@ func TestInMemoryCredentialStoreSweepsExpired(t *testing.T) {
 
 // The sweep is paced: it costs O(entries), so it must not run on every call.
 func TestInMemoryCredentialStoreSweepIsPaced(t *testing.T) {
-	clock := time.Date(2030, 1, 1, 0, 0, 0, 0, time.UTC)
-	ctx := platform.WithTimeProvider(t.Context(), func() time.Time { return clock })
 	s := NewInMemoryCredentialStore()
-
 	key := CredentialKey{UserID: "u", Key: "res"}
-	if err := s.Set(ctx, key, BearerCredential{Token: "t"}, clock.Add(10*time.Second)); err != nil {
+	if err := s.Set(t.Context(), key, BearerCredential{Token: "t"}, time.Now().Add(-time.Hour)); err != nil {
 		t.Fatalf("Set() error = %v", err)
 	}
-	// Expired, but the next sweep is not due yet, so a Get for some other key
+
+	// Expired, but the next sweep is a minute away, so a Get for some other key
 	// must leave the entry alone.
-	clock = clock.Add(sweepInterval / 2)
 	swept := s.swept()
-	if _, _, err := s.Get(ctx, CredentialKey{UserID: "other", Key: "res"}); err != nil {
+	if _, _, err := s.Get(t.Context(), CredentialKey{UserID: "other", Key: "res"}); err != nil {
 		t.Fatalf("Get() error = %v", err)
 	}
 	if !s.swept().Equal(swept) {
@@ -75,52 +70,78 @@ func TestInMemoryCredentialStoreSweepIsPaced(t *testing.T) {
 	}
 }
 
-func (s *InMemoryCredentialStore) size() int {
-	s.mu.Lock()
-	defer s.mu.Unlock()
-	return len(s.entries)
-}
-
-func (s *InMemoryCredentialStore) swept() time.Time {
-	s.mu.Lock()
-	defer s.mu.Unlock()
-	return s.lastSweep
-}
-
-// A clock that jumps forward once must not switch eviction off for good. The
-// clock is caller-supplied and need not be monotonic, so one call arriving with
-// a far-future reading would otherwise park lastSweep there and suppress every
-// later sweep until real time caught up.
-func TestInMemoryCredentialStoreSweepSurvivesAClockJump(t *testing.T) {
-	base := time.Date(2030, 1, 1, 0, 0, 0, 0, time.UTC)
-	clock := base
-	ctx := platform.WithTimeProvider(t.Context(), func() time.Time { return clock })
+// The sweep decides the fate of every entry in the store, so it must run on the
+// store's own clock. platform.Now is scoped to one call tree by design, and one
+// request arriving with a clock pinned to next year must not empty a store that
+// other call trees share.
+func TestInMemoryCredentialStoreSweepIgnoresTheCallersClock(t *testing.T) {
 	s := NewInMemoryCredentialStore()
-
-	// One call lands with a clock five years ahead, on an empty store.
-	ahead := platform.WithTimeProvider(t.Context(), func() time.Time { return base.AddDate(5, 0, 0) })
-	if _, _, err := s.Get(ahead, CredentialKey{UserID: "other", Key: "res"}); err != nil {
-		t.Fatalf("Get() error = %v", err)
-	}
-
-	// Entries written on the real clock, short-lived.
 	for i := range 3 {
-		key := CredentialKey{UserID: "gone-" + strconv.Itoa(i), Key: "res"}
-		if err := s.Set(ctx, key, BearerCredential{Token: "t"}, clock.Add(time.Minute)); err != nil {
+		key := CredentialKey{UserID: "live-" + strconv.Itoa(i), Key: "res"}
+		if err := s.Set(t.Context(), key, BearerCredential{Token: "t"}, time.Now().Add(time.Hour)); err != nil {
 			t.Fatalf("Set() error = %v", err)
 		}
 	}
 
-	// An hour later on the real clock, they are all expired and a sweep is due.
-	// Nobody ever reads their keys, so the sweep is the only thing that can
-	// remove them.
-	clock = clock.Add(time.Hour)
-	if _, _, err := s.Get(ctx, CredentialKey{UserID: "other", Key: "res"}); err != nil {
+	s.arm()
+	ahead := platform.WithTimeProvider(t.Context(), func() time.Time { return time.Now().AddDate(5, 0, 0) })
+	if _, _, err := s.Get(ahead, CredentialKey{UserID: "someone-else", Key: "res"}); err != nil {
 		t.Fatalf("Get() error = %v", err)
 	}
-	if got := s.size(); got != 0 {
-		t.Errorf("store holds %d entries, want them swept once the clock came back", got)
+	if got := s.size(); got != 3 {
+		t.Errorf("store holds %d entries, want all 3 — one caller's clock must not expire another's credentials", got)
 	}
+}
+
+// The store is documented safe for concurrent use, and Get writes to the map on
+// eviction while the sweep deletes from it, so a plain RWMutex read lock would
+// not do. Armed so the sweep body actually runs while readers are in flight:
+// left at its default pacing it fires once, on an empty map, before any of these
+// goroutines start.
+func TestInMemoryCredentialStoreConcurrent(t *testing.T) {
+	ctx := t.Context()
+	s := NewInMemoryCredentialStore()
+	s.mu.Lock()
+	s.sweepEvery = time.Nanosecond
+	s.mu.Unlock()
+
+	keyFor := func(i int) CredentialKey {
+		return CredentialKey{AppName: "app", UserID: "user-" + strconv.Itoa(i%4), Key: "res"}
+	}
+	var wg sync.WaitGroup
+	for g := range 8 {
+		wg.Add(1)
+		go func() {
+			defer wg.Done()
+			for i := range 200 {
+				key := keyFor(g + i)
+				switch (g + i) % 3 {
+				case 0:
+					// Every other write is already spent, so Get's eviction and the
+					// sweep's deletes run while other goroutines read.
+					expires := time.Now().Add(time.Hour)
+					if (g+i)%2 == 0 {
+						expires = time.Now().Add(-time.Hour)
+					}
+					if err := s.Set(ctx, key, BearerCredential{Token: "t"}, expires); err != nil {
+						t.Errorf("Set() error = %v", err)
+						return
+					}
+				case 1:
+					if _, _, err := s.Get(ctx, key); err != nil {
+						t.Errorf("Get() error = %v", err)
+						return
+					}
+				case 2:
+					if err := s.Delete(ctx, key); err != nil {
+						t.Errorf("Delete() error = %v", err)
+						return
+					}
+				}
+			}
+		}()
+	}
+	wg.Wait()
 }
 
 // An entry's expiry is compared against later clock readings, so it must not
@@ -140,5 +161,45 @@ func TestInMemoryCredentialStoreSetStripsMonotonic(t *testing.T) {
 	// == compares the monotonic reading too, so this holds only once it is gone.
 	if stored != stored.Round(0) {
 		t.Errorf("stored expiry %v carries a monotonic reading", stored)
+	}
+}
+
+// arm makes the next call sweep, so a test need not wait out sweepInterval.
+func (s *InMemoryCredentialStore) arm() {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	s.sweepEvery = time.Nanosecond
+}
+
+func (s *InMemoryCredentialStore) size() int {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	return len(s.entries)
+}
+
+func (s *InMemoryCredentialStore) swept() time.Time {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	return s.lastSweep
+}
+
+// Delete sweeps too. A caller whose only traffic after a burst is invalidation
+// would otherwise never run one, and the type's doc says any call does.
+func TestInMemoryCredentialStoreDeleteSweeps(t *testing.T) {
+	s := NewInMemoryCredentialStore()
+	stale := CredentialKey{UserID: "gone", Key: "res"}
+	if err := s.Set(t.Context(), stale, BearerCredential{Token: "t"}, time.Now().Add(-time.Hour)); err != nil {
+		t.Fatalf("Set() error = %v", err)
+	}
+	if got := s.size(); got != 1 {
+		t.Fatalf("store holds %d entries, want the expired one still resident until a sweep is due", got)
+	}
+
+	s.arm()
+	if err := s.Delete(t.Context(), CredentialKey{UserID: "unrelated", Key: "res"}); err != nil {
+		t.Fatalf("Delete() error = %v", err)
+	}
+	if got := s.size(); got != 0 {
+		t.Errorf("store holds %d entries after an armed Delete, want the expired one swept", got)
 	}
 }

--- a/auth/store_internal_test.go
+++ b/auth/store_internal_test.go
@@ -96,9 +96,11 @@ func TestInMemoryCredentialStoreSweepIgnoresTheCallersClock(t *testing.T) {
 // The store is documented safe for concurrent use, and Get writes to the map on
 // eviction while the sweep deletes from it, so a plain RWMutex read lock would
 // not do. The pacing is shortened so the sweep body runs while readers are in
-// flight — at its default it fires once, on an empty map, before any of these
-// goroutines start — but not to zero, which would sweep every expired entry
-// before any Get could reach one and leave the eviction branch uncovered.
+// flight: left alone it fires once, on an empty map, before any of these
+// goroutines start. Shortened, but not to the point of sweeping on every call,
+// which would remove every expired entry before a Get could reach one and leave
+// the eviction branch with no concurrent coverage. Note that a zero sweepEvery
+// is the sentinel for the one-minute default, not for "always".
 func TestInMemoryCredentialStoreConcurrent(t *testing.T) {
 	ctx := t.Context()
 	s := NewInMemoryCredentialStore()

--- a/auth/store_internal_test.go
+++ b/auth/store_internal_test.go
@@ -23,30 +23,66 @@ import (
 )
 
 // Expired entries for principals that never come back must not accumulate:
-// nothing but the sweep evicts them.
+// nothing but the sweep evicts them, and a read of some other key is enough to
+// trigger one.
 func TestInMemoryCredentialStoreSweepsExpired(t *testing.T) {
 	clock := time.Date(2030, 1, 1, 0, 0, 0, 0, time.UTC)
 	ctx := platform.WithTimeProvider(t.Context(), func() time.Time { return clock })
 	s := NewInMemoryCredentialStore()
 	cred := BearerCredential{Token: "t"}
 
-	fill := func(prefix string, n int) {
-		t.Helper()
-		for i := range n {
-			key := CredentialKey{UserID: prefix + strconv.Itoa(i), Key: "res"}
-			if err := s.Set(ctx, key, cred, clock.Add(time.Minute)); err != nil {
-				t.Fatalf("Set() error = %v", err)
-			}
+	for i := range 300 {
+		key := CredentialKey{UserID: "gone-" + strconv.Itoa(i), Key: "res"}
+		if err := s.Set(ctx, key, cred, clock.Add(time.Minute)); err != nil {
+			t.Fatalf("Set() error = %v", err)
 		}
 	}
-	fill("early-", 300)
-	clock = clock.Add(time.Hour) // every entry above is now expired
-	fill("late-", 300)
-
-	s.mu.Lock()
-	got := len(s.entries)
-	s.mu.Unlock()
-	if got > 300 {
-		t.Errorf("store holds %d entries, want the 300 expired ones swept", got)
+	if got := s.size(); got != 300 {
+		t.Fatalf("store holds %d entries before expiry, want 300", got)
 	}
+
+	clock = clock.Add(time.Hour) // every entry above is now expired
+	if _, _, err := s.Get(ctx, CredentialKey{UserID: "someone-else", Key: "res"}); err != nil {
+		t.Fatalf("Get() error = %v", err)
+	}
+	if got := s.size(); got != 0 {
+		t.Errorf("store holds %d entries, want the expired ones swept", got)
+	}
+}
+
+// The sweep is paced: it costs O(entries), so it must not run on every call.
+func TestInMemoryCredentialStoreSweepIsPaced(t *testing.T) {
+	clock := time.Date(2030, 1, 1, 0, 0, 0, 0, time.UTC)
+	ctx := platform.WithTimeProvider(t.Context(), func() time.Time { return clock })
+	s := NewInMemoryCredentialStore()
+
+	key := CredentialKey{UserID: "u", Key: "res"}
+	if err := s.Set(ctx, key, BearerCredential{Token: "t"}, clock.Add(10*time.Second)); err != nil {
+		t.Fatalf("Set() error = %v", err)
+	}
+	// Expired, but the next sweep is not due yet, so a Get for some other key
+	// must leave the entry alone.
+	clock = clock.Add(sweepInterval / 2)
+	swept := s.swept()
+	if _, _, err := s.Get(ctx, CredentialKey{UserID: "other", Key: "res"}); err != nil {
+		t.Fatalf("Get() error = %v", err)
+	}
+	if !s.swept().Equal(swept) {
+		t.Error("a sweep ran twice inside one sweepInterval")
+	}
+	if got := s.size(); got != 1 {
+		t.Errorf("store holds %d entries, want the expired one still resident until a sweep is due", got)
+	}
+}
+
+func (s *InMemoryCredentialStore) size() int {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	return len(s.entries)
+}
+
+func (s *InMemoryCredentialStore) swept() time.Time {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	return s.lastSweep
 }

--- a/auth/store_internal_test.go
+++ b/auth/store_internal_test.go
@@ -95,14 +95,15 @@ func TestInMemoryCredentialStoreSweepIgnoresTheCallersClock(t *testing.T) {
 
 // The store is documented safe for concurrent use, and Get writes to the map on
 // eviction while the sweep deletes from it, so a plain RWMutex read lock would
-// not do. Armed so the sweep body actually runs while readers are in flight:
-// left at its default pacing it fires once, on an empty map, before any of these
-// goroutines start.
+// not do. The pacing is shortened so the sweep body runs while readers are in
+// flight — at its default it fires once, on an empty map, before any of these
+// goroutines start — but not to zero, which would sweep every expired entry
+// before any Get could reach one and leave the eviction branch uncovered.
 func TestInMemoryCredentialStoreConcurrent(t *testing.T) {
 	ctx := t.Context()
 	s := NewInMemoryCredentialStore()
 	s.mu.Lock()
-	s.sweepEvery = time.Nanosecond
+	s.sweepEvery = 200 * time.Microsecond
 	s.mu.Unlock()
 
 	keyFor := func(i int) CredentialKey {
@@ -201,5 +202,53 @@ func TestInMemoryCredentialStoreDeleteSweeps(t *testing.T) {
 	}
 	if got := s.size(); got != 0 {
 		t.Errorf("store holds %d entries after an armed Delete, want the expired one swept", got)
+	}
+}
+
+// Get evicts the expired entry it was asked for, rather than only reporting a
+// miss. That write is the reason the store takes a full Mutex instead of an
+// RWMutex, so nothing else in the suite distinguishes the two designs.
+func TestInMemoryCredentialStoreGetEvicts(t *testing.T) {
+	s := NewInMemoryCredentialStore()
+	key := CredentialKey{UserID: "u", Key: "res"}
+	if err := s.Set(t.Context(), key, BearerCredential{Token: "t"}, time.Now().Add(-time.Hour)); err != nil {
+		t.Fatalf("Set() error = %v", err)
+	}
+	if got := s.size(); got != 1 {
+		t.Fatalf("store holds %d entries, want the expired one resident until something removes it", got)
+	}
+
+	// No sweep is due, so a miss here can only come from Get's own eviction.
+	if _, ok, _ := s.Get(t.Context(), key); ok {
+		t.Fatal("Get() of an expired entry = hit, want miss")
+	}
+	if got := s.size(); got != 0 {
+		t.Error("Get() reported a miss without evicting the expired entry")
+	}
+}
+
+// expired's boundary is the exact complement of the floor a producer applies
+// before caching, so the store serves precisely what the auth/gcp provider is
+// willing to write and nothing it is not. It is pinned here rather than through
+// Get because a wall clock cannot hold still: any reading taken after the write
+// has already moved past the equality case.
+func TestExpiredBoundary(t *testing.T) {
+	now := time.Date(2030, 1, 1, 0, 0, 0, 0, time.UTC)
+	tests := []struct {
+		name      string
+		expiresAt time.Time
+		want      bool
+	}{
+		{"a nanosecond beyond the margin", now.Add(ExpirySkew + time.Nanosecond), false},
+		{"exactly the margin", now.Add(ExpirySkew), true},
+		{"a nanosecond inside the margin", now.Add(ExpirySkew - time.Nanosecond), true},
+		{"already past", now.Add(-time.Nanosecond), true},
+	}
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			if got := expired(now, tc.expiresAt); got != tc.want {
+				t.Errorf("expired(now, now%+v) = %v, want %v", tc.expiresAt.Sub(now), got, tc.want)
+			}
+		})
 	}
 }

--- a/auth/store_internal_test.go
+++ b/auth/store_internal_test.go
@@ -86,3 +86,59 @@ func (s *InMemoryCredentialStore) swept() time.Time {
 	defer s.mu.Unlock()
 	return s.lastSweep
 }
+
+// A clock that jumps forward once must not switch eviction off for good. The
+// clock is caller-supplied and need not be monotonic, so one call arriving with
+// a far-future reading would otherwise park lastSweep there and suppress every
+// later sweep until real time caught up.
+func TestInMemoryCredentialStoreSweepSurvivesAClockJump(t *testing.T) {
+	base := time.Date(2030, 1, 1, 0, 0, 0, 0, time.UTC)
+	clock := base
+	ctx := platform.WithTimeProvider(t.Context(), func() time.Time { return clock })
+	s := NewInMemoryCredentialStore()
+
+	// One call lands with a clock five years ahead, on an empty store.
+	ahead := platform.WithTimeProvider(t.Context(), func() time.Time { return base.AddDate(5, 0, 0) })
+	if _, _, err := s.Get(ahead, CredentialKey{UserID: "other", Key: "res"}); err != nil {
+		t.Fatalf("Get() error = %v", err)
+	}
+
+	// Entries written on the real clock, short-lived.
+	for i := range 3 {
+		key := CredentialKey{UserID: "gone-" + strconv.Itoa(i), Key: "res"}
+		if err := s.Set(ctx, key, BearerCredential{Token: "t"}, clock.Add(time.Minute)); err != nil {
+			t.Fatalf("Set() error = %v", err)
+		}
+	}
+
+	// An hour later on the real clock, they are all expired and a sweep is due.
+	// Nobody ever reads their keys, so the sweep is the only thing that can
+	// remove them.
+	clock = clock.Add(time.Hour)
+	if _, _, err := s.Get(ctx, CredentialKey{UserID: "other", Key: "res"}); err != nil {
+		t.Fatalf("Get() error = %v", err)
+	}
+	if got := s.size(); got != 0 {
+		t.Errorf("store holds %d entries, want them swept once the clock came back", got)
+	}
+}
+
+// An entry's expiry is compared against later clock readings, so it must not
+// carry a monotonic reading one of them might lack: the monotonic clock stops
+// across a suspend and the wall clock does not, and two entries in different
+// clock domains then expire on different timelines.
+func TestInMemoryCredentialStoreSetStripsMonotonic(t *testing.T) {
+	s := NewInMemoryCredentialStore()
+	key := CredentialKey{UserID: "u", Key: "res"}
+	// time.Now() carries a monotonic reading; Round(0) is the only way to drop it.
+	if err := s.Set(t.Context(), key, BearerCredential{Token: "t"}, time.Now().Add(time.Hour)); err != nil {
+		t.Fatalf("Set() error = %v", err)
+	}
+	s.mu.Lock()
+	stored := s.entries[key].expiresAt
+	s.mu.Unlock()
+	// == compares the monotonic reading too, so this holds only once it is gone.
+	if stored != stored.Round(0) {
+		t.Errorf("stored expiry %v carries a monotonic reading", stored)
+	}
+}

--- a/auth/store_test.go
+++ b/auth/store_test.go
@@ -15,6 +15,7 @@
 package auth_test
 
 import (
+	"context"
 	"testing"
 	"time"
 
@@ -31,7 +32,7 @@ func TestInMemoryCredentialStoreGetSet(t *testing.T) {
 	if _, ok, err := s.Get(ctx, key); err != nil || ok {
 		t.Fatalf("Get() on empty store = (_, %v, %v), want (_, false, nil)", ok, err)
 	}
-	if err := s.Set(ctx, key, cred, time.Time{}); err != nil {
+	if err := s.Set(ctx, key, cred, time.Now().Add(time.Hour)); err != nil {
 		t.Fatalf("Set() error = %v", err)
 	}
 	got, ok, err := s.Get(ctx, key)
@@ -64,14 +65,6 @@ func TestInMemoryCredentialStoreExpiry(t *testing.T) {
 	if _, ok, _ := s.Get(ctx, key); ok {
 		t.Error("Get() with past expiry = hit, want miss")
 	}
-
-	// Within the clock-skew window the entry is treated as expired.
-	if err := s.Set(ctx, key, cred, time.Now().Add(2*time.Second)); err != nil {
-		t.Fatal(err)
-	}
-	if _, ok, _ := s.Get(ctx, key); ok {
-		t.Error("Get() within skew window = hit, want miss")
-	}
 }
 
 // TestInMemoryCredentialStoreGetHonorsClock verifies Get evaluates expiry
@@ -87,6 +80,7 @@ func TestInMemoryCredentialStoreGetHonorsClock(t *testing.T) {
 	}{
 		{name: "before expiry", clock: base, wantHit: true},
 		{name: "past expiry", clock: base.Add(2 * time.Hour), wantHit: false},
+		{name: "inside the skew window", clock: expiry.Add(-time.Second), wantHit: false},
 	}
 	for _, tc := range tests {
 		t.Run(tc.name, func(t *testing.T) {
@@ -110,13 +104,81 @@ func TestInMemoryCredentialStoreOverwrite(t *testing.T) {
 	first := auth.BearerCredential{Token: "a"}
 	second := auth.BearerCredential{Token: "b"}
 
-	if err := s.Set(ctx, key, first, time.Time{}); err != nil {
+	expiry := time.Now().Add(time.Hour)
+	if err := s.Set(ctx, key, first, expiry); err != nil {
 		t.Fatal(err)
 	}
-	if err := s.Set(ctx, key, second, time.Time{}); err != nil {
+	if err := s.Set(ctx, key, second, expiry); err != nil {
 		t.Fatal(err)
 	}
 	if got, _, _ := s.Get(ctx, key); got != second {
 		t.Fatalf("Get() after overwrite = %v, want the second credential", got)
+	}
+}
+
+func TestInMemoryCredentialStoreSetRequiresCredentialAndExpiry(t *testing.T) {
+	s := auth.NewInMemoryCredentialStore()
+	key := auth.CredentialKey{Key: "res"}
+	if err := s.Set(t.Context(), key, nil, time.Now().Add(time.Hour)); err == nil {
+		t.Error("Set() with a nil credential = nil error, want error")
+	}
+	// A zero expiry must not silently mean "cache forever".
+	if err := s.Set(t.Context(), key, auth.BearerCredential{Token: "t"}, time.Time{}); err == nil {
+		t.Error("Set() with a zero expiry = nil error, want error")
+	}
+}
+
+func TestInMemoryCredentialStoreDelete(t *testing.T) {
+	ctx := t.Context()
+	s := auth.NewInMemoryCredentialStore()
+	key := auth.CredentialKey{Key: "res"}
+	if err := s.Set(ctx, key, auth.BearerCredential{Token: "t"}, time.Now().Add(time.Hour)); err != nil {
+		t.Fatal(err)
+	}
+	if err := s.Delete(ctx, key); err != nil {
+		t.Fatalf("Delete() error = %v", err)
+	}
+	if _, ok, _ := s.Get(ctx, key); ok {
+		t.Error("Get() after Delete = hit, want miss")
+	}
+	if err := s.Delete(ctx, key); err != nil {
+		t.Errorf("Delete() of an absent key = %v, want nil", err)
+	}
+}
+
+// The zero value is usable: Set used to panic on the nil map.
+func TestInMemoryCredentialStoreZeroValue(t *testing.T) {
+	var s auth.InMemoryCredentialStore
+	key := auth.CredentialKey{Key: "res"}
+	if err := s.Set(t.Context(), key, auth.BearerCredential{Token: "t"}, time.Now().Add(time.Hour)); err != nil {
+		t.Fatalf("Set() on a zero store error = %v", err)
+	}
+	if _, ok, _ := s.Get(t.Context(), key); !ok {
+		t.Error("Get() after Set on a zero store = miss, want hit")
+	}
+}
+
+// The clock is caller-supplied code; calling it under the store's non-reentrant
+// mutex would deadlock a TimeProvider that reaches back into the store.
+func TestInMemoryCredentialStoreClockMayTouchStore(t *testing.T) {
+	s := auth.NewInMemoryCredentialStore()
+	key := auth.CredentialKey{Key: "res"}
+	ctx := platform.WithTimeProvider(t.Context(), func() time.Time {
+		_, _, _ = s.Get(context.Background(), auth.CredentialKey{Key: "other"})
+		return time.Now()
+	})
+	if err := s.Set(ctx, key, auth.BearerCredential{Token: "t"}, time.Now().Add(time.Hour)); err != nil {
+		t.Fatalf("Set() error = %v", err)
+	}
+
+	done := make(chan struct{})
+	go func() {
+		defer close(done)
+		_, _, _ = s.Get(ctx, key)
+	}()
+	select {
+	case <-done:
+	case <-time.After(5 * time.Second):
+		t.Fatal("Get() deadlocked; the clock must not be called while holding the lock")
 	}
 }

--- a/auth/store_test.go
+++ b/auth/store_test.go
@@ -1,0 +1,122 @@
+// Copyright 2026 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package auth_test
+
+import (
+	"testing"
+	"time"
+
+	"google.golang.org/adk/v2/auth"
+	"google.golang.org/adk/v2/platform"
+)
+
+func TestInMemoryCredentialStoreGetSet(t *testing.T) {
+	ctx := t.Context()
+	s := auth.NewInMemoryCredentialStore()
+	key := auth.CredentialKey{AppName: "app", UserID: "user", Key: "res"}
+	cred := auth.BearerCredential{Token: "tok"}
+
+	if _, ok, err := s.Get(ctx, key); err != nil || ok {
+		t.Fatalf("Get() on empty store = (_, %v, %v), want (_, false, nil)", ok, err)
+	}
+	if err := s.Set(ctx, key, cred, time.Time{}); err != nil {
+		t.Fatalf("Set() error = %v", err)
+	}
+	got, ok, err := s.Get(ctx, key)
+	if err != nil || !ok || got != cred {
+		t.Fatalf("Get() after Set = (%v, %v, %v), want the stored credential", got, ok, err)
+	}
+
+	// A different key is a miss.
+	if _, ok, _ := s.Get(ctx, auth.CredentialKey{AppName: "app", UserID: "other", Key: "res"}); ok {
+		t.Error("Get() for a different user = hit, want miss")
+	}
+}
+
+func TestInMemoryCredentialStoreExpiry(t *testing.T) {
+	ctx := t.Context()
+	s := auth.NewInMemoryCredentialStore()
+	key := auth.CredentialKey{Key: "res"}
+	cred := auth.APIKeyCredential{Name: "X", Value: "v"}
+
+	if err := s.Set(ctx, key, cred, time.Now().Add(time.Hour)); err != nil {
+		t.Fatal(err)
+	}
+	if _, ok, _ := s.Get(ctx, key); !ok {
+		t.Error("Get() with far-future expiry = miss, want hit")
+	}
+
+	if err := s.Set(ctx, key, cred, time.Now().Add(-time.Second)); err != nil {
+		t.Fatal(err)
+	}
+	if _, ok, _ := s.Get(ctx, key); ok {
+		t.Error("Get() with past expiry = hit, want miss")
+	}
+
+	// Within the clock-skew window the entry is treated as expired.
+	if err := s.Set(ctx, key, cred, time.Now().Add(2*time.Second)); err != nil {
+		t.Fatal(err)
+	}
+	if _, ok, _ := s.Get(ctx, key); ok {
+		t.Error("Get() within skew window = hit, want miss")
+	}
+}
+
+// TestInMemoryCredentialStoreGetHonorsClock verifies Get evaluates expiry
+// against the context's clock (platform.Now), so a test can drive time
+// deterministically via platform.WithTimeProvider — no real sleeping.
+func TestInMemoryCredentialStoreGetHonorsClock(t *testing.T) {
+	base := time.Date(2030, 1, 1, 0, 0, 0, 0, time.UTC)
+	expiry := base.Add(time.Hour)
+	tests := []struct {
+		name    string
+		clock   time.Time
+		wantHit bool
+	}{
+		{name: "before expiry", clock: base, wantHit: true},
+		{name: "past expiry", clock: base.Add(2 * time.Hour), wantHit: false},
+	}
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			ctx := platform.WithTimeProvider(t.Context(), func() time.Time { return tc.clock })
+			s := auth.NewInMemoryCredentialStore()
+			key := auth.CredentialKey{Key: "res"}
+			if err := s.Set(ctx, key, auth.BearerCredential{Token: "tok"}, expiry); err != nil {
+				t.Fatal(err)
+			}
+			if _, ok, _ := s.Get(ctx, key); ok != tc.wantHit {
+				t.Errorf("Get() with clock %s = hit %v, want %v", tc.clock, ok, tc.wantHit)
+			}
+		})
+	}
+}
+
+func TestInMemoryCredentialStoreOverwrite(t *testing.T) {
+	ctx := t.Context()
+	s := auth.NewInMemoryCredentialStore()
+	key := auth.CredentialKey{Key: "res"}
+	first := auth.BearerCredential{Token: "a"}
+	second := auth.BearerCredential{Token: "b"}
+
+	if err := s.Set(ctx, key, first, time.Time{}); err != nil {
+		t.Fatal(err)
+	}
+	if err := s.Set(ctx, key, second, time.Time{}); err != nil {
+		t.Fatal(err)
+	}
+	if got, _, _ := s.Get(ctx, key); got != second {
+		t.Fatalf("Get() after overwrite = %v, want the second credential", got)
+	}
+}

--- a/auth/store_test.go
+++ b/auth/store_test.go
@@ -76,7 +76,7 @@ func TestInMemoryCredentialStoreExpiryBoundaries(t *testing.T) {
 	}{
 		{name: "an hour left", left: time.Hour, wantHit: true},
 		{name: "long past", left: -time.Hour, wantHit: false},
-		{name: "inside the skew window", left: auth.ExpirySkew - time.Second, wantHit: false},
+		{name: "inside the skew window", left: auth.ExpirySkew / 2, wantHit: false},
 	}
 	for _, tc := range tests {
 		t.Run(tc.name, func(t *testing.T) {
@@ -154,24 +154,29 @@ func TestInMemoryCredentialStoreZeroValue(t *testing.T) {
 	}
 }
 
-// ExpirySkew is public API and the provider's caching floor, so its value is
-// pinned from both sides: a wider margin would silently raise that floor, and a
-// narrower one would hand out credentials with no usable life left.
+// ExpirySkew is public API and the provider's caching floor. Its value is
+// asserted against a literal rather than measured against itself: a test written
+// only in terms of the constant moves with it and pins nothing, and changing a
+// released package's constant should have to be deliberate.
+func TestExpirySkewValue(t *testing.T) {
+	if auth.ExpirySkew != 10*time.Second {
+		t.Errorf("auth.ExpirySkew = %v, want 10s; changing it changes both what this store serves and what producers cache", auth.ExpirySkew)
+	}
+}
+
+// Which side of the margin is inclusive decides whether the store serves exactly
+// what a producer will cache. The exact boundary is pinned in an internal test of
+// expired(), since a wall clock moves between the write and the read; these
+// cases carry enough slack that the read cannot cross a boundary on its own.
 func TestExpirySkewBoundary(t *testing.T) {
 	tests := []struct {
 		name    string
 		left    time.Duration
 		wantHit bool
 	}{
-		// Relative to the constant: these pin which side of the boundary is
-		// inclusive, so that the store serves exactly what a producer will cache.
-		{"just outside the margin", auth.ExpirySkew + time.Second, true},
+		{"well outside the margin", auth.ExpirySkew + time.Minute, true},
 		{"exactly the margin", auth.ExpirySkew, false},
-		{"just inside the margin", auth.ExpirySkew - time.Millisecond, false},
-		// Spelled in seconds, so they move if the constant does. A test written
-		// only against ExpirySkew measures it against itself and pins nothing.
-		{"eleven seconds left", 11 * time.Second, true},
-		{"nine seconds left", 9 * time.Second, false},
+		{"well inside the margin", auth.ExpirySkew / 2, false},
 	}
 	for _, tc := range tests {
 		t.Run(tc.name, func(t *testing.T) {

--- a/auth/store_test.go
+++ b/auth/store_test.go
@@ -191,8 +191,7 @@ func TestInMemoryCredentialStoreClockMayTouchStore(t *testing.T) {
 func TestInMemoryCredentialStoreConcurrent(t *testing.T) {
 	ctx := t.Context()
 	s := auth.NewInMemoryCredentialStore()
-	// A short spread of keys and a mix of live and already-expired entries, so
-	// readers, writers, evictions and sweeps overlap on the same keys.
+	// A short spread of keys, so readers, writers and evictions collide on them.
 	keyFor := func(i int) auth.CredentialKey {
 		return auth.CredentialKey{AppName: "app", UserID: "user-" + strconv.Itoa(i%4), Key: "res"}
 	}
@@ -206,7 +205,15 @@ func TestInMemoryCredentialStoreConcurrent(t *testing.T) {
 				key := keyFor(g + i)
 				switch (g + i) % 3 {
 				case 0:
-					if err := s.Set(ctx, key, auth.BearerCredential{Token: "t"}, time.Now().Add(time.Hour)); err != nil {
+					// Every third write is already spent, so Get's eviction and the
+					// sweep's deletes actually run while other goroutines read. With
+					// only live entries neither branch executes, and the run says
+					// nothing about the write Get performs.
+					expires := time.Now().Add(time.Hour)
+					if (g+i)%2 == 0 {
+						expires = time.Now().Add(-time.Hour)
+					}
+					if err := s.Set(ctx, key, auth.BearerCredential{Token: "t"}, expires); err != nil {
 						t.Errorf("Set() error = %v", err)
 						return
 					}
@@ -225,4 +232,30 @@ func TestInMemoryCredentialStoreConcurrent(t *testing.T) {
 		}()
 	}
 	wg.Wait()
+}
+
+// Get evicts the expired entry it was asked for, rather than only reporting a
+// miss. That write is the reason the store takes a full Mutex instead of an
+// RWMutex, so nothing else in the suite distinguishes the two designs.
+func TestInMemoryCredentialStoreGetEvicts(t *testing.T) {
+	clock := time.Date(2030, 1, 1, 0, 0, 0, 0, time.UTC)
+	ctx := platform.WithTimeProvider(t.Context(), func() time.Time { return clock })
+	s := auth.NewInMemoryCredentialStore()
+	key := auth.CredentialKey{UserID: "u", Key: "res"}
+	if err := s.Set(ctx, key, auth.BearerCredential{Token: "t"}, clock.Add(10*time.Second)); err != nil {
+		t.Fatalf("Set() error = %v", err)
+	}
+
+	// Past the entry's expiry but well inside the sweep interval, so only Get's
+	// own eviction can remove it.
+	clock = clock.Add(15 * time.Second)
+	if _, ok, _ := s.Get(ctx, key); ok {
+		t.Fatal("Get() of an expired entry = hit, want miss")
+	}
+	// Set a far-future entry under a second key and read the first one back
+	// through a clock that would make it live again: it must be gone.
+	past := platform.WithTimeProvider(t.Context(), func() time.Time { return clock.Add(-time.Hour) })
+	if _, ok, _ := s.Get(past, key); ok {
+		t.Error("the expired entry survived the Get that reported it a miss")
+	}
 }

--- a/auth/store_test.go
+++ b/auth/store_test.go
@@ -16,6 +16,8 @@ package auth_test
 
 import (
 	"context"
+	"strconv"
+	"sync"
 	"testing"
 	"time"
 
@@ -181,4 +183,46 @@ func TestInMemoryCredentialStoreClockMayTouchStore(t *testing.T) {
 	case <-time.After(5 * time.Second):
 		t.Fatal("Get() deadlocked; the clock must not be called while holding the lock")
 	}
+}
+
+// The store is documented as safe for concurrent use, and Get writes to the map
+// too — on eviction and on a sweep — so a plain RWMutex read lock would not do.
+// Under -race this fails if the locking is dropped or weakened.
+func TestInMemoryCredentialStoreConcurrent(t *testing.T) {
+	ctx := t.Context()
+	s := auth.NewInMemoryCredentialStore()
+	// A short spread of keys and a mix of live and already-expired entries, so
+	// readers, writers, evictions and sweeps overlap on the same keys.
+	keyFor := func(i int) auth.CredentialKey {
+		return auth.CredentialKey{AppName: "app", UserID: "user-" + strconv.Itoa(i%4), Key: "res"}
+	}
+
+	var wg sync.WaitGroup
+	for g := range 8 {
+		wg.Add(1)
+		go func() {
+			defer wg.Done()
+			for i := range 200 {
+				key := keyFor(g + i)
+				switch (g + i) % 3 {
+				case 0:
+					if err := s.Set(ctx, key, auth.BearerCredential{Token: "t"}, time.Now().Add(time.Hour)); err != nil {
+						t.Errorf("Set() error = %v", err)
+						return
+					}
+				case 1:
+					if _, _, err := s.Get(ctx, key); err != nil {
+						t.Errorf("Get() error = %v", err)
+						return
+					}
+				case 2:
+					if err := s.Delete(ctx, key); err != nil {
+						t.Errorf("Delete() error = %v", err)
+						return
+					}
+				}
+			}
+		}()
+	}
+	wg.Wait()
 }

--- a/auth/store_test.go
+++ b/auth/store_test.go
@@ -16,8 +16,6 @@ package auth_test
 
 import (
 	"context"
-	"strconv"
-	"sync"
 	"testing"
 	"time"
 
@@ -185,55 +183,6 @@ func TestInMemoryCredentialStoreClockMayTouchStore(t *testing.T) {
 	}
 }
 
-// The store is documented as safe for concurrent use, and Get writes to the map
-// too — on eviction and on a sweep — so a plain RWMutex read lock would not do.
-// Under -race this fails if the locking is dropped or weakened.
-func TestInMemoryCredentialStoreConcurrent(t *testing.T) {
-	ctx := t.Context()
-	s := auth.NewInMemoryCredentialStore()
-	// A short spread of keys, so readers, writers and evictions collide on them.
-	keyFor := func(i int) auth.CredentialKey {
-		return auth.CredentialKey{AppName: "app", UserID: "user-" + strconv.Itoa(i%4), Key: "res"}
-	}
-
-	var wg sync.WaitGroup
-	for g := range 8 {
-		wg.Add(1)
-		go func() {
-			defer wg.Done()
-			for i := range 200 {
-				key := keyFor(g + i)
-				switch (g + i) % 3 {
-				case 0:
-					// Every third write is already spent, so Get's eviction and the
-					// sweep's deletes actually run while other goroutines read. With
-					// only live entries neither branch executes, and the run says
-					// nothing about the write Get performs.
-					expires := time.Now().Add(time.Hour)
-					if (g+i)%2 == 0 {
-						expires = time.Now().Add(-time.Hour)
-					}
-					if err := s.Set(ctx, key, auth.BearerCredential{Token: "t"}, expires); err != nil {
-						t.Errorf("Set() error = %v", err)
-						return
-					}
-				case 1:
-					if _, _, err := s.Get(ctx, key); err != nil {
-						t.Errorf("Get() error = %v", err)
-						return
-					}
-				case 2:
-					if err := s.Delete(ctx, key); err != nil {
-						t.Errorf("Delete() error = %v", err)
-						return
-					}
-				}
-			}
-		}()
-	}
-	wg.Wait()
-}
-
 // Get evicts the expired entry it was asked for, rather than only reporting a
 // miss. That write is the reason the store takes a full Mutex instead of an
 // RWMutex, so nothing else in the suite distinguishes the two designs.
@@ -252,10 +201,39 @@ func TestInMemoryCredentialStoreGetEvicts(t *testing.T) {
 	if _, ok, _ := s.Get(ctx, key); ok {
 		t.Fatal("Get() of an expired entry = hit, want miss")
 	}
-	// Set a far-future entry under a second key and read the first one back
-	// through a clock that would make it live again: it must be gone.
+	// Read it back through a clock that would make it live again: it must be gone,
+	// which only holds if the miss above also deleted it.
 	past := platform.WithTimeProvider(t.Context(), func() time.Time { return clock.Add(-time.Hour) })
 	if _, ok, _ := s.Get(past, key); ok {
 		t.Error("the expired entry survived the Get that reported it a miss")
+	}
+}
+
+// ExpirySkew is public API and the provider's caching floor, so its value is
+// pinned from both sides: a wider margin would silently raise that floor, and a
+// narrower one would hand out credentials with no usable life left.
+func TestExpirySkewBoundary(t *testing.T) {
+	now := time.Date(2030, 1, 1, 0, 0, 0, 0, time.UTC)
+	ctx := platform.WithTimeProvider(t.Context(), func() time.Time { return now })
+	tests := []struct {
+		name    string
+		expiry  time.Time
+		wantHit bool
+	}{
+		{"a nanosecond outside the margin", now.Add(auth.ExpirySkew + time.Nanosecond), true},
+		{"exactly the margin", now.Add(auth.ExpirySkew), false},
+		{"a nanosecond inside the margin", now.Add(auth.ExpirySkew - time.Nanosecond), false},
+	}
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			s := auth.NewInMemoryCredentialStore()
+			key := auth.CredentialKey{Key: "res"}
+			if err := s.Set(ctx, key, auth.BearerCredential{Token: "t"}, tc.expiry); err != nil {
+				t.Fatalf("Set() error = %v", err)
+			}
+			if _, ok, _ := s.Get(ctx, key); ok != tc.wantHit {
+				t.Errorf("Get() = hit %v, want %v", ok, tc.wantHit)
+			}
+		})
 	}
 }

--- a/auth/store_test.go
+++ b/auth/store_test.go
@@ -15,12 +15,10 @@
 package auth_test
 
 import (
-	"context"
 	"testing"
 	"time"
 
 	"google.golang.org/adk/v2/auth"
-	"google.golang.org/adk/v2/platform"
 )
 
 func TestInMemoryCredentialStoreGetSet(t *testing.T) {
@@ -67,31 +65,29 @@ func TestInMemoryCredentialStoreExpiry(t *testing.T) {
 	}
 }
 
-// TestInMemoryCredentialStoreGetHonorsClock verifies Get evaluates expiry
-// against the context's clock (platform.Now), so a test can drive time
-// deterministically via platform.WithTimeProvider — no real sleeping.
-func TestInMemoryCredentialStoreGetHonorsClock(t *testing.T) {
-	base := time.Date(2030, 1, 1, 0, 0, 0, 0, time.UTC)
-	expiry := base.Add(time.Hour)
+// Expiry is judged on the wall clock, and a test drives it by choosing how much
+// life to store rather than by moving a clock: a credential dies when its issuer
+// says it does, so this type reads no overridable clock at all.
+func TestInMemoryCredentialStoreExpiryBoundaries(t *testing.T) {
 	tests := []struct {
 		name    string
-		clock   time.Time
+		left    time.Duration
 		wantHit bool
 	}{
-		{name: "before expiry", clock: base, wantHit: true},
-		{name: "past expiry", clock: base.Add(2 * time.Hour), wantHit: false},
-		{name: "inside the skew window", clock: expiry.Add(-time.Second), wantHit: false},
+		{name: "an hour left", left: time.Hour, wantHit: true},
+		{name: "long past", left: -time.Hour, wantHit: false},
+		{name: "inside the skew window", left: auth.ExpirySkew - time.Second, wantHit: false},
 	}
 	for _, tc := range tests {
 		t.Run(tc.name, func(t *testing.T) {
-			ctx := platform.WithTimeProvider(t.Context(), func() time.Time { return tc.clock })
+			ctx := t.Context()
 			s := auth.NewInMemoryCredentialStore()
 			key := auth.CredentialKey{Key: "res"}
-			if err := s.Set(ctx, key, auth.BearerCredential{Token: "tok"}, expiry); err != nil {
+			if err := s.Set(ctx, key, auth.BearerCredential{Token: "tok"}, time.Now().Add(tc.left)); err != nil {
 				t.Fatal(err)
 			}
 			if _, ok, _ := s.Get(ctx, key); ok != tc.wantHit {
-				t.Errorf("Get() with clock %s = hit %v, want %v", tc.clock, ok, tc.wantHit)
+				t.Errorf("Get() with %s left = hit %v, want %v", tc.left, ok, tc.wantHit)
 			}
 		})
 	}
@@ -158,81 +154,35 @@ func TestInMemoryCredentialStoreZeroValue(t *testing.T) {
 	}
 }
 
-// The clock is caller-supplied code; calling it under the store's non-reentrant
-// mutex would deadlock a TimeProvider that reaches back into the store.
-func TestInMemoryCredentialStoreClockMayTouchStore(t *testing.T) {
-	s := auth.NewInMemoryCredentialStore()
-	key := auth.CredentialKey{Key: "res"}
-	ctx := platform.WithTimeProvider(t.Context(), func() time.Time {
-		_, _, _ = s.Get(context.Background(), auth.CredentialKey{Key: "other"})
-		return time.Now()
-	})
-	if err := s.Set(ctx, key, auth.BearerCredential{Token: "t"}, time.Now().Add(time.Hour)); err != nil {
-		t.Fatalf("Set() error = %v", err)
-	}
-
-	done := make(chan struct{})
-	go func() {
-		defer close(done)
-		_, _, _ = s.Get(ctx, key)
-	}()
-	select {
-	case <-done:
-	case <-time.After(5 * time.Second):
-		t.Fatal("Get() deadlocked; the clock must not be called while holding the lock")
-	}
-}
-
-// Get evicts the expired entry it was asked for, rather than only reporting a
-// miss. That write is the reason the store takes a full Mutex instead of an
-// RWMutex, so nothing else in the suite distinguishes the two designs.
-func TestInMemoryCredentialStoreGetEvicts(t *testing.T) {
-	clock := time.Date(2030, 1, 1, 0, 0, 0, 0, time.UTC)
-	ctx := platform.WithTimeProvider(t.Context(), func() time.Time { return clock })
-	s := auth.NewInMemoryCredentialStore()
-	key := auth.CredentialKey{UserID: "u", Key: "res"}
-	if err := s.Set(ctx, key, auth.BearerCredential{Token: "t"}, clock.Add(10*time.Second)); err != nil {
-		t.Fatalf("Set() error = %v", err)
-	}
-
-	// Past the entry's expiry but well inside the sweep interval, so only Get's
-	// own eviction can remove it.
-	clock = clock.Add(15 * time.Second)
-	if _, ok, _ := s.Get(ctx, key); ok {
-		t.Fatal("Get() of an expired entry = hit, want miss")
-	}
-	// Read it back through a clock that would make it live again: it must be gone,
-	// which only holds if the miss above also deleted it.
-	past := platform.WithTimeProvider(t.Context(), func() time.Time { return clock.Add(-time.Hour) })
-	if _, ok, _ := s.Get(past, key); ok {
-		t.Error("the expired entry survived the Get that reported it a miss")
-	}
-}
-
 // ExpirySkew is public API and the provider's caching floor, so its value is
 // pinned from both sides: a wider margin would silently raise that floor, and a
 // narrower one would hand out credentials with no usable life left.
 func TestExpirySkewBoundary(t *testing.T) {
-	now := time.Date(2030, 1, 1, 0, 0, 0, 0, time.UTC)
-	ctx := platform.WithTimeProvider(t.Context(), func() time.Time { return now })
 	tests := []struct {
 		name    string
-		expiry  time.Time
+		left    time.Duration
 		wantHit bool
 	}{
-		{"a nanosecond outside the margin", now.Add(auth.ExpirySkew + time.Nanosecond), true},
-		{"exactly the margin", now.Add(auth.ExpirySkew), false},
-		{"a nanosecond inside the margin", now.Add(auth.ExpirySkew - time.Nanosecond), false},
+		// Relative to the constant: these pin which side of the boundary is
+		// inclusive, so that the store serves exactly what a producer will cache.
+		{"just outside the margin", auth.ExpirySkew + time.Second, true},
+		{"exactly the margin", auth.ExpirySkew, false},
+		{"just inside the margin", auth.ExpirySkew - time.Millisecond, false},
+		// Spelled in seconds, so they move if the constant does. A test written
+		// only against ExpirySkew measures it against itself and pins nothing.
+		{"eleven seconds left", 11 * time.Second, true},
+		{"nine seconds left", 9 * time.Second, false},
 	}
 	for _, tc := range tests {
 		t.Run(tc.name, func(t *testing.T) {
+			ctx := t.Context()
 			s := auth.NewInMemoryCredentialStore()
 			key := auth.CredentialKey{Key: "res"}
-			if err := s.Set(ctx, key, auth.BearerCredential{Token: "t"}, tc.expiry); err != nil {
+			if err := s.Set(ctx, key, auth.BearerCredential{Token: "t"}, time.Now().Add(tc.left)); err != nil {
 				t.Fatalf("Set() error = %v", err)
 			}
 			if _, ok, _ := s.Get(ctx, key); ok != tc.wantHit {
-				t.Errorf("Get() = hit %v, want %v", ok, tc.wantHit)
+				t.Errorf("Get() with %s left = hit %v, want %v", tc.left, ok, tc.wantHit)
 			}
 		})
 	}

--- a/auth/transport.go
+++ b/auth/transport.go
@@ -25,8 +25,9 @@ import (
 // The provider receives the request context (req.Context()), which — for a
 // request made during a tool call — descends from the ADK context that flowed
 // into the call. The resolver runs on every request so that per-user
-// credentials are never shared across users; refresh and caching are handled by
-// the provider's underlying token source.
+// credentials are never shared across users. Refresh and caching belong to the
+// provider: a token-source-backed one refreshes itself, and a network-backed one
+// can cache in a [CredentialStore].
 type Transport struct {
 	// Provider resolves the credential to apply. Required.
 	Provider CredentialProvider


### PR DESCRIPTION
## Problem

The GCP provider (#1173) does a credential-service round trip — plus up to a ~10s pending poll — on every outbound request. There is no caching. adk-python has an `InMemoryCredentialService`, but it is not on this provider's path at all, so caching GCP credentials is new work rather than a port.

A credential cache is also exactly where cross-user leaks live, so most of the design here is about what the key must cover.

## Summary

- Adds `auth.CredentialStore` and `InMemoryCredentialStore`: concurrency-safe, per-entry expiry, a small clock-skew margin exported as `auth.ExpirySkew`, and a paced sweep so a principal that resolves once and never returns does not keep its credential for the life of the process.
- The GCP provider caches through the store (a private in-memory one by default, or `ProviderConfig.Store`). `Client.RetrieveCredential` returns a `*Retrieval` carrying the service's `expireTime`, so entries expire when the credential does.
- **The cache key covers everything that decides which credential comes back**: the app, the end user, the resource, the scopes, the continue URI, and the `*Client` — which fixes both the service asked and the identity the ask is authenticated as. Components are length-prefixed before hashing, so no delimiter inside a scope or URI can collide two schemes. Entries are shared exactly among providers that share a `Client`, which is what makes one store safe behind several providers.
- **Nothing is cached without a usable lifetime.** An absent, unparseable, already-past, or too-short expiry is declined, and the far end is clamped to an hour so a wrong or injected `expireTime` cannot pin an entry. That hour is also the bound on how long a credential revoked before its expiry keeps being served; `Client.CacheKey` names the entry to `Delete` sooner.
- Caching never fails auth: a store read error, a write error, or a malformed hit all fall through to a fresh retrieval.

Two things worth flagging for review rather than reading out of the diff:

- `Client.RetrieveCredential`'s signature changes, which `apidiff` reports as the only incompatible change in either package. `auth/gcp` is absent from v2.0.0, v2.1.0 and v2.2.0, so this reaches only someone tracking `main`.
- Concurrent cold misses on one key are not coalesced — N misses make N round trips. This is never worse than the per-request round trip it replaces, and `singleflight` would need a context detached from any one caller to avoid one cancellation failing everybody who joined. Left as a follow-up rather than folded into this change.