### PR TITLE
fix(ci): unbreak the lint job by skipping golangci-lint's stale cache

### DIFF
--- a/.github/actions/setup/action.yml
+++ b/.github/actions/setup/action.yml
@@ -22,5 +22,11 @@ runs:
         path: |
           ~/.cache/go-build
           ~/go/pkg/mod
-        key: ${{ runner.os }}-go-build-${{ hashFiles('**/go.mod', '**/go.sum') }}
-        restore-keys: ${{ runner.os }}-go-build-
+        # The Go version has to be part of the key. The build cache holds export
+        # data written by the toolchain that produced it, and a bare restore-keys
+        # prefix will happily restore a cache written by an older Go. Analyses
+        # that read stdlib facts then work from stale data: staticcheck stops
+        # seeing the runtime.Goexit behind t.Fatal and reports SA5011 nil
+        # dereferences throughout the tests.
+        key: ${{ runner.os }}-go-${{ steps.setup-go.outputs.go-version }}-build-${{ hashFiles('**/go.mod', '**/go.sum') }}
+        restore-keys: ${{ runner.os }}-go-${{ steps.setup-go.outputs.go-version }}-build-

--- a/.github/workflows/go.yml
+++ b/.github/workflows/go.yml
@@ -80,6 +80,12 @@ jobs:
         working-directory: ${{ matrix.module }}
         install-mode: goinstall
         version: 5256574b81bcedfbcae9099f745f6aee9335da10 # v2.3.1
+        # golangci-lint's analysis cache stores the facts analyzers derive about
+        # dependencies, and its key does not track the toolchain. Restoring one
+        # written by an older Go leaves staticcheck without the runtime.Goexit
+        # inside testing.(*common).FailNow, so it stops treating t.Fatal as
+        # terminating and reports SA5011 nil dereferences throughout the tests.
+        skip-cache: true
 
   guardrail:
     runs-on: ubuntu-latest

--- a/.github/workflows/go.yml
+++ b/.github/workflows/go.yml
@@ -18,6 +18,12 @@ concurrency:
   group: ${{ github.workflow }}-${{ github.head_ref || github.ref }}
   cancel-in-progress: true
 
+# Every job here only reads the repository: it checks out, builds, tests and
+# lints. Declaring that once at the top keeps each job from inheriting the
+# broader default token.
+permissions:
+  contents: read
+
 jobs:
   discover:
     runs-on: ubuntu-latest


### PR DESCRIPTION
**Please ensure you have read the [contribution guide](./CONTRIBUTING.md) before creating a pull request.**

### Link to Issue or Description of Change

No issue filed; this unblocks CI for everyone. Found while working on #1246.

**Problem:**

`lint (.)` fails on `main`, not just on PRs. Fresh `workflow_dispatch` run against clean `main` (`046ae95c`, no changes): [run 30927083935](https://github.com/google/adk-go/actions/runs/30927083935) — every other job green.

```
internal/configurable/conformance/replayplugin/replay_plugin_test.go:112,115,119,189,192
internal/llminternal/functions_test.go:250
* staticcheck: 6
```

All six are `SA5011` on values guarded by `t.Fatal`:

```go
if result == nil {
    t.Fatal("expected non-nil result")
}
if result.Content == nil {   // <- "possible nil pointer dereference"
```

which is only reachable if staticcheck believes `t.Fatal` can return.

**Root cause:**

Not the code, and not the analyzer. Two probes in the same package, linted locally with the exact golangci-lint commit CI pins:

```go
// flagged, correctly - the nil branch only prints
if p == nil { fmt.Println("nil") }
if p.Field == "" { ... }

// not flagged, correctly - staticcheck knows t.Fatal terminates
if p == nil { t.Fatal("nil") }
if p.Field == "" { ... }
```

So staticcheck models `t.Fatal` correctly when it has current facts for `testing`. It reaches that conclusion by following `Fatal` -> `FailNow` -> `runtime.Goexit`, which needs facts derived from the stdlib.

Those facts live in golangci-lint's own analysis cache, and the action restored the same entry on every run (`golangci-lint.cache-Linux-.-2952-a18bdd4aac…`, cache hit). Its key tracks the config and linter version but not the toolchain, so an entry written by an older Go survives a toolchain bump. Without usable `testing` facts staticcheck cannot see the `Goexit`, stops treating `t.Fatal` as terminating, and flags every value guarded that way.

That also explains why nothing else helped: re-running restored the same entry, rebasing did not change the key, and the first commit here — keying the *Go build* cache by toolchain — left the lint job still failing with a cold (~0 MB) build cache.

**Solution:**

Three commits:

1. `fix(ci): key the Go cache by toolchain version` — the build cache's `restore-keys` prefix is bare, so a cache written by an older Go is restored against a newer one. **This was not the fix**; it is adjacent hygiene against the same class of bug. Happy to drop it if you would rather keep this PR minimal.
2. `fix(ci): skip the golangci-lint analysis cache` — the actual fix. `skip-cache: true` on the lint action. The cache is ~2 MB against a ~3 min job, so the cost is negligible and correctness is worth more than the saving.
3. `fix(ci): declare read-only permissions for the Go workflow` — editing a workflow activates the `zizmor` scan, which only runs when workflow files change. It reported pre-existing `excessive-permissions` on all four jobs, none of which declared a `permissions` block. They only read the repository, so `contents: read` is declared once at the top level.

**Why not change the tests:** the six reported are capped by golangci-lint's default `max-same-issues: 3`. Scanning for the same shape (`if x == nil { t.Fatal… }` followed by a dereference of `x`) finds **79 sites across 39 files**. Rewriting those, or excluding `SA5011` from tests, would work around a stale cache and give up a genuinely useful check.

### Testing Plan

**Unit Tests:**

- [ ] I have added or updated unit tests for my change. *(CI configuration; not unit-testable)*
- [x] All unit tests pass locally.

CI is the test here, and it moved in the expected steps:

| commits | `lint (.)` |
|---|---|
| Go build cache keyed by toolchain | fail — same 6, with a cold ~0 MB build cache |
| \+ `skip-cache: true` | **pass** |
| \+ workflow permissions | pass, and `zizmor-output` green |

All 13 checks currently pass on this PR.

Locally: `go build -mod=readonly work` and `go test -race -mod=readonly -count=1 -shuffle=on work` are green apart from a pre-existing `TestConfigureExporters` OTel schema-URL conflict that also fails on clean `main`; `golangci-lint run` reports 0 issues in both modules; `actionlint` is clean on the edited workflow.

### Checklist

- [x] I have read the CONTRIBUTING.md document.
- [x] I have performed a self-review of my own code.
- [x] I have commented my code, particularly in hard-to-understand areas.
- [ ] I have added tests that prove my fix is effective. *(CI itself, see the table)*
- [x] New and existing unit tests pass locally with my changes.
- [x] I have manually tested my changes end-to-end.
- [x] Any dependent changes have been merged and published in downstream modules.

### Additional context

If you would rather keep the cache and pin the problem differently, the alternatives are bumping the lint action so its key includes the toolchain, or `skip-save-cache` with a manual key. `skip-cache: true` is the smallest change that is certainly correct.