### PR TITLE
fix(llminternal): drop other agents' thought parts in ConvertForeignEvent

### DIFF
--- a/internal/llminternal/contents_processor.go
+++ b/internal/llminternal/contents_processor.go
@@ -103,7 +103,11 @@ func buildContentsDefault(agentName, invocationBranch, isolationScope string, ev
 			continue
 		}
 		if isOtherAgentReply(agentName, ev) {
-			filtered = append(filtered, ConvertForeignEvent(ev))
+			// ConvertForeignEvent returns nil to signal the foreign event
+			// should be dropped (e.g. a thought-only turn).
+			if converted := ConvertForeignEvent(ev); converted != nil {
+				filtered = append(filtered, converted)
+			}
 		} else {
 			filtered = append(filtered, ev)
 		}
@@ -566,6 +570,12 @@ func ConvertForeignEvent(ev *session.Event) *session.Event {
 		Parts: []*genai.Part{{Text: "For context:"}},
 	}
 	for _, p := range content.Parts {
+		// Never replay another agent's private reasoning into the current
+		// agent's context. Matches adk-python's _present_other_agent_message,
+		// which drops thought parts as the first step of its per-part loop.
+		if p.Thought {
+			continue
+		}
 		switch {
 		case p.Text != "":
 			converted.Parts = append(converted.Parts, &genai.Part{
@@ -582,6 +592,13 @@ func ConvertForeignEvent(ev *session.Event) *session.Event {
 		default: // fallback to the original part for non-text and non-functionCall parts.
 			converted.Parts = append(converted.Parts, p)
 		}
+	}
+
+	// If only the "For context:" header remains (e.g. a thought-only foreign
+	// turn), drop the event entirely rather than emitting a bare header, as
+	// adk-python's _present_other_agent_message returns None in this case.
+	if len(converted.Parts) == 1 {
+		return nil
 	}
 
 	return &session.Event{ // made-up event. Don't go through types.NewEvent.

--- a/internal/llminternal/contents_processor_test.go
+++ b/internal/llminternal/contents_processor_test.go
@@ -872,6 +872,93 @@ func TestConvertForeignEvent(t *testing.T) {
 				Branch: "b",
 			},
 		},
+		{
+			// A thought part (with text) must be excluded so another agent's
+			// private reasoning never leaks into the current agent's context;
+			// the non-thought text is still presented.
+			name: "ThoughtWithTextExcluded",
+			event: &session.Event{
+				Timestamp: now,
+				Author:    "foreign",
+				LLMResponse: model.LLMResponse{
+					Content: &genai.Content{
+						Role: "model",
+						Parts: []*genai.Part{
+							{Text: "secret reasoning", Thought: true},
+							{Text: "the answer"},
+						},
+					},
+				},
+				Branch: "b",
+			},
+			want: &session.Event{
+				Timestamp: now,
+				Author:    "user",
+				LLMResponse: model.LLMResponse{
+					Content: &genai.Content{
+						Role: "user",
+						Parts: []*genai.Part{
+							{Text: "For context:"},
+							{Text: "[foreign] said: the answer"},
+						},
+					},
+				},
+				Branch: "b",
+			},
+		},
+		{
+			// An empty-text thought part previously fell through to the default
+			// branch and was copied verbatim; it must now be dropped too.
+			name: "EmptyTextThoughtExcluded",
+			event: &session.Event{
+				Timestamp: now,
+				Author:    "foreign",
+				LLMResponse: model.LLMResponse{
+					Content: &genai.Content{
+						Role: "model",
+						Parts: []*genai.Part{
+							{Thought: true},
+							{Text: "the answer"},
+						},
+					},
+				},
+				Branch: "b",
+			},
+			want: &session.Event{
+				Timestamp: now,
+				Author:    "user",
+				LLMResponse: model.LLMResponse{
+					Content: &genai.Content{
+						Role: "user",
+						Parts: []*genai.Part{
+							{Text: "For context:"},
+							{Text: "[foreign] said: the answer"},
+						},
+					},
+				},
+				Branch: "b",
+			},
+		},
+		{
+			// A foreign turn made up entirely of thoughts leaves only the
+			// "For context:" header, so the event is dropped (nil) rather than
+			// emitting a bare header.
+			name: "ThoughtOnlyDropped",
+			event: &session.Event{
+				Timestamp: now,
+				Author:    "foreign",
+				LLMResponse: model.LLMResponse{
+					Content: &genai.Content{
+						Role: "model",
+						Parts: []*genai.Part{
+							{Text: "only reasoning", Thought: true},
+						},
+					},
+				},
+				Branch: "b",
+			},
+			want: nil,
+		},
 	}
 
 	for _, tc := range testCases {


### PR DESCRIPTION
## Summary

Fixes #1096.

In multi-agent flows, one agent's events are presented to another as a `user`-role "For context:" message via `ConvertForeignEvent` (`internal/llminternal/contents_processor.go`). Unlike adk-python's equivalent `_present_other_agent_message`, it had **no guard for thought parts**:

- a thought part *with text* fell into the text branch and was re-emitted as `"[author] said: <reasoning>"`;
- an empty-text thought part fell into the `default` branch and was copied through verbatim;
- a foreign turn made up **only** of thoughts produced a bare `"For context:"` content instead of being dropped.

The result: one agent's private chain-of-thought leaks into another agent's context (a correctness/privacy issue, now visible with thinking-capable models that populate `Thought` parts).

## Change

Match adk-python's `_present_other_agent_message`:
- Skip `Thought` parts as the first step of the per-part loop (`if p.Thought { continue }`).
- Return `nil` when only the `"For context:"` header remains; the single caller now skips a `nil` result, so a thought-only foreign turn is dropped entirely.

`ConvertForeignEvent` was ported from the pre-fix `_convert_foreign_event` and never picked up adk-python commit `a30851e` ("fix: Fixes `thought` handling in contents.py").

## Testing Plan

- Extended `TestConvertForeignEvent` with cases mirroring adk-python's `test_other_agent_thoughts_are_excluded` / `test_other_agent_empty_content`:
  - `ThoughtWithTextExcluded` — thought-with-text dropped, real text kept
  - `EmptyTextThoughtExcluded` — empty-text thought dropped, real text kept
  - `ThoughtOnlyDropped` — thought-only turn returns `nil`
- Verified the additions are genuine regression guards: they **pass** with the fix and **fail** against the pre-fix code (thought-only turn wrongly retained as a bare header).
- `go test -race -count=1 ./internal/llminternal/` — pass (full package)
- `go build -mod=readonly ./...` — pass
- `go vet ./internal/llminternal/` — pass
- `golangci-lint run ./internal/llminternal/` — 0 issues
- `gofmt -l` — clean