### PR TITLE
fix(workflow): resume LlmAgent nodes paused on a long-running tool request

### DIFF
--- a/agent/common_context.go
+++ b/agent/common_context.go
@@ -242,9 +242,15 @@ func (c *commonContext) ResumedInput(interruptID string) (any, bool) {
 
 // IsResumeActivation reports whether this context belongs to an activation
 // started to resume a paused node: the workflow engine injects the resolved
-// interrupt responses only then. A later activation of the same node in the
-// same invocation (loop-back edge, retry, per-item fan-out) is a fresh
-// lifecycle and reports false.
+// interrupt responses only then. A later activation of the same node that the
+// scheduler starts afresh (loop-back edge, retry) reports false.
+//
+// It is inherited rather than per-node: a child delegated via RunNode and a
+// ParallelWorker item both run under the resumed ancestor's context and report
+// true, though they are themselves fresh activations. So this answers "is a
+// resume in progress here", not "is THIS activation the resumed one" — for the
+// latter, also establish that the pause was raised under this activation, as
+// workflow.AgentNode does before dropping its input.
 //
 // Not on [Context] — read it through an optional-interface assertion.
 func (c *commonContext) IsResumeActivation() bool {

--- a/agent/common_context.go
+++ b/agent/common_context.go
@@ -240,6 +240,17 @@ func (c *commonContext) ResumedInput(interruptID string) (any, bool) {
 	return c.invocationContext.ResumedInput(interruptID)
 }
 
+// IsResumeActivation reports whether this context belongs to an activation
+// started to resume a paused node: the workflow engine injects the resolved
+// interrupt responses only then. A later activation of the same node in the
+// same invocation (loop-back edge, retry, per-item fan-out) is a fresh
+// lifecycle and reports false.
+//
+// Not on [Context] — read it through an optional-interface assertion.
+func (c *commonContext) IsResumeActivation() bool {
+	return c.resumeInputs != nil
+}
+
 // RunConfig implements [InvocationContext].
 func (c *commonContext) RunConfig() *RunConfig {
 	return c.invocationContext.RunConfig()

--- a/agent/workflowagent/hitl_test.go
+++ b/agent/workflowagent/hitl_test.go
@@ -357,9 +357,11 @@ func TestWorkflowAgent_AgentNode_CredentialResume(t *testing.T) {
 
 	var workerRuns atomic.Int32
 	var resumeGotInput atomic.Bool
+	// The fake isn't an LlmAgent, so opt into RerunOnResume explicitly (a
+	// real LlmAgent node gets it by default).
 	worker, err := workflow.NewAgentNode(
 		newConsentAgent(t, "worker", fcID, &workerRuns, &resumeGotInput),
-		workflow.NodeConfig{},
+		workflow.NodeConfig{RerunOnResume: ptrTrue()},
 	)
 	if err != nil {
 		t.Fatalf("NewAgentNode: %v", err)

--- a/agent/workflowagent/hitl_test.go
+++ b/agent/workflowagent/hitl_test.go
@@ -27,6 +27,7 @@ import (
 	"google.golang.org/genai"
 
 	"google.golang.org/adk/v2/agent"
+	"google.golang.org/adk/v2/internal/utils"
 	"google.golang.org/adk/v2/model"
 	"google.golang.org/adk/v2/session"
 	"google.golang.org/adk/v2/workflow"
@@ -328,6 +329,76 @@ func TestWorkflowAgent_RunThenResume_DynamicNodeOrchestrator(t *testing.T) {
 	}
 	if want := "Hello, Wolo!"; got != want {
 		t.Errorf("orchestrator output = %v, want %q", got, want)
+	}
+}
+
+// TestWorkflowAgent_AgentNode_CredentialResume pins resume for interactive
+// consent inside a workflow: an AgentNode whose agent pauses on a long-running
+// tool request (adk_request_credential — NOT the workflow's own
+// adk_request_input) must, on the follow-up turn, RESUME the paused node rather
+// than restart the graph or hand off. Concretely:
+//
+//   - the consent FunctionResponse (a non-adk_request_input name) is detected
+//     as a resume (name-agnostic detectResume);
+//   - the paused node re-enters and its agent finishes (AgentNode defaults to
+//     RerunOnResume, so Resume re-runs it instead of the handoff path);
+//   - the upstream node does NOT re-run (a fresh Workflow.Run would replay it);
+//   - the resumed agent is not re-fed its node input (it continues from
+//     history, so a single_turn/task agent would not re-call the tool).
+func TestWorkflowAgent_AgentNode_CredentialResume(t *testing.T) {
+	const fcID = "cred-1"
+
+	var upstreamRuns atomic.Int32
+	upstream := workflow.NewFunctionNode("upstream",
+		func(_ agent.Context, _ any) (string, error) {
+			upstreamRuns.Add(1)
+			return "upstream-out", nil
+		}, workflow.NodeConfig{})
+
+	var workerRuns atomic.Int32
+	var resumeGotInput atomic.Bool
+	worker, err := workflow.NewAgentNode(
+		newConsentAgent(t, "worker", fcID, &workerRuns, &resumeGotInput),
+		workflow.NodeConfig{},
+	)
+	if err != nil {
+		t.Fatalf("NewAgentNode: %v", err)
+	}
+
+	a := makeAgent(t, workflow.Chain(workflow.Start, upstream, worker))
+	sess := newFakeSession()
+
+	// Turn 1: fresh run. upstream runs, then worker's tool needs consent, so
+	// the node pauses on the long-running request.
+	turn1 := runFreshTurn(t, sess, a, "start")
+	if !hasLongRunning(turn1, fcID) {
+		t.Fatalf("turn 1 did not pause on the long-running consent request %q", fcID)
+	}
+	if got := upstreamRuns.Load(); got != 1 {
+		t.Fatalf("upstream runs after turn 1 = %d, want 1", got)
+	}
+	if got := workerRuns.Load(); got != 1 {
+		t.Fatalf("worker runs after turn 1 = %d, want 1", got)
+	}
+
+	// Turn 2: the user grants consent. The name is adk_request_credential, so
+	// this also exercises the name-agnostic resume dispatch.
+	turn2 := drainAgent(t, sess, a.Run(newMockCtx(sess, a, credentialResume(fcID))), nil)
+
+	if hasAnyLongRunning(turn2) {
+		t.Errorf("turn 2 paused again instead of completing: %v", turn2)
+	}
+	if !hasOutput(turn2, "done") {
+		t.Errorf("turn 2 did not produce the worker's completion output %q", "done")
+	}
+	if got := upstreamRuns.Load(); got != 1 {
+		t.Errorf("upstream runs after resume = %d, want 1 (upstream must NOT re-run)", got)
+	}
+	if got := workerRuns.Load(); got != 2 {
+		t.Errorf("worker runs = %d, want 2 (paused once, resumed once)", got)
+	}
+	if resumeGotInput.Load() {
+		t.Error("worker was re-fed its node input on resume; it must continue from history")
 	}
 }
 
@@ -661,4 +732,114 @@ func approvalSchema() *jsonschema.Schema {
 		},
 		Required: []string{"approved"},
 	}
+}
+
+// newConsentAgent builds a fake agent that, on its first activation, emits a
+// long-running adk_request_credential request (a tool needing interactive
+// consent) and pauses; once that request is answered in history it completes
+// with output "done". It records its activation count and whether it was given
+// node input on the resume activation.
+func newConsentAgent(t *testing.T, name, fcID string, runs *atomic.Int32, gotInputOnResume *atomic.Bool) agent.Agent {
+	t.Helper()
+	a, err := agent.New(agent.Config{
+		Name: name,
+		Run: func(ctx agent.InvocationContext) iter.Seq2[*session.Event, error] {
+			return func(yield func(*session.Event, error) bool) {
+				runs.Add(1)
+				if answeredInHistory(ctx.Session(), fcID) {
+					if ctx.UserContent() != nil {
+						gotInputOnResume.Store(true)
+					}
+					done := session.NewEvent(ctx, ctx.InvocationID())
+					done.Author = name
+					done.Output = "done"
+					done.LLMResponse = model.LLMResponse{Content: &genai.Content{
+						Role:  genai.RoleModel,
+						Parts: []*genai.Part{{Text: "done"}},
+					}}
+					yield(done, nil)
+					return
+				}
+				req := session.NewEvent(ctx, ctx.InvocationID())
+				req.Author = name
+				req.LongRunningToolIDs = []string{fcID}
+				req.LLMResponse = model.LLMResponse{Content: &genai.Content{
+					Role: genai.RoleModel,
+					Parts: []*genai.Part{{FunctionCall: &genai.FunctionCall{
+						ID:   fcID,
+						Name: "adk_request_credential",
+					}}},
+				}}
+				yield(req, nil)
+			}
+		},
+	})
+	if err != nil {
+		t.Fatalf("agent.New: %v", err)
+	}
+	return a
+}
+
+// credentialResume builds a user message carrying a consent FunctionResponse.
+// The name is adk_request_credential (not adk_request_input) to exercise the
+// name-agnostic resume dispatch.
+func credentialResume(fcID string) *genai.Content {
+	return &genai.Content{
+		Parts: []*genai.Part{{
+			FunctionResponse: &genai.FunctionResponse{
+				ID:       fcID,
+				Name:     "adk_request_credential",
+				Response: map[string]any{"status": "approved"},
+			},
+		}},
+	}
+}
+
+// answeredInHistory reports whether a FunctionResponse with the given id is in
+// session history.
+func answeredInHistory(sess session.Session, id string) bool {
+	events := sess.Events()
+	if events == nil {
+		return false
+	}
+	for i := 0; i < events.Len(); i++ {
+		for _, fr := range utils.FunctionResponses(utils.Content(events.At(i))) {
+			if fr != nil && fr.ID == id {
+				return true
+			}
+		}
+	}
+	return false
+}
+
+// hasLongRunning reports whether any event carries id in LongRunningToolIDs.
+func hasLongRunning(events []*session.Event, id string) bool {
+	for _, ev := range events {
+		for _, x := range ev.LongRunningToolIDs {
+			if x == id {
+				return true
+			}
+		}
+	}
+	return false
+}
+
+// hasAnyLongRunning reports whether any event carries a long-running interrupt.
+func hasAnyLongRunning(events []*session.Event) bool {
+	for _, ev := range events {
+		if len(ev.LongRunningToolIDs) > 0 {
+			return true
+		}
+	}
+	return false
+}
+
+// hasOutput reports whether any event carries the given Output value.
+func hasOutput(events []*session.Event, want any) bool {
+	for _, ev := range events {
+		if ev.Output == want {
+			return true
+		}
+	}
+	return false
 }

--- a/agent/workflowagent/hitl_test.go
+++ b/agent/workflowagent/hitl_test.go
@@ -845,3 +845,36 @@ func hasOutput(events []*session.Event, want any) bool {
 	}
 	return false
 }
+
+// TestWorkflowAgent_UnmatchedFunctionResponseRunsFresh pins that dropping the
+// function-name filter did not turn every function-response turn into a resume.
+// A reply that answers no waiting interrupt must fall through to a fresh
+// Workflow.Run, as it did before the ID-keyed matching landed — the runner
+// deliberately allows a turn to carry both text and a function response
+// (see runner.buildResumeResponses, which filters the same way).
+func TestWorkflowAgent_UnmatchedFunctionResponseRunsFresh(t *testing.T) {
+	var upstream atomic.Int32
+	asker := newAskerNode("approval", "decide", nil)
+	a := makeAgent(t, workflow.Chain(workflow.Start,
+		newCountingHandlerNode("upstream", &upstream), asker))
+	sess := newFakeSession()
+
+	runFreshTurn(t, sess, a, "start")
+	if got := upstream.Load(); got != 1 {
+		t.Fatalf("upstream runs after turn 1 = %d, want 1", got)
+	}
+
+	// A function response that answers nothing, alongside real user text.
+	msg := &genai.Content{Role: genai.RoleUser, Parts: []*genai.Part{
+		{Text: "forget it, start over"},
+		{FunctionResponse: &genai.FunctionResponse{
+			ID: "unrelated-call", Name: "get_weather", Response: map[string]any{"temp": 20},
+		}},
+	}}
+	drainAgent(t, sess, a.Run(newMockCtx(sess, a, msg)), nil)
+
+	if got := upstream.Load(); got != 2 {
+		t.Errorf("upstream runs after the unmatched reply = %d, want 2 (a fresh run); "+
+			"the turn was misrouted to Resume and the user's text was dropped", got)
+	}
+}

--- a/agent/workflowagent/hitl_test.go
+++ b/agent/workflowagent/hitl_test.go
@@ -878,3 +878,34 @@ func TestWorkflowAgent_UnmatchedFunctionResponseRunsFresh(t *testing.T) {
 			"the turn was misrouted to Resume and the user's text was dropped", got)
 	}
 }
+
+// TestWorkflowAgent_Resume_ReentryIsIdempotent is the re-entry twin of
+// TestWorkflowAgent_Resume_Idempotent, which only covers handoff. Re-entry is
+// now the default for LlmAgent nodes, so a replayed approval must not re-run
+// the node — otherwise a double-submit re-executes whatever the human approved.
+func TestWorkflowAgent_Resume_ReentryIsIdempotent(t *testing.T) {
+	const fcID = "cred-1"
+	var runs atomic.Int32
+	var gotInput atomic.Bool
+	worker, err := workflow.NewAgentNode(
+		newConsentAgent(t, "worker", fcID, &runs, &gotInput),
+		workflow.NodeConfig{RerunOnResume: ptrTrue()},
+	)
+	if err != nil {
+		t.Fatalf("NewAgentNode: %v", err)
+	}
+	a := makeAgent(t, workflow.Chain(workflow.Start, worker))
+	sess := newFakeSession()
+
+	runFreshTurn(t, sess, a, "start")
+	drainAgent(t, sess, a.Run(newMockCtx(sess, a, credentialResume(fcID))), nil)
+	afterFirst := runs.Load()
+
+	// Byte-identical replay of the same approval.
+	drainAgent(t, sess, a.Run(newMockCtx(sess, a, credentialResume(fcID))), workflow.ErrNothingToResume)
+
+	if got := runs.Load(); got != afterFirst {
+		t.Errorf("worker runs = %d after a replayed approval, want %d "+
+			"(a duplicate resume must reschedule nothing)", got, afterFirst)
+	}
+}

--- a/agent/workflowagent/hitl_test.go
+++ b/agent/workflowagent/hitl_test.go
@@ -782,6 +782,57 @@ func newConsentAgent(t *testing.T, name, fcID string, runs *atomic.Int32, gotInp
 	return a
 }
 
+// newTwoInterruptAgent pauses on TWO long-running requests at once, the shape
+// that rehydrates through inferNodeState's partial-resume arm. Once the first
+// is answered it performs a counted action and pauses on the second alone;
+// once both are answered it completes. approved counts the actions, so a
+// replayed answer that re-runs the node shows up as a second count.
+func newTwoInterruptAgent(t *testing.T, name, idX, idY string, runs, approved *atomic.Int32) agent.Agent {
+	t.Helper()
+	pause := func(ctx agent.InvocationContext, ids ...string) *session.Event {
+		ev := session.NewEvent(ctx, ctx.InvocationID())
+		ev.Author = name
+		ev.LongRunningToolIDs = ids
+		parts := make([]*genai.Part, 0, len(ids))
+		for _, id := range ids {
+			parts = append(parts, &genai.Part{FunctionCall: &genai.FunctionCall{
+				ID: id, Name: "adk_request_credential",
+			}})
+		}
+		ev.LLMResponse = model.LLMResponse{Content: &genai.Content{Role: genai.RoleModel, Parts: parts}}
+		return ev
+	}
+	a, err := agent.New(agent.Config{
+		Name: name,
+		Run: func(ctx agent.InvocationContext) iter.Seq2[*session.Event, error] {
+			return func(yield func(*session.Event, error) bool) {
+				runs.Add(1)
+				switch {
+				case !answeredInHistory(ctx.Session(), idX):
+					yield(pause(ctx, idX, idY), nil)
+				case !answeredInHistory(ctx.Session(), idY):
+					approved.Add(1)
+					yield(pause(ctx, idY), nil)
+				default:
+					approved.Add(1)
+					done := session.NewEvent(ctx, ctx.InvocationID())
+					done.Author = name
+					done.Output = "done"
+					done.LLMResponse = model.LLMResponse{Content: &genai.Content{
+						Role:  genai.RoleModel,
+						Parts: []*genai.Part{{Text: "done"}},
+					}}
+					yield(done, nil)
+				}
+			}
+		},
+	})
+	if err != nil {
+		t.Fatalf("agent.New: %v", err)
+	}
+	return a
+}
+
 // credentialResume builds a user message carrying a consent FunctionResponse.
 // The name is adk_request_credential (not adk_request_input) to exercise the
 // name-agnostic resume dispatch.
@@ -907,5 +958,89 @@ func TestWorkflowAgent_Resume_ReentryIsIdempotent(t *testing.T) {
 	if got := runs.Load(); got != afterFirst {
 		t.Errorf("worker runs = %d after a replayed approval, want %d "+
 			"(a duplicate resume must reschedule nothing)", got, afterFirst)
+	}
+}
+
+// TestWorkflowAgent_SettledReplyDoesNotDiscardNewText covers the case the
+// ID-keyed filter alone gets wrong. History never un-answers an interrupt, so a
+// re-entry node's settled ID stays recognisable for the rest of the session; a
+// client that echoes it back alongside the human's next instruction would
+// otherwise route the whole turn to Resume, which schedules nothing and fails
+// with ErrNothingToResume — losing the instruction. The bare replay above is
+// still an error; this one has work to do.
+func TestWorkflowAgent_SettledReplyDoesNotDiscardNewText(t *testing.T) {
+	const fcID = "cred-2"
+	var runs atomic.Int32
+	var gotInput atomic.Bool
+	worker, err := workflow.NewAgentNode(
+		newConsentAgent(t, "worker", fcID, &runs, &gotInput),
+		workflow.NodeConfig{RerunOnResume: ptrTrue()},
+	)
+	if err != nil {
+		t.Fatalf("NewAgentNode: %v", err)
+	}
+	a := makeAgent(t, workflow.Chain(workflow.Start, worker))
+	sess := newFakeSession()
+
+	runFreshTurn(t, sess, a, "start")
+	drainAgent(t, sess, a.Run(newMockCtx(sess, a, credentialResume(fcID))), nil)
+	afterFirst := runs.Load()
+
+	// The human's next instruction, with the settled approval echoed back.
+	msg := &genai.Content{Role: genai.RoleUser, Parts: []*genai.Part{
+		{Text: "now do something else"},
+		{FunctionResponse: &genai.FunctionResponse{
+			ID: fcID, Name: "adk_request_credential",
+			Response: map[string]any{"status": "approved"},
+		}},
+	}}
+	drainAgent(t, sess, a.Run(newMockCtx(sess, a, msg)), nil)
+
+	if got := runs.Load(); got == afterFirst {
+		t.Errorf("worker runs = %d, want more than %d; the turn was routed to "+
+			"Resume on a settled reply and the user's text was dropped", got, afterFirst)
+	}
+}
+
+// TestWorkflowAgent_Resume_ReentryIsIdempotentWithAnOpenInterrupt is the
+// partial-resume twin of TestWorkflowAgent_Resume_ReentryIsIdempotent. A node
+// pausing on two long-running IDs at once rehydrates through a different arm of
+// inferNodeState, and a node still holding an open interrupt is no less exposed
+// to a duplicate answer than one that has none.
+func TestWorkflowAgent_Resume_ReentryIsIdempotentWithAnOpenInterrupt(t *testing.T) {
+	const idX, idY = "cred-3", "confirm-3"
+	var runs, approved atomic.Int32
+	worker, err := workflow.NewAgentNode(
+		newTwoInterruptAgent(t, "worker", idX, idY, &runs, &approved),
+		workflow.NodeConfig{RerunOnResume: ptrTrue()},
+	)
+	if err != nil {
+		t.Fatalf("NewAgentNode: %v", err)
+	}
+	a := makeAgent(t, workflow.Chain(workflow.Start, worker))
+	sess := newFakeSession()
+
+	runFreshTurn(t, sess, a, "start")
+	// Answer the first of the two; the node re-enters, acts on it, and pauses
+	// again on the second.
+	drainAgent(t, sess, a.Run(newMockCtx(sess, a, credentialResume(idX))), nil)
+	afterFirst := approved.Load()
+	if afterFirst != 1 {
+		t.Fatalf("approved actions after the first answer = %d, want 1", afterFirst)
+	}
+
+	// Replay that same answer. The second interrupt is still open, so the node
+	// is not settled — but this answer is, and re-running on it would redo
+	// what the human already approved.
+	drainAgent(t, sess, a.Run(newMockCtx(sess, a, credentialResume(idX))), workflow.ErrNothingToResume)
+	if got := approved.Load(); got != afterFirst {
+		t.Errorf("approved actions after a replayed answer = %d, want %d", got, afterFirst)
+	}
+
+	// The still-open interrupt must remain answerable.
+	drainAgent(t, sess, a.Run(newMockCtx(sess, a, credentialResume(idY))), nil)
+	if got := approved.Load(); got <= afterFirst {
+		t.Errorf("approved actions after answering the open interrupt = %d, want more than %d "+
+			"(the replay guard swallowed a genuine answer)", got, afterFirst)
 	}
 }

--- a/agent/workflowagent/hitl_test.go
+++ b/agent/workflowagent/hitl_test.go
@@ -1044,3 +1044,203 @@ func TestWorkflowAgent_Resume_ReentryIsIdempotentWithAnOpenInterrupt(t *testing.
 			"(the replay guard swallowed a genuine answer)", got, afterFirst)
 	}
 }
+
+// TestWorkflowAgent_Handoff_PartialAnswerKeepsNodeWaiting covers a handoff node
+// that raised several interrupts at once and has been answered on only some of
+// them. Completing it there would drop the unanswered ones and hand its
+// successors an output standing in for a decision nobody made — for a rejected
+// confirmation, one gating the very work it rejected. adk-python's replay
+// interceptor keeps such a node waiting and re-bubbles the unresolved IDs.
+func TestWorkflowAgent_Handoff_PartialAnswerKeepsNodeWaiting(t *testing.T) {
+	const idA, idB = "confirm-a", "confirm-b"
+	var successorRuns atomic.Int32
+	worker, err := workflow.NewAgentNode(
+		newTwoConfirmAgent(t, "approve_payment", idA, idB),
+		workflow.NodeConfig{}, // handoff: the engine default for a non-LlmAgent
+	)
+	if err != nil {
+		t.Fatalf("NewAgentNode: %v", err)
+	}
+	guarded := workflow.NewFunctionNode("execute_payment",
+		func(_ agent.Context, _ any) (string, error) {
+			successorRuns.Add(1)
+			return "paid", nil
+		}, workflow.NodeConfig{})
+	a := makeAgent(t, workflow.Chain(workflow.Start, worker, guarded))
+	sess := newFakeSession()
+	runFreshTurn(t, sess, a, "pay 500")
+
+	// Reject the first; leave the second unanswered.
+	reject := &genai.Content{Role: genai.RoleUser, Parts: []*genai.Part{{
+		FunctionResponse: &genai.FunctionResponse{
+			ID: idA, Name: "adk_request_confirmation",
+			Response: map[string]any{"confirmed": false},
+		},
+	}}}
+	drainAgent(t, sess, a.Run(newMockCtx(sess, a, reject)), nil)
+
+	if got := successorRuns.Load(); got != 0 {
+		t.Errorf("successor ran %d time(s) while an interrupt was still unanswered, want 0", got)
+	}
+}
+
+// TestWorkflowAgent_Handoff_AllAnswersCompleteTheNode is the control for the
+// test above: once every interrupt has an answer the node completes and hands
+// off as before.
+func TestWorkflowAgent_Handoff_AllAnswersCompleteTheNode(t *testing.T) {
+	const idA, idB = "confirm-c", "confirm-d"
+	var successorRuns atomic.Int32
+	worker, err := workflow.NewAgentNode(
+		newTwoConfirmAgent(t, "approve_payment", idA, idB),
+		workflow.NodeConfig{},
+	)
+	if err != nil {
+		t.Fatalf("NewAgentNode: %v", err)
+	}
+	guarded := workflow.NewFunctionNode("execute_payment",
+		func(_ agent.Context, _ any) (string, error) {
+			successorRuns.Add(1)
+			return "paid", nil
+		}, workflow.NodeConfig{})
+	a := makeAgent(t, workflow.Chain(workflow.Start, worker, guarded))
+	sess := newFakeSession()
+	runFreshTurn(t, sess, a, "pay 500")
+
+	both := &genai.Content{Role: genai.RoleUser, Parts: []*genai.Part{
+		{FunctionResponse: &genai.FunctionResponse{
+			ID: idA, Name: "adk_request_confirmation",
+			Response: map[string]any{"confirmed": true},
+		}},
+		{FunctionResponse: &genai.FunctionResponse{
+			ID: idB, Name: "adk_request_confirmation",
+			Response: map[string]any{"confirmed": true},
+		}},
+	}}
+	drainAgent(t, sess, a.Run(newMockCtx(sess, a, both)), nil)
+
+	if got := successorRuns.Load(); got != 1 {
+		t.Errorf("successor ran %d time(s) once every interrupt was answered, want 1", got)
+	}
+}
+
+// TestWorkflowAgent_Resume_FailedActivationStaysResumable covers an activation
+// that persists an event and then fails — an agent whose tool call succeeds and
+// whose next model call does not. Treating any emitted event as proof the node
+// acted on its answers wedges the run for good, because history never
+// un-answers an interrupt: every retry is skipped as a replay and the approved
+// work never settles.
+func TestWorkflowAgent_Resume_FailedActivationStaysResumable(t *testing.T) {
+	const fcID = "cred-4"
+	var runs atomic.Int32
+	var failResume atomic.Bool
+	worker, err := workflow.NewAgentNode(
+		newFailingResumeAgent(t, "worker", fcID, &runs, &failResume),
+		workflow.NodeConfig{RerunOnResume: ptrTrue()},
+	)
+	if err != nil {
+		t.Fatalf("NewAgentNode: %v", err)
+	}
+	a := makeAgent(t, workflow.Chain(workflow.Start, worker))
+	sess := newFakeSession()
+	runFreshTurn(t, sess, a, "start")
+
+	// The approval arrives, the tool result is persisted, then the agent dies.
+	failResume.Store(true)
+	for ev, err := range a.Run(newMockCtx(sess, a, credentialResume(fcID))) {
+		if err != nil {
+			continue
+		}
+		sess.appendEvent(ev)
+	}
+	afterFailure := runs.Load()
+
+	// Retrying the same approval has to re-run the node.
+	failResume.Store(false)
+	drainAgent(t, sess, a.Run(newMockCtx(sess, a, credentialResume(fcID))), nil)
+	if got := runs.Load(); got == afterFailure {
+		t.Errorf("worker runs = %d after retrying a failed resume, want more than %d "+
+			"(the run is wedged and the approved work can never settle)", got, afterFailure)
+	}
+}
+
+// newTwoConfirmAgent raises TWO confirmation interrupts in one event, the shape
+// a model produces when two tool calls each need approval.
+func newTwoConfirmAgent(t *testing.T, name, idA, idB string) agent.Agent {
+	t.Helper()
+	a, err := agent.New(agent.Config{
+		Name: name,
+		Run: func(ctx agent.InvocationContext) iter.Seq2[*session.Event, error] {
+			return func(yield func(*session.Event, error) bool) {
+				ev := session.NewEvent(ctx, ctx.InvocationID())
+				ev.Author = name
+				ev.LongRunningToolIDs = []string{idA, idB}
+				ev.LLMResponse = model.LLMResponse{Content: &genai.Content{
+					Role: genai.RoleModel,
+					Parts: []*genai.Part{
+						{FunctionCall: &genai.FunctionCall{ID: idA, Name: "adk_request_confirmation"}},
+						{FunctionCall: &genai.FunctionCall{ID: idB, Name: "adk_request_confirmation"}},
+					},
+				}}
+				yield(ev, nil)
+			}
+		},
+	})
+	if err != nil {
+		t.Fatalf("agent.New: %v", err)
+	}
+	return a
+}
+
+// newFailingResumeAgent pauses on fcID, and on the resume activation persists a
+// tool result before optionally failing — an event that is neither an output
+// nor a new interrupt, so it leaves the node mid-flight rather than settled.
+func newFailingResumeAgent(t *testing.T, name, fcID string, runs *atomic.Int32, failResume *atomic.Bool) agent.Agent {
+	t.Helper()
+	a, err := agent.New(agent.Config{
+		Name: name,
+		Run: func(ctx agent.InvocationContext) iter.Seq2[*session.Event, error] {
+			return func(yield func(*session.Event, error) bool) {
+				runs.Add(1)
+				if !answeredInHistory(ctx.Session(), fcID) {
+					req := session.NewEvent(ctx, ctx.InvocationID())
+					req.Author = name
+					req.LongRunningToolIDs = []string{fcID}
+					req.LLMResponse = model.LLMResponse{Content: &genai.Content{
+						Role: genai.RoleModel,
+						Parts: []*genai.Part{{FunctionCall: &genai.FunctionCall{
+							ID: fcID, Name: "adk_request_credential",
+						}}},
+					}}
+					yield(req, nil)
+					return
+				}
+				toolResult := session.NewEvent(ctx, ctx.InvocationID())
+				toolResult.Author = name
+				toolResult.LLMResponse = model.LLMResponse{Content: &genai.Content{
+					Role: genai.RoleUser,
+					Parts: []*genai.Part{{FunctionResponse: &genai.FunctionResponse{
+						ID: "tool-call", Name: "charge_card",
+						Response: map[string]any{"ok": true},
+					}}},
+				}}
+				yield(toolResult, nil)
+				if failResume.Load() {
+					yield(nil, errors.New("model call failed"))
+					return
+				}
+				done := session.NewEvent(ctx, ctx.InvocationID())
+				done.Author = name
+				done.Output = "charged"
+				done.LLMResponse = model.LLMResponse{Content: &genai.Content{
+					Role:  genai.RoleModel,
+					Parts: []*genai.Part{{Text: "charged"}},
+				}}
+				yield(done, nil)
+			}
+		},
+	})
+	if err != nil {
+		t.Fatalf("agent.New: %v", err)
+	}
+	return a
+}

--- a/agent/workflowagent/workflow.go
+++ b/agent/workflowagent/workflow.go
@@ -142,11 +142,25 @@ func (a *workflowAgent) detectResume(ctx agent.InvocationContext) (map[string]an
 	// tool's long-running request (adk_request_credential /
 	// adk_request_confirmation), not just the workflow's own
 	// adk_request_input, and the engine's pause is name-agnostic
-	// (Event.LongRunningToolIDs). A stale response matches nothing, so
-	// Workflow.Resume yields ErrNothingToResume instead of a silent fresh Run.
+	// (Event.LongRunningToolIDs).
+	//
+	// A response only routes this turn to Resume when it is actually aimed at
+	// this run: either its ID is an interrupt the run knows about, or it is
+	// explicitly an answer to the workflow's own input request. Otherwise the
+	// turn falls through to a fresh Run, as it did before ID-keyed matching —
+	// a turn may legitimately carry both text and an unrelated tool reply, and
+	// routing that to Resume would fail it with ErrNothingToResume and discard
+	// the text. Mirrors runner.buildResumeResponses, which filters the same way.
+	//
+	// A wrong-but-deliberate answer (right name, unknown ID) still reaches
+	// Resume, so the caller keeps the ErrNothingToResume diagnostic.
+	known := knownInterruptIDs(state)
 	responses := map[string]any{}
 	for _, fr := range frs {
 		if fr == nil || fr.ID == "" {
+			continue
+		}
+		if _, ok := known[fr.ID]; !ok && fr.Name != workflow.WorkflowInputFunctionCallName {
 			continue
 		}
 		responses[fr.ID] = utils.UnwrapResponse(fr.Response)
@@ -156,4 +170,32 @@ func (a *workflowAgent) detectResume(ctx agent.InvocationContext) (map[string]an
 	}
 
 	return responses, state, true, nil
+}
+
+// knownInterruptIDs collects the interrupt IDs of nodes the rehydrated run can
+// still act on — those waiting for an answer, and those a re-entry node is
+// about to be re-run with. A node that already settled is excluded, so a reply
+// to an interrupt this run has finished with no longer counts as a resume.
+//
+// ResumedInputs is included, not just Interrupts: the runner appends the reply
+// to the session before the agent runs, so on a genuine first resume the
+// interrupt is already resolved and rehydration hands it back on the node.
+func knownInterruptIDs(state *workflow.RunState) map[string]struct{} {
+	ids := map[string]struct{}{}
+	for _, ns := range state.Nodes {
+		if ns == nil || (ns.Status != workflow.NodeWaiting && ns.Status != workflow.NodePending) {
+			continue
+		}
+		for _, id := range ns.Interrupts {
+			if id != "" {
+				ids[id] = struct{}{}
+			}
+		}
+		for id := range ns.ResumedInputs {
+			if id != "" {
+				ids[id] = struct{}{}
+			}
+		}
+	}
+	return ids
 }

--- a/agent/workflowagent/workflow.go
+++ b/agent/workflowagent/workflow.go
@@ -15,11 +15,8 @@
 package workflowagent
 
 import (
-	"encoding/json"
 	"fmt"
 	"iter"
-
-	"google.golang.org/genai"
 
 	"google.golang.org/adk/v2/agent"
 	agentinternal "google.golang.org/adk/v2/internal/agent"
@@ -152,42 +149,11 @@ func (a *workflowAgent) detectResume(ctx agent.InvocationContext) (map[string]an
 		if fr == nil || fr.ID == "" {
 			continue
 		}
-		responses[fr.ID] = decodeResumeResponse(fr)
+		responses[fr.ID] = utils.UnwrapResponse(fr.Response)
 	}
 	if len(responses) == 0 {
 		return nil, nil, false, nil
 	}
 
 	return responses, state, true, nil
-}
-
-// decodeResumeResponse extracts the user-supplied payload from a
-// FunctionResponse that answers a paused node's interrupt — a workflow input
-// (adk_request_input), tool consent (adk_request_credential), or confirmation
-// (adk_request_confirmation). detectResume matches by interrupt ID, so this is
-// no longer specific to workflow input.
-//
-// Three accepted shapes, in priority order:
-//
-//  1. {"response": <value>}  — when value is a string, it is
-//     parsed as JSON and the result returned; if the string is
-//     not valid JSON it is returned verbatim. When value is any
-//     other type, it is returned as-is.
-//  2. {"payload": <any>}     — value returned verbatim.
-//  3. anything else           — the whole Response map is returned.
-func decodeResumeResponse(fr *genai.FunctionResponse) any {
-	if raw, ok := fr.Response["response"]; ok {
-		if s, isStr := raw.(string); isStr {
-			var decoded any
-			if err := json.Unmarshal([]byte(s), &decoded); err == nil {
-				return decoded
-			}
-			return s
-		}
-		return raw
-	}
-	if payload, ok := fr.Response["payload"]; ok {
-		return payload
-	}
-	return fr.Response
 }

--- a/agent/workflowagent/workflow.go
+++ b/agent/workflowagent/workflow.go
@@ -78,18 +78,17 @@ func New(cfg Config) (agent.Agent, error) {
 // workflowAgent is the wrapper that dispatches between
 // Workflow.Run (fresh turn) and Workflow.Resume (resume turn).
 // The dispatch decision is made by inspecting ctx.UserContent for
-// a FunctionResponse targeting a previously-emitted RequestInput.
-// The workflow's RunState lives in session.State, not on this
-// struct, so a single *workflowAgent safely services many
-// concurrent sessions.
+// a FunctionResponse that answers an interrupt this run can still
+// act on — see detectResume. The workflow's RunState lives in
+// session.State, not on this struct, so a single *workflowAgent
+// safely services many concurrent sessions.
 type workflowAgent struct {
 	workflow *workflow.Workflow
 }
 
 // run is the agent.Config.Run callback. It dispatches between
-// Workflow.Resume (when the inbound user content carries a
-// FunctionResponse to a previously-emitted RequestInput) and
-// Workflow.Run (every other turn).
+// Workflow.Resume (when the inbound user content answers one of
+// this run's open interrupts) and Workflow.Run (every other turn).
 func (a *workflowAgent) run(ctx agent.InvocationContext) iter.Seq2[*session.Event, error] {
 	return func(yield func(*session.Event, error) bool) {
 		responses, state, ok, err := a.detectResume(ctx)

--- a/agent/workflowagent/workflow.go
+++ b/agent/workflowagent/workflow.go
@@ -128,15 +128,6 @@ func (a *workflowAgent) detectResume(ctx agent.InvocationContext) (map[string]an
 		return nil, nil, false, nil
 	}
 
-	// A resume answers a paused node by matching a FunctionResponse to an
-	// open interrupt by ID. Match by ID, not by function name: besides the
-	// workflow's own adk_request_input, an LlmAgent node can pause on a
-	// tool's long-running request (adk_request_credential /
-	// adk_request_confirmation), and the engine's pause is name-agnostic
-	// (it rides on Event.LongRunningToolIDs). A stale or mistargeted
-	// response still reconstructs state; Workflow.Resume then yields
-	// ErrNothingToResume rather than silently starting a fresh Run.
-	//
 	// Scope rehydration to this run's invocation (the runner reuses the
 	// paused run's ID on resume) so a prior completed run in the same
 	// session does not leak in.
@@ -150,12 +141,18 @@ func (a *workflowAgent) detectResume(ctx agent.InvocationContext) (map[string]an
 		return nil, nil, false, nil
 	}
 
+	// Key by interrupt ID, not function name: an agent node pauses on a
+	// tool's long-running request (adk_request_credential /
+	// adk_request_confirmation), not just the workflow's own
+	// adk_request_input, and the engine's pause is name-agnostic
+	// (Event.LongRunningToolIDs). A stale response matches nothing, so
+	// Workflow.Resume yields ErrNothingToResume instead of a silent fresh Run.
 	responses := map[string]any{}
 	for _, fr := range frs {
 		if fr == nil || fr.ID == "" {
 			continue
 		}
-		responses[fr.ID] = decodeWorkflowInputResponse(fr)
+		responses[fr.ID] = decodeResumeResponse(fr)
 	}
 	if len(responses) == 0 {
 		return nil, nil, false, nil
@@ -164,8 +161,11 @@ func (a *workflowAgent) detectResume(ctx agent.InvocationContext) (map[string]an
 	return responses, state, true, nil
 }
 
-// decodeWorkflowInputResponse extracts the user-supplied payload
-// from a FunctionResponse targeting a workflow input request.
+// decodeResumeResponse extracts the user-supplied payload from a
+// FunctionResponse that answers a paused node's interrupt — a workflow input
+// (adk_request_input), tool consent (adk_request_credential), or confirmation
+// (adk_request_confirmation). detectResume matches by interrupt ID, so this is
+// no longer specific to workflow input.
 //
 // Three accepted shapes, in priority order:
 //
@@ -175,7 +175,7 @@ func (a *workflowAgent) detectResume(ctx agent.InvocationContext) (map[string]an
 //     other type, it is returned as-is.
 //  2. {"payload": <any>}     — value returned verbatim.
 //  3. anything else           — the whole Response map is returned.
-func decodeWorkflowInputResponse(fr *genai.FunctionResponse) any {
+func decodeResumeResponse(fr *genai.FunctionResponse) any {
 	if raw, ok := fr.Response["response"]; ok {
 		if s, isStr := raw.(string); isStr {
 			var decoded any

--- a/agent/workflowagent/workflow.go
+++ b/agent/workflowagent/workflow.go
@@ -118,27 +118,25 @@ func (a *workflowAgent) run(ctx agent.InvocationContext) iter.Seq2[*session.Even
 }
 
 // detectResume inspects the inbound user message for FunctionResponses
-// targeting a previously-emitted RequestInput. Returns the
-// responses map keyed by InterruptID (suitable for
-// Workflow.Resume), the RunState loaded from session, and true if
-// this turn is a resume; (nil, nil, false) for a fresh turn.
+// that answer a paused node's long-running interrupt. Returns the
+// responses map keyed by InterruptID (suitable for Workflow.Resume),
+// the RunState loaded from session, and true if this turn is a resume;
+// (nil, nil, false) for a fresh turn.
 func (a *workflowAgent) detectResume(ctx agent.InvocationContext) (map[string]any, *workflow.RunState, bool, error) {
 	frs := utils.FunctionResponses(ctx.UserContent())
 	if len(frs) == 0 {
 		return nil, nil, false, nil
 	}
 
-	responses := map[string]any{}
-	for _, fr := range frs {
-		if fr.Name != workflow.WorkflowInputFunctionCallName {
-			continue
-		}
-		responses[fr.ID] = decodeWorkflowInputResponse(fr)
-	}
-	if len(responses) == 0 {
-		return nil, nil, false, nil
-	}
-
+	// A resume answers a paused node by matching a FunctionResponse to an
+	// open interrupt by ID. Match by ID, not by function name: besides the
+	// workflow's own adk_request_input, an LlmAgent node can pause on a
+	// tool's long-running request (adk_request_credential /
+	// adk_request_confirmation), and the engine's pause is name-agnostic
+	// (it rides on Event.LongRunningToolIDs). A stale or mistargeted
+	// response still reconstructs state; Workflow.Resume then yields
+	// ErrNothingToResume rather than silently starting a fresh Run.
+	//
 	// Scope rehydration to this run's invocation (the runner reuses the
 	// paused run's ID on resume) so a prior completed run in the same
 	// session does not leak in.
@@ -149,6 +147,17 @@ func (a *workflowAgent) detectResume(ctx agent.InvocationContext) (map[string]an
 		return nil, nil, false, err
 	}
 	if state == nil {
+		return nil, nil, false, nil
+	}
+
+	responses := map[string]any{}
+	for _, fr := range frs {
+		if fr == nil || fr.ID == "" {
+			continue
+		}
+		responses[fr.ID] = decodeWorkflowInputResponse(fr)
+	}
+	if len(responses) == 0 {
 		return nil, nil, false, nil
 	}
 

--- a/agent/workflowagent/workflow.go
+++ b/agent/workflowagent/workflow.go
@@ -24,6 +24,7 @@ import (
 	"google.golang.org/adk/v2/agent"
 	agentinternal "google.golang.org/adk/v2/internal/agent"
 	"google.golang.org/adk/v2/internal/utils"
+	"google.golang.org/adk/v2/internal/workflowstate"
 	"google.golang.org/adk/v2/session"
 	"google.golang.org/adk/v2/workflow"
 )
@@ -156,7 +157,7 @@ func (a *workflowAgent) detectResume(ctx agent.InvocationContext) (map[string]an
 	//
 	// A wrong-but-deliberate answer (right name, unknown ID) still reaches
 	// Resume, so the caller keeps the ErrNothingToResume diagnostic.
-	known := knownInterruptIDs(state)
+	known := workflowstate.ActionableInterruptIDs(state)
 	responses := map[string]any{}
 	for _, fr := range frs {
 		if fr == nil || fr.ID == "" {
@@ -172,32 +173,4 @@ func (a *workflowAgent) detectResume(ctx agent.InvocationContext) (map[string]an
 	}
 
 	return responses, state, true, nil
-}
-
-// knownInterruptIDs collects the interrupt IDs of nodes the rehydrated run can
-// still act on — those waiting for an answer, and those a re-entry node is
-// about to be re-run with. A node that already settled is excluded, so a reply
-// to an interrupt this run has finished with no longer counts as a resume.
-//
-// ResumedInputs is included, not just Interrupts: the runner appends the reply
-// to the session before the agent runs, so on a genuine first resume the
-// interrupt is already resolved and rehydration hands it back on the node.
-func knownInterruptIDs(state *workflow.RunState) map[string]struct{} {
-	ids := map[string]struct{}{}
-	for _, ns := range state.Nodes {
-		if ns == nil || (ns.Status != workflow.NodeWaiting && ns.Status != workflow.NodePending) {
-			continue
-		}
-		for _, id := range ns.Interrupts {
-			if id != "" {
-				ids[id] = struct{}{}
-			}
-		}
-		for id := range ns.ResumedInputs {
-			if id != "" {
-				ids[id] = struct{}{}
-			}
-		}
-	}
-	return ids
 }

--- a/agent/workflowagent/workflow.go
+++ b/agent/workflowagent/workflow.go
@@ -145,11 +145,25 @@ func (a *workflowAgent) detectResume(ctx agent.InvocationContext) (map[string]an
 	// tool's long-running request (adk_request_credential /
 	// adk_request_confirmation), not just the workflow's own
 	// adk_request_input, and the engine's pause is name-agnostic
-	// (Event.LongRunningToolIDs). A stale response matches nothing, so
-	// Workflow.Resume yields ErrNothingToResume instead of a silent fresh Run.
+	// (Event.LongRunningToolIDs).
+	//
+	// A response only routes this turn to Resume when it is actually aimed at
+	// this run: either its ID is an interrupt the run knows about, or it is
+	// explicitly an answer to the workflow's own input request. Otherwise the
+	// turn falls through to a fresh Run, as it did before ID-keyed matching —
+	// a turn may legitimately carry both text and an unrelated tool reply, and
+	// routing that to Resume would fail it with ErrNothingToResume and discard
+	// the text. Mirrors runner.buildResumeResponses, which filters the same way.
+	//
+	// A wrong-but-deliberate answer (right name, unknown ID) still reaches
+	// Resume, so the caller keeps the ErrNothingToResume diagnostic.
+	known := knownInterruptIDs(state)
 	responses := map[string]any{}
 	for _, fr := range frs {
 		if fr == nil || fr.ID == "" {
+			continue
+		}
+		if _, ok := known[fr.ID]; !ok && fr.Name != workflow.WorkflowInputFunctionCallName {
 			continue
 		}
 		responses[fr.ID] = utils.UnwrapResponse(fr.Response)
@@ -159,4 +173,32 @@ func (a *workflowAgent) detectResume(ctx agent.InvocationContext) (map[string]an
 	}
 
 	return responses, state, true, nil
+}
+
+// knownInterruptIDs collects the interrupt IDs of nodes the rehydrated run can
+// still act on — those waiting for an answer, and those a re-entry node is
+// about to be re-run with. A node that already settled is excluded, so a reply
+// to an interrupt this run has finished with no longer counts as a resume.
+//
+// ResumedInputs is included, not just Interrupts: the runner appends the reply
+// to the session before the agent runs, so on a genuine first resume the
+// interrupt is already resolved and rehydration hands it back on the node.
+func knownInterruptIDs(state *workflow.RunState) map[string]struct{} {
+	ids := map[string]struct{}{}
+	for _, ns := range state.Nodes {
+		if ns == nil || (ns.Status != workflow.NodeWaiting && ns.Status != workflow.NodePending) {
+			continue
+		}
+		for _, id := range ns.Interrupts {
+			if id != "" {
+				ids[id] = struct{}{}
+			}
+		}
+		for id := range ns.ResumedInputs {
+			if id != "" {
+				ids[id] = struct{}{}
+			}
+		}
+	}
+	return ids
 }

--- a/agent/workflowagent/workflow.go
+++ b/agent/workflowagent/workflow.go
@@ -131,15 +131,6 @@ func (a *workflowAgent) detectResume(ctx agent.InvocationContext) (map[string]an
 		return nil, nil, false, nil
 	}
 
-	// A resume answers a paused node by matching a FunctionResponse to an
-	// open interrupt by ID. Match by ID, not by function name: besides the
-	// workflow's own adk_request_input, an LlmAgent node can pause on a
-	// tool's long-running request (adk_request_credential /
-	// adk_request_confirmation), and the engine's pause is name-agnostic
-	// (it rides on Event.LongRunningToolIDs). A stale or mistargeted
-	// response still reconstructs state; Workflow.Resume then yields
-	// ErrNothingToResume rather than silently starting a fresh Run.
-	//
 	// Scope rehydration to this run's invocation (the runner reuses the
 	// paused run's ID on resume) so a prior completed run in the same
 	// session does not leak in.
@@ -153,12 +144,18 @@ func (a *workflowAgent) detectResume(ctx agent.InvocationContext) (map[string]an
 		return nil, nil, false, nil
 	}
 
+	// Key by interrupt ID, not function name: an agent node pauses on a
+	// tool's long-running request (adk_request_credential /
+	// adk_request_confirmation), not just the workflow's own
+	// adk_request_input, and the engine's pause is name-agnostic
+	// (Event.LongRunningToolIDs). A stale response matches nothing, so
+	// Workflow.Resume yields ErrNothingToResume instead of a silent fresh Run.
 	responses := map[string]any{}
 	for _, fr := range frs {
 		if fr == nil || fr.ID == "" {
 			continue
 		}
-		responses[fr.ID] = decodeWorkflowInputResponse(fr)
+		responses[fr.ID] = decodeResumeResponse(fr)
 	}
 	if len(responses) == 0 {
 		return nil, nil, false, nil
@@ -167,8 +164,11 @@ func (a *workflowAgent) detectResume(ctx agent.InvocationContext) (map[string]an
 	return responses, state, true, nil
 }
 
-// decodeWorkflowInputResponse extracts the user-supplied payload
-// from a FunctionResponse targeting a workflow input request.
+// decodeResumeResponse extracts the user-supplied payload from a
+// FunctionResponse that answers a paused node's interrupt — a workflow input
+// (adk_request_input), tool consent (adk_request_credential), or confirmation
+// (adk_request_confirmation). detectResume matches by interrupt ID, so this is
+// no longer specific to workflow input.
 //
 // Three accepted shapes, in priority order:
 //
@@ -178,7 +178,7 @@ func (a *workflowAgent) detectResume(ctx agent.InvocationContext) (map[string]an
 //     other type, it is returned as-is.
 //  2. {"payload": <any>}     — value returned verbatim.
 //  3. anything else           — the whole Response map is returned.
-func decodeWorkflowInputResponse(fr *genai.FunctionResponse) any {
+func decodeResumeResponse(fr *genai.FunctionResponse) any {
 	if raw, ok := fr.Response["response"]; ok {
 		if s, isStr := raw.(string); isStr {
 			var decoded any

--- a/agent/workflowagent/workflow.go
+++ b/agent/workflowagent/workflow.go
@@ -81,18 +81,17 @@ func New(cfg Config) (agent.Agent, error) {
 // workflowAgent is the wrapper that dispatches between
 // Workflow.Run (fresh turn) and Workflow.Resume (resume turn).
 // The dispatch decision is made by inspecting ctx.UserContent for
-// a FunctionResponse targeting a previously-emitted RequestInput.
-// The workflow's RunState lives in session.State, not on this
-// struct, so a single *workflowAgent safely services many
-// concurrent sessions.
+// a FunctionResponse that answers an interrupt this run can still
+// act on — see detectResume. The workflow's RunState lives in
+// session.State, not on this struct, so a single *workflowAgent
+// safely services many concurrent sessions.
 type workflowAgent struct {
 	workflow *workflow.Workflow
 }
 
 // run is the agent.Config.Run callback. It dispatches between
-// Workflow.Resume (when the inbound user content carries a
-// FunctionResponse to a previously-emitted RequestInput) and
-// Workflow.Run (every other turn).
+// Workflow.Resume (when the inbound user content answers one of
+// this run's open interrupts) and Workflow.Run (every other turn).
 func (a *workflowAgent) run(ctx agent.InvocationContext) iter.Seq2[*session.Event, error] {
 	return func(yield func(*session.Event, error) bool) {
 		responses, state, ok, err := a.detectResume(ctx)

--- a/agent/workflowagent/workflow.go
+++ b/agent/workflowagent/workflow.go
@@ -121,27 +121,25 @@ func (a *workflowAgent) run(ctx agent.InvocationContext) iter.Seq2[*session.Even
 }
 
 // detectResume inspects the inbound user message for FunctionResponses
-// targeting a previously-emitted RequestInput. Returns the
-// responses map keyed by InterruptID (suitable for
-// Workflow.Resume), the RunState loaded from session, and true if
-// this turn is a resume; (nil, nil, false) for a fresh turn.
+// that answer a paused node's long-running interrupt. Returns the
+// responses map keyed by InterruptID (suitable for Workflow.Resume),
+// the RunState loaded from session, and true if this turn is a resume;
+// (nil, nil, false) for a fresh turn.
 func (a *workflowAgent) detectResume(ctx agent.InvocationContext) (map[string]any, *workflow.RunState, bool, error) {
 	frs := utils.FunctionResponses(ctx.UserContent())
 	if len(frs) == 0 {
 		return nil, nil, false, nil
 	}
 
-	responses := map[string]any{}
-	for _, fr := range frs {
-		if fr.Name != workflow.WorkflowInputFunctionCallName {
-			continue
-		}
-		responses[fr.ID] = decodeWorkflowInputResponse(fr)
-	}
-	if len(responses) == 0 {
-		return nil, nil, false, nil
-	}
-
+	// A resume answers a paused node by matching a FunctionResponse to an
+	// open interrupt by ID. Match by ID, not by function name: besides the
+	// workflow's own adk_request_input, an LlmAgent node can pause on a
+	// tool's long-running request (adk_request_credential /
+	// adk_request_confirmation), and the engine's pause is name-agnostic
+	// (it rides on Event.LongRunningToolIDs). A stale or mistargeted
+	// response still reconstructs state; Workflow.Resume then yields
+	// ErrNothingToResume rather than silently starting a fresh Run.
+	//
 	// Scope rehydration to this run's invocation (the runner reuses the
 	// paused run's ID on resume) so a prior completed run in the same
 	// session does not leak in.
@@ -152,6 +150,17 @@ func (a *workflowAgent) detectResume(ctx agent.InvocationContext) (map[string]an
 		return nil, nil, false, err
 	}
 	if state == nil {
+		return nil, nil, false, nil
+	}
+
+	responses := map[string]any{}
+	for _, fr := range frs {
+		if fr == nil || fr.ID == "" {
+			continue
+		}
+		responses[fr.ID] = decodeWorkflowInputResponse(fr)
+	}
+	if len(responses) == 0 {
 		return nil, nil, false, nil
 	}
 

--- a/agent/workflowagent/workflow.go
+++ b/agent/workflowagent/workflow.go
@@ -18,11 +18,8 @@
 package workflowagent
 
 import (
-	"encoding/json"
 	"fmt"
 	"iter"
-
-	"google.golang.org/genai"
 
 	"google.golang.org/adk/v2/agent"
 	agentinternal "google.golang.org/adk/v2/internal/agent"
@@ -155,42 +152,11 @@ func (a *workflowAgent) detectResume(ctx agent.InvocationContext) (map[string]an
 		if fr == nil || fr.ID == "" {
 			continue
 		}
-		responses[fr.ID] = decodeResumeResponse(fr)
+		responses[fr.ID] = utils.UnwrapResponse(fr.Response)
 	}
 	if len(responses) == 0 {
 		return nil, nil, false, nil
 	}
 
 	return responses, state, true, nil
-}
-
-// decodeResumeResponse extracts the user-supplied payload from a
-// FunctionResponse that answers a paused node's interrupt — a workflow input
-// (adk_request_input), tool consent (adk_request_credential), or confirmation
-// (adk_request_confirmation). detectResume matches by interrupt ID, so this is
-// no longer specific to workflow input.
-//
-// Three accepted shapes, in priority order:
-//
-//  1. {"response": <value>}  — when value is a string, it is
-//     parsed as JSON and the result returned; if the string is
-//     not valid JSON it is returned verbatim. When value is any
-//     other type, it is returned as-is.
-//  2. {"payload": <any>}     — value returned verbatim.
-//  3. anything else           — the whole Response map is returned.
-func decodeResumeResponse(fr *genai.FunctionResponse) any {
-	if raw, ok := fr.Response["response"]; ok {
-		if s, isStr := raw.(string); isStr {
-			var decoded any
-			if err := json.Unmarshal([]byte(s), &decoded); err == nil {
-				return decoded
-			}
-			return s
-		}
-		return raw
-	}
-	if payload, ok := fr.Response["payload"]; ok {
-		return payload
-	}
-	return fr.Response
 }

--- a/agent/workflowagent/workflow.go
+++ b/agent/workflowagent/workflow.go
@@ -21,6 +21,8 @@ import (
 	"fmt"
 	"iter"
 
+	"google.golang.org/genai"
+
 	"google.golang.org/adk/v2/agent"
 	agentinternal "google.golang.org/adk/v2/internal/agent"
 	"google.golang.org/adk/v2/internal/utils"
@@ -159,18 +161,54 @@ func (a *workflowAgent) detectResume(ctx agent.InvocationContext) (map[string]an
 	// Resume, so the caller keeps the ErrNothingToResume diagnostic.
 	known := workflowstate.ActionableInterruptIDs(state)
 	responses := map[string]any{}
+	live := false
 	for _, fr := range frs {
 		if fr == nil || fr.ID == "" {
 			continue
 		}
-		if _, ok := known[fr.ID]; !ok && fr.Name != workflow.WorkflowInputFunctionCallName {
+		actionable, ok := known[fr.ID]
+		if !ok && fr.Name != workflow.WorkflowInputFunctionCallName {
 			continue
 		}
+		live = live || actionable
 		responses[fr.ID] = utils.UnwrapResponse(fr.Response)
 	}
 	if len(responses) == 0 {
 		return nil, nil, false, nil
 	}
+	// Every match is a replay of an answer the run has already acted on, so
+	// Resume would schedule nothing and fail the turn. Alone that is the
+	// right diagnostic and the caller reports it, but when the message
+	// carries anything else the failure would discard that too — a client
+	// that echoes a settled approval alongside the human's next instruction
+	// must still get the instruction run.
+	if !live && carriesOtherContent(ctx.UserContent(), responses) {
+		return nil, nil, false, nil
+	}
 
 	return responses, state, true, nil
+}
+
+// carriesOtherContent reports whether msg holds anything beyond the
+// FunctionResponses in matched — user text, a reply aimed elsewhere, an
+// attachment. Such a turn has work of its own, so it must run rather than fail.
+func carriesOtherContent(msg *genai.Content, matched map[string]any) bool {
+	if msg == nil {
+		return false
+	}
+	for _, p := range msg.Parts {
+		if p == nil {
+			continue
+		}
+		if fr := p.FunctionResponse; fr != nil {
+			if _, ok := matched[fr.ID]; !ok {
+				return true
+			}
+			continue
+		}
+		if p.Text != "" || p.FunctionCall != nil || p.InlineData != nil || p.FileData != nil {
+			return true
+		}
+	}
+	return false
 }

--- a/agent/workflowagent/workflow_test.go
+++ b/agent/workflowagent/workflow_test.go
@@ -25,6 +25,7 @@ import (
 	"google.golang.org/genai"
 
 	"google.golang.org/adk/v2/agent"
+	"google.golang.org/adk/v2/internal/utils"
 	"google.golang.org/adk/v2/session"
 	"google.golang.org/adk/v2/workflow"
 )
@@ -170,7 +171,7 @@ func TestWorkflowAgent(t *testing.T) {
 	}
 }
 
-func TestDecodeResumeResponse(t *testing.T) {
+func TestUnwrapResumeResponse(t *testing.T) {
 	tests := []struct {
 		name string
 		fr   *genai.FunctionResponse
@@ -219,14 +220,44 @@ func TestDecodeResumeResponse(t *testing.T) {
 			want: map[string]any{"k": "v"},
 		},
 		{
-			name: "PriorityOrder_ResponseWinsOverPayload",
+			// A multi-key map is the caller's own shape, not a wrapper:
+			// unwrapping one key would drop the rest.
+			name: "MultiKey_ReturnsRawMap",
 			fr: &genai.FunctionResponse{
 				Response: map[string]any{
 					"response": `"from-response"`,
 					"payload":  "from-payload",
 				},
 			},
-			want: "from-response",
+			want: map[string]any{
+				"response": `"from-response"`,
+				"payload":  "from-payload",
+			},
+		},
+		{
+			// Tool confirmation's wire shape: unwrapping "payload" would
+			// drop the confirmed flag, making a rejection look like an
+			// approval to a handoff successor.
+			name: "ToolConfirmation_KeepsConfirmedFlag",
+			fr: &genai.FunctionResponse{
+				Response: map[string]any{
+					"confirmed": false,
+					"payload":   map[string]any{"daysApproved": float64(0)},
+				},
+			},
+			want: map[string]any{
+				"confirmed": false,
+				"payload":   map[string]any{"daysApproved": float64(0)},
+			},
+		},
+		{
+			// adk-python _wrap_response and the web frontend wrap a scalar
+			// reply as {"result": v}.
+			name: "ResultShape_PythonAndWebFrontend",
+			fr: &genai.FunctionResponse{
+				Response: map[string]any{"result": "approve"},
+			},
+			want: "approve",
 		},
 		{
 			name: "Fallback_NeitherKey_ReturnsRawMap",
@@ -244,9 +275,9 @@ func TestDecodeResumeResponse(t *testing.T) {
 
 	for _, tc := range tests {
 		t.Run(tc.name, func(t *testing.T) {
-			got := decodeResumeResponse(tc.fr)
+			got := utils.UnwrapResponse(tc.fr.Response)
 			if diff := cmp.Diff(tc.want, got); diff != "" {
-				t.Errorf("decodeResumeResponse(%+v) mismatch (-want +got):\n%s", tc.fr.Response, diff)
+				t.Errorf("UnwrapResponse(%+v) mismatch (-want +got):\n%s", tc.fr.Response, diff)
 			}
 		})
 	}

--- a/agent/workflowagent/workflow_test.go
+++ b/agent/workflowagent/workflow_test.go
@@ -170,7 +170,7 @@ func TestWorkflowAgent(t *testing.T) {
 	}
 }
 
-func TestDecodeWorkflowInputResponse(t *testing.T) {
+func TestDecodeResumeResponse(t *testing.T) {
 	tests := []struct {
 		name string
 		fr   *genai.FunctionResponse
@@ -244,9 +244,9 @@ func TestDecodeWorkflowInputResponse(t *testing.T) {
 
 	for _, tc := range tests {
 		t.Run(tc.name, func(t *testing.T) {
-			got := decodeWorkflowInputResponse(tc.fr)
+			got := decodeResumeResponse(tc.fr)
 			if diff := cmp.Diff(tc.want, got); diff != "" {
-				t.Errorf("decodeWorkflowInputResponse(%+v) mismatch (-want +got):\n%s", tc.fr.Response, diff)
+				t.Errorf("decodeResumeResponse(%+v) mismatch (-want +got):\n%s", tc.fr.Response, diff)
 			}
 		})
 	}

--- a/internal/configurable/configurable_workflow.go
+++ b/internal/configurable/configurable_workflow.go
@@ -67,6 +67,16 @@ type joinNodeYAMLConfig struct {
 	Name string `yaml:"name"`
 }
 
+// agentNodeYAMLConfig represents the node-level knobs an agent's own config
+// file may carry when that agent is wrapped as a workflow node. It is read
+// from the agent's file rather than from the graph because nodes are cached
+// per config path (see resolveNodeLike): two workflows referencing one agent
+// file share a single node, so the setting could not vary by graph position
+// anyway.
+type agentNodeYAMLConfig struct {
+	RerunOnResume *bool `yaml:"rerun_on_resume,omitempty"`
+}
+
 // toolNodeYAMLConfig represents the YAML schema for a ToolNode.
 type toolNodeYAMLConfig struct {
 	Name           string         `yaml:"name"`
@@ -331,8 +341,13 @@ func resolveNodeFromYAML(ctx context.Context, parentPath, ref, absPath string) (
 		*collector = append(*collector, ag)
 	}
 
+	var nodeCfg agentNodeYAMLConfig
+	if err := yaml.Unmarshal(data, &nodeCfg); err != nil {
+		return nil, fmt.Errorf("failed to parse agent node config %q: %w", absPath, err)
+	}
+
 	// Wrap standard agent in workflow Node
-	return workflow.NewAgentNode(ag, workflow.NodeConfig{})
+	return workflow.NewAgentNode(ag, workflow.NodeConfig{RerunOnResume: nodeCfg.RerunOnResume})
 }
 
 // castNodeFunction normalizes function signatures to a standard non-generic workflow function.

--- a/internal/configurable/configurable_workflow_test.go
+++ b/internal/configurable/configurable_workflow_test.go
@@ -587,3 +587,46 @@ edges:
 		t.Errorf("expected tool output result 'tool_output', got %v", toolOut["result"])
 	}
 }
+
+// TestLoadWorkflowAgentNodeRerunOnResume pins that an agent used as a workflow
+// node can opt out of the LlmAgent re-entry default from its own config file.
+// Before the key was plumbed, baseAgentConfig's extra-fields map swallowed it
+// and the author silently got the default.
+func TestLoadWorkflowAgentNodeRerunOnResume(t *testing.T) {
+	for _, tc := range []struct {
+		name string
+		key  string
+		want *bool
+	}{
+		{name: "explicit false is honoured", key: "rerun_on_resume: false\n", want: ptrTo(false)},
+		{name: "explicit true is honoured", key: "rerun_on_resume: true\n", want: ptrTo(true)},
+		{name: "absent leaves the node kind's default", key: "", want: nil},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			tempDir := t.TempDir()
+			agentYAML := "name: my_agent\nagent_class: LoopAgent\nmax_iterations: 1\n" + tc.key
+			agentPath := filepath.Join(tempDir, "my_agent.yaml")
+			if err := os.WriteFile(agentPath, []byte(agentYAML), 0o644); err != nil {
+				t.Fatalf("write agent yaml: %v", err)
+			}
+
+			// parentPath is the referencing file; only its directory is used.
+			parentPath := filepath.Join(tempDir, "wf.yaml")
+			node, err := resolveNodeFromYAML(t.Context(), parentPath, "my_agent.yaml", agentPath)
+			if err != nil {
+				t.Fatalf("resolveNodeFromYAML: %v", err)
+			}
+			got := node.Config().RerunOnResume
+			switch {
+			case tc.want == nil && got != nil:
+				t.Errorf("RerunOnResume = %v, want nil (no key in YAML)", *got)
+			case tc.want != nil && got == nil:
+				t.Errorf("RerunOnResume = nil, want %v", *tc.want)
+			case tc.want != nil && got != nil && *got != *tc.want:
+				t.Errorf("RerunOnResume = %v, want %v", *got, *tc.want)
+			}
+		})
+	}
+}
+
+func ptrTo[T any](v T) *T { return &v }

--- a/internal/utils/utils.go
+++ b/internal/utils/utils.go
@@ -16,6 +16,7 @@ package utils
 
 import (
 	"context"
+	"encoding/json"
 	"strings"
 
 	"google.golang.org/genai"
@@ -101,6 +102,40 @@ func FunctionResponses(c *genai.Content) (ret []*genai.FunctionResponse) {
 		}
 	}
 	return ret
+}
+
+// UnwrapResponse extracts the original value from a FunctionResponse payload.
+// A sole single-key wrapper — {"result": v} (adk-python and the web frontend),
+// {"response": v} or {"payload": v} (adk-go) — is unwrapped, with string values
+// JSON-parsed when possible; anything else, including a multi-key map such as
+// a tool confirmation's {"confirmed": b, "payload": v}, passes through whole.
+// Mirrors adk-python _unwrap_response, extended with the adk-go keys for
+// cross-runtime sessions.
+//
+// Every resume path decodes through here, so a reply read back from history
+// yields the same value as the same reply taken from the inbound turn.
+func UnwrapResponse(data map[string]any) any {
+	if data == nil {
+		return nil // untyped nil, not a nil map: callers compare against nil
+	}
+	if len(data) != 1 {
+		return data
+	}
+	for _, key := range []string{"result", "response", "payload"} {
+		v, ok := data[key]
+		if !ok {
+			continue
+		}
+		if s, isStr := v.(string); isStr {
+			var parsed any
+			if err := json.Unmarshal([]byte(s), &parsed); err == nil {
+				return parsed
+			}
+			return s
+		}
+		return v
+	}
+	return data
 }
 
 // TextParts extracts all Text parts from the content.

--- a/internal/utils/utils.go
+++ b/internal/utils/utils.go
@@ -112,8 +112,13 @@ func FunctionResponses(c *genai.Content) (ret []*genai.FunctionResponse) {
 // Mirrors adk-python _unwrap_response, extended with the adk-go keys for
 // cross-runtime sessions.
 //
-// Every resume path decodes through here, so a reply read back from history
-// yields the same value as the same reply taken from the inbound turn.
+// The workflow engine's three resume paths — the inbound turn in runner and in
+// workflowagent, and the replay from session history — all decode through here,
+// so a reply read back from history yields the same value as the same reply
+// taken from the inbound turn. Tool confirmation is decoded separately, by
+// llminternal's confirmation request processor, which produces the Confirmed
+// flag the tool layer enforces; that decision must not be routed through here,
+// since this function has no notion of it.
 func UnwrapResponse(data map[string]any) any {
 	if data == nil {
 		return nil // untyped nil, not a nil map: callers compare against nil

--- a/internal/workflowstate/workflowstate.go
+++ b/internal/workflowstate/workflowstate.go
@@ -1,0 +1,33 @@
+// Copyright 2026 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+// Package workflowstate hands a few facts about a rehydrated workflow run to
+// the packages that drive it, without widening the workflow package's public
+// API. It deliberately imports nothing: the workflow package installs the hooks
+// below from its own init, and any package that reads them already imports
+// workflow, so they are non-nil by the time they are called.
+//
+// The arguments are typed any because naming *workflow.RunState here would be
+// an import cycle — workflow imports this package.
+package workflowstate
+
+// ActionableInterruptIDs reports the interrupt IDs a rehydrated run can still
+// do something about: those a node is waiting for, those a re-entry node is
+// about to be re-run with, and those a node settled on this very turn. A
+// FunctionResponse matching none of them answers nothing in that run.
+//
+// Installed by workflow.init; the argument is a *workflow.RunState. Returns nil
+// for anything else, which callers should read as "cannot tell" rather than
+// "nothing is actionable".
+var ActionableInterruptIDs func(runState any) map[string]struct{}

--- a/internal/workflowstate/workflowstate.go
+++ b/internal/workflowstate/workflowstate.go
@@ -22,12 +22,18 @@
 // an import cycle — workflow imports this package.
 package workflowstate
 
-// ActionableInterruptIDs reports the interrupt IDs a rehydrated run can still
-// do something about: those a node is waiting for, those a re-entry node is
-// about to be re-run with, and those a node settled on this very turn. A
-// FunctionResponse matching none of them answers nothing in that run.
+// ActionableInterruptIDs reports the interrupt IDs a rehydrated run recognises,
+// mapped to whether Resume can still do something with them. Live (true): one a
+// node is waiting for, one a re-entry node is about to be re-run with, or one a
+// node settled on this very turn. Spent (false): an answer a re-entry node has
+// already acted on, which Resume skips. An ID absent from the map answers
+// nothing in that run.
+//
+// The distinction matters to a caller deciding whether a turn is a resume. A
+// spent ID on its own is a replay, and routing the turn to Resume on its
+// strength alone would fail the whole turn with ErrNothingToResume.
 //
 // Installed by workflow.init; the argument is a *workflow.RunState. Returns nil
 // for anything else, which callers should read as "cannot tell" rather than
 // "nothing is actionable".
-var ActionableInterruptIDs func(runState any) map[string]struct{}
+var ActionableInterruptIDs func(runState any) map[string]bool

--- a/runner/hitl_integration_test.go
+++ b/runner/hitl_integration_test.go
@@ -441,3 +441,55 @@ func eventFields(ev *session.Event) []string {
 	}
 	return fields
 }
+
+// TestRunner_WorkflowHITL_SettledResponseDoesNotHijackTurn guards the
+// permissiveness documented on buildResumeResponses at the workflow-agent
+// front door too: a turn may carry a function response the run has already
+// finished with — the A2A flow sends the human's reply text alongside the
+// approval response in one message — and must still run, not fail the whole
+// turn with ErrNothingToResume and drop the text.
+func TestRunner_WorkflowHITL_SettledResponseDoesNotHijackTurn(t *testing.T) {
+	ctx := t.Context()
+
+	var upstream, handler atomic.Int32
+	counter := workflow.NewFunctionNode("upstream",
+		func(_ agent.Context, in any) (any, error) {
+			upstream.Add(1)
+			return "up", nil
+		}, workflow.NodeConfig{})
+	asker := newHitlAsker("asker", "", false /*rerunOnResume*/)
+	sink := workflow.NewFunctionNode("handler",
+		func(_ agent.Context, in any) (any, error) {
+			handler.Add(1)
+			return "handled", nil
+		}, workflow.NodeConfig{})
+
+	r := newWorkflowRunner(t, workflow.Chain(workflow.Start, counter, asker, sink))
+
+	turn1 := drainRunner(t, r.Run(ctx, nodeTestUser, nodeTestSession,
+		userText("go"), agent.RunConfig{}))
+	id, name := findLongRunningInterrupt(turn1)
+	if id == "" {
+		t.Fatal("turn 1 did not pause on a long-running interrupt")
+	}
+	drainRunner(t, r.Run(ctx, nodeTestUser, nodeTestSession,
+		resumeContent(id, name, "yes"), agent.RunConfig{}))
+	if got := handler.Load(); got != 1 {
+		t.Fatalf("handler runs after the real resume = %d, want 1", got)
+	}
+
+	// The interrupt is settled. A later turn echoes it back under another
+	// name, alongside new user text.
+	msg := &genai.Content{Role: genai.RoleUser, Parts: []*genai.Part{
+		{Text: "now do something new"},
+		{FunctionResponse: &genai.FunctionResponse{
+			ID: id, Name: "some_client_tool", Response: map[string]any{"ok": true},
+		}},
+	}}
+	drainRunner(t, r.Run(ctx, nodeTestUser, nodeTestSession, msg, agent.RunConfig{}))
+
+	if got := upstream.Load(); got != 2 {
+		t.Errorf("upstream runs = %d, want 2: the turn was routed to Resume "+
+			"against a settled interrupt instead of running the workflow", got)
+	}
+}

--- a/runner/hitl_integration_test.go
+++ b/runner/hitl_integration_test.go
@@ -515,3 +515,55 @@ func eventFields(ev *session.Event) []string {
 	}
 	return fields
 }
+
+// TestRunner_WorkflowHITL_SettledResponseDoesNotHijackTurn guards the
+// permissiveness documented on buildResumeResponses at the workflow-agent
+// front door too: a turn may carry a function response the run has already
+// finished with — the A2A flow sends the human's reply text alongside the
+// approval response in one message — and must still run, not fail the whole
+// turn with ErrNothingToResume and drop the text.
+func TestRunner_WorkflowHITL_SettledResponseDoesNotHijackTurn(t *testing.T) {
+	ctx := t.Context()
+
+	var upstream, handler atomic.Int32
+	counter := workflow.NewFunctionNode("upstream",
+		func(_ agent.Context, in any) (any, error) {
+			upstream.Add(1)
+			return "up", nil
+		}, workflow.NodeConfig{})
+	asker := newHitlAsker("asker", "", false /*rerunOnResume*/)
+	sink := workflow.NewFunctionNode("handler",
+		func(_ agent.Context, in any) (any, error) {
+			handler.Add(1)
+			return "handled", nil
+		}, workflow.NodeConfig{})
+
+	r := newWorkflowRunner(t, workflow.Chain(workflow.Start, counter, asker, sink))
+
+	turn1 := drainRunner(t, r.Run(ctx, nodeTestUser, nodeTestSession,
+		userText("go"), agent.RunConfig{}))
+	id, name := findLongRunningInterrupt(turn1)
+	if id == "" {
+		t.Fatal("turn 1 did not pause on a long-running interrupt")
+	}
+	drainRunner(t, r.Run(ctx, nodeTestUser, nodeTestSession,
+		resumeContent(id, name, "yes"), agent.RunConfig{}))
+	if got := handler.Load(); got != 1 {
+		t.Fatalf("handler runs after the real resume = %d, want 1", got)
+	}
+
+	// The interrupt is settled. A later turn echoes it back under another
+	// name, alongside new user text.
+	msg := &genai.Content{Role: genai.RoleUser, Parts: []*genai.Part{
+		{Text: "now do something new"},
+		{FunctionResponse: &genai.FunctionResponse{
+			ID: id, Name: "some_client_tool", Response: map[string]any{"ok": true},
+		}},
+	}}
+	drainRunner(t, r.Run(ctx, nodeTestUser, nodeTestSession, msg, agent.RunConfig{}))
+
+	if got := upstream.Load(); got != 2 {
+		t.Errorf("upstream runs = %d, want 2: the turn was routed to Resume "+
+			"against a settled interrupt instead of running the workflow", got)
+	}
+}

--- a/runner/run_node.go
+++ b/runner/run_node.go
@@ -16,7 +16,6 @@ package runner
 
 import (
 	"context"
-	"encoding/json"
 	"fmt"
 	"iter"
 
@@ -289,7 +288,7 @@ func buildResumeResponses(msg *genai.Content, state *workflow.RunState, sess ses
 			out = map[string]any{}
 		}
 		// Opaque payload; Workflow.Resume validates against any schema.
-		out[fr.ID] = decodeResumeResponse(fr)
+		out[fr.ID] = utils.UnwrapResponse(fr.Response)
 	}
 	return out
 }
@@ -319,29 +318,6 @@ func openLongRunningCallIDs(sess session.Session) map[string]struct{} {
 		delete(open, id)
 	}
 	return open
-}
-
-// decodeResumeResponse extracts the user payload from a function
-// response, accepting {"response": v}, {"payload": v}, or the raw map. A
-// string under "response" is JSON-parsed when possible.
-func decodeResumeResponse(fr *genai.FunctionResponse) any {
-	if fr.Response == nil {
-		return nil
-	}
-	if raw, ok := fr.Response["response"]; ok {
-		if s, isStr := raw.(string); isStr {
-			var decoded any
-			if err := json.Unmarshal([]byte(s), &decoded); err == nil {
-				return decoded
-			}
-			return s
-		}
-		return raw
-	}
-	if payload, ok := fr.Response["payload"]; ok {
-		return payload
-	}
-	return fr.Response
 }
 
 // waitingInterruptIDs returns the set of interrupt IDs for every node

--- a/runner/run_node.go
+++ b/runner/run_node.go
@@ -16,7 +16,6 @@ package runner
 
 import (
 	"context"
-	"encoding/json"
 	"fmt"
 	"iter"
 	"log"
@@ -352,7 +351,7 @@ func buildResumeResponses(msg *genai.Content, state *workflow.RunState, sess ses
 			out = map[string]any{}
 		}
 		// Opaque payload; Workflow.Resume validates against any schema.
-		out[fr.ID] = decodeResumeResponse(fr)
+		out[fr.ID] = utils.UnwrapResponse(fr.Response)
 	}
 	return out
 }
@@ -382,29 +381,6 @@ func openLongRunningCallIDs(sess session.Session) map[string]struct{} {
 		delete(open, id)
 	}
 	return open
-}
-
-// decodeResumeResponse extracts the user payload from a function
-// response, accepting {"response": v}, {"payload": v}, or the raw map. A
-// string under "response" is JSON-parsed when possible.
-func decodeResumeResponse(fr *genai.FunctionResponse) any {
-	if fr.Response == nil {
-		return nil
-	}
-	if raw, ok := fr.Response["response"]; ok {
-		if s, isStr := raw.(string); isStr {
-			var decoded any
-			if err := json.Unmarshal([]byte(s), &decoded); err == nil {
-				return decoded
-			}
-			return s
-		}
-		return raw
-	}
-	if payload, ok := fr.Response["payload"]; ok {
-		return payload
-	}
-	return fr.Response
 }
 
 // waitingInterruptIDs returns the set of interrupt IDs for every node

--- a/workflow/agent_node.go
+++ b/workflow/agent_node.go
@@ -192,28 +192,40 @@ func (n *AgentNode) Run(ctx agent.Context, input any) iter.Seq2[*session.Event, 
 // alone latches: history never un-answers an interrupt, so a later loop-back,
 // retry or per-item activation of the same node would lose its input too.
 //
-// Interrupts are attributed as rehydration attributes them (NodeInfo.Path,
-// Author as the fallback), so a pause raised by a delegated sub-agent counts as
-// this node's — matching the engine, which parks and re-enters the node on
-// exactly those interrupts.
+// Interrupts are attributed by the activation's node PATH ("orch@1/child@2"),
+// which the scheduler stamps on every event leaving a node. The path, not the
+// node name, is the identity that matters: an orchestrator delegating the same
+// child twice produces child@1 and child@2, and only the delegation that
+// paused may drop its input. A pause raised by a sub-agent the node's agent
+// delegated to carries the node's own path, so it still counts as this node's
+// — matching the engine, which parks and re-enters the node on exactly those
+// interrupts.
 func (n *AgentNode) isResuming(ctx agent.Context) bool {
 	ra, ok := ctx.(interface{ IsResumeActivation() bool })
 	if !ok || !ra.IsResumeActivation() {
 		return false
 	}
-	return raisedInterrupt(ctx.Session(), ctx.InvocationID(), n.Name())
+	return raisedInterrupt(ctx.Session(), ctx.InvocationID(), ctx.Path(), n.Name())
 }
 
-// raisedInterrupt reports whether nodeName raised a long-running interrupt in
-// invocationID. Runs only on a resume activation, keeping the scan off the
-// normal path.
-func raisedInterrupt(sess session.Session, invocationID, nodeName string) bool {
-	if sess == nil {
+// raisedInterrupt reports whether the activation at nodePath raised a
+// long-running interrupt in invocationID. Runs only on a resume activation,
+// keeping the scan off the normal path.
+//
+// nodePath is empty for a root-wrapper activation, where the scheduler stamps
+// the bare node name instead. An event carrying no path at all is attributed by
+// Author, the same fallback rehydration's eventNodeName uses.
+func raisedInterrupt(sess session.Session, invocationID, nodePath, nodeName string) bool {
+	if sess == nil || nodeName == "" {
 		return false
 	}
 	events := sess.Events()
 	if events == nil {
 		return false
+	}
+	want := nodePath
+	if want == "" {
+		want = nodeName
 	}
 	for i := 0; i < events.Len(); i++ {
 		ev := events.At(i)
@@ -223,25 +235,33 @@ func raisedInterrupt(sess session.Session, invocationID, nodeName string) bool {
 		if invocationID != "" && ev.InvocationID != invocationID {
 			continue
 		}
-		if ev.Author == nodeName {
-			return true
+		if ev.NodeInfo != nil && ev.NodeInfo.Path != "" {
+			if samePathActivation(ev.NodeInfo.Path, want) {
+				return true
+			}
+			continue
 		}
-		if ev.NodeInfo != nil && nodePathHas(ev.NodeInfo.Path, nodeName) {
+		if ev.Author == nodeName {
 			return true
 		}
 	}
 	return false
 }
 
-// nodePathHas reports whether a node path ("parent@1/child@2") has a segment
-// naming nodeName — the segment walk eventNodeName uses for attribution.
-func nodePathHas(path, nodeName string) bool {
-	for _, seg := range strings.Split(path, "/") {
-		if name, _, _ := strings.Cut(seg, "@"); name == nodeName {
-			return true
-		}
+// samePathActivation reports whether an event's node path names the same
+// activation as nodePath. It compares trailing segments rather than the whole
+// string: a workflow agent records its events under its own prefix
+// ("wf@1/worker@1") while a later Resume rebuilds the node path without it
+// ("worker@1"), so exact equality would miss a node's own pause across the
+// turn boundary.
+func samePathActivation(evPath, nodePath string) bool {
+	if evPath == nodePath {
+		return true
 	}
-	return false
+	if evPath == "" || nodePath == "" {
+		return false
+	}
+	return strings.HasSuffix(evPath, "/"+nodePath) || strings.HasSuffix(nodePath, "/"+evPath)
 }
 
 // synthesizeAgentOutput sets Event.Output from concatenated model

--- a/workflow/agent_node.go
+++ b/workflow/agent_node.go
@@ -51,36 +51,36 @@ func newAgentNodeWithSchemasTyped[Input, Output any](a agent.Agent, inputSchema,
 		return nil, fmt.Errorf("resolving output schema for agent %q: %w", a.Name(), err)
 	}
 
-	if llmA, ok := a.(llminternal.Agent); ok {
-		state := llminternal.Reveal(llmA)
-		if state.Mode == llminternal.ModeUnset {
-			state.Mode = llminternal.ModeSingleTurn
-		}
-	}
-
-	// The wrapped agent's Run already emits an invoke_agent span, so
-	// the scheduler must not add a redundant invoke_node wrapper —
-	// whether this node is activated by a static edge or delegated to
-	// via RunNode. Mirrors runner.newAgentNode.
-	cfg.EmitsOwnSpan = true
-
-	// A paused AgentNode must re-run its agent to finish the work it
-	// started — e.g. complete a tool call after the user answered a
-	// long-running request (adk_request_credential / adk_request_confirmation)
-	// the agent's tool raised. Default to re-entry so Resume re-activates
-	// the node from history instead of taking the handoff path, which
-	// would treat the raw user response as the node's output and never
-	// re-run the agent. Mirrors runner.newAgentNode + the DynamicNode
-	// default; an explicit caller value still wins.
-	if cfg.RerunOnResume == nil {
-		rerun := true
-		cfg.RerunOnResume = &rerun
-	}
+	cfg = applyAgentNodeDefaults(a, cfg)
 
 	return &AgentNode{
 		BaseNode: NewBaseNodeWithSchemas(a.Name(), a.Description(), cfg, ischema, oschema),
 		agent:    a,
 	}, nil
+}
+
+// applyAgentNodeDefaults fills in the AgentNode config defaults, mirroring
+// applyDynamicDefaults. EmitsOwnSpan is always set: the agent's Run already
+// emits invoke_agent, so the scheduler must not add a redundant invoke_node
+// wrapper. LlmAgent nodes additionally default to single_turn mode and to
+// re-entry on resume (so a paused agent finishes instead of handing off),
+// matching runner.newAgentNode / adk-python build_node; other kinds keep the
+// engine default and an explicit RerunOnResume always wins.
+func applyAgentNodeDefaults(a agent.Agent, cfg NodeConfig) NodeConfig {
+	cfg.EmitsOwnSpan = true
+
+	llmA, ok := a.(llminternal.Agent)
+	if !ok {
+		return cfg
+	}
+	if state := llminternal.Reveal(llmA); state.Mode == llminternal.ModeUnset {
+		state.Mode = llminternal.ModeSingleTurn
+	}
+	if cfg.RerunOnResume == nil {
+		rerun := true
+		cfg.RerunOnResume = &rerun
+	}
+	return cfg
 }
 
 // NewAgentNodeWithSchemas is a convenience wrapper for NewAgentNodeWithSchemasTyped[any, any].
@@ -104,13 +104,10 @@ func NewAgentNode(a agent.Agent, cfg NodeConfig) (*AgentNode, error) {
 // Run implements the Node interface.
 func (n *AgentNode) Run(ctx agent.Context, input any) iter.Seq2[*session.Event, error] {
 	return func(yield func(*session.Event, error) bool) {
-		// On resume — this node paused earlier on a long-running interrupt
-		// its agent raised (e.g. adk_request_credential), now answered in
-		// history — the agent must CONTINUE from history, not re-process the
-		// original input. Re-seeding the input would make a single_turn/task
-		// LlmAgent re-call the still-pending tool and pause again, looping.
-		// Drop the input so the agent resumes. Mirrors runner.runAgentNodeBody.
-		if nodeIsResuming(ctx.Session(), n.agent.Name()) {
+		// On resume, re-feeding the input would make a single_turn/task
+		// LlmAgent re-call the still-pending tool and pause again; drop it
+		// so the agent continues from history. Mirrors runner.runAgentNodeBody.
+		if nodeIsResuming(ctx.Session(), ctx.InvocationID(), n.agent.Name()) {
 			input = nil
 		}
 		userContent, err := nodeInputToContent(input)
@@ -186,13 +183,19 @@ func (n *AgentNode) Run(ctx agent.Context, input any) iter.Seq2[*session.Event, 
 	}
 }
 
-// nodeIsResuming reports whether this node's agent is being re-run after
-// a long-running interrupt it raised earlier was answered in session
-// history. Scoped to the agent's own events (by author) so a different
-// node resuming in the same run is not mistaken for this one. On resume
-// the agent continues from history, so the node input is dropped (see
-// AgentNode.Run). Mirrors runner.answeredOpenInterrupts.
-func nodeIsResuming(sess session.Session, agentName string) bool {
+// nodeIsResuming reports whether this node's agent raised a long-running
+// interrupt that a later FunctionResponse has since answered — i.e. this turn is
+// a HITL resume of THIS node, so Run should drop the node input.
+//
+// The open-interrupt set is scoped to invocationID and to the agent's own events
+// (by author), stricter than the runner's unscoped answeredOpenInterrupts, so a
+// prior run or a sibling node's resume isn't taken for this node's. (A single
+// agent per invocation lets the runner stay unscoped; a graph can't.)
+//
+// Author scoping means an interrupt raised under a different author — e.g. a
+// sub-agent the coordinator delegated to — is not seen here; that resume rides
+// on the child node's own Run.
+func nodeIsResuming(sess session.Session, invocationID, agentName string) bool {
 	if sess == nil {
 		return false
 	}
@@ -205,6 +208,9 @@ func nodeIsResuming(sess session.Session, agentName string) bool {
 	for i := 0; i < events.Len(); i++ {
 		ev := events.At(i)
 		if ev == nil {
+			continue
+		}
+		if invocationID != "" && ev.InvocationID != invocationID {
 			continue
 		}
 		if ev.Author == agentName {

--- a/workflow/agent_node.go
+++ b/workflow/agent_node.go
@@ -25,6 +25,7 @@ import (
 	"google.golang.org/adk/v2/agent"
 	internalcontext "google.golang.org/adk/v2/internal/context"
 	"google.golang.org/adk/v2/internal/llminternal"
+	"google.golang.org/adk/v2/internal/utils"
 	"google.golang.org/adk/v2/session"
 )
 
@@ -63,6 +64,19 @@ func newAgentNodeWithSchemasTyped[Input, Output any](a agent.Agent, inputSchema,
 	// via RunNode. Mirrors runner.newAgentNode.
 	cfg.EmitsOwnSpan = true
 
+	// A paused AgentNode must re-run its agent to finish the work it
+	// started — e.g. complete a tool call after the user answered a
+	// long-running request (adk_request_credential / adk_request_confirmation)
+	// the agent's tool raised. Default to re-entry so Resume re-activates
+	// the node from history instead of taking the handoff path, which
+	// would treat the raw user response as the node's output and never
+	// re-run the agent. Mirrors runner.newAgentNode + the DynamicNode
+	// default; an explicit caller value still wins.
+	if cfg.RerunOnResume == nil {
+		rerun := true
+		cfg.RerunOnResume = &rerun
+	}
+
 	return &AgentNode{
 		BaseNode: NewBaseNodeWithSchemas(a.Name(), a.Description(), cfg, ischema, oschema),
 		agent:    a,
@@ -90,6 +104,15 @@ func NewAgentNode(a agent.Agent, cfg NodeConfig) (*AgentNode, error) {
 // Run implements the Node interface.
 func (n *AgentNode) Run(ctx agent.Context, input any) iter.Seq2[*session.Event, error] {
 	return func(yield func(*session.Event, error) bool) {
+		// On resume — this node paused earlier on a long-running interrupt
+		// its agent raised (e.g. adk_request_credential), now answered in
+		// history — the agent must CONTINUE from history, not re-process the
+		// original input. Re-seeding the input would make a single_turn/task
+		// LlmAgent re-call the still-pending tool and pause again, looping.
+		// Drop the input so the agent resumes. Mirrors runner.runAgentNodeBody.
+		if nodeIsResuming(ctx.Session(), n.agent.Name()) {
+			input = nil
+		}
 		userContent, err := nodeInputToContent(input)
 		if err != nil {
 			yield(nil, err)
@@ -161,6 +184,48 @@ func (n *AgentNode) Run(ctx agent.Context, input any) iter.Seq2[*session.Event, 
 			}
 		}
 	}
+}
+
+// nodeIsResuming reports whether this node's agent is being re-run after
+// a long-running interrupt it raised earlier was answered in session
+// history. Scoped to the agent's own events (by author) so a different
+// node resuming in the same run is not mistaken for this one. On resume
+// the agent continues from history, so the node input is dropped (see
+// AgentNode.Run). Mirrors runner.answeredOpenInterrupts.
+func nodeIsResuming(sess session.Session, agentName string) bool {
+	if sess == nil {
+		return false
+	}
+	events := sess.Events()
+	if events == nil {
+		return false
+	}
+	open := map[string]struct{}{}
+	answered := map[string]struct{}{}
+	for i := 0; i < events.Len(); i++ {
+		ev := events.At(i)
+		if ev == nil {
+			continue
+		}
+		if ev.Author == agentName {
+			for _, id := range ev.LongRunningToolIDs {
+				if id != "" {
+					open[id] = struct{}{}
+				}
+			}
+		}
+		for _, fr := range utils.FunctionResponses(utils.Content(ev)) {
+			if fr != nil && fr.ID != "" {
+				answered[fr.ID] = struct{}{}
+			}
+		}
+	}
+	for id := range open {
+		if _, ok := answered[id]; ok {
+			return true
+		}
+	}
+	return false
 }
 
 // synthesizeAgentOutput sets Event.Output from concatenated model

--- a/workflow/agent_node.go
+++ b/workflow/agent_node.go
@@ -18,6 +18,7 @@ import (
 	"encoding/json"
 	"fmt"
 	"iter"
+	"strings"
 
 	"github.com/google/jsonschema-go/jsonschema"
 	"google.golang.org/genai"
@@ -25,7 +26,6 @@ import (
 	"google.golang.org/adk/v2/agent"
 	internalcontext "google.golang.org/adk/v2/internal/context"
 	"google.golang.org/adk/v2/internal/llminternal"
-	"google.golang.org/adk/v2/internal/utils"
 	"google.golang.org/adk/v2/session"
 )
 
@@ -107,7 +107,7 @@ func (n *AgentNode) Run(ctx agent.Context, input any) iter.Seq2[*session.Event, 
 		// On resume, re-feeding the input would make a single_turn/task
 		// LlmAgent re-call the still-pending tool and pause again; drop it
 		// so the agent continues from history. Mirrors runner.runAgentNodeBody.
-		if nodeIsResuming(ctx.Session(), ctx.InvocationID(), n.agent.Name()) {
+		if n.isResuming(ctx) {
 			input = nil
 		}
 		userContent, err := nodeInputToContent(input)
@@ -183,19 +183,31 @@ func (n *AgentNode) Run(ctx agent.Context, input any) iter.Seq2[*session.Event, 
 	}
 }
 
-// nodeIsResuming reports whether this node's agent raised a long-running
-// interrupt that a later FunctionResponse has since answered — i.e. this turn is
-// a HITL resume of THIS node, so Run should drop the node input.
+// isResuming reports whether this activation resumes a pause of THIS node, in
+// which case Run drops the node input so the agent continues from history.
 //
-// The open-interrupt set is scoped to invocationID and to the agent's own events
-// (by author), stricter than the runner's unscoped answeredOpenInterrupts, so a
-// prior run or a sibling node's resume isn't taken for this node's. (A single
-// agent per invocation lets the runner stay unscoped; a graph can't.)
+// Both signals are needed. The scheduler's per-activation resume flag alone
+// over-fires: a dynamic child inherits the resume context of the ancestor that
+// paused, so a freshly delegated child would lose its input. A history scan
+// alone latches: history never un-answers an interrupt, so a later loop-back,
+// retry or per-item activation of the same node would lose its input too.
 //
-// Author scoping means an interrupt raised under a different author — e.g. a
-// sub-agent the coordinator delegated to — is not seen here; that resume rides
-// on the child node's own Run.
-func nodeIsResuming(sess session.Session, invocationID, agentName string) bool {
+// Interrupts are attributed as rehydration attributes them (NodeInfo.Path,
+// Author as the fallback), so a pause raised by a delegated sub-agent counts as
+// this node's — matching the engine, which parks and re-enters the node on
+// exactly those interrupts.
+func (n *AgentNode) isResuming(ctx agent.Context) bool {
+	ra, ok := ctx.(interface{ IsResumeActivation() bool })
+	if !ok || !ra.IsResumeActivation() {
+		return false
+	}
+	return raisedInterrupt(ctx.Session(), ctx.InvocationID(), n.Name())
+}
+
+// raisedInterrupt reports whether nodeName raised a long-running interrupt in
+// invocationID. Runs only on a resume activation, keeping the scan off the
+// normal path.
+func raisedInterrupt(sess session.Session, invocationID, nodeName string) bool {
 	if sess == nil {
 		return false
 	}
@@ -203,31 +215,29 @@ func nodeIsResuming(sess session.Session, invocationID, agentName string) bool {
 	if events == nil {
 		return false
 	}
-	open := map[string]struct{}{}
-	answered := map[string]struct{}{}
 	for i := 0; i < events.Len(); i++ {
 		ev := events.At(i)
-		if ev == nil {
+		if ev == nil || len(ev.LongRunningToolIDs) == 0 {
 			continue
 		}
 		if invocationID != "" && ev.InvocationID != invocationID {
 			continue
 		}
-		if ev.Author == agentName {
-			for _, id := range ev.LongRunningToolIDs {
-				if id != "" {
-					open[id] = struct{}{}
-				}
-			}
+		if ev.Author == nodeName {
+			return true
 		}
-		for _, fr := range utils.FunctionResponses(utils.Content(ev)) {
-			if fr != nil && fr.ID != "" {
-				answered[fr.ID] = struct{}{}
-			}
+		if ev.NodeInfo != nil && nodePathHas(ev.NodeInfo.Path, nodeName) {
+			return true
 		}
 	}
-	for id := range open {
-		if _, ok := answered[id]; ok {
+	return false
+}
+
+// nodePathHas reports whether a node path ("parent@1/child@2") has a segment
+// naming nodeName — the segment walk eventNodeName uses for attribution.
+func nodePathHas(path, nodeName string) bool {
+	for _, seg := range strings.Split(path, "/") {
+		if name, _, _ := strings.Cut(seg, "@"); name == nodeName {
 			return true
 		}
 	}

--- a/workflow/agent_node.go
+++ b/workflow/agent_node.go
@@ -64,8 +64,11 @@ func newAgentNodeWithSchemasTyped[Input, Output any](a agent.Agent, inputSchema,
 // emits invoke_agent, so the scheduler must not add a redundant invoke_node
 // wrapper. LlmAgent nodes additionally default to single_turn mode and to
 // re-entry on resume (so a paused agent finishes instead of handing off),
-// matching runner.newAgentNode / adk-python build_node; other kinds keep the
-// engine default and an explicit RerunOnResume always wins.
+// matching runner.newAgentNode and the mode/rerun_on_resume defaults of
+// adk-python's build_node; other kinds keep the engine default and an explicit
+// RerunOnResume always wins.
+//
+// The mode default is a write to the wrapped agent's own state, not to cfg.
 func applyAgentNodeDefaults(a agent.Agent, cfg NodeConfig) NodeConfig {
 	cfg.EmitsOwnSpan = true
 
@@ -84,19 +87,28 @@ func applyAgentNodeDefaults(a agent.Agent, cfg NodeConfig) NodeConfig {
 }
 
 // NewAgentNodeWithSchemas is a convenience wrapper for NewAgentNodeWithSchemasTyped[any, any].
-// It uses explicitly provided schemas for both input and output.
+// It uses explicitly provided schemas for both input and output, and applies
+// the same LlmAgent defaults as [NewAgentNode].
 func NewAgentNodeWithSchemas(a agent.Agent, inputSchema, outputSchema *jsonschema.Schema, cfg NodeConfig) (*AgentNode, error) {
 	return newAgentNodeWithSchemasTyped[any, any](a, inputSchema, outputSchema, cfg)
 }
 
 // NewAgentNodeTyped creates a new node wrapping an agent using generics to
 // automatically infer input and output schemas from the provided types.
+// It applies the same LlmAgent defaults as [NewAgentNode].
 func NewAgentNodeTyped[Input, Output any](a agent.Agent, cfg NodeConfig) (*AgentNode, error) {
 	return newAgentNodeWithSchemasTyped[Input, Output](a, nil, nil, cfg)
 }
 
 // NewAgentNode creates a new node wrapping an agent. Input and output schemas
 // are inferred as `any`.
+//
+// When a is an LlmAgent, its mode defaults to single_turn and
+// cfg.RerunOnResume defaults to &true, so a node paused on a long-running tool
+// request re-enters and finishes instead of handing the raw reply to its
+// successor. An explicit RerunOnResume is respected, and other agent kinds
+// keep the engine default (handoff). The mode default is applied to the agent
+// itself, so wrapping one agent in several nodes settles its mode once.
 func NewAgentNode(a agent.Agent, cfg NodeConfig) (*AgentNode, error) {
 	return NewAgentNodeTyped[any, any](a, cfg)
 }

--- a/workflow/agent_node.go
+++ b/workflow/agent_node.go
@@ -229,28 +229,40 @@ func (n *AgentNode) Run(ctx agent.Context, input any) iter.Seq2[*session.Event, 
 // alone latches: history never un-answers an interrupt, so a later loop-back,
 // retry or per-item activation of the same node would lose its input too.
 //
-// Interrupts are attributed as rehydration attributes them (NodeInfo.Path,
-// Author as the fallback), so a pause raised by a delegated sub-agent counts as
-// this node's — matching the engine, which parks and re-enters the node on
-// exactly those interrupts.
+// Interrupts are attributed by the activation's node PATH ("orch@1/child@2"),
+// which the scheduler stamps on every event leaving a node. The path, not the
+// node name, is the identity that matters: an orchestrator delegating the same
+// child twice produces child@1 and child@2, and only the delegation that
+// paused may drop its input. A pause raised by a sub-agent the node's agent
+// delegated to carries the node's own path, so it still counts as this node's
+// — matching the engine, which parks and re-enters the node on exactly those
+// interrupts.
 func (n *AgentNode) isResuming(ctx agent.Context) bool {
 	ra, ok := ctx.(interface{ IsResumeActivation() bool })
 	if !ok || !ra.IsResumeActivation() {
 		return false
 	}
-	return raisedInterrupt(ctx.Session(), ctx.InvocationID(), n.Name())
+	return raisedInterrupt(ctx.Session(), ctx.InvocationID(), ctx.Path(), n.Name())
 }
 
-// raisedInterrupt reports whether nodeName raised a long-running interrupt in
-// invocationID. Runs only on a resume activation, keeping the scan off the
-// normal path.
-func raisedInterrupt(sess session.Session, invocationID, nodeName string) bool {
-	if sess == nil {
+// raisedInterrupt reports whether the activation at nodePath raised a
+// long-running interrupt in invocationID. Runs only on a resume activation,
+// keeping the scan off the normal path.
+//
+// nodePath is empty for a root-wrapper activation, where the scheduler stamps
+// the bare node name instead. An event carrying no path at all is attributed by
+// Author, the same fallback rehydration's eventNodeName uses.
+func raisedInterrupt(sess session.Session, invocationID, nodePath, nodeName string) bool {
+	if sess == nil || nodeName == "" {
 		return false
 	}
 	events := sess.Events()
 	if events == nil {
 		return false
+	}
+	want := nodePath
+	if want == "" {
+		want = nodeName
 	}
 	for i := 0; i < events.Len(); i++ {
 		ev := events.At(i)
@@ -260,25 +272,33 @@ func raisedInterrupt(sess session.Session, invocationID, nodeName string) bool {
 		if invocationID != "" && ev.InvocationID != invocationID {
 			continue
 		}
-		if ev.Author == nodeName {
-			return true
+		if ev.NodeInfo != nil && ev.NodeInfo.Path != "" {
+			if samePathActivation(ev.NodeInfo.Path, want) {
+				return true
+			}
+			continue
 		}
-		if ev.NodeInfo != nil && nodePathHas(ev.NodeInfo.Path, nodeName) {
+		if ev.Author == nodeName {
 			return true
 		}
 	}
 	return false
 }
 
-// nodePathHas reports whether a node path ("parent@1/child@2") has a segment
-// naming nodeName — the segment walk eventNodeName uses for attribution.
-func nodePathHas(path, nodeName string) bool {
-	for _, seg := range strings.Split(path, "/") {
-		if name, _, _ := strings.Cut(seg, "@"); name == nodeName {
-			return true
-		}
+// samePathActivation reports whether an event's node path names the same
+// activation as nodePath. It compares trailing segments rather than the whole
+// string: a workflow agent records its events under its own prefix
+// ("wf@1/worker@1") while a later Resume rebuilds the node path without it
+// ("worker@1"), so exact equality would miss a node's own pause across the
+// turn boundary.
+func samePathActivation(evPath, nodePath string) bool {
+	if evPath == nodePath {
+		return true
 	}
-	return false
+	if evPath == "" || nodePath == "" {
+		return false
+	}
+	return strings.HasSuffix(evPath, "/"+nodePath) || strings.HasSuffix(nodePath, "/"+evPath)
 }
 
 // synthesizeAgentOutput sets Event.Output from concatenated model

--- a/workflow/agent_node.go
+++ b/workflow/agent_node.go
@@ -52,29 +52,36 @@ func newAgentNodeWithSchemasTyped[Input, Output any](a agent.Agent, inputSchema,
 		return nil, fmt.Errorf("resolving output schema for agent %q: %w", a.Name(), err)
 	}
 
-	// The wrapped agent's Run already emits an invoke_agent span, so
-	// the scheduler must not add a redundant invoke_node wrapper —
-	// whether this node is activated by a static edge or delegated to
-	// via RunNode. Mirrors runner.newAgentNode.
-	cfg.EmitsOwnSpan = true
-
-	// A paused AgentNode must re-run its agent to finish the work it
-	// started — e.g. complete a tool call after the user answered a
-	// long-running request (adk_request_credential / adk_request_confirmation)
-	// the agent's tool raised. Default to re-entry so Resume re-activates
-	// the node from history instead of taking the handoff path, which
-	// would treat the raw user response as the node's output and never
-	// re-run the agent. Mirrors runner.newAgentNode + the DynamicNode
-	// default; an explicit caller value still wins.
-	if cfg.RerunOnResume == nil {
-		rerun := true
-		cfg.RerunOnResume = &rerun
-	}
+	cfg = applyAgentNodeDefaults(a, cfg)
 
 	return &AgentNode{
 		BaseNode: NewBaseNodeWithSchemas(a.Name(), a.Description(), cfg, ischema, oschema),
 		agent:    a,
 	}, nil
+}
+
+// applyAgentNodeDefaults fills in the AgentNode config defaults, mirroring
+// applyDynamicDefaults. EmitsOwnSpan is always set: the agent's Run already
+// emits invoke_agent, so the scheduler must not add a redundant invoke_node
+// wrapper. An LlmAgent node additionally defaults to re-entry on resume, so a
+// paused agent finishes its pending tool call instead of handing the raw reply
+// to its successor. Other kinds keep the engine default, and an explicit
+// RerunOnResume always wins.
+//
+// The single_turn placement default is NOT applied here. Run resolves it per
+// activation and binds it to the invocation, so one agent instance can sit at
+// two placements at once.
+func applyAgentNodeDefaults(a agent.Agent, cfg NodeConfig) NodeConfig {
+	cfg.EmitsOwnSpan = true
+
+	if _, ok := a.(llminternal.Agent); !ok {
+		return cfg
+	}
+	if cfg.RerunOnResume == nil {
+		rerun := true
+		cfg.RerunOnResume = &rerun
+	}
+	return cfg
 }
 
 // NewAgentNodeWithSchemas is a convenience wrapper for NewAgentNodeWithSchemasTyped[any, any].
@@ -98,13 +105,10 @@ func NewAgentNode(a agent.Agent, cfg NodeConfig) (*AgentNode, error) {
 // Run implements the Node interface.
 func (n *AgentNode) Run(ctx agent.Context, input any) iter.Seq2[*session.Event, error] {
 	return func(yield func(*session.Event, error) bool) {
-		// On resume — this node paused earlier on a long-running interrupt
-		// its agent raised (e.g. adk_request_credential), now answered in
-		// history — the agent must CONTINUE from history, not re-process the
-		// original input. Re-seeding the input would make a single_turn/task
-		// LlmAgent re-call the still-pending tool and pause again, looping.
-		// Drop the input so the agent resumes. Mirrors runner.runAgentNodeBody.
-		if nodeIsResuming(ctx.Session(), n.agent.Name()) {
+		// On resume, re-feeding the input would make a single_turn/task
+		// LlmAgent re-call the still-pending tool and pause again; drop it
+		// so the agent continues from history. Mirrors runner.runAgentNodeBody.
+		if nodeIsResuming(ctx.Session(), ctx.InvocationID(), n.agent.Name()) {
 			input = nil
 		}
 		userContent, err := nodeInputToContent(input)
@@ -216,13 +220,19 @@ func (n *AgentNode) Run(ctx agent.Context, input any) iter.Seq2[*session.Event, 
 	}
 }
 
-// nodeIsResuming reports whether this node's agent is being re-run after
-// a long-running interrupt it raised earlier was answered in session
-// history. Scoped to the agent's own events (by author) so a different
-// node resuming in the same run is not mistaken for this one. On resume
-// the agent continues from history, so the node input is dropped (see
-// AgentNode.Run). Mirrors runner.answeredOpenInterrupts.
-func nodeIsResuming(sess session.Session, agentName string) bool {
+// nodeIsResuming reports whether this node's agent raised a long-running
+// interrupt that a later FunctionResponse has since answered — i.e. this turn is
+// a HITL resume of THIS node, so Run should drop the node input.
+//
+// The open-interrupt set is scoped to invocationID and to the agent's own events
+// (by author), stricter than the runner's unscoped answeredOpenInterrupts, so a
+// prior run or a sibling node's resume isn't taken for this node's. (A single
+// agent per invocation lets the runner stay unscoped; a graph can't.)
+//
+// Author scoping means an interrupt raised under a different author — e.g. a
+// sub-agent the coordinator delegated to — is not seen here; that resume rides
+// on the child node's own Run.
+func nodeIsResuming(sess session.Session, invocationID, agentName string) bool {
 	if sess == nil {
 		return false
 	}
@@ -235,6 +245,9 @@ func nodeIsResuming(sess session.Session, agentName string) bool {
 	for i := 0; i < events.Len(); i++ {
 		ev := events.At(i)
 		if ev == nil {
+			continue
+		}
+		if invocationID != "" && ev.InvocationID != invocationID {
 			continue
 		}
 		if ev.Author == agentName {

--- a/workflow/agent_node.go
+++ b/workflow/agent_node.go
@@ -19,6 +19,7 @@ import (
 	"encoding/json"
 	"fmt"
 	"iter"
+	"strings"
 
 	"github.com/google/jsonschema-go/jsonschema"
 	"google.golang.org/genai"
@@ -26,7 +27,6 @@ import (
 	"google.golang.org/adk/v2/agent"
 	internalcontext "google.golang.org/adk/v2/internal/context"
 	"google.golang.org/adk/v2/internal/llminternal"
-	"google.golang.org/adk/v2/internal/utils"
 	"google.golang.org/adk/v2/session"
 )
 
@@ -108,7 +108,7 @@ func (n *AgentNode) Run(ctx agent.Context, input any) iter.Seq2[*session.Event, 
 		// On resume, re-feeding the input would make a single_turn/task
 		// LlmAgent re-call the still-pending tool and pause again; drop it
 		// so the agent continues from history. Mirrors runner.runAgentNodeBody.
-		if nodeIsResuming(ctx.Session(), ctx.InvocationID(), n.agent.Name()) {
+		if n.isResuming(ctx) {
 			input = nil
 		}
 		userContent, err := nodeInputToContent(input)
@@ -220,19 +220,31 @@ func (n *AgentNode) Run(ctx agent.Context, input any) iter.Seq2[*session.Event, 
 	}
 }
 
-// nodeIsResuming reports whether this node's agent raised a long-running
-// interrupt that a later FunctionResponse has since answered — i.e. this turn is
-// a HITL resume of THIS node, so Run should drop the node input.
+// isResuming reports whether this activation resumes a pause of THIS node, in
+// which case Run drops the node input so the agent continues from history.
 //
-// The open-interrupt set is scoped to invocationID and to the agent's own events
-// (by author), stricter than the runner's unscoped answeredOpenInterrupts, so a
-// prior run or a sibling node's resume isn't taken for this node's. (A single
-// agent per invocation lets the runner stay unscoped; a graph can't.)
+// Both signals are needed. The scheduler's per-activation resume flag alone
+// over-fires: a dynamic child inherits the resume context of the ancestor that
+// paused, so a freshly delegated child would lose its input. A history scan
+// alone latches: history never un-answers an interrupt, so a later loop-back,
+// retry or per-item activation of the same node would lose its input too.
 //
-// Author scoping means an interrupt raised under a different author — e.g. a
-// sub-agent the coordinator delegated to — is not seen here; that resume rides
-// on the child node's own Run.
-func nodeIsResuming(sess session.Session, invocationID, agentName string) bool {
+// Interrupts are attributed as rehydration attributes them (NodeInfo.Path,
+// Author as the fallback), so a pause raised by a delegated sub-agent counts as
+// this node's — matching the engine, which parks and re-enters the node on
+// exactly those interrupts.
+func (n *AgentNode) isResuming(ctx agent.Context) bool {
+	ra, ok := ctx.(interface{ IsResumeActivation() bool })
+	if !ok || !ra.IsResumeActivation() {
+		return false
+	}
+	return raisedInterrupt(ctx.Session(), ctx.InvocationID(), n.Name())
+}
+
+// raisedInterrupt reports whether nodeName raised a long-running interrupt in
+// invocationID. Runs only on a resume activation, keeping the scan off the
+// normal path.
+func raisedInterrupt(sess session.Session, invocationID, nodeName string) bool {
 	if sess == nil {
 		return false
 	}
@@ -240,31 +252,29 @@ func nodeIsResuming(sess session.Session, invocationID, agentName string) bool {
 	if events == nil {
 		return false
 	}
-	open := map[string]struct{}{}
-	answered := map[string]struct{}{}
 	for i := 0; i < events.Len(); i++ {
 		ev := events.At(i)
-		if ev == nil {
+		if ev == nil || len(ev.LongRunningToolIDs) == 0 {
 			continue
 		}
 		if invocationID != "" && ev.InvocationID != invocationID {
 			continue
 		}
-		if ev.Author == agentName {
-			for _, id := range ev.LongRunningToolIDs {
-				if id != "" {
-					open[id] = struct{}{}
-				}
-			}
+		if ev.Author == nodeName {
+			return true
 		}
-		for _, fr := range utils.FunctionResponses(utils.Content(ev)) {
-			if fr != nil && fr.ID != "" {
-				answered[fr.ID] = struct{}{}
-			}
+		if ev.NodeInfo != nil && nodePathHas(ev.NodeInfo.Path, nodeName) {
+			return true
 		}
 	}
-	for id := range open {
-		if _, ok := answered[id]; ok {
+	return false
+}
+
+// nodePathHas reports whether a node path ("parent@1/child@2") has a segment
+// naming nodeName — the segment walk eventNodeName uses for attribution.
+func nodePathHas(path, nodeName string) bool {
+	for _, seg := range strings.Split(path, "/") {
+		if name, _, _ := strings.Cut(seg, "@"); name == nodeName {
 			return true
 		}
 	}

--- a/workflow/agent_node.go
+++ b/workflow/agent_node.go
@@ -85,19 +85,26 @@ func applyAgentNodeDefaults(a agent.Agent, cfg NodeConfig) NodeConfig {
 }
 
 // NewAgentNodeWithSchemas is a convenience wrapper for NewAgentNodeWithSchemasTyped[any, any].
-// It uses explicitly provided schemas for both input and output.
+// It uses explicitly provided schemas for both input and output, and applies
+// the same LlmAgent defaults as [NewAgentNode].
 func NewAgentNodeWithSchemas(a agent.Agent, inputSchema, outputSchema *jsonschema.Schema, cfg NodeConfig) (*AgentNode, error) {
 	return newAgentNodeWithSchemasTyped[any, any](a, inputSchema, outputSchema, cfg)
 }
 
 // NewAgentNodeTyped creates a new node wrapping an agent using generics to
 // automatically infer input and output schemas from the provided types.
+// It applies the same LlmAgent defaults as [NewAgentNode].
 func NewAgentNodeTyped[Input, Output any](a agent.Agent, cfg NodeConfig) (*AgentNode, error) {
 	return newAgentNodeWithSchemasTyped[Input, Output](a, nil, nil, cfg)
 }
 
 // NewAgentNode creates a new node wrapping an agent. Input and output schemas
 // are inferred as `any`.
+//
+// When a is an LlmAgent, cfg.RerunOnResume defaults to &true, so a node paused
+// on a long-running tool request re-enters and finishes instead of handing the
+// raw reply to its successor. An explicit RerunOnResume is respected, and other
+// agent kinds keep the engine default (handoff).
 func NewAgentNode(a agent.Agent, cfg NodeConfig) (*AgentNode, error) {
 	return NewAgentNodeTyped[any, any](a, cfg)
 }

--- a/workflow/agent_node.go
+++ b/workflow/agent_node.go
@@ -26,6 +26,7 @@ import (
 	"google.golang.org/adk/v2/agent"
 	internalcontext "google.golang.org/adk/v2/internal/context"
 	"google.golang.org/adk/v2/internal/llminternal"
+	"google.golang.org/adk/v2/internal/utils"
 	"google.golang.org/adk/v2/session"
 )
 
@@ -57,6 +58,19 @@ func newAgentNodeWithSchemasTyped[Input, Output any](a agent.Agent, inputSchema,
 	// via RunNode. Mirrors runner.newAgentNode.
 	cfg.EmitsOwnSpan = true
 
+	// A paused AgentNode must re-run its agent to finish the work it
+	// started — e.g. complete a tool call after the user answered a
+	// long-running request (adk_request_credential / adk_request_confirmation)
+	// the agent's tool raised. Default to re-entry so Resume re-activates
+	// the node from history instead of taking the handoff path, which
+	// would treat the raw user response as the node's output and never
+	// re-run the agent. Mirrors runner.newAgentNode + the DynamicNode
+	// default; an explicit caller value still wins.
+	if cfg.RerunOnResume == nil {
+		rerun := true
+		cfg.RerunOnResume = &rerun
+	}
+
 	return &AgentNode{
 		BaseNode: NewBaseNodeWithSchemas(a.Name(), a.Description(), cfg, ischema, oschema),
 		agent:    a,
@@ -84,6 +98,15 @@ func NewAgentNode(a agent.Agent, cfg NodeConfig) (*AgentNode, error) {
 // Run implements the Node interface.
 func (n *AgentNode) Run(ctx agent.Context, input any) iter.Seq2[*session.Event, error] {
 	return func(yield func(*session.Event, error) bool) {
+		// On resume — this node paused earlier on a long-running interrupt
+		// its agent raised (e.g. adk_request_credential), now answered in
+		// history — the agent must CONTINUE from history, not re-process the
+		// original input. Re-seeding the input would make a single_turn/task
+		// LlmAgent re-call the still-pending tool and pause again, looping.
+		// Drop the input so the agent resumes. Mirrors runner.runAgentNodeBody.
+		if nodeIsResuming(ctx.Session(), n.agent.Name()) {
+			input = nil
+		}
 		userContent, err := nodeInputToContent(input)
 		if err != nil {
 			yield(nil, err)
@@ -191,6 +214,48 @@ func (n *AgentNode) Run(ctx agent.Context, input any) iter.Seq2[*session.Event, 
 			}
 		}
 	}
+}
+
+// nodeIsResuming reports whether this node's agent is being re-run after
+// a long-running interrupt it raised earlier was answered in session
+// history. Scoped to the agent's own events (by author) so a different
+// node resuming in the same run is not mistaken for this one. On resume
+// the agent continues from history, so the node input is dropped (see
+// AgentNode.Run). Mirrors runner.answeredOpenInterrupts.
+func nodeIsResuming(sess session.Session, agentName string) bool {
+	if sess == nil {
+		return false
+	}
+	events := sess.Events()
+	if events == nil {
+		return false
+	}
+	open := map[string]struct{}{}
+	answered := map[string]struct{}{}
+	for i := 0; i < events.Len(); i++ {
+		ev := events.At(i)
+		if ev == nil {
+			continue
+		}
+		if ev.Author == agentName {
+			for _, id := range ev.LongRunningToolIDs {
+				if id != "" {
+					open[id] = struct{}{}
+				}
+			}
+		}
+		for _, fr := range utils.FunctionResponses(utils.Content(ev)) {
+			if fr != nil && fr.ID != "" {
+				answered[fr.ID] = struct{}{}
+			}
+		}
+	}
+	for id := range open {
+		if _, ok := answered[id]; ok {
+			return true
+		}
+	}
+	return false
 }
 
 // synthesizeAgentOutput sets Event.Output from concatenated model

--- a/workflow/agent_node_modes_test.go
+++ b/workflow/agent_node_modes_test.go
@@ -243,3 +243,54 @@ func assertSubAgentOutputsNotSynthesized(t *testing.T, node workflow.Node, nodeN
 		}
 	}
 }
+
+// TestNewAgentNode_RerunOnResumeDefault pins the isLlmAgent-gated default: an
+// LlmAgent node re-enters on resume so its paused agent can finish, other agent
+// kinds keep the engine default (handoff), and an explicit value always wins.
+func TestNewAgentNode_RerunOnResumeDefault(t *testing.T) {
+	t.Parallel()
+	llmA, err := llmagent.New(llmagent.Config{Name: "llm"})
+	if err != nil {
+		t.Fatalf("llmagent.New: %v", err)
+	}
+	plain, err := agent.New(agent.Config{
+		Name: "plain",
+		Run: func(agent.InvocationContext) iter.Seq2[*session.Event, error] {
+			return func(func(*session.Event, error) bool) {}
+		},
+	})
+	if err != nil {
+		t.Fatalf("agent.New: %v", err)
+	}
+	rerunTrue, rerunFalse := true, false
+
+	tests := []struct {
+		name  string
+		agent agent.Agent
+		cfg   workflow.NodeConfig
+		want  *bool
+	}{
+		{name: "LlmAgent defaults to re-entry", agent: llmA, cfg: workflow.NodeConfig{}, want: &rerunTrue},
+		{name: "non-LlmAgent gets no default", agent: plain, cfg: workflow.NodeConfig{}, want: nil},
+		{name: "explicit false wins over the LlmAgent default", agent: llmA, cfg: workflow.NodeConfig{RerunOnResume: &rerunFalse}, want: &rerunFalse},
+		{name: "explicit true wins", agent: plain, cfg: workflow.NodeConfig{RerunOnResume: &rerunTrue}, want: &rerunTrue},
+	}
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			node, err := workflow.NewAgentNode(tc.agent, tc.cfg)
+			if err != nil {
+				t.Fatalf("NewAgentNode: %v", err)
+			}
+			switch got := node.Config().RerunOnResume; {
+			case tc.want == nil:
+				if got != nil {
+					t.Errorf("RerunOnResume = %v, want nil", *got)
+				}
+			case got == nil:
+				t.Errorf("RerunOnResume = nil, want %v", *tc.want)
+			case *got != *tc.want:
+				t.Errorf("RerunOnResume = %v, want %v", *got, *tc.want)
+			}
+		})
+	}
+}

--- a/workflow/agent_node_test.go
+++ b/workflow/agent_node_test.go
@@ -19,6 +19,7 @@ import (
 	"errors"
 	"iter"
 	"strings"
+	"sync"
 	"testing"
 	"time"
 
@@ -832,114 +833,238 @@ func TestAgentNode_AutomaticOutputExtraction(t *testing.T) {
 	}
 }
 
-// TestNodeIsResuming_InvocationScope pins resume detection scoping to the
-// current invocation and the node's own agent.
-func TestNodeIsResuming_InvocationScope(t *testing.T) {
-	const agentName = "worker"
-	raise := func(inv, author, id string) *session.Event {
-		return &session.Event{InvocationID: inv, Author: author, LongRunningToolIDs: []string{id}}
-	}
-	answer := func(inv, id string) *session.Event {
-		ev := &session.Event{InvocationID: inv, Author: "user"}
-		ev.LLMResponse.Content = &genai.Content{
-			Parts: []*genai.Part{{FunctionResponse: &genai.FunctionResponse{ID: id}}},
-		}
-		return ev
-	}
-
-	tests := []struct {
-		name         string
-		events       sliceEvents
-		invocationID string
-		want         bool
-	}{
-		{
-			name:         "answered in current invocation is a resume",
-			events:       sliceEvents{raise("inv1", agentName, "A"), answer("inv1", "A")},
-			invocationID: "inv1",
-			want:         true,
-		},
-		{
-			// A finished cycle stays in history but must not resume inv2.
-			name:         "answered only in a prior invocation is not a resume",
-			events:       sliceEvents{raise("inv1", agentName, "A"), answer("inv1", "A")},
-			invocationID: "inv2",
-			want:         false,
-		},
-		{
-			name:         "raised but unanswered is not a resume",
-			events:       sliceEvents{raise("inv1", agentName, "A")},
-			invocationID: "inv1",
-			want:         false,
-		},
-		{
-			name:         "interrupt raised by another node is not this node's resume",
-			events:       sliceEvents{raise("inv1", "other", "A"), answer("inv1", "A")},
-			invocationID: "inv1",
-			want:         false,
-		},
-		{
-			// Nested delegation: the interrupt is authored by a sub-agent, not
-			// this node's agent, so author scoping excludes it (see nodeIsResuming).
-			name: "delegated sub-agent's interrupt is not the coordinator's resume",
-			events: sliceEvents{
-				{InvocationID: "inv1", Author: agentName},
-				raise("inv1", "subagent", "A"),
-				answer("inv1", "A"),
-			},
-			invocationID: "inv1",
-			want:         false,
-		},
-	}
-	for _, tc := range tests {
-		t.Run(tc.name, func(t *testing.T) {
-			sess := &eventsSession{events: tc.events}
-			if got := nodeIsResuming(sess, tc.invocationID, agentName); got != tc.want {
-				t.Errorf("nodeIsResuming(_, %q, %q) = %v, want %v", tc.invocationID, agentName, got, tc.want)
-			}
-		})
-	}
+// resumeProbeAgent records the user content of every activation and, on its
+// first one, raises a long-running interrupt authored by author (a sub-agent
+// name exercises attribution beyond the node's own agent).
+type resumeProbeAgent struct {
+	mu       sync.Mutex
+	inputs   []*genai.Content
+	author   string
+	routes   []string
+	interrID string
 }
 
-// TestNewAgentNode_RerunOnResumeDefault pins the isLlmAgent-gated default:
-// a non-LlmAgent node gets no default, and an explicit value always wins.
-func TestNewAgentNode_RerunOnResumeDefault(t *testing.T) {
-	nonLLM, err := agent.New(agent.Config{
-		Name: "plain",
-		Run: func(agent.InvocationContext) iter.Seq2[*session.Event, error] {
-			return func(func(*session.Event, error) bool) {}
+func (p *resumeProbeAgent) new(t *testing.T, name string) agent.Agent {
+	t.Helper()
+	a, err := agent.New(agent.Config{
+		Name: name,
+		Run: func(ctx agent.InvocationContext) iter.Seq2[*session.Event, error] {
+			return func(yield func(*session.Event, error) bool) {
+				p.mu.Lock()
+				n := len(p.inputs)
+				p.inputs = append(p.inputs, ctx.UserContent())
+				p.mu.Unlock()
+
+				ev := session.NewEvent(ctx, ctx.InvocationID())
+				ev.Author = name
+				if p.author != "" {
+					ev.Author = p.author
+				}
+				if n == 0 && p.interrID != "" {
+					ev.LongRunningToolIDs = []string{p.interrID}
+				} else {
+					ev.Output = "out"
+				}
+				if n < len(p.routes) {
+					ev.Routes = []string{p.routes[n]}
+				}
+				yield(ev, nil)
+			}
 		},
 	})
 	if err != nil {
 		t.Fatalf("agent.New: %v", err)
 	}
-	rerunTrue, rerunFalse := true, false
+	return a
+}
 
-	tests := []struct {
-		name string
-		cfg  NodeConfig
-		want *bool
-	}{
-		{name: "non-LlmAgent gets no default", cfg: NodeConfig{}, want: nil},
-		{name: "explicit true wins", cfg: NodeConfig{RerunOnResume: &rerunTrue}, want: &rerunTrue},
-		{name: "explicit false wins", cfg: NodeConfig{RerunOnResume: &rerunFalse}, want: &rerunFalse},
+func (p *resumeProbeAgent) activation(t *testing.T, i int) *genai.Content {
+	t.Helper()
+	p.mu.Lock()
+	defer p.mu.Unlock()
+	if i >= len(p.inputs) {
+		t.Fatalf("activation %d missing; node ran %d time(s)", i+1, len(p.inputs))
 	}
-	for _, tc := range tests {
-		t.Run(tc.name, func(t *testing.T) {
-			node, err := NewAgentNode(nonLLM, tc.cfg)
+	return p.inputs[i]
+}
+
+// answeredEvent is a user turn answering interrupt id.
+func answeredEvent(invocationID, id string) *session.Event {
+	ev := &session.Event{InvocationID: invocationID, Author: "user"}
+	ev.LLMResponse.Content = &genai.Content{
+		Parts: []*genai.Part{{FunctionResponse: &genai.FunctionResponse{ID: id, Response: map[string]any{"response": "ok"}}}},
+	}
+	return ev
+}
+
+// TestAgentNode_LoopBackKeepsInput pins that only the resume activation drops
+// the node input: a node re-activated by a loop-back edge later in the same
+// invocation starts a fresh lifecycle and must still receive its input.
+func TestAgentNode_LoopBackKeepsInput(t *testing.T) {
+	const name = "looper"
+	probe := &resumeProbeAgent{routes: []string{"loop", "finish"}}
+	node, err := NewAgentNode(probe.new(t, name), NodeConfig{})
+	if err != nil {
+		t.Fatalf("NewAgentNode: %v", err)
+	}
+	finish := newRecordingNode("Finish")
+	finish.release()
+
+	w := mustNew(t, []Edge{
+		{From: Start, To: node},
+		{From: node, To: node, Route: StringRoute("loop")},
+		{From: node, To: finish, Route: StringRoute("finish")},
+	})
+
+	// An interrupt of this node's, answered in the current invocation: a
+	// history scan would latch on it and starve every later activation.
+	ctx := newSeededMockCtx(t)
+	ctx.sess = &eventsSession{events: sliceEvents{
+		{InvocationID: "test-invocation-id", Author: name, LongRunningToolIDs: []string{"X"}},
+		answeredEvent("test-invocation-id", "X"),
+	}}
+
+	for _, err := range w.Run(ctx) {
+		if err != nil {
+			t.Fatalf("Run: %v", err)
+		}
+	}
+	if got := probe.activation(t, 1); got == nil {
+		t.Error("loop-back activation got no input, want the routed input")
+	}
+}
+
+// TestAgentNode_ResumesOnSubAgentInterrupt pins that a pause raised by a
+// sub-agent the node's agent delegated to still counts as the node's own
+// resume: the engine attributes it to the node and re-enters it, so Run must
+// drop the input rather than re-feed it and re-trigger the pending tool.
+func TestAgentNode_ResumesOnSubAgentInterrupt(t *testing.T) {
+	const (
+		name        = "coord"
+		invocation  = "test-invocation-id"
+		interruptID = "X"
+	)
+	probe := &resumeProbeAgent{author: "subagent", interrID: interruptID}
+	rerun := true
+	node, err := NewAgentNode(probe.new(t, name), NodeConfig{RerunOnResume: &rerun})
+	if err != nil {
+		t.Fatalf("NewAgentNode: %v", err)
+	}
+	producer := newStubNode("producer", "task-input")
+	w := mustNew(t, []Edge{{From: Start, To: producer}, {From: producer, To: node}})
+
+	ctx1 := newSeededMockCtx(t)
+	ctx1.sess = &eventsSession{events: sliceEvents{}}
+	var history sliceEvents
+	for ev, err := range w.Run(ctx1) {
+		if err != nil {
+			t.Fatalf("Run: %v", err)
+		}
+		if ev.InvocationID == "" {
+			ev.InvocationID = invocation
+		}
+		history = append(history, ev)
+	}
+	history = append(history, answeredEvent(invocation, interruptID))
+
+	sess := &eventsSession{events: history}
+	state, err := w.ReconstructRunState(sess, invocation)
+	if err != nil {
+		t.Fatalf("ReconstructRunState: %v", err)
+	}
+	if state == nil {
+		t.Fatal("the sub-agent's interrupt was not attributed to the node")
+	}
+	ctx2 := newSeededMockCtx(t)
+	ctx2.sess = sess
+	for _, err := range w.Resume(agent.NewContext(ctx2), state, map[string]any{interruptID: "ok"}) {
+		if err != nil {
+			t.Fatalf("Resume: %v", err)
+		}
+	}
+	if got := probe.activation(t, 1); got != nil {
+		t.Errorf("resume activation got input %v, want none (continue from history)", got)
+	}
+}
+
+// TestAgentNode_FreshDynamicChildKeepsInput pins the other side of resume
+// detection: a dynamic child inherits the resume context of the ancestor that
+// paused, but a child that never paused is a fresh run and keeps its input.
+func TestAgentNode_FreshDynamicChildKeepsInput(t *testing.T) {
+	const (
+		invocation  = "test-invocation-id"
+		interruptID = "ask-1"
+	)
+	probe := &resumeProbeAgent{}
+	childNode, err := NewAgentNode(probe.new(t, "child"), NodeConfig{})
+	if err != nil {
+		t.Fatalf("NewAgentNode: %v", err)
+	}
+	asker := &resumeAskerNode{BaseNode: NewBaseNode("asker", "", NodeConfig{}), id: interruptID}
+
+	orchestrator := NewDynamicNode[any, string]("orch",
+		func(nc agent.Context, _ any, _ func(*session.Event) error) (string, error) {
+			if _, err := RunNode[any](nc, asker, nil); err != nil {
+				return "", err
+			}
+			out, err := RunNode[any](nc, childNode, "fresh-child-input")
 			if err != nil {
-				t.Fatalf("NewAgentNode: %v", err)
+				return "", err
 			}
-			switch got := node.Config().RerunOnResume; {
-			case tc.want == nil:
-				if got != nil {
-					t.Errorf("RerunOnResume = %v, want nil", *got)
-				}
-			case got == nil:
-				t.Errorf("RerunOnResume = nil, want %v", *tc.want)
-			case *got != *tc.want:
-				t.Errorf("RerunOnResume = %v, want %v", *got, *tc.want)
-			}
-		})
+			s, _ := out.(string)
+			return s, nil
+		}, NodeConfig{})
+
+	w := mustNew(t, []Edge{{From: Start, To: orchestrator}})
+
+	ctx1 := newSeededMockCtx(t)
+	ctx1.sess = &eventsSession{events: sliceEvents{}}
+	var history sliceEvents
+	for ev, err := range w.Run(ctx1) {
+		if err != nil {
+			t.Fatalf("Run: %v", err)
+		}
+		if ev.InvocationID == "" {
+			ev.InvocationID = invocation
+		}
+		history = append(history, ev)
+	}
+	history = append(history, answeredEvent(invocation, interruptID))
+
+	sess := &eventsSession{events: history}
+	state, err := w.ReconstructRunState(sess, invocation)
+	if err != nil {
+		t.Fatalf("ReconstructRunState: %v", err)
+	}
+	if state == nil {
+		t.Fatal("no run state rehydrated")
+	}
+	ctx2 := newSeededMockCtx(t)
+	ctx2.sess = sess
+	for _, err := range w.Resume(agent.NewContext(ctx2), state, map[string]any{interruptID: "ok"}) {
+		if err != nil {
+			t.Fatalf("Resume: %v", err)
+		}
+	}
+	if got := probe.activation(t, 0); got == nil {
+		t.Error("freshly delegated child got no input, want the delegated input")
+	}
+}
+
+// resumeAskerNode pauses once on its interrupt, then returns the reply.
+type resumeAskerNode struct {
+	BaseNode
+	id string
+}
+
+func (n *resumeAskerNode) Run(ctx agent.Context, _ any) iter.Seq2[*session.Event, error] {
+	return func(yield func(*session.Event, error) bool) {
+		if resp, ok := ctx.ResumedInput(n.id); ok {
+			ev := session.NewEvent(ctx, ctx.InvocationID())
+			ev.Output = resp
+			yield(ev, nil)
+			return
+		}
+		yield(NewRequestInputEvent(ctx, session.RequestInput{InterruptID: n.id, Message: "?"}), nil)
 	}
 }

--- a/workflow/agent_node_test.go
+++ b/workflow/agent_node_test.go
@@ -1068,3 +1068,118 @@ func (n *resumeAskerNode) Run(ctx agent.Context, _ any) iter.Seq2[*session.Event
 		yield(NewRequestInputEvent(ctx, session.RequestInput{InterruptID: n.id, Message: "?"}), nil)
 	}
 }
+
+// TestAgentNode_RedelegatedChildKeepsInput pins the other half of
+// TestAgentNode_FreshDynamicChildKeepsInput: a dynamic child that paused
+// earlier and is delegated AGAIN, with new input, during the resumed
+// orchestrator's body. The child inherits the ancestor's resume context, so
+// the per-activation flag alone cannot tell the two delegations apart —
+// attribution has to be per node PATH (child@1 vs child@2), not per node name.
+func TestAgentNode_RedelegatedChildKeepsInput(t *testing.T) {
+	const (
+		invocation  = "test-invocation-id"
+		interruptID = "ask-1"
+	)
+	probe := &pausingProbeAgent{interrID: interruptID}
+	child, err := NewAgentNode(probe.new(t, "child"), NodeConfig{})
+	if err != nil {
+		t.Fatalf("NewAgentNode: %v", err)
+	}
+	orchestrator := NewDynamicNode[any, string]("orch",
+		func(nc agent.Context, _ any, _ func(*session.Event) error) (string, error) {
+			if _, err := RunNode[any](nc, child, "first"); err != nil {
+				return "", err
+			}
+			out, err := RunNode[any](nc, child, "second")
+			s, _ := out.(string)
+			return s, err
+		}, NodeConfig{})
+	w := mustNew(t, []Edge{{From: Start, To: orchestrator}})
+
+	ctx1 := newSeededMockCtx(t)
+	ctx1.sess = &eventsSession{events: sliceEvents{}}
+	var history sliceEvents
+	for ev, err := range w.Run(ctx1) {
+		if err != nil {
+			t.Fatalf("Run: %v", err)
+		}
+		if ev.InvocationID == "" {
+			ev.InvocationID = invocation
+		}
+		history = append(history, ev)
+	}
+	history = append(history, answeredEvent(invocation, interruptID))
+
+	sess := &eventsSession{events: history}
+	state, err := w.ReconstructRunState(sess, invocation)
+	if err != nil {
+		t.Fatalf("ReconstructRunState: %v", err)
+	}
+	if state == nil {
+		t.Fatal("no run state rehydrated")
+	}
+	ctx2 := newSeededMockCtx(t)
+	ctx2.sess = sess
+	for _, err := range w.Resume(agent.NewContext(ctx2), state, map[string]any{interruptID: "ok"}) {
+		if err != nil {
+			t.Fatalf("Resume: %v", err)
+		}
+	}
+	// activation 0: turn 1, "first" (paused). activation 1: the replayed
+	// child@1 — input correctly dropped. activation 2: the fresh child@2.
+	if got := probe.activation(t, 1); got != nil {
+		t.Errorf("replayed child@1 got input %v, want none (it is the paused delegation)", got)
+	}
+	if got := probe.activation(t, 2); got == nil {
+		t.Error("re-delegated child@2 lost its input; a fresh delegation must keep it")
+	}
+}
+
+// pausingProbeAgent parks its node on the first activation with a real
+// RequestInput pause (a bare LongRunningToolIDs event does not halt a
+// delegating orchestrator's body), and records every activation's input.
+type pausingProbeAgent struct {
+	mu       sync.Mutex
+	inputs   []*genai.Content
+	interrID string
+}
+
+func (p *pausingProbeAgent) new(t *testing.T, name string) agent.Agent {
+	t.Helper()
+	a, err := agent.New(agent.Config{
+		Name: name,
+		Run: func(ctx agent.InvocationContext) iter.Seq2[*session.Event, error] {
+			return func(yield func(*session.Event, error) bool) {
+				p.mu.Lock()
+				n := len(p.inputs)
+				p.inputs = append(p.inputs, ctx.UserContent())
+				p.mu.Unlock()
+
+				if n == 0 {
+					yield(NewRequestInputEvent(ctx, session.RequestInput{
+						InterruptID: p.interrID, Message: "?",
+					}), nil)
+					return
+				}
+				ev := session.NewEvent(ctx, ctx.InvocationID())
+				ev.Author = name
+				ev.Output = "out"
+				yield(ev, nil)
+			}
+		},
+	})
+	if err != nil {
+		t.Fatalf("agent.New: %v", err)
+	}
+	return a
+}
+
+func (p *pausingProbeAgent) activation(t *testing.T, i int) *genai.Content {
+	t.Helper()
+	p.mu.Lock()
+	defer p.mu.Unlock()
+	if i >= len(p.inputs) {
+		t.Fatalf("activation %d missing; node ran %d time(s)", i+1, len(p.inputs))
+	}
+	return p.inputs[i]
+}

--- a/workflow/agent_node_test.go
+++ b/workflow/agent_node_test.go
@@ -831,3 +831,115 @@ func TestAgentNode_AutomaticOutputExtraction(t *testing.T) {
 		t.Errorf("expected automatically extracted output %q, got %q", want, got)
 	}
 }
+
+// TestNodeIsResuming_InvocationScope pins resume detection scoping to the
+// current invocation and the node's own agent.
+func TestNodeIsResuming_InvocationScope(t *testing.T) {
+	const agentName = "worker"
+	raise := func(inv, author, id string) *session.Event {
+		return &session.Event{InvocationID: inv, Author: author, LongRunningToolIDs: []string{id}}
+	}
+	answer := func(inv, id string) *session.Event {
+		ev := &session.Event{InvocationID: inv, Author: "user"}
+		ev.LLMResponse.Content = &genai.Content{
+			Parts: []*genai.Part{{FunctionResponse: &genai.FunctionResponse{ID: id}}},
+		}
+		return ev
+	}
+
+	tests := []struct {
+		name         string
+		events       sliceEvents
+		invocationID string
+		want         bool
+	}{
+		{
+			name:         "answered in current invocation is a resume",
+			events:       sliceEvents{raise("inv1", agentName, "A"), answer("inv1", "A")},
+			invocationID: "inv1",
+			want:         true,
+		},
+		{
+			// A finished cycle stays in history but must not resume inv2.
+			name:         "answered only in a prior invocation is not a resume",
+			events:       sliceEvents{raise("inv1", agentName, "A"), answer("inv1", "A")},
+			invocationID: "inv2",
+			want:         false,
+		},
+		{
+			name:         "raised but unanswered is not a resume",
+			events:       sliceEvents{raise("inv1", agentName, "A")},
+			invocationID: "inv1",
+			want:         false,
+		},
+		{
+			name:         "interrupt raised by another node is not this node's resume",
+			events:       sliceEvents{raise("inv1", "other", "A"), answer("inv1", "A")},
+			invocationID: "inv1",
+			want:         false,
+		},
+		{
+			// Nested delegation: the interrupt is authored by a sub-agent, not
+			// this node's agent, so author scoping excludes it (see nodeIsResuming).
+			name: "delegated sub-agent's interrupt is not the coordinator's resume",
+			events: sliceEvents{
+				{InvocationID: "inv1", Author: agentName},
+				raise("inv1", "subagent", "A"),
+				answer("inv1", "A"),
+			},
+			invocationID: "inv1",
+			want:         false,
+		},
+	}
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			sess := &eventsSession{events: tc.events}
+			if got := nodeIsResuming(sess, tc.invocationID, agentName); got != tc.want {
+				t.Errorf("nodeIsResuming(_, %q, %q) = %v, want %v", tc.invocationID, agentName, got, tc.want)
+			}
+		})
+	}
+}
+
+// TestNewAgentNode_RerunOnResumeDefault pins the isLlmAgent-gated default:
+// a non-LlmAgent node gets no default, and an explicit value always wins.
+func TestNewAgentNode_RerunOnResumeDefault(t *testing.T) {
+	nonLLM, err := agent.New(agent.Config{
+		Name: "plain",
+		Run: func(agent.InvocationContext) iter.Seq2[*session.Event, error] {
+			return func(func(*session.Event, error) bool) {}
+		},
+	})
+	if err != nil {
+		t.Fatalf("agent.New: %v", err)
+	}
+	rerunTrue, rerunFalse := true, false
+
+	tests := []struct {
+		name string
+		cfg  NodeConfig
+		want *bool
+	}{
+		{name: "non-LlmAgent gets no default", cfg: NodeConfig{}, want: nil},
+		{name: "explicit true wins", cfg: NodeConfig{RerunOnResume: &rerunTrue}, want: &rerunTrue},
+		{name: "explicit false wins", cfg: NodeConfig{RerunOnResume: &rerunFalse}, want: &rerunFalse},
+	}
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			node, err := NewAgentNode(nonLLM, tc.cfg)
+			if err != nil {
+				t.Fatalf("NewAgentNode: %v", err)
+			}
+			switch got := node.Config().RerunOnResume; {
+			case tc.want == nil:
+				if got != nil {
+					t.Errorf("RerunOnResume = %v, want nil", *got)
+				}
+			case got == nil:
+				t.Errorf("RerunOnResume = nil, want %v", *tc.want)
+			case *got != *tc.want:
+				t.Errorf("RerunOnResume = %v, want %v", *got, *tc.want)
+			}
+		})
+	}
+}

--- a/workflow/config.go
+++ b/workflow/config.go
@@ -62,7 +62,9 @@ type NodeConfig struct {
 	// &true re-runs the interrupted node from scratch on resume
 	// (re-entry mode), &false routes the resume payload to the
 	// node's successor as input (handoff mode), and nil defers to
-	// the engine. The engine currently treats nil as handoff.
+	// the node kind. NewDynamicNode, and NewAgentNode over an
+	// LlmAgent, default nil to &true; every other kind leaves it
+	// nil, which the engine treats as handoff.
 	RerunOnResume *bool
 
 	// WaitForOutput, when true, parks the parent (ErrNodeInterrupted) to

--- a/workflow/config.go
+++ b/workflow/config.go
@@ -63,7 +63,7 @@ type NodeConfig struct {
 	// (re-entry mode), &false routes the resume payload to the
 	// node's successor as input (handoff mode), and nil defers to
 	// the node kind. NewDynamicNode, and NewAgentNode over an
-	// LlmAgent, default nil to &true; every other kind leaves it
+	// LlmAgent, default nil to &true. Every other kind leaves it
 	// nil, which the engine treats as handoff.
 	RerunOnResume *bool
 

--- a/workflow/persistence.go
+++ b/workflow/persistence.go
@@ -15,13 +15,13 @@
 package workflow
 
 import (
-	"encoding/json"
 	"fmt"
 	"strings"
 
 	"github.com/google/jsonschema-go/jsonschema"
 	"google.golang.org/genai"
 
+	"google.golang.org/adk/v2/internal/utils"
 	"google.golang.org/adk/v2/session"
 )
 
@@ -158,7 +158,7 @@ func scanHistory(events session.Events, nodesByName map[string]Node, invocationI
 					continue
 				}
 				sf := scanFor(owner)
-				sf.resolved[fr.ID] = unwrapResponse(fr.Response)
+				sf.resolved[fr.ID] = utils.UnwrapResponse(fr.Response)
 				sf.resolvedCount[fr.ID]++
 			}
 			continue
@@ -499,31 +499,4 @@ func schemaFromEvent(ev *session.Event, id string) *jsonschema.Schema {
 		}
 	}
 	return nil
-}
-
-// unwrapResponse extracts the original value from a FunctionResponse
-// payload. A sole single-key wrapper — {"result": v} (adk-python),
-// {"response": v} or {"payload": v} (adk-go) — is unwrapped, with
-// string values JSON-parsed when possible; anything else passes
-// through. Mirrors adk-python _unwrap_response, extended with the
-// adk-go keys for cross-runtime sessions.
-func unwrapResponse(data map[string]any) any {
-	if len(data) != 1 {
-		return data
-	}
-	for _, key := range []string{"result", "response", "payload"} {
-		v, ok := data[key]
-		if !ok {
-			continue
-		}
-		if s, isStr := v.(string); isStr {
-			var parsed any
-			if err := json.Unmarshal([]byte(s), &parsed); err == nil {
-				return parsed
-			}
-			return s
-		}
-		return v
-	}
-	return data
 }

--- a/workflow/persistence.go
+++ b/workflow/persistence.go
@@ -40,6 +40,12 @@ type nodeScanState struct {
 	// duplicate resume replayed an already-consumed response. Lets
 	// Resume tell a genuine first resume from an idempotent no-op.
 	resolvedCount map[string]int
+	// consumed marks an interrupt whose answer the node has already
+	// acted on: it emitted an event after that answer first appeared.
+	// Counting responses cannot express this — a retry after a
+	// rejected payload and a duplicate replay both leave two responses
+	// in history, but only the replay follows a run of the node.
+	consumed map[string]bool
 	// schemas maps an interrupt ID to its declared response schema,
 	// re-extracted from the pause FunctionCall args.
 	schemas map[string]*jsonschema.Schema
@@ -127,7 +133,7 @@ func scanHistory(events session.Events, nodesByName map[string]Node, invocationI
 	scanFor := func(name string) *nodeScanState {
 		s := scans[name]
 		if s == nil {
-			s = &nodeScanState{resolved: map[string]any{}, resolvedCount: map[string]int{}, schemas: map[string]*jsonschema.Schema{}}
+			s = &nodeScanState{resolved: map[string]any{}, resolvedCount: map[string]int{}, consumed: map[string]bool{}, schemas: map[string]*jsonschema.Schema{}}
 			scans[name] = s
 		}
 		return s
@@ -158,6 +164,13 @@ func scanHistory(events session.Events, nodesByName map[string]Node, invocationI
 					continue
 				}
 				sf := scanFor(owner)
+				if _, first := sf.resolved[fr.ID]; !first {
+					// First answer for this interrupt: nothing has run
+					// on it yet. A later answer does not reset that —
+					// the node either acted after the first one or it
+					// did not.
+					sf.consumed[fr.ID] = false
+				}
 				sf.resolved[fr.ID] = utils.UnwrapResponse(fr.Response)
 				sf.resolvedCount[fr.ID]++
 			}
@@ -172,6 +185,13 @@ func scanHistory(events session.Events, nodesByName map[string]Node, invocationI
 			continue
 		}
 		s := scanFor(owner)
+		// The node produced this event, so it has acted on every answer
+		// already in history. Recorded per interrupt, not per node: a
+		// node that re-entered on one answer and paused again must still
+		// act on the answer to the new interrupt.
+		for id := range s.resolved {
+			s.consumed[id] = true
+		}
 		if ev.Output != nil {
 			s.branch = ev.Branch
 		}
@@ -348,6 +368,10 @@ func (w *Workflow) inferNodeState(node Node, scan *nodeScanState, nodeOutputs ma
 		ns.Status = NodePending
 		ns.ResumedInputs = resumed
 		ns.Input, ns.TriggeredBy = w.predecessorInput(node, nodeOutputs, workflowInput)
+		// Unless the node already ran on every one of them, in which
+		// case this turn is a replay and re-running would re-do
+		// whatever the human approved.
+		ns.reentryConsumed = len(resumed) > 0 && allConsumed(scan, resumed)
 	default:
 		// All resolved, handoff: the node is done; its output is the
 		// response, which Resume forwards to successors. Keep the
@@ -367,6 +391,17 @@ func (w *Workflow) inferNodeState(node Node, scan *nodeScanState, nodeOutputs ma
 		}
 	}
 	return ns, nil
+}
+
+// allConsumed reports whether the node has already acted on every one of the
+// given resolved interrupts.
+func allConsumed(scan *nodeScanState, resumed map[string]any) bool {
+	for id := range resumed {
+		if !scan.consumed[id] {
+			return false
+		}
+	}
+	return true
 }
 
 // predecessorInput walks incoming edges backward to find a resuming

--- a/workflow/persistence.go
+++ b/workflow/persistence.go
@@ -185,12 +185,22 @@ func scanHistory(events session.Events, nodesByName map[string]Node, invocationI
 			continue
 		}
 		s := scanFor(owner)
-		// The node produced this event, so it has acted on every answer
-		// already in history. Recorded per interrupt, not per node: a
-		// node that re-entered on one answer and paused again must still
-		// act on the answer to the new interrupt.
-		for id := range s.resolved {
-			s.consumed[id] = true
+		// The node SETTLED on every answer already in history: it either
+		// produced its output or paused again on a new interrupt.
+		//
+		// Any other event is work in progress, and an activation that
+		// emitted one and then failed must stay resumable. History never
+		// un-answers an interrupt, so marking those answers consumed
+		// wedges the run for good — every later retry is skipped as a
+		// replay and the approved side effect never settles.
+		//
+		// Recorded per interrupt, not per node: a node that re-entered
+		// on one answer and paused again must still act on the answer to
+		// the new interrupt.
+		if ev.Output != nil || len(ev.LongRunningToolIDs) > 0 {
+			for id := range s.resolved {
+				s.consumed[id] = true
+			}
 		}
 		if ev.Output != nil {
 			s.branch = ev.Branch
@@ -348,6 +358,19 @@ func (w *Workflow) inferNodeState(node Node, scan *nodeScanState, nodeOutputs ma
 
 	ns := &NodeState{Branch: scan.branch, interruptSchemas: scan.schemas}
 
+	// A response seen for the first time this turn (count == 1) marks a
+	// genuine first resume; a duplicate turn replays an already-counted
+	// response (>= 2) and must stay a no-op. Every arm needs this, not just
+	// the completed one: a node left waiting on its other interrupts still
+	// took delivery of the answer that did arrive, so the turn is not the
+	// empty no-op ErrNothingToResume reports.
+	for id := range resumed {
+		if scan.resolvedCount[id] == 1 {
+			ns.answeredThisTurn = true
+			break
+		}
+	}
+
 	switch {
 	case len(unresolved) > 0 && reenter && len(resumed) > 0:
 		// Partial resume: re-run with resolved responses so the node
@@ -384,15 +407,6 @@ func (w *Workflow) inferNodeState(node Node, scan *nodeScanState, nodeOutputs ma
 		ns.Status = NodeCompleted
 		ns.Output = resumeOutput(resumed)
 		ns.ResumedInputs = resumed
-		// A response seen for the first time this turn (count == 1)
-		// marks a genuine first resume; a duplicate turn replays an
-		// already-counted response (>= 2) and must stay a no-op.
-		for id := range resumed {
-			if scan.resolvedCount[id] == 1 {
-				ns.answeredThisTurn = true
-				break
-			}
-		}
 	}
 	return ns, nil
 }

--- a/workflow/persistence.go
+++ b/workflow/persistence.go
@@ -356,6 +356,10 @@ func (w *Workflow) inferNodeState(node Node, scan *nodeScanState, nodeOutputs ma
 		ns.ResumedInputs = resumed
 		ns.Interrupts = unresolved
 		ns.Input, ns.TriggeredBy = w.predecessorInput(node, nodeOutputs, workflowInput)
+		// Same replay guard as the all-resolved arm below: a node still
+		// holding an open interrupt is no less exposed to a duplicate
+		// answer than one that has none.
+		ns.reentryConsumed = allConsumed(scan, resumed)
 	case len(unresolved) > 0:
 		// Still waiting for the remaining interrupts.
 		ns.Status = NodeWaiting

--- a/workflow/resume.go
+++ b/workflow/resume.go
@@ -146,6 +146,13 @@ func (w *Workflow) Resume(
 			if !answeredNow && len(freshMatched) == 0 {
 				continue
 			}
+			// The node already ran on these answers; this turn replays
+			// them. Skipping keeps a re-entry node as idempotent as a
+			// handoff one — without it, ResumedInputs (which history
+			// never un-answers) re-fires the node on every later turn.
+			if ns.reentryConsumed && len(freshMatched) == 0 {
+				continue
+			}
 
 			reenter := false
 			if r := node.Config().RerunOnResume; r != nil && *r {

--- a/workflow/resume.go
+++ b/workflow/resume.go
@@ -171,6 +171,21 @@ func (w *Workflow) Resume(
 				ns.Status = NodePending
 				s.scheduleResumedNode(node, ns.Input, ns.TriggeredBy, ns.Branch, ns.ResumedInputs)
 				scheduled++
+			} else if remaining := unansweredInterrupts(ns, freshMatched); len(remaining) > 0 {
+				// Handoff, but the node raised interrupts nobody has
+				// answered yet. It is still waiting: completing it here
+				// would drop the unanswered ones and hand successors an
+				// output standing in for a decision that was never made
+				// — for a rejected confirmation, one gating the very
+				// work it rejected. Mirrors adk-python's replay
+				// interceptor, which keeps such a node waiting and
+				// re-bubbles the unresolved IDs.
+				ns.Interrupts = remaining
+				// The answer that did arrive is recorded, so the turn is
+				// not the empty no-op ErrNothingToResume reports.
+				if ns.answeredThisTurn || len(freshMatched) > 0 {
+					scheduled++
+				}
 			} else {
 				// Handoff: the response is the asker's output for its
 				// successors; the asker does not re-run.
@@ -266,4 +281,19 @@ func validateResumeResponse(resp any, schema *jsonschema.Schema) (any, error) {
 		return nil, fmt.Errorf("resolve schema: %w", err)
 	}
 	return typeutil.ConvertToWithJSONSchema[any, any](resp, resolved)
+}
+
+// unansweredInterrupts returns the interrupts a node raised that still have no
+// answer: those rehydration left unresolved, minus any answered directly this
+// turn via the runner's node path. A handoff node with any of these left is not
+// finished, whatever else the turn resolved.
+func unansweredInterrupts(ns *NodeState, freshMatched map[string]any) []string {
+	var remaining []string
+	for _, id := range ns.Interrupts {
+		if _, answered := freshMatched[id]; answered {
+			continue
+		}
+		remaining = append(remaining, id)
+	}
+	return remaining
 }

--- a/workflow/state.go
+++ b/workflow/state.go
@@ -133,6 +133,14 @@ type NodeState struct {
 	// duplicates (idempotency).
 	answeredThisTurn bool
 
+	// reentryConsumed is true when every response this node resumed on
+	// has already been acted on by a later activation of the node —
+	// i.e. the answers are replays, not new. Not persisted; rebuilt
+	// each turn from event history. Only meaningful for re-entry
+	// nodes, whose reschedule is otherwise driven by ResumedInputs,
+	// which history never un-answers.
+	reentryConsumed bool
+
 	// Attempt is the number of times this node has been failed.
 	Attempt int `json:"attempt,omitempty"`
 

--- a/workflow/state.go
+++ b/workflow/state.go
@@ -135,6 +135,14 @@ type NodeState struct {
 	// duplicates (idempotency).
 	answeredThisTurn bool
 
+	// reentryConsumed is true when every response this node resumed on
+	// has already been acted on by a later activation of the node —
+	// i.e. the answers are replays, not new. Not persisted; rebuilt
+	// each turn from event history. Only meaningful for re-entry
+	// nodes, whose reschedule is otherwise driven by ResumedInputs,
+	// which history never un-answers.
+	reentryConsumed bool
+
 	// Attempt is the number of times this node has been failed.
 	Attempt int `json:"attempt,omitempty"`
 

--- a/workflow/state.go
+++ b/workflow/state.go
@@ -14,7 +14,11 @@
 
 package workflow
 
-import "github.com/google/jsonschema-go/jsonschema"
+import (
+	"github.com/google/jsonschema-go/jsonschema"
+
+	"google.golang.org/adk/v2/internal/workflowstate"
+)
 
 // NodeStatus is the lifecycle status of a node in the workflow graph.
 //
@@ -173,6 +177,53 @@ type RunState struct {
 	// and used by Resume to avoid re-triggering a handoff successor
 	// that already ran on a prior turn (idempotency). Not persisted.
 	completed map[string]bool
+}
+
+// actionableInterruptIDs returns the interrupt IDs this run can still do
+// something about: those a node is waiting for, those a re-entry node is about
+// to be re-run with, and those a node settled on this very turn. A
+// FunctionResponse matching none of them answers nothing here — it is a reply
+// to an interrupt this run has finished with, or was never aimed at this run.
+//
+// Reachable from the packages that dispatch a turn through
+// internal/workflowstate rather than as public API, since "settled on this very
+// turn" is only observable on a state fresh from ReconstructRunState.
+//
+//nolint:unused // installed into internal/workflowstate by init below.
+func (s *RunState) actionableInterruptIDs() map[string]struct{} {
+	ids := map[string]struct{}{}
+	for _, ns := range s.Nodes {
+		if ns == nil {
+			continue
+		}
+		// A completed node still counts on the turn its answer arrived:
+		// a handoff asker resolves from history and rehydrates completed,
+		// so its genuine first resume looks settled already.
+		if ns.Status != NodeWaiting && ns.Status != NodePending && !ns.answeredThisTurn {
+			continue
+		}
+		for _, id := range ns.Interrupts {
+			if id != "" {
+				ids[id] = struct{}{}
+			}
+		}
+		for id := range ns.ResumedInputs {
+			if id != "" {
+				ids[id] = struct{}{}
+			}
+		}
+	}
+	return ids
+}
+
+func init() {
+	workflowstate.ActionableInterruptIDs = func(runState any) map[string]struct{} {
+		st, ok := runState.(*RunState)
+		if !ok || st == nil {
+			return nil
+		}
+		return st.actionableInterruptIDs()
+	}
 }
 
 // NewRunState returns an empty state with the Nodes map

--- a/workflow/state.go
+++ b/workflow/state.go
@@ -179,19 +179,30 @@ type RunState struct {
 	completed map[string]bool
 }
 
-// actionableInterruptIDs returns the interrupt IDs this run can still do
-// something about: those a node is waiting for, those a re-entry node is about
-// to be re-run with, and those a node settled on this very turn. A
-// FunctionResponse matching none of them answers nothing here — it is a reply
-// to an interrupt this run has finished with, or was never aimed at this run.
+// actionableInterruptIDs returns the interrupt IDs this run recognises, mapped
+// to whether Resume can still do something with them: those a node is waiting
+// for, those a re-entry node is about to be re-run with, and those a node
+// settled on this very turn are live (true). An answer a re-entry node has
+// already acted on is recognised but spent (false) — Resume will skip that node
+// rather than re-run it, so routing a turn there on its strength alone would
+// fail the turn with ErrNothingToResume. A FunctionResponse absent from the map
+// answers nothing here at all: it replies to an interrupt this run has finished
+// with, or was never aimed at this run.
 //
 // Reachable from the packages that dispatch a turn through
 // internal/workflowstate rather than as public API, since "settled on this very
 // turn" is only observable on a state fresh from ReconstructRunState.
 //
 //nolint:unused // installed into internal/workflowstate by init below.
-func (s *RunState) actionableInterruptIDs() map[string]struct{} {
-	ids := map[string]struct{}{}
+func (s *RunState) actionableInterruptIDs() map[string]bool {
+	ids := map[string]bool{}
+	mark := func(id string, live bool) {
+		if id == "" {
+			return
+		}
+		// Two nodes can name one ID; live anywhere wins.
+		ids[id] = ids[id] || live
+	}
 	for _, ns := range s.Nodes {
 		if ns == nil {
 			continue
@@ -203,21 +214,18 @@ func (s *RunState) actionableInterruptIDs() map[string]struct{} {
 			continue
 		}
 		for _, id := range ns.Interrupts {
-			if id != "" {
-				ids[id] = struct{}{}
-			}
+			// Still open, whatever became of this node's other answers.
+			mark(id, true)
 		}
 		for id := range ns.ResumedInputs {
-			if id != "" {
-				ids[id] = struct{}{}
-			}
+			mark(id, !ns.reentryConsumed)
 		}
 	}
 	return ids
 }
 
 func init() {
-	workflowstate.ActionableInterruptIDs = func(runState any) map[string]struct{} {
+	workflowstate.ActionableInterruptIDs = func(runState any) map[string]bool {
 		st, ok := runState.(*RunState)
 		if !ok || st == nil {
 			return nil


### PR DESCRIPTION
## Problem

An LlmAgent running as an `AgentNode` inside a graph can pause on a tool's long-running request — interactive OAuth consent (`adk_request_credential`) or tool confirmation (`adk_request_confirmation`) — exactly as it does as a root agent. The pause already works: the scheduler parks the node on the generic `Event.LongRunningToolIDs` signal. Resuming did not.

- `workflowagent.detectResume` only recognised `adk_request_input` responses, matching the `FunctionResponse` by function name, so a consent or confirmation reply fell through to a fresh `Workflow.Run` instead of a targeted `Resume` — which, in a multi-node graph, re-runs already-completed upstream nodes.
- Even when resumed, an `AgentNode` did not opt into re-entry, so `Workflow.Resume` took the handoff path — mark the node completed, treat the raw response as its output — and never re-ran the agent to finish the pending tool call.
- On re-entry the node re-fed its original input, which makes a single_turn or task LlmAgent re-call the still-pending tool and pause again, a loop.

Parity note: adk-python's `build_node` defaults an LlmAgent node to `rerun_on_resume=True`, and an LlmAgent node there resumes on the same `LongRunningToolIDs` signal, re-running from history. It sets the single_turn placement default on a `clone()` of the agent rather than on the agent itself, which is the same separation `AgentNode.Run` reaches by binding the resolved mode to the invocation.

## Summary

- `detectResume` matches `FunctionResponse`s to open interrupts by **ID**, not by function name — the engine's pause is already name-agnostic, riding on `Event.LongRunningToolIDs`. A stale or mistargeted reply still reconstructs state and surfaces `ErrNothingToResume` rather than silently starting a fresh `Run`.
- `AgentNode` defaults `RerunOnResume=true` **for LlmAgent nodes**, gated on `isLlmAgent` to match `runner.newAgentNode` and adk-python's `build_node`. Other agent kinds keep the engine default of handoff, and an explicit caller value always wins. The single_turn placement default is left to `AgentNode.Run`, which resolves it per activation and binds it to the invocation, so wrapping a shared agent in a node never mutates it.
- `AgentNode.Run` drops the node input on resume so the agent continues from history. Resume detection needs **two** signals, because neither is sufficient alone:
  - the scheduler's per-activation resume flag (`IsResumeActivation`), since the engine injects resolved interrupt responses only on the `Resume` path. A history scan cannot express this — history never un-answers an interrupt, so it latches and starves every later activation of the node in the same invocation, whether from a loop-back edge, a `RetryConfig` retry or a `ParallelWorker` item.
  - proof the pause was raised **under this node**. The flag alone over-fires, because a dynamic child inherits the resume context of the ancestor that paused, so a freshly delegated child would lose its input.

  Interrupts are attributed the way rehydration attributes them, by `NodeInfo.Path` with `Author` as the fallback, so a pause raised by a sub-agent the node's agent delegated to counts as the node's own — matching the engine, which parks and re-enters the node on exactly those interrupts.
- Node config defaults are consolidated into `applyAgentNodeDefaults`, mirroring `applyDynamicDefaults`.
- Every resume payload decodes through one `utils.UnwrapResponse`. The fresh-reply decoder was duplicated in `runner` and `workflowagent` and disagreed with the history decoder, so the same reply decoded differently depending on whether it was taken from the inbound turn or read back from history. It also unwrapped `"payload"` out of a multi-key map, silently dropping the flag from a tool confirmation's `{"confirmed": b, "payload": v}`, and did not understand `{"result": v}` — the shape adk-python's `_wrap_response` and the web frontend emit.
  The unification also widens where a string value is JSON-parsed. The old inbound decoders did it only under `response`, so `{"payload": "true"}` and `{"result": "123"}` now yield a bool and a number where the runner and workflowagent paths previously yielded the string. The history decoder already parsed all three, and making the two agree is the point of the change, but it is a change to the wire contract for anything that sent a JSON-looking string under `payload` or `result`.
- Replaying an answer a node has already acted on no longer re-runs it. Rehydration marks such a resume consumed on both arms that can produce one, including a node that still holds a second interrupt open, and `Resume` skips it. Answering the still-open interrupt continues to re-run the node.
- A settled reply echoed back alongside new user text no longer fails the turn. History never un-answers an interrupt, so a re-entry node's settled ID stays recognisable for the rest of the session. `detectResume` now distinguishes an ID the run can still act on from one it has already acted on, and a turn whose only matches are spent falls through to a fresh `Run` when it carries anything else. A bare replay with nothing else in it still reaches `Resume`, so its diagnostic is unchanged.
- A handoff node's genuine first resume stays in the filter. Such a node resolves its interrupt from history and rehydrates as `NodeCompleted`, which a status-only filter excluded, so a credential or confirmation reply to a non-LlmAgent `AgentNode` restarted the workflow instead of resuming it. The rule is handed to the dispatching packages through `internal/workflowstate` rather than widening the workflow package's API.
- A handoff node that raised several interrupts at once and has been answered on only some of them stays waiting instead of completing. Completing it dropped the unanswered requests and handed successors an output standing in for a decision nobody had made — for a rejected confirmation, one gating the very work it rejected. Mirrors adk-python's replay interceptor, which bubbles the unresolved IDs rather than completing the node.
- An answer counts as acted upon only once the node settles on it, by producing an output or pausing again on a new interrupt. Treating any emitted event as proof wedged the run when an activation persisted a tool result and then lost its model call: history never un-answers an interrupt, so every retry was skipped as a replay and the approved work could never complete.
- The YAML surface honours `rerun_on_resume` on an agent node, so a configured workflow can keep the handoff behaviour it had before the default changed.
