### PR TITLE
docs(llminternal): correct comment on synthetic user-turn injection

### DIFF
--- a/internal/llminternal/contents_processor.go
+++ b/internal/llminternal/contents_processor.go
@@ -61,8 +61,9 @@ func ContentsRequestProcessor(ctx agent.InvocationContext, req *model.LLMRequest
 			return
 		}
 		req.Contents = append(req.Contents, contents...)
-		// Gemini API requires role alternation (model turns cannot be consecutive).
-		// If the conversation history concludes on a model turn, inject a synthetic user continuation turn.
+		// If the conversation history concludes on a non-user turn, inject a synthetic
+		// user continuation turn to prompt the model to continue processing the
+		// previous request or provide a final summary if the work is complete.
 		if len(req.Contents) > 0 {
 			if last := req.Contents[len(req.Contents)-1]; last != nil && last.Role != "user" {
 				req.Contents = append(req.Contents, genai.NewContentFromText("Continue processing previous requests as instructed. Exit or provide a summary if no more outputs are needed.", "user"))


### PR DESCRIPTION
## Summary

Fixes #1218

The comment at `internal/llminternal/contents_processor.go:64-65` stated that the Gemini API requires role alternation and rejects consecutive model turns. As the issue documents, this is incorrect — the API accepts consecutive `model` contents (HTTP 200 in all tested shapes).

The code itself is correct and should stay. The real justification for injecting a synthetic user continuation turn is a **generation-quality nudge**: without it the model may return an empty response or fail to summarise completed work. This matches the rationale in:
- `model/gemini/gemini.go:163-164` — "appends a user content, so that model can continue to output"
- adk-python's `base_llm.py` — "Insert a user content to preserve user intent and to avoid empty model response"

## Changes

- Updated the two-line comment to accurately describe why the synthetic user turn is injected.

## Test results

```
ok  google.golang.org/adk/v2/internal/llminternal  0.608s
ok  google.golang.org/adk/v2/internal/llminternal/googlellm  0.007s
```

## AI Usage

Implemented with Claude Code assistance. All changed lines reviewed manually.