### PR TITLE
fix(llm): retain streaming usage metadata

### DIFF
--- a/internal/llminternal/stream_aggregator.go
+++ b/internal/llminternal/stream_aggregator.go
@@ -78,7 +78,9 @@ func (s *streamingResponseAggregator) ProcessResponse(ctx context.Context, genRe
 
 func (s *streamingResponseAggregator) aggregateResponse(llmResponse *model.LLMResponse) *model.LLMResponse {
 	s.response = llmResponse
-	s.usageMetadata = llmResponse.UsageMetadata
+	if llmResponse.UsageMetadata != nil {
+		s.usageMetadata = llmResponse.UsageMetadata
+	}
 	if llmResponse.GroundingMetadata != nil {
 		s.groundingMetadata = llmResponse.GroundingMetadata
 	}

--- a/internal/llminternal/stream_aggregator_test.go
+++ b/internal/llminternal/stream_aggregator_test.go
@@ -1104,6 +1104,50 @@ func TestMetadataOnlyChunkDoesNotAbortStream(t *testing.T) {
 	}
 }
 
+func TestUsageMetadataRetainedWhenLaterChunkHasNoUsageMetadata(t *testing.T) {
+	aggregator := llminternal.NewStreamingResponseAggregator()
+	ctx := t.Context()
+
+	usageMetadata := &genai.GenerateContentResponseUsageMetadata{
+		PromptTokenCount:     3,
+		CandidatesTokenCount: 5,
+		TotalTokenCount:      8,
+	}
+	chunks := []*genai.GenerateContentResponse{
+		{
+			Candidates:    []*genai.Candidate{{Content: genai.NewContentFromText("Hello", "model")}},
+			UsageMetadata: usageMetadata,
+		},
+		{
+			Candidates: []*genai.Candidate{{
+				Content:      genai.NewContentFromText(" world", "model"),
+				FinishReason: genai.FinishReasonStop,
+			}},
+		},
+	}
+
+	for _, chunk := range chunks {
+		for _, err := range aggregator.ProcessResponse(ctx, chunk) {
+			if err != nil {
+				t.Fatalf("unexpected error processing chunk: %v", err)
+			}
+		}
+	}
+
+	finalResponse := aggregator.Close()
+	if finalResponse == nil {
+		t.Fatal("expected a final aggregated response, got nil")
+	}
+	if finalResponse.UsageMetadata == nil {
+		t.Fatal("expected usage metadata in the final aggregated response, got nil")
+	}
+	if finalResponse.UsageMetadata.PromptTokenCount != usageMetadata.PromptTokenCount ||
+		finalResponse.UsageMetadata.CandidatesTokenCount != usageMetadata.CandidatesTokenCount ||
+		finalResponse.UsageMetadata.TotalTokenCount != usageMetadata.TotalTokenCount {
+		t.Errorf("usage metadata was not retained: got %+v, want %+v", finalResponse.UsageMetadata, usageMetadata)
+	}
+}
+
 func TestFinishReasonUnexpectedToolCallPreservesErrorCode(t *testing.T) {
 	aggregator := llminternal.NewStreamingResponseAggregator()
 	ctx := t.Context()


### PR DESCRIPTION
Fixes #1248

Retain non nil UsageMetadata across streaming chunks so a later chunk without usage cannot erase usage reported earlier. Added regression coverage.

Tests:
* go test ./internal/llminternal/...