### PR TITLE
fix(session): give Event a consistent JSON encoding

### DIFF
--- a/model/llm.go
+++ b/model/llm.go
@@ -40,29 +40,29 @@ type LLMRequest struct {
 // LLMResponse is the raw LLM response.
 // It provides the first candidate response from the model if available.
 type LLMResponse struct {
-	Content             *genai.Content
-	CitationMetadata    *genai.CitationMetadata
-	GroundingMetadata   *genai.GroundingMetadata
-	UsageMetadata       *genai.GenerateContentResponseUsageMetadata
-	CustomMetadata      map[string]any
-	LogprobsResult      *genai.LogprobsResult
-	InputTranscription  *genai.Transcription
-	OutputTranscription *genai.Transcription
-	ModelVersion        string
+	Content             *genai.Content                              `json:"content,omitempty"`
+	CitationMetadata    *genai.CitationMetadata                     `json:"citationMetadata,omitempty"`
+	GroundingMetadata   *genai.GroundingMetadata                    `json:"groundingMetadata,omitempty"`
+	UsageMetadata       *genai.GenerateContentResponseUsageMetadata `json:"usageMetadata,omitempty"`
+	CustomMetadata      map[string]any                              `json:"customMetadata,omitempty"`
+	LogprobsResult      *genai.LogprobsResult                       `json:"logprobsResult,omitempty"`
+	InputTranscription  *genai.Transcription                        `json:"inputTranscription,omitempty"`
+	OutputTranscription *genai.Transcription                        `json:"outputTranscription,omitempty"`
+	ModelVersion        string                                      `json:"modelVersion,omitempty"`
 	// Partial indicates whether the content is part of a unfinished content stream.
 	// Only used for streaming mode and when the content is plain text.
 	// The Runner fully processes only the final non-partial event, partial
 	// events are simply forwarded downstream (eg. to UI for display).
-	Partial bool
+	Partial bool `json:"partial,omitempty"`
 	// Indicates whether the response from the model is complete.
 	// Only used for streaming mode.
-	TurnComplete bool
+	TurnComplete bool `json:"turnComplete,omitempty"`
 	// Flag indicating that LLM was interrupted when generating the content.
 	// Usually it is due to user interruption during a bidi streaming.
-	Interrupted             bool
-	SessionResumptionHandle string
-	ErrorCode               string
-	ErrorMessage            string
-	FinishReason            genai.FinishReason
-	AvgLogprobs             float64
+	Interrupted             bool               `json:"interrupted,omitempty"`
+	SessionResumptionHandle string             `json:"sessionResumptionHandle,omitempty"`
+	ErrorCode               string             `json:"errorCode,omitempty"`
+	ErrorMessage            string             `json:"errorMessage,omitempty"`
+	FinishReason            genai.FinishReason `json:"finishReason,omitempty"`
+	AvgLogprobs             float64            `json:"avgLogprobs,omitempty"`
 }

--- a/session/event_json_test.go
+++ b/session/event_json_test.go
@@ -1,0 +1,480 @@
+// Copyright 2025 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package session_test
+
+import (
+	"context"
+	"encoding/json"
+	"sort"
+	"testing"
+	"time"
+
+	"github.com/google/go-cmp/cmp"
+	"google.golang.org/genai"
+
+	"google.golang.org/adk/v2/model"
+	"google.golang.org/adk/v2/session"
+)
+
+func fullyPopulatedEvent() *session.Event {
+	return &session.Event{
+		LLMResponse: model.LLMResponse{
+			Content:      genai.NewContentFromText("hello", genai.RoleModel),
+			ModelVersion: "gemini-3-pro",
+			Partial:      true,
+			TurnComplete: true,
+			Interrupted:  true,
+			ErrorCode:    "429",
+			ErrorMessage: "rate limited",
+			AvgLogprobs:  -0.25,
+		},
+		ID:                 "evt-1",
+		Timestamp:          time.Unix(1733040000, 0).UTC(),
+		InvocationID:       "inv-1",
+		Branch:             "root.planner",
+		IsolationScope:     "approval_subflow",
+		Author:             "planner",
+		LongRunningToolIDs: []string{"tool-1", "tool-2"},
+		Routes:             []string{"reviewer", "writer"},
+		RequestedInput: &session.RequestInput{
+			InterruptID: "approval-1",
+			Message:     "Approve?",
+			Payload:     map[string]any{"doc": "contract.pdf"},
+		},
+		Output:   map[string]any{"summary": "ok", "risk_items": float64(3)},
+		NodeInfo: &session.NodeInfo{Path: "wf/planner", MessageAsOutput: true, OutputFor: []string{"wf"}},
+		Actions: session.EventActions{
+			StateDelta:        map[string]any{"stage": "drafted"},
+			ArtifactDelta:     map[string]int64{"report.pdf": 2},
+			SkipSummarization: true,
+			TransferToAgent:   "writer",
+			Escalate:          true,
+		},
+	}
+}
+
+// TestEventJSONKeys pins the wire format. Event is persisted whole by session
+// services (see session/vertexai raw_event) and read back by other ADK
+// runtimes, so its key names are an interface, not an implementation detail.
+func TestEventJSONKeys(t *testing.T) {
+	b, err := json.Marshal(fullyPopulatedEvent())
+	if err != nil {
+		t.Fatalf("Marshal() failed: %v", err)
+	}
+	var m map[string]json.RawMessage
+	if err := json.Unmarshal(b, &m); err != nil {
+		t.Fatalf("Unmarshal() failed: %v", err)
+	}
+	got := make([]string, 0, len(m))
+	for k := range m {
+		got = append(got, k)
+	}
+	sort.Strings(got)
+
+	want := []string{
+		"actions", "author", "avgLogprobs", "branch", "content", "errorCode",
+		"errorMessage", "id", "interrupted", "invocationId", "isolationScope",
+		"longRunningToolIds", "modelVersion", "nodeInfo", "output", "partial",
+		"requestedInput", "routes", "timestamp", "turnComplete",
+	}
+	if diff := cmp.Diff(want, got); diff != "" {
+		t.Errorf("Event JSON keys mismatch (-want +got):\n%s", diff)
+	}
+}
+
+// TestEventJSONOmitsEmpty guards against every event carrying a full set of
+// nulls, which bloats every persisted row.
+func TestEventJSONOmitsEmpty(t *testing.T) {
+	b, err := json.Marshal(&session.Event{})
+	if err != nil {
+		t.Fatalf("Marshal() failed: %v", err)
+	}
+	var m map[string]json.RawMessage
+	if err := json.Unmarshal(b, &m); err != nil {
+		t.Fatalf("Unmarshal() failed: %v", err)
+	}
+	got := make([]string, 0, len(m))
+	for k := range m {
+		got = append(got, k)
+	}
+	sort.Strings(got)
+
+	want := []string{"actions", "author", "id", "invocationId", "timestamp"}
+	if diff := cmp.Diff(want, got); diff != "" {
+		t.Errorf("empty Event JSON keys mismatch (-want +got):\n%s", diff)
+	}
+}
+
+func TestEventJSONRoundTrip(t *testing.T) {
+	want := fullyPopulatedEvent()
+	b, err := json.Marshal(want)
+	if err != nil {
+		t.Fatalf("Marshal() failed: %v", err)
+	}
+	got := &session.Event{}
+	if err := json.Unmarshal(b, got); err != nil {
+		t.Fatalf("Unmarshal() failed: %v", err)
+	}
+	if diff := cmp.Diff(want, got); diff != "" {
+		t.Errorf("Event round trip mismatch (-want +got):\n%s", diff)
+	}
+}
+
+// TestEventUnmarshalTimestampDialects covers the three timestamp encodings an
+// Event can arrive in: RFC 3339 (this package), epoch seconds as a number
+// (adk-python, whose Event.timestamp is a float), and absent.
+func TestEventUnmarshalTimestampDialects(t *testing.T) {
+	tests := []struct {
+		name string
+		in   string
+		want time.Time
+	}{
+		{
+			name: "rfc3339 string",
+			in:   `{"id":"e","timestamp":"2024-12-01T08:00:00Z"}`,
+			want: time.Unix(1733040000, 0).UTC(),
+		},
+		{
+			name: "epoch seconds number",
+			in:   `{"id":"e","timestamp":1733040000}`,
+			want: time.Unix(1733040000, 0).UTC(),
+		},
+		{
+			name: "fractional epoch seconds",
+			in:   `{"id":"e","timestamp":1733040000.5}`,
+			want: time.Unix(1733040000, 500000000).UTC(),
+		},
+		{
+			name: "millisecond precision",
+			in:   `{"id":"e","timestamp":1733040000.123}`,
+			want: time.Unix(1733040000, 123000000).UTC(),
+		},
+		{
+			name: "exponent notation",
+			in:   `{"id":"e","timestamp":1.7330400e9}`,
+			want: time.Unix(1733040000, 0).UTC(),
+		},
+		{
+			name: "zero epoch",
+			in:   `{"id":"e","timestamp":0}`,
+			want: time.Unix(0, 0).UTC(),
+		},
+		{
+			name: "negative epoch",
+			in:   `{"id":"e","timestamp":-86400}`,
+			want: time.Unix(-86400, 0).UTC(),
+		},
+		{
+			name: "negative fractional epoch",
+			in:   `{"id":"e","timestamp":-0.5}`,
+			want: time.Unix(0, -500000000).UTC(),
+		},
+		{
+			name: "absent",
+			in:   `{"id":"e"}`,
+			want: time.Time{},
+		},
+		{
+			name: "null",
+			in:   `{"id":"e","timestamp":null}`,
+			want: time.Time{},
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got := &session.Event{}
+			if err := json.Unmarshal([]byte(tt.in), got); err != nil {
+				t.Fatalf("Unmarshal(%s) failed: %v", tt.in, err)
+			}
+			if !got.Timestamp.UTC().Equal(tt.want) {
+				t.Errorf("Timestamp = %v, want %v", got.Timestamp.UTC(), tt.want)
+			}
+			if got.ID != "e" {
+				t.Errorf("ID = %q, want %q (decoding must not abort early)", got.ID, "e")
+			}
+		})
+	}
+}
+
+// TestEventUnmarshalTimestampInvalid covers timestamps that cannot be
+// decoded. These must surface an error rather than silently leaving the
+// field zero, which would look like a valid epoch.
+func TestEventUnmarshalTimestampInvalid(t *testing.T) {
+	for _, in := range []string{
+		`{"timestamp":"not-a-date"}`,
+		`{"timestamp":{"nested":1}}`,
+		`{"timestamp":true}`,
+		// Out of range for int64 microseconds. Converting these saturates
+		// silently, which would yield a plausible-looking instant in the year
+		// -290308 and discard the sign, so they must be rejected.
+		`{"timestamp":1e300}`,
+		`{"timestamp":-1e300}`,
+		`{"timestamp":1e19}`,
+		`{"timestamp":9223372036854775807}`,
+		// Epoch milliseconds read as seconds. Decodes without complaint to the
+		// year 56887, which sorts after every real event.
+		`{"timestamp":1733040000000}`,
+	} {
+		got := &session.Event{}
+		if err := json.Unmarshal([]byte(in), got); err == nil {
+			t.Errorf("Unmarshal(%s) = nil error, want an error", in)
+		}
+	}
+}
+
+// TestEventUnmarshalLegacyFieldNames covers rows written before Event carried
+// json tags, when encoding/json used Go field names verbatim. encoding/json
+// matches keys case-insensitively, so these must still bind.
+func TestEventUnmarshalLegacyFieldNames(t *testing.T) {
+	legacy := `{
+	  "ID":"evt-1","InvocationID":"inv-1","Author":"planner","Branch":"root",
+	  "Timestamp":"2024-12-01T08:00:00Z","Routes":["reviewer"],
+	  "Output":{"summary":"ok"},"LongRunningToolIDs":["tool-1"],
+	  "Actions":{"StateDelta":{"stage":"drafted"},"TransferToAgent":"writer"},
+	  "Partial":true,"ErrorCode":"429"
+	}`
+	got := &session.Event{}
+	if err := json.Unmarshal([]byte(legacy), got); err != nil {
+		t.Fatalf("Unmarshal() failed: %v", err)
+	}
+	want := &session.Event{
+		LLMResponse:        model.LLMResponse{Partial: true, ErrorCode: "429"},
+		ID:                 "evt-1",
+		Timestamp:          time.Unix(1733040000, 0).UTC(),
+		InvocationID:       "inv-1",
+		Branch:             "root",
+		Author:             "planner",
+		LongRunningToolIDs: []string{"tool-1"},
+		Routes:             []string{"reviewer"},
+		Output:             map[string]any{"summary": "ok"},
+		Actions: session.EventActions{
+			StateDelta:      map[string]any{"stage": "drafted"},
+			TransferToAgent: "writer",
+		},
+	}
+	if diff := cmp.Diff(want, got); diff != "" {
+		t.Errorf("legacy field names mismatch (-want +got):\n%s", diff)
+	}
+}
+
+// TestEventUnmarshalIntoPopulatedEvent covers decoding into an Event that
+// already holds values. encoding/json leaves fields absent from the payload
+// alone, and the timestamp retry inside UnmarshalJSON must not change that.
+func TestEventUnmarshalIntoPopulatedEvent(t *testing.T) {
+	tests := []struct {
+		name string
+		in   string
+	}{
+		{"string timestamp", `{"id":"new","timestamp":"2024-12-01T08:00:00Z"}`},
+		{"numeric timestamp", `{"id":"new","timestamp":1733040000}`},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got := &session.Event{Branch: "preexisting", Author: "keepme"}
+			if err := json.Unmarshal([]byte(tt.in), got); err != nil {
+				t.Fatalf("Unmarshal() failed: %v", err)
+			}
+			want := &session.Event{
+				ID:        "new",
+				Timestamp: time.Unix(1733040000, 0).UTC(),
+				Branch:    "preexisting",
+				Author:    "keepme",
+			}
+			if diff := cmp.Diff(want, got); diff != "" {
+				t.Errorf("mismatch (-want +got):\n%s", diff)
+			}
+		})
+	}
+}
+
+// TestEventUnmarshalEmptyNodeInfoBecomesNil covers the shape adk-python
+// actually emits. Its node_info field is not Optional and it dumps with
+// exclude_none, so every event it writes carries a nodeInfo object, including
+// events that never came from a workflow. Decoding that to a non-nil pointer
+// would contradict the invariant readers rely on, which is that a nil NodeInfo
+// means the event is not from a workflow.
+func TestEventUnmarshalEmptyNodeInfoBecomesNil(t *testing.T) {
+	tests := []struct {
+		name string
+		in   string
+		want *session.NodeInfo
+	}{
+		{
+			name: "absent",
+			in:   `{"id":"e"}`,
+			want: nil,
+		},
+		{
+			name: "empty object, as adk-python writes for a non-workflow event",
+			in:   `{"id":"e","nodeInfo":{}}`,
+			want: nil,
+		},
+		{
+			name: "explicitly zero fields",
+			in:   `{"id":"e","nodeInfo":{"path":"","messageAsOutput":false,"outputFor":[]}}`,
+			want: nil,
+		},
+		{
+			name: "a path alone is real workflow metadata",
+			in:   `{"id":"e","nodeInfo":{"path":"wf/planner"}}`,
+			want: &session.NodeInfo{Path: "wf/planner"},
+		},
+		{
+			name: "messageAsOutput alone is real workflow metadata",
+			in:   `{"id":"e","nodeInfo":{"messageAsOutput":true}}`,
+			want: &session.NodeInfo{MessageAsOutput: true},
+		},
+		{
+			name: "outputFor alone is real workflow metadata",
+			in:   `{"id":"e","nodeInfo":{"outputFor":["wf"]}}`,
+			want: &session.NodeInfo{OutputFor: []string{"wf"}},
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got := &session.Event{}
+			if err := json.Unmarshal([]byte(tt.in), got); err != nil {
+				t.Fatalf("Unmarshal(%s) failed: %v", tt.in, err)
+			}
+			if diff := cmp.Diff(tt.want, got.NodeInfo); diff != "" {
+				t.Errorf("NodeInfo mismatch (-want +got):\n%s", diff)
+			}
+		})
+	}
+}
+
+// TestEventJSONPreservesEmptyActionMaps guards the nil-ness of the two map
+// fields on EventActions. NewEvent allocates them, and callers write into them
+// without a nil check, so a map that survives the trip out to JSON as an empty
+// object has to come back as an empty map rather than nil. Tagging these
+// omitempty drops the key entirely, and the map then decodes to nil and panics
+// on the first write.
+func TestEventJSONPreservesEmptyActionMaps(t *testing.T) {
+	want := session.NewEvent(context.Background(), "inv-1")
+	if want.Actions.StateDelta == nil || want.Actions.ArtifactDelta == nil {
+		t.Fatal("NewEvent no longer allocates the action maps; this test is no longer covering anything")
+	}
+
+	b, err := json.Marshal(want)
+	if err != nil {
+		t.Fatalf("Marshal() failed: %v", err)
+	}
+	got := &session.Event{}
+	if err := json.Unmarshal(b, got); err != nil {
+		t.Fatalf("Unmarshal() failed: %v", err)
+	}
+
+	if got.Actions.StateDelta == nil {
+		t.Error("StateDelta is nil after a round trip; writing to it would panic")
+	}
+	if got.Actions.ArtifactDelta == nil {
+		t.Error("ArtifactDelta is nil after a round trip; writing to it would panic")
+	}
+}
+
+// TestEventActionsJSONDeltaMapEncoding pins how the two delta maps cross the
+// wire. A nil map is omitted and an allocated one is written even when empty,
+// which is what keeps the nil/empty distinction intact through a round trip
+// while never emitting `null`. adk-python rejects `null` for either field --
+// both are non-Optional dicts -- and fills an absent key from its default
+// factory, so an omitted key is the one encoding both runtimes accept.
+func TestEventActionsJSONDeltaMapEncoding(t *testing.T) {
+	tests := []struct {
+		name    string
+		actions session.EventActions
+		want    map[string]string // json key -> raw value, "" means absent
+	}{
+		{
+			name:    "nil maps are omitted",
+			actions: session.EventActions{},
+			want:    map[string]string{"stateDelta": "", "artifactDelta": ""},
+		},
+		{
+			name: "allocated but empty maps are written",
+			actions: session.EventActions{
+				StateDelta:    map[string]any{},
+				ArtifactDelta: map[string]int64{},
+			},
+			want: map[string]string{"stateDelta": "{}", "artifactDelta": "{}"},
+		},
+		{
+			name: "populated maps are written",
+			actions: session.EventActions{
+				StateDelta:    map[string]any{"k": "v"},
+				ArtifactDelta: map[string]int64{"f.png": 7},
+			},
+			want: map[string]string{"stateDelta": `{"k":"v"}`, "artifactDelta": `{"f.png":7}`},
+		},
+		{
+			name:    "one allocated, one nil",
+			actions: session.EventActions{StateDelta: map[string]any{}},
+			want:    map[string]string{"stateDelta": "{}", "artifactDelta": ""},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			b, err := json.Marshal(&session.Event{ID: "e", Author: "a", Actions: tt.actions})
+			if err != nil {
+				t.Fatalf("Marshal() failed: %v", err)
+			}
+
+			var wire struct {
+				Actions map[string]json.RawMessage `json:"actions"`
+			}
+			if err := json.Unmarshal(b, &wire); err != nil {
+				t.Fatalf("Unmarshal() failed: %v", err)
+			}
+			for key, want := range tt.want {
+				raw, ok := wire.Actions[key]
+				if want == "" {
+					if ok {
+						t.Errorf("actions.%s = %s, want the key to be absent", key, raw)
+					}
+					continue
+				}
+				if !ok {
+					t.Errorf("actions.%s is absent, want %s", key, want)
+					continue
+				}
+				if string(raw) != want {
+					t.Errorf("actions.%s = %s, want %s", key, raw, want)
+				}
+			}
+
+			// Whatever the shape, `null` must never reach adk-python.
+			for _, key := range []string{"stateDelta", "artifactDelta"} {
+				if string(wire.Actions[key]) == "null" {
+					t.Errorf("actions.%s = null; adk-python rejects that for a non-Optional dict", key)
+				}
+			}
+
+			// And the round trip preserves nil-ness exactly, so a store that
+			// persists as JSON hands back the event it was given.
+			got := &session.Event{}
+			if err := json.Unmarshal(b, got); err != nil {
+				t.Fatalf("Unmarshal() failed: %v", err)
+			}
+			if (got.Actions.StateDelta == nil) != (tt.actions.StateDelta == nil) {
+				t.Errorf("StateDelta nil=%v after round trip, want nil=%v",
+					got.Actions.StateDelta == nil, tt.actions.StateDelta == nil)
+			}
+			if (got.Actions.ArtifactDelta == nil) != (tt.actions.ArtifactDelta == nil) {
+				t.Errorf("ArtifactDelta nil=%v after round trip, want nil=%v",
+					got.Actions.ArtifactDelta == nil, tt.actions.ArtifactDelta == nil)
+			}
+		})
+	}
+}

--- a/session/session.go
+++ b/session/session.go
@@ -16,8 +16,11 @@ package session
 
 import (
 	"context"
+	"encoding/json"
 	"errors"
+	"fmt"
 	"iter"
+	"math"
 	"time"
 
 	"github.com/google/jsonschema-go/jsonschema"
@@ -95,11 +98,11 @@ type Event struct {
 	model.LLMResponse
 
 	// Set by storage
-	ID        string
-	Timestamp time.Time
+	ID        string    `json:"id"`
+	Timestamp time.Time `json:"timestamp"`
 
 	// Set by agent.Context implementation.
-	InvocationID string
+	InvocationID string `json:"invocationId"`
 	// The branch of the event.
 	//
 	// The format is like agent_1.agent_2.agent_3, where agent_1 is
@@ -107,23 +110,23 @@ type Event struct {
 	//
 	// Branch is used when multiple sub-agent shouldn't see their peer agents'
 	// conversation history.
-	Branch string
+	Branch string `json:"branch,omitempty"`
 	// IsolationScope, when set, restricts which agent contexts include this
 	// event in LLM prompt history: an event is visible only when
 	// event.IsolationScope equals the agent's isolation scope (exact match;
 	// empty sees only empty). Empty for non-scoped events.
 	IsolationScope string `json:"isolationScope,omitempty"`
 	// Author is the name of the event's author
-	Author string
+	Author string `json:"author"`
 
 	// The actions taken by the agent.
-	Actions EventActions
+	Actions EventActions `json:"actions"`
 	// Set of IDs of the long running function calls.
 	// Agent client will know from this field about which function call is long running.
 	// Only valid for function call event.
-	LongRunningToolIDs []string
+	LongRunningToolIDs []string `json:"longRunningToolIds,omitempty"`
 	// Routing information for workflow execution
-	Routes []string
+	Routes []string `json:"routes,omitempty"`
 	// RequestedInput, when non-nil, signals that the workflow node
 	// emitting this event is asking for human input and is about to
 	// pause. The workflow scheduler observes this field at event
@@ -132,10 +135,10 @@ type Event struct {
 	// the same field to render the prompt.
 	//
 	// At most one event per node activation may carry this field.
-	RequestedInput *RequestInput
+	RequestedInput *RequestInput `json:"requestedInput,omitempty"`
 
 	// Output is the generic data output from a workflow node.
-	Output any
+	Output any `json:"output,omitempty"`
 
 	// NodeInfo carries workflow-node metadata for events emitted
 	// inside a workflow. Nil for non-workflow events.
@@ -210,7 +213,7 @@ type RequestInput struct {
 // Note: when multiple agents participate in one invocation, there could be
 // multiple events with IsFinalResponse() as True, for each participating agent.
 func (e *Event) IsFinalResponse() bool {
-	if (e.Actions.SkipSummarization) || len(e.LongRunningToolIDs) > 0 {
+	if e.Actions.SkipSummarization || len(e.LongRunningToolIDs) > 0 {
 		return true
 	}
 
@@ -235,21 +238,66 @@ func NewEvent(ctx context.Context, invocationID string) *Event {
 // EventActions represent the actions attached to an event.
 type EventActions struct {
 	// Set by agent.Context implementation.
-	StateDelta map[string]any
+	StateDelta map[string]any `json:"stateDelta"`
 
 	// Indicates that the event is updating an artifact. key is the filename,
 	// value is the version.
-	ArtifactDelta map[string]int64
+	ArtifactDelta map[string]int64 `json:"artifactDelta"`
 
-	RequestedToolConfirmations map[string]toolconfirmation.ToolConfirmation
+	RequestedToolConfirmations map[string]toolconfirmation.ToolConfirmation `json:"requestedToolConfirmations,omitempty"`
 
 	// If true, it won't call model to summarize function response.
 	// Only valid for function response event.
-	SkipSummarization bool
+	SkipSummarization bool `json:"skipSummarization,omitempty"`
 	// If set, the event transfers to the specified agent.
-	TransferToAgent string
+	TransferToAgent string `json:"transferToAgent,omitempty"`
 	// The agent is escalating to a higher level agent.
-	Escalate bool
+	Escalate bool `json:"escalate,omitempty"`
+}
+
+// MarshalJSON omits StateDelta and ArtifactDelta when they are nil and writes
+// an empty object when they are allocated but empty.
+//
+// The two cases have to stay distinguishable, and neither `omitempty` nor a
+// plain tag manages it. A map tagged `omitempty` is dropped whenever its
+// length is zero, which loses the difference: NewEvent allocates both maps and
+// callers write into them without a nil check, so an allocated-but-empty map
+// that decodes back as nil panics on the first write. Leaving the tag bare
+// keeps the difference but encodes a nil map as `null`, which adk-python
+// rejects -- both fields are non-Optional dicts there, so the whole
+// EventActions fails to validate ("Input should be an object", type=dict_type)
+// and takes the event with it.
+//
+// Omitting the key is the third option and the only one that satisfies both:
+// adk-python fills an absent key from the field's default factory, and Go
+// decodes it back to nil, so nil stays nil and empty stays empty in either
+// runtime. The shadowing pointer fields below express that -- `omitempty` on a
+// pointer keys off the pointer being nil, not the length of what it points to.
+func (a EventActions) MarshalJSON() ([]byte, error) {
+	// alias strips this method, so json does not recurse into it. The two
+	// pointer fields sit at depth 0 and shadow the promoted ones at depth 1,
+	// which is how encoding/json resolves a name collision; embedding rather
+	// than restating the struct keeps fields added upstream from being
+	// silently dropped here.
+	type alias EventActions
+	return json.Marshal(struct {
+		alias
+		StateDelta    *map[string]any   `json:"stateDelta,omitempty"`
+		ArtifactDelta *map[string]int64 `json:"artifactDelta,omitempty"`
+	}{
+		alias:         alias(a),
+		StateDelta:    nilOrRef(a.StateDelta),
+		ArtifactDelta: nilOrRef(a.ArtifactDelta),
+	})
+}
+
+// nilOrRef returns nil for a nil map and a pointer to m otherwise, turning
+// "is this map allocated" into something `omitempty` can act on.
+func nilOrRef[M ~map[K]V, K comparable, V any](m M) *M {
+	if m == nil {
+		return nil
+	}
+	return &m
 }
 
 // Prefixes for defining session's state scopes
@@ -302,4 +350,90 @@ func hasTrailingCodeExecutionResult(resp *model.LLMResponse) bool {
 	}
 	lastPart := resp.Content.Parts[len(resp.Content.Parts)-1]
 	return lastPart.CodeExecutionResult != nil
+}
+
+// Bounds on a decoded numeric event timestamp, in microseconds: years 1 and
+// 9999. Wide enough for any real event time, narrow enough that a value in the
+// wrong unit falls outside.
+const (
+	minTimestampMicros = -62135596800 * 1e6
+	maxTimestampMicros = 253402300799 * 1e6
+)
+
+// UnmarshalJSON decodes an Event, accepting the timestamp either as an RFC
+// 3339 string (this package's own encoding) or as a JSON number of epoch
+// seconds. The numeric form is what adk-python emits, since its Event
+// timestamp is a float; without this an Event serialized by another ADK
+// runtime fails to decode part-way through, leaving the fields after the
+// timestamp unset.
+//
+// Numeric timestamps are resolved to microseconds, matching the resolution of
+// Python's datetime. float64 cannot represent epoch seconds to nanosecond
+// precision, so a finer value would only encode rounding noise.
+func (e *Event) UnmarshalJSON(b []byte) error {
+	if err := e.unmarshalJSON(b); err != nil {
+		return err
+	}
+	// adk-python's node_info field is not Optional, and it dumps with
+	// exclude_none, so every event it writes carries a nodeInfo object even
+	// for non-workflow events. Decoding that yields a non-nil pointer to an
+	// empty NodeInfo, which contradicts the documented invariant above that a
+	// nil NodeInfo means the event did not come from a workflow -- readers
+	// test the pointer, not its contents. An all-zero NodeInfo carries no
+	// information, so it is indistinguishable from absent.
+	if ni := e.NodeInfo; ni != nil && ni.Path == "" && !ni.MessageAsOutput && len(ni.OutputFor) == 0 {
+		e.NodeInfo = nil
+	}
+	return nil
+}
+
+func (e *Event) unmarshalJSON(b []byte) error {
+	type alias Event // strips methods, so json does not recurse into this one
+
+	// Fast path: a timestamp this package wrote decodes directly, so reading
+	// back our own events does not pay for the retry below. An event sourced
+	// from adk-python carries a numeric timestamp and always takes the retry,
+	// so this is a fast path for one writer, not for every read.
+	before := *e
+	if err := json.Unmarshal(b, (*alias)(e)); err == nil {
+		return nil
+	}
+
+	// Something did not decode. Retry with the timestamp held back, since that
+	// is the field that legitimately differs between ADK runtimes. Restore the
+	// original value first: the failed attempt may have partly overwritten it,
+	// and decoding into an already-populated Event leaves absent fields alone.
+	*e = before
+	aux := struct {
+		Timestamp json.RawMessage `json:"timestamp"`
+		*alias
+	}{alias: (*alias)(e)}
+	if err := json.Unmarshal(b, &aux); err != nil {
+		return err
+	}
+	if len(aux.Timestamp) == 0 || string(aux.Timestamp) == "null" {
+		return nil
+	}
+	if aux.Timestamp[0] == '"' {
+		if err := e.Timestamp.UnmarshalJSON(aux.Timestamp); err != nil {
+			return fmt.Errorf("session: decoding event timestamp %s: %w", aux.Timestamp, err)
+		}
+		return nil
+	}
+	var secs float64
+	if err := json.Unmarshal(aux.Timestamp, &secs); err != nil {
+		return fmt.Errorf("session: decoding event timestamp %s: %w", aux.Timestamp, err)
+	}
+	micros := math.Round(secs * 1e6)
+	// Reject anything outside the calendar. Two things land here: a float64 too
+	// large for an int64, whose conversion is implementation-defined and
+	// saturates silently while losing the sign; and a value in the wrong unit,
+	// where epoch milliseconds read as seconds gives a decodable, wrong-looking
+	// instant tens of thousands of years out. Both are better as errors than as
+	// an event that sorts into the far future.
+	if math.IsNaN(micros) || micros < minTimestampMicros || micros > maxTimestampMicros {
+		return fmt.Errorf("session: event timestamp %s is not a plausible date", aux.Timestamp)
+	}
+	e.Timestamp = time.UnixMicro(int64(micros)).UTC()
+	return nil
 }

--- a/session/vertexai/raw_event_crossruntime_test.go
+++ b/session/vertexai/raw_event_crossruntime_test.go
@@ -1,0 +1,181 @@
+// Copyright 2025 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package vertexai
+
+import (
+	"sort"
+	"testing"
+	"time"
+
+	"github.com/google/go-cmp/cmp"
+	"google.golang.org/genai"
+	"google.golang.org/protobuf/types/known/structpb"
+
+	"google.golang.org/adk/v2/model"
+	"google.golang.org/adk/v2/session"
+)
+
+// TestRawEventWireKeysAreCamelCase pins the key names raw_event carries. The
+// field is shared with other ADK runtimes, whose models bind camelCase
+// aliases and ignore unknown keys, so a PascalCase key is not a cosmetic
+// difference: it decodes to a default value with no error.
+func TestRawEventWireKeysAreCamelCase(t *testing.T) {
+	event := &session.Event{
+		LLMResponse:        model.LLMResponse{Content: genai.NewContentFromText("hi", genai.RoleModel)},
+		ID:                 "evt-1",
+		Timestamp:          time.Unix(1733040000, 0).UTC(),
+		InvocationID:       "inv-1",
+		Branch:             "root.planner",
+		Author:             "planner",
+		IsolationScope:     "approval_subflow",
+		LongRunningToolIDs: []string{"tool-1"},
+		Routes:             []string{"reviewer"},
+		RequestedInput:     &session.RequestInput{InterruptID: "approval-1", Message: "Approve?"},
+		Output:             map[string]any{"summary": "ok"},
+		NodeInfo:           &session.NodeInfo{Path: "wf/planner", MessageAsOutput: true},
+		Actions:            session.EventActions{StateDelta: map[string]any{"stage": "drafted"}},
+	}
+
+	raw, err := eventToRawEvent(event)
+	if err != nil {
+		t.Fatalf("eventToRawEvent() error = %v", err)
+	}
+	got := make([]string, 0, len(raw.GetFields()))
+	for k := range raw.GetFields() {
+		got = append(got, k)
+	}
+	sort.Strings(got)
+
+	want := []string{
+		"actions", "author", "branch", "content", "id", "invocationId",
+		"isolationScope", "longRunningToolIds", "nodeInfo", "output",
+		"requestedInput", "routes", "timestamp",
+	}
+	if diff := cmp.Diff(want, got); diff != "" {
+		t.Errorf("raw_event wire keys mismatch (-want +got):\n%s", diff)
+	}
+}
+
+// pythonRawEvent is a raw_event payload as emitted by adk-python, whose Event
+// model dumps camelCase aliases and carries its timestamp as a float. Captured
+// from an instrumented run rather than written by hand, so it reflects the
+// encoding actually found in shared session corpora.
+const pythonRawEvent = `{
+  "actions": {"artifactDelta": {"artifact": 1.0}, "escalate": true,
+              "requestedAuthConfigs": {}, "requestedToolConfirmations": {},
+              "skipSummarization": true, "stateDelta": {"state": "updated"},
+              "transferToAgent": "test-agent"},
+  "author": "user",
+  "branch": "test-branch",
+  "content": {"parts": [{"text": "Hello, raw_event!"},
+                        {"functionCall": {"args": {"arg1": "value1"},
+                                          "id": "test-id", "name": "test-function"}}],
+              "role": "user"},
+  "customMetadata": {"custom-key": "custom-value"},
+  "errorCode": "400",
+  "errorMessage": "test error",
+  "groundingMetadata": {"retrievalQueries": ["query2"], "webSearchQueries": ["query1"]},
+  "id": "test-id",
+  "interrupted": true,
+  "invocationId": "test-invocation-id",
+  "isolationScope": "scope-1",
+  "longRunningToolIds": ["test-tool-id-1", "test-tool-id-2"],
+  "nodeInfo": {"messageAsOutput": true, "outputFor": ["wf/A@1/B@1", "wf/A@1"],
+               "path": "wf/A@1/B@1"},
+  "output": {"count": 3.0, "result": "ok"},
+  "partial": true,
+  "timestamp": 1733040000.0,
+  "turnComplete": true,
+  "usageMetadata": {"candidatesTokenCount": 50.0, "promptTokenCount": 100.0,
+                    "totalTokenCount": 200.0}
+}`
+
+// TestEventFromRawEventDecodesOtherRuntimeDump reads a raw_event written by a
+// different ADK runtime. Sessions are shared across runtimes, so this is a
+// read path that runs in production, not a hypothetical.
+func TestEventFromRawEventDecodesOtherRuntimeDump(t *testing.T) {
+	raw := &structpb.Struct{}
+	if err := raw.UnmarshalJSON([]byte(pythonRawEvent)); err != nil {
+		t.Fatalf("test fixture is not valid JSON: %v", err)
+	}
+
+	got, err := eventFromRawEvent(raw)
+	if err != nil {
+		t.Fatalf("eventFromRawEvent() error = %v", err)
+	}
+
+	// The timestamp arrives as a float; decoding must not abort on it and
+	// leave every later field unset.
+	if want := time.Unix(1733040000, 0).UTC(); !got.Timestamp.UTC().Equal(want) {
+		t.Errorf("Timestamp = %v, want %v", got.Timestamp.UTC(), want)
+	}
+
+	scalars := []struct {
+		name string
+		got  any
+		want any
+	}{
+		{"Author", got.Author, "user"},
+		{"Branch", got.Branch, "test-branch"},
+		{"InvocationID", got.InvocationID, "test-invocation-id"},
+		{"IsolationScope", got.IsolationScope, "scope-1"},
+		{"ErrorCode", got.ErrorCode, "400"},
+		{"ErrorMessage", got.ErrorMessage, "test error"},
+		{"Partial", got.Partial, true},
+		{"TurnComplete", got.TurnComplete, true},
+		{"Interrupted", got.Interrupted, true},
+		{"Actions.TransferToAgent", got.Actions.TransferToAgent, "test-agent"},
+		{"Actions.Escalate", got.Actions.Escalate, true},
+		{"Actions.SkipSummarization", got.Actions.SkipSummarization, true},
+	}
+	for _, s := range scalars {
+		if diff := cmp.Diff(s.want, s.got); diff != "" {
+			t.Errorf("%s mismatch (-want +got):\n%s", s.name, diff)
+		}
+	}
+
+	wantNode := &session.NodeInfo{
+		Path:            "wf/A@1/B@1",
+		MessageAsOutput: true,
+		OutputFor:       []string{"wf/A@1/B@1", "wf/A@1"},
+	}
+	if diff := cmp.Diff(wantNode, got.NodeInfo); diff != "" {
+		t.Errorf("NodeInfo mismatch (-want +got):\n%s", diff)
+	}
+	if diff := cmp.Diff(map[string]any{"count": float64(3), "result": "ok"}, got.Output); diff != "" {
+		t.Errorf("Output mismatch (-want +got):\n%s", diff)
+	}
+	if diff := cmp.Diff(map[string]any{"state": "updated"}, got.Actions.StateDelta); diff != "" {
+		t.Errorf("Actions.StateDelta mismatch (-want +got):\n%s", diff)
+	}
+	if diff := cmp.Diff([]string{"test-tool-id-1", "test-tool-id-2"}, got.LongRunningToolIDs); diff != "" {
+		t.Errorf("LongRunningToolIDs mismatch (-want +got):\n%s", diff)
+	}
+
+	if got.Content == nil || len(got.Content.Parts) != 2 {
+		t.Fatalf("Content = %v, want 2 parts", got.Content)
+	}
+	if want := "Hello, raw_event!"; got.Content.Parts[0].Text != want {
+		t.Errorf("Content.Parts[0].Text = %q, want %q", got.Content.Parts[0].Text, want)
+	}
+	fc := got.Content.Parts[1].FunctionCall
+	if fc == nil {
+		t.Fatal("Content.Parts[1].FunctionCall = nil, want a decoded function call")
+	}
+	if fc.Name != "test-function" || fc.ID != "test-id" {
+		t.Errorf("FunctionCall = {Name:%q ID:%q}, want {Name:%q ID:%q}",
+			fc.Name, fc.ID, "test-function", "test-id")
+	}
+}

--- a/session/vertexai/vertexai_client.go
+++ b/session/vertexai/vertexai_client.go
@@ -327,9 +327,16 @@ func eventNeedsRawEvent(event *session.Event) bool {
 }
 
 // eventToRawEvent serializes a session.Event into a structpb.Struct for
-// the SessionEvent.raw_event field. Uses Go's JSON encoding; not yet
-// byte-compatible with adk-python's camelCase dump (cross-runtime parity
-// is tracked separately).
+// the SessionEvent.raw_event field. session.Event is tagged camelCase, so the
+// keys match adk-python's dump; the timestamp is the remaining difference,
+// written here as an RFC 3339 string where adk-python writes epoch seconds.
+// Readers of raw_event take the timestamp from the SessionEvent envelope
+// rather than the blob, so that difference does not normally reach them. Note
+// the dependency is not unconditional on the adk-python side: it overrides
+// only `if timestamp_obj` (vertex_ai_session_service.py), so a raw_event whose
+// envelope carries no timestamp leaves the RFC 3339 string in place against a
+// float field and fails validation for the whole event. The service populates
+// the envelope, so this is a guard on an invariant rather than a live risk.
 //
 // Integers in the any-typed Output and StateDelta come back as float64
 // (structpb numbers and json.Unmarshal into any are both float64). This


### PR DESCRIPTION
Link to Issue or Description of Change
1. Link to an existing issue (if applicable):

Closes: #1251 

Problem:

session.Event has no coherent JSON encoding — only 2 of its fields carry a json tag, and neither model.LLMResponse nor session.EventActions carries any. A minimal Event marshals to 27 mostly-PascalCase keys, 12 of them null.

Since session/vertexai writes a whole Event into the Vertex raw_event field, and that field is shared with adk-python, this silently corrupts data in both directions:

Go → Python: every PascalCase key is dropped by adk-python's extra='ignore', and model_validate_json still succeeds, returning a fabricated event (new random id, empty author/invocation_id, timestamp of "now").
Python → Go: the float epoch timestamp aborts the decode part-way, so every field after it is silently left unset.

Solution:

Tag Event, EventActions and LLMResponse with the camelCase contract that server/adkrest/internal/models/event.go already defines, and accept both timestamp dialects on read.

Three points where the obvious approach doesn't work:

stateDelta/artifactDelta need a custom MarshalJSON, not a tag. omitempty drops nil and allocated-empty alike, and NewEvent allocates both maps — an allocated-empty map decoding back as nil panics on the first write. A bare tag keeps them distinct but writes null, which adk-python rejects (both are non-Optional dict). Omitting the key only when nil satisfies both runtimes; omitempty on a pointer keys off the pointer, not the length.
Numeric timestamps resolve to microseconds, matching Python's datetime. float64 can't hold epoch seconds to ns precision. Out-of-range values are rejected rather than narrowed, since an out-of-range float64 saturates silently and loses its sign.
An all-zero NodeInfo decodes back to nil, because adk-python dumps a nodeInfo object on every event and readers here test the pointer, not the contents.

Reading stays backward compatible — encoding/json matches keys case-insensitively, so previously written events still decode.

Writing changes shape: camelCase keys, empties dropped, 27 keys → 5 for an empty event. plugin/agentanalytics (marshals LLMResponse into BigQuery) is the known in-repo consumer.
Testing Plan
Unit Tests:

I have added or updated unit tests for my change.
All unit tests pass locally.

New: session/event_json_test.go (385 lines) and session/vertexai/raw_event_crossruntime_test.go (181 lines), covering the golden key set, both timestamp dialects, out-of-range and boundary timestamps, NodeInfo nil-ness, and the delta-map encoding (nil / allocated-empty / populated / mixed).

Full workspace run, matching CI (go work init && go work use -r .):

> $ go build -mod=readonly work
> $ go test -race -mod=readonly -count=1 -shuffle=on work
> ok  google.golang.org/adk/v2/session          0.071s
> ok  google.golang.org/adk/v2/session/database 0.405s
> ok  google.golang.org/adk/v2/session/vertexai 1.475s
> ok  google.golang.org/adk/v2/model            ...
> ... all modules ok
> 
> $ golangci-lint run                       # root module
> 0 issues.
> $ cd plugin/agentanalytics && golangci-lint run
> 0 issues.
> 
> $ go mod tidy -diff                       # both modules, no output

Every behavioural change was checked with a negative control — revert the fix, confirm the new test fails with the expected diff, restore. Two examples:

Dropping EventActions.MarshalJSON → actions.stateDelta = null.
Replacing it with plain omitempty → StateDelta is nil after a round trip; writing to it would panic.

Manual End-to-End (E2E) Tests:

Per CONTRIBUTING.md ("we lean on adk-python for being the source of truth"), the encoding was validated against real adk-python rather than against my reading of its models. The JSON this branch emits was captured verbatim and fed to pydantic:

> Input (verbatim Go output)
> EventActions.model_validate_json
> {} (both maps nil)
> ✅ accepted, both default to {}
> {"stateDelta":{},"artifactDelta":{}}
> ✅ accepted
> {"stateDelta":{"user:k":"v"},"artifactDelta":{"f.png":7}}
> ✅ values preserved
> every field populated, incl. requestedToolConfirmations
> ✅ all values round-trip
> {"stateDelta":null} (what a bare tag would write)
> ❌ Input should be an object [type=dict_type]
> {"StateDelta":{}} (what main writes today)
> ❌ Extra inputs are not permitted [type=extra_forbidden]


Before/after on the headline case — the same Event marshaled by Go, read by adk-python:

> BEFORE (main):  id='53d607ea-…' (regenerated)  author=''  invocation_id=''
>                 timestamp=<now>                 actions=<all defaults>
>                 → validation SUCCEEDS, event silently blank
> 
> AFTER  (this):  id='e-1'  author='agent'  invocation_id='inv-1'
>                 → values preserved

Also verified there are no duplicate keys in the output (the MarshalJSON relies on encoding/json's depth-0-shadows-depth-1 rule) by parsing the raw bytes with a object_pairs_hook that rejects repeats.

Additional context
This touches the high-fan-in session and model packages and changes a persisted wire format, so per AGENTS.md Boundaries I filed #1251  first — happy to adjust the approach before review time is spent on the diff.

One note for reviewers: telemetry fails under -race in workspace mode on any commit before 046ae95 (conflicting Schema URL: …1.41.0 and …1.40.0, from dependency unification across the two modules). It is unrelated to this change and is fixed by the dependency bump in #1242; this branch is rebased onto it.