### PR TITLE
fix(parallelagent): await sub-agent teardown before returning on earl…

### DIFF
--- a/agent/workflowagents/parallelagent/agent.go
+++ b/agent/workflowagents/parallelagent/agent.go
@@ -16,6 +16,7 @@
 package parallelagent
 
 import (
+	"context"
 	"fmt"
 	"iter"
 
@@ -67,8 +68,13 @@ func New(cfg Config) (agent.Agent, error) {
 func run(ctx agent.InvocationContext) iter.Seq2[*session.Event, error] {
 	curAgent := ctx.Agent()
 
+	// Cancelable so an early consumer stop aborts each sub-agent's in-flight Run
+	// promptly. Teardown still runs to completion and the iterator waits for it
+	// (see the deferred cleanup), so a sub-agent that blocks in teardown blocks run.
+	subAgentsCtx, cancelSubAgents := context.WithCancel(ctx)
+
 	var (
-		errGroup, errGroupCtx = errgroup.WithContext(ctx)
+		errGroup, errGroupCtx = errgroup.WithContext(subAgentsCtx)
 		doneChan              = make(chan bool)
 		resultsChan           = make(chan result)
 	)
@@ -110,7 +116,16 @@ func run(ctx agent.InvocationContext) iter.Seq2[*session.Event, error] {
 	}()
 
 	return func(yield func(*session.Event, error) bool) {
-		defer close(doneChan)
+		// Await sub-agent goroutines (incl. their deferred teardown) before
+		// returning, even on early stop: cancel them, then drain resultsChan, which
+		// the funnel closes only after errGroup.Wait(). Otherwise teardown can
+		// outlive the run and touch an already-ended context.
+		defer func() {
+			cancelSubAgents()
+			close(doneChan)
+			for range resultsChan { // drain until the funnel closes resultsChan
+			}
+		}()
 
 		for res := range resultsChan {
 			shouldContinue := yield(res.event, res.err)

--- a/agent/workflowagents/parallelagent/agent_test.go
+++ b/agent/workflowagents/parallelagent/agent_test.go
@@ -23,6 +23,7 @@ import (
 	"path/filepath"
 	"slices"
 	"strings"
+	"sync/atomic"
 	"testing"
 	"time"
 
@@ -233,6 +234,112 @@ func customRun(id int, agentErr error) func(agent.InvocationContext) iter.Seq2[*
 				},
 			}, nil)
 		}
+	}
+}
+
+// TestParallelAgent_AwaitsSubAgentTeardownOnEarlyStop verifies that when the
+// consumer stops early, Run does not return until every sub-agent goroutine has
+// finished its deferred teardown. Otherwise teardown can outlive the run and
+// touch an already-ended context.
+func TestParallelAgent_AwaitsSubAgentTeardownOnEarlyStop(t *testing.T) {
+	t.Parallel()
+
+	const numSubAgents = 3
+	// Each sub-agent teardown announces it began (buffered so it never blocks) and
+	// then blocks on releaseTeardown, so the test can prove Run waits for teardown
+	// without relying on wall-clock timing.
+	teardownStarted := make(chan struct{}, numSubAgents)
+	releaseTeardown := make(chan struct{})
+	var teardownFinished atomic.Int32
+
+	var subAgents []agent.Agent
+	for i := 1; i <= numSubAgents; i++ {
+		subAgents = append(subAgents, must(agent.New(agent.Config{
+			Name: fmt.Sprintf("sub%d", i),
+			Run: func(agent.InvocationContext) iter.Seq2[*session.Event, error] {
+				return func(yield func(*session.Event, error) bool) {
+					defer func() {
+						teardownStarted <- struct{}{}
+						<-releaseTeardown
+						teardownFinished.Add(1)
+					}()
+					for {
+						if !yield(&session.Event{
+							LLMResponse: model.LLMResponse{
+								Content: genai.NewContentFromText(fmt.Sprintf("hello %d", i), genai.RoleModel),
+							},
+						}, nil) {
+							return
+						}
+					}
+				}
+			},
+		})))
+	}
+
+	parallelAgent, err := parallelagent.New(parallelagent.Config{
+		AgentConfig: agent.Config{
+			Name:      "test_agent",
+			SubAgents: subAgents,
+		},
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	agentRunner, err := runner.New(runner.Config{
+		AppName:           "test_app",
+		Agent:             parallelAgent,
+		SessionService:    session.InMemoryService(),
+		AutoCreateSession: true,
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	runReturned := make(chan struct{})
+	go func() {
+		defer close(runReturned)
+		for _, err := range agentRunner.Run(t.Context(), "user_id", "session_id", genai.NewContentFromText("user input", genai.RoleUser), agent.RunConfig{}) {
+			if err != nil {
+				t.Errorf("Run() yielded error: %v", err)
+			}
+			break // stop after the first event
+		}
+	}()
+
+	// Always release gated teardowns so no goroutine is left blocked, even if an
+	// assertion fails. Safe to call twice (same goroutine as the explicit release).
+	released := false
+	release := func() {
+		if !released {
+			released = true
+			close(releaseTeardown)
+		}
+	}
+	defer release()
+
+	// Every sub-agent must reach teardown once the consumer stops early.
+	for range numSubAgents {
+		select {
+		case <-teardownStarted:
+		case <-runReturned:
+			t.Fatal("Run returned before all sub-agent teardowns started")
+		}
+	}
+
+	// Teardowns are now gated; Run must still be blocked waiting for them.
+	select {
+	case <-runReturned:
+		t.Fatal("Run returned while sub-agent teardowns were still in progress")
+	default:
+	}
+
+	release()
+	<-runReturned
+
+	if got := teardownFinished.Load(); got != numSubAgents {
+		t.Errorf("teardownFinished = %d, want %d", got, numSubAgents)
 	}
 }
 


### PR DESCRIPTION
## Problem
When `parallelagent` runs its sub-agents and the consumer stops iterating early
(a sibling produced a terminal result, or the invocation was cancelled /
deadline-exceeded), the returned iterator closed `doneChan` and returned
immediately, without joining the sub-agent goroutines it spawned via `errgroup`.
A sub-agent's deferred teardown therefore keeps running after the parallel agent
(and the runner above it) have already returned — e.g. a remote A2A sub-agent's
`cleanupRemoteTask` issues a `CancelTask` RPC on `context.WithoutCancel(ctx)`
that outlives the run and reads request-scoped context values. In google3 that
leaked RPC reads an already-ended detached context and panics, cascading into a
wave of DEADLINE_EXCEEDED under load. v1 carries the identical parallelagent
logic, so the same bug is present.

## Summary
- The iterator now cancels the sub-agent context and drains `resultsChan` in its
  deferred cleanup. The funnel goroutine closes `resultsChan` only after
  `errGroup.Wait()`, so draining blocks until every sub-agent goroutine — and its
  deferred teardown — has returned.
- Behavioral note: an early stop now blocks until sub-agent teardown completes,
  bounded by whatever the sub-agent bounds itself to.