### PR TITLE
ci: run Go workflow on main and v1 branches (#1117)

### DIFF
--- a/.github/workflows/go.yml
+++ b/.github/workflows/go.yml
@@ -7,10 +7,10 @@ name: Go
 
 on:
   push:
-    branches: [ "main", "v2" ]
+    branches: [ "main", "v1" ]
 
   pull_request:
-    branches: [ "main", "v2" ]
+    branches: [ "main", "v1" ]
 
   workflow_dispatch:
 


### PR DESCRIPTION
## Problem
`.github/workflows/go.yml` on v1 triggers only on base branches `main`/`v2`, so
the Go CI (build/test/lint/tidy) never runs on PRs targeting `v1`. With v1's
branch protection requiring those checks, every v1 PR is stuck in "Expected —
waiting for status to be reported" and cannot be merged (e.g. #1188). This is the
leftover of the v1/v2 branch rename: #1117 fixed the trigger on `main` but the
change never landed on `v1`.

## Summary
Cherry-pick of #1117 onto v1: switch the `push`/`pull_request` branch filters from
`[main, v2]` to `[main, v1]` so PRs targeting v1 run the Go workflow.