### PR TITLE
fix(llminternal): guard RunLive errChan sends to prevent goroutine leak

### DIFF
--- a/internal/llminternal/base_flow.go
+++ b/internal/llminternal/base_flow.go
@@ -386,7 +386,14 @@ func (f *Flow) RunLive(ctx agent.InvocationContext) (agent.LiveSession, iter.Seq
 				for {
 					resp, err := liveConn.Recv(connCtx)
 					if err != nil {
-						errChan <- err
+						// Guard the send: on a resumable error the consumer
+						// abandons this errChan and reconnects, so an unguarded
+						// send would block this goroutine forever (leak). cleanup
+						// cancels connCtx on every path, unblocking us here.
+						select {
+						case errChan <- err:
+						case <-connCtx.Done():
+						}
 						return
 					}
 					if resp != nil {
@@ -427,7 +434,10 @@ func (f *Flow) RunLive(ctx agent.InvocationContext) (agent.LiveSession, iter.Seq
 						}
 						if req.Content != nil {
 							if err := liveConn.SendContent(connCtx, req.Content); err != nil {
-								errChan <- err
+								select {
+								case errChan <- err:
+								case <-connCtx.Done():
+								}
 								return
 							}
 						}
@@ -436,7 +446,10 @@ func (f *Flow) RunLive(ctx agent.InvocationContext) (agent.LiveSession, iter.Seq
 								sess.audioMgr.CacheInput(ctx, blob.Data, blob.MIMEType)
 							}
 							if err := liveConn.SendRealtime(connCtx, req.RealtimeInput); err != nil {
-								errChan <- err
+								select {
+								case errChan <- err:
+								case <-connCtx.Done():
+								}
 								return
 							}
 						}


### PR DESCRIPTION
## Summary

Fixes #1152.

`Flow.RunLive` creates a fresh unbuffered `errChan` per connection attempt, and its reader and sender goroutines send to it with no cancellation guard:

- reader: `errChan <- err`
- sender: `errChan <- err` (SendContent / SendRealtime)

The consumer reads a single error in the main `select`. When that error `isResumable`, the loop sets `reconnect = true`, breaks out, and starts a new attempt with a **new** `errChan` — abandoning the previous one. If the *other* goroutine of the old attempt subsequently fails (e.g. the sender hits the closed connection after the reader already reported), it blocks forever on a send to the abandoned unbuffered channel: **one leaked goroutine (plus its stack and captured connection state) per reconnect cycle**. Long-lived live sessions on flaky networks accumulate these.

## Change

Wrap each `errChan` send in a `select` with a `case <-connCtx.Done()` — mirroring the existing `eventsChan` send a few lines above. `cleanup()` already calls `cancelConn()` on every path (terminal *and* reconnect, line ~541), so the guarded producers now observe the cancellation and return instead of blocking. Chose this over buffering `errChan` because it models the connection lifecycle rather than masking it (buffering would just paper over the abandoned-channel case).

## Testing Plan

- `go build -mod=readonly ./...` — pass
- `go test -race -count=1 ./internal/llminternal/` — pass (existing suite, no regressions)
- `go vet` / `golangci-lint run` — 0 issues; `gofmt -l` — clean

**Verification caveat (please read):** the leak path only triggers on a live reconnect, and `RunLive`'s connection (`liveConn` over a real websocket `genai.Session`) has no injectable seam, so I could not add a deterministic regression test without first refactoring the flow to make the connection mockable — a larger, separate change. This fix is therefore **verified by inspection** against the existing `eventsChan` guard pattern, not by a new automated test. Flagging explicitly so reviewers can weigh whether a follow-up test seam is wanted.