### PR TITLE
feat: support both string and object function call arguments and improve error reporting

### DIFF
--- a/model/openaimodel/errors.go
+++ b/model/openaimodel/errors.go
@@ -50,6 +50,8 @@ var (
 	ErrUnsupportedMessageContentType = errors.New("openai: unsupported message content type")
 	// ErrUnsupportedOutputItemType is returned when an unsupported output item type is used.
 	ErrUnsupportedOutputItemType = errors.New("openai: unsupported output item type")
+	// ErrFunctionCallArgs is returned when a function call's arguments are not a decodable JSON object.
+	ErrFunctionCallArgs = errors.New("openai: parse function call args")
 	// ErrNoTextOrToolContent is returned when the response output does not contain text or tool content.
 	ErrNoTextOrToolContent = errors.New("openai: response output did not contain text or tool content")
 )

--- a/model/openaimodel/response.go
+++ b/model/openaimodel/response.go
@@ -111,11 +111,11 @@ func convertOutputItems(items []responses.ResponseOutputItemUnion) ([]*genai.Par
 }
 
 func convertFunctionCall(item responses.ResponseOutputItemUnion) (*genai.Part, error) {
-	args := map[string]any{}
-	if item.Arguments.OfString != "" {
-		if err := json.Unmarshal([]byte(item.Arguments.OfString), &args); err != nil {
-			return nil, fmt.Errorf("openai: parse function call args: %w", err)
-		}
+	args, err := functionCallArgs(item.Arguments)
+	if err != nil {
+		// Name the offending call: convertOutputItems aborts the entire
+		// response on the first error, so nothing else identifies it.
+		return nil, fmt.Errorf("%w (name %q, call_id %q)", err, item.Name, item.CallID)
 	}
 	return &genai.Part{
 		FunctionCall: &genai.FunctionCall{
@@ -124,6 +124,42 @@ func convertFunctionCall(item responses.ResponseOutputItemUnion) (*genai.Part, e
 			Args: args,
 		},
 	}, nil
+}
+
+// functionCallArgs decodes the arguments of a function call output item.
+func functionCallArgs(arguments responses.ResponseOutputItemUnionArguments) (map[string]any, error) {
+	var raw string
+	switch v := arguments.OfResponseToolSearchCallArguments.(type) {
+	case nil:
+		// Absent, null, or a value built by hand rather than decoded.
+		raw = arguments.OfString
+	case string:
+		// A JSON string; OfString holds the same value already unquoted.
+		raw = arguments.OfString
+	default:
+		raw = arguments.JSON.OfResponseToolSearchCallArguments.Raw()
+		if raw == "" {
+			// No wire bytes to recover, so this value was built by hand; there
+			// is no original payload for a re-encode to disagree with.
+			b, err := json.Marshal(v)
+			if err != nil {
+				return nil, fmt.Errorf("%w: %w", ErrFunctionCallArgs, err)
+			}
+			raw = string(b)
+		}
+	}
+	if raw == "" {
+		return map[string]any{}, nil
+	}
+	args := map[string]any{}
+	if err := json.Unmarshal([]byte(raw), &args); err != nil {
+		return nil, fmt.Errorf("%w: %w", ErrFunctionCallArgs, err)
+	}
+	if args == nil {
+		// The payload was JSON null: the call takes no arguments.
+		return map[string]any{}, nil
+	}
+	return args, nil
 }
 
 func finishReason(resp *responses.Response) genai.FinishReason {

--- a/model/openaimodel/response_test.go
+++ b/model/openaimodel/response_test.go
@@ -15,7 +15,9 @@
 package openaimodel
 
 import (
+	"encoding/json"
 	"errors"
+	"strings"
 	"testing"
 
 	"github.com/google/go-cmp/cmp"
@@ -242,6 +244,209 @@ func TestConvertFunctionCall(t *testing.T) {
 				t.Fatalf("unexpected args: %+v", got.FunctionCall.Args)
 			}
 		})
+	}
+}
+
+// TestConvertFunctionCall_DecodedArguments exercises the arguments field
+// through the SDK's real UnmarshalJSON path. Constructing
+// ResponseOutputItemUnionArguments as a struct literal bypasses that decoding
+// entirely, so it cannot tell which union arm a given wire payload populates.
+func TestConvertFunctionCall_DecodedArguments(t *testing.T) {
+	tests := []struct {
+		name     string
+		raw      string
+		wantArgs map[string]any
+		wantErr  bool
+	}{
+		{
+			name:     "string arguments",
+			raw:      `{"type":"function_call","name":"f","call_id":"c","arguments":"{\"location\":\"Paris\"}"}`,
+			wantArgs: map[string]any{"location": "Paris"},
+		},
+		{
+			// OpenAI-compatible endpoints commonly send a bare JSON object
+			// here rather than a string. These arguments must not be dropped.
+			name:     "object arguments",
+			raw:      `{"type":"function_call","name":"f","call_id":"c","arguments":{"location":"Paris"}}`,
+			wantArgs: map[string]any{"location": "Paris"},
+		},
+		{
+			name:     "empty object arguments",
+			raw:      `{"type":"function_call","name":"f","call_id":"c","arguments":{}}`,
+			wantArgs: map[string]any{},
+		},
+		{
+			name:     "empty string arguments",
+			raw:      `{"type":"function_call","name":"f","call_id":"c","arguments":""}`,
+			wantArgs: map[string]any{},
+		},
+		{
+			name:     "null arguments",
+			raw:      `{"type":"function_call","name":"f","call_id":"c","arguments":null}`,
+			wantArgs: map[string]any{},
+		},
+		{
+			name:     "absent arguments",
+			raw:      `{"type":"function_call","name":"f","call_id":"c"}`,
+			wantArgs: map[string]any{},
+		},
+		{
+			// A JSON string holding the literal null means "no arguments",
+			// matching a null in the bare arm. It must not yield a nil map:
+			// a tool wrapper writing to one would panic.
+			name:     "null string arguments",
+			raw:      `{"type":"function_call","name":"f","call_id":"c","arguments":"null"}`,
+			wantArgs: map[string]any{},
+		},
+		{
+			// Both arms must follow encoding/json's last-one-wins rule, as
+			// every other JSON consumer in the package does. The SDK decodes
+			// with gjson, which keeps the first occurrence, so decoding the
+			// bare arm from anything but the original bytes would resolve
+			// this to /tmp/safe and make the two arms disagree.
+			name:     "duplicate keys in object arguments",
+			raw:      `{"type":"function_call","name":"f","call_id":"c","arguments":{"path":"/tmp/safe","path":"/etc/shadow"}}`,
+			wantArgs: map[string]any{"path": "/etc/shadow"},
+		},
+		{
+			name:     "duplicate keys in string arguments",
+			raw:      `{"type":"function_call","name":"f","call_id":"c","arguments":"{\"path\":\"/tmp/safe\",\"path\":\"/etc/shadow\"}"}`,
+			wantArgs: map[string]any{"path": "/etc/shadow"},
+		},
+		{
+			// A non-object payload must surface an error rather than degrade
+			// into an empty argument map.
+			name:    "array arguments",
+			raw:     `{"type":"function_call","name":"f","call_id":"c","arguments":[1,2]}`,
+			wantErr: true,
+		},
+		{
+			name:    "number arguments",
+			raw:     `{"type":"function_call","name":"f","call_id":"c","arguments":42}`,
+			wantErr: true,
+		},
+		{
+			name:    "bool arguments",
+			raw:     `{"type":"function_call","name":"f","call_id":"c","arguments":true}`,
+			wantErr: true,
+		},
+		{
+			name:    "non-object string arguments",
+			raw:     `{"type":"function_call","name":"f","call_id":"c","arguments":"[1,2]"}`,
+			wantErr: true,
+		},
+		{
+			// Out of range for float64. The SDK's decoder turns this into
+			// +Inf, so it must be rejected from the original bytes rather
+			// than reported as a re-encoding failure.
+			name:    "out of range number in object arguments",
+			raw:     `{"type":"function_call","name":"f","call_id":"c","arguments":{"x":1e400}}`,
+			wantErr: true,
+		},
+		{
+			name:    "malformed string arguments",
+			raw:     `{"type":"function_call","name":"f","call_id":"c","arguments":"{not json"}`,
+			wantErr: true,
+		},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			var item responses.ResponseOutputItemUnion
+			if err := json.Unmarshal([]byte(tc.raw), &item); err != nil {
+				t.Fatalf("json.Unmarshal(%s) err = %v", tc.raw, err)
+			}
+			got, err := convertFunctionCall(item)
+			if (err != nil) != tc.wantErr {
+				t.Fatalf("convertFunctionCall() error = %v, wantErr %v", err, tc.wantErr)
+			}
+			if tc.wantErr {
+				if !errors.Is(err, ErrFunctionCallArgs) {
+					t.Errorf("error = %v, want errors.Is(err, ErrFunctionCallArgs)", err)
+				}
+				return
+			}
+			if got.FunctionCall.Args == nil {
+				t.Errorf("Args = nil, want non-nil (a nil map panics on write)")
+			}
+			if diff := cmp.Diff(tc.wantArgs, got.FunctionCall.Args); diff != "" {
+				t.Errorf("Args mismatch (-want +got):\n%s", diff)
+			}
+		})
+	}
+}
+
+// TestConvertFunctionCall_HandBuiltArguments covers values constructed as struct
+// literals rather than decoded from the wire, as callers do in their own tests.
+// These carry no JSON metadata and no original bytes, so neither arm can be
+// discriminated by presence alone.
+func TestConvertFunctionCall_HandBuiltArguments(t *testing.T) {
+	tests := []struct {
+		name     string
+		args     responses.ResponseOutputItemUnionArguments
+		wantArgs map[string]any
+	}{
+		{
+			name:     "string arm",
+			args:     responses.ResponseOutputItemUnionArguments{OfString: `{"location":"Paris"}`},
+			wantArgs: map[string]any{"location": "Paris"},
+		},
+		{
+			name:     "bare arm",
+			args:     responses.ResponseOutputItemUnionArguments{OfResponseToolSearchCallArguments: map[string]any{"location": "Paris"}},
+			wantArgs: map[string]any{"location": "Paris"},
+		},
+		{
+			name:     "zero value",
+			args:     responses.ResponseOutputItemUnionArguments{},
+			wantArgs: map[string]any{},
+		},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			got, err := convertFunctionCall(responses.ResponseOutputItemUnion{Arguments: tc.args})
+			if err != nil {
+				t.Fatalf("convertFunctionCall() err = %v", err)
+			}
+			if diff := cmp.Diff(tc.wantArgs, got.FunctionCall.Args); diff != "" {
+				t.Errorf("Args mismatch (-want +got):\n%s", diff)
+			}
+		})
+	}
+}
+
+// TestConvertResponse_BadFunctionCallArgs covers what the convertFunctionCall
+// tests structurally cannot, by going through the whole conversion:
+// convertOutputItems stops at the first error, so a single undecodable
+// arguments payload discards the entire response — the model's text is lost
+// with it, rather than the response degrading to its remaining parts. The
+// sentinel must also survive that wrapping chain, and the error must name the
+// offending call, since nothing else survives to identify it.
+func TestConvertResponse_BadFunctionCallArgs(t *testing.T) {
+	const raw = `{"id":"r","model":"m","output":[
+		{"type":"message","content":[{"type":"output_text","text":"hello"}]},
+		{"type":"function_call","name":"write_file","call_id":"call-1","arguments":[1,2]}]}`
+
+	var resp responses.Response
+	if err := json.Unmarshal([]byte(raw), &resp); err != nil {
+		t.Fatalf("json.Unmarshal() err = %v", err)
+	}
+	got, err := convertResponse(&resp)
+	if err == nil {
+		t.Fatalf("convertResponse() = %+v, want error", got)
+	}
+	// The preceding text part does not survive.
+	if got != nil {
+		t.Errorf("convertResponse() = %+v, want nil alongside the error", got)
+	}
+	if !errors.Is(err, ErrFunctionCallArgs) {
+		t.Errorf("error = %v, want errors.Is(err, ErrFunctionCallArgs)", err)
+	}
+	for _, want := range []string{`write_file`, `call-1`} {
+		if !strings.Contains(err.Error(), want) {
+			t.Errorf("error = %q, want it to mention %q", err, want)
+		}
 	}
 }
 


### PR DESCRIPTION
After the openai-go v3.46.0 bump (#1242), `function_call.arguments` is a union rather than a plain string, and `convertFunctionCall` read only the `OfString` arm — so an OpenAI-compatible endpoint sending arguments as a bare JSON object had them silently dropped and the tool ran with `{}`. This decodes both arms, taking the bare one from its original wire bytes rather than re-encoding the SDK's decoded value, because the SDK parses with gjson (first duplicate key wins) while the string arm, the SDK transport and `stream.go` all use encoding/json (last wins) — re-encoding would make the same payload yield different tool arguments depending only on its encoding. Null in any form now yields a non-nil empty map rather than a nil one that panics on write, and a non-object payload is an error instead of a silent `{}`; note that erroring aborts the whole response, so a bad tool call now discards the model's text too. Adds an `ErrFunctionCallArgs` sentinel so callers can `errors.Is`, and names the offending call in the error.
