### PR TITLE
docs(examples/openai): add OpenAI model integration sample

### DIFF
--- a/examples/openai/README.md
+++ b/examples/openai/README.md
@@ -1,0 +1,80 @@
+# OpenAI model integration
+
+Runs an ordinary ADK `llmagent` — with a tool — on an **OpenAI** model instead
+of Gemini, using the `google.golang.org/adk/v2/model/openai` package (the
+`openaimodel.NewModel` constructor). It talks to OpenAI's **Responses API**, so
+the same `model.LLM` also serves any endpoint that implements that API — recent
+**Ollama**, **LM Studio**, and **vLLM** builds — via a base URL. (Endpoints that
+only expose the older Chat Completions API won't work.)
+
+- **Concept:** Swap `gemini.NewModel(...)` for `openaimodel.NewModel(...)`; agents, tools, the runner, and the launcher are unchanged.
+- **Needs LLM?** Yes (OpenAI, or an OpenAI-compatible endpoint)
+
+## Goal
+
+Show that ADK is model-agnostic: the OpenAI model plugs into the exact same
+`llmagent.New` / launcher wiring as the [quickstart](../quickstart). The only
+difference is the constructor —
+
+```go
+model, err := openaimodel.NewModel(ctx, "gpt-4o-mini", &openaimodel.ClientConfig{
+    APIKey:  os.Getenv("OPENAI_API_KEY"),
+    BaseURL: os.Getenv("OPENAI_BASE_URL"), // empty for api.openai.com
+})
+```
+
+— and everything downstream stays identical. The sample also registers a
+`get_weather` function tool to demonstrate that OpenAI tool calling flows
+through ADK's normal `functiontool` path.
+
+This mirrors adk-python, where the same idea is expressed with the LiteLLM
+wrapper (`LlmAgent(model=LiteLlm(model="openai/gpt-4o"))`); adk-go instead ships
+a native OpenAI model that implements `model.LLM` directly.
+
+## Configuration
+
+| Variable          | Required                         | Default       | Purpose                                          |
+| ----------------- | -------------------------------- | ------------- | ------------------------------------------------ |
+| `OPENAI_API_KEY`  | Yes for api.openai.com           | —             | Your OpenAI API key.                             |
+| `OPENAI_BASE_URL` | Yes for a compatible endpoint    | api.openai.com | Base URL of a Responses-API-compatible server.  |
+| `OPENAI_MODEL`    | No                               | `gpt-4o-mini` | Model name to serve.                             |
+
+## Running the sample
+
+Against OpenAI:
+
+```bash
+export OPENAI_API_KEY=sk-...
+go run ./examples/openai/ console
+```
+
+Against a local endpoint that implements the Responses API (recent Ollama shown;
+no key needed):
+
+```bash
+export OPENAI_BASE_URL=http://localhost:11434/v1
+export OPENAI_MODEL=llama3.1
+go run ./examples/openai/ console
+```
+
+The console streams tokens by default; add `-streaming_mode none` for
+block-at-a-time output.
+
+## Example session
+
+The model calls `get_weather` and relays the result (exact wording varies):
+
+```text
+User -> what's the weather in Paris?
+Agent -> It is currently 22°C and sunny in Paris.
+```
+
+## Notes
+
+The OpenAI model targets the [Responses API]. `Temperature`, `TopP`,
+`MaxOutputTokens`, structured output (JSON schema), and system instructions all
+work as usual. A few Gemini-style `GenerateContentConfig` knobs are not supported
+and return a descriptive error if set: `TopK`, `StopSequences`, multiple
+candidates, frequency/presence penalties, request labels, and safety settings.
+
+[Responses API]: https://platform.openai.com/docs/api-reference/responses

--- a/examples/openai/main.go
+++ b/examples/openai/main.go
@@ -1,0 +1,110 @@
+// Copyright 2026 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+// Package demonstrates an ADK agent backed by an OpenAI (or OpenAI-compatible)
+// chat model instead of Gemini. The only ADK-specific difference from the
+// Gemini quickstart is the model constructor; everything downstream (agents,
+// tools, the runner, the launcher) is identical.
+package main
+
+import (
+	"context"
+	"fmt"
+	"log"
+	"os"
+
+	"google.golang.org/adk/v2/agent"
+	"google.golang.org/adk/v2/agent/llmagent"
+	"google.golang.org/adk/v2/cmd/launcher"
+	"google.golang.org/adk/v2/cmd/launcher/full"
+	openaimodel "google.golang.org/adk/v2/model/openai"
+	"google.golang.org/adk/v2/tool"
+	"google.golang.org/adk/v2/tool/functiontool"
+)
+
+// defaultModel is used when OPENAI_MODEL is unset. gpt-4o-mini is cheap and
+// serves the Responses API that this integration targets.
+const defaultModel = "gpt-4o-mini"
+
+type weatherInput struct {
+	City string `json:"city"`
+}
+
+type weatherOutput struct {
+	Report string `json:"report"`
+}
+
+// getWeather is a stand-in for a real weather API so the sample runs offline
+// once the model call returns. It shows a plain Go function surfaced to an
+// OpenAI model as a tool via ADK's function-calling support.
+func getWeather(_ agent.Context, in weatherInput) (weatherOutput, error) {
+	return weatherOutput{
+		Report: fmt.Sprintf("It is currently 22°C and sunny in %s.", in.City),
+	}, nil
+}
+
+func main() {
+	ctx := context.Background()
+
+	// Point at api.openai.com with a key, or at any endpoint that implements the
+	// OpenAI Responses API (recent Ollama, LM Studio, vLLM) via OPENAI_BASE_URL.
+	apiKey := os.Getenv("OPENAI_API_KEY")
+	baseURL := os.Getenv("OPENAI_BASE_URL")
+	if apiKey == "" && baseURL == "" {
+		log.Fatal("set OPENAI_API_KEY (for OpenAI) or OPENAI_BASE_URL (for an OpenAI-compatible endpoint)")
+	}
+
+	modelName := os.Getenv("OPENAI_MODEL")
+	if modelName == "" {
+		modelName = defaultModel
+	}
+
+	model, err := openaimodel.NewModel(ctx, modelName, &openaimodel.ClientConfig{
+		APIKey:  apiKey,
+		BaseURL: baseURL,
+	})
+	if err != nil {
+		log.Fatalf("Failed to create model: %v", err)
+	}
+
+	weatherTool, err := functiontool.New(functiontool.Config{
+		Name:        "get_weather",
+		Description: "Returns the current weather for a given city.",
+	}, getWeather)
+	if err != nil {
+		log.Fatalf("Failed to create tool: %v", err)
+	}
+
+	a, err := llmagent.New(llmagent.Config{
+		Name:        "openai_weather_agent",
+		Model:       model,
+		Description: "Answers weather questions using an OpenAI model.",
+		Instruction: "You are a helpful assistant. When asked about the weather in a city, call the get_weather tool and report the result.",
+		Tools: []tool.Tool{
+			weatherTool,
+		},
+	})
+	if err != nil {
+		log.Fatalf("Failed to create agent: %v", err)
+	}
+
+	config := &launcher.Config{
+		AgentLoader: agent.NewSingleLoader(a),
+	}
+
+	l := full.NewLauncher()
+	if err = l.Execute(ctx, config, os.Args[1:]); err != nil {
+		log.Fatalf("Run failed: %v\n\n%s", err, l.CommandLineSyntax())
+	}
+}


### PR DESCRIPTION
## Problem
adk-go gains native OpenAI model support in #1178, but there's no runnable
example showing how to use it. Every existing example (quickstart, tools,
multiagent, workflow) is wired to Gemini, so a newcomer has no reference for
plugging a non-Gemini model into an agent. adk-python documents this path via
the LiteLLM wrapper (`LlmAgent(model=LiteLlm(model="openai/gpt-4o"))`); adk-go
has had no equivalent sample.

## Summary
Adds `examples/openai/` — a runnable sample (README + code) built on #1178:
- An `llmagent` backed by `openaimodel.NewModel(...)` instead of Gemini. Agents,
  the `functiontool`, the runner, and the launcher are identical to the Gemini
  quickstart — the model constructor is the only difference, which is the point
  the sample makes.
- Registers a `get_weather` function tool to exercise OpenAI tool calling
  end-to-end.
- Defaults to `gpt-4o-mini` (override with `OPENAI_MODEL`), reads
  `OPENAI_API_KEY`, and supports OpenAI-compatible endpoints (Ollama, LM Studio,
  vLLM, …) via `OPENAI_BASE_URL`.
- README follows the `examples/workflow` sample layout: concept, goal, config
  table, run instructions, example session, and a note on the unsupported
  `GenerateContentConfig` knobs.