### PR TITLE
fix(session): maintain app and user state update times

### DIFF
--- a/session/database/service_test.go
+++ b/session/database/service_test.go
@@ -51,6 +51,63 @@ func Test_databaseService_CreateUsesProviders(t *testing.T) {
 	}
 }
 
+func Test_databaseService_AppAndUserStateUpdateTimes(t *testing.T) {
+	dbNow := time.Date(2026, time.July, 22, 1, 2, 3, 456000000, time.UTC)
+	s := emptyService(t)
+	s.db.NowFunc = func() time.Time { return dbNow }
+
+	created, err := s.Create(t.Context(), &session.CreateRequest{
+		AppName: "app",
+		UserID:  "user",
+		State: map[string]any{
+			"app:setting":     "initial",
+			"user:preference": "initial",
+		},
+	})
+	if err != nil {
+		t.Fatalf("Create() error = %v", err)
+	}
+
+	assertStateUpdateTimes(t, s, "app", "user", dbNow)
+
+	dbNow = dbNow.Add(time.Minute)
+	event := &session.Event{
+		ID:        "state-update",
+		Timestamp: created.Session.LastUpdateTime().Add(time.Second),
+		Actions: session.EventActions{
+			StateDelta: map[string]any{
+				"app:setting":     "updated",
+				"user:preference": "updated",
+			},
+		},
+	}
+	if err := s.AppendEvent(t.Context(), created.Session, event); err != nil {
+		t.Fatalf("AppendEvent() error = %v", err)
+	}
+
+	assertStateUpdateTimes(t, s, "app", "user", dbNow)
+}
+
+func assertStateUpdateTimes(t *testing.T, s *databaseService, appName, userID string, want time.Time) {
+	t.Helper()
+
+	var appState storageAppState
+	if err := s.db.First(&appState, "app_name = ?", appName).Error; err != nil {
+		t.Fatalf("fetch app state: %v", err)
+	}
+	if !appState.UpdateTime.Equal(want) {
+		t.Errorf("app state UpdateTime = %v, want %v", appState.UpdateTime, want)
+	}
+
+	var userState storageUserState
+	if err := s.db.First(&userState, "app_name = ? AND user_id = ?", appName, userID).Error; err != nil {
+		t.Fatalf("fetch user state: %v", err)
+	}
+	if !userState.UpdateTime.Equal(want) {
+		t.Errorf("user state UpdateTime = %v, want %v", userState.UpdateTime, want)
+	}
+}
+
 // TestDatabaseService_AppendEvent_WorkflowFieldsRoundTrip guards that
 // the storage layer serializes/deserializes the workflow event fields
 // (NodeInfo, RequestedInput, Routes, IsolationScope); dropping them

--- a/session/database/storage_session.go
+++ b/session/database/storage_session.go
@@ -366,7 +366,7 @@ func createEventFromStorageEvent(se *storageEvent) (*session.Event, error) {
 type storageAppState struct {
 	AppName    string `gorm:"primaryKey;"`
 	State      stateMap
-	UpdateTime time.Time `gorm:"precision:6"`
+	UpdateTime time.Time `gorm:"precision:6;autoUpdateTime"`
 }
 
 // TableName explicitly sets the table name for the AppState struct.
@@ -379,7 +379,7 @@ type storageUserState struct {
 	AppName    string `gorm:"primaryKey;"`
 	UserID     string `gorm:"primaryKey;"`
 	State      stateMap
-	UpdateTime time.Time `gorm:"precision:6"`
+	UpdateTime time.Time `gorm:"precision:6;autoUpdateTime"`
 }
 
 // TableName explicitly sets the table name for the UserState struct.


### PR DESCRIPTION
### Link to Issue or Description of Change

- Closes: #1177

**Problem:**

The GORM-backed session service writes a zero `time.Time` to `app_states.update_time` and `user_states.update_time`. MySQL rejects that explicit zero date in its default strict mode, so persisting `app:` or `user:` state fails.

**Solution:**

Enable GORM-managed update timestamps for `storageAppState` and `storageUserState`, while retaining microsecond column precision.

The regression test covers both:

- initial app/user state persistence through `Create`
- subsequent app/user state updates through `AppendEvent`

No public API or dependency changes.

### Testing Plan

- [x] Added an offline regression test.
- [x] Verified the test fails on the previous code with zero timestamps.
- [x] All tests pass locally.

```sh
go build -mod=readonly ./...
go test -race -mod=readonly -count=1 ./session/database
go test -race -mod=readonly -count=1 -shuffle=on ./...
golangci-lint run
go mod tidy -diff
```

`golangci-lint` reported `0 issues`; `go mod tidy -diff` produced no output.

### Checklist

- [x] I have read the CONTRIBUTING.md document.
- [x] I have performed a self-review.
- [x] I have added tests that prove the fix works.
- [x] New and existing tests pass locally.