### PR TITLE
fix(workflow): propagate external context cancellation

### DIFF
--- a/workflow/scheduler.go
+++ b/workflow/scheduler.go
@@ -498,6 +498,23 @@ func runNode(
 	}
 }
 
+// echoesCancellation reports whether err is the dying invocation
+// context reflected back by a node rather than a failure the node
+// determined for itself. runNode sets completion.err to ctx.Err() when
+// a node returns because its context died, so the echo takes three
+// shapes: the parent's own error (context.DeadlineExceeded for a
+// request timeout), its cause (set via context.WithCancelCause), or a
+// plain context.Canceled from the per-node cancel that cancelAll fires
+// in response — a node can observe that before the parent's deadline.
+//
+// Only meaningful once s.parentCtx has failed; context.Cause returns
+// nil for a live context and errors.Is(err, nil) is never true.
+func (s *scheduler) echoesCancellation(err error) bool {
+	return errors.Is(err, context.Canceled) ||
+		errors.Is(err, s.parentCtx.Err()) ||
+		errors.Is(err, context.Cause(s.parentCtx))
+}
+
 // cancelAll cancels every running task. Idempotent: cancelled
 // goroutines may still push events that already left the producer
 // before observing ctx.Done(); the consumer continues draining
@@ -535,6 +552,7 @@ func (s *scheduler) cancelAll() {
 // node-side accumulators.
 func (s *scheduler) run(yield func(*session.Event, error) bool) {
 	var pendingErr error  // first non-nil node error; surfaced after drain
+	var cancelErr error   // cause of an external cancellation; surfaced only when no node reported an error
 	draining := false     // true once cancelAll has run; remaining queue items are drained without yielding or scheduling new successors
 	consumerGone := false // true once the caller broke the range loop; no further yield is allowed
 
@@ -545,12 +563,24 @@ func (s *scheduler) run(yield func(*session.Event, error) bool) {
 		select {
 		case item = <-s.eventQueue:
 		case <-doneChan:
+			doneChan = nil // Disable this case so we don't busy loop
+		}
+
+		// Cancellation of the invocation context is external to the
+		// scheduler: cancelAll only cancels the per-node contexts, so
+		// parentCtx stays live through sibling cancellation. Record the
+		// cause and start draining here rather than in the doneChan case
+		// alone, because a ready doneChan does not have to win the select
+		// — a queued completion can be picked ahead of it, and the loop
+		// can exit before it is ever selected (e.g. cancelAll stops the
+		// last pending retry timer). Either way the run must not report
+		// success.
+		if cancelErr == nil && s.parentCtx.Err() != nil {
+			cancelErr = context.Cause(s.parentCtx)
 			if !draining {
 				draining = true
-				pendingErr = context.Cause(s.parentCtx)
 				s.cancelAll()
 			}
-			doneChan = nil // Disable this case so we don't busy loop
 		}
 
 		switch it := item.(type) {
@@ -595,8 +625,16 @@ func (s *scheduler) run(yield func(*session.Event, error) bool) {
 	// Surface the first error to the caller — but not if the caller
 	// already broke the range loop, since yielding after a false return
 	// panics the iterator.
-	if pendingErr != nil && !consumerGone {
-		yield(nil, pendingErr)
+	//
+	// A node's own error outranks the cancellation cause: when a caller
+	// cancels because a node failed, "context canceled" alone would hide
+	// the reason the run stopped.
+	runErr := pendingErr
+	if runErr == nil {
+		runErr = cancelErr
+	}
+	if runErr != nil && !consumerGone {
+		yield(nil, runErr)
 		return
 	}
 
@@ -784,12 +822,26 @@ func (s *scheduler) handleCompletion(it completionItem, scheduleSuccessors bool)
 	delete(s.runsByName, it.nodeName)
 	delete(s.runCancels, it.nodeName)
 
-	// A cancellation of the invocation context is external to the
-	// scheduler. Do not mistake it for the cancellation of a sibling
-	// after another node failed; that cancellation does not affect the
-	// parent context.
+	// A dead invocation context means the cancellation came from outside
+	// the scheduler, so this completion is not the benign sibling
+	// cancellation handled below — cancelAll never touches parentCtx.
+	// Classified before the retry block: ShouldRetry's default predicate
+	// does not exclude cancellation, and re-running a node under a dead
+	// context only re-fails.
+	//
+	// run surfaces the cancellation cause on its own, so a node that has
+	// nothing of its own to report returns nil here. One that failed for
+	// its own reason keeps that error, which says more than "cancelled".
 	if s.parentCtx.Err() != nil {
-		return context.Cause(s.parentCtx)
+		if it.err != nil && !s.echoesCancellation(it.err) {
+			ns.Status = NodeFailed
+			return it.err
+		}
+		// Matches adk-python, which marks every task it reaps during
+		// shutdown CANCELLED regardless of who cancelled it
+		// (_workflow.py _cleanup_all_tasks, run from a finally).
+		ns.Status = NodeCancelled
+		return nil
 	}
 	if errors.Is(it.err, context.Canceled) {
 		ns.Status = NodeCancelled

--- a/workflow/scheduler.go
+++ b/workflow/scheduler.go
@@ -547,6 +547,7 @@ func (s *scheduler) run(yield func(*session.Event, error) bool) {
 		case <-doneChan:
 			if !draining {
 				draining = true
+				pendingErr = context.Cause(s.parentCtx)
 				s.cancelAll()
 			}
 			doneChan = nil // Disable this case so we don't busy loop
@@ -783,6 +784,13 @@ func (s *scheduler) handleCompletion(it completionItem, scheduleSuccessors bool)
 	delete(s.runsByName, it.nodeName)
 	delete(s.runCancels, it.nodeName)
 
+	// A cancellation of the invocation context is external to the
+	// scheduler. Do not mistake it for the cancellation of a sibling
+	// after another node failed; that cancellation does not affect the
+	// parent context.
+	if s.parentCtx.Err() != nil {
+		return context.Cause(s.parentCtx)
+	}
 	if errors.Is(it.err, context.Canceled) {
 		ns.Status = NodeCancelled
 		return nil // sibling cancellation; not the original error

--- a/workflow/scheduler_test.go
+++ b/workflow/scheduler_test.go
@@ -225,6 +225,222 @@ func TestScheduler_ExternalCancellationFailsRun(t *testing.T) {
 	}
 }
 
+// TestScheduler_ExternalCancellationDuringPendingRetry covers the ordering
+// in which no completion is left to classify: the node's activation has
+// already been handled and rescheduled as a retry, so the only thing
+// keeping the loop alive is the retry timer. Cancelling here makes
+// cancelAll stop that timer and empty retryTimers, ending the loop without
+// another trip through handleCompletion. The cancellation has to be
+// recorded when it is observed, or the run reports success with the graph
+// half-executed.
+func TestScheduler_ExternalCancellationDuringPendingRetry(t *testing.T) {
+	mockCtx := newSeededMockCtx(t)
+	ctx, cancel := context.WithCancel(mockCtx.Context)
+	mockCtx = mockCtx.WithContext(ctx).(*MockInvocationContext)
+
+	// The delay only has to outlast the test: the retry must still be
+	// pending when the context is cancelled, and must never fire.
+	n := newRetryTestNode("flaky", 100, NodeConfig{
+		RetryConfig: &RetryConfig{
+			MaxAttempts:   5,
+			InitialDelay:  time.Hour,
+			BackoffFactor: 1.0,
+			ShouldRetry:   func(error) bool { return true },
+		},
+	})
+	w := mustNew(t, []Edge{{From: Start, To: n}})
+
+	errCh := make(chan error, 1)
+	go func() {
+		var firstErr error
+		for _, err := range w.Run(mockCtx) {
+			if err != nil && firstErr == nil {
+				firstErr = err
+			}
+		}
+		errCh <- firstErr
+	}()
+
+	// Wait for the first attempt to fail, then give the consumer a moment
+	// to process that completion and arm the retry timer. If the sleep is
+	// too short the cancel merely lands on a different ordering, one the
+	// test above already covers -- it cannot make this test flaky.
+	waitForCalls(t, n, 1)
+	time.Sleep(50 * time.Millisecond)
+	cancel()
+
+	select {
+	case err := <-errCh:
+		if !errors.Is(err, context.Canceled) {
+			t.Fatalf("Run error = %v, want context.Canceled", err)
+		}
+	case <-time.After(5 * time.Second):
+		t.Fatal("timeout waiting for workflow to finish")
+	}
+	if got := n.calls.Load(); got != 1 {
+		t.Errorf("node attempts = %d, want 1 (the retry must not run under a dead context)", got)
+	}
+}
+
+// TestScheduler_ExternalCancellationPrefersNodeError verifies that a node
+// that failed for its own reason keeps that error even though the
+// invocation context is dead. Reporting a bare context.Canceled here would
+// hide the reason the run stopped, which matters most when the caller
+// cancelled *because* something went wrong.
+func TestScheduler_ExternalCancellationPrefersNodeError(t *testing.T) {
+	mockCtx := newSeededMockCtx(t)
+	ctx, cancel := context.WithCancel(mockCtx.Context)
+	mockCtx = mockCtx.WithContext(ctx).(*MockInvocationContext)
+
+	nodeErr := errors.New("node failed on its own terms")
+	n := newReleasableErroringNode("n", nodeErr)
+	w := mustNew(t, []Edge{{From: Start, To: n}})
+
+	errCh := make(chan error, 1)
+	go func() {
+		var firstErr error
+		for _, err := range w.Run(mockCtx) {
+			if err != nil && firstErr == nil {
+				firstErr = err
+			}
+		}
+		errCh <- firstErr
+	}()
+
+	select {
+	case <-n.started:
+	case <-time.After(time.Second):
+		t.Fatal("timeout waiting for node to start")
+	}
+	// Cancel first, then let the node fail: its completion is classified
+	// with parentCtx already dead.
+	cancel()
+	close(n.release)
+
+	select {
+	case err := <-errCh:
+		if !errors.Is(err, nodeErr) {
+			t.Fatalf("Run error = %v, want it to wrap %v", err, nodeErr)
+		}
+	case <-time.After(5 * time.Second):
+		t.Fatal("timeout waiting for workflow to finish")
+	}
+}
+
+// TestScheduler_ExternalCancellationMarksNodeCancelled pins the lifecycle
+// status of an externally cancelled node. adk-python marks every task it
+// reaps during shutdown CANCELLED whether the engine or the caller
+// cancelled it (_workflow.py _cleanup_all_tasks, run from a finally), and
+// leaving the node at NodeRunning here would instead claim it still has a
+// task in flight.
+// Both flavours of a dying context are covered: on a deadline runNode
+// reports context.DeadlineExceeded, which must still read as the context
+// dying rather than as a failure the node decided on by itself.
+func TestScheduler_ExternalCancellationMarksNodeCancelled(t *testing.T) {
+	tests := []struct {
+		name string
+		kill func(context.Context) (context.Context, func())
+	}{
+		{
+			name: "cancel",
+			kill: func(parent context.Context) (context.Context, func()) {
+				return context.WithCancel(parent)
+			},
+		},
+		{
+			name: "deadline",
+			kill: func(parent context.Context) (context.Context, func()) {
+				ctx, cancel := context.WithTimeout(parent, 100*time.Millisecond)
+				return ctx, func() {
+					// The deadline does the killing; waiting on Done makes
+					// the ordering explicit, and cancel only frees the timer.
+					<-ctx.Done()
+					cancel()
+				}
+			},
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			mockCtx := newSeededMockCtx(t)
+			ctx, kill := tt.kill(mockCtx.Context)
+			mockCtx = mockCtx.WithContext(ctx).(*MockInvocationContext)
+
+			n := newCancelObservingNode("n")
+			w := mustNew(t, []Edge{{From: Start, To: n}})
+
+			// Drive the scheduler directly, as Workflow.RunNode does, so
+			// the RunState survives the run and can be inspected.
+			c := agent.Promote(mockCtx)
+			s := newScheduler(c, w.graph, w.maxConcurrency)
+			s.state.EnsureNode(Start.Name()).Input = nil
+			s.scheduleNode(Start, nil, "", c.Branch())
+
+			done := make(chan struct{})
+			go func() {
+				defer close(done)
+				s.run(func(*session.Event, error) bool { return true })
+				s.wg.Wait()
+			}()
+
+			select {
+			case <-n.started:
+			case <-time.After(time.Second):
+				t.Fatal("timeout waiting for node to start")
+			}
+			kill()
+
+			select {
+			case <-done:
+			case <-time.After(5 * time.Second):
+				t.Fatal("timeout waiting for scheduler to finish")
+			}
+
+			ns := s.state.Nodes[n.Name()]
+			if ns == nil {
+				t.Fatalf("no NodeState recorded for %q", n.Name())
+			}
+			if ns.Status != NodeCancelled {
+				t.Errorf("node status = %v, want NodeCancelled", ns.Status)
+			}
+		})
+	}
+}
+
+// TestScheduler_ExternalDeadlineSurfacesCause covers the other way an
+// invocation context dies. The run must report the cause rather than a
+// blanket context.Canceled, so a caller can tell a request timeout apart
+// from a deliberate cancellation.
+func TestScheduler_ExternalDeadlineSurfacesCause(t *testing.T) {
+	mockCtx := newSeededMockCtx(t)
+	ctx, cancel := context.WithTimeout(mockCtx.Context, 50*time.Millisecond)
+	defer cancel()
+	mockCtx = mockCtx.WithContext(ctx).(*MockInvocationContext)
+
+	n := newCancelObservingNode("n")
+	w := mustNew(t, []Edge{{From: Start, To: n}})
+
+	errCh := make(chan error, 1)
+	go func() {
+		var firstErr error
+		for _, err := range w.Run(mockCtx) {
+			if err != nil && firstErr == nil {
+				firstErr = err
+			}
+		}
+		errCh <- firstErr
+	}()
+
+	select {
+	case err := <-errCh:
+		if !errors.Is(err, context.DeadlineExceeded) {
+			t.Fatalf("Run error = %v, want context.DeadlineExceeded", err)
+		}
+	case <-time.After(5 * time.Second):
+		t.Fatal("timeout waiting for workflow to finish")
+	}
+}
+
 // TestScheduler_CallerBreakStopsScheduling verifies that when the
 // caller breaks out of the event range loop, the scheduler stops
 // dispatching new successor nodes — not just stops yielding events.
@@ -441,6 +657,48 @@ func newErroringNode(name string, err error) *erroringNode {
 func (n *erroringNode) Run(_ agent.Context, _ any) iter.Seq2[*session.Event, error] {
 	return func(yield func(*session.Event, error) bool) {
 		yield(nil, n.err)
+	}
+}
+
+// releasableErroringNode signals when it has started and then blocks
+// until release is closed before failing. It lets a test order the
+// node's failure after some other event, such as the cancellation of
+// the invocation context.
+type releasableErroringNode struct {
+	BaseNode
+	started chan struct{}
+	release chan struct{}
+	err     error
+}
+
+func newReleasableErroringNode(name string, err error) *releasableErroringNode {
+	return &releasableErroringNode{
+		BaseNode: NewBaseNode(name, "", NodeConfig{}),
+		started:  make(chan struct{}),
+		release:  make(chan struct{}),
+		err:      err,
+	}
+}
+
+func (n *releasableErroringNode) Run(_ agent.Context, _ any) iter.Seq2[*session.Event, error] {
+	return func(yield func(*session.Event, error) bool) {
+		close(n.started)
+		<-n.release
+		yield(nil, n.err)
+	}
+}
+
+// waitForCalls blocks until the node has been activated at least want
+// times, so a test can order an action after a given attempt without
+// reaching into scheduler state.
+func waitForCalls(t *testing.T, n *retryTestNode, want int32) {
+	t.Helper()
+	deadline := time.Now().Add(time.Second)
+	for n.calls.Load() < want {
+		if time.Now().After(deadline) {
+			t.Fatalf("timeout waiting for %d node attempts, got %d", want, n.calls.Load())
+		}
+		time.Sleep(time.Millisecond)
 	}
 }
 

--- a/workflow/scheduler_test.go
+++ b/workflow/scheduler_test.go
@@ -183,6 +183,48 @@ func TestScheduler_FailedSiblingsCancelled(t *testing.T) {
 	}
 }
 
+// TestScheduler_ExternalCancellationFailsRun verifies that cancellation of
+// the workflow's invocation context is surfaced to the caller, rather than
+// being mistaken for scheduler-initiated sibling cancellation.
+func TestScheduler_ExternalCancellationFailsRun(t *testing.T) {
+	mockCtx := newSeededMockCtx(t)
+	ctx, cancel := context.WithCancel(mockCtx.Context)
+	mockCtx = mockCtx.WithContext(ctx).(*MockInvocationContext)
+
+	n := newCancelObservingNode("n")
+	w := mustNew(t, []Edge{{From: Start, To: n}})
+
+	errCh := make(chan error, 1)
+	go func() {
+		var firstErr error
+		for _, err := range w.Run(mockCtx) {
+			if err != nil && firstErr == nil {
+				firstErr = err
+			}
+		}
+		errCh <- firstErr
+	}()
+
+	select {
+	case <-n.started:
+	case <-time.After(time.Second):
+		t.Fatal("timeout waiting for node to start")
+	}
+	cancel()
+
+	select {
+	case err := <-errCh:
+		if err == nil {
+			t.Fatal("Workflow.Run ended cleanly after external cancellation")
+		}
+		if !errors.Is(err, context.Canceled) {
+			t.Fatalf("Run error = %v, want context.Canceled", err)
+		}
+	case <-time.After(time.Second):
+		t.Fatal("timeout waiting for workflow to finish")
+	}
+}
+
 // TestScheduler_CallerBreakStopsScheduling verifies that when the
 // caller breaks out of the event range loop, the scheduler stops
 // dispatching new successor nodes — not just stops yielding events.
@@ -407,15 +449,20 @@ func (n *erroringNode) Run(_ agent.Context, _ any) iter.Seq2[*session.Event, err
 // cancellation and timeout behaviour.
 type cancelObservingNode struct {
 	BaseNode
+	started        chan struct{}
 	cancelObserved atomic.Bool
 }
 
 func newCancelObservingNode(name string) *cancelObservingNode {
-	return &cancelObservingNode{BaseNode: NewBaseNode(name, "", NodeConfig{})}
+	return &cancelObservingNode{
+		BaseNode: NewBaseNode(name, "", NodeConfig{}),
+		started:  make(chan struct{}),
+	}
 }
 
 func (n *cancelObservingNode) Run(ctx agent.Context, _ any) iter.Seq2[*session.Event, error] {
 	return func(yield func(*session.Event, error) bool) {
+		close(n.started)
 		<-ctx.Done()
 		n.cancelObserved.Store(true)
 	}

--- a/workflow/state.go
+++ b/workflow/state.go
@@ -65,9 +65,11 @@ const (
 	// policy (if any) has been exhausted. Terminal.
 	NodeFailed
 
-	// NodeCancelled means the node was cancelled, typically because
-	// a sibling node failed and the engine cancelled all running
-	// tasks. Terminal.
+	// NodeCancelled means the node was cancelled: either because a
+	// sibling node failed and the engine cancelled all running tasks,
+	// or because the invocation context was cancelled from outside the
+	// engine. Terminal in both cases — the two are told apart by
+	// whether the run reports an error, not by this status.
 	NodeCancelled
 )
 

--- a/workflow/workflow_node_test.go
+++ b/workflow/workflow_node_test.go
@@ -344,9 +344,10 @@ func TestNestedWorkflow_Cancellation(t *testing.T) {
 	cancel()
 	wg.Wait()
 
-	// Assert: run finished without error (cancellation is handled gracefully) and context was cancelled.
-	if runErr != nil {
-		t.Errorf("expected no error on cancellation, got %v", runErr)
+	// Assert: external cancellation is surfaced to the caller and the
+	// underlying context was cancelled.
+	if !errors.Is(runErr, context.Canceled) {
+		t.Errorf("expected context.Canceled on cancellation, got %v", runErr)
 	}
 	if !errors.Is(baseCtx.Err(), context.Canceled) {
 		t.Errorf("expected baseCtx.Err() to be context.Canceled, got %v", baseCtx.Err())


### PR DESCRIPTION
Fixes #1253

External cancellation of a workflow invocation is now propagated instead of being classified as benign sibling cancellation. The scheduler records cancellation in the parent Done path and uses context.Cause while preserving sibling cancellation behavior.

Tests:
* go test ./workflow -count=1
* go test -race ./workflow -run TestScheduler_ExternalCancellationFailsRun_or_FailedSiblingsCancelled -count=1