### PR TITLE
fix(llmagent): resolve run mode once to avoid parallel-dispatch data race

### DIFF
--- a/agent/llmagent/llm_agent_wrapper.go
+++ b/agent/llmagent/llm_agent_wrapper.go
@@ -71,9 +71,10 @@ func RunLLMAgentAsNode(a agent.Agent, ctx agent.Context, nodeInput any) iter.Seq
 		}
 		state := llminternal.Reveal(llmA)
 
-		if state.Mode == llminternal.ModeUnset {
-			state.Mode = llminternal.ModeSingleTurn
-		}
+		// Resolve the run mode (and the single_turn IncludeContents default)
+		// exactly once; parallel dispatch of the same sub-agent must not race
+		// on these shared-state writes (google/adk-go#1137).
+		state.ResolveMode(llminternal.ModeSingleTurn)
 		switch state.Mode {
 		case llminternal.ModeTask, llminternal.ModeSingleTurn, llminternal.ModeChat:
 		default:
@@ -82,9 +83,6 @@ func RunLLMAgentAsNode(a agent.Agent, ctx agent.Context, nodeInput any) iter.Seq
 			return
 		}
 
-		if state.Mode == llminternal.ModeSingleTurn {
-			state.IncludeContents = "none"
-		}
 		// Task/single_turn modes build a per-agent InvocationContext that:
 		//   - rebinds Agent to a (matching adk-python's ic.agent=agent),
 		//   - threads isolation_scope so the content processor

--- a/agent/llmagent/llm_agent_wrapper_test.go
+++ b/agent/llmagent/llm_agent_wrapper_test.go
@@ -197,6 +197,23 @@ func (s *scriptedLLM) GenerateContent(_ context.Context, _ *model.LLMRequest, _ 
 
 var _ model.LLM = (*scriptedLLM)(nil)
 
+// constLLM is a stateless model.LLM safe for concurrent use: every call yields
+// the same final text response. Used by parallel-dispatch tests where the
+// scriptedLLM's mutable callIdx would itself race.
+type constLLM struct{ text string }
+
+func (constLLM) Name() string { return "const-mock" }
+
+func (m constLLM) GenerateContent(_ context.Context, _ *model.LLMRequest, _ bool) iter.Seq2[*model.LLMResponse, error] {
+	return func(yield func(*model.LLMResponse, error) bool) {
+		yield(&model.LLMResponse{
+			Content: &genai.Content{Role: "model", Parts: []*genai.Part{genai.NewPartFromText(m.text)}},
+		}, nil)
+	}
+}
+
+var _ model.LLM = constLLM{}
+
 func newStubNodeContext(t *testing.T, a agent.Agent, isolationScope string) agent.Context {
 	t.Helper()
 	ic := icontext.NewInvocationContext(t.Context(), icontext.InvocationContextParams{
@@ -787,6 +804,68 @@ func TestRunLLMAgentAsNode_Task_HappyPath(t *testing.T) {
 	}
 	if !sawSuccessFR {
 		t.Error("expected the task agent to receive a finish_task FunctionResponse event")
+	}
+}
+
+// TestRunLLMAgentAsNode_ParallelDispatchNoRace guards against a data race when
+// the same single_turn sub-agent is dispatched by multiple parallel function
+// calls in one model turn (google/adk-go#1137). Each dispatch previously wrote
+// the sub-agent's shared IncludeContents/Mode state unsynchronized. Under
+// -race this fails on the pre-fix code and passes once resolution is guarded.
+func TestRunLLMAgentAsNode_ParallelDispatchNoRace(t *testing.T) {
+	t.Parallel()
+
+	doer := makeLLMAgent(t, "doer",
+		withMode(llmagent.ModeSingleTurn),
+		func(c *llmagent.Config) { c.Model = constLLM{text: "sub-agent done"} },
+	)
+
+	// One coordinator turn emits two function calls to the same sub-agent, so
+	// the runner dispatches "doer" on two goroutines concurrently.
+	coordLLM := &scriptedLLM{
+		turns: []*model.LLMResponse{
+			{
+				Content: &genai.Content{
+					Role: "model",
+					Parts: []*genai.Part{
+						{FunctionCall: &genai.FunctionCall{ID: "fc-1", Name: "doer", Args: map[string]any{"request": "a"}}},
+						{FunctionCall: &genai.FunctionCall{ID: "fc-2", Name: "doer", Args: map[string]any{"request": "b"}}},
+					},
+				},
+			},
+			{
+				Content: &genai.Content{
+					Role:  "model",
+					Parts: []*genai.Part{genai.NewPartFromText("all done")},
+				},
+			},
+		},
+	}
+	coord, err := llmagent.New(llmagent.Config{
+		Name:      "coord",
+		Model:     coordLLM,
+		Mode:      llmagent.ModeChat,
+		SubAgents: []agent.Agent{doer},
+	})
+	if err != nil {
+		t.Fatalf("llmagent.New(coord): %v", err)
+	}
+
+	svc := session.InMemoryService()
+	if _, err := svc.Create(t.Context(), &session.CreateRequest{AppName: "app", UserID: "u", SessionID: "s"}); err != nil {
+		t.Fatal(err)
+	}
+	r, err := runner.New(runner.Config{Agent: coord, SessionService: svc, AppName: "app"})
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	for _, err := range r.Run(t.Context(), "u", "s",
+		&genai.Content{Parts: []*genai.Part{genai.NewPartFromText("go")}, Role: "user"},
+		agent.RunConfig{StreamingMode: agent.StreamingModeSSE}) {
+		if err != nil {
+			t.Fatalf("runner.Run: %v", err)
+		}
 	}
 }
 

--- a/internal/llminternal/agent.go
+++ b/internal/llminternal/agent.go
@@ -15,6 +15,8 @@
 package llminternal
 
 import (
+	"sync"
+
 	"google.golang.org/genai"
 
 	"google.golang.org/adk/v2/agent"
@@ -60,6 +62,10 @@ type State struct {
 	OutputSchema *genai.Schema
 
 	OutputKey string
+
+	// resolveOnce guards the one-time, race-free resolution of Mode and the
+	// derived IncludeContents default. See ResolveMode.
+	resolveOnce sync.Once
 }
 
 type InstructionProvider func(ctx agent.ReadonlyContext) (string, error)
@@ -67,3 +73,25 @@ type InstructionProvider func(ctx agent.ReadonlyContext) (string, error)
 func (s *State) internal() *State { return s }
 
 func Reveal(a Agent) *State { return a.internal() }
+
+// ResolveMode resolves the agent's run Mode exactly once: an unset Mode is
+// defaulted to def, and single_turn agents get IncludeContents "none". The
+// default is context-dependent (chat for a root agent, single_turn for a
+// sub-agent node), so it must be resolved at first run rather than at
+// construction.
+//
+// It is safe for concurrent callers: dispatching the same sub-agent on parallel
+// branches previously raced on these writes (google/adk-go#1137). The sync.Once
+// both dedupes the write and establishes a happens-before edge, so after any
+// call returns, Mode and IncludeContents are stable and may be read without
+// further synchronization.
+func (s *State) ResolveMode(def Mode) {
+	s.resolveOnce.Do(func() {
+		if s.Mode == ModeUnset {
+			s.Mode = def
+		}
+		if s.Mode == ModeSingleTurn {
+			s.IncludeContents = "none"
+		}
+	})
+}

--- a/runner/runner.go
+++ b/runner/runner.go
@@ -207,10 +207,10 @@ func (r *Runner) Run(ctx context.Context, userID, sessionID string, msg *genai.C
 
 			llmInternalState := llminternal.Reveal(llmInternalAgent)
 
-			if llmInternalState.Mode == "" {
-				// LlmAgent as root agent must have chat mode.
-				llmInternalState.Mode = llminternal.ModeChat
-			}
+			// LlmAgent as root agent must have chat mode. Resolve once so
+			// servers sharing one root agent across concurrent Run calls don't
+			// race on this write (google/adk-go#1137).
+			llmInternalState.ResolveMode(llminternal.ModeChat)
 
 			if llmInternalState.Mode != llminternal.ModeChat {
 				yield(nil, fmt.Errorf("root agent %s must be a chat LlmAgent, but has mode %s", r.rootAgent.Name(), llmInternalState.Mode))

--- a/workflow/agent_node.go
+++ b/workflow/agent_node.go
@@ -51,10 +51,9 @@ func newAgentNodeWithSchemasTyped[Input, Output any](a agent.Agent, inputSchema,
 	}
 
 	if llmA, ok := a.(llminternal.Agent); ok {
-		state := llminternal.Reveal(llmA)
-		if state.Mode == llminternal.ModeUnset {
-			state.Mode = llminternal.ModeSingleTurn
-		}
+		// Resolve the mode once; concurrent node construction/dispatch of the
+		// same agent must not race on this write (google/adk-go#1137).
+		llminternal.Reveal(llmA).ResolveMode(llminternal.ModeSingleTurn)
 	}
 
 	// The wrapped agent's Run already emits an invoke_agent span, so


### PR DESCRIPTION
## Summary

Fixes #1137.

Dispatching the same `single_turn` sub-agent via **parallel function calls in one model turn** is a data race. `handleFunctionCalls` runs each call on its own goroutine, and each `RunLLMAgentAsNode` wrote the sub-agent's **shared** internal state on every dispatch:

- `state.Mode` (`ModeUnset` → `ModeSingleTurn`)
- `state.IncludeContents = "none"`

Concurrent dispatches produce write-write and write-read races on that shared `State` (the race detector reports `llm_agent_wrapper.go:86`) — undefined behavior per the Go memory model even though the written values are equal. The same lazy-defaulting pattern also races in `workflow.NewAgentNode` and `runner.Run` (a root agent shared across concurrent `Run` calls).

## Change

The mode default is **context-dependent** (chat for a root agent, single_turn for a sub-agent node), so it can't be resolved at construction. Add `State.ResolveMode(def Mode)`, guarded by a `sync.Once`, that defaults an unset `Mode` and applies the single_turn `IncludeContents` default **exactly once**. The `Once` both dedupes the write and establishes a happens-before edge, so later reads (including the content processors that read `IncludeContents`/`Mode` directly) observe stable values without further synchronization. All three defaulting sites are routed through it.

> Note: this touches high-fan-in packages (`llmagent`, `workflow`, `runner`, `internal/llminternal`). It preserves behavior for the normal case (an agent used in a single role); happy to adjust the resolution semantics if maintainers prefer a different approach for the degenerate case of one agent instance shared across conflicting roles.

## Testing Plan

- Added `TestRunLLMAgentAsNode_ParallelDispatchNoRace`: a chat coordinator whose model emits two function calls to the same single_turn sub-agent in one turn, run via the runner (so the two dispatches run on separate goroutines).
- Verified it's a genuine regression guard under `-race`: **fails** on the pre-fix code with `WARNING: DATA RACE` at `llm_agent_wrapper.go:86` (the exact reported line), **passes** with the fix.
- `go test -race -count=1 ./internal/llminternal/ ./agent/llmagent/ ./workflow/ ./runner/` — all pass (no regressions in existing suites).
- `go build -mod=readonly ./...` — pass; `go vet` (incl. copylock on the new `sync.Once` field) — clean.
- `golangci-lint run` (all four packages) — 0 issues; `gofmt -l` — clean.