### PR TITLE
fix(llminternal): close the live connection when SendHistory fails

### DIFF
--- a/internal/llminternal/base_flow.go
+++ b/internal/llminternal/base_flow.go
@@ -380,6 +380,12 @@ func (f *Flow) RunLive(ctx agent.InvocationContext) (agent.LiveSession, iter.Seq
 				if err := liveConn.SendHistory(ctx, nreq.Contents); err != nil {
 					log.Printf("failed to send history: %v\n", err)
 					sess.pushError(err)
+					// cleanup, not a bare return: genai dials the live socket
+					// with a context-less websocket.DefaultDialer.Dial, and
+					// nothing in the SDK watches a context, so only an explicit
+					// Close releases it. Returning without cleanup strands the
+					// connection for the life of the process.
+					cleanup()
 					return
 				}
 			}

--- a/internal/llminternal/base_flow_live_test.go
+++ b/internal/llminternal/base_flow_live_test.go
@@ -16,7 +16,10 @@ package llminternal
 
 import (
 	"context"
+	"errors"
 	"iter"
+	"math"
+	"net"
 	"net/http"
 	"net/http/httptest"
 	"runtime"
@@ -391,4 +394,95 @@ func TestRunLiveNoGoroutineLeak(t *testing.T) {
 			assertNoRunLiveLeak(t, baseline)
 		})
 	}
+}
+
+// liveHistoryProcessor populates req.Contents with a turn the SDK cannot
+// marshal, so RunLive's SendHistory call fails on the client side.
+//
+// The failure has to be client-side: a broken socket would also fail the send,
+// but then there would be no live connection left to observe. json.Marshal
+// rejects NaN, so the send fails while the websocket stays healthy.
+func liveHistoryProcessor(ctx agent.InvocationContext, req *model.LLMRequest, f *Flow) iter.Seq2[*session.Event, error] {
+	req.Config = &genai.GenerateContentConfig{}
+	req.Contents = []*genai.Content{{
+		Role: "user",
+		Parts: []*genai.Part{{
+			FunctionCall: &genai.FunctionCall{
+				Name: "unmarshalable",
+				Args: map[string]any{"nan": math.NaN()},
+			},
+		}},
+	}}
+	return func(yield func(*session.Event, error) bool) {}
+}
+
+// TestRunLiveClosesConnectionOnSendHistoryFailure pins the cleanup discipline
+// on RunLive's one early-return path.
+//
+// Every other return in RunLive's own body releases the attempt through
+// cleanup (or cancelConn, before the connection exists). The SendHistory
+// failure path returns without either, so the websocket is never closed.
+// Cancelling the context would not help: genai dials with
+// websocket.DefaultDialer.Dial, which takes no context, and nothing in the SDK
+// watches one — only an explicit Close releases that socket. So the connection
+// survives for the lifetime of the process, not just the invocation.
+func TestRunLiveClosesConnectionOnSendHistoryFailure(t *testing.T) {
+	// How long the fake server waits for the client's close before concluding
+	// the socket was abandoned. Only paid on failure.
+	const closeWait = 3 * time.Second
+
+	baseline, _ := runLiveStacks()
+
+	// clientClosed reports whether the client tore the connection down, as
+	// opposed to leaving the server parked until its read deadline expired.
+	clientClosed := make(chan bool, 1)
+	client, connCount := startFakeLiveServer(t, func(connNum int, conn *websocket.Conn) {
+		_ = conn.SetReadDeadline(time.Now().Add(closeWait))
+		_, _, err := conn.ReadMessage()
+		var netErr net.Error
+		clientClosed <- !(errors.As(err, &netErr) && netErr.Timeout())
+	})
+
+	f := &Flow{
+		Model:             &fakeLiveModel{client: client},
+		RequestProcessors: []func(ctx agent.InvocationContext, req *model.LLMRequest, f *Flow) iter.Seq2[*session.Event, error]{liveHistoryProcessor},
+	}
+	ctx, cancel := newLiveInvocationContext(t)
+	defer cancel()
+
+	_, seq, err := f.RunLive(ctx)
+	if err != nil {
+		t.Fatalf("RunLive failed: %v", err)
+	}
+
+	// RunLive pushes the SendHistory error and returns. Stop iterating at that
+	// error: nothing closes the session, so ranging further would block.
+	var gotErr error
+	for _, e := range seq {
+		if e != nil {
+			gotErr = e
+			break
+		}
+	}
+	if gotErr == nil {
+		t.Fatal("expected the SendHistory failure to surface through the iterator")
+	}
+	if !strings.Contains(gotErr.Error(), "history") {
+		t.Errorf("surfaced error = %v, want it to mention the history send", gotErr)
+	}
+	if got := connCount.Load(); got != 1 {
+		t.Errorf("connection count = %d, want 1", got)
+	}
+
+	select {
+	case closed := <-clientClosed:
+		if !closed {
+			t.Error("RunLive returned without closing the live connection: the socket " +
+				"is leaked for the life of the process (missing cleanup on the SendHistory path)")
+		}
+	case <-time.After(closeWait + 2*time.Second):
+		t.Fatal("fake server never reported a connection outcome")
+	}
+
+	assertNoRunLiveLeak(t, baseline)
 }


### PR DESCRIPTION
**Please ensure you have read the [contribution guide](./CONTRIBUTING.md) before creating a pull request.**

### Link to Issue or Description of Change

**1. Link to an existing issue (if applicable):**

- Closes: #1260
- Related: #1167 (same bug class, different failure path — found by @hanorik while reviewing that PR)

**Problem:**

`Flow.RunLive`'s `SendHistory` failure path is the only `return` in the function's own body that releases neither `connCtx` nor `liveConn`:

```go
if err := liveConn.SendHistory(ctx, nreq.Contents); err != nil {
    log.Printf("failed to send history: %v\n", err)
    sess.pushError(err)
    return          // no cleanup()
}
```

Auditing all 11 returns in the body (excluding the two producer goroutines, where returning without `cleanup` is correct), this is the only one that releases nothing.

Cancelling the context would not be enough. `genai` dials the live socket with `websocket.DefaultDialer.Dial` (`genai/live.go:123`), which takes no `context.Context`, and nothing in the SDK watches one — `Session.Close()` closing the underlying conn is the only thing that releases it. So this early return strands the connection for the **life of the process**, not merely until the invocation ends. `go vet`'s `lostcancel` misses it because `cancelConn` is reached through the `cleanup` closure.

**Solution:**

Call `cleanup()` before returning, matching every other return in the body. One line, plus a comment recording why cancelling the context is not a substitute.

### Testing Plan

**Unit Tests:**

- [x] I have added or updated unit tests for my change.
- [x] All unit tests pass locally.

`TestRunLiveClosesConnectionOnSendHistoryFailure` drives a real websocket through the fake Live server already in `base_flow_live_test.go` and asserts the server observes the client's close.

One design note: the send has to fail **client-side**. A broken socket would also fail it, but would leave no connection to observe. The test feeds `SendHistory` a turn carrying `NaN`, which `json.Marshal` rejects inside the SDK's `deepMarshal` before it touches the wire — so the send fails while the websocket stays healthy, and the test can distinguish "client closed it" from "client abandoned it" via a server-side read deadline.

Written before the fix and confirmed to fail on unmodified `main`:

```
--- FAIL: TestRunLiveClosesConnectionOnSendHistoryFailure (3.03s)
    base_flow_live_test.go:480: RunLive returned without closing the live connection: the socket
        is leaked for the life of the process (missing cleanup on the SendHistory path)
```

With the fix, and a re-audit showing 0 remaining unreleased returns (was 1 of 11):

```
go build -mod=readonly ./...                                              # pass
go test -race -mod=readonly -count=10 -run TestRunLive ./internal/llminternal/   # pass
go test -race -mod=readonly -count=1 -shuffle=on ./internal/llminternal/         # pass
go test -race -mod=readonly -count=1 ./...                                # pass, full repo
golangci-lint run ./internal/llminternal/...                              # 0 issues
gofmt -l internal/llminternal/                                            # clean
go mod tidy -diff                                                         # clean, no new deps
```

**Manual End-to-End (E2E) Tests:**

Not run against a live Gemini endpoint — the failure is a local connection-lifecycle bug and the regression test exercises it over a real websocket, including the pre-fix failure. Reproducing it against the real service would require inducing a server-side history-send rejection, which the fake server models directly.

### Checklist

- [x] I have read the [CONTRIBUTING.md](./CONTRIBUTING.md) document.
- [x] I have performed a self-review of my own code.
- [x] I have commented my code, particularly in hard-to-understand areas.
- [x] I have added tests that prove my fix is effective or that my feature works.
- [x] New and existing unit tests pass locally with my changes.
- [ ] I have manually tested my changes end-to-end. — see note above
- [x] Any dependent changes have been merged and published in downstream modules. — branched off `main` after #1167 landed

### Additional context

Credit to @hanorik, who spotted this reviewing #1167 and flagged it as outside that diff.
