### PR TITLE
fix(remoteagent): skip best-effort remote cancel on cancel/deadline teardown

### DIFF
--- a/agent/remoteagent/v2/a2a_agent.go
+++ b/agent/remoteagent/v2/a2a_agent.go
@@ -337,7 +337,7 @@ func cleanupRemoteTask(ctx context.Context, cfg A2AConfig, card *a2a.AgentCard, 
 	// torn down by cancellation or a deadline. The context lifetime is unreliable
 	// during forced teardown (a detached parent may already have ended), and
 	// adk-python does not cancel remote tasks at all; the remote task expires on its own.
-	if cause != nil && (errors.Is(cause, context.Canceled) || errors.Is(cause, context.DeadlineExceeded)) {
+	if errors.Is(cause, context.Canceled) || errors.Is(cause, context.DeadlineExceeded) {
 		return
 	}
 

--- a/agent/remoteagent/v2/a2a_agent.go
+++ b/agent/remoteagent/v2/a2a_agent.go
@@ -17,6 +17,7 @@ package remoteagent
 import (
 	"context"
 	"encoding/json"
+	"errors"
 	"fmt"
 	"iter"
 	"os"
@@ -329,6 +330,14 @@ func cleanupRemoteTask(ctx context.Context, cfg A2AConfig, card *a2a.AgentCard, 
 
 	if cfg.RemoteTaskCleanupCallback != nil {
 		cfg.RemoteTaskCleanupCallback(ctx, card, client, lastEvent.TaskInfo(), cause)
+		return
+	}
+
+	// Best-effort remote cancellation: skip the cancel RPC when the invocation was
+	// torn down by cancellation or a deadline. The context lifetime is unreliable
+	// during forced teardown (a detached parent may already have ended), and
+	// adk-python does not cancel remote tasks at all; the remote task expires on its own.
+	if cause != nil && (errors.Is(cause, context.Canceled) || errors.Is(cause, context.DeadlineExceeded)) {
 		return
 	}
 

--- a/agent/remoteagent/v2/a2a_agent_test.go
+++ b/agent/remoteagent/v2/a2a_agent_test.go
@@ -1397,28 +1397,6 @@ func TestRemoteAgent_CleanupCallback(t *testing.T) {
 	}
 }
 
-// fakeA2AClient records whether CancelTask was invoked. Only CancelTask has behavior.
-type fakeA2AClient struct {
-	cancelCalled bool
-}
-
-var _ A2AClient = (*fakeA2AClient)(nil)
-
-func (c *fakeA2AClient) SendMessage(ctx context.Context, req *a2a.SendMessageRequest) (a2a.SendMessageResult, error) {
-	return nil, nil
-}
-
-func (c *fakeA2AClient) SendStreamingMessage(ctx context.Context, req *a2a.SendMessageRequest) iter.Seq2[a2a.Event, error] {
-	return func(yield func(a2a.Event, error) bool) {}
-}
-
-func (c *fakeA2AClient) CancelTask(ctx context.Context, req *a2a.CancelTaskRequest) (*a2a.Task, error) {
-	c.cancelCalled = true
-	return &a2a.Task{}, nil
-}
-
-func (c *fakeA2AClient) Destroy() error { return nil }
-
 func TestCleanupRemoteTask_SkipsCancelOnTeardown(t *testing.T) {
 	lastEvent := &a2a.Task{ID: a2a.NewTaskID(), Status: a2a.TaskStatus{State: a2a.TaskStateWorking}}
 	if lastEvent.TaskInfo().TaskID == "" {
@@ -1440,13 +1418,35 @@ func TestCleanupRemoteTask_SkipsCancelOnTeardown(t *testing.T) {
 	for _, tc := range testCases {
 		t.Run(tc.name, func(t *testing.T) {
 			fake := &fakeA2AClient{}
-			cleanupRemoteTask(context.Background(), A2AConfig{}, &a2a.AgentCard{}, fake, lastEvent, tc.cause)
+			cleanupRemoteTask(t.Context(), A2AConfig{}, &a2a.AgentCard{}, fake, lastEvent, tc.cause)
 			if fake.cancelCalled != tc.wantCancel {
 				t.Fatalf("CancelTask called = %v, want %v (cause = %v)", fake.cancelCalled, tc.wantCancel, tc.cause)
 			}
 		})
 	}
 }
+
+// fakeA2AClient records whether CancelTask was invoked. Only CancelTask has behavior.
+type fakeA2AClient struct {
+	cancelCalled bool
+}
+
+var _ A2AClient = (*fakeA2AClient)(nil)
+
+func (c *fakeA2AClient) SendMessage(ctx context.Context, req *a2a.SendMessageRequest) (a2a.SendMessageResult, error) {
+	return nil, nil
+}
+
+func (c *fakeA2AClient) SendStreamingMessage(ctx context.Context, req *a2a.SendMessageRequest) iter.Seq2[a2a.Event, error] {
+	return func(yield func(a2a.Event, error) bool) {}
+}
+
+func (c *fakeA2AClient) CancelTask(ctx context.Context, req *a2a.CancelTaskRequest) (*a2a.Task, error) {
+	c.cancelCalled = true
+	return &a2a.Task{}, nil
+}
+
+func (c *fakeA2AClient) Destroy() error { return nil }
 
 func TestRemoteAgent_PartConverter(t *testing.T) {
 	event := &session.Event{

--- a/agent/remoteagent/v2/a2a_agent_test.go
+++ b/agent/remoteagent/v2/a2a_agent_test.go
@@ -1397,6 +1397,57 @@ func TestRemoteAgent_CleanupCallback(t *testing.T) {
 	}
 }
 
+// fakeA2AClient records whether CancelTask was invoked. Only CancelTask has behavior.
+type fakeA2AClient struct {
+	cancelCalled bool
+}
+
+var _ A2AClient = (*fakeA2AClient)(nil)
+
+func (c *fakeA2AClient) SendMessage(ctx context.Context, req *a2a.SendMessageRequest) (a2a.SendMessageResult, error) {
+	return nil, nil
+}
+
+func (c *fakeA2AClient) SendStreamingMessage(ctx context.Context, req *a2a.SendMessageRequest) iter.Seq2[a2a.Event, error] {
+	return func(yield func(a2a.Event, error) bool) {}
+}
+
+func (c *fakeA2AClient) CancelTask(ctx context.Context, req *a2a.CancelTaskRequest) (*a2a.Task, error) {
+	c.cancelCalled = true
+	return &a2a.Task{}, nil
+}
+
+func (c *fakeA2AClient) Destroy() error { return nil }
+
+func TestCleanupRemoteTask_SkipsCancelOnTeardown(t *testing.T) {
+	lastEvent := &a2a.Task{ID: a2a.NewTaskID(), Status: a2a.TaskStatus{State: a2a.TaskStateWorking}}
+	if lastEvent.TaskInfo().TaskID == "" {
+		t.Fatalf("lastEvent.TaskInfo().TaskID is empty, want non-empty")
+	}
+
+	testCases := []struct {
+		name       string
+		cause      error
+		wantCancel bool
+	}{
+		{name: "deadline exceeded", cause: context.DeadlineExceeded, wantCancel: false},
+		{name: "canceled", cause: context.Canceled, wantCancel: false},
+		{name: "wrapped deadline exceeded", cause: fmt.Errorf("wrapped: %w", context.DeadlineExceeded), wantCancel: false},
+		{name: "nil cause still cancels", cause: nil, wantCancel: true},
+		{name: "other error still cancels", cause: errors.New("some rpc error"), wantCancel: true},
+	}
+
+	for _, tc := range testCases {
+		t.Run(tc.name, func(t *testing.T) {
+			fake := &fakeA2AClient{}
+			cleanupRemoteTask(context.Background(), A2AConfig{}, &a2a.AgentCard{}, fake, lastEvent, tc.cause)
+			if fake.cancelCalled != tc.wantCancel {
+				t.Fatalf("CancelTask called = %v, want %v (cause = %v)", fake.cancelCalled, tc.wantCancel, tc.cause)
+			}
+		})
+	}
+}
+
 func TestRemoteAgent_PartConverter(t *testing.T) {
 	event := &session.Event{
 		LLMResponse: model.LLMResponse{Content: genai.NewContentFromParts([]*genai.Part{


### PR DESCRIPTION
## Problem
`cleanupRemoteTask` issues a best-effort `CancelTask` RPC for a non-terminal remote A2A task, using `ctx = context.WithoutCancel(ctx)` so the RPC can still go out after the run ended. `WithoutCancel` keeps the parent value chain.
When the invocation was torn down by cancellation or a deadline, that value chain can reference a context whose lifetime has already ended. In google3 the a2a-go server runs task execution under a detached context that invalidates `.Value()` after its callback returns; the in-flight `CancelTask` then reads request-scoped values (`census`) from that dead context → panic → `DEADLINE_EXCEEDED` cascade in production.

Remote-task cancellation is best-effort and adk-go-specific — adk-python does not cancel remote tasks at all.

## Summary
- In the default cleanup path, skip the `CancelTask` RPC when `cause` is `context.Canceled` or `context.DeadlineExceeded` (via `errors.Is`, so wrapped causes are caught too).
- A custom `RemoteTaskCleanupCallback` is left untouched — it still receives `cause` and decides for itself.
- Trade-off: on the cancel/deadline path the remote task is no longer proactively cancelled and will expire on its own (via the remote server's timeout). This is the best-effort contract; it's the same early-cancel window discussed in #1076.
- This is a targeted safety net; the structural fix for the underlying goroutine-lifetime race is #1186. They compose as defense-in-depth.