### PR TITLE
docs: fix AGENTS.md build commands for the multi-module layout

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -8,22 +8,40 @@ CONTRIBUTING.md.
 
 ADK Go (`google.golang.org/adk/v2`) is an open-source, code-first Go toolkit for
 building, evaluating, and deploying AI agents. It is model-agnostic but
-optimized for Gemini, and is one of three ADK implementations — Go, Python, and
-Java — that share a conceptual model but are independent codebases. Requires
-Go 1.25+.
+optimized for Gemini, and is one of several ADK implementations — Go, Python,
+Java, Kotlin, and TypeScript — that share a conceptual model but are independent
+codebases. Requires the Go version declared in `go.mod` (currently 1.26.5).
+
+Development happens on `main`, the 2.x line. `v1` is the maintenance branch for
+1.x; target it only for fixes that must ship to 1.x. See
+[Branches](CONTRIBUTING.md#branches).
 
 ## Setup & core commands
 
-Run from the repo root. These match what CI enforces (CI also passes `-v`):
+This repo is multi-module: the root module `google.golang.org/adk/v2` plus
+`plugin/agentanalytics`. Set up a Go workspace first — `go.work` is local-only
+and gitignored, and `go work init` fails if one already exists:
 
-- Build:       `go build -mod=readonly ./...`
-- Test:        `go test -race -mod=readonly -count=1 -shuffle=on ./...`
+```bash
+test -f go.work || go work init
+go work use -r .
+```
+
+Then run from the repo root. The `work` pattern spans every module in the
+workspace, while `./...` matches only the module you are standing in:
+
+- Build:       `go build -mod=readonly work`
+- Test:        `go test -race -mod=readonly -count=1 -shuffle=on work`
 - Single pkg:  `go test -race ./agent/...`
-- Lint:        `golangci-lint run`   (golangci-lint v2; CI pins v2.3.1; config in `.golangci.yml`)
-- Tidy check:  `go mod tidy -diff`   (must print nothing)
-- Format:      `golangci-lint fmt`   (applies gofumpt + goimports per config)
+- Lint:        `golangci-lint run`   (per module; v2, CI pins v2.3.1; config in `.golangci.yml`)
+- Tidy check:  `go mod tidy -diff`   (per module; must print nothing)
+- Format:      `golangci-lint fmt`   (per module; applies gofumpt + goimports per config)
 
-**Local Development**: Contributors should use `go work init && go work use -r .` to set up their local workspaces.
+Without a `go.work`, `work` silently falls back to the root module alone and
+still exits 0, so confirm the workspace exists before trusting a green run.
+`golangci-lint` and `go mod tidy` are per-module either way: run them inside each
+submodule too (for example, `cd plugin/agentanalytics`). CI does the same,
+running build, test, tidy, and lint once per module, with `-v` on build and test.
 
 ## Definition of done
 
@@ -31,27 +49,33 @@ A change is complete only when all of these pass locally:
 
 1. `go build` (above) succeeds.
 2. `go test` (above) is green.
-3. `golangci-lint run` reports no findings.
-4. `go mod tidy -diff` prints nothing.
+3. `golangci-lint run` reports no findings, in every module.
+4. `go mod tidy -diff` prints nothing, in every module.
 5. New/changed behavior has tests; a bug fix has a test that reproduces the bug.
 6. Every new Go file starts with the Apache 2.0 license header (enforced by `goheader`).
+7. The root `go.mod` does not require an in-repo submodule (enforced by the
+   `guardrail` CI job).
 
 ## Repository layout
 
-- `agent/`     Agent interface + types (`llmagent`, `workflowagent(s)`, `remoteagent`)
+- `agent/`     Agent interface + types (`llmagent`, `remoteagent`, `workflowagent`;
+  `workflowagents/` holds `loopagent`, `parallelagent`, `sequentialagent`)
 - `runner/`    Execution engine that drives the run loop
 - `workflow/`  Node/graph-based workflow engine for multi-agent apps
-- `model/`     LLM abstraction (`gemini`, `apigee`)
+- `model/`     LLM abstraction (`gemini`, `apigee`, `openaimodel`)
 - `tool/`      Tool/Toolset interface + built-in tools (incl. `skilltoolset/`, `mcptoolset/`)
 - `session/`   Conversation state + events
 - `memory/`, `artifact/`   Long-term memory and file/data services
-- `plugin/`    Cross-cutting lifecycle hooks
+- `auth/`      Credentials and auth providers for outbound requests
+- `agentregistry/`  Client for Google Cloud Agent Registry (A2A agents, MCP servers, models)
+- `plugin/`    Cross-cutting lifecycle hooks; `plugin/agentanalytics` is a separate module
 - `server/`    HTTP servers (`adkrest` is primary; `adka2a`, `agentengine`)
 - `cmd/`       CLI (`adkgo`) and server launchers
 - `telemetry/`, `util/`   Public helper packages
 - `platform/`  Overridable seams for time & UUID generation (deterministic tests)
 - `internal/`  Private packages — NOT public API; `internal/httprr` is vendored
 - `examples/`  Runnable example agents (quickstart, tools, a2a, skills, …)
+- `scripts/`   Repo tooling (ADK Web container build and asset refresh)
 
 ## Conventions & idioms
 
@@ -106,9 +130,10 @@ See `examples/quickstart` for a full runnable program.
 - **Add cross-cutting behavior:** register a `plugin.New(plugin.Config{...})`
   hook (`Before*`/`After*` for run/agent/model/tool) instead of editing the loop.
 
-## Multi-Module Development
+## Multi-module development
 
-See the [Multi-Module Development](CONTRIBUTING.md#multi-module-development) section in `CONTRIBUTING.md` for policy, steps to add a new module, and release tagging information.
+See [Multi-Module Development](CONTRIBUTING.md#multi-module-development) in
+`CONTRIBUTING.md` for policy, steps to add a new module, and release tagging.
 
 ## Testing
 
@@ -154,4 +179,7 @@ Python implementation.
 
 - Docs: https://google.github.io/adk-docs/
 - Examples: `./examples`
-- Java ADK: https://github.com/google/adk-java
+- Other ADK implementations: [Python](https://github.com/google/adk-python),
+  [Java](https://github.com/google/adk-java),
+  [Kotlin](https://github.com/google/adk-kotlin),
+  [TypeScript](https://github.com/google/adk-js)


### PR DESCRIPTION
## Summary

`AGENTS.md` tells agents to build and test with `./...` from the repo root. Since the repo became multi-module, that command silently skips `plugin/agentanalytics` — even inside a `go.work` workspace — so an agent can get a green local run and still break CI. It also contradicts `CONTRIBUTING.md`, which already prescribes `go build work && go test work`.

Measured from the repo root with a workspace configured:

| command | packages | includes `plugin/agentanalytics` |
| --- | --- | --- |
| `go list ./...` | 154 | no |
| `go list work` | 155 | yes |

This PR switches build and test to the `work` pattern, marks lint, tidy, and format as per-module (which is how CI runs them), and refreshes the facts that went stale since the file was written.

## Changes

- **Commands** — `work` instead of `./...` for build and test. Workspace setup is promoted from a trailing note to a prerequisite, with an idempotent snippet (`go work init` fails if `go.work` already exists). Adds the warning that `work` silently falls back to the root module, still exiting 0, when no `go.work` is present.
- **Definition of done** — lint and tidy apply to every module; adds the `guardrail` CI job (the root `go.mod` must not require an in-repo submodule).
- **Go version** — `Requires Go 1.25+` was stale; now points at the version declared in `go.mod` (currently 1.26.5) so it stops drifting.
- **Branches** — records that `main` is the 2.x line and `v1` the 1.x maintenance branch, linking `CONTRIBUTING.md#branches`.
- **Repository layout** — adds `auth/`, `agentregistry/`, and `scripts/`; adds `openaimodel` to `model/`; flags `plugin/agentanalytics` as a separate module; replaces the ambiguous `workflowagent(s)` with the two packages that actually exist.
- **Implementations** — "one of three" is out of date; now Go, Python, Java, Kotlin, and TypeScript, with Resources linking the sibling repos.

## Testing plan

Docs-only; no code paths change. Every command the file now prescribes was run from the repo root on this branch:

- `go build -mod=readonly work` — exit 0.
- `go test -race -mod=readonly -count=1 -shuffle=on work` — full suite across both modules, including `ok google.golang.org/adk/plugin/agentanalytics`. One failure, `telemetry.TestConfigureExporters` (`conflicting Schema URL: https://opentelemetry.io/schemas/1.41.0 and .../1.40.0`), reproduces unchanged on a pristine tree, so it is pre-existing on `main` and unrelated to this change. Happy to file it separately.
- `go mod tidy -diff` — no output, at the root and in `plugin/agentanalytics`.
- `go list ./...` vs `go list work` — the package counts in the table above.
- Each layout entry checked against the tree and the packages' own doc comments; the `CONTRIBUTING.md#branches` and `#multi-module-development` anchors both resolve.

`golangci-lint` was not run locally (not installed on this machine); no lint-relevant content changed.

## Follow-up

`README.md` still lists only Python ADK and Java ADK under Important Links, so it now disagrees with the implementation list here. Left out to keep this PR to one concern.