### PR TITLE
fix: keep latest function response as the final content when rearranging history

### DIFF
--- a/internal/llminternal/contents_processor.go
+++ b/internal/llminternal/contents_processor.go
@@ -355,6 +355,11 @@ SearchLoop: // A label to allow breaking out of the nested loop
 // responses may not have originally been consecutive. It preserves all
 // non-tool-call events (like user messages) in their original order.
 //
+// The call/response pair answered by the final event in the history is
+// emitted last: the latest function response is the newest information in
+// the session, and models act on the final contents, so it must not be
+// re-attached mid-history behind older (now stale) exchanges.
+//
 // It returns a new, correctly ordered slice of events or an error if the
 // history is malformed (e.g., a response is found without a corresponding call).
 func rearrangeEventsForFunctionResponsesInHistory(events []*session.Event) ([]*session.Event, error) {
@@ -374,8 +379,16 @@ func rearrangeEventsForFunctionResponsesInHistory(events []*session.Event) ([]*s
 		}
 	}
 
+	// The last event is the model's freshest information. When it is a
+	// function response (e.g. a long running tool completed after later,
+	// unrelated exchanges), its call/response pair must remain the last
+	// exchange in the rebuilt history.
+	lastEventIndex := len(events) - 1
+
 	// Rebuild the event list
 	var resultEvents []*session.Event
+	// Call/response pair answered by the final event; appended last.
+	var tailPair []*session.Event
 
 	for _, event := range events {
 		// If the event contains responses, skip it. It will be handled
@@ -389,9 +402,6 @@ func rearrangeEventsForFunctionResponsesInHistory(events []*session.Event) ([]*s
 			// This is a regular event (e.g., user message). Just append it.
 			resultEvents = append(resultEvents, event)
 		} else {
-			// This is a function call event, append it and search for responses
-			resultEvents = append(resultEvents, event)
-
 			// Find the unique indices of all corresponding response events.
 			// Using a map[int]struct{} as a set.
 			responseEventIndicesSet := make(map[int]struct{})
@@ -401,6 +411,15 @@ func rearrangeEventsForFunctionResponsesInHistory(events []*session.Event) ([]*s
 				}
 			}
 
+			// This is a function call event: append it, then its responses.
+			// If the pair is answered by the final event, route the whole
+			// pair (call + consolidated response) to the tail instead.
+			dst := &resultEvents
+			if _, found := responseEventIndicesSet[lastEventIndex]; found {
+				dst = &tailPair
+			}
+			*dst = append(*dst, event)
+
 			// If no responses were found for any calls in this event, continue.
 			if len(responseEventIndicesSet) == 0 {
 				continue
@@ -409,7 +428,7 @@ func rearrangeEventsForFunctionResponsesInHistory(events []*session.Event) ([]*s
 			// If there's only one unique response event, append it directly.
 			if len(responseEventIndicesSet) == 1 {
 				for index := range responseEventIndicesSet { // A trick to get the single key
-					resultEvents = append(resultEvents, events[index])
+					*dst = append(*dst, events[index])
 				}
 			} else {
 				// Multiple response events exist for that function call so we merge them.
@@ -431,12 +450,12 @@ func rearrangeEventsForFunctionResponsesInHistory(events []*session.Event) ([]*s
 				if err != nil {
 					return nil, fmt.Errorf("failed to merge response events: %w", err)
 				}
-				resultEvents = append(resultEvents, mergedEvent)
+				*dst = append(*dst, mergedEvent)
 			}
 		}
 	}
 
-	return resultEvents, nil
+	return append(resultEvents, tailPair...), nil
 }
 
 // mergeFunctionResponseEvents merges a list of function response events into one.

--- a/internal/llminternal/contents_processor_test.go
+++ b/internal/llminternal/contents_processor_test.go
@@ -1096,6 +1096,44 @@ func TestContentsRequestProcessor_Rearrange(t *testing.T) {
 		Response: map[string]any{"confirmed": false},
 	}
 
+	// Async Call/Responses: a long-running call whose final response arrives
+	// after later, unrelated exchanges (the async / late-completion flow).
+	fcAsyncPlan := &genai.FunctionCall{
+		ID:   "async_plan_call",
+		Name: "plan_tool",
+		Args: map[string]any{"task": "feature"},
+	}
+	frAsyncPlanAck := &genai.FunctionResponse{
+		ID:       "async_plan_call",
+		Name:     "plan_tool",
+		Response: map[string]any{"status": "dispatched"},
+	}
+	frAsyncPlanFinal := &genai.FunctionResponse{
+		ID:       "async_plan_call",
+		Name:     "plan_tool",
+		Response: map[string]any{"status": "completed", "result": "plan ready"},
+	}
+	fcAsyncStatus := &genai.FunctionCall{
+		ID:   "async_status_call",
+		Name: "status_tool",
+		Args: map[string]any{"target": "plan"},
+	}
+	frAsyncStatus := &genai.FunctionResponse{
+		ID:       "async_status_call",
+		Name:     "status_tool",
+		Response: map[string]any{"status": "running", "elapsed": "21s"},
+	}
+	fcAsyncWait := &genai.FunctionCall{
+		ID:   "async_wait_call",
+		Name: "wait_for",
+		Args: map[string]any{"target": "plan"},
+	}
+	frAsyncWait := &genai.FunctionResponse{
+		ID:       "async_wait_call",
+		Name:     "wait_for",
+		Response: map[string]any{"status": "timeout"},
+	}
+
 	// Error Call/Response
 	frOrphaned := &genai.FunctionResponse{
 		ID:       "no_matching_call",
@@ -1165,12 +1203,138 @@ func TestContentsRequestProcessor_Rearrange(t *testing.T) {
 				{Author: "user", LLMResponse: model.LLMResponse{Content: NewContentFromFunctionResponse(frBasic, "user")}},
 				{Author: "user", LLMResponse: model.LLMResponse{Content: NewContentFromFunctionResponse(frLROFinal, "user")}},
 			},
+			// The completed long-running pair stays LAST: frLROFinal is the
+			// newest information in the session, and models act on the final
+			// contents. The unrelated fcBasic exchange is still preserved (the
+			// property this case exists to verify) — before the completion, no
+			// longer after it, so the freshest response is never buried behind
+			// a stale exchange.
 			want: []*genai.Content{
 				genai.NewContentFromText("Run long process and search", "user"),
-				NewContentFromFunctionCall(fcLRO, "model"),
-				NewContentFromFunctionResponse(frLROFinal, "user"),
 				NewContentFromFunctionCall(fcBasic, "model"),
 				NewContentFromFunctionResponse(frBasic, "user"),
+				NewContentFromFunctionCall(fcLRO, "model"),
+				NewContentFromFunctionResponse(frLROFinal, "user"),
+			},
+		},
+		{
+			// A long-running tool's completion arrives as the last event, after
+			// an unrelated status exchange. The completion is the newest
+			// information: its call/response pair must remain the LAST contents.
+			// Intervening plain-text events are dropped by
+			// rearrangeEventsForLatestFunctionResponse (pre-existing behavior,
+			// matches adk-python).
+			name: "Late async completion stays the final content",
+			events: []*session.Event{
+				{Author: "user", LLMResponse: model.LLMResponse{Content: genai.NewContentFromText("Plan how to add feature Q", "user")}},
+				{Author: agentName, LLMResponse: model.LLMResponse{Content: NewContentFromFunctionCall(fcAsyncPlan, "model")}},
+				{Author: "user", LLMResponse: model.LLMResponse{Content: NewContentFromFunctionResponse(frAsyncPlanAck, "user")}},
+				{Author: agentName, LLMResponse: model.LLMResponse{Content: genai.NewContentFromText("I dispatched the planning task.", "model")}},
+				{Author: "user", LLMResponse: model.LLMResponse{Content: genai.NewContentFromText("What is the status?", "user")}},
+				{Author: agentName, LLMResponse: model.LLMResponse{Content: NewContentFromFunctionCall(fcAsyncStatus, "model")}},
+				{Author: "user", LLMResponse: model.LLMResponse{Content: NewContentFromFunctionResponse(frAsyncStatus, "user")}},
+				{Author: agentName, LLMResponse: model.LLMResponse{Content: genai.NewContentFromText("Still running.", "model")}},
+				{Author: "user", LLMResponse: model.LLMResponse{Content: NewContentFromFunctionResponse(frAsyncPlanFinal, "user")}},
+			},
+			want: []*genai.Content{
+				genai.NewContentFromText("Plan how to add feature Q", "user"),
+				NewContentFromFunctionCall(fcAsyncStatus, "model"),
+				NewContentFromFunctionResponse(frAsyncStatus, "user"),
+				NewContentFromFunctionCall(fcAsyncPlan, "model"),
+				NewContentFromFunctionResponse(frAsyncPlanFinal, "user"),
+			},
+		},
+		{
+			// Production shape (Gemini): model turns carry text alongside the
+			// FunctionCall part, and tool acks are authored by the agent. The
+			// tail pair moves as a unit, carrying its text part with it.
+			name: "Late async completion stays final with mixed text and call parts",
+			events: []*session.Event{
+				{Author: "user", LLMResponse: model.LLMResponse{Content: genai.NewContentFromText("Plan the new subcommand", "user")}},
+				{Author: agentName, LLMResponse: model.LLMResponse{Content: &genai.Content{Role: "model", Parts: []*genai.Part{{Text: "Planning..."}, {FunctionCall: fcAsyncPlan}}}}},
+				{Author: agentName, LLMResponse: model.LLMResponse{Content: NewContentFromFunctionResponse(frAsyncPlanAck, "user")}},
+				{Author: agentName, LLMResponse: model.LLMResponse{Content: genai.NewContentFromText("The planning agent is running.", "model")}},
+				{Author: "user", LLMResponse: model.LLMResponse{Content: genai.NewContentFromText("What's the status?", "user")}},
+				{Author: agentName, LLMResponse: model.LLMResponse{Content: &genai.Content{Role: "model", Parts: []*genai.Part{{Text: "Checking..."}, {FunctionCall: fcAsyncStatus}}}}},
+				{Author: agentName, LLMResponse: model.LLMResponse{Content: NewContentFromFunctionResponse(frAsyncStatus, "user")}},
+				{Author: agentName, LLMResponse: model.LLMResponse{Content: &genai.Content{Role: "model", Parts: []*genai.Part{{Text: "Waiting..."}, {FunctionCall: fcAsyncWait}}}}},
+				{Author: agentName, LLMResponse: model.LLMResponse{Content: NewContentFromFunctionResponse(frAsyncWait, "user")}},
+				{Author: agentName, LLMResponse: model.LLMResponse{Content: genai.NewContentFromText("Still running.", "model")}},
+				{Author: "user", LLMResponse: model.LLMResponse{Content: NewContentFromFunctionResponse(frAsyncPlanFinal, "user")}},
+			},
+			want: []*genai.Content{
+				genai.NewContentFromText("Plan the new subcommand", "user"),
+				{Role: "model", Parts: []*genai.Part{{Text: "Checking..."}, {FunctionCall: fcAsyncStatus}}},
+				NewContentFromFunctionResponse(frAsyncStatus, "user"),
+				{Role: "model", Parts: []*genai.Part{{Text: "Waiting..."}, {FunctionCall: fcAsyncWait}}},
+				NewContentFromFunctionResponse(frAsyncWait, "user"),
+				{Role: "model", Parts: []*genai.Part{{Text: "Planning..."}, {FunctionCall: fcAsyncPlan}}},
+				NewContentFromFunctionResponse(frAsyncPlanFinal, "user"),
+			},
+		},
+		{
+			// Naturally ordered history: the final response is already adjacent
+			// to its call. The tail-pair relocation must be an identity
+			// operation.
+			name: "Adjacent final response after earlier exchange keeps order",
+			events: []*session.Event{
+				{Author: "user", LLMResponse: model.LLMResponse{Content: genai.NewContentFromText("Search then check status", "user")}},
+				{Author: agentName, LLMResponse: model.LLMResponse{Content: NewContentFromFunctionCall(fcBasic, "model")}},
+				{Author: "user", LLMResponse: model.LLMResponse{Content: NewContentFromFunctionResponse(frBasic, "user")}},
+				{Author: "user", LLMResponse: model.LLMResponse{Content: genai.NewContentFromText("Now the status", "user")}},
+				{Author: agentName, LLMResponse: model.LLMResponse{Content: NewContentFromFunctionCall(fcAsyncStatus, "model")}},
+				{Author: "user", LLMResponse: model.LLMResponse{Content: NewContentFromFunctionResponse(frAsyncStatus, "user")}},
+			},
+			want: []*genai.Content{
+				genai.NewContentFromText("Search then check status", "user"),
+				NewContentFromFunctionCall(fcBasic, "model"),
+				NewContentFromFunctionResponse(frBasic, "user"),
+				genai.NewContentFromText("Now the status", "user"),
+				NewContentFromFunctionCall(fcAsyncStatus, "model"),
+				NewContentFromFunctionResponse(frAsyncStatus, "user"),
+			},
+		},
+		{
+			// Parallel calls whose late merged completion arrives last, with an
+			// unrelated exchange in between: the parallel pair moves to the
+			// tail as one unit (both calls, both responses).
+			name: "Late parallel completion stays final past unrelated exchange",
+			events: []*session.Event{
+				{Author: "user", LLMResponse: model.LLMResponse{Content: genai.NewContentFromText("Analyze and search, then look up basics", "user")}},
+				{
+					Author: agentName,
+					LLMResponse: model.LLMResponse{
+						Content: &genai.Content{
+							Role:  "model",
+							Parts: []*genai.Part{{FunctionCall: fcLROMixed}, {FunctionCall: fcNormalMixed}},
+						},
+					},
+				},
+				{
+					Author: "user",
+					LLMResponse: model.LLMResponse{
+						Content: &genai.Content{
+							Role:  "user",
+							Parts: []*genai.Part{{FunctionResponse: frLROInterMixed}, {FunctionResponse: frNormalMixed}},
+						},
+					},
+				},
+				{Author: agentName, LLMResponse: model.LLMResponse{Content: NewContentFromFunctionCall(fcBasic, "model")}},
+				{Author: "user", LLMResponse: model.LLMResponse{Content: NewContentFromFunctionResponse(frBasic, "user")}},
+				{Author: "user", LLMResponse: model.LLMResponse{Content: NewContentFromFunctionResponse(frLROFinalMixed, "user")}},
+			},
+			want: []*genai.Content{
+				genai.NewContentFromText("Analyze and search, then look up basics", "user"),
+				NewContentFromFunctionCall(fcBasic, "model"),
+				NewContentFromFunctionResponse(frBasic, "user"),
+				{
+					Role:  "model",
+					Parts: []*genai.Part{{FunctionCall: fcLROMixed}, {FunctionCall: fcNormalMixed}},
+				},
+				{
+					Role:  "user",
+					Parts: []*genai.Part{{FunctionResponse: frLROFinalMixed}, {FunctionResponse: frNormalMixed}},
+				},
 			},
 		},
 		{


### PR DESCRIPTION

**Please ensure you have read the [contribution guide](./CONTRIBUTING.md) before creating a pull request.**

### Link to Issue or Description of Change

**1. Link to an existing issue (if applicable):**

- Closes: #1181
- Related: #767, #761

**Problem:**

When a long-running tool's final response arrives as the latest session event,
`rearrangeEventsForLatestFunctionResponse` correctly consolidates it as the last content — but
`rearrangeEventsForFunctionResponsesInHistory` then re-attaches it immediately after its (much
earlier) call, leaving a stale unrelated exchange as the final content. Models act on the final
contents: in a production multi-agent supervisor, three different models (gemini-3.1-pro native;
DeepSeek V3.2 and Kimi K2 via an OpenAI-compatible path) were consistently blind to long-running
completions, re-answering the stale status exchange left at the tail instead. Full mechanism and
minimal repro in the linked issue.

Adjacency — the invariant pass 2 enforces — is necessary but not sufficient: the **latest
response must also remain the final content**.

**Solution:**

Pass 2 keeps its full adjacency invariant and adds one rule: **the call/response pair answered by
the final event is emitted last.** While rebuilding, if a call event's response set includes the
final event, the pair (call + consolidated response) is routed to a `tailPair` slice appended at
the end. ~25-line one-function change, no new imports.

Three guarantees, all test-covered:

1. **No events are dropped** — #761/#767's preservation property is intact; the unrelated exchange
   moves before the completion instead of after it.
2. **Every call is still immediately followed by its consolidated response** (parallel calls move
   with their call event as one unit, text parts included) — no new turn-structure shape is
   introduced.
3. **Pure no-op whenever the last event is not a function response**: the relocation gate keys on
   the final event's index appearing in a response set, which only ever holds response-event
   indices. All non-async histories produce byte-identical output (both "…in history (non-final
   event)" cases and all other existing rows pass unchanged).

One existing expectation updates: `"Rearrangement preserves unrelated function events"` (added by
#767). Its purpose — the unrelated `fcBasic` exchange must survive — still holds and is still
asserted; the previous `want` additionally encoded the incidental mid-history placement of the
merged completion, which is the bug this PR fixes. The updated `want` keeps the preserved exchange
*before* the completed pair so the freshest response is never buried behind a stale one (this also
matches adk-python's observable tail for the same flow — python truncates intervening events in
its pass 1, so its final content is always the merged latest response).

### Testing Plan

**Unit Tests:**

- [x] I have added or updated unit tests for my change.
- [x] All unit tests pass locally.

4 new rows in the existing `TestContentsRequestProcessor_Rearrange` table: `Late async completion
stays the final content` (the minimal repro), `Late async completion stays final with mixed text
and call parts` (production Gemini shape — text parts ride the call events; the tail pair moves as
a unit), `Adjacent final response after earlier exchange keeps order` (identity guard), `Late
parallel completion stays final past unrelated exchange` (parallel pair moves as one unit). Before
the fix, the three async rows + the updated #767 row fail with the completion buried mid-history;
after the fix all 17 rows pass.

```
go build -mod=readonly ./...                                  # ok
go test -race -mod=readonly -count=1 -shuffle=on ./...        # ok — 69 packages, 0 failures
go mod tidy -diff                                             # clean
golangci-lint run   (v2.3.1, repo config)                     # 0 issues
golangci-lint fmt --diff                                      # clean
```

**Manual End-to-End (E2E) Tests:**

Ran our production multi-agent supervisor against this branch (`go.mod` replace onto the patched
module), with tool completions delivered through the FunctionResponse path. Setup: dispatch a
long-running plan tool asynchronously; while it runs, ask "What's the status?" so a status/wait
exchange lands after the dispatch (the exact shape that triggers the bug); let the completion
arrive as a late `FunctionResponse` reusing the original call id.

Observed with gemini-3.1-pro, exercising the vulnerable shape twice in one session (the plan
completion, then a follow-up inspect tool completing the same way):

- Every completion-turn request was accepted by the Gemini API — no `INVALID_ARGUMENT` /
  turn-structure rejections (guarantee 2 verified live, not just analytically).
- The model acted on the fresh tail both times: it summarized the completed result and
  autonomously continued the pipeline off it — exactly the behavior the bug suppressed (on
  unpatched adk-go, the same scenario ends with the model re-answering the stale status).

Event-sequence excerpt (late completion as final event → next model turn acts on it):

```text
user|RESP:plan id=adk-e6beb946        ← late completion, original call id, last event
model|TEXT: "I've completed the plan and have the result. …"   ← model sees it
model|RESP:inspect (DISPATCHED)       ← pipeline continues off the result
```

### Checklist

- [x] I have read the [CONTRIBUTING.md](./CONTRIBUTING.md) document.
- [x] I have performed a self-review of my own code.
- [x] I have commented my code, particularly in hard-to-understand areas.
- [x] I have added tests that prove my fix is effective or that my feature works.
- [x] New and existing unit tests pass locally with my changes.
- [x] I have manually tested my changes end-to-end.
- [x] Any dependent changes have been merged and published in downstream modules. (N/A — no dependent changes)

### Additional context

- The merged-responses branch writing to `tailPair` is defensive consistency: through the standard
  two-pass pipeline it is unreachable (`rearrangeEventsForLatestFunctionResponse` pre-merges the
  final pair's responses into a single event, so the tail pair always takes the single-response
  branch); it matters only if this function is ever driven standalone.
- Fallback considered and rejected: gating the relocation on `LongRunningToolIDs` — pass 2 has
  never read that field, the #767 fixture doesn't set it (the suite would assert opposite outcomes
  for identical event shapes), and unmarked async flows (A2A, session resume, injected events)
  would stay broken. Can switch to the gated variant if you prefer the narrower blast radius.
- Same-file neighbors: #766 / #880 (competing fixes for #760's orphan-response error path in
  pass 1) and #1044 (compaction filtering) — function-disjoint from this change; test-file
  conflicts are additive. Happy to rebase in any order.
- The bug exists identically on the `v1` line (the three functions are byte-identical
  v1.5.0 ↔ main). Happy to open a `v1` backport if you still cut 1.x releases — maintainers' call.
