### PR TITLE
Consistent %w / %v usage in fmt.Errorf

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -85,8 +85,12 @@ A change is complete only when all of these pass locally:
   `Toolset`, `Service`); concrete impls live in sub-packages or `internal/`.
 - **Callbacks over subclassing** (`Before*`/`After*` for Agent/Model/Tool);
   returning non-nil from a `Before` callback short-circuits execution.
-- **Errors:** wrap with `fmt.Errorf("…: %w", err)`. Tool confirmation uses
-  sentinel errors (e.g. `tool.ErrConfirmationRequired`).
+- **Errors:** wrap with `fmt.Errorf("…: %w", err)`. Use `%v` only when
+  deliberately not exposing the wrapped error's type — ask "would I be OK if a
+  caller wrote `errors.Is` against this?". Don't convert existing `%w` to `%v`;
+  it might break callers silently. Wrap sentinels first:
+  `fmt.Errorf("%w: …: %w", ErrX, err)`. Tool confirmation uses sentinel errors
+  (e.g. `tool.ErrConfirmationRequired`).
 - Prefer an existing helper over a new one; keep packages small and focused.
 
 ## Minimal example

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -86,8 +86,7 @@ A change is complete only when all of these pass locally:
 - **Callbacks over subclassing** (`Before*`/`After*` for Agent/Model/Tool);
   returning non-nil from a `Before` callback short-circuits execution.
 - **Errors:** wrap with `fmt.Errorf("…: %w", err)`. Use `%v` only when
-  deliberately not exposing the wrapped error's type — ask "would I be OK if a
-  caller wrote `errors.Is` against this?". Don't convert existing `%w` to `%v`;
+  deliberately not exposing the wrapped error's type. Don't convert existing `%w` to `%v`;
   it might break callers silently. Wrap sentinels first:
   `fmt.Errorf("%w: …: %w", ErrX, err)`. Tool confirmation uses sentinel errors
   (e.g. `tool.ErrConfirmationRequired`).

--- a/examples/telemetry/main.go
+++ b/examples/telemetry/main.go
@@ -84,7 +84,7 @@ func run() error {
 	// Launcher automatically starts the telemetry.
 	l := full.NewLauncher()
 	if err = l.Execute(ctx, config, os.Args[1:]); err != nil {
-		return fmt.Errorf("run failed: %v\n\n%s", err, l.CommandLineSyntax())
+		return fmt.Errorf("run failed: %w\n\n%s", err, l.CommandLineSyntax())
 	}
 	return nil
 }

--- a/server/adkrest/controllers/triggers/pubsub.go
+++ b/server/adkrest/controllers/triggers/pubsub.go
@@ -106,7 +106,7 @@ func messageContentFromPubSub(req models.PubSubTriggerRequest) (string, error) {
 
 	agentMessage, err := json.Marshal(messageContent)
 	if err != nil {
-		return "", fmt.Errorf("failed to marshal agent message: %v", err)
+		return "", fmt.Errorf("failed to marshal agent message: %w", err)
 	}
 	return string(agentMessage), nil
 }

--- a/server/adkrest/controllers/triggers/triggers.go
+++ b/server/adkrest/controllers/triggers/triggers.go
@@ -52,7 +52,7 @@ func (r *RetriableRunner) RunAgent(ctx context.Context, appName, userID, message
 	}
 	sessResp, err := r.sessionService.Create(ctx, sessReq)
 	if err != nil {
-		return nil, fmt.Errorf("failed to create session: %v", err)
+		return nil, fmt.Errorf("failed to create session: %w", err)
 	}
 
 	userMessage := genai.Content{
@@ -64,7 +64,7 @@ func (r *RetriableRunner) RunAgent(ctx context.Context, appName, userID, message
 
 	curAgent, err := r.agentLoader.LoadAgent(appName)
 	if err != nil {
-		return nil, fmt.Errorf("failed to load agent: %v", err)
+		return nil, fmt.Errorf("failed to load agent: %w", err)
 	}
 
 	runR, err := runner.New(runner.Config{
@@ -76,7 +76,7 @@ func (r *RetriableRunner) RunAgent(ctx context.Context, appName, userID, message
 		PluginConfig:    r.pluginConfig,
 	})
 	if err != nil {
-		return nil, fmt.Errorf("failed to create runner: %v", err)
+		return nil, fmt.Errorf("failed to create runner: %w", err)
 	}
 
 	return r.runAgentWithRetry(ctx, runR, sessResp.Session.UserID(), sessResp.Session.ID(), &userMessage)

--- a/server/agentengine/controllers/method/create_session.go
+++ b/server/agentengine/controllers/method/create_session.go
@@ -82,7 +82,7 @@ func (c *createSessionHandler) Handle(ctx context.Context, rw http.ResponseWrite
 
 	err := json.Unmarshal(payload, &req)
 	if err != nil {
-		return fmt.Errorf("json.Unmarshal() failed: %v", err)
+		return fmt.Errorf("json.Unmarshal() failed: %w", err)
 	}
 
 	ssReq := &session.CreateRequest{
@@ -92,7 +92,7 @@ func (c *createSessionHandler) Handle(ctx context.Context, rw http.ResponseWrite
 	}
 	resp, err := c.sessionService.Create(ctx, ssReq)
 	if err != nil {
-		return fmt.Errorf("c.sessionservice.Create() failed: %v", err)
+		return fmt.Errorf("c.sessionservice.Create() failed: %w", err)
 	}
 
 	sd := models.FromSession(resp.Session)
@@ -102,7 +102,7 @@ func (c *createSessionHandler) Handle(ctx context.Context, rw http.ResponseWrite
 	}
 	err = json.NewEncoder(rw).Encode(result)
 	if err != nil {
-		return fmt.Errorf("json.NewEncoder failed: %v", err)
+		return fmt.Errorf("json.NewEncoder failed: %w", err)
 	}
 	return nil
 }

--- a/server/agentengine/controllers/method/delete_session.go
+++ b/server/agentengine/controllers/method/delete_session.go
@@ -83,7 +83,7 @@ func (g *deleteSessionHandler) Handle(ctx context.Context, rw http.ResponseWrite
 
 	err := json.Unmarshal(payload, &req)
 	if err != nil {
-		return fmt.Errorf("json.Unmarshal() failed: %v", err)
+		return fmt.Errorf("json.Unmarshal() failed: %w", err)
 	}
 
 	ssReq := &session.DeleteRequest{
@@ -93,13 +93,13 @@ func (g *deleteSessionHandler) Handle(ctx context.Context, rw http.ResponseWrite
 	}
 	err = g.sessionservice.Delete(ctx, ssReq)
 	if err != nil {
-		return fmt.Errorf("g.sessionservice.Delete() failed: %v", err)
+		return fmt.Errorf("g.sessionservice.Delete() failed: %w", err)
 	}
 
 	result := models.DeleteSessionResponse{}
 	err = json.NewEncoder(rw).Encode(result)
 	if err != nil {
-		return fmt.Errorf("json.NewEncoder failed: %v", err)
+		return fmt.Errorf("json.NewEncoder failed: %w", err)
 	}
 	return nil
 }

--- a/server/agentengine/controllers/method/get_session.go
+++ b/server/agentengine/controllers/method/get_session.go
@@ -83,7 +83,7 @@ func (g *getSessionHandler) Handle(ctx context.Context, rw http.ResponseWriter, 
 
 	err := json.Unmarshal(payload, &req)
 	if err != nil {
-		return fmt.Errorf("json.Unmarshal() failed: %v", err)
+		return fmt.Errorf("json.Unmarshal() failed: %w", err)
 	}
 
 	ssReq := &session.GetRequest{
@@ -93,7 +93,7 @@ func (g *getSessionHandler) Handle(ctx context.Context, rw http.ResponseWriter, 
 	}
 	resp, err := g.sessionservice.Get(ctx, ssReq)
 	if err != nil {
-		return fmt.Errorf("c.sessionservice.Get() failed: %v", err)
+		return fmt.Errorf("c.sessionservice.Get() failed: %w", err)
 	}
 
 	sd := models.FromSession(resp.Session)
@@ -104,7 +104,7 @@ func (g *getSessionHandler) Handle(ctx context.Context, rw http.ResponseWriter, 
 
 	err = json.NewEncoder(rw).Encode(result)
 	if err != nil {
-		return fmt.Errorf("json.NewEncoder failed: %v", err)
+		return fmt.Errorf("json.NewEncoder failed: %w", err)
 	}
 	return nil
 }

--- a/server/agentengine/controllers/method/list_sessions.go
+++ b/server/agentengine/controllers/method/list_sessions.go
@@ -76,7 +76,7 @@ func (l *listSessionHandler) Handle(ctx context.Context, rw http.ResponseWriter,
 
 	err := json.Unmarshal(payload, &req)
 	if err != nil {
-		return fmt.Errorf("json.Unmarshal() failed: %v", err)
+		return fmt.Errorf("json.Unmarshal() failed: %w", err)
 	}
 
 	ssReq := &session.ListRequest{
@@ -85,7 +85,7 @@ func (l *listSessionHandler) Handle(ctx context.Context, rw http.ResponseWriter,
 	}
 	resp, err := l.sessionservice.List(ctx, ssReq)
 	if err != nil {
-		return fmt.Errorf("c.sessionservice.List() failed: %v", err)
+		return fmt.Errorf("c.sessionservice.List() failed: %w", err)
 	}
 
 	sessions := []models.SessionData{}
@@ -101,7 +101,7 @@ func (l *listSessionHandler) Handle(ctx context.Context, rw http.ResponseWriter,
 	}
 	err = json.NewEncoder(rw).Encode(result)
 	if err != nil {
-		return fmt.Errorf("json.NewEncoder failed: %v", err)
+		return fmt.Errorf("json.NewEncoder failed: %w", err)
 	}
 	return nil
 }

--- a/server/agentengine/controllers/method/stream_query.go
+++ b/server/agentengine/controllers/method/stream_query.go
@@ -68,7 +68,7 @@ func (s *streamQueryHandler) streamJSONL(ctx context.Context, rw http.ResponseWr
 		errText := json.Unmarshal(payload, &reqText)
 		if errText != nil {
 			// cannot unmarshall to models.StreamQueryRequest and models.StreamQueryTextRequest
-			err = fmt.Errorf("json.Unmarshal() failed both for models.StreamQueryRequest (%v) and models.StreamQueryTextRequest (%v)", err, errText)
+			err = fmt.Errorf("json.Unmarshal() failed both for models.StreamQueryRequest (%w) and models.StreamQueryTextRequest (%w)", err, errText)
 			log.Print(err.Error())
 			return err
 		}
@@ -200,7 +200,7 @@ func (s *streamQueryHandler) run(ctx context.Context, req *models.StreamQueryReq
 		AutoCreateSession: true,
 	})
 	if err != nil {
-		return nil, fmt.Errorf("failed to create runner: %v", err)
+		return nil, fmt.Errorf("failed to create runner: %w", err)
 	}
 
 	return r.Run(ctx, req.Input.UserID, req.Input.SessionID, message, agent.RunConfig{

--- a/server/agentengine/controllers/method/streaming_agent_run_with_events.go
+++ b/server/agentengine/controllers/method/streaming_agent_run_with_events.go
@@ -239,7 +239,7 @@ func (s *streamingAgentRunWithEventsHandler) run(ctx context.Context, req *model
 		AutoCreateSession: true,
 	})
 	if err != nil {
-		return nil, fmt.Errorf("failed to create runner: %v", err)
+		return nil, fmt.Errorf("failed to create runner: %w", err)
 	}
 
 	// The path mirrors Python AdkApp.streaming_agent_run_with_events,

--- a/server/agentengine/handler.go
+++ b/server/agentengine/handler.go
@@ -42,13 +42,13 @@ func NewHandler(config *launcher.Config, sseWriteTimeout time.Duration, maxPaylo
 	nonStreamAgentEngineController, err := controllers.NewAgentEngineAPIController(config.SessionService, sseWriteTimeout, maxPayloadSize,
 		listNonStreamHandlers(config, agentEngineID))
 	if err != nil {
-		return nil, fmt.Errorf("controllers.NewAgentEngineAPIController failed (for non-streaming): %v", err)
+		return nil, fmt.Errorf("controllers.NewAgentEngineAPIController failed (for non-streaming): %w", err)
 	}
 
 	streamAgentEngineController, err := controllers.NewAgentEngineAPIController(config.SessionService, sseWriteTimeout, maxPayloadSize,
 		listStreamHandlers(config, agentEngineID))
 	if err != nil {
-		return nil, fmt.Errorf("controllers.NewAgentEngineAPIController failed (for streaming): %v", err)
+		return nil, fmt.Errorf("controllers.NewAgentEngineAPIController failed (for streaming): %w", err)
 	}
 
 	setupRouter(router,
@@ -58,7 +58,7 @@ func NewHandler(config *launcher.Config, sseWriteTimeout time.Duration, maxPaylo
 
 	methods, err := ListClassMethods()
 	if err != nil {
-		return nil, fmt.Errorf("ListClassMethods() failed: %v", err)
+		return nil, fmt.Errorf("ListClassMethods() failed: %w", err)
 	}
 
 	log.Println("Supported methods:")
@@ -66,7 +66,7 @@ func NewHandler(config *launcher.Config, sseWriteTimeout time.Duration, maxPaylo
 		sb := &strings.Builder{}
 		err = json.NewEncoder(sb).Encode(m)
 		if err != nil {
-			return nil, fmt.Errorf("json.NewEncoder failed: %v", err)
+			return nil, fmt.Errorf("json.NewEncoder failed: %w", err)
 		}
 		log.Println(sb.String())
 	}

--- a/tool/preloadmemorytool/tool.go
+++ b/tool/preloadmemorytool/tool.go
@@ -81,7 +81,7 @@ func (t *preloadMemoryTool) ProcessRequest(ctx agent.Context, req *model.LLMRequ
 
 	searchResponse, err := ctx.SearchMemory(ctx, userQuery)
 	if err != nil {
-		return fmt.Errorf("preload memory search failed: %v", err)
+		return fmt.Errorf("preload memory search failed: %w", err)
 	}
 
 	if searchResponse == nil || len(searchResponse.Memories) == 0 {

--- a/tool/skilltoolset/skill/frontmatter.go
+++ b/tool/skilltoolset/skill/frontmatter.go
@@ -141,11 +141,11 @@ func Validate(fm *Frontmatter) error {
 // Markdown instruction body. It validates the Frontmatter before building.
 func Build(fm *Frontmatter, markdown string) ([]byte, error) {
 	if err := Validate(fm); err != nil {
-		return nil, fmt.Errorf("invalid frontmatter: %v", err)
+		return nil, fmt.Errorf("invalid frontmatter: %w", err)
 	}
 	marshalled, err := yaml.Marshal(fm)
 	if err != nil {
-		return nil, fmt.Errorf("marshal frontmatter: %v", err)
+		return nil, fmt.Errorf("marshal frontmatter: %w", err)
 	}
 	return slices.Concat(frontmatterSeparator, marshalled, frontmatterSeparator, []byte(markdown)), nil
 }

--- a/tool/skilltoolset/skill/frontmatter.go
+++ b/tool/skilltoolset/skill/frontmatter.go
@@ -141,7 +141,7 @@ func Validate(fm *Frontmatter) error {
 // Markdown instruction body. It validates the Frontmatter before building.
 func Build(fm *Frontmatter, markdown string) ([]byte, error) {
 	if err := Validate(fm); err != nil {
-		return nil, fmt.Errorf("%w: %w", ErrInvalidFrontmatter, err)
+		return nil, fmt.Errorf("invalid frontmatter: %v", err)
 	}
 	marshalled, err := yaml.Marshal(fm)
 	if err != nil {

--- a/tool/skilltoolset/skill/frontmatter.go
+++ b/tool/skilltoolset/skill/frontmatter.go
@@ -141,7 +141,7 @@ func Validate(fm *Frontmatter) error {
 // Markdown instruction body. It validates the Frontmatter before building.
 func Build(fm *Frontmatter, markdown string) ([]byte, error) {
 	if err := Validate(fm); err != nil {
-		return nil, fmt.Errorf("invalid frontmatter: %v", err)
+		return nil, fmt.Errorf("%w: %w", ErrInvalidFrontmatter, err)
 	}
 	marshalled, err := yaml.Marshal(fm)
 	if err != nil {


### PR DESCRIPTION
**Problem:**

`fmt.Errorf` calls across the codebase are inconsistent about the `%w` / `%v` error verb.

The `%v` pattern should be used mainly for logging / displaying purpose, creating fresh, independent errors, purposefully not exposing implementation details or at the serialization boundaries. 

While `%w` should be used in most of other cases, since it allows programmatic inspection and error chaining and keeps the error unwrappable via `errors.Is` / `errors.As`.

(Sources: [Go Style Guide - error-handling](https://google.github.io/styleguide/go/best-practices#error-handling), [go.dev - whether to wrap](https://go.dev/blog/go1.13-errors#whether-to-wrap))

**Solution:**
Standardise on `%w` where it adds value or consistency across file/package, keep `%v` where exposing the wrapped type would be wrong or could introduce breaking change, and document the rule in AGENTS.md so future code stays consistent.

Of **59** `%v`-on-error sites in the repo, this PR converts **28** and deliberately leaves **31**:

| Area | Sites | Action | Why |
|---|---|---|---|
| `server/**` | 24 | → `%w` | Consistency: `server/` is already ~3:1 `%w`; 6 of 9 touched files were internally mixed with `%v` as the outlier. No behaviour change — these errors are serialized at the HTTP boundary. |
| `examples/telemetry/main.go:87` | 1 | → `%w` | Lone `%v` in a file that was otherwise `%w`. |
| `tool/preloadmemorytool/tool.go:84` | 1 | → `%w` | The error reaches the caller's `runner.Run` event stream as a Go value — `%w` preserves `errors.Is` / `As` for callers. |
| `tool/skilltoolset/skill/frontmatter.go:144` | 2 | → `%w` sentinel | Message unchanged. |
| **Deliberately kept `%v`** | 5 | keep | See below. |
| `cmd/**`, `internal/configurable/**` | 26 | keep | These errors terminate at a CLI / serialization boundary or in loggers which is canonical use case for `%v` |

The **5 deliberate `%v` keeps** (exposing the wrapped type would be wrong or is impossible):

- `internal/httprr/rr.go` ×2 — vendored code (must not edit).
- `workflow/dynamic_scheduler.go` ×2 — `%v` is intentional and documented; the surrounding telemetry classification relies on `context.Canceled` **not** entering the `NodeRunError` chain.
- `tool/mcptoolset/client.go` — the reconnection failure is informational

Also updates **AGENTS.md** with the convention (`%w` by default; `%v` only when deliberately not exposing the type; never convert `%w`→`%v`; wrap sentinels first).

### Testing Plan

**Unit Tests:**

- [x] I have added or updated unit tests for my change. *(no behavior change. wrapped-error messages are byte-identical, so existing tests cover it).
- [x] All unit tests pass locally.

```
go build -mod=readonly ./... # ok
go test -race -mod=readonly -count=1 -shuffle=on work # everything green
```

### Checklist

- [x] I have read the CONTRIBUTING.md document.
- [x] I have performed a self-review of my own code.
- [x] I have commented my code, particularly in hard-to-understand areas.
- [ ] I have added tests that prove my fix is effective or that my feature works. *(no behavior change)
- [x] New and existing unit tests pass locally with my changes.
- [ ] I have manually tested my changes end-to-end. *(no runtime behavior change)
- [x] Any dependent changes have been merged and published in downstream modules.
