### PR TITLE
fix(parallelagent): await sub-agent teardown before returning on early stop

### DIFF
--- a/agent/workflowagents/parallelagent/agent.go
+++ b/agent/workflowagents/parallelagent/agent.go
@@ -68,8 +68,9 @@ func New(cfg Config) (agent.Agent, error) {
 func run(ctx agent.InvocationContext) iter.Seq2[*session.Event, error] {
 	curAgent := ctx.Agent()
 
-	// Cancelable so an early consumer stop aborts the sub-agents promptly instead
-	// of blocking until they next yield (see the iterator's deferred cleanup).
+	// Cancelable so an early consumer stop aborts each sub-agent's in-flight Run
+	// promptly. Teardown still runs to completion and the iterator waits for it
+	// (see the deferred cleanup), so a sub-agent that blocks in teardown blocks run.
 	subAgentsCtx, cancelSubAgents := context.WithCancel(ctx)
 
 	var (
@@ -116,9 +117,9 @@ func run(ctx agent.InvocationContext) iter.Seq2[*session.Event, error] {
 
 	return func(yield func(*session.Event, error) bool) {
 		// Await sub-agent goroutines (incl. their deferred teardown) before
-		// returning, even on early stop: cancel them so they abort promptly, then
-		// drain resultsChan — the funnel closes it only after errGroup.Wait().
-		// Otherwise teardown can outlive the run and touch an already-ended context.
+		// returning, even on early stop: cancel them, then drain resultsChan, which
+		// the funnel closes only after errGroup.Wait(). Otherwise teardown can
+		// outlive the run and touch an already-ended context.
 		defer func() {
 			cancelSubAgents()
 			close(doneChan)

--- a/agent/workflowagents/parallelagent/agent.go
+++ b/agent/workflowagents/parallelagent/agent.go
@@ -16,6 +16,7 @@
 package parallelagent
 
 import (
+	"context"
 	"fmt"
 	"iter"
 
@@ -67,8 +68,12 @@ func New(cfg Config) (agent.Agent, error) {
 func run(ctx agent.InvocationContext) iter.Seq2[*session.Event, error] {
 	curAgent := ctx.Agent()
 
+	// Cancelable so an early consumer stop aborts the sub-agents promptly instead
+	// of blocking until they next yield (see the iterator's deferred cleanup).
+	subAgentsCtx, cancelSubAgents := context.WithCancel(ctx)
+
 	var (
-		errGroup, errGroupCtx = errgroup.WithContext(ctx)
+		errGroup, errGroupCtx = errgroup.WithContext(subAgentsCtx)
 		doneChan              = make(chan bool)
 		resultsChan           = make(chan result)
 	)
@@ -110,14 +115,14 @@ func run(ctx agent.InvocationContext) iter.Seq2[*session.Event, error] {
 	}()
 
 	return func(yield func(*session.Event, error) bool) {
-		// Await sub-agent goroutines (incl. their deferred teardown, e.g. a remote
-		// agent's cancel RPC) before returning, even on early stop: the funnel closes
-		// resultsChan only after errGroup.Wait(), so draining it blocks until every
-		// sub-agent has returned. Otherwise teardown can outlive the run and touch a
-		// context whose lifetime already ended.
+		// Await sub-agent goroutines (incl. their deferred teardown) before
+		// returning, even on early stop: cancel them so they abort promptly, then
+		// drain resultsChan — the funnel closes it only after errGroup.Wait().
+		// Otherwise teardown can outlive the run and touch an already-ended context.
 		defer func() {
+			cancelSubAgents()
 			close(doneChan)
-			for range resultsChan {
+			for range resultsChan { // drain until the funnel closes resultsChan
 			}
 		}()
 

--- a/agent/workflowagents/parallelagent/agent.go
+++ b/agent/workflowagents/parallelagent/agent.go
@@ -110,7 +110,16 @@ func run(ctx agent.InvocationContext) iter.Seq2[*session.Event, error] {
 	}()
 
 	return func(yield func(*session.Event, error) bool) {
-		defer close(doneChan)
+		// Await sub-agent goroutines (incl. their deferred teardown, e.g. a remote
+		// agent's cancel RPC) before returning, even on early stop: the funnel closes
+		// resultsChan only after errGroup.Wait(), so draining it blocks until every
+		// sub-agent has returned. Otherwise teardown can outlive the run and touch a
+		// context whose lifetime already ended.
+		defer func() {
+			close(doneChan)
+			for range resultsChan {
+			}
+		}()
 
 		for res := range resultsChan {
 			shouldContinue := yield(res.event, res.err)

--- a/agent/workflowagents/parallelagent/agent_test.go
+++ b/agent/workflowagents/parallelagent/agent_test.go
@@ -238,15 +238,19 @@ func customRun(id int, agentErr error) func(agent.InvocationContext) iter.Seq2[*
 }
 
 // TestParallelAgent_AwaitsSubAgentTeardownOnEarlyStop verifies that when the
-// consumer stops early, the iterator does not return until every sub-agent
-// goroutine (and its deferred teardown, e.g. a remote agent's cancel RPC) has
-// finished. Otherwise teardown can outlive the run and touch an already-ended
-// context.
+// consumer stops early, Run does not return until every sub-agent goroutine has
+// finished its deferred teardown. Otherwise teardown can outlive the run and
+// touch an already-ended context.
 func TestParallelAgent_AwaitsSubAgentTeardownOnEarlyStop(t *testing.T) {
 	t.Parallel()
 
 	const numSubAgents = 3
-	var teardownDone atomic.Int32
+	// Each sub-agent teardown announces it began (buffered so it never blocks) and
+	// then blocks on releaseTeardown, so the test can prove Run waits for teardown
+	// without relying on wall-clock timing.
+	teardownStarted := make(chan struct{}, numSubAgents)
+	releaseTeardown := make(chan struct{})
+	var teardownFinished atomic.Int32
 
 	var subAgents []agent.Agent
 	for i := 1; i <= numSubAgents; i++ {
@@ -254,11 +258,10 @@ func TestParallelAgent_AwaitsSubAgentTeardownOnEarlyStop(t *testing.T) {
 			Name: fmt.Sprintf("sub%d", i),
 			Run: func(agent.InvocationContext) iter.Seq2[*session.Event, error] {
 				return func(yield func(*session.Event, error) bool) {
-					// Stands in for a sub-agent's deferred teardown that must complete
-					// before the run returns.
 					defer func() {
-						time.Sleep(50 * time.Millisecond)
-						teardownDone.Add(1)
+						teardownStarted <- struct{}{}
+						<-releaseTeardown
+						teardownFinished.Add(1)
 					}()
 					for {
 						if !yield(&session.Event{
@@ -294,16 +297,49 @@ func TestParallelAgent_AwaitsSubAgentTeardownOnEarlyStop(t *testing.T) {
 		t.Fatal(err)
 	}
 
-	for _, err := range agentRunner.Run(t.Context(), "user_id", "session_id", genai.NewContentFromText("user input", genai.RoleUser), agent.RunConfig{}) {
-		if err != nil {
-			t.Fatal(err)
+	runReturned := make(chan struct{})
+	go func() {
+		defer close(runReturned)
+		for _, err := range agentRunner.Run(t.Context(), "user_id", "session_id", genai.NewContentFromText("user input", genai.RoleUser), agent.RunConfig{}) {
+			if err != nil {
+				t.Errorf("Run() yielded error: %v", err)
+			}
+			break // stop after the first event
 		}
-		break // stop after the first event
+	}()
+
+	// Always release gated teardowns so no goroutine is left blocked, even if an
+	// assertion fails. Safe to call twice (same goroutine as the explicit release).
+	released := false
+	release := func() {
+		if !released {
+			released = true
+			close(releaseTeardown)
+		}
+	}
+	defer release()
+
+	// Every sub-agent must reach teardown once the consumer stops early.
+	for range numSubAgents {
+		select {
+		case <-teardownStarted:
+		case <-runReturned:
+			t.Fatal("Run returned before all sub-agent teardowns started")
+		}
 	}
 
-	// No sleep: the fix must have joined all sub-agents before Run returned.
-	if got := teardownDone.Load(); got != numSubAgents {
-		t.Errorf("sub-agent teardown outlived the parallel agent run: %d/%d completed", got, numSubAgents)
+	// Teardowns are now gated; Run must still be blocked waiting for them.
+	select {
+	case <-runReturned:
+		t.Fatal("Run returned while sub-agent teardowns were still in progress")
+	default:
+	}
+
+	release()
+	<-runReturned
+
+	if got := teardownFinished.Load(); got != numSubAgents {
+		t.Errorf("teardownFinished = %d, want %d", got, numSubAgents)
 	}
 }
 

--- a/agent/workflowagents/parallelagent/agent_test.go
+++ b/agent/workflowagents/parallelagent/agent_test.go
@@ -23,6 +23,7 @@ import (
 	"path/filepath"
 	"slices"
 	"strings"
+	"sync/atomic"
 	"testing"
 	"time"
 
@@ -233,6 +234,76 @@ func customRun(id int, agentErr error) func(agent.InvocationContext) iter.Seq2[*
 				},
 			}, nil)
 		}
+	}
+}
+
+// TestParallelAgent_AwaitsSubAgentTeardownOnEarlyStop verifies that when the
+// consumer stops early, the iterator does not return until every sub-agent
+// goroutine (and its deferred teardown, e.g. a remote agent's cancel RPC) has
+// finished. Otherwise teardown can outlive the run and touch an already-ended
+// context.
+func TestParallelAgent_AwaitsSubAgentTeardownOnEarlyStop(t *testing.T) {
+	t.Parallel()
+
+	const numSubAgents = 3
+	var teardownDone atomic.Int32
+
+	var subAgents []agent.Agent
+	for i := 1; i <= numSubAgents; i++ {
+		subAgents = append(subAgents, must(agent.New(agent.Config{
+			Name: fmt.Sprintf("sub%d", i),
+			Run: func(agent.InvocationContext) iter.Seq2[*session.Event, error] {
+				return func(yield func(*session.Event, error) bool) {
+					// Stands in for a sub-agent's deferred teardown that must complete
+					// before the run returns.
+					defer func() {
+						time.Sleep(50 * time.Millisecond)
+						teardownDone.Add(1)
+					}()
+					for {
+						if !yield(&session.Event{
+							LLMResponse: model.LLMResponse{
+								Content: genai.NewContentFromText(fmt.Sprintf("hello %d", i), genai.RoleModel),
+							},
+						}, nil) {
+							return
+						}
+					}
+				}
+			},
+		})))
+	}
+
+	parallelAgent, err := parallelagent.New(parallelagent.Config{
+		AgentConfig: agent.Config{
+			Name:      "test_agent",
+			SubAgents: subAgents,
+		},
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	agentRunner, err := runner.New(runner.Config{
+		AppName:           "test_app",
+		Agent:             parallelAgent,
+		SessionService:    session.InMemoryService(),
+		AutoCreateSession: true,
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	for _, err := range agentRunner.Run(t.Context(), "user_id", "session_id", genai.NewContentFromText("user input", genai.RoleUser), agent.RunConfig{}) {
+		if err != nil {
+			t.Fatal(err)
+		}
+		break // stop after the first event
+	}
+
+	// No sleep: the fix must have joined all sub-agents before Run returned.
+	if got := teardownDone.Load(); got != numSubAgents {
+		t.Errorf("sub-agent teardown outlived the parallel agent run: %d/%d completed", got, numSubAgents)
 	}
 }
 


### PR DESCRIPTION
## Problem
When `parallelagent` runs its sub-agents and the consumer stops iterating early — a sibling produced a terminal result, or the invocation was cancelled / deadline-exceeded — the returned iterator closed `doneChan` and returned immediately, **without joining the sub-agent goroutines** it spawned via `errgroup`.
A sub-agent's deferred teardown therefore keeps running after the parallel agent (and the runner above it) have already returned. The concrete case: a remote A2A sub-agent (`remoteagent/v2`) runs `cleanupRemoteTask` in a `defer`, which issues a `CancelTask` RPC (up to 5s) on `context.WithoutCancel(ctx)`. That RPC outlives the run and still reads request-scoped context values.
In google3 the a2a-go server executes each task under a detached context that invalidates `.Value()` lookups once its execution callback returns. The leaked cleanup RPC then reads `census` from that already-ended context and panics (`detach: Value called for key census after callback passed to detach.Go has already returned`), which cascades into a wave of `DEADLINE_EXCEEDED` under load.
`parallelagent` is the only goroutine-spawning primitive in `agent/` and `runner/`, so this is the single place a sub-agent's teardown can escape the run's lifetime.

## Summary
- The iterator now drains `resultsChan` in its deferred cleanup. The funnel goroutine closes `resultsChan` only after `errGroup.Wait()`, so draining blocks until every sub-agent goroutine — and its deferred teardown — has returned.
- Deadlock-free: on the normal path the outer loop already exited because the funnel closed the channel (the drain returns at once); on early stop, `close(doneChan)` unblocks the sub-agents, they run teardown and return, the funnel closes the channel, and the drain returns.
- Behavioral note: an early stop now **blocks until sub-agent teardown completes**, bounded by whatever the sub-agent bounds itself to (e.g. remoteagent's 5s cancel timeout).
