### PR TITLE
fix(openaimodel): replay assistant turns with output_text content

### DIFF
--- a/model/openaimodel/request.go
+++ b/model/openaimodel/request.go
@@ -95,12 +95,26 @@ func convertContents(contents []*genai.Content) (responses.ResponseInputParam, e
 			if len(textParts) == 0 {
 				return nil
 			}
-			msg, err := newMessage(curRole, textParts)
-			if err != nil {
-				return err
-			}
-			if msg != nil {
-				items = append(items, responses.ResponseInputItemUnionParam{OfMessage: msg})
+			// Assistant turns must be replayed as output messages whose content
+			// uses "output_text"; the OpenAI Responses API rejects "input_text"
+			// for the assistant role (EasyInputMessageParam can only emit
+			// input_text). Every other role stays an easy input message.
+			if curRole == genai.RoleModel {
+				msg, err := newOutputMessage(textParts)
+				if err != nil {
+					return err
+				}
+				if msg != nil {
+					items = append(items, responses.ResponseInputItemUnionParam{OfOutputMessage: msg})
+				}
+			} else {
+				msg, err := newMessage(curRole, textParts)
+				if err != nil {
+					return err
+				}
+				if msg != nil {
+					items = append(items, responses.ResponseInputItemUnionParam{OfMessage: msg})
+				}
 			}
 			textParts = textParts[:0]
 			return nil
@@ -181,6 +195,35 @@ func newMessage(role genai.Role, texts []string) (*responses.EasyInputMessagePar
 		Content: responses.EasyInputMessageContentUnionParam{
 			OfInputItemContentList: contentList,
 		},
+	}, nil
+}
+
+// newOutputMessage builds an assistant output message whose content uses the
+// "output_text" type, as required when replaying a prior assistant turn to the
+// OpenAI Responses API. The message ID is left unset: OpenAI assigns message
+// IDs on output, and a replayed turn has none to echo back.
+func newOutputMessage(texts []string) (*responses.ResponseOutputMessageParam, error) {
+	if len(texts) == 0 {
+		return nil, nil
+	}
+	contentList := make([]responses.ResponseOutputMessageContentUnionParam, 0, len(texts))
+	for _, txt := range texts {
+		if strings.TrimSpace(txt) == "" {
+			continue
+		}
+		contentList = append(contentList, responses.ResponseOutputMessageContentUnionParam{
+			OfOutputText: &responses.ResponseOutputTextParam{
+				Text: txt,
+				Type: constant.OutputText("output_text"),
+			},
+		})
+	}
+	if len(contentList) == 0 {
+		return nil, nil
+	}
+	return &responses.ResponseOutputMessageParam{
+		Content: contentList,
+		Status:  responses.ResponseOutputMessageStatusCompleted,
 	}, nil
 }
 

--- a/model/openaimodel/request_test.go
+++ b/model/openaimodel/request_test.go
@@ -15,6 +15,7 @@
 package openaimodel
 
 import (
+	"encoding/json"
 	"errors"
 	"reflect"
 	"strings"
@@ -53,6 +54,67 @@ func TestBuildOpenAIParams_Text(t *testing.T) {
 	}
 	if got, want := textParts[0].OfInputText.Text, "ping"; got != want {
 		t.Fatalf("text mismatch got=%q want=%q", got, want)
+	}
+}
+
+// TestBuildOpenAIParams_MultiTurnAssistantUsesOutputText guards that a replayed
+// assistant turn is serialized as an output message with content type
+// "output_text". Sending "input_text" for the assistant role makes the OpenAI
+// Responses API reject every multi-turn request with HTTP 400 from the second
+// message onward.
+func TestBuildOpenAIParams_MultiTurnAssistantUsesOutputText(t *testing.T) {
+	req := &model.LLMRequest{
+		Model: "gpt-4o-mini",
+		Contents: []*genai.Content{
+			genai.NewContentFromText("hi", genai.RoleUser),
+			genai.NewContentFromText("hello there", genai.RoleModel),
+			genai.NewContentFromText("can you code", genai.RoleUser),
+		},
+	}
+	params, err := buildOpenAIParams("fallback", req)
+	if err != nil {
+		t.Fatalf("buildOpenAIParams() err = %v", err)
+	}
+
+	items := params.Input.OfInputItemList
+	if len(items) != 3 {
+		t.Fatalf("got %d input items, want 3: %+v", len(items), items)
+	}
+
+	// User turns remain easy input messages using input_text.
+	if items[0].OfMessage == nil || items[2].OfMessage == nil {
+		t.Fatalf("user turns should be easy input messages: %+v", items)
+	}
+	if got := items[0].OfMessage.Content.OfInputItemContentList[0].OfInputText.Type; got != constant.InputText("input_text") {
+		t.Errorf("user content type = %q, want input_text", got)
+	}
+
+	// The assistant turn must be an output message using output_text.
+	out := items[1].OfOutputMessage
+	if out == nil {
+		t.Fatalf("assistant turn should be an output message, got %+v", items[1])
+	}
+	if len(out.Content) != 1 || out.Content[0].OfOutputText == nil {
+		t.Fatalf("assistant output message content malformed: %+v", out.Content)
+	}
+	if got, want := out.Content[0].OfOutputText.Text, "hello there"; got != want {
+		t.Errorf("assistant text = %q, want %q", got, want)
+	}
+	if got := out.Content[0].OfOutputText.Type; got != constant.OutputText("output_text") {
+		t.Errorf("assistant content type = %q, want output_text", got)
+	}
+
+	// Verify the wire format OpenAI actually receives: the assistant item must
+	// marshal with "output_text" and never "input_text".
+	raw, err := json.Marshal(items[1])
+	if err != nil {
+		t.Fatalf("marshal assistant item: %v", err)
+	}
+	if !strings.Contains(string(raw), `"output_text"`) {
+		t.Errorf("assistant item JSON missing output_text: %s", raw)
+	}
+	if strings.Contains(string(raw), `"input_text"`) {
+		t.Errorf("assistant item JSON must not contain input_text: %s", raw)
 	}
 }
 


### PR DESCRIPTION
## Summary

Fixes #1197.

`convertContents` (`model/openaimodel/request.go`) routed **every** role through `newMessage`, which hardcodes the content item type as `input_text`. When a prior assistant turn is replayed in a multi-turn conversation, the OpenAI Responses API rejects it — assistant content must use `output_text` — so every conversation fails from the **second** message onward, on any model:

```
400 Bad Request: Invalid value: 'input_text'. Supported values are:
'output_text' and 'refusal'. (param: input[1].content[0])
```

`EasyInputMessageParam`'s content union (`ResponseInputContentUnionParam`) can only represent `input_text`/`input_image`/`input_file`, so an assistant turn must instead be sent as an **output message** item.

## Change

Branch `flushText` on role:
- `genai.RoleModel` → new `newOutputMessage` helper builds a `ResponseOutputMessageParam` with `output_text` content (`Status: completed`; `ID` left unset, since OpenAI mints message IDs on output and a replayed turn has none to echo), appended as `OfOutputMessage`.
- `user` / `system` / `developer` → unchanged easy input message with `input_text`.

## Testing Plan

- Added `TestBuildOpenAIParams_MultiTurnAssistantUsesOutputText`: a user → assistant → user conversation. Asserts the assistant turn becomes an `OfOutputMessage` with `output_text` content, user turns stay `OfMessage` with `input_text`, and — crucially — that the assistant item **marshals to JSON** containing `"output_text"` and never `"input_text"` (the actual wire format sent to OpenAI).
- Verified it's a genuine regression guard: **passes** with the fix, **fails** against the pre-fix code (assistant turn was an `OfMessage`, `OfOutputMessage == nil`).
- Confirmed the marshaled request body:
  ```json
  { "content": [{ "text": "hello there", "type": "output_text" }],
    "status": "completed", "role": "assistant", "type": "message" }
  ```
- `go test -race -count=1 ./model/openaimodel/` — pass (full package)
- `go build -mod=readonly ./...` — pass
- `go vet` / `golangci-lint run` — 0 issues; `gofmt -l` — clean

**Note on live verification:** I don't have an OpenAI API key, so I could not exercise the real multi-turn round-trip end-to-end. Verification is offline: the emitted request now matches the `output_text` shape the API documents and that the 400 error demands. @-the-reporter (who has a repro) confirming the live multi-turn flow would be appreciated.