### PR TITLE
fix(llmagent): resolve agent mode per placement instead of mutating the shared agent

### DIFF
--- a/agent/llmagent/llm_agent_wrapper.go
+++ b/agent/llmagent/llm_agent_wrapper.go
@@ -39,10 +39,11 @@ import (
 // RunLLMAgentAsNode runs an LlmAgent as a workflow node.
 // Per-mode behaviour:
 //
-//   - single_turn: the wrapper forces IncludeContents=none, seeds the
-//     agent with a single user-content event derived from nodeInput,
-//     drives one Agent.Run, post-processes the model reply into the
-//     terminal Output, then returns.
+//   - single_turn: the wrapper binds the mode to the agent for this
+//     invocation, so the contents processor scopes history to the
+//     current turn. It seeds the agent with a single user-content event
+//     derived from nodeInput, drives one Agent.Run, post-processes the
+//     model reply into the terminal Output, then returns.
 //   - task: the wrapper drives Agent.Run and watches for the
 //     finish_task FunctionCall; once the matching FinishTaskTool
 //     FunctionResponse signals success, the wrapper promotes the FC
@@ -70,9 +71,12 @@ func RunLLMAgentAsNode(a agent.Agent, ctx agent.Context, nodeInput any) iter.Seq
 		}
 		state := llminternal.Reveal(llmA)
 
+		// A placement binds the mode it resolved for this agent. Without one
+		// the agent is a plain conversational callee (a transfer target, say),
+		// which is what an undeclared mode means everywhere else.
 		mode := llminternal.ResolveMode(
-			state.Mode,
-			llminternal.PlacementMode(ctx, llminternal.ModeSingleTurn),
+			llminternal.ModeFor(ctx, a.Name(), state.Mode),
+			llminternal.ModeChat,
 		)
 		switch mode {
 		case llminternal.ModeTask, llminternal.ModeSingleTurn, llminternal.ModeChat:
@@ -81,9 +85,10 @@ func RunLLMAgentAsNode(a agent.Agent, ctx agent.Context, nodeInput any) iter.Seq
 				a.Name(), mode))
 			return
 		}
-		// Publish the resolved mode so the request processors downstream
-		// see this placement's mode, not the agent's declaration.
-		ctx = ctx.WithAgentContext(llminternal.WithResolvedMode(ctx, mode))
+		// Re-bind under this agent's own name so the request processors
+		// downstream agree with the branch taken here, and so a mode resolved
+		// for this agent never governs a peer or child.
+		ctx = ctx.WithAgentContext(llminternal.WithBoundMode(ctx, a.Name(), mode))
 
 		// Task/single_turn modes build a per-agent InvocationContext that:
 		//   - rebinds Agent to a (matching adk-python's ic.agent=agent),
@@ -138,7 +143,10 @@ func PrepareLLMAgentInput(a agent.Agent, ctx agent.InvocationContext, nodeInput 
 	if !ok || llmA == nil {
 		return nil
 	}
-	if llminternal.ResolvedMode(ctx, llminternal.Reveal(llmA).Mode) != llminternal.ModeSingleTurn {
+	if ctx == nil {
+		return nil
+	}
+	if llminternal.ModeFor(ctx, a.Name(), llminternal.Reveal(llmA).Mode) != llminternal.ModeSingleTurn {
 		return nil
 	}
 	content := nodeInputToContent(nodeInput)

--- a/agent/llmagent/llm_agent_wrapper.go
+++ b/agent/llmagent/llm_agent_wrapper.go
@@ -70,20 +70,21 @@ func RunLLMAgentAsNode(a agent.Agent, ctx agent.Context, nodeInput any) iter.Seq
 		}
 		state := llminternal.Reveal(llmA)
 
-		if state.Mode == llminternal.ModeUnset {
-			state.Mode = llminternal.ModeSingleTurn
-		}
-		switch state.Mode {
+		mode := llminternal.ResolveMode(
+			state.Mode,
+			llminternal.PlacementMode(ctx, llminternal.ModeSingleTurn),
+		)
+		switch mode {
 		case llminternal.ModeTask, llminternal.ModeSingleTurn, llminternal.ModeChat:
 		default:
 			yield(nil, fmt.Errorf("RunLLMAgentAsNode: LlmAgent %q only supports task, single_turn, and chat mode, got %q",
-				a.Name(), state.Mode))
+				a.Name(), mode))
 			return
 		}
+		// Publish the resolved mode so the request processors downstream
+		// see this placement's mode, not the agent's declaration.
+		ctx = ctx.WithAgentContext(llminternal.WithResolvedMode(ctx, mode))
 
-		if state.Mode == llminternal.ModeSingleTurn {
-			state.IncludeContents = "none"
-		}
 		// Task/single_turn modes build a per-agent InvocationContext that:
 		//   - rebinds Agent to a (matching adk-python's ic.agent=agent),
 		//   - threads isolation_scope so the content processor
@@ -95,7 +96,7 @@ func RunLLMAgentAsNode(a agent.Agent, ctx agent.Context, nodeInput any) iter.Seq
 		//     carry one,
 		//   - relies on the embedded InvocationContext for everything
 		//     else (memory, run config, etc.).
-		switch state.Mode {
+		switch mode {
 		case llminternal.ModeChat:
 			runChat(a, ctx, yield)
 		case llminternal.ModeSingleTurn, llminternal.ModeTask:
@@ -118,7 +119,7 @@ func RunLLMAgentAsNode(a agent.Agent, ctx agent.Context, nodeInput any) iter.Seq
 				RunConfig:      ctx.RunConfig(),
 				InvocationID:   ctx.InvocationID(),
 			})
-			if state.Mode == llminternal.ModeSingleTurn {
+			if mode == llminternal.ModeSingleTurn {
 				runSingleTurn(a, ic, yield)
 			} else {
 				runTask(a, ic, yield)
@@ -137,7 +138,7 @@ func PrepareLLMAgentInput(a agent.Agent, ctx agent.InvocationContext, nodeInput 
 	if !ok || llmA == nil {
 		return nil
 	}
-	if llminternal.Reveal(llmA).Mode != llminternal.ModeSingleTurn {
+	if llminternal.ResolvedMode(ctx, llminternal.Reveal(llmA).Mode) != llminternal.ModeSingleTurn {
 		return nil
 	}
 	content := nodeInputToContent(nodeInput)

--- a/agent/llmagent/llm_agent_wrapper.go
+++ b/agent/llmagent/llm_agent_wrapper.go
@@ -134,7 +134,13 @@ func RunLLMAgentAsNode(a agent.Agent, ctx agent.Context, nodeInput any) iter.Seq
 }
 
 // PrepareLLMAgentInput returns the seeded user-role event for the
-// single_turn agent's first turn.
+// single_turn agent's first turn, and nil for any other agent.
+//
+// Which agents count as single_turn is decided per invocation: the mode ctx
+// bound for a, else a's own declaration. Only the runner and the workflow
+// engine bind one, so a caller outside this module gets a seed for an agent
+// that declares single_turn, and nil for one that leaves the mode to its
+// placement.
 func PrepareLLMAgentInput(a agent.Agent, ctx agent.InvocationContext, nodeInput any) *session.Event {
 	if nodeInput == nil {
 		return nil

--- a/agent/llmagent/llm_agent_wrapper.go
+++ b/agent/llmagent/llm_agent_wrapper.go
@@ -71,20 +71,21 @@ func RunLLMAgentAsNode(a agent.Agent, ctx agent.Context, nodeInput any) iter.Seq
 		}
 		state := llminternal.Reveal(llmA)
 
-		if state.Mode == llminternal.ModeUnset {
-			state.Mode = llminternal.ModeSingleTurn
-		}
-		switch state.Mode {
+		mode := llminternal.ResolveMode(
+			state.Mode,
+			llminternal.PlacementMode(ctx, llminternal.ModeSingleTurn),
+		)
+		switch mode {
 		case llminternal.ModeTask, llminternal.ModeSingleTurn, llminternal.ModeChat:
 		default:
 			yield(nil, fmt.Errorf("RunLLMAgentAsNode: LlmAgent %q only supports task, single_turn, and chat mode, got %q",
-				a.Name(), state.Mode))
+				a.Name(), mode))
 			return
 		}
+		// Publish the resolved mode so the request processors downstream
+		// see this placement's mode, not the agent's declaration.
+		ctx = ctx.WithAgentContext(llminternal.WithResolvedMode(ctx, mode))
 
-		if state.Mode == llminternal.ModeSingleTurn {
-			state.IncludeContents = "none"
-		}
 		// Task/single_turn modes build a per-agent InvocationContext that:
 		//   - rebinds Agent to a (matching adk-python's ic.agent=agent),
 		//   - threads isolation_scope so the content processor
@@ -96,7 +97,7 @@ func RunLLMAgentAsNode(a agent.Agent, ctx agent.Context, nodeInput any) iter.Seq
 		//     carry one,
 		//   - relies on the embedded InvocationContext for everything
 		//     else (memory, run config, etc.).
-		switch state.Mode {
+		switch mode {
 		case llminternal.ModeChat:
 			runChat(a, ctx, yield)
 		case llminternal.ModeSingleTurn, llminternal.ModeTask:
@@ -119,7 +120,7 @@ func RunLLMAgentAsNode(a agent.Agent, ctx agent.Context, nodeInput any) iter.Seq
 				RunConfig:      ctx.RunConfig(),
 				InvocationID:   ctx.InvocationID(),
 			})
-			if state.Mode == llminternal.ModeSingleTurn {
+			if mode == llminternal.ModeSingleTurn {
 				runSingleTurn(a, ic, yield)
 			} else {
 				runTask(a, ic, yield)
@@ -138,7 +139,7 @@ func PrepareLLMAgentInput(a agent.Agent, ctx agent.InvocationContext, nodeInput 
 	if !ok || llmA == nil {
 		return nil
 	}
-	if llminternal.Reveal(llmA).Mode != llminternal.ModeSingleTurn {
+	if llminternal.ResolvedMode(ctx, llminternal.Reveal(llmA).Mode) != llminternal.ModeSingleTurn {
 		return nil
 	}
 	content := nodeInputToContent(nodeInput)

--- a/agent/llmagent/llm_agent_wrapper.go
+++ b/agent/llmagent/llm_agent_wrapper.go
@@ -15,10 +15,11 @@
 // Package workflowinternal provides utilities for running an LlmAgent as
 // a workflow node. Per-mode behaviour:
 //
-//   - single_turn: the wrapper forces IncludeContents=none, seeds the
-//     agent with a single user-content event derived from nodeInput,
-//     drives one Agent.Run, post-processes the model reply into the
-//     terminal Output, then returns.
+//   - single_turn: the wrapper binds the mode to the agent for this
+//     invocation, so the contents processor scopes history to the current
+//     turn; it seeds the agent with a single user-content event derived
+//     from nodeInput, drives one Agent.Run, post-processes the model reply
+//     into the terminal Output, then returns.
 //   - task: the wrapper drives Agent.Run and watches for the
 //     finish_task FunctionCall; once the matching FinishTaskTool
 //     FunctionResponse signals success, the wrapper promotes the FC
@@ -71,9 +72,12 @@ func RunLLMAgentAsNode(a agent.Agent, ctx agent.Context, nodeInput any) iter.Seq
 		}
 		state := llminternal.Reveal(llmA)
 
+		// A placement binds the mode it resolved for this agent. Without one
+		// the agent is a plain conversational callee (a transfer target, say),
+		// which is what an undeclared mode means everywhere else.
 		mode := llminternal.ResolveMode(
-			state.Mode,
-			llminternal.PlacementMode(ctx, llminternal.ModeSingleTurn),
+			llminternal.ModeFor(ctx, a.Name(), state.Mode),
+			llminternal.ModeChat,
 		)
 		switch mode {
 		case llminternal.ModeTask, llminternal.ModeSingleTurn, llminternal.ModeChat:
@@ -82,9 +86,10 @@ func RunLLMAgentAsNode(a agent.Agent, ctx agent.Context, nodeInput any) iter.Seq
 				a.Name(), mode))
 			return
 		}
-		// Publish the resolved mode so the request processors downstream
-		// see this placement's mode, not the agent's declaration.
-		ctx = ctx.WithAgentContext(llminternal.WithResolvedMode(ctx, mode))
+		// Re-bind under this agent's own name so the request processors
+		// downstream agree with the branch taken here, and so a mode resolved
+		// for this agent never governs a peer or child.
+		ctx = ctx.WithAgentContext(llminternal.WithBoundMode(ctx, a.Name(), mode))
 
 		// Task/single_turn modes build a per-agent InvocationContext that:
 		//   - rebinds Agent to a (matching adk-python's ic.agent=agent),
@@ -139,7 +144,10 @@ func PrepareLLMAgentInput(a agent.Agent, ctx agent.InvocationContext, nodeInput 
 	if !ok || llmA == nil {
 		return nil
 	}
-	if llminternal.ResolvedMode(ctx, llminternal.Reveal(llmA).Mode) != llminternal.ModeSingleTurn {
+	if ctx == nil {
+		return nil
+	}
+	if llminternal.ModeFor(ctx, a.Name(), llminternal.Reveal(llmA).Mode) != llminternal.ModeSingleTurn {
 		return nil
 	}
 	content := nodeInputToContent(nodeInput)

--- a/agent/llmagent/llm_agent_wrapper.go
+++ b/agent/llmagent/llm_agent_wrapper.go
@@ -88,7 +88,16 @@ func RunLLMAgentAsNode(a agent.Agent, ctx agent.Context, nodeInput any) iter.Seq
 		// Re-bind under this agent's own name so the request processors
 		// downstream agree with the branch taken here, and so a mode resolved
 		// for this agent never governs a peer or child.
-		ctx = ctx.WithAgentContext(llminternal.WithBoundMode(ctx, a.Name(), mode))
+		//
+		// As in AgentNode.Run, the binding travels in the context passed DOWN,
+		// which is what reaches the request processors. ctx.WithAgentContext
+		// returns nil for a tool or callback context rather than erroring, so
+		// the chat path below takes a re-bound Context only when there is one
+		// to take.
+		bound := llminternal.WithBoundMode(ctx, a.Name(), mode)
+		if rebound := ctx.WithAgentContext(bound); rebound != nil {
+			ctx = rebound
+		}
 
 		// Task/single_turn modes build a per-agent InvocationContext that:
 		//   - rebinds Agent to a (matching adk-python's ic.agent=agent),
@@ -113,7 +122,7 @@ func RunLLMAgentAsNode(a agent.Agent, ctx agent.Context, nodeInput any) iter.Seq
 			if seed := PrepareLLMAgentInput(a, ctx, nodeInput); seed != nil {
 				sess = newWrappedSession(sess, seed)
 			}
-			ic := icontext.NewInvocationContext(ctx, icontext.InvocationContextParams{
+			ic := icontext.NewInvocationContext(bound, icontext.InvocationContextParams{
 				Artifacts:      ctx.Artifacts(),
 				Memory:         ctx.Memory(),
 				Session:        sess,
@@ -149,6 +158,10 @@ func PrepareLLMAgentInput(a agent.Agent, ctx agent.InvocationContext, nodeInput 
 	if !ok || llmA == nil {
 		return nil
 	}
+	// Exported, so nil is worth surviving rather than panicking: ModeFor reads
+	// ctx.Value below, and the event built further down reads InvocationID off
+	// it. This catches an untyped nil only — a typed-nil InvocationContext still
+	// panics, as it would anywhere else in the package.
 	if ctx == nil {
 		return nil
 	}

--- a/agent/llmagent/llm_agent_wrapper.go
+++ b/agent/llmagent/llm_agent_wrapper.go
@@ -39,8 +39,9 @@ import (
 // RunLLMAgentAsNode runs an LlmAgent as a workflow node.
 //
 // The mode is the one this invocation bound for the agent, else the agent's own
-// declaration, else chat. An out-of-module caller cannot bind — only the runner
-// and the workflow engine do — so an agent that declares nothing runs chat here,
+// declaration, else chat. An out-of-module caller cannot bind — only the runner,
+// the workflow engine, and this function once it has resolved — so an agent that
+// declares nothing runs chat here,
 // where it ran single_turn before the placement was made per-invocation.
 //
 // Per-mode behaviour:

--- a/agent/llmagent/llm_agent_wrapper.go
+++ b/agent/llmagent/llm_agent_wrapper.go
@@ -76,6 +76,13 @@ func RunLLMAgentAsNode(a agent.Agent, ctx agent.Context, nodeInput any) iter.Seq
 			yield(nil, fmt.Errorf("RunLLMAgentAsNode: %q is not an LlmAgent", a.Name()))
 			return
 		}
+		// Resolving the mode reads ctx, so a nil one has to be rejected before
+		// that rather than dereferenced. Exported, and the merge base reached
+		// its mode check without touching ctx at all.
+		if ctx == nil {
+			yield(nil, fmt.Errorf("RunLLMAgentAsNode: nil context for LlmAgent %q", a.Name()))
+			return
+		}
 		state := llminternal.Reveal(llmA)
 
 		// A placement binds the mode it resolved for this agent. Without one
@@ -158,10 +165,11 @@ func RunLLMAgentAsNode(a agent.Agent, ctx agent.Context, nodeInput any) iter.Seq
 // single_turn agent's first turn, and nil for any other agent.
 //
 // Which agents count as single_turn is decided per invocation: the mode ctx
-// bound for a, else a's own declaration. Only the runner and the workflow
-// engine bind one, so a caller outside this module gets a seed for an agent
-// that declares single_turn, and nil for one that leaves the mode to its
-// placement.
+// bound for a, else a's own declaration. Binding is internal — the runner, the
+// workflow engine, and RunLLMAgentAsNode once it has resolved — so an
+// out-of-module caller gets a seed whenever a declares single_turn, and
+// whenever it is called with a ctx from inside a placement that bound it,
+// which a callback or tool running under a graph node holds.
 func PrepareLLMAgentInput(a agent.Agent, ctx agent.InvocationContext, nodeInput any) *session.Event {
 	if nodeInput == nil {
 		return nil

--- a/agent/llmagent/llm_agent_wrapper.go
+++ b/agent/llmagent/llm_agent_wrapper.go
@@ -90,14 +90,8 @@ func RunLLMAgentAsNode(a agent.Agent, ctx agent.Context, nodeInput any) iter.Seq
 		// for this agent never governs a peer or child.
 		//
 		// As in AgentNode.Run, the binding travels in the context passed DOWN,
-		// which is what reaches the request processors. ctx.WithAgentContext
-		// returns nil for a tool or callback context rather than erroring, so
-		// the chat path below takes a re-bound Context only when there is one
-		// to take.
+		// which is what reaches the request processors.
 		bound := llminternal.WithBoundMode(ctx, a.Name(), mode)
-		if rebound := ctx.WithAgentContext(bound); rebound != nil {
-			ctx = rebound
-		}
 
 		// Task/single_turn modes build a per-agent InvocationContext that:
 		//   - rebinds Agent to a (matching adk-python's ic.agent=agent),
@@ -112,6 +106,17 @@ func RunLLMAgentAsNode(a agent.Agent, ctx agent.Context, nodeInput any) iter.Seq
 		//     else (memory, run config, etc.).
 		switch mode {
 		case llminternal.ModeChat:
+			// runChat needs the agent.Context itself, for the sub-scheduler its
+			// task delegations dispatch through, so this is the one branch that
+			// re-binds rather than passing `bound` down. WithAgentContext
+			// returns nil for a tool or callback context instead of erroring,
+			// hence the guard. Losing the binding there costs nothing: mode is
+			// chat on this branch, and every reader treats a chat binding and
+			// an absent one identically, which is the same reason the runner's
+			// root bind is inert.
+			if rebound := ctx.WithAgentContext(bound); rebound != nil {
+				ctx = rebound
+			}
 			runChat(a, ctx, yield)
 		case llminternal.ModeSingleTurn, llminternal.ModeTask:
 			userContent := ctx.UserContent()

--- a/agent/llmagent/llm_agent_wrapper.go
+++ b/agent/llmagent/llm_agent_wrapper.go
@@ -37,6 +37,12 @@ import (
 )
 
 // RunLLMAgentAsNode runs an LlmAgent as a workflow node.
+//
+// The mode is the one this invocation bound for the agent, else the agent's own
+// declaration, else chat. An out-of-module caller cannot bind — only the runner
+// and the workflow engine do — so an agent that declares nothing runs chat here,
+// where it ran single_turn before the placement was made per-invocation.
+//
 // Per-mode behaviour:
 //
 //   - single_turn: the wrapper binds the mode to the agent for this

--- a/agent/llmagent/llm_agent_wrapper.go
+++ b/agent/llmagent/llm_agent_wrapper.go
@@ -91,7 +91,7 @@ func RunLLMAgentAsNode(a agent.Agent, ctx agent.Context, nodeInput any) iter.Seq
 		// the agent is a plain conversational callee (a transfer target, say),
 		// which is what an undeclared mode means everywhere else.
 		mode := llminternal.ResolveMode(
-			llminternal.ModeFor(ctx, a.Name(), state.Mode),
+			llminternal.ModeFor(ctx, a.Name(), state),
 			llminternal.ModeChat,
 		)
 		switch mode {
@@ -107,7 +107,7 @@ func RunLLMAgentAsNode(a agent.Agent, ctx agent.Context, nodeInput any) iter.Seq
 		//
 		// As in AgentNode.Run, the binding travels in the context passed DOWN,
 		// which is what reaches the request processors.
-		bound := llminternal.WithBoundMode(ctx, a.Name(), mode)
+		bound := llminternal.WithBoundMode(ctx, a.Name(), state, mode)
 
 		// Task/single_turn modes build a per-agent InvocationContext that:
 		//   - rebinds Agent to a (matching adk-python's ic.agent=agent),
@@ -187,7 +187,7 @@ func PrepareLLMAgentInput(a agent.Agent, ctx agent.InvocationContext, nodeInput 
 	if ctx == nil {
 		return nil
 	}
-	if llminternal.ModeFor(ctx, a.Name(), llminternal.Reveal(llmA).Mode) != llminternal.ModeSingleTurn {
+	if llminternal.ModeFor(ctx, a.Name(), llminternal.Reveal(llmA)) != llminternal.ModeSingleTurn {
 		return nil
 	}
 	content := nodeInputToContent(nodeInput)

--- a/agent/llmagent/llm_agent_wrapper.go
+++ b/agent/llmagent/llm_agent_wrapper.go
@@ -101,9 +101,10 @@ func RunLLMAgentAsNode(a agent.Agent, ctx agent.Context, nodeInput any) iter.Seq
 				a.Name(), mode))
 			return
 		}
-		// Re-bind under this agent's own name so the request processors
-		// downstream agree with the branch taken here, and so a mode resolved
-		// for this agent never governs a peer or child.
+		// Re-bind under this agent's own key — its name and its identity — so
+		// the request processors downstream agree with the branch taken here,
+		// and so a mode resolved for this agent never governs a peer, a child,
+		// or a same-named agent nested beneath it.
 		//
 		// As in AgentNode.Run, the binding travels in the context passed DOWN,
 		// which is what reaches the request processors.
@@ -130,10 +131,15 @@ func RunLLMAgentAsNode(a agent.Agent, ctx agent.Context, nodeInput any) iter.Seq
 			// chat on this branch, and every reader treats a chat binding and
 			// an absent one identically, which is the same reason the runner's
 			// root bind is inert.
+			//
+			// Kept in a local rather than assigned back to ctx: ctx is this
+			// closure's captured parameter, and writing it would make the
+			// returned iterator stateful for a caller that ranges it twice.
+			chatCtx := ctx
 			if rebound := ctx.WithAgentContext(bound); rebound != nil {
-				ctx = rebound
+				chatCtx = rebound
 			}
-			runChat(a, ctx, yield)
+			runChat(a, chatCtx, yield)
 		case llminternal.ModeSingleTurn, llminternal.ModeTask:
 			userContent := ctx.UserContent()
 			if nodeInput != nil {

--- a/agent/llmagent/llm_agent_wrapper.go
+++ b/agent/llmagent/llm_agent_wrapper.go
@@ -130,30 +130,24 @@ func RunLLMAgentAsNode(a agent.Agent, ctx agent.Context, nodeInput any) iter.Seq
 			// re-binds rather than passing `bound` down.
 			//
 			// WithAgentContext returns nil for a tool or callback context
-			// instead of erroring, and a chat run cannot survive one: agent.Run
-			// calls ctx.WithContext, which those same wrappers also return nil
-			// from, and the flow dereferences it. Reporting that is the whole
-			// point of this branch. Carrying on with the unbound context
-			// instead — which an earlier revision did — reaches the same dead
-			// end by way of a nil-pointer panic several frames down.
+			// instead of erroring, and a chat run cannot survive one anyway:
+			// agent.Run calls ctx.WithContext, which those wrappers also return
+			// nil from, and the flow dereferences it. So report it here rather
+			// than crash several frames down.
 			//
-			// This is where an undeclared agent over a tool or callback context
-			// notices the chat fallback: the merge base stamped it single_turn,
-			// which took the branch below and built its own context, so the
-			// same call used to work. It is not the only place the fallback is
-			// observable — a composite's undeclared child re-entered by a
-			// transfer-back also runs chat here where it ran single_turn, over
-			// an ordinary context and without any error. Both are documented
-			// behaviour changes rather than accidents.
+			// An undeclared agent notices the chat fallback here, where the
+			// merge base stamped it single_turn and the branch below built its
+			// own context. Enumerated in the PR description, along with the
+			// other place it shows: a composite's undeclared child re-entered
+			// by a transfer-back.
 			//
-			// Kept in a local rather than assigned back to ctx, which is this
-			// closure's captured parameter. A second sequential range would be
-			// unharmed either way — re-deriving the binding gives the same key
-			// and value — so what the local prevents is two goroutines ranging
-			// one returned iterator, a write/write race on that parameter.
+			// Kept in a local rather than assigned back to ctx, this closure's
+			// captured parameter: re-deriving the binding on a second range is
+			// harmless, but two goroutines ranging one returned iterator would
+			// be a write/write race on that parameter.
 			chatCtx := ctx.WithAgentContext(bound)
 			if chatCtx == nil {
-				yield(nil, fmt.Errorf("RunLLMAgentAsNode: LlmAgent %q runs as chat here, which a tool or callback context cannot drive", a.Name()))
+				yield(nil, fmt.Errorf("RunLLMAgentAsNode: LlmAgent %q runs as chat here, which needs an agent context this one cannot produce (a tool or callback context, typically)", a.Name()))
 				return
 			}
 			runChat(a, chatCtx, yield)
@@ -216,10 +210,10 @@ func PrepareLLMAgentInput(a agent.Agent, ctx agent.InvocationContext, nodeInput 
 	if !ok || llmA == nil {
 		return nil
 	}
-	// Exported, so nil is worth surviving rather than panicking: ModeFor reads
-	// ctx.Value below, and the event built further down reads InvocationID off
-	// it. This catches an untyped nil only — a typed-nil InvocationContext still
-	// panics, as it would anywhere else in the package.
+	// Exported, and everything below reads ctx, so return the same nil this
+	// function already returns for an agent it cannot seed rather than
+	// panicking. Untyped nil only: a typed-nil InvocationContext still panics,
+	// as it would anywhere else in the package.
 	if ctx == nil {
 		return nil
 	}

--- a/agent/llmagent/llm_agent_wrapper.go
+++ b/agent/llmagent/llm_agent_wrapper.go
@@ -38,8 +38,8 @@ import (
 
 // RunLLMAgentAsNode runs an LlmAgent as a workflow node.
 //
-// The mode is the agent's own declaration, else the one this invocation bound
-// for it, else chat. An out-of-module caller cannot bind — only the runner, the
+// The mode is the one this invocation bound for the agent, else the agent's
+// own declaration, else chat. An out-of-module caller cannot bind — only the runner, the
 // workflow engine, and this function once it has resolved — so an agent that
 // declares nothing runs chat here, where it ran single_turn before the
 // placement was made per-invocation.
@@ -166,8 +166,8 @@ func RunLLMAgentAsNode(a agent.Agent, ctx agent.Context, nodeInput any) iter.Seq
 // PrepareLLMAgentInput returns the seeded user-role event for the
 // single_turn agent's first turn, and nil for any other agent.
 //
-// Which agents count as single_turn is decided per invocation: a's own
-// declaration, else the mode ctx bound for it. Binding is internal — the
+// Which agents count as single_turn is decided per invocation: the mode ctx
+// bound for a, else a's own declaration. Binding is internal — the
 // runner, the workflow engine, and RunLLMAgentAsNode once it has resolved — so
 // an out-of-module caller gets a seed whenever a declares single_turn, and
 // whenever it is called with a ctx from inside a placement that bound it,

--- a/agent/llmagent/llm_agent_wrapper.go
+++ b/agent/llmagent/llm_agent_wrapper.go
@@ -58,7 +58,9 @@ import (
 //     FunctionResponse signals success, the wrapper promotes the FC
 //     args (or the wrapped value) as the terminal Output and returns.
 //     Non-success FRs let the LLM see the validation error and retry.
-//   - chat: the wrapper runs an outer dispatch loop. Before re-entering
+//   - chat: nodeInput is ignored — runChat is driven from the session, so a
+//     caller whose nodeInput is not also in the session sees it dropped. The
+//     wrapper runs an outer dispatch loop. Before re-entering
 //     Agent.Run on each iteration it scans the session for unresolved
 //     task delegations (task FCs from this coordinator without a
 //     matching FR), dispatches each via workflow.RunNode under a

--- a/agent/llmagent/llm_agent_wrapper.go
+++ b/agent/llmagent/llm_agent_wrapper.go
@@ -137,14 +137,20 @@ func RunLLMAgentAsNode(a agent.Agent, ctx agent.Context, nodeInput any) iter.Seq
 			// instead — which an earlier revision did — reaches the same dead
 			// end by way of a nil-pointer panic several frames down.
 			//
-			// This is the one place an undeclared agent notices the chat
-			// fallback: the merge base stamped it single_turn, which took the
-			// branch below and built its own context, so the same call used to
-			// work. It is a documented behaviour change, not an accident.
+			// This is where an undeclared agent over a tool or callback context
+			// notices the chat fallback: the merge base stamped it single_turn,
+			// which took the branch below and built its own context, so the
+			// same call used to work. It is not the only place the fallback is
+			// observable — a composite's undeclared child re-entered by a
+			// transfer-back also runs chat here where it ran single_turn, over
+			// an ordinary context and without any error. Both are documented
+			// behaviour changes rather than accidents.
 			//
-			// Kept in a local rather than assigned back to ctx: ctx is this
-			// closure's captured parameter, and writing it would make the
-			// returned iterator stateful for a caller that ranges it twice.
+			// Kept in a local rather than assigned back to ctx, which is this
+			// closure's captured parameter. A second sequential range would be
+			// unharmed either way — re-deriving the binding gives the same key
+			// and value — so what the local prevents is two goroutines ranging
+			// one returned iterator, a write/write race on that parameter.
 			chatCtx := ctx.WithAgentContext(bound)
 			if chatCtx == nil {
 				yield(nil, fmt.Errorf("RunLLMAgentAsNode: LlmAgent %q runs as chat here, which a tool or callback context cannot drive", a.Name()))
@@ -158,6 +164,19 @@ func RunLLMAgentAsNode(a agent.Agent, ctx agent.Context, nodeInput any) iter.Seq
 			}
 			sess := ctx.Session()
 			if seed := PrepareLLMAgentInput(a, ctx, nodeInput); seed != nil {
+				// A tool or callback context reports no session, and wrapping a
+				// nil one panics further down in telemetry. That panic predates
+				// this change; the set of callers that reach it does not. An
+				// undeclared sub-agent adopted by a chat coordinator used to be
+				// stamped chat, and chat ignores nodeInput and never seeds — it
+				// now resolves single_turn at a node and arrives here. Measured:
+				// the same call completes on the merge base. Same treatment as
+				// the chat branch, then: say what is missing rather than crash
+				// several frames later.
+				if sess == nil {
+					yield(nil, fmt.Errorf("RunLLMAgentAsNode: LlmAgent %q needs a session to seed its input, which a tool or callback context does not provide", a.Name()))
+					return
+				}
 				sess = newWrappedSession(sess, seed)
 			}
 			ic := icontext.NewInvocationContext(bound, icontext.InvocationContextParams{

--- a/agent/llmagent/llm_agent_wrapper.go
+++ b/agent/llmagent/llm_agent_wrapper.go
@@ -127,19 +127,28 @@ func RunLLMAgentAsNode(a agent.Agent, ctx agent.Context, nodeInput any) iter.Seq
 		case llminternal.ModeChat:
 			// runChat needs the agent.Context itself, for the sub-scheduler its
 			// task delegations dispatch through, so this is the one branch that
-			// re-binds rather than passing `bound` down. WithAgentContext
-			// returns nil for a tool or callback context instead of erroring,
-			// hence the guard. Losing the binding there costs nothing: mode is
-			// chat on this branch, and every reader treats a chat binding and
-			// an absent one identically, which is the same reason the runner's
-			// root bind is inert.
+			// re-binds rather than passing `bound` down.
+			//
+			// WithAgentContext returns nil for a tool or callback context
+			// instead of erroring, and a chat run cannot survive one: agent.Run
+			// calls ctx.WithContext, which those same wrappers also return nil
+			// from, and the flow dereferences it. Reporting that is the whole
+			// point of this branch. Carrying on with the unbound context
+			// instead — which an earlier revision did — reaches the same dead
+			// end by way of a nil-pointer panic several frames down.
+			//
+			// This is the one place an undeclared agent notices the chat
+			// fallback: the merge base stamped it single_turn, which took the
+			// branch below and built its own context, so the same call used to
+			// work. It is a documented behaviour change, not an accident.
 			//
 			// Kept in a local rather than assigned back to ctx: ctx is this
 			// closure's captured parameter, and writing it would make the
 			// returned iterator stateful for a caller that ranges it twice.
-			chatCtx := ctx
-			if rebound := ctx.WithAgentContext(bound); rebound != nil {
-				chatCtx = rebound
+			chatCtx := ctx.WithAgentContext(bound)
+			if chatCtx == nil {
+				yield(nil, fmt.Errorf("RunLLMAgentAsNode: LlmAgent %q runs as chat here, which a tool or callback context cannot drive", a.Name()))
+				return
 			}
 			runChat(a, chatCtx, yield)
 		case llminternal.ModeSingleTurn, llminternal.ModeTask:

--- a/agent/llmagent/llm_agent_wrapper.go
+++ b/agent/llmagent/llm_agent_wrapper.go
@@ -38,19 +38,21 @@ import (
 
 // RunLLMAgentAsNode runs an LlmAgent as a workflow node.
 //
-// The mode is the one this invocation bound for the agent, else the agent's own
-// declaration, else chat. An out-of-module caller cannot bind — only the runner,
-// the workflow engine, and this function once it has resolved — so an agent that
-// declares nothing runs chat here,
-// where it ran single_turn before the placement was made per-invocation.
+// The mode is the agent's own declaration, else the one this invocation bound
+// for it, else chat. An out-of-module caller cannot bind — only the runner, the
+// workflow engine, and this function once it has resolved — so an agent that
+// declares nothing runs chat here, where it ran single_turn before the
+// placement was made per-invocation.
 //
 // Per-mode behaviour:
 //
 //   - single_turn: the wrapper binds the mode to the agent for this
 //     invocation, so the contents processor scopes history to the
-//     current turn. It seeds the agent with a single user-content event
-//     derived from nodeInput, drives one Agent.Run, post-processes the
-//     model reply into the terminal Output, then returns.
+//     current turn — unless the agent explicitly set IncludeContents to
+//     IncludeContentsDefault, which keeps the history. It seeds the agent
+//     with a single user-content event derived from nodeInput, drives one
+//     Agent.Run, post-processes the model reply into the terminal Output,
+//     then returns.
 //   - task: the wrapper drives Agent.Run and watches for the
 //     finish_task FunctionCall; once the matching FinishTaskTool
 //     FunctionResponse signals success, the wrapper promotes the FC
@@ -164,10 +166,10 @@ func RunLLMAgentAsNode(a agent.Agent, ctx agent.Context, nodeInput any) iter.Seq
 // PrepareLLMAgentInput returns the seeded user-role event for the
 // single_turn agent's first turn, and nil for any other agent.
 //
-// Which agents count as single_turn is decided per invocation: the mode ctx
-// bound for a, else a's own declaration. Binding is internal — the runner, the
-// workflow engine, and RunLLMAgentAsNode once it has resolved — so an
-// out-of-module caller gets a seed whenever a declares single_turn, and
+// Which agents count as single_turn is decided per invocation: a's own
+// declaration, else the mode ctx bound for it. Binding is internal — the
+// runner, the workflow engine, and RunLLMAgentAsNode once it has resolved — so
+// an out-of-module caller gets a seed whenever a declares single_turn, and
 // whenever it is called with a ctx from inside a placement that bound it,
 // which a callback or tool running under a graph node holds.
 func PrepareLLMAgentInput(a agent.Agent, ctx agent.InvocationContext, nodeInput any) *session.Event {

--- a/agent/llmagent/llm_agent_wrapper_test.go
+++ b/agent/llmagent/llm_agent_wrapper_test.go
@@ -684,6 +684,90 @@ func TestRunLLMAgentAsNode_UnsupportedMode_Errors(t *testing.T) {
 	}
 }
 
+// A declared single_turn agent can reach the wrapper with nothing bound for
+// it: runner.findAgentToRun picks such a sub-agent to handle the next turn,
+// and no graph node is involved. The wrapper binds the mode it resolved before
+// running the agent, so the request processors take the same branch it did.
+// Without that, the wrapper drives one turn while the contents processor still
+// assembles the whole conversation.
+func TestRunLLMAgentAsNode_DeclaredSingleTurn_BindsForTheRequestProcessors(t *testing.T) {
+	t.Parallel()
+
+	llm := &recordingLLM{}
+	a, err := llmagent.New(llmagent.Config{
+		Name:  "worker",
+		Model: llm,
+		Mode:  llmagent.ModeSingleTurn,
+	})
+	if err != nil {
+		t.Fatalf("llmagent.New: %v", err)
+	}
+
+	svc := session.InMemoryService()
+	resp, err := svc.Create(t.Context(), &session.CreateRequest{AppName: "app", UserID: "u"})
+	if err != nil {
+		t.Fatalf("session.Create: %v", err)
+	}
+	// The current user turn has to be in the session, as the runner puts it
+	// there before running the agent: the backward scan that isolates the
+	// current turn skips this agent's own events, so a history ending on one
+	// pivots at index 0 and returns everything either way.
+	prior := []*session.Event{
+		{Author: "user", LLMResponse: model.LLMResponse{Content: genai.NewContentFromText("EARLIER_TURN", "user")}},
+		{Author: "worker", LLMResponse: model.LLMResponse{Content: genai.NewContentFromText("earlier answer", "model")}},
+		{Author: "user", LLMResponse: model.LLMResponse{Content: genai.NewContentFromText("current question", "user")}},
+	}
+	for _, ev := range prior {
+		if err := svc.AppendEvent(t.Context(), resp.Session, ev); err != nil {
+			t.Fatalf("AppendEvent: %v", err)
+		}
+	}
+
+	ic := icontext.NewInvocationContext(t.Context(), icontext.InvocationContextParams{
+		Agent:        a,
+		Session:      resp.Session,
+		UserContent:  genai.NewContentFromText("current question", "user"),
+		InvocationID: "inv-declared-single-turn",
+	})
+	// nodeInput is nil, as it is on the runner path: nothing seeds this agent,
+	// so hiding history rests on the binding alone.
+	for _, err := range llmagent.RunLLMAgentAsNode(a, agent.NewContext(ic), nil) {
+		if err != nil {
+			t.Fatalf("RunLLMAgentAsNode: %v", err)
+		}
+	}
+
+	if llm.got == nil {
+		t.Fatal("model was never called")
+	}
+	for _, c := range llm.got.Contents {
+		for _, p := range c.Parts {
+			if p != nil && strings.Contains(p.Text, "EARLIER_TURN") {
+				t.Errorf("declared single_turn agent saw conversation history; contents = %v", llm.got.Contents)
+			}
+		}
+	}
+}
+
+// recordingLLM keeps the first request it serves and always answers with text.
+type recordingLLM struct{ got *model.LLMRequest }
+
+func (*recordingLLM) Name() string { return "recording" }
+
+func (m *recordingLLM) GenerateContent(_ context.Context, r *model.LLMRequest, _ bool) iter.Seq2[*model.LLMResponse, error] {
+	if m.got == nil {
+		m.got = r
+	}
+	return func(yield func(*model.LLMResponse, error) bool) {
+		yield(&model.LLMResponse{Content: &genai.Content{
+			Role:  "model",
+			Parts: []*genai.Part{{Text: "answer"}},
+		}}, nil)
+	}
+}
+
+var _ model.LLM = (*recordingLLM)(nil)
+
 // TestRunLLMAgentAsNode_Task_HappyPath drives a task-mode agent
 // end-to-end via the runner. The scripted LLM emits finish_task
 // immediately; the wrapper must promote the args under the wrapper

--- a/agent/llmagent/llm_agent_wrapper_test.go
+++ b/agent/llmagent/llm_agent_wrapper_test.go
@@ -695,6 +695,27 @@ func TestRunLLMAgentAsNode_UnsupportedMode_Errors(t *testing.T) {
 	}
 }
 
+// Resolving the mode reads ctx, so an exported entry point has to reject a nil
+// one rather than dereference it. The merge base reached its mode check without
+// touching ctx, so a caller passing nil got an error there and must still.
+func TestRunLLMAgentAsNode_NilContext_Errors(t *testing.T) {
+	t.Parallel()
+	a := makeLLMAgent(t, "x", withMode(llmagent.ModeSingleTurn))
+
+	var gotErr error
+	for _, err := range llmagent.RunLLMAgentAsNode(a, nil, nil) {
+		if err != nil {
+			gotErr = err
+		}
+	}
+	if gotErr == nil {
+		t.Fatal("expected an error for a nil context; got nil")
+	}
+	if !strings.Contains(gotErr.Error(), "nil context") {
+		t.Errorf("err = %q, want it to mention a nil context", gotErr.Error())
+	}
+}
+
 // A declared single_turn agent can reach the wrapper with nothing bound for
 // it: runner.findAgentToRun picks such a sub-agent to handle the next turn,
 // and no graph node is involved. The wrapper binds the mode it resolved before

--- a/agent/llmagent/llm_agent_wrapper_test.go
+++ b/agent/llmagent/llm_agent_wrapper_test.go
@@ -1256,3 +1256,42 @@ func fcContent(id, name string, args map[string]any) *genai.Content {
 		}},
 	}
 }
+
+// RunLLMAgentAsNode is exported, and agent.Context.WithAgentContext returns nil
+// for the tool and callback wrappers rather than erroring, so routing the mode
+// binding back through it nils the context out. The single_turn and task
+// branches now resolve their binding without touching WithAgentContext at all,
+// which this pins.
+//
+// The chat branch is deliberately not covered. It is the one branch that still
+// re-binds, because runChat needs the agent.Context itself, and it guards the
+// nil — but a chat run cannot be driven from a tool context on the merge base
+// either. Both that and a seeded single_turn run (a tool context reports no
+// session, which wrappedSession then wraps) panic identically without this
+// change, so neither is this PR's to fix or to assert.
+func TestRunLLMAgentAsNode_SingleTurnAcceptsAToolContext(t *testing.T) {
+	t.Parallel()
+
+	a := makeLLMAgent(t, "worker", withMode(llmagent.ModeSingleTurn),
+		func(c *llmagent.Config) { c.Model = &recordingLLM{} })
+
+	svc := session.InMemoryService()
+	resp, err := svc.Create(t.Context(), &session.CreateRequest{AppName: "app", UserID: "u"})
+	if err != nil {
+		t.Fatalf("session.Create: %v", err)
+	}
+	ic := icontext.NewInvocationContext(t.Context(), icontext.InvocationContextParams{
+		Agent:        a,
+		Session:      resp.Session,
+		UserContent:  genai.NewContentFromText("hi", "user"),
+		InvocationID: "inv-tool-ctx",
+	})
+	toolCtx := agent.NewToolContext(ic, "fc-1", &session.EventActions{}, nil)
+
+	// The assertion is that this drains rather than panicking.
+	for _, err := range llmagent.RunLLMAgentAsNode(a, toolCtx, nil) {
+		if err != nil {
+			t.Fatalf("RunLLMAgentAsNode: %v", err)
+		}
+	}
+}

--- a/agent/llmagent/llm_agent_wrapper_test.go
+++ b/agent/llmagent/llm_agent_wrapper_test.go
@@ -255,6 +255,17 @@ func TestPrepareLLMAgentInput(t *testing.T) {
 		}
 	})
 
+	// The function is exported, and both things it does with ctx — resolving the
+	// mode, and reading InvocationID for the event — dereference it. Every other
+	// subtest supplies a real context, so without this one the guard never runs.
+	t.Run("nil ctx returns nil instead of panicking", func(t *testing.T) {
+		t.Parallel()
+		a := makeLLMAgent(t, "x", withMode(llmagent.ModeSingleTurn))
+		if got := llmagent.PrepareLLMAgentInput(a, nil, "some input"); got != nil {
+			t.Errorf("llmagent.PrepareLLMAgentInput with a nil ctx = %v, want nil", got)
+		}
+	})
+
 	t.Run("non-LlmAgent returns nil", func(t *testing.T) {
 		t.Parallel()
 		a, err := agent.New(agent.Config{Name: "plain"})

--- a/agent/llmagent/llm_agent_wrapper_test.go
+++ b/agent/llmagent/llm_agent_wrapper_test.go
@@ -1371,3 +1371,47 @@ func TestRunLLMAgentAsNode_DoesNotMutateTheAgentsIncludeContents(t *testing.T) {
 		t.Errorf("IncludeContents after a single_turn run = %q, want empty (a run must not mutate the agent)", got)
 	}
 }
+
+// The third write this PR removes that lives in this package, and the third
+// pinned only from workflow_test. installTaskTools used to stamp chat onto an
+// undeclared sub-agent while building a coordinator's tool list, which is what
+// made a coordinator's view of a shared sub-agent depend on construction order.
+// `go test ./agent/llmagent/` was green with that write restored — the whole
+// suite catches it, but not from the package that owns it.
+func TestLlmAgent_New_DoesNotMutateASubAgentsMode(t *testing.T) {
+	t.Parallel()
+
+	sub, err := llmagent.New(llmagent.Config{Name: "worker"})
+	if err != nil {
+		t.Fatalf("llmagent.New(worker): %v", err)
+	}
+	internalSub, ok := sub.(llminternal.Agent)
+	if !ok {
+		t.Fatal("sub-agent is not an llminternal.Agent")
+	}
+	if got := llminternal.Reveal(internalSub).Mode; got != llminternal.ModeUnset {
+		t.Fatalf("precondition: declared mode = %q, want unset", got)
+	}
+
+	// A declared task sibling, so installTaskTools has something to install and
+	// the loop that used to carry the write actually runs over the undeclared one.
+	task, err := llmagent.New(llmagent.Config{Name: "tasker", Mode: llmagent.ModeTask})
+	if err != nil {
+		t.Fatalf("llmagent.New(tasker): %v", err)
+	}
+	coord, err := llmagent.New(llmagent.Config{
+		Name:      "coordinator",
+		Mode:      llmagent.ModeChat,
+		SubAgents: []agent.Agent{sub, task},
+	})
+	if err != nil {
+		t.Fatalf("llmagent.New(coordinator): %v", err)
+	}
+	if len(llminternal.Reveal(coord.(llminternal.Agent)).Tools) == 0 {
+		t.Fatal("the coordinator installed no tools, so installTaskTools did not run")
+	}
+
+	if got := llminternal.Reveal(internalSub).Mode; got != llminternal.ModeUnset {
+		t.Errorf("the undeclared sub-agent's mode after building a coordinator = %q, want unset", got)
+	}
+}

--- a/agent/llmagent/llm_agent_wrapper_test.go
+++ b/agent/llmagent/llm_agent_wrapper_test.go
@@ -1323,17 +1323,10 @@ func fcContent(id, name string, args map[string]any) *genai.Content {
 // single_turn, so deleting the bind leaves the same branch selected and this
 // test still passes. Its workflow-side sibling avoids that by declaring no
 // mode, and the same trick does not work here: an undeclared agent with no
-// binding resolves to chat at this entry point, and a chat run over a tool
-// context panics on the merge base and on head alike. The binding is pinned
-// locally instead by TestRunLLMAgentAsNode_DeclaredSingleTurn_BindsForTheRequestProcessors,
-// which fails when it is deleted.
-//
-// The chat branch is deliberately not covered. It is the one branch that still
-// re-binds, because runChat needs the agent.Context itself, and it guards the
-// nil. That guard has no test because it cannot change an outcome: a chat run
-// over a tool context dies either way, guarded a line later or unguarded a line
-// earlier. A seeded single_turn run over one panics identically on the merge
-// base too, so neither is this PR's to fix or to assert.
+// binding resolves to chat at this entry point, which is a different case
+// covered by the test below. The binding is pinned locally instead by
+// TestRunLLMAgentAsNode_DeclaredSingleTurn_BindsForTheRequestProcessors, which
+// fails when it is deleted.
 func TestRunLLMAgentAsNode_SingleTurnAcceptsAToolContext(t *testing.T) {
 	t.Parallel()
 
@@ -1365,6 +1358,58 @@ func TestRunLLMAgentAsNode_SingleTurnAcceptsAToolContext(t *testing.T) {
 	// regression, and only reaching the model rules it out.
 	if llm.got == nil {
 		t.Error("the model was never called; the single_turn branch did not run the agent")
+	}
+}
+
+// The regression this change came closest to shipping, and the one case where
+// the chat fallback is not free.
+//
+// An UNDECLARED agent driven from a tool or callback context worked on the merge
+// base: the wrapper stamped it single_turn, and that branch builds its own
+// InvocationContext, which a tool context survives. Resolving to chat instead
+// sends it to runChat, which hands the tool context to agent.Run, whose
+// ctx.WithContext returns nil for that wrapper — a nil dereference several
+// frames down. Measured both ways: the same call completes on the merge base
+// and panicked here until the chat branch started reporting it.
+//
+// So the mode flip is kept, deliberately and documented, and the failure it
+// exposes is made legible instead of fatal. A caller that needs this agent to
+// run over a tool context must declare single_turn or place it at a node.
+func TestRunLLMAgentAsNode_UndeclaredOverAToolContext_ErrorsRatherThanPanics(t *testing.T) {
+	t.Parallel()
+
+	a := makeLLMAgent(t, "worker") // undeclared: resolves to chat with nothing bound
+
+	svc := session.InMemoryService()
+	resp, err := svc.Create(t.Context(), &session.CreateRequest{AppName: "app", UserID: "u"})
+	if err != nil {
+		t.Fatalf("session.Create: %v", err)
+	}
+	ic := icontext.NewInvocationContext(t.Context(), icontext.InvocationContextParams{
+		Agent:        a,
+		Session:      resp.Session,
+		UserContent:  genai.NewContentFromText("hi", "user"),
+		InvocationID: "inv-undeclared-tool-ctx",
+	})
+	toolCtx := agent.NewToolContext(ic, "fc-1", &session.EventActions{}, nil)
+
+	defer func() {
+		if r := recover(); r != nil {
+			t.Fatalf("panicked instead of reporting the unusable context: %v", r)
+		}
+	}()
+
+	var gotErr error
+	for _, err := range llmagent.RunLLMAgentAsNode(a, toolCtx, nil) {
+		if err != nil {
+			gotErr = err
+		}
+	}
+	if gotErr == nil {
+		t.Fatal("expected an error for a chat run over a tool context; got nil")
+	}
+	if !strings.Contains(gotErr.Error(), "tool or callback context") {
+		t.Errorf("err = %q, want it to name the unusable context", gotErr.Error())
 	}
 }
 

--- a/agent/llmagent/llm_agent_wrapper_test.go
+++ b/agent/llmagent/llm_agent_wrapper_test.go
@@ -696,8 +696,10 @@ func TestRunLLMAgentAsNode_UnsupportedMode_Errors(t *testing.T) {
 }
 
 // Resolving the mode reads ctx, so an exported entry point has to reject a nil
-// one rather than dereference it. The merge base reached its mode check without
-// touching ctx, so a caller passing nil got an error there and must still.
+// one rather than dereference it. This agent declares single_turn, so on the
+// merge base it passed the mode check and then panicked at ctx.UserContent().
+// An error is better than either. (The bogus-mode test above is the case where
+// the base did error at the check.)
 func TestRunLLMAgentAsNode_NilContext_Errors(t *testing.T) {
 	t.Parallel()
 	a := makeLLMAgent(t, "x", withMode(llmagent.ModeSingleTurn))

--- a/agent/llmagent/llm_agent_wrapper_test.go
+++ b/agent/llmagent/llm_agent_wrapper_test.go
@@ -390,10 +390,14 @@ func TestPrepareLLMAgentInput(t *testing.T) {
 		}
 	})
 
-	// The two rows that cover what this function's change actually did: it
-	// reads the resolved mode rather than the declaration, so an UNDECLARED
-	// agent seeds when a placement bound it single_turn and does not otherwise.
-	// Every row above declares a mode, so none of them can tell the two apart.
+	// What this function's change actually did: it reads the resolved mode
+	// rather than the declaration, so an UNDECLARED agent seeds when a
+	// placement bound it single_turn and does not otherwise. Every row above
+	// declares a mode, so none of them can tell the two apart.
+	//
+	// Only the second row discriminates — the first passes on the merge base
+	// too, where an undeclared agent simply failed the declaration test. It is
+	// the control, and it is here because there was no unset-mode row at all.
 	t.Run("undeclared with no binding returns nil", func(t *testing.T) {
 		t.Parallel()
 		a := makeLLMAgent(t, "u")
@@ -796,8 +800,10 @@ func TestRunLLMAgentAsNode_DeclaredSingleTurn_BindsForTheRequestProcessors(t *te
 		UserContent:  genai.NewContentFromText("current question", "user"),
 		InvocationID: "inv-declared-single-turn",
 	})
-	// nodeInput is nil, as it is on the runner path: nothing seeds this agent,
-	// so hiding history rests on the binding alone.
+	// nodeInput is nil, which is the resume shape of the runner path rather than
+	// every turn of it — a fresh turn passes the user text down. Nil is what
+	// this test wants either way: with nothing to seed, hiding history rests on
+	// the binding alone.
 	for _, err := range llmagent.RunLLMAgentAsNode(a, agent.NewContext(ic), nil) {
 		if err != nil {
 			t.Fatalf("RunLLMAgentAsNode: %v", err)

--- a/agent/llmagent/llm_agent_wrapper_test.go
+++ b/agent/llmagent/llm_agent_wrapper_test.go
@@ -1322,17 +1322,11 @@ func fcContent(id, name string, args map[string]any) *genai.Content {
 // RunLLMAgentAsNode is exported, and agent.Context.WithAgentContext returns nil
 // for the tool and callback wrappers rather than erroring, so routing the mode
 // binding back through it nils the context out. This pins that the single_turn
-// and task branches do not do that: they panic if the binding is routed back
-// unguarded.
+// branch does not do that: it panics if the binding is routed back unguarded.
 //
-// What it does NOT pin is the binding itself. The agent here declares
-// single_turn, so deleting the bind leaves the same branch selected and this
-// test still passes. Its workflow-side sibling avoids that by declaring no
-// mode, and the same trick does not work here: an undeclared agent with no
-// binding resolves to chat at this entry point, which is a different case
-// covered by the test below. The binding is pinned locally instead by
-// TestRunLLMAgentAsNode_DeclaredSingleTurn_BindsForTheRequestProcessors, which
-// fails when it is deleted.
+// It does not pin the binding itself — the agent declares single_turn, so
+// deleting the bind selects the same branch. Another test in this file covers
+// that.
 func TestRunLLMAgentAsNode_SingleTurnAcceptsAToolContext(t *testing.T) {
 	t.Parallel()
 

--- a/agent/llmagent/llm_agent_wrapper_test.go
+++ b/agent/llmagent/llm_agent_wrapper_test.go
@@ -1329,9 +1329,12 @@ func TestRunLLMAgentAsNode_SingleTurnAcceptsAToolContext(t *testing.T) {
 
 // The wrapper's two removed writes are pinned from workflow_test, which leaves
 // `go test ./agent/llmagent/` — the loop someone editing this file runs — unable
-// to see one of them come back. Restoring the mode write fails ten tests here,
-// so that one is covered locally. Restoring the IncludeContents write in its
-// guarded form fails nothing in this package at all.
+// to see one of them come back. The mode write needs no pin of its own:
+// restoring it fails TestCompactionE2E, TestAgentTransfer and
+// TestToolCallbacksAgent right here, because each drives an undeclared agent
+// whose system instruction changes once it is stamped single_turn. Restoring
+// the IncludeContents write in its guarded form fails nothing in this package
+// at all, hence this test.
 func TestRunLLMAgentAsNode_DoesNotMutateTheAgentsIncludeContents(t *testing.T) {
 	t.Parallel()
 

--- a/agent/llmagent/llm_agent_wrapper_test.go
+++ b/agent/llmagent/llm_agent_wrapper_test.go
@@ -389,6 +389,38 @@ func TestPrepareLLMAgentInput(t *testing.T) {
 			t.Errorf("IsolationScope = %q, want empty", got.IsolationScope)
 		}
 	})
+
+	// The two rows that cover what this function's change actually did: it
+	// reads the resolved mode rather than the declaration, so an UNDECLARED
+	// agent seeds when a placement bound it single_turn and does not otherwise.
+	// Every row above declares a mode, so none of them can tell the two apart.
+	t.Run("undeclared with no binding returns nil", func(t *testing.T) {
+		t.Parallel()
+		a := makeLLMAgent(t, "u")
+		ctx := newStubNodeContext(t, a, "")
+		if got := llmagent.PrepareLLMAgentInput(a, ctx, "hello"); got != nil {
+			t.Errorf("PrepareLLMAgentInput for an unplaced undeclared agent = %v, want nil", got)
+		}
+	})
+
+	t.Run("undeclared bound single_turn by a placement seeds", func(t *testing.T) {
+		t.Parallel()
+		a := makeLLMAgent(t, "u")
+		internalAgent, ok := a.(llminternal.Agent)
+		if !ok {
+			t.Fatal("agent is not an llminternal.Agent")
+		}
+		state := llminternal.Reveal(internalAgent)
+		bound := llminternal.WithBoundMode(t.Context(), a.Name(), state, llminternal.ModeSingleTurn)
+		ic := icontext.NewInvocationContext(bound, icontext.InvocationContextParams{
+			Agent:        a,
+			InvocationID: "inv-bound",
+		})
+		got := llmagent.PrepareLLMAgentInput(a, agent.NewContext(ic), "hello")
+		if got == nil {
+			t.Fatal("expected a seed event for an agent a placement bound single_turn; got nil")
+		}
+	})
 }
 
 func TestProcessLLMAgentOutput(t *testing.T) {
@@ -1283,16 +1315,25 @@ func fcContent(id, name string, args map[string]any) *genai.Content {
 
 // RunLLMAgentAsNode is exported, and agent.Context.WithAgentContext returns nil
 // for the tool and callback wrappers rather than erroring, so routing the mode
-// binding back through it nils the context out. The single_turn and task
-// branches now resolve their binding without touching WithAgentContext at all,
-// which this pins.
+// binding back through it nils the context out. This pins that the single_turn
+// and task branches do not do that: they panic if the binding is routed back
+// unguarded.
+//
+// What it does NOT pin is the binding itself. The agent here declares
+// single_turn, so deleting the bind leaves the same branch selected and this
+// test still passes. Its workflow-side sibling avoids that by declaring no
+// mode, and the same trick does not work here: an undeclared agent with no
+// binding resolves to chat at this entry point, and a chat run over a tool
+// context panics on the merge base and on head alike. The binding is pinned
+// locally instead by TestRunLLMAgentAsNode_DeclaredSingleTurn_BindsForTheRequestProcessors,
+// which fails when it is deleted.
 //
 // The chat branch is deliberately not covered. It is the one branch that still
 // re-binds, because runChat needs the agent.Context itself, and it guards the
-// nil — but a chat run cannot be driven from a tool context on the merge base
-// either. Both that and a seeded single_turn run (a tool context reports no
-// session, which wrappedSession then wraps) panic identically without this
-// change, so neither is this PR's to fix or to assert.
+// nil. That guard has no test because it cannot change an outcome: a chat run
+// over a tool context dies either way, guarded a line later or unguarded a line
+// earlier. A seeded single_turn run over one panics identically on the merge
+// base too, so neither is this PR's to fix or to assert.
 func TestRunLLMAgentAsNode_SingleTurnAcceptsAToolContext(t *testing.T) {
 	t.Parallel()
 

--- a/agent/llmagent/llm_agent_wrapper_test.go
+++ b/agent/llmagent/llm_agent_wrapper_test.go
@@ -1293,8 +1293,9 @@ func fcContent(id, name string, args map[string]any) *genai.Content {
 func TestRunLLMAgentAsNode_SingleTurnAcceptsAToolContext(t *testing.T) {
 	t.Parallel()
 
+	llm := &recordingLLM{}
 	a := makeLLMAgent(t, "worker", withMode(llmagent.ModeSingleTurn),
-		func(c *llmagent.Config) { c.Model = &recordingLLM{} })
+		func(c *llmagent.Config) { c.Model = llm })
 
 	svc := session.InMemoryService()
 	resp, err := svc.Create(t.Context(), &session.CreateRequest{AppName: "app", UserID: "u"})
@@ -1309,10 +1310,16 @@ func TestRunLLMAgentAsNode_SingleTurnAcceptsAToolContext(t *testing.T) {
 	})
 	toolCtx := agent.NewToolContext(ic, "fc-1", &session.EventActions{}, nil)
 
-	// The assertion is that this drains rather than panicking.
 	for _, err := range llmagent.RunLLMAgentAsNode(a, toolCtx, nil) {
 		if err != nil {
 			t.Fatalf("RunLLMAgentAsNode: %v", err)
 		}
+	}
+	// Not panicking is most of the point, but a branch that quietly stopped
+	// running the agent would satisfy that too. A tool context reports no
+	// session and no run config, so an early bail on either is the plausible
+	// regression, and only reaching the model rules it out.
+	if llm.got == nil {
+		t.Error("the model was never called; the single_turn branch did not run the agent")
 	}
 }

--- a/agent/llmagent/llm_agent_wrapper_test.go
+++ b/agent/llmagent/llm_agent_wrapper_test.go
@@ -26,6 +26,7 @@ import (
 	"google.golang.org/adk/v2/agent"
 	"google.golang.org/adk/v2/agent/llmagent"
 	icontext "google.golang.org/adk/v2/internal/context"
+	"google.golang.org/adk/v2/internal/llminternal"
 	"google.golang.org/adk/v2/internal/workflowinternal"
 	"google.golang.org/adk/v2/model"
 	"google.golang.org/adk/v2/runner"
@@ -698,8 +699,8 @@ func TestRunLLMAgentAsNode_UnsupportedMode_Errors(t *testing.T) {
 // Resolving the mode reads ctx, so an exported entry point has to reject a nil
 // one rather than dereference it. This agent declares single_turn, so on the
 // merge base it passed the mode check and then panicked at ctx.UserContent().
-// An error is better than either. (The bogus-mode test above is the case where
-// the base did error at the check.)
+// Erroring before any of that is better. (The bogus-mode test above is the case
+// where the base did error at the check.)
 func TestRunLLMAgentAsNode_NilContext_Errors(t *testing.T) {
 	t.Parallel()
 	a := makeLLMAgent(t, "x", withMode(llmagent.ModeSingleTurn))
@@ -1323,5 +1324,50 @@ func TestRunLLMAgentAsNode_SingleTurnAcceptsAToolContext(t *testing.T) {
 	// regression, and only reaching the model rules it out.
 	if llm.got == nil {
 		t.Error("the model was never called; the single_turn branch did not run the agent")
+	}
+}
+
+// The wrapper's two removed writes are pinned from workflow_test, which leaves
+// `go test ./agent/llmagent/` — the loop someone editing this file runs — unable
+// to see one of them come back. Restoring the mode write fails ten tests here,
+// so that one is covered locally. Restoring the IncludeContents write in its
+// guarded form fails nothing in this package at all.
+func TestRunLLMAgentAsNode_DoesNotMutateTheAgentsIncludeContents(t *testing.T) {
+	t.Parallel()
+
+	llm := &recordingLLM{}
+	a := makeLLMAgent(t, "worker", withMode(llmagent.ModeSingleTurn),
+		func(c *llmagent.Config) { c.Model = llm })
+
+	internalAgent, ok := a.(llminternal.Agent)
+	if !ok {
+		t.Fatal("agent is not an llminternal.Agent")
+	}
+	if got := llminternal.Reveal(internalAgent).IncludeContents; got != "" {
+		t.Fatalf("precondition: IncludeContents = %q, want empty", got)
+	}
+
+	svc := session.InMemoryService()
+	resp, err := svc.Create(t.Context(), &session.CreateRequest{AppName: "app", UserID: "u"})
+	if err != nil {
+		t.Fatalf("session.Create: %v", err)
+	}
+	ic := icontext.NewInvocationContext(t.Context(), icontext.InvocationContextParams{
+		Agent:        a,
+		Session:      resp.Session,
+		UserContent:  genai.NewContentFromText("hi", "user"),
+		InvocationID: "inv-ic",
+	})
+	for _, err := range llmagent.RunLLMAgentAsNode(a, agent.NewContext(ic), "go") {
+		if err != nil {
+			t.Fatalf("RunLLMAgentAsNode: %v", err)
+		}
+	}
+	if llm.got == nil {
+		t.Fatal("the model was never called, so the single_turn path was not exercised")
+	}
+
+	if got := llminternal.Reveal(internalAgent).IncludeContents; got != "" {
+		t.Errorf("IncludeContents after a single_turn run = %q, want empty (a run must not mutate the agent)", got)
 	}
 }

--- a/agent/llmagent/llmagent.go
+++ b/agent/llmagent/llmagent.go
@@ -153,11 +153,9 @@ func installTaskTools(a *llmAgent) error {
 			continue
 		}
 		subState := llminternal.Reveal(subInternal)
-		if subState.Mode == llminternal.ModeUnset {
-			subState.Mode = llminternal.ModeChat
-		}
-
-		switch subState.Mode {
+		// A sub-agent that declares no mode is a chat peer, reached via
+		// transfer_to_agent rather than through a tool on the parent.
+		switch llminternal.ResolveMode(subState.Mode, llminternal.ModeChat) {
 		case llminternal.ModeSingleTurn:
 			t, err := workflowinternal.NewSingleTurnTool(sub)
 			if err != nil {

--- a/agent/llmagent/llmagent.go
+++ b/agent/llmagent/llmagent.go
@@ -301,6 +301,10 @@ type Config struct {
 	DisallowTransferToPeers bool
 
 	// Whether to include contents (conversation history) in the model request.
+	//
+	// Left unset, an agent placed as a single_turn workflow node sees only the
+	// current turn. Setting IncludeContentsDefault explicitly keeps the history
+	// even there.
 	IncludeContents IncludeContents
 
 	// TODO(ngeorgy): consider to switch to jsonschema for input and output schema.

--- a/agent/llmagent/llmagent.go
+++ b/agent/llmagent/llmagent.go
@@ -149,11 +149,9 @@ func installTaskTools(a *llmAgent) error {
 			continue
 		}
 		subState := llminternal.Reveal(subInternal)
-		if subState.Mode == llminternal.ModeUnset {
-			subState.Mode = llminternal.ModeChat
-		}
-
-		switch subState.Mode {
+		// A sub-agent that declares no mode is a chat peer, reached via
+		// transfer_to_agent rather than through a tool on the parent.
+		switch llminternal.ResolveMode(subState.Mode, llminternal.ModeChat) {
 		case llminternal.ModeSingleTurn:
 			t, err := workflowinternal.NewSingleTurnTool(sub)
 			if err != nil {

--- a/agent/llmagent/llmagent.go
+++ b/agent/llmagent/llmagent.go
@@ -297,6 +297,10 @@ type Config struct {
 	DisallowTransferToPeers bool
 
 	// Whether to include contents (conversation history) in the model request.
+	//
+	// Left unset, an agent placed as a single_turn workflow node sees only the
+	// current turn. Setting IncludeContentsDefault explicitly keeps the history
+	// even there.
 	IncludeContents IncludeContents
 
 	// TODO(ngeorgy): consider to switch to jsonschema for input and output schema.

--- a/agent/llmagent/llmagent.go
+++ b/agent/llmagent/llmagent.go
@@ -418,7 +418,11 @@ type IncludeContents string
 const (
 	// IncludeContentsNone makes the llmagent operate solely on its current turn (latest user input + any following agent events).
 	IncludeContentsNone IncludeContents = "none"
-	// IncludeContentsDefault is enabled by default. The llmagent receives the relevant conversation history.
+	// IncludeContentsDefault is what an unset IncludeContents behaves as for a
+	// plain conversational agent: the llmagent receives the relevant
+	// conversation history. Setting it explicitly is not the same as leaving
+	// the field unset — it also keeps the history for an agent placed as a
+	// single_turn workflow node, which otherwise sees only the current turn.
 	IncludeContentsDefault IncludeContents = "default"
 )
 

--- a/agent/llmagent/llmagent_delegation_test.go
+++ b/agent/llmagent/llmagent_delegation_test.go
@@ -840,8 +840,8 @@ always contains everything needed for both steps.`,
 // TestDelegation_03_ChatToSingleTurn covers the SingleTurnTool path:
 // the coordinator emits an FC for the sub-agent, the standard tool-
 // execution pipeline runs it through an AgentNode in a sub-branch,
-// the sub-agent runs exactly ONE LLM round with IncludeContents="none"
-// (so it doesn't see the coordinator's conversation), and its
+// the sub-agent runs exactly ONE LLM round with its history scoped to
+// that turn (so it doesn't see the coordinator's conversation), and its
 // structured reply is returned to the coordinator as a regular FR.
 //
 // Unlike task mode, single_turn does NOT install a finish_task tool;
@@ -935,7 +935,7 @@ the sub-agent more than once. Do NOT ask the user follow-up questions.`,
 	// Verifies single_turn sub-agents are re-invocable across user
 	// turns: the coordinator re-dispatches `translator` for a new
 	// language. The previous translation should NOT leak into the
-	// new sub-branch (single_turn agents see IncludeContents="none"),
+	// new sub-branch (a single_turn placement scopes history to the turn),
 	// but the coordinator's own history still includes both
 	// translator FRs across turns.
 	events2 := dr.turn("Now translate the same word to French.")

--- a/examples/workflow/complex/README.md
+++ b/examples/workflow/complex/README.md
@@ -91,6 +91,6 @@ Agent -> ## Recent Sustainable Technology Advancements                    (Synth
 
 ## Notes
 
-A `JoinNode` is the only node that may have several **unconditional** incoming edges; converging plain nodes that way is rejected (`ErrUnsupportedFanIn`). Wrapping an `LlmAgent` in an `AgentNode` defaults it to single-turn mode, which is what lets the synthesis agent sit mid-graph: a chat-mode agent may only be wired directly from `Start`.
+A `JoinNode` is the only node that may have several **unconditional** incoming edges; converging plain nodes that way is rejected (`ErrUnsupportedFanIn`). An `LlmAgent` that declares no mode runs single-turn at a graph node, which is what lets the synthesis agent sit mid-graph: a chat-mode agent may only be wired directly from `Start`. The mode is resolved per placement, so the agent's own declaration is left untouched and the same instance may be placed elsewhere.
 
 This fan-out/gather behavior matches adk-python's graph workflow, which emits the same per-researcher events before the synthesis.

--- a/examples/workflow/complex/main.go
+++ b/examples/workflow/complex/main.go
@@ -196,9 +196,9 @@ func newResearchPipeline(m model.LLM) (agent.Agent, error) {
 	// resilientModel already bounds, retries, and fails open on each call,
 	// so the nodes need no scheduler-level RetryConfig or Timeout.
 	//
-	// Wrapping an LlmAgent in an AgentNode defaults it to single-turn mode,
-	// so the synthesis node consumes the formatter's output instead of the
-	// chat history — which is why it may sit mid-graph rather than at Start.
+	// An LlmAgent that declares no mode runs single-turn at a graph node, so
+	// the synthesis node consumes the formatter's output instead of the chat
+	// history — which is why it may sit mid-graph rather than at Start.
 	renewableNode, err := workflow.NewAgentNode(renewableAgent, workflow.NodeConfig{})
 	if err != nil {
 		return nil, fmt.Errorf("creating renewable node: %w", err)

--- a/internal/llminternal/agent_transfer.go
+++ b/internal/llminternal/agent_transfer.go
@@ -83,7 +83,7 @@ func AgentTransferRequestProcessor(ctx agent.InvocationContext, req *model.LLMRe
 
 		// TODO(hyangah): why do we set this up in request processor
 		// instead of registering this as a normal function tool of the Agent?
-		transferToAgentTool, err := NewTransferToAgentTool(agent, parents[agent.Name()], targets)
+		transferToAgentTool, err := NewTransferToAgentTool(ctx, agent, parents[agent.Name()], targets)
 		if err != nil {
 			yield(nil, err)
 			return
@@ -104,9 +104,10 @@ type TransferToAgentTool struct {
 	supportedAgents []agent.Agent
 }
 
-// NewTransferToAgentTool creates a new TransferToAgentTool.
-func NewTransferToAgentTool(curAgent, parent agent.Agent, targets []agent.Agent) (*TransferToAgentTool, error) {
-	si, err := instructionsForTransferToAgent(curAgent, parent, targets)
+// NewTransferToAgentTool creates a new TransferToAgentTool. ctx supplies the
+// mode curAgent runs under, which decides whether transfer applies at all.
+func NewTransferToAgentTool(ctx agent.InvocationContext, curAgent, parent agent.Agent, targets []agent.Agent) (*TransferToAgentTool, error) {
+	si, err := instructionsForTransferToAgent(ctx, curAgent, parent, targets)
 	if err != nil {
 		return nil, err
 	}
@@ -306,12 +307,12 @@ func appendTools(r *model.LLMRequest, tools ...tool.Tool) error {
 var transferToAgentPromptTmpl = template.Must(
 	template.New("transfer_to_agent_prompt").Parse(agentTransferInstructionTemplate))
 
-func instructionsForTransferToAgent(curAgent, parent agent.Agent, targets []agent.Agent) (string, error) {
+func instructionsForTransferToAgent(ctx agent.InvocationContext, curAgent, parent agent.Agent, targets []agent.Agent) (string, error) {
 	cur := asLLMAgent(curAgent)
 	// Suppress transfer instructions for task / single_turn agents:
 	// they reach their callees via FC delegation (TaskAgentTool /
 	// SingleTurnTool), not via transfer.
-	switch cur.internal().Mode {
+	switch ModeFor(ctx, curAgent.Name(), cur.internal().Mode) {
 	case ModeTask, ModeSingleTurn:
 		return "", nil
 	}

--- a/internal/llminternal/agent_transfer.go
+++ b/internal/llminternal/agent_transfer.go
@@ -105,7 +105,9 @@ type TransferToAgentTool struct {
 }
 
 // NewTransferToAgentTool creates a new TransferToAgentTool. ctx supplies the
-// mode curAgent runs under, which decides whether transfer applies at all.
+// mode curAgent runs under, which decides whether the transfer INSTRUCTIONS are
+// generated. The tool declaration itself ships either way, so a single_turn
+// agent is still able to call it.
 func NewTransferToAgentTool(ctx agent.InvocationContext, curAgent, parent agent.Agent, targets []agent.Agent) (*TransferToAgentTool, error) {
 	si, err := instructionsForTransferToAgent(ctx, curAgent, parent, targets)
 	if err != nil {

--- a/internal/llminternal/agent_transfer.go
+++ b/internal/llminternal/agent_transfer.go
@@ -314,7 +314,7 @@ func instructionsForTransferToAgent(ctx agent.InvocationContext, curAgent, paren
 	// Suppress transfer instructions for task / single_turn agents:
 	// they reach their callees via FC delegation (TaskAgentTool /
 	// SingleTurnTool), not via transfer.
-	switch ModeFor(ctx, curAgent.Name(), cur.internal().Mode) {
+	switch ModeFor(ctx, curAgent.Name(), cur.internal()) {
 	case ModeTask, ModeSingleTurn:
 		return "", nil
 	}

--- a/internal/llminternal/compaction_mode_test.go
+++ b/internal/llminternal/compaction_mode_test.go
@@ -1,0 +1,65 @@
+// Copyright 2026 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package llminternal
+
+import (
+	"testing"
+
+	"google.golang.org/genai"
+
+	"google.golang.org/adk/v2/agent"
+	icontext "google.golang.org/adk/v2/internal/context"
+	"google.golang.org/adk/v2/internal/utils"
+	"google.golang.org/adk/v2/session"
+)
+
+// The estimate decides when a turn is compacted, so it has to describe the
+// prompt the flow will actually build. Both read the mode the agent runs under
+// rather than the one it declares: an agent placed single_turn is sent the
+// single-turn nudge, and an estimate taken from the bare declaration leaves it
+// out. The nudge only reaches a scoped run, which is where a delegated
+// single_turn agent lives, so the fixture supplies an isolation scope.
+func TestPromptTokenEstimator_UsesTheResolvedMode(t *testing.T) {
+	t.Parallel()
+
+	const agentName = "worker"
+
+	newCtx := func(bind bool) agent.InvocationContext {
+		stdCtx := t.Context()
+		if bind {
+			stdCtx = WithBoundMode(stdCtx, agentName, ModeSingleTurn)
+		}
+		return icontext.NewInvocationContext(stdCtx, icontext.InvocationContextParams{
+			Agent: &mockLLMAgent{
+				Agent: utils.Must(agent.New(agent.Config{Name: agentName})),
+				s:     &State{},
+			},
+			IsolationScope: "scope-1",
+			UserContent:    genai.NewContentFromText("do the thing", "user"),
+		})
+	}
+
+	// Identical events and an identical declaration on both sides. The only
+	// difference is whether a placement resolved single_turn for this agent.
+	var events []*session.Event
+	placed := promptTokenEstimator(newCtx(true))(events)
+	unplaced := promptTokenEstimator(newCtx(false))(events)
+
+	if placed <= unplaced {
+		t.Errorf("estimate with a single_turn placement = %d, without one = %d; the placed "+
+			"estimate must be the larger of the two, because its prompt carries the "+
+			"single-turn nudge and the unplaced one does not", placed, unplaced)
+	}
+}

--- a/internal/llminternal/compaction_mode_test.go
+++ b/internal/llminternal/compaction_mode_test.go
@@ -37,14 +37,15 @@ func TestPromptTokenEstimator_UsesTheResolvedMode(t *testing.T) {
 	const agentName = "worker"
 
 	newCtx := func(bind bool) agent.InvocationContext {
+		state := &State{}
 		stdCtx := t.Context()
 		if bind {
-			stdCtx = WithBoundMode(stdCtx, agentName, ModeSingleTurn)
+			stdCtx = WithBoundMode(stdCtx, agentName, state, ModeSingleTurn)
 		}
 		return icontext.NewInvocationContext(stdCtx, icontext.InvocationContextParams{
 			Agent: &mockLLMAgent{
 				Agent: utils.Must(agent.New(agent.Config{Name: agentName})),
-				s:     &State{},
+				s:     state,
 			},
 			IsolationScope: "scope-1",
 			UserContent:    genai.NewContentFromText("do the thing", "user"),

--- a/internal/llminternal/compaction_processor.go
+++ b/internal/llminternal/compaction_processor.go
@@ -228,12 +228,16 @@ func promptTokenEstimator(ctx agent.InvocationContext) compactioninternal.TokenC
 			return 0
 		}
 		state := llmAgent.internal()
+		// Resolve the mode the same way the contents processor does. Reading
+		// the declaration instead would estimate a prompt without the
+		// single-turn nudge for an agent whose placement resolved single_turn,
+		// and the estimate decides when to compact.
 		contents, err := buildContentsDefault(
 			ctx.Agent().Name(),
 			ctx.Branch(),
 			ctx.IsolationScope(),
 			events,
-			state.Mode == ModeSingleTurn,
+			ModeFor(ctx, ctx.Agent().Name(), state.Mode) == ModeSingleTurn,
 			ctx.UserContent(),
 		)
 		if err != nil {

--- a/internal/llminternal/compaction_processor.go
+++ b/internal/llminternal/compaction_processor.go
@@ -237,7 +237,7 @@ func promptTokenEstimator(ctx agent.InvocationContext) compactioninternal.TokenC
 			ctx.Branch(),
 			ctx.IsolationScope(),
 			events,
-			ModeFor(ctx, ctx.Agent().Name(), state.Mode) == ModeSingleTurn,
+			ModeFor(ctx, ctx.Agent().Name(), state) == ModeSingleTurn,
 			ctx.UserContent(),
 		)
 		if err != nil {

--- a/internal/llminternal/compaction_processor.go
+++ b/internal/llminternal/compaction_processor.go
@@ -228,10 +228,16 @@ func promptTokenEstimator(ctx agent.InvocationContext) compactioninternal.TokenC
 			return 0
 		}
 		state := llmAgent.internal()
-		// Resolve the mode the same way the contents processor does. Reading
-		// the declaration instead would estimate a prompt without the
-		// single-turn nudge for an agent whose placement resolved single_turn,
-		// and the estimate decides when to compact.
+		// Resolve the mode the way the contents processor resolves it for the
+		// NUDGE. Reading the declaration instead would estimate a prompt
+		// without the single-turn nudge for an agent whose placement resolved
+		// single_turn, and the estimate decides when to compact.
+		//
+		// It does not mirror that processor's other half: the estimate always
+		// builds with buildContentsDefault below, so for a placement that hides
+		// history it counts turns the real prompt will not carry. That
+		// divergence predates this change — an explicit IncludeContents="none"
+		// reached it the same way — and a placement is now a second route in.
 		contents, err := buildContentsDefault(
 			ctx.Agent().Name(),
 			ctx.Branch(),

--- a/internal/llminternal/contents_processor.go
+++ b/internal/llminternal/contents_processor.go
@@ -48,16 +48,20 @@ func ContentsRequestProcessor(ctx agent.InvocationContext, req *model.LLMRequest
 		// Two questions, deliberately answered from different sources.
 		//
 		// Whether to hide history follows the placement alone — a mode this
-		// invocation bound to THIS agent. A single_turn agent that merely
-		// declares the mode and is then reached by transfer_to_agent keeps
-		// the conversation, because no placement put it where history has
-		// to go.
+		// invocation bound to THIS agent. An agent that merely declares
+		// single_turn and is then reached by transfer_to_agent keeps the
+		// conversation, because no placement put it where history has to go.
+		// The placement also loses to an explicit IncludeContents: asking
+		// for history beats being placed somewhere that hides it, as in
+		// adk-python, where _llm_agent_wrapper.py gates the same override on
+		// include_contents being absent from model_fields_set.
 		//
 		// How to shape the turn also honours the declaration, since the
 		// single-turn nudge describes the agent rather than its placement.
 		boundMode, bound := BoundMode(ctx, name)
+		placementHidesHistory := bound && boundMode == ModeSingleTurn && state.IncludeContents == ""
 		fn := buildContentsDefault // "" or "default".
-		if state.IncludeContents == "none" || (bound && boundMode == ModeSingleTurn) {
+		if state.IncludeContents == "none" || placementHidesHistory {
 			fn = buildContentsCurrentTurnContextOnly
 		}
 		isSingleTurn := ModeFor(ctx, name, state.Mode) == ModeSingleTurn

--- a/internal/llminternal/contents_processor.go
+++ b/internal/llminternal/contents_processor.go
@@ -44,9 +44,11 @@ func ContentsRequestProcessor(ctx agent.InvocationContext, req *model.LLMRequest
 			return // In python, no error is yielded.
 		}
 		state := llmAgent.internal()
+		isSingleTurn := ResolvedMode(ctx, state.Mode) == ModeSingleTurn
 		fn := buildContentsDefault // "" or "default".
-		if state.IncludeContents == "none" {
-			// Include current turn context only (no conversation history)
+		// A single_turn agent produces its answer in one exchange, so it
+		// gets the current turn only, never the conversation history.
+		if state.IncludeContents == "none" || isSingleTurn {
 			fn = buildContentsCurrentTurnContextOnly
 		}
 		// A compaction record instructs prompt assembly to drop a span of
@@ -67,7 +69,6 @@ func ContentsRequestProcessor(ctx agent.InvocationContext, req *model.LLMRequest
 				events = append(events, e)
 			}
 		}
-		isSingleTurn := state.Mode == ModeSingleTurn
 		contents, err := fn(ctx.Agent().Name(), ctx.Branch(), ctx.IsolationScope(), events, isSingleTurn, ctx.UserContent())
 		if err != nil {
 			yield(nil, err)

--- a/internal/llminternal/contents_processor.go
+++ b/internal/llminternal/contents_processor.go
@@ -44,13 +44,24 @@ func ContentsRequestProcessor(ctx agent.InvocationContext, req *model.LLMRequest
 			return // In python, no error is yielded.
 		}
 		state := llmAgent.internal()
-		isSingleTurn := ResolvedMode(ctx, state.Mode) == ModeSingleTurn
+		name := ctx.Agent().Name()
+		// Two questions, deliberately answered from different sources.
+		//
+		// Whether to hide history follows the placement alone — a mode this
+		// invocation bound to THIS agent. A single_turn agent that merely
+		// declares the mode and is then reached by transfer_to_agent keeps
+		// the conversation, because no placement put it where history has
+		// to go.
+		//
+		// How to shape the turn also honours the declaration, since the
+		// single-turn nudge describes the agent rather than its placement.
+		boundMode, bound := BoundMode(ctx, name)
 		fn := buildContentsDefault // "" or "default".
-		// A single_turn agent produces its answer in one exchange, so it
-		// gets the current turn only, never the conversation history.
-		if state.IncludeContents == "none" || isSingleTurn {
+		if state.IncludeContents == "none" || (bound && boundMode == ModeSingleTurn) {
 			fn = buildContentsCurrentTurnContextOnly
 		}
+		isSingleTurn := ModeFor(ctx, name, state.Mode) == ModeSingleTurn
+
 		// A compaction record instructs prompt assembly to drop a span of
 		// history and substitute content in its place. EventActions is
 		// writable by tool code, and the REST create-session body maps it

--- a/internal/llminternal/contents_processor.go
+++ b/internal/llminternal/contents_processor.go
@@ -46,11 +46,16 @@ func ContentsRequestProcessor(ctx agent.InvocationContext, req *model.LLMRequest
 		name := ctx.Agent().Name()
 		// Two questions, deliberately answered from different sources.
 		// Hiding history follows the placement alone: only an agent a
-		// placement seeded with one synthetic turn loses its history.
+		// placement seeded with one synthetic turn loses its history, and
+		// only while the caller left IncludeContents unset — asking for
+		// history explicitly beats the placement, as it does in adk-python
+		// (_llm_agent_wrapper.py gates the same override on
+		// include_contents being absent from model_fields_set).
 		// Shaping that turn as single_turn also honours the declaration.
 		boundMode, bound := BoundMode(ctx, name)
+		placementHidesHistory := bound && boundMode == ModeSingleTurn && state.IncludeContents == ""
 		fn := buildContentsDefault // "" or "default".
-		if state.IncludeContents == "none" || (bound && boundMode == ModeSingleTurn) {
+		if state.IncludeContents == "none" || placementHidesHistory {
 			fn = buildContentsCurrentTurnContextOnly
 		}
 		isSingleTurn := ModeFor(ctx, name, state.Mode) == ModeSingleTurn

--- a/internal/llminternal/contents_processor.go
+++ b/internal/llminternal/contents_processor.go
@@ -43,9 +43,11 @@ func ContentsRequestProcessor(ctx agent.InvocationContext, req *model.LLMRequest
 			return // In python, no error is yielded.
 		}
 		state := llmAgent.internal()
+		isSingleTurn := ResolvedMode(ctx, state.Mode) == ModeSingleTurn
 		fn := buildContentsDefault // "" or "default".
-		if state.IncludeContents == "none" {
-			// Include current turn context only (no conversation history)
+		// A single_turn agent produces its answer in one exchange, so it
+		// gets the current turn only, never the conversation history.
+		if state.IncludeContents == "none" || isSingleTurn {
 			fn = buildContentsCurrentTurnContextOnly
 		}
 		var events []*session.Event
@@ -54,7 +56,6 @@ func ContentsRequestProcessor(ctx agent.InvocationContext, req *model.LLMRequest
 				events = append(events, e)
 			}
 		}
-		isSingleTurn := state.Mode == ModeSingleTurn
 		contents, err := fn(ctx.Agent().Name(), ctx.Branch(), ctx.IsolationScope(), events, isSingleTurn, ctx.UserContent())
 		if err != nil {
 			yield(nil, err)

--- a/internal/llminternal/contents_processor.go
+++ b/internal/llminternal/contents_processor.go
@@ -43,13 +43,17 @@ func ContentsRequestProcessor(ctx agent.InvocationContext, req *model.LLMRequest
 			return // In python, no error is yielded.
 		}
 		state := llmAgent.internal()
-		isSingleTurn := ResolvedMode(ctx, state.Mode) == ModeSingleTurn
+		name := ctx.Agent().Name()
+		// Two questions, deliberately answered from different sources.
+		// Hiding history follows the placement alone: only an agent a
+		// placement seeded with one synthetic turn loses its history.
+		// Shaping that turn as single_turn also honours the declaration.
+		boundMode, bound := BoundMode(ctx, name)
 		fn := buildContentsDefault // "" or "default".
-		// A single_turn agent produces its answer in one exchange, so it
-		// gets the current turn only, never the conversation history.
-		if state.IncludeContents == "none" || isSingleTurn {
+		if state.IncludeContents == "none" || (bound && boundMode == ModeSingleTurn) {
 			fn = buildContentsCurrentTurnContextOnly
 		}
+		isSingleTurn := ModeFor(ctx, name, state.Mode) == ModeSingleTurn
 		var events []*session.Event
 		if ctx.Session() != nil {
 			for e := range ctx.Session().Events().All() {

--- a/internal/llminternal/contents_processor.go
+++ b/internal/llminternal/contents_processor.go
@@ -49,8 +49,10 @@ func ContentsRequestProcessor(ctx agent.InvocationContext, req *model.LLMRequest
 		//
 		// Whether to hide history follows the placement alone — a mode this
 		// invocation bound to THIS agent. An agent that merely declares
-		// single_turn and is then reached by transfer_to_agent keeps the
-		// conversation, because no placement put it where history has to go.
+		// single_turn keeps the conversation when it is run without one, which
+		// in practice means a child a composite agent runs directly rather than
+		// through the node wrapper. Reaching it through the wrapper does not
+		// count: the wrapper binds the mode it resolved, declaration included.
 		// The placement also loses to an explicit IncludeContents: asking
 		// for history beats being placed somewhere that hides it, as in
 		// adk-python, where _llm_agent_wrapper.py gates the same override on
@@ -59,9 +61,15 @@ func ContentsRequestProcessor(ctx agent.InvocationContext, req *model.LLMRequest
 		// How to shape the turn also honours the declaration, since the
 		// single-turn nudge describes the agent rather than its placement.
 		boundMode, bound := BoundMode(ctx, name)
-		placementHidesHistory := bound && boundMode == ModeSingleTurn && state.IncludeContents == ""
+		// Only "default" opts out of the placement. Testing for "" instead
+		// would let any unrecognised value opt out too, and IncludeContents is
+		// an unvalidated string, so a typo — "None", "defualt" — would hand a
+		// one-shot node the whole transcript. The merge base forced "none" here
+		// and so could not be misconfigured this way.
+		placementHidesHistory := bound && boundMode == ModeSingleTurn &&
+			state.IncludeContents != includeContentsDefault
 		fn := buildContentsDefault // "" or "default".
-		if state.IncludeContents == "none" || placementHidesHistory {
+		if state.IncludeContents == includeContentsNone || placementHidesHistory {
 			fn = buildContentsCurrentTurnContextOnly
 		}
 		isSingleTurn := ModeFor(ctx, name, state.Mode) == ModeSingleTurn

--- a/internal/llminternal/contents_processor.go
+++ b/internal/llminternal/contents_processor.go
@@ -47,8 +47,9 @@ func ContentsRequestProcessor(ctx agent.InvocationContext, req *model.LLMRequest
 		name := ctx.Agent().Name()
 		// Two questions, deliberately answered from different sources.
 		//
-		// Whether to hide history follows the placement alone — a mode this
-		// invocation bound to THIS agent. An agent that merely declares
+		// Whether to hide history follows the placement — a mode this invocation
+		// bound to THIS agent — or an explicit IncludeContentsNone, which hides
+		// it with or without one. An agent that merely declares
 		// single_turn keeps the conversation when it is run without one, which
 		// in practice means a child a composite agent runs directly rather than
 		// through the node wrapper. Reaching it through the wrapper does not
@@ -68,7 +69,7 @@ func ContentsRequestProcessor(ctx agent.InvocationContext, req *model.LLMRequest
 		// and so could not be misconfigured this way.
 		placementHidesHistory := bound && boundMode == ModeSingleTurn &&
 			state.IncludeContents != includeContentsDefault
-		fn := buildContentsDefault // "" or "default".
+		fn := buildContentsDefault // anything but "none", unless the placement hides it.
 		if state.IncludeContents == includeContentsNone || placementHidesHistory {
 			fn = buildContentsCurrentTurnContextOnly
 		}

--- a/internal/llminternal/contents_processor.go
+++ b/internal/llminternal/contents_processor.go
@@ -61,7 +61,7 @@ func ContentsRequestProcessor(ctx agent.InvocationContext, req *model.LLMRequest
 		//
 		// How to shape the turn also honours the declaration, since the
 		// single-turn nudge describes the agent rather than its placement.
-		boundMode, bound := PlacedMode(ctx, name, state.Mode)
+		boundMode, bound := BoundMode(ctx, name, state)
 		// Only "default" opts out of the placement. Testing for "" instead
 		// would let any unrecognised value opt out too, and IncludeContents is
 		// an unvalidated string, so a typo — "None", "defualt" — would hand a
@@ -73,7 +73,7 @@ func ContentsRequestProcessor(ctx agent.InvocationContext, req *model.LLMRequest
 		if state.IncludeContents == includeContentsNone || placementHidesHistory {
 			fn = buildContentsCurrentTurnContextOnly
 		}
-		isSingleTurn := ModeFor(ctx, name, state.Mode) == ModeSingleTurn
+		isSingleTurn := ModeFor(ctx, name, state) == ModeSingleTurn
 
 		// A compaction record instructs prompt assembly to drop a span of
 		// history and substitute content in its place. EventActions is

--- a/internal/llminternal/contents_processor.go
+++ b/internal/llminternal/contents_processor.go
@@ -61,7 +61,7 @@ func ContentsRequestProcessor(ctx agent.InvocationContext, req *model.LLMRequest
 		//
 		// How to shape the turn also honours the declaration, since the
 		// single-turn nudge describes the agent rather than its placement.
-		boundMode, bound := BoundMode(ctx, name)
+		boundMode, bound := PlacedMode(ctx, name, state.Mode)
 		// Only "default" opts out of the placement. Testing for "" instead
 		// would let any unrecognised value opt out too, and IncludeContents is
 		// an unvalidated string, so a typo — "None", "defualt" — would hand a

--- a/internal/llminternal/contents_processor_test.go
+++ b/internal/llminternal/contents_processor_test.go
@@ -135,7 +135,7 @@ func TestContentsRequestProcessor_IncludeContents(t *testing.T) {
 		},
 		{
 			name:            "helloAndGoodBye",
-			includeContents: "default", // default == ""
+			includeContents: "default", // same as "" here: nothing is bound, so there is no placement to opt out of
 			events:          helloAndGoodBye,
 			want: []*genai.Content{
 				genai.NewContentFromText("hello", "user"),

--- a/internal/llminternal/identity_request_processor.go
+++ b/internal/llminternal/identity_request_processor.go
@@ -32,7 +32,7 @@ func identityRequestProcessor(ctx agent.InvocationContext, req *model.LLMRequest
 		if llmAgent == nil {
 			return // do nothing.
 		}
-		if llmAgent.internal().Mode == ModeSingleTurn {
+		if ModeFor(ctx, ctx.Agent().Name(), llmAgent.internal().Mode) == ModeSingleTurn {
 			return
 		}
 

--- a/internal/llminternal/identity_request_processor.go
+++ b/internal/llminternal/identity_request_processor.go
@@ -32,7 +32,7 @@ func identityRequestProcessor(ctx agent.InvocationContext, req *model.LLMRequest
 		if llmAgent == nil {
 			return // do nothing.
 		}
-		if ModeFor(ctx, ctx.Agent().Name(), llmAgent.internal().Mode) == ModeSingleTurn {
+		if ModeFor(ctx, ctx.Agent().Name(), llmAgent.internal()) == ModeSingleTurn {
 			return
 		}
 

--- a/internal/llminternal/mode.go
+++ b/internal/llminternal/mode.go
@@ -1,0 +1,68 @@
+// Copyright 2026 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package llminternal
+
+import "context"
+
+// An agent that declares no Mode takes one from where it is placed: chat
+// as a runner root, single_turn as a workflow node. Placement belongs to
+// the invocation and one agent instance serves many concurrent
+// invocations, so both the placement default and the mode it resolves to
+// travel on the context. State.Mode stays the agent's own declaration and
+// is never written to after construction.
+
+// ResolveMode returns declared when set, else byPlacement.
+func ResolveMode(declared, byPlacement Mode) Mode {
+	if declared == ModeUnset {
+		return byPlacement
+	}
+	return declared
+}
+
+type (
+	placementModeKey struct{}
+	resolvedModeKey  struct{}
+)
+
+// WithPlacementMode returns ctx carrying the mode agents run under here
+// unless they declare otherwise. Set by whatever places an agent: the
+// runner for a root agent, an AgentNode for a graph node.
+func WithPlacementMode(ctx context.Context, mode Mode) context.Context {
+	return context.WithValue(ctx, placementModeKey{}, mode)
+}
+
+// PlacementMode returns the default imposed by ctx's placement, or
+// fallback when it imposes none.
+func PlacementMode(ctx context.Context, fallback Mode) Mode {
+	if m, ok := ctx.Value(placementModeKey{}).(Mode); ok && m != ModeUnset {
+		return m
+	}
+	return fallback
+}
+
+// WithResolvedMode returns ctx carrying the mode now in effect, so the
+// request processors downstream agree with the agent runner on it.
+func WithResolvedMode(ctx context.Context, mode Mode) context.Context {
+	return context.WithValue(ctx, resolvedModeKey{}, mode)
+}
+
+// ResolvedMode returns the mode in effect on ctx, or fallback when the
+// agent runs outside a path that resolves one.
+func ResolvedMode(ctx context.Context, fallback Mode) Mode {
+	if m, ok := ctx.Value(resolvedModeKey{}).(Mode); ok && m != ModeUnset {
+		return m
+	}
+	return fallback
+}

--- a/internal/llminternal/mode.go
+++ b/internal/llminternal/mode.go
@@ -16,12 +16,22 @@ package llminternal
 
 import "context"
 
-// An agent that declares no Mode takes one from where it is placed: chat
-// as a runner root, single_turn as a workflow node. Placement belongs to
-// the invocation and one agent instance serves many concurrent
-// invocations, so both the placement default and the mode it resolves to
-// travel on the context. State.Mode stays the agent's own declaration and
-// is never written to after construction.
+// Mode resolution.
+//
+// An agent that declares no Mode takes one from where it is placed: chat at a
+// runner root, single_turn at a workflow node. State.Mode is the agent's own
+// immutable declaration, so the resolved mode lives on the invocation instead —
+// one agent instance serves many concurrent invocations, and the same instance
+// may sit at two different placements.
+//
+// Readers that only test for task mode (basic_processor, outputschema_processor)
+// deliberately stay on the declaration: no placement ever defaults to task, so
+// there is nothing for them to resolve.
+//
+// The binding names the agent it describes. A bare context value would be
+// inherited by every nested activation and would then govern an agent it was
+// never resolved for: a peer reached by transfer, or a child that declares its
+// own mode. Callers therefore bind per agent and read per agent.
 
 // ResolveMode returns declared when set, else byPlacement.
 func ResolveMode(declared, byPlacement Mode) Mode {
@@ -31,38 +41,42 @@ func ResolveMode(declared, byPlacement Mode) Mode {
 	return declared
 }
 
-type (
-	placementModeKey struct{}
-	resolvedModeKey  struct{}
-)
+type boundModeKey struct{}
 
-// WithPlacementMode returns ctx carrying the mode agents run under here
-// unless they declare otherwise. Set by whatever places an agent: the
-// runner for a root agent, an AgentNode for a graph node.
-func WithPlacementMode(ctx context.Context, mode Mode) context.Context {
-	return context.WithValue(ctx, placementModeKey{}, mode)
+type boundMode struct {
+	agent string
+	mode  Mode
 }
 
-// PlacementMode returns the default imposed by ctx's placement, or
-// fallback when it imposes none.
-func PlacementMode(ctx context.Context, fallback Mode) Mode {
-	if m, ok := ctx.Value(placementModeKey{}).(Mode); ok && m != ModeUnset {
+// WithBoundMode returns ctx carrying the mode the named agent runs under for
+// this invocation. Set by whatever places the agent: the runner for a root
+// agent, an AgentNode for a graph node.
+func WithBoundMode(ctx context.Context, agentName string, mode Mode) context.Context {
+	if agentName == "" || mode == ModeUnset {
+		return ctx
+	}
+	return context.WithValue(ctx, boundModeKey{}, boundMode{agent: agentName, mode: mode})
+}
+
+// BoundMode reports the mode this invocation bound to agentName, and whether it
+// bound one at all. A binding made for a different agent does not count.
+//
+// Use this only to ask "did a placement put THIS agent in that mode" — a
+// declared mode is deliberately not consulted. Callers wanting the mode an
+// agent actually runs under want [ModeFor].
+func BoundMode(ctx context.Context, agentName string) (Mode, bool) {
+	b, ok := ctx.Value(boundModeKey{}).(boundMode)
+	if !ok || b.agent == "" || b.agent != agentName {
+		return ModeUnset, false
+	}
+	return b.mode, true
+}
+
+// ModeFor returns the mode agentName runs under: the mode this invocation bound
+// to it, else its own declaration.
+func ModeFor(ctx context.Context, agentName string, declared Mode) Mode {
+	if m, ok := BoundMode(ctx, agentName); ok {
 		return m
 	}
-	return fallback
-}
-
-// WithResolvedMode returns ctx carrying the mode now in effect, so the
-// request processors downstream agree with the agent runner on it.
-func WithResolvedMode(ctx context.Context, mode Mode) context.Context {
-	return context.WithValue(ctx, resolvedModeKey{}, mode)
-}
-
-// ResolvedMode returns the mode in effect on ctx, or fallback when the
-// agent runs outside a path that resolves one.
-func ResolvedMode(ctx context.Context, fallback Mode) Mode {
-	if m, ok := ctx.Value(resolvedModeKey{}).(Mode); ok && m != ModeUnset {
-		return m
-	}
-	return fallback
+	return declared
 }

--- a/internal/llminternal/mode.go
+++ b/internal/llminternal/mode.go
@@ -24,9 +24,18 @@ import "context"
 // one agent instance serves many concurrent invocations, and the same instance
 // may sit at two different placements.
 //
-// Readers that only test for task mode (basic_processor, outputschema_processor)
-// deliberately stay on the declaration: no placement ever defaults to task, so
-// there is nothing for them to resolve.
+// Two kinds of reader deliberately stay on the declaration.
+//
+// Those that only test for task mode — basic_processor, outputschema_processor,
+// installTaskTools, AgentNode's synthesizeMode, the runner's task-sub-agent
+// scan — have nothing to resolve, because no placement ever defaults to task.
+//
+// isUntransferableMode asks about a PEER rather than the running agent, and a
+// binding only ever describes the agent being run, so there is no binding for
+// it to consult.
+//
+// Every other reader resolves. A reader that tests for single_turn and skips
+// the resolution disagrees with the request the flow actually builds.
 //
 // The binding names the agent it describes. A bare context value would be
 // inherited by every nested activation and would then govern an agent it was

--- a/internal/llminternal/mode.go
+++ b/internal/llminternal/mode.go
@@ -51,8 +51,15 @@ type boundMode struct {
 // WithBoundMode returns ctx carrying the mode the named agent runs under for
 // this invocation. Set by whatever places the agent: the runner for a root
 // agent, an AgentNode for a graph node.
+//
+// An empty agentName is bound like any other. Config.Name is documented as
+// required and nothing here can supply a missing one, but skipping the binding
+// would silently turn a nameless agent at a graph node into a chat agent
+// carrying the whole transcript. Binding "" leaves such an agent at the
+// placement it was given, and leaves the missing name to whatever validates
+// names.
 func WithBoundMode(ctx context.Context, agentName string, mode Mode) context.Context {
-	if agentName == "" || mode == ModeUnset {
+	if mode == ModeUnset {
 		return ctx
 	}
 	return context.WithValue(ctx, boundModeKey{}, boundMode{agent: agentName, mode: mode})
@@ -66,7 +73,7 @@ func WithBoundMode(ctx context.Context, agentName string, mode Mode) context.Con
 // agent actually runs under want [ModeFor].
 func BoundMode(ctx context.Context, agentName string) (Mode, bool) {
 	b, ok := ctx.Value(boundModeKey{}).(boundMode)
-	if !ok || b.agent == "" || b.agent != agentName {
+	if !ok || b.agent != agentName {
 		return ModeUnset, false
 	}
 	return b.mode, true

--- a/internal/llminternal/mode.go
+++ b/internal/llminternal/mode.go
@@ -24,23 +24,38 @@ import "context"
 // one agent instance serves many concurrent invocations, and the same instance
 // may sit at two different placements.
 //
-// Two kinds of reader deliberately stay on the declaration.
+// Three kinds of reader deliberately stay on the declaration.
 //
 // Those that only test for task mode — basic_processor, outputschema_processor,
-// installTaskTools, AgentNode's synthesizeMode, the runner's task-sub-agent
-// scan — have nothing to resolve, because no placement ever defaults to task.
+// AgentNode's synthesizeMode, the runner's task-sub-agent scan — have nothing to
+// resolve, because no placement ever defaults to task.
 //
 // isUntransferableMode asks about a PEER rather than the running agent, and a
 // binding only ever describes the agent being run, so there is no binding for
 // it to consult.
 //
+// installTaskTools runs at construction, where there is no invocation to
+// consult. It does branch on single_turn, but it is choosing which tool to give
+// a parent for a sub-agent, which is a property of the tree rather than of any
+// one run.
+//
 // Every other reader resolves. A reader that tests for single_turn and skips
 // the resolution disagrees with the request the flow actually builds.
 //
-// The binding names the agent it describes. A bare context value would be
-// inherited by every nested activation and would then govern an agent it was
-// never resolved for: a peer reached by transfer, or a child that declares its
-// own mode. Callers therefore bind per agent and read per agent.
+// The binding names the agent it describes, and the name is part of the context
+// KEY rather than of the value. Two properties follow, and both are needed.
+//
+// A binding never governs an agent it was not resolved for. A bare context value
+// would be inherited by every nested activation — a peer reached by transfer, a
+// child that declares its own mode — and would govern all of them.
+//
+// A binding also survives a nested activation that binds a different agent.
+// Storing one pair under one key gave only the first property: a single_turn
+// graph node that transferred to a chat peer had its slot overwritten, and when
+// the peer transferred back the node's own agent was re-entered on the peer's
+// context and fell back to chat, taking the identity preamble, the transfer
+// instructions and the whole conversation with it. Placements nest, so the
+// bindings have to nest too.
 
 // ResolveMode returns declared when set, else byPlacement.
 func ResolveMode(declared, byPlacement Mode) Mode {
@@ -50,16 +65,18 @@ func ResolveMode(declared, byPlacement Mode) Mode {
 	return declared
 }
 
-type boundModeKey struct{}
-
-type boundMode struct {
-	agent string
-	mode  Mode
-}
+// boundModeKey is the context key for one agent's binding. The agent name is
+// part of the key, so each agent gets its own slot and binding one cannot
+// disturb another's.
+type boundModeKey struct{ agent string }
 
 // WithBoundMode returns ctx carrying the mode the named agent runs under for
 // this invocation. Set by whatever places the agent: the runner for a root
 // agent, an AgentNode for a graph node.
+//
+// Binding an agent that already has one shadows it for the rest of that
+// context, which is what a re-entrant placement of the same agent should do.
+// Binding a different agent leaves the first alone.
 //
 // An empty agentName is bound like any other. Config.Name is documented as
 // required and nothing here can supply a missing one, but skipping the binding
@@ -71,7 +88,7 @@ func WithBoundMode(ctx context.Context, agentName string, mode Mode) context.Con
 	if mode == ModeUnset {
 		return ctx
 	}
-	return context.WithValue(ctx, boundModeKey{}, boundMode{agent: agentName, mode: mode})
+	return context.WithValue(ctx, boundModeKey{agent: agentName}, mode)
 }
 
 // BoundMode reports the mode this invocation bound to agentName, and whether it
@@ -81,11 +98,11 @@ func WithBoundMode(ctx context.Context, agentName string, mode Mode) context.Con
 // declared mode is deliberately not consulted. Callers wanting the mode an
 // agent actually runs under want [ModeFor].
 func BoundMode(ctx context.Context, agentName string) (Mode, bool) {
-	b, ok := ctx.Value(boundModeKey{}).(boundMode)
-	if !ok || b.agent != agentName {
+	mode, ok := ctx.Value(boundModeKey{agent: agentName}).(Mode)
+	if !ok {
 		return ModeUnset, false
 	}
-	return b.mode, true
+	return mode, true
 }
 
 // ModeFor returns the mode agentName runs under: the mode this invocation bound

--- a/internal/llminternal/mode.go
+++ b/internal/llminternal/mode.go
@@ -30,14 +30,16 @@ import "context"
 // AgentNode's synthesizeMode, the runner's task-sub-agent scan — have nothing to
 // resolve, because no placement ever defaults to task.
 //
-// isUntransferableMode asks about a PEER rather than the running agent, and a
-// binding only ever describes the agent being run, so there is no binding for
-// it to consult.
+// isUntransferableMode and installTaskTools both branch on single_turn, and
+// both are right to read the declaration, for the same reason: each is deciding
+// something about the shape of the agent TREE — whether a peer is reachable by
+// transfer, which tool a parent installs for a sub-agent — not about how one
+// agent behaves on one run. A placement is per-run and cannot answer either.
 //
-// installTaskTools runs at construction, where there is no invocation to
-// consult. It does branch on single_turn, but it is choosing which tool to give
-// a parent for a sub-agent, which is a property of the tree rather than of any
-// one run.
+// Note that "there is no binding to consult" would be the wrong reason for
+// isUntransferableMode. Bindings nest, so when a callee computes its transfer
+// targets the caller's binding is still live in that context. It is looked past
+// deliberately.
 //
 // Every other reader resolves. A reader that tests for single_turn and skips
 // the resolution disagrees with the request the flow actually builds.
@@ -84,6 +86,14 @@ type boundModeKey struct{ agent string }
 // carrying the whole transcript. Binding "" leaves such an agent at the
 // placement it was given, and leaves the missing name to whatever validates
 // names.
+//
+// ctx must be non-nil, as for any context helper.
+//
+// A ModeUnset mode returns ctx untouched. That is a guard against recording a
+// placement that resolved nothing, not a way to decline to bind: every binder
+// passes a ResolveMode whose fallback is concrete, so it is unreachable today.
+// There is deliberately no way to CLEAR a binding — a nested placement shadows
+// an outer one by binding its own value, and nothing needs to un-place an agent.
 func WithBoundMode(ctx context.Context, agentName string, mode Mode) context.Context {
 	if mode == ModeUnset {
 		return ctx
@@ -97,6 +107,10 @@ func WithBoundMode(ctx context.Context, agentName string, mode Mode) context.Con
 // Use this only to ask "did a placement put THIS agent in that mode" — a
 // declared mode is deliberately not consulted. Callers wanting the mode an
 // agent actually runs under want [ModeFor].
+//
+// ctx must be non-nil. Passing nil panics in ctx.Value, as it would for any
+// context helper, so callers holding a context that may be nil check it
+// themselves rather than relying on this.
 func BoundMode(ctx context.Context, agentName string) (Mode, bool) {
 	mode, ok := ctx.Value(boundModeKey{agent: agentName}).(Mode)
 	if !ok {

--- a/internal/llminternal/mode.go
+++ b/internal/llminternal/mode.go
@@ -59,6 +59,14 @@ import "context"
 // instructions and the whole conversation with it. Placements nest, so the
 // bindings have to nest too.
 
+// The two values agent/llmagent's IncludeContents constants carry. Duplicated
+// as untyped constants because llminternal cannot import llmagent, which
+// depends on it.
+const (
+	includeContentsNone    = "none"
+	includeContentsDefault = "default"
+)
+
 // ResolveMode returns declared when set, else byPlacement.
 func ResolveMode(declared, byPlacement Mode) Mode {
 	if declared == ModeUnset {
@@ -79,6 +87,14 @@ type boundModeKey struct{ agent string }
 // Binding an agent that already has one shadows it for the rest of that
 // context, which is what a re-entrant placement of the same agent should do.
 // Binding a different agent leaves the first alone.
+//
+// The key is the name alone, so the binding is only as well-scoped as names are
+// unique within one context chain. runner.New rejects a duplicate name anywhere
+// in its agent tree and workflow.New rejects two nodes sharing one, but neither
+// covers a node agent's own descendants, so two distinct same-named agents
+// nested inside one placement would share a slot. Every other name-keyed lookup
+// in the framework — FindAgent, findAgentToRun, transfer targets — has the same
+// precondition.
 //
 // An empty agentName is bound like any other. Config.Name is documented as
 // required and nothing here can supply a missing one, but skipping the binding

--- a/internal/llminternal/mode.go
+++ b/internal/llminternal/mode.go
@@ -41,8 +41,16 @@ import "context"
 // targets the caller's binding is still live in that context. It is looked past
 // deliberately.
 //
-// Every other reader resolves. A reader that tests for single_turn and skips
-// the resolution disagrees with the request the flow actually builds.
+// Every other reader resolves, with one deliberate exception. A reader that
+// tests for single_turn and skips the resolution disagrees with the request the
+// flow actually builds.
+//
+// The exception is the history half of the contents processor, which asks
+// BoundMode directly rather than going through ModeFor. It is the one reader
+// that has to tell a single_turn PLACEMENT from a single_turn DECLARATION —
+// only the placement hides the conversation — and resolving flattens exactly
+// that distinction. Its other half, the single-turn nudge, resolves like
+// everything else.
 //
 // The binding names the agent it describes, and the name is part of the context
 // KEY rather than of the value. Two properties follow, and both are needed.

--- a/internal/llminternal/mode.go
+++ b/internal/llminternal/mode.go
@@ -59,12 +59,17 @@ import "context"
 // instructions and the whole conversation with it. Placements nest, so the
 // bindings have to nest too.
 //
-// The name is a proxy for the agent, and an imperfect one: names are unique
+// The name alone is not enough to say WHOSE binding one is. Names are unique
 // only across SubAgents(), and a graph node's agent is not in SubAgents(), so
-// two distinct same-named agents can share one context chain. Readers go
-// through [PlacedMode] and [ModeFor], which drop a binding that contradicts the
-// reading agent's own declaration — a placement only ever supplies a default,
-// so for the agent it was resolved for the two always agree.
+// two distinct same-named agents can share one context chain and runner.New
+// will not reject the tree. The binding therefore also carries the *State of
+// the agent it was resolved for, and a reader whose own *State differs treats
+// it as someone else's and falls back to its own declaration.
+//
+// Identity has to be the *State rather than the agent.Agent: Reveal hands every
+// binder and every reader the same pointer for one agent, a pointer is always
+// comparable, and comparing two interface values would panic on an agent whose
+// dynamic type is not.
 
 // The two values agent/llmagent's IncludeContents constants carry. Duplicated
 // as untyped constants because llminternal cannot import llmagent, which
@@ -87,6 +92,14 @@ func ResolveMode(declared, byPlacement Mode) Mode {
 // disturb another's.
 type boundModeKey struct{ agent string }
 
+// binding is what a placement records: the mode, and the identity of the agent
+// it was resolved for. The name in the key scopes and nests the slot; the state
+// pointer says whose it is.
+type binding struct {
+	mode  Mode
+	state *State
+}
+
 // WithBoundMode returns ctx carrying the mode the named agent runs under for
 // this invocation. Set by whatever places the agent: the runner for a root
 // agent, an AgentNode for a graph node.
@@ -95,13 +108,12 @@ type boundModeKey struct{ agent string }
 // context, which is what a re-entrant placement of the same agent should do.
 // Binding a different agent leaves the first alone.
 //
-// The key is the name alone, so the binding is only as well-scoped as names are
-// unique within one context chain. runner.New rejects a duplicate name anywhere
-// in its agent tree and workflow.New rejects two nodes sharing one, but neither
-// covers a node agent's own descendants, so two distinct same-named agents
-// nested inside one placement would share a slot. Every other name-keyed lookup
-// in the framework — FindAgent, findAgentToRun, transfer targets — has the same
-// precondition.
+// state identifies the agent the mode was resolved for, and is what makes a
+// same-named agent nested inside this placement fall back to its own
+// declaration instead of inheriting this one. runner.New rejects a duplicate
+// name anywhere in its agent tree and workflow.New rejects two nodes sharing
+// one, but neither covers a node agent's own descendants — so the collision is
+// constructible, and the name in the key cannot resolve it on its own.
 //
 // An empty agentName is bound like any other. Config.Name is documented as
 // required and nothing here can supply a missing one, but skipping the binding
@@ -117,15 +129,16 @@ type boundModeKey struct{ agent string }
 // passes a ResolveMode whose fallback is concrete, so it is unreachable today.
 // There is deliberately no way to CLEAR a binding — a nested placement shadows
 // an outer one by binding its own value, and nothing needs to un-place an agent.
-func WithBoundMode(ctx context.Context, agentName string, mode Mode) context.Context {
+func WithBoundMode(ctx context.Context, agentName string, state *State, mode Mode) context.Context {
 	if mode == ModeUnset {
 		return ctx
 	}
-	return context.WithValue(ctx, boundModeKey{agent: agentName}, mode)
+	return context.WithValue(ctx, boundModeKey{agent: agentName}, binding{mode: mode, state: state})
 }
 
-// BoundMode reports the mode this invocation bound to agentName, and whether it
-// bound one at all. A binding made for a different agent does not count.
+// BoundMode reports the mode this invocation bound for the agent identified by
+// state, and whether it bound one at all. A binding made for a different agent
+// does not count, including one made for a DIFFERENT agent of the same name.
 //
 // Use this only to ask "did a placement put THIS agent in that mode" — a
 // declared mode is deliberately not consulted. Callers wanting the mode an
@@ -134,55 +147,25 @@ func WithBoundMode(ctx context.Context, agentName string, mode Mode) context.Con
 // ctx must be non-nil. Passing nil panics in ctx.Value, as it would for any
 // context helper, so callers holding a context that may be nil check it
 // themselves rather than relying on this.
-func BoundMode(ctx context.Context, agentName string) (Mode, bool) {
-	mode, ok := ctx.Value(boundModeKey{agent: agentName}).(Mode)
-	if !ok {
+func BoundMode(ctx context.Context, agentName string, state *State) (Mode, bool) {
+	b, ok := ctx.Value(boundModeKey{agent: agentName}).(binding)
+	if !ok || b.state != state {
 		return ModeUnset, false
 	}
-	return mode, true
+	return b.mode, true
 }
 
-// PlacedMode reports the mode a placement bound for agentName, and whether one
-// governs the agent that declares declared.
+// ModeFor returns the mode agentName runs under: the mode this invocation bound
+// for it, else its own declaration.
 //
-// A binding found under the name is not necessarily this agent's. The key is
-// the name, names are only unique across SubAgents(), and a graph node's agent
-// is not in SubAgents() — so an agent nested behind a node can share a name
-// with one that has a live binding, and runner.New will not reject the tree.
-//
-// A binding that CONTRADICTS an explicit declaration cannot have been resolved
-// for this agent: a placement only supplies a default, so every binder binds
-// ResolveMode(declared, placementDefault), which equals the declaration
-// whenever there is one. A disagreement therefore identifies the binding as
-// someone else's, and it is ignored. This does not rescue two same-named
-// agents that declare the SAME mode, or that both declare nothing — nothing
-// keyed by name can — but it does stop a placement resolved for one agent from
-// overriding another's explicit declaration.
-func PlacedMode(ctx context.Context, agentName string, declared Mode) (Mode, bool) {
-	m, ok := BoundMode(ctx, agentName)
-	if !ok {
-		return ModeUnset, false
-	}
-	if declared != ModeUnset && declared != m {
-		return ModeUnset, false
-	}
-	return m, true
-}
-
-// ModeFor returns the mode agentName runs under: its own declaration, else the
-// mode this invocation bound for it.
-//
-// The declaration is consulted first. For the agent a binding was actually
-// resolved for the two always agree, because a binder binds
-// ResolveMode(declared, placementDefault); they differ only when the binding
-// belongs to a same-named agent, and then the declaration is the right answer.
-// See [PlacedMode].
-func ModeFor(ctx context.Context, agentName string, declared Mode) Mode {
-	if declared != ModeUnset {
-		return declared
-	}
-	if m, ok := BoundMode(ctx, agentName); ok {
+// The binding is consulted first and is authoritative, because it is the only
+// thing that knows where the agent was placed. It is safe to prefer because
+// [BoundMode] has already established the binding was resolved for this exact
+// agent — for any other, including a same-named one, it reports nothing and the
+// declaration stands.
+func ModeFor(ctx context.Context, agentName string, state *State) Mode {
+	if m, ok := BoundMode(ctx, agentName, state); ok {
 		return m
 	}
-	return declared
+	return state.Mode
 }

--- a/internal/llminternal/mode.go
+++ b/internal/llminternal/mode.go
@@ -38,8 +38,12 @@ import "context"
 //
 // Note that "there is no binding to consult" would be the wrong reason for
 // isUntransferableMode. Bindings nest, so when a callee computes its transfer
-// targets the caller's binding is still live in that context. It is looked past
-// deliberately.
+// targets the caller's binding is still live in that context, and it is looked
+// past deliberately. That said, the caller is the one agent the function is
+// never applied to — agent_transfer appends the parent without the check and
+// filters only sub-agents and peers — so the live binding this paragraph is
+// about belongs to an agent the filter never sees. The decision stands on the
+// tree-shape argument above, not on this one.
 //
 // Every other reader resolves, with one deliberate exception. A reader that
 // tests for single_turn and skips the resolution disagrees with the request the

--- a/internal/llminternal/mode.go
+++ b/internal/llminternal/mode.go
@@ -98,8 +98,17 @@ func ResolveMode(declared, byPlacement Mode) Mode {
 // lookup chain, and the reader then rejected it, so the agent that owned it
 // silently lost its placement.
 //
-// The name keeps the slot per-agent even so, which is what makes re-binding the
-// SAME agent shadow its outer binding rather than sit beside it.
+// The name earns its place differently, and not the way it might look. It is
+// NOT what makes re-binding the same agent shadow its outer binding — that is
+// the identity, which is equal on both binds, so the key would be equal with or
+// without the name. Every binder and every reader pairs an agent's name with
+// that same agent's state, so the name is a function of the identity and adds
+// nothing to a lookup.
+//
+// It is kept as a cheap guard against a future binder or reader that pairs the
+// two inconsistently, which is precisely the mistake that produced the three
+// regressions above, and because a key that names the agent is far easier to
+// read in a dump than a bare pointer.
 type boundModeKey struct {
 	agent string
 	state *State
@@ -162,6 +171,8 @@ func BoundMode(ctx context.Context, agentName string, state *State) (Mode, bool)
 
 // ModeFor returns the mode agentName runs under: the mode this invocation bound
 // for it, else its own declaration.
+//
+// state must be non-nil — the declaration is read off it.
 //
 // The binding is consulted first and is authoritative, because it is the only
 // thing that knows where the agent was placed. It is safe to prefer because

--- a/internal/llminternal/mode.go
+++ b/internal/llminternal/mode.go
@@ -106,8 +106,11 @@ func ResolveMode(declared, byPlacement Mode) Mode {
 // nothing to a lookup.
 //
 // It is kept as a cheap guard against a future binder or reader that pairs the
-// two inconsistently, which is precisely the mistake that produced the three
-// regressions above, and because a key that names the agent is far easier to
+// two inconsistently. Against a state-only key such a pairing is a wrong HIT —
+// one agent governed by another's resolved mode — and the name turns it into a
+// miss, which is the safer failure. That is a different mistake from the three
+// regressions above, which were all errors in the key's design rather than in
+// how a call site pairs a name with a state. It also makes a key far easier to
 // read in a dump than a bare pointer.
 type boundModeKey struct {
 	agent string

--- a/internal/llminternal/mode.go
+++ b/internal/llminternal/mode.go
@@ -62,14 +62,14 @@ import "context"
 // The name alone is not enough to say WHOSE binding one is. Names are unique
 // only across SubAgents(), and a graph node's agent is not in SubAgents(), so
 // two distinct same-named agents can share one context chain and runner.New
-// will not reject the tree. The binding therefore also carries the *State of
-// the agent it was resolved for, and a reader whose own *State differs treats
-// it as someone else's and falls back to its own declaration.
+// will not reject the tree. The agent's identity is therefore part of the
+// context key, so each gets a slot of its own: a reader never sees another
+// agent's placement, and never loses its own to one.
 //
 // Identity has to be the *State rather than the agent.Agent: Reveal hands every
 // binder and every reader the same pointer for one agent, a pointer is always
-// comparable, and comparing two interface values would panic on an agent whose
-// dynamic type is not.
+// comparable, and an agent.Agent in a context key would panic on an
+// implementation whose dynamic type is not.
 
 // The two values agent/llmagent's IncludeContents constants carry. Duplicated
 // as untyped constants because llminternal cannot import llmagent, which
@@ -87,16 +87,21 @@ func ResolveMode(declared, byPlacement Mode) Mode {
 	return declared
 }
 
-// boundModeKey is the context key for one agent's binding. The agent name is
-// part of the key, so each agent gets its own slot and binding one cannot
-// disturb another's.
-type boundModeKey struct{ agent string }
-
-// binding is what a placement records: the mode, and the identity of the agent
-// it was resolved for. The name in the key scopes and nests the slot; the state
-// pointer says whose it is.
-type binding struct {
-	mode  Mode
+// boundModeKey is the context key for one agent's binding. BOTH the name and
+// the agent's identity are part of the key, and each does a different job.
+//
+// Identity keeps a binding from reaching an agent it was not resolved for, and
+// keeps a placement resolved for one agent from being destroyed by a placement
+// for a same-named other: the two occupy different slots rather than one
+// overwriting the other. Putting identity only in the VALUE gave the first
+// property and not the second — the second bind still replaced the first in the
+// lookup chain, and the reader then rejected it, so the agent that owned it
+// silently lost its placement.
+//
+// The name keeps the slot per-agent even so, which is what makes re-binding the
+// SAME agent shadow its outer binding rather than sit beside it.
+type boundModeKey struct {
+	agent string
 	state *State
 }
 
@@ -133,7 +138,7 @@ func WithBoundMode(ctx context.Context, agentName string, state *State, mode Mod
 	if mode == ModeUnset {
 		return ctx
 	}
-	return context.WithValue(ctx, boundModeKey{agent: agentName}, binding{mode: mode, state: state})
+	return context.WithValue(ctx, boundModeKey{agent: agentName, state: state}, mode)
 }
 
 // BoundMode reports the mode this invocation bound for the agent identified by
@@ -148,11 +153,11 @@ func WithBoundMode(ctx context.Context, agentName string, state *State, mode Mod
 // context helper, so callers holding a context that may be nil check it
 // themselves rather than relying on this.
 func BoundMode(ctx context.Context, agentName string, state *State) (Mode, bool) {
-	b, ok := ctx.Value(boundModeKey{agent: agentName}).(binding)
-	if !ok || b.state != state {
+	mode, ok := ctx.Value(boundModeKey{agent: agentName, state: state}).(Mode)
+	if !ok {
 		return ModeUnset, false
 	}
-	return b.mode, true
+	return mode, true
 }
 
 // ModeFor returns the mode agentName runs under: the mode this invocation bound

--- a/internal/llminternal/mode.go
+++ b/internal/llminternal/mode.go
@@ -64,12 +64,9 @@ import "context"
 // child that declares its own mode — and would govern all of them.
 //
 // A binding also survives a nested activation that binds a different agent.
-// Storing one pair under one key gave only the first property: a single_turn
-// graph node that transferred to a chat peer had its slot overwritten, and when
-// the peer transferred back the node's own agent was re-entered on the peer's
-// context and fell back to chat, taking the identity preamble, the transfer
-// instructions and the whole conversation with it. Placements nest, so the
-// bindings have to nest too.
+// Placements nest — a single_turn graph node transfers to a chat peer, which
+// transfers back — so the bindings have to nest too, which one pair under one
+// shared key does not do.
 //
 // The name alone is not enough to say WHOSE binding one is. Names are unique
 // only across SubAgents(), and a graph node's agent is not in SubAgents(), so
@@ -110,20 +107,11 @@ func ResolveMode(declared, byPlacement Mode) Mode {
 // lookup chain, and the reader then rejected it, so the agent that owned it
 // silently lost its placement.
 //
-// The name earns its place differently, and not the way it might look. It is
-// NOT what makes re-binding the same agent shadow its outer binding — that is
-// the identity, which is equal on both binds, so the key would be equal with or
-// without the name. Every binder and every reader pairs an agent's name with
-// that same agent's state, so the name is a function of the identity and adds
-// nothing to a lookup.
-//
-// It is kept as a cheap guard against a future binder or reader that pairs the
-// two inconsistently. Against a state-only key such a pairing is a wrong HIT —
-// one agent governed by another's resolved mode — and the name turns it into a
-// miss, which is the safer failure. That is a different mistake from the three
-// regressions above, which were all errors in the key's design rather than in
-// how a call site pairs a name with a state. It also makes a key far easier to
-// read in a dump than a bare pointer.
+// The name adds nothing to a lookup: every binder and reader pairs an agent's
+// name with that same agent's state, so it is a function of the identity. It is
+// kept because a future call site that pairs them inconsistently would be a
+// wrong HIT against a state-only key — one agent governed by another's resolved
+// mode — and the name turns that into a miss, which is the safer failure.
 type boundModeKey struct {
 	agent string
 	state *State

--- a/internal/llminternal/mode.go
+++ b/internal/llminternal/mode.go
@@ -39,11 +39,11 @@ import "context"
 // Note that "there is no binding to consult" would be the wrong reason for
 // isUntransferableMode. Bindings nest, so when a callee computes its transfer
 // targets the caller's binding is still live in that context, and it is looked
-// past deliberately. That said, the caller is the one agent the function is
-// never applied to — agent_transfer appends the parent without the check and
-// filters only sub-agents and peers — so the live binding this paragraph is
-// about belongs to an agent the filter never sees. The decision stands on the
-// tree-shape argument above, not on this one.
+// past deliberately, and it has to be. A transfer up to a parent has the caller
+// filtered as one of the callee's sub-agents, and a transfer to a peer has it
+// filtered as a peer, so a resolving isUntransferableMode would drop a placed
+// undeclared agent off a callee's target list on the strength of a placement
+// made for somebody else's activation.
 //
 // Every other reader resolves, with one deliberate exception. A reader that
 // tests for single_turn and skips the resolution disagrees with the request the

--- a/internal/llminternal/mode.go
+++ b/internal/llminternal/mode.go
@@ -58,6 +58,13 @@ import "context"
 // context and fell back to chat, taking the identity preamble, the transfer
 // instructions and the whole conversation with it. Placements nest, so the
 // bindings have to nest too.
+//
+// The name is a proxy for the agent, and an imperfect one: names are unique
+// only across SubAgents(), and a graph node's agent is not in SubAgents(), so
+// two distinct same-named agents can share one context chain. Readers go
+// through [PlacedMode] and [ModeFor], which drop a binding that contradicts the
+// reading agent's own declaration — a placement only ever supplies a default,
+// so for the agent it was resolved for the two always agree.
 
 // The two values agent/llmagent's IncludeContents constants carry. Duplicated
 // as untyped constants because llminternal cannot import llmagent, which
@@ -135,9 +142,45 @@ func BoundMode(ctx context.Context, agentName string) (Mode, bool) {
 	return mode, true
 }
 
-// ModeFor returns the mode agentName runs under: the mode this invocation bound
-// to it, else its own declaration.
+// PlacedMode reports the mode a placement bound for agentName, and whether one
+// governs the agent that declares declared.
+//
+// A binding found under the name is not necessarily this agent's. The key is
+// the name, names are only unique across SubAgents(), and a graph node's agent
+// is not in SubAgents() — so an agent nested behind a node can share a name
+// with one that has a live binding, and runner.New will not reject the tree.
+//
+// A binding that CONTRADICTS an explicit declaration cannot have been resolved
+// for this agent: a placement only supplies a default, so every binder binds
+// ResolveMode(declared, placementDefault), which equals the declaration
+// whenever there is one. A disagreement therefore identifies the binding as
+// someone else's, and it is ignored. This does not rescue two same-named
+// agents that declare the SAME mode, or that both declare nothing — nothing
+// keyed by name can — but it does stop a placement resolved for one agent from
+// overriding another's explicit declaration.
+func PlacedMode(ctx context.Context, agentName string, declared Mode) (Mode, bool) {
+	m, ok := BoundMode(ctx, agentName)
+	if !ok {
+		return ModeUnset, false
+	}
+	if declared != ModeUnset && declared != m {
+		return ModeUnset, false
+	}
+	return m, true
+}
+
+// ModeFor returns the mode agentName runs under: its own declaration, else the
+// mode this invocation bound for it.
+//
+// The declaration is consulted first. For the agent a binding was actually
+// resolved for the two always agree, because a binder binds
+// ResolveMode(declared, placementDefault); they differ only when the binding
+// belongs to a same-named agent, and then the declaration is the right answer.
+// See [PlacedMode].
 func ModeFor(ctx context.Context, agentName string, declared Mode) Mode {
+	if declared != ModeUnset {
+		return declared
+	}
 	if m, ok := BoundMode(ctx, agentName); ok {
 		return m
 	}

--- a/internal/llminternal/mode_contents_test.go
+++ b/internal/llminternal/mode_contents_test.go
@@ -99,9 +99,14 @@ func TestContentsRequestProcessor_HonoursResolvedModeOverDeclaration(t *testing.
 // A mode bound for one agent must not reach another: the second agent falls
 // back to its own declaration.
 func TestContentsRequestProcessor_BoundModeIsScopedToItsAgent(t *testing.T) {
+	// The agent's own reply has to sit between the two user turns: the
+	// backward scan in buildContentsCurrentTurnContextOnly skips this agent's
+	// events, so a history that ends on one pivots at index 0 and returns
+	// everything whether or not history is being hidden.
 	history := []*session.Event{
 		{Author: "user", LLMResponse: model.LLMResponse{Content: genai.NewContentFromText("older turn", "user")}},
-		{Author: "other", LLMResponse: model.LLMResponse{Content: genai.NewContentFromText("current turn", "user")}},
+		{Author: "other", LLMResponse: model.LLMResponse{Content: genai.NewContentFromText("older answer", "model")}},
+		{Author: "user", LLMResponse: model.LLMResponse{Content: genai.NewContentFromText("current turn", "user")}},
 	}
 	testAgent := utils.Must(llmagent.New(llmagent.Config{Name: "other", Model: &testModel{}}))
 
@@ -131,12 +136,14 @@ func TestContentsRequestProcessor_BoundModeIsScopedToItsAgent(t *testing.T) {
 }
 
 // Declaring single_turn shapes the turn, but it does not by itself hide the
-// conversation: only a placement that seeded the agent with one synthetic turn
-// does that. A single_turn agent run outside such a placement keeps its history.
+// conversation: only a placement that put this agent in that mode does. A
+// declared single_turn agent reached some other way — by transfer_to_agent,
+// say — keeps its history.
 func TestContentsRequestProcessor_DeclaredSingleTurnWithoutPlacementKeepsHistory(t *testing.T) {
 	history := []*session.Event{
 		{Author: "user", LLMResponse: model.LLMResponse{Content: genai.NewContentFromText("older turn", "user")}},
-		{Author: "worker", LLMResponse: model.LLMResponse{Content: genai.NewContentFromText("current turn", "user")}},
+		{Author: "worker", LLMResponse: model.LLMResponse{Content: genai.NewContentFromText("older answer", "model")}},
+		{Author: "user", LLMResponse: model.LLMResponse{Content: genai.NewContentFromText("current turn", "user")}},
 	}
 	testAgent := utils.Must(llmagent.New(llmagent.Config{
 		Name:  "worker",
@@ -164,5 +171,65 @@ func TestContentsRequestProcessor_DeclaredSingleTurnWithoutPlacementKeepsHistory
 	}
 	if !sawHistory {
 		t.Errorf("declared single_turn outside a placement lost its history; contents = %v", req.Contents)
+	}
+}
+
+// Shaping the turn is the other half of the resolution, and it does consult
+// the declaration: an agent that declares nothing and is placed single_turn is
+// told it will get no follow-up questions, the same as one that declares the
+// mode. The nudge only reaches a scoped run, which is where a delegated
+// single_turn agent lives.
+func TestContentsRequestProcessor_ResolvedSingleTurnGetsTheNudge(t *testing.T) {
+	const agentName = "worker"
+
+	tests := []struct {
+		name     string
+		declared llmagent.Mode
+		bind     bool
+		want     bool
+	}{
+		{name: "placement resolves it", bind: true, want: true},
+		{name: "declaration alone", declared: llmagent.ModeSingleTurn, want: true},
+		{name: "neither", want: false},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			testAgent := utils.Must(llmagent.New(llmagent.Config{
+				Name:  agentName,
+				Model: &testModel{},
+				Mode:  tc.declared,
+			}))
+
+			stdCtx := t.Context()
+			if tc.bind {
+				stdCtx = llminternal.WithBoundMode(stdCtx, agentName, llminternal.ModeSingleTurn)
+			}
+			ctx := icontext.NewInvocationContext(stdCtx, icontext.InvocationContextParams{
+				Agent:          testAgent,
+				Session:        &fakeSession{},
+				IsolationScope: "scope-1",
+				UserContent:    genai.NewContentFromText("do the thing", "user"),
+			})
+
+			req := &model.LLMRequest{}
+			for _, err := range llminternal.ContentsRequestProcessor(ctx, req, &llminternal.Flow{}) {
+				if err != nil {
+					t.Fatalf("ContentsRequestProcessor: %v", err)
+				}
+			}
+
+			var gotNudge bool
+			for _, c := range req.Contents {
+				for _, p := range c.Parts {
+					if p != nil && p.Text == llminternal.SingleTurnNudge {
+						gotNudge = true
+					}
+				}
+			}
+			if gotNudge != tc.want {
+				t.Errorf("single-turn nudge present = %v, want %v (contents: %v)", gotNudge, tc.want, req.Contents)
+			}
+		})
 	}
 }

--- a/internal/llminternal/mode_contents_test.go
+++ b/internal/llminternal/mode_contents_test.go
@@ -28,9 +28,10 @@ import (
 )
 
 // An agent that declares no mode gets one from its placement, and the
-// contents processor must honour that resolved mode rather than the
-// agent's blank declaration: a single_turn placement sees the current
-// turn only, a chat placement sees the whole conversation.
+// contents processor must honour the mode bound to THAT agent rather than
+// the agent's blank declaration: a single_turn placement sees the current
+// turn only, a chat placement sees the whole conversation. A binding made
+// for a different agent must be ignored.
 func TestContentsRequestProcessor_HonoursResolvedModeOverDeclaration(t *testing.T) {
 	const agentName = "worker"
 
@@ -66,7 +67,7 @@ func TestContentsRequestProcessor_HonoursResolvedModeOverDeclaration(t *testing.
 			}))
 
 			ctx := icontext.NewInvocationContext(
-				llminternal.WithResolvedMode(t.Context(), tc.resolved),
+				llminternal.WithBoundMode(t.Context(), agentName, tc.resolved),
 				icontext.InvocationContextParams{
 					Agent:   testAgent,
 					Session: &fakeSession{events: history},
@@ -92,5 +93,76 @@ func TestContentsRequestProcessor_HonoursResolvedModeOverDeclaration(t *testing.
 				t.Errorf("history present = %v, want %v (contents: %v)", gotHistory, tc.wantHistory, req.Contents)
 			}
 		})
+	}
+}
+
+// A mode bound for one agent must not reach another: the second agent falls
+// back to its own declaration.
+func TestContentsRequestProcessor_BoundModeIsScopedToItsAgent(t *testing.T) {
+	history := []*session.Event{
+		{Author: "user", LLMResponse: model.LLMResponse{Content: genai.NewContentFromText("older turn", "user")}},
+		{Author: "other", LLMResponse: model.LLMResponse{Content: genai.NewContentFromText("current turn", "user")}},
+	}
+	testAgent := utils.Must(llmagent.New(llmagent.Config{Name: "other", Model: &testModel{}}))
+
+	// single_turn was resolved for "worker", not for the agent running here.
+	ctx := icontext.NewInvocationContext(
+		llminternal.WithBoundMode(t.Context(), "worker", llminternal.ModeSingleTurn),
+		icontext.InvocationContextParams{Agent: testAgent, Session: &fakeSession{events: history}},
+	)
+
+	req := &model.LLMRequest{}
+	for _, err := range llminternal.ContentsRequestProcessor(ctx, req, &llminternal.Flow{}) {
+		if err != nil {
+			t.Fatalf("ContentsRequestProcessor: %v", err)
+		}
+	}
+	var sawHistory bool
+	for _, c := range req.Contents {
+		for _, p := range c.Parts {
+			if p != nil && p.Text == "older turn" {
+				sawHistory = true
+			}
+		}
+	}
+	if !sawHistory {
+		t.Errorf("a mode bound for another agent suppressed this agent's history; contents = %v", req.Contents)
+	}
+}
+
+// Declaring single_turn shapes the turn, but it does not by itself hide the
+// conversation: only a placement that seeded the agent with one synthetic turn
+// does that. A single_turn agent run outside such a placement keeps its history.
+func TestContentsRequestProcessor_DeclaredSingleTurnWithoutPlacementKeepsHistory(t *testing.T) {
+	history := []*session.Event{
+		{Author: "user", LLMResponse: model.LLMResponse{Content: genai.NewContentFromText("older turn", "user")}},
+		{Author: "worker", LLMResponse: model.LLMResponse{Content: genai.NewContentFromText("current turn", "user")}},
+	}
+	testAgent := utils.Must(llmagent.New(llmagent.Config{
+		Name:  "worker",
+		Model: &testModel{},
+		Mode:  llmagent.ModeSingleTurn,
+	}))
+
+	ctx := icontext.NewInvocationContext(t.Context(), icontext.InvocationContextParams{
+		Agent:   testAgent,
+		Session: &fakeSession{events: history},
+	})
+	req := &model.LLMRequest{}
+	for _, err := range llminternal.ContentsRequestProcessor(ctx, req, &llminternal.Flow{}) {
+		if err != nil {
+			t.Fatalf("ContentsRequestProcessor: %v", err)
+		}
+	}
+	var sawHistory bool
+	for _, c := range req.Contents {
+		for _, p := range c.Parts {
+			if p != nil && p.Text == "older turn" {
+				sawHistory = true
+			}
+		}
+	}
+	if !sawHistory {
+		t.Errorf("declared single_turn outside a placement lost its history; contents = %v", req.Contents)
 	}
 }

--- a/internal/llminternal/mode_contents_test.go
+++ b/internal/llminternal/mode_contents_test.go
@@ -1,0 +1,96 @@
+// Copyright 2026 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package llminternal_test
+
+import (
+	"testing"
+
+	"google.golang.org/genai"
+
+	"google.golang.org/adk/v2/agent/llmagent"
+	icontext "google.golang.org/adk/v2/internal/context"
+	"google.golang.org/adk/v2/internal/llminternal"
+	"google.golang.org/adk/v2/internal/utils"
+	"google.golang.org/adk/v2/model"
+	"google.golang.org/adk/v2/session"
+)
+
+// An agent that declares no mode gets one from its placement, and the
+// contents processor must honour that resolved mode rather than the
+// agent's blank declaration: a single_turn placement sees the current
+// turn only, a chat placement sees the whole conversation.
+func TestContentsRequestProcessor_HonoursResolvedModeOverDeclaration(t *testing.T) {
+	const agentName = "worker"
+
+	history := []*session.Event{
+		{
+			Author:      "user",
+			LLMResponse: model.LLMResponse{Content: genai.NewContentFromText("older turn", "user")},
+		},
+		{
+			Author:      agentName,
+			LLMResponse: model.LLMResponse{Content: genai.NewContentFromText("older answer", "model")},
+		},
+		{
+			Author:      "user",
+			LLMResponse: model.LLMResponse{Content: genai.NewContentFromText("current turn", "user")},
+		},
+	}
+
+	tests := []struct {
+		name        string
+		resolved    llminternal.Mode
+		wantHistory bool
+	}{
+		{name: "single_turn placement drops history", resolved: llminternal.ModeSingleTurn, wantHistory: false},
+		{name: "chat placement keeps history", resolved: llminternal.ModeChat, wantHistory: true},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			testAgent := utils.Must(llmagent.New(llmagent.Config{
+				Name:  agentName,
+				Model: &testModel{},
+			}))
+
+			ctx := icontext.NewInvocationContext(
+				llminternal.WithResolvedMode(t.Context(), tc.resolved),
+				icontext.InvocationContextParams{
+					Agent:   testAgent,
+					Session: &fakeSession{events: history},
+				},
+			)
+
+			req := &model.LLMRequest{}
+			for _, err := range llminternal.ContentsRequestProcessor(ctx, req, &llminternal.Flow{}) {
+				if err != nil {
+					t.Fatalf("ContentsRequestProcessor: %v", err)
+				}
+			}
+
+			var gotHistory bool
+			for _, c := range req.Contents {
+				for _, p := range c.Parts {
+					if p != nil && p.Text == "older turn" {
+						gotHistory = true
+					}
+				}
+			}
+			if gotHistory != tc.wantHistory {
+				t.Errorf("history present = %v, want %v (contents: %v)", gotHistory, tc.wantHistory, req.Contents)
+			}
+		})
+	}
+}

--- a/internal/llminternal/mode_contents_test.go
+++ b/internal/llminternal/mode_contents_test.go
@@ -139,9 +139,10 @@ func TestContentsRequestProcessor_BoundModeIsScopedToItsAgent(t *testing.T) {
 // conversation: only a placement that put this agent in that mode does. A
 // declared single_turn agent reached some other way keeps its history — a
 // child run directly by a sequential, loop or parallel agent, say, which calls
-// subAgent.Run and never goes through the node wrapper. Not by transfer:
-// isUntransferableMode keeps a declared single_turn agent off the target list
-// entirely.
+// subAgent.Run and never goes through the node wrapper. Transfer is not that
+// way: isUntransferableMode keeps a declared single_turn agent off the sub-agent
+// and peer target lists, and the one route that does reach it, a child
+// transferring back up to it, goes through the wrapper, which re-binds.
 func TestContentsRequestProcessor_DeclaredSingleTurnWithoutPlacementKeepsHistory(t *testing.T) {
 	history := []*session.Event{
 		{Author: "user", LLMResponse: model.LLMResponse{Content: genai.NewContentFromText("older turn", "user")}},

--- a/internal/llminternal/mode_contents_test.go
+++ b/internal/llminternal/mode_contents_test.go
@@ -137,8 +137,11 @@ func TestContentsRequestProcessor_BoundModeIsScopedToItsAgent(t *testing.T) {
 
 // Declaring single_turn shapes the turn, but it does not by itself hide the
 // conversation: only a placement that put this agent in that mode does. A
-// declared single_turn agent reached some other way — by transfer_to_agent,
-// say — keeps its history.
+// declared single_turn agent reached some other way keeps its history — a
+// child run directly by a sequential, loop or parallel agent, say, which calls
+// subAgent.Run and never goes through the node wrapper. Not by transfer:
+// isUntransferableMode keeps a declared single_turn agent off the target list
+// entirely.
 func TestContentsRequestProcessor_DeclaredSingleTurnWithoutPlacementKeepsHistory(t *testing.T) {
 	history := []*session.Event{
 		{Author: "user", LLMResponse: model.LLMResponse{Content: genai.NewContentFromText("older turn", "user")}},

--- a/internal/llminternal/mode_contents_test.go
+++ b/internal/llminternal/mode_contents_test.go
@@ -19,6 +19,7 @@ import (
 
 	"google.golang.org/genai"
 
+	"google.golang.org/adk/v2/agent"
 	"google.golang.org/adk/v2/agent/llmagent"
 	icontext "google.golang.org/adk/v2/internal/context"
 	"google.golang.org/adk/v2/internal/llminternal"
@@ -67,7 +68,7 @@ func TestContentsRequestProcessor_HonoursResolvedModeOverDeclaration(t *testing.
 			}))
 
 			ctx := icontext.NewInvocationContext(
-				llminternal.WithBoundMode(t.Context(), agentName, tc.resolved),
+				llminternal.WithBoundMode(t.Context(), agentName, stateOf(t, testAgent), tc.resolved),
 				icontext.InvocationContextParams{
 					Agent:   testAgent,
 					Session: &fakeSession{events: history},
@@ -112,7 +113,7 @@ func TestContentsRequestProcessor_BoundModeIsScopedToItsAgent(t *testing.T) {
 
 	// single_turn was resolved for "worker", not for the agent running here.
 	ctx := icontext.NewInvocationContext(
-		llminternal.WithBoundMode(t.Context(), "worker", llminternal.ModeSingleTurn),
+		llminternal.WithBoundMode(t.Context(), "worker", &llminternal.State{}, llminternal.ModeSingleTurn),
 		icontext.InvocationContextParams{Agent: testAgent, Session: &fakeSession{events: history}},
 	)
 
@@ -207,7 +208,7 @@ func TestContentsRequestProcessor_ResolvedSingleTurnGetsTheNudge(t *testing.T) {
 
 			stdCtx := t.Context()
 			if tc.bind {
-				stdCtx = llminternal.WithBoundMode(stdCtx, agentName, llminternal.ModeSingleTurn)
+				stdCtx = llminternal.WithBoundMode(stdCtx, agentName, stateOf(t, testAgent), llminternal.ModeSingleTurn)
 			}
 			ctx := icontext.NewInvocationContext(stdCtx, icontext.InvocationContextParams{
 				Agent:          testAgent,
@@ -244,9 +245,9 @@ func TestContentsRequestProcessor_ResolvedSingleTurnGetsTheNudge(t *testing.T) {
 // single_turn for. Its own declaration says it is conversational, so the
 // foreign placement must not take its history away.
 //
-// This is the direction in which the history gate's PlacedMode differs from a
-// bare BoundMode: without the contradiction guard, reverting the call site to
-// BoundMode leaves every other test in the suite green.
+// This was the direction that separated a name-only lookup from one that also
+// checks which agent the binding was resolved for: with the name alone, every
+// other test in the suite stayed green while this agent lost its history.
 func TestContentsRequestProcessor_AForeignSingleTurnBindingDoesNotHideAChatAgentsHistory(t *testing.T) {
 	// The agent's own reply sits between the two user turns, as above: a
 	// history ending on one pivots at index 0 and returns everything whether
@@ -263,9 +264,10 @@ func TestContentsRequestProcessor_AForeignSingleTurnBindingDoesNotHideAChatAgent
 	}))
 
 	// single_turn resolved for a DIFFERENT agent that happens to be called
-	// "worker" too — the collision runner.New does not reject.
+	// "worker" too — the collision runner.New does not reject. A distinct
+	// *State is exactly what makes it a different agent.
 	ctx := icontext.NewInvocationContext(
-		llminternal.WithBoundMode(t.Context(), "worker", llminternal.ModeSingleTurn),
+		llminternal.WithBoundMode(t.Context(), "worker", &llminternal.State{}, llminternal.ModeSingleTurn),
 		icontext.InvocationContextParams{Agent: testAgent, Session: &fakeSession{events: history}},
 	)
 
@@ -289,4 +291,16 @@ func TestContentsRequestProcessor_AForeignSingleTurnBindingDoesNotHideAChatAgent
 	if !sawHistory {
 		t.Errorf("a single_turn placement resolved for another agent hid this chat agent's history; contents = %v", req.Contents)
 	}
+}
+
+// stateOf returns the llminternal state behind an LlmAgent — the same pointer a
+// binder and a reader both see, and therefore the agent's identity as far as a
+// mode binding is concerned.
+func stateOf(t *testing.T, a agent.Agent) *llminternal.State {
+	t.Helper()
+	internal, ok := a.(llminternal.Agent)
+	if !ok {
+		t.Fatalf("agent %q is not an llminternal.Agent", a.Name())
+	}
+	return llminternal.Reveal(internal)
 }

--- a/internal/llminternal/mode_contents_test.go
+++ b/internal/llminternal/mode_contents_test.go
@@ -111,9 +111,11 @@ func TestContentsRequestProcessor_BoundModeIsScopedToItsAgent(t *testing.T) {
 	}
 	testAgent := utils.Must(llmagent.New(llmagent.Config{Name: "other", Model: &testModel{}}))
 
-	// single_turn was resolved for "worker", not for the agent running here.
+	// single_turn was resolved under the name "worker", not the name of the
+	// agent running here. The IDENTITY is this agent's, so the name is the only
+	// thing that differs and the only thing this test can be passing on.
 	ctx := icontext.NewInvocationContext(
-		llminternal.WithBoundMode(t.Context(), "worker", &llminternal.State{}, llminternal.ModeSingleTurn),
+		llminternal.WithBoundMode(t.Context(), "worker", stateOf(t, testAgent), llminternal.ModeSingleTurn),
 		icontext.InvocationContextParams{Agent: testAgent, Session: &fakeSession{events: history}},
 	)
 

--- a/internal/llminternal/mode_contents_test.go
+++ b/internal/llminternal/mode_contents_test.go
@@ -237,3 +237,56 @@ func TestContentsRequestProcessor_ResolvedSingleTurnGetsTheNudge(t *testing.T) {
 		})
 	}
 }
+
+// A binding found under this agent's name is not necessarily this agent's.
+// Names are unique only across SubAgents(), and a graph node's agent is not in
+// SubAgents(), so a chat agent can share a name with one a placement resolved
+// single_turn for. Its own declaration says it is conversational, so the
+// foreign placement must not take its history away.
+//
+// This is the direction in which the history gate's PlacedMode differs from a
+// bare BoundMode: without the contradiction guard, reverting the call site to
+// BoundMode leaves every other test in the suite green.
+func TestContentsRequestProcessor_AForeignSingleTurnBindingDoesNotHideAChatAgentsHistory(t *testing.T) {
+	// The agent's own reply sits between the two user turns, as above: a
+	// history ending on one pivots at index 0 and returns everything whether
+	// or not history is being hidden, which would make this vacuous.
+	history := []*session.Event{
+		{Author: "user", LLMResponse: model.LLMResponse{Content: genai.NewContentFromText("older turn", "user")}},
+		{Author: "worker", LLMResponse: model.LLMResponse{Content: genai.NewContentFromText("older answer", "model")}},
+		{Author: "user", LLMResponse: model.LLMResponse{Content: genai.NewContentFromText("current turn", "user")}},
+	}
+	testAgent := utils.Must(llmagent.New(llmagent.Config{
+		Name:  "worker",
+		Model: &testModel{},
+		Mode:  llmagent.ModeChat,
+	}))
+
+	// single_turn resolved for a DIFFERENT agent that happens to be called
+	// "worker" too — the collision runner.New does not reject.
+	ctx := icontext.NewInvocationContext(
+		llminternal.WithBoundMode(t.Context(), "worker", llminternal.ModeSingleTurn),
+		icontext.InvocationContextParams{Agent: testAgent, Session: &fakeSession{events: history}},
+	)
+
+	req := &model.LLMRequest{}
+	for _, err := range llminternal.ContentsRequestProcessor(ctx, req, &llminternal.Flow{}) {
+		if err != nil {
+			t.Fatalf("ContentsRequestProcessor: %v", err)
+		}
+	}
+	if len(req.Contents) == 0 {
+		t.Fatal("no contents were built, so this test pins nothing")
+	}
+	var sawHistory bool
+	for _, c := range req.Contents {
+		for _, p := range c.Parts {
+			if p != nil && p.Text == "older turn" {
+				sawHistory = true
+			}
+		}
+	}
+	if !sawHistory {
+		t.Errorf("a single_turn placement resolved for another agent hid this chat agent's history; contents = %v", req.Contents)
+	}
+}

--- a/internal/llminternal/mode_test.go
+++ b/internal/llminternal/mode_test.go
@@ -1,0 +1,128 @@
+// Copyright 2026 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package llminternal
+
+import (
+	"context"
+	"testing"
+)
+
+func TestResolveMode(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		name        string
+		declared    Mode
+		byPlacement Mode
+		want        Mode
+	}{
+		{name: "undeclared takes the placement", declared: ModeUnset, byPlacement: ModeSingleTurn, want: ModeSingleTurn},
+		{name: "declaration beats the placement", declared: ModeChat, byPlacement: ModeSingleTurn, want: ModeChat},
+		{name: "declared task beats a chat placement", declared: ModeTask, byPlacement: ModeChat, want: ModeTask},
+		{name: "no placement leaves it unset", declared: ModeUnset, byPlacement: ModeUnset, want: ModeUnset},
+	}
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			if got := ResolveMode(tc.declared, tc.byPlacement); got != tc.want {
+				t.Errorf("ResolveMode(%q, %q) = %q, want %q", tc.declared, tc.byPlacement, got, tc.want)
+			}
+		})
+	}
+}
+
+// The binding is keyed by agent, and the two properties that follow from that
+// are what the whole design rests on. Neither is otherwise reachable from a
+// test: no in-tree path binds two different values for one name, and no in-tree
+// path reads a binding for an agent that is not the one running.
+func TestBoundMode_Scoping(t *testing.T) {
+	t.Parallel()
+
+	t.Run("a binding is invisible to another agent", func(t *testing.T) {
+		ctx := WithBoundMode(t.Context(), "worker", ModeSingleTurn)
+		if _, ok := BoundMode(ctx, "other"); ok {
+			t.Error("a binding made for \"worker\" was visible to \"other\"")
+		}
+		if got := ModeFor(ctx, "other", ModeChat); got != ModeChat {
+			t.Errorf("ModeFor(other) = %q, want the declaration %q", got, ModeChat)
+		}
+	})
+
+	t.Run("binding one agent leaves another's alone", func(t *testing.T) {
+		ctx := WithBoundMode(t.Context(), "worker", ModeSingleTurn)
+		ctx = WithBoundMode(ctx, "helper", ModeChat)
+
+		// This is the transfer round trip in miniature: helper's binding must
+		// not erase worker's, or worker loses its placement on re-entry.
+		if got, ok := BoundMode(ctx, "worker"); !ok || got != ModeSingleTurn {
+			t.Errorf("BoundMode(worker) = (%q, %v) after binding helper, want (%q, true)", got, ok, ModeSingleTurn)
+		}
+		if got, ok := BoundMode(ctx, "helper"); !ok || got != ModeChat {
+			t.Errorf("BoundMode(helper) = (%q, %v), want (%q, true)", got, ok, ModeChat)
+		}
+	})
+
+	t.Run("re-binding the same agent shadows the outer binding", func(t *testing.T) {
+		outer := WithBoundMode(t.Context(), "worker", ModeChat)
+		inner := WithBoundMode(outer, "worker", ModeSingleTurn)
+
+		if got, ok := BoundMode(inner, "worker"); !ok || got != ModeSingleTurn {
+			t.Errorf("BoundMode on the inner context = (%q, %v), want (%q, true) — "+
+				"a re-binding placement must win over the one it nests inside", got, ok, ModeSingleTurn)
+		}
+		// Shadowing, not mutation: the outer context is a separate value and
+		// still answers with what it was given.
+		if got, ok := BoundMode(outer, "worker"); !ok || got != ModeChat {
+			t.Errorf("BoundMode on the outer context = (%q, %v), want (%q, true) — "+
+				"an inner bind must not reach back into the context it derived from", got, ok, ModeChat)
+		}
+	})
+
+	t.Run("an unset mode does not bind", func(t *testing.T) {
+		ctx := WithBoundMode(t.Context(), "worker", ModeUnset)
+		if _, ok := BoundMode(ctx, "worker"); ok {
+			t.Error("ModeUnset produced a binding; BoundMode would then report a placement that resolved nothing")
+		}
+		if got := ModeFor(ctx, "worker", ModeTask); got != ModeTask {
+			t.Errorf("ModeFor = %q, want the declaration %q", got, ModeTask)
+		}
+	})
+
+	t.Run("an empty name binds like any other", func(t *testing.T) {
+		ctx := WithBoundMode(t.Context(), "", ModeSingleTurn)
+		if got, ok := BoundMode(ctx, ""); !ok || got != ModeSingleTurn {
+			t.Errorf("BoundMode(\"\") = (%q, %v), want (%q, true)", got, ok, ModeSingleTurn)
+		}
+		if _, ok := BoundMode(ctx, "worker"); ok {
+			t.Error("a binding for the empty name was visible to a named agent")
+		}
+	})
+}
+
+func TestModeFor(t *testing.T) {
+	t.Parallel()
+
+	t.Run("the binding wins over the declaration", func(t *testing.T) {
+		ctx := WithBoundMode(t.Context(), "worker", ModeSingleTurn)
+		if got := ModeFor(ctx, "worker", ModeChat); got != ModeSingleTurn {
+			t.Errorf("ModeFor = %q, want %q", got, ModeSingleTurn)
+		}
+	})
+
+	t.Run("the declaration is the fallback", func(t *testing.T) {
+		if got := ModeFor(context.Background(), "worker", ModeChat); got != ModeChat {
+			t.Errorf("ModeFor with no binding = %q, want %q", got, ModeChat)
+		}
+	})
+}

--- a/internal/llminternal/mode_test.go
+++ b/internal/llminternal/mode_test.go
@@ -42,70 +42,105 @@ func TestResolveMode(t *testing.T) {
 	}
 }
 
-// The binding is keyed by agent, and the two properties that follow from that
-// are what the whole design rests on. Neither is otherwise reachable from a
-// test: no in-tree path binds two different values for one name, and no in-tree
-// path reads a binding for an agent that is not the one running.
+// The binding is keyed by agent NAME and validated against agent IDENTITY, and
+// the properties that follow are what the whole design rests on. None is
+// otherwise reachable from a test: no in-tree path binds two different values
+// for one name, and no in-tree path reads a binding for an agent that is not
+// the one running.
 func TestBoundMode_Scoping(t *testing.T) {
 	t.Parallel()
 
 	t.Run("a binding is invisible to another agent", func(t *testing.T) {
-		ctx := WithBoundMode(t.Context(), "worker", ModeSingleTurn)
-		if _, ok := BoundMode(ctx, "other"); ok {
+		worker, other := &State{}, &State{Mode: ModeChat}
+		ctx := WithBoundMode(t.Context(), "worker", worker, ModeSingleTurn)
+		if _, ok := BoundMode(ctx, "other", other); ok {
 			t.Error("a binding made for \"worker\" was visible to \"other\"")
 		}
-		if got := ModeFor(ctx, "other", ModeChat); got != ModeChat {
+		if got := ModeFor(ctx, "other", other); got != ModeChat {
 			t.Errorf("ModeFor(other) = %q, want the declaration %q", got, ModeChat)
 		}
 	})
 
 	t.Run("binding one agent leaves another's alone", func(t *testing.T) {
-		ctx := WithBoundMode(t.Context(), "worker", ModeSingleTurn)
-		ctx = WithBoundMode(ctx, "helper", ModeChat)
+		worker, helper := &State{}, &State{}
+		ctx := WithBoundMode(t.Context(), "worker", worker, ModeSingleTurn)
+		ctx = WithBoundMode(ctx, "helper", helper, ModeChat)
 
 		// This is the transfer round trip in miniature: helper's binding must
 		// not erase worker's, or worker loses its placement on re-entry.
-		if got, ok := BoundMode(ctx, "worker"); !ok || got != ModeSingleTurn {
+		if got, ok := BoundMode(ctx, "worker", worker); !ok || got != ModeSingleTurn {
 			t.Errorf("BoundMode(worker) = (%q, %v) after binding helper, want (%q, true)", got, ok, ModeSingleTurn)
 		}
-		if got, ok := BoundMode(ctx, "helper"); !ok || got != ModeChat {
+		if got, ok := BoundMode(ctx, "helper", helper); !ok || got != ModeChat {
 			t.Errorf("BoundMode(helper) = (%q, %v), want (%q, true)", got, ok, ModeChat)
 		}
 	})
 
 	t.Run("re-binding the same agent shadows the outer binding", func(t *testing.T) {
-		outer := WithBoundMode(t.Context(), "worker", ModeChat)
-		inner := WithBoundMode(outer, "worker", ModeSingleTurn)
+		worker := &State{}
+		outer := WithBoundMode(t.Context(), "worker", worker, ModeChat)
+		inner := WithBoundMode(outer, "worker", worker, ModeSingleTurn)
 
-		if got, ok := BoundMode(inner, "worker"); !ok || got != ModeSingleTurn {
+		if got, ok := BoundMode(inner, "worker", worker); !ok || got != ModeSingleTurn {
 			t.Errorf("BoundMode on the inner context = (%q, %v), want (%q, true) — "+
 				"a re-binding placement must win over the one it nests inside", got, ok, ModeSingleTurn)
 		}
 		// Shadowing, not mutation: the outer context is a separate value and
 		// still answers with what it was given.
-		if got, ok := BoundMode(outer, "worker"); !ok || got != ModeChat {
+		if got, ok := BoundMode(outer, "worker", worker); !ok || got != ModeChat {
 			t.Errorf("BoundMode on the outer context = (%q, %v), want (%q, true) — "+
 				"an inner bind must not reach back into the context it derived from", got, ok, ModeChat)
 		}
 	})
 
+	// The collision the name key alone cannot resolve, and the reason the
+	// binding carries a state pointer. Two DISTINCT agents share one name —
+	// runner.New accepts that when one of them sits behind a graph node — and
+	// the one that was never placed must keep its own declaration.
+	t.Run("a binding does not reach a different agent of the same name", func(t *testing.T) {
+		placed, nested := &State{}, &State{}
+		ctx := WithBoundMode(t.Context(), "worker", placed, ModeSingleTurn)
+
+		if _, ok := BoundMode(ctx, "worker", nested); ok {
+			t.Error("a placement resolved for one agent was reported as governing a different agent of the same name")
+		}
+		if got := ModeFor(ctx, "worker", nested); got != ModeUnset {
+			t.Errorf("ModeFor(nested) = %q, want its own (unset) declaration", got)
+		}
+		if got, ok := BoundMode(ctx, "worker", placed); !ok || got != ModeSingleTurn {
+			t.Errorf("BoundMode(placed) = (%q, %v), want (%q, true) — the agent it WAS resolved for still sees it", got, ok, ModeSingleTurn)
+		}
+	})
+
 	t.Run("an unset mode does not bind", func(t *testing.T) {
-		ctx := WithBoundMode(t.Context(), "worker", ModeUnset)
-		if _, ok := BoundMode(ctx, "worker"); ok {
+		worker := &State{Mode: ModeTask}
+		ctx := WithBoundMode(t.Context(), "worker", worker, ModeUnset)
+		if _, ok := BoundMode(ctx, "worker", worker); ok {
 			t.Error("ModeUnset produced a binding; BoundMode would then report a placement that resolved nothing")
 		}
-		if got := ModeFor(ctx, "worker", ModeTask); got != ModeTask {
+		if got := ModeFor(ctx, "worker", worker); got != ModeTask {
 			t.Errorf("ModeFor = %q, want the declaration %q", got, ModeTask)
 		}
 	})
 
 	t.Run("an empty name binds like any other", func(t *testing.T) {
-		ctx := WithBoundMode(t.Context(), "", ModeSingleTurn)
-		if got, ok := BoundMode(ctx, ""); !ok || got != ModeSingleTurn {
+		nameless, worker := &State{}, &State{}
+		ctx := WithBoundMode(t.Context(), "", nameless, ModeSingleTurn)
+		if got, ok := BoundMode(ctx, "", nameless); !ok || got != ModeSingleTurn {
 			t.Errorf("BoundMode(\"\") = (%q, %v), want (%q, true)", got, ok, ModeSingleTurn)
 		}
-		if _, ok := BoundMode(ctx, "worker"); ok {
+		if _, ok := BoundMode(ctx, "worker", worker); ok {
 			t.Error("a binding for the empty name was visible to a named agent")
+		}
+	})
+
+	// Two NAMELESS agents are the case identity rescues and a name key cannot:
+	// they share the empty-string slot entirely.
+	t.Run("two nameless agents do not share a binding", func(t *testing.T) {
+		placed, nested := &State{}, &State{}
+		ctx := WithBoundMode(t.Context(), "", placed, ModeSingleTurn)
+		if _, ok := BoundMode(ctx, "", nested); ok {
+			t.Error("a nameless agent inherited a placement resolved for a different nameless agent")
 		}
 	})
 }
@@ -114,55 +149,43 @@ func TestModeFor(t *testing.T) {
 	t.Parallel()
 
 	t.Run("the binding supplies a mode the agent did not declare", func(t *testing.T) {
-		ctx := WithBoundMode(t.Context(), "worker", ModeSingleTurn)
-		if got := ModeFor(ctx, "worker", ModeUnset); got != ModeSingleTurn {
+		worker := &State{}
+		ctx := WithBoundMode(t.Context(), "worker", worker, ModeSingleTurn)
+		if got := ModeFor(ctx, "worker", worker); got != ModeSingleTurn {
 			t.Errorf("ModeFor = %q, want %q", got, ModeSingleTurn)
 		}
 	})
 
 	t.Run("the declaration is the fallback", func(t *testing.T) {
-		if got := ModeFor(context.Background(), "worker", ModeChat); got != ModeChat {
+		if got := ModeFor(context.Background(), "worker", &State{Mode: ModeChat}); got != ModeChat {
 			t.Errorf("ModeFor with no binding = %q, want %q", got, ModeChat)
 		}
 	})
 
-	// A binder binds ResolveMode(declared, placementDefault), so for the agent
-	// a binding was resolved for it always equals the declaration. A binding
-	// that contradicts one therefore belongs to a same-named agent, and the
-	// declaration is the right answer. Without this, a chat root placed a
-	// same-named nested single_turn agent into chat.
-	t.Run("a contradicting binding is another agent's and loses", func(t *testing.T) {
-		ctx := WithBoundMode(t.Context(), "worker", ModeChat)
-		if got := ModeFor(ctx, "worker", ModeSingleTurn); got != ModeSingleTurn {
-			t.Errorf("ModeFor = %q, want the declaration %q", got, ModeSingleTurn)
+	// A placement is authoritative for the agent it was resolved for, including
+	// over that agent's own declaration — they agree in practice, since a binder
+	// binds ResolveMode(declared, placementDefault), but the binding is what
+	// knows where the agent was put.
+	t.Run("the binding wins for the agent it was resolved for", func(t *testing.T) {
+		worker := &State{Mode: ModeChat}
+		ctx := WithBoundMode(t.Context(), "worker", worker, ModeSingleTurn)
+		if got := ModeFor(ctx, "worker", worker); got != ModeSingleTurn {
+			t.Errorf("ModeFor = %q, want the bound %q", got, ModeSingleTurn)
 		}
 	})
-}
 
-func TestPlacedMode(t *testing.T) {
-	t.Parallel()
-
-	tests := []struct {
-		name     string
-		bind     Mode // ModeUnset means "bind nothing"
-		declared Mode
-		want     Mode
-		wantOK   bool
-	}{
-		{"no binding, no declaration", ModeUnset, ModeUnset, ModeUnset, false},
-		{"no binding at all", ModeUnset, ModeSingleTurn, ModeUnset, false},
-		{"binding for an undeclared agent governs it", ModeSingleTurn, ModeUnset, ModeSingleTurn, true},
-		{"binding agreeing with the declaration governs it", ModeSingleTurn, ModeSingleTurn, ModeSingleTurn, true},
-		{"binding contradicting the declaration is another agent's", ModeChat, ModeSingleTurn, ModeUnset, false},
-		{"single_turn binding contradicting a chat declaration is another agent's", ModeSingleTurn, ModeChat, ModeUnset, false},
-	}
-	for _, tt := range tests {
-		t.Run(tt.name, func(t *testing.T) {
-			ctx := WithBoundMode(t.Context(), "worker", tt.bind)
-			got, ok := PlacedMode(ctx, "worker", tt.declared)
-			if got != tt.want || ok != tt.wantOK {
-				t.Errorf("PlacedMode = (%q, %v), want (%q, %v)", got, ok, tt.want, tt.wantOK)
+	// ...and carries no weight for anyone else, whatever they declare. Without
+	// this, a chat root placed a same-named nested single_turn agent into chat,
+	// and a single_turn graph node placed a same-named nested undeclared agent
+	// into single_turn.
+	t.Run("another agent's binding loses to this agent's declaration", func(t *testing.T) {
+		placed := &State{}
+		for _, declared := range []Mode{ModeUnset, ModeChat, ModeSingleTurn, ModeTask} {
+			nested := &State{Mode: declared}
+			ctx := WithBoundMode(t.Context(), "worker", placed, ModeSingleTurn)
+			if got := ModeFor(ctx, "worker", nested); got != declared {
+				t.Errorf("ModeFor with declared %q = %q, want %q", declared, got, declared)
 			}
-		})
-	}
+		}
+	})
 }

--- a/internal/llminternal/mode_test.go
+++ b/internal/llminternal/mode_test.go
@@ -113,9 +113,9 @@ func TestBoundMode_Scoping(t *testing.T) {
 func TestModeFor(t *testing.T) {
 	t.Parallel()
 
-	t.Run("the binding wins over the declaration", func(t *testing.T) {
+	t.Run("the binding supplies a mode the agent did not declare", func(t *testing.T) {
 		ctx := WithBoundMode(t.Context(), "worker", ModeSingleTurn)
-		if got := ModeFor(ctx, "worker", ModeChat); got != ModeSingleTurn {
+		if got := ModeFor(ctx, "worker", ModeUnset); got != ModeSingleTurn {
 			t.Errorf("ModeFor = %q, want %q", got, ModeSingleTurn)
 		}
 	})
@@ -125,4 +125,43 @@ func TestModeFor(t *testing.T) {
 			t.Errorf("ModeFor with no binding = %q, want %q", got, ModeChat)
 		}
 	})
+
+	// A binder binds ResolveMode(declared, placementDefault), so for the agent
+	// a binding was resolved for it always equals the declaration. A binding
+	// that contradicts one therefore belongs to a same-named agent, and the
+	// declaration is the right answer. Without this, a chat root placed a
+	// same-named nested single_turn agent into chat.
+	t.Run("a contradicting binding is another agent's and loses", func(t *testing.T) {
+		ctx := WithBoundMode(t.Context(), "worker", ModeChat)
+		if got := ModeFor(ctx, "worker", ModeSingleTurn); got != ModeSingleTurn {
+			t.Errorf("ModeFor = %q, want the declaration %q", got, ModeSingleTurn)
+		}
+	})
+}
+
+func TestPlacedMode(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		name     string
+		bind     Mode // ModeUnset means "bind nothing"
+		declared Mode
+		want     Mode
+		wantOK   bool
+	}{
+		{"no binding at all", ModeUnset, ModeSingleTurn, ModeUnset, false},
+		{"binding for an undeclared agent governs it", ModeSingleTurn, ModeUnset, ModeSingleTurn, true},
+		{"binding agreeing with the declaration governs it", ModeSingleTurn, ModeSingleTurn, ModeSingleTurn, true},
+		{"binding contradicting the declaration is another agent's", ModeChat, ModeSingleTurn, ModeUnset, false},
+		{"single_turn binding contradicting a chat declaration is another agent's", ModeSingleTurn, ModeChat, ModeUnset, false},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			ctx := WithBoundMode(t.Context(), "worker", tt.bind)
+			got, ok := PlacedMode(ctx, "worker", tt.declared)
+			if got != tt.want || ok != tt.wantOK {
+				t.Errorf("PlacedMode = (%q, %v), want (%q, %v)", got, ok, tt.want, tt.wantOK)
+			}
+		})
+	}
 }

--- a/internal/llminternal/mode_test.go
+++ b/internal/llminternal/mode_test.go
@@ -42,11 +42,10 @@ func TestResolveMode(t *testing.T) {
 	}
 }
 
-// The binding is keyed by agent NAME and validated against agent IDENTITY, and
-// the properties that follow are what the whole design rests on. None is
-// otherwise reachable from a test: no in-tree path binds two different values
-// for one name, and no in-tree path reads a binding for an agent that is not
-// the one running.
+// The binding is keyed by agent name AND agent identity, and the properties
+// that follow are what the whole design rests on. None is otherwise reachable
+// from a test: no in-tree path binds two different values for one name, and no
+// in-tree path reads a binding for an agent that is not the one running.
 func TestBoundMode_Scoping(t *testing.T) {
 	t.Parallel()
 

--- a/internal/llminternal/mode_test.go
+++ b/internal/llminternal/mode_test.go
@@ -43,9 +43,13 @@ func TestResolveMode(t *testing.T) {
 }
 
 // The binding is keyed by agent name AND agent identity, and the properties
-// that follow are what the whole design rests on. None is otherwise reachable
-// from a test: no in-tree path binds two different values for one name, and no
+// that follow are what the whole design rests on. Two of them are reachable
+// only here: no in-tree path binds two different values for one name, and no
 // in-tree path reads a binding for an agent that is not the one running.
+// Nesting is the exception — TestAgentNode_PlacementSurvivesATransferRoundTrip
+// drives it end to end — and the nesting subtest below is that round trip in
+// miniature, kept because it isolates the property from everything else that
+// test needs to be true.
 func TestBoundMode_Scoping(t *testing.T) {
 	t.Parallel()
 

--- a/internal/llminternal/mode_test.go
+++ b/internal/llminternal/mode_test.go
@@ -149,6 +149,7 @@ func TestPlacedMode(t *testing.T) {
 		want     Mode
 		wantOK   bool
 	}{
+		{"no binding, no declaration", ModeUnset, ModeUnset, ModeUnset, false},
 		{"no binding at all", ModeUnset, ModeSingleTurn, ModeUnset, false},
 		{"binding for an undeclared agent governs it", ModeSingleTurn, ModeUnset, ModeSingleTurn, true},
 		{"binding agreeing with the declaration governs it", ModeSingleTurn, ModeSingleTurn, ModeSingleTurn, true},

--- a/internal/llminternal/mode_test.go
+++ b/internal/llminternal/mode_test.go
@@ -180,12 +180,38 @@ func TestModeFor(t *testing.T) {
 	// into single_turn.
 	t.Run("another agent's binding loses to this agent's declaration", func(t *testing.T) {
 		placed := &State{}
-		for _, declared := range []Mode{ModeUnset, ModeChat, ModeSingleTurn, ModeTask} {
-			nested := &State{Mode: declared}
-			ctx := WithBoundMode(t.Context(), "worker", placed, ModeSingleTurn)
-			if got := ModeFor(ctx, "worker", nested); got != declared {
-				t.Errorf("ModeFor with declared %q = %q, want %q", declared, got, declared)
+		// Each arm binds a mode the nested agent did NOT declare, so an arm
+		// cannot pass merely because the two happen to coincide.
+		for _, tc := range []struct{ declared, bound Mode }{
+			{ModeUnset, ModeSingleTurn},
+			{ModeChat, ModeSingleTurn},
+			{ModeSingleTurn, ModeTask},
+			{ModeTask, ModeSingleTurn},
+		} {
+			nested := &State{Mode: tc.declared}
+			ctx := WithBoundMode(t.Context(), "worker", placed, tc.bound)
+			if got := ModeFor(ctx, "worker", nested); got != tc.declared {
+				t.Errorf("ModeFor with declared %q and another agent bound %q = %q, want %q",
+					tc.declared, tc.bound, got, tc.declared)
 			}
+		}
+	})
+
+	// A placement resolved for one agent must not be DESTROYED by a placement
+	// for a different agent of the same name either. Identity in the context
+	// key gives them separate slots; with identity only in the value, the
+	// second bind replaced the first and its owner silently fell back to its
+	// declaration.
+	t.Run("a same-named agent's binding does not displace ours", func(t *testing.T) {
+		ours, theirs := &State{}, &State{}
+		ctx := WithBoundMode(t.Context(), "worker", ours, ModeSingleTurn)
+		ctx = WithBoundMode(ctx, "worker", theirs, ModeTask)
+
+		if got, ok := BoundMode(ctx, "worker", ours); !ok || got != ModeSingleTurn {
+			t.Errorf("BoundMode(ours) = (%q, %v), want (%q, true)", got, ok, ModeSingleTurn)
+		}
+		if got, ok := BoundMode(ctx, "worker", theirs); !ok || got != ModeTask {
+			t.Errorf("BoundMode(theirs) = (%q, %v), want (%q, true)", got, ok, ModeTask)
 		}
 	})
 }

--- a/runner/mode_no_mutation_test.go
+++ b/runner/mode_no_mutation_test.go
@@ -1,0 +1,79 @@
+// Copyright 2026 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package runner
+
+import (
+	"testing"
+
+	"google.golang.org/genai"
+
+	"google.golang.org/adk/v2/agent"
+	"google.golang.org/adk/v2/agent/llmagent"
+	"google.golang.org/adk/v2/internal/llminternal"
+	"google.golang.org/adk/v2/session"
+)
+
+// The last of the five writes this change removes, and the only one nothing
+// else can see gone. Run used to stamp ModeChat onto an undeclared root's
+// shared State. Every reader treats chat and unset alike, so no value assertion
+// elsewhere can tell the write from its absence, and no concurrent test drives
+// Run, so the race detector cannot either.
+//
+// It lives in package runner on purpose. The property is about this package's
+// behaviour, and a version of it in another package leaves `go test ./runner/`
+// green while the write is back — which is the loop someone editing this file
+// actually runs.
+func TestRun_DoesNotMutateTheRootAgentsMode(t *testing.T) {
+	t.Parallel()
+
+	root, err := llmagent.New(llmagent.Config{
+		Name:  "root",
+		Model: &scriptedModel{replyFmt: "reply %d"},
+	})
+	if err != nil {
+		t.Fatalf("llmagent.New: %v", err)
+	}
+	internalRoot, ok := root.(llminternal.Agent)
+	if !ok {
+		t.Fatal("root is not an llminternal.Agent")
+	}
+	if got := llminternal.Reveal(internalRoot).Mode; got != llminternal.ModeUnset {
+		t.Fatalf("precondition: declared mode = %q, want unset", got)
+	}
+
+	r, err := New(Config{
+		AppName:           "app",
+		Agent:             root,
+		SessionService:    session.InMemoryService(),
+		AutoCreateSession: true,
+	})
+	if err != nil {
+		t.Fatalf("New: %v", err)
+	}
+	var events int
+	for _, err := range r.Run(t.Context(), "u", "s1", genai.NewContentFromText("hi", genai.RoleUser), agent.RunConfig{}) {
+		if err != nil {
+			t.Fatalf("Run: %v", err)
+		}
+		events++
+	}
+	if events == 0 {
+		t.Fatal("the run produced no events, so it may not have reached the root bind")
+	}
+
+	if got := llminternal.Reveal(internalRoot).Mode; got != llminternal.ModeUnset {
+		t.Errorf("declared mode after Run = %q, want unset (a run must not mutate the agent)", got)
+	}
+}

--- a/runner/mode_no_mutation_test.go
+++ b/runner/mode_no_mutation_test.go
@@ -25,11 +25,14 @@ import (
 	"google.golang.org/adk/v2/session"
 )
 
-// The last of the five writes this change removes, and the only one nothing
-// else can see gone. Run used to stamp ModeChat onto an undeclared root's
-// shared State. Every reader treats chat and unset alike, so no value assertion
-// elsewhere can tell the write from its absence, and no concurrent test drives
-// Run, so the race detector cannot either.
+// The last of the five writes this change removes. Run used to stamp ModeChat
+// onto an undeclared root's shared State. Every reader ON THE RUN PATH treats
+// chat and unset alike, so no assertion about a run can tell the write from its
+// absence, and no concurrent test drives Run, so the race detector cannot
+// either. One reader off that path does distinguish them: workflow's
+// agentNodeMode resolves unset to single_turn and leaves chat alone, so the
+// stamp used to make a later graph fail validateChatModeWiring. That is a
+// separate consequence, pinned in workflow, and not what this test is for.
 //
 // It lives in this directory on purpose. The property is about this package's
 // behaviour, and a version of it in another DIRECTORY leaves `go test ./runner/`

--- a/runner/mode_no_mutation_test.go
+++ b/runner/mode_no_mutation_test.go
@@ -31,10 +31,11 @@ import (
 // elsewhere can tell the write from its absence, and no concurrent test drives
 // Run, so the race detector cannot either.
 //
-// It lives in package runner on purpose. The property is about this package's
-// behaviour, and a version of it in another package leaves `go test ./runner/`
+// It lives in this directory on purpose. The property is about this package's
+// behaviour, and a version of it in another DIRECTORY leaves `go test ./runner/`
 // green while the write is back — which is the loop someone editing this file
-// actually runs.
+// actually runs. package runner rather than runner_test only so it can reuse
+// scriptedModel.
 func TestRun_DoesNotMutateTheRootAgentsMode(t *testing.T) {
 	t.Parallel()
 

--- a/runner/runner.go
+++ b/runner/runner.go
@@ -582,7 +582,7 @@ func (r *Runner) Run(ctx context.Context, userID, sessionID string, msg *genai.C
 				yield(nil, fmt.Errorf("root agent %s must be a chat LlmAgent, but has mode %s", r.rootAgent.Name(), rootMode))
 				return
 			}
-			ctx = llminternal.WithPlacementMode(ctx, llminternal.ModeChat)
+			ctx = llminternal.WithBoundMode(ctx, r.rootAgent.Name(), rootMode)
 
 			hasTaskSubAgent := func() bool {
 				for _, subAgent := range r.rootAgent.SubAgents() {

--- a/runner/runner.go
+++ b/runner/runner.go
@@ -576,15 +576,13 @@ func (r *Runner) Run(ctx context.Context, userID, sessionID string, msg *genai.C
 
 			llmInternalState := llminternal.Reveal(llmInternalAgent)
 
-			if llmInternalState.Mode == "" {
-				// LlmAgent as root agent must have chat mode.
-				llmInternalState.Mode = llminternal.ModeChat
-			}
-
-			if llmInternalState.Mode != llminternal.ModeChat {
-				yield(nil, fmt.Errorf("root agent %s must be a chat LlmAgent, but has mode %s", r.rootAgent.Name(), llmInternalState.Mode))
+			// LlmAgent as root agent must have chat mode.
+			rootMode := llminternal.ResolveMode(llmInternalState.Mode, llminternal.ModeChat)
+			if rootMode != llminternal.ModeChat {
+				yield(nil, fmt.Errorf("root agent %s must be a chat LlmAgent, but has mode %s", r.rootAgent.Name(), rootMode))
 				return
 			}
+			ctx = llminternal.WithPlacementMode(ctx, llminternal.ModeChat)
 
 			hasTaskSubAgent := func() bool {
 				for _, subAgent := range r.rootAgent.SubAgents() {

--- a/runner/runner.go
+++ b/runner/runner.go
@@ -582,6 +582,14 @@ func (r *Runner) Run(ctx context.Context, userID, sessionID string, msg *genai.C
 				yield(nil, fmt.Errorf("root agent %s must be a chat LlmAgent, but has mode %s", r.rootAgent.Name(), rootMode))
 				return
 			}
+			// Record the root's placement, as every other placement does.
+			// This changes no behavior today: the check above has already
+			// rejected anything but chat, and chat is also what an unbound
+			// agent falls back to, so no reader can tell a chat binding from
+			// an absent one. It is here so the runner is not the one
+			// placement that resolves a mode and then keeps it to itself,
+			// which is how a later reader would come to be right about graph
+			// nodes and wrong about roots.
 			ctx = llminternal.WithBoundMode(ctx, r.rootAgent.Name(), rootMode)
 
 			hasTaskSubAgent := func() bool {

--- a/runner/runner.go
+++ b/runner/runner.go
@@ -207,15 +207,13 @@ func (r *Runner) Run(ctx context.Context, userID, sessionID string, msg *genai.C
 
 			llmInternalState := llminternal.Reveal(llmInternalAgent)
 
-			if llmInternalState.Mode == "" {
-				// LlmAgent as root agent must have chat mode.
-				llmInternalState.Mode = llminternal.ModeChat
-			}
-
-			if llmInternalState.Mode != llminternal.ModeChat {
-				yield(nil, fmt.Errorf("root agent %s must be a chat LlmAgent, but has mode %s", r.rootAgent.Name(), llmInternalState.Mode))
+			// LlmAgent as root agent must have chat mode.
+			rootMode := llminternal.ResolveMode(llmInternalState.Mode, llminternal.ModeChat)
+			if rootMode != llminternal.ModeChat {
+				yield(nil, fmt.Errorf("root agent %s must be a chat LlmAgent, but has mode %s", r.rootAgent.Name(), rootMode))
 				return
 			}
+			ctx = llminternal.WithPlacementMode(ctx, llminternal.ModeChat)
 
 			hasTaskSubAgent := func() bool {
 				for _, subAgent := range r.rootAgent.SubAgents() {

--- a/runner/runner.go
+++ b/runner/runner.go
@@ -213,7 +213,7 @@ func (r *Runner) Run(ctx context.Context, userID, sessionID string, msg *genai.C
 				yield(nil, fmt.Errorf("root agent %s must be a chat LlmAgent, but has mode %s", r.rootAgent.Name(), rootMode))
 				return
 			}
-			ctx = llminternal.WithPlacementMode(ctx, llminternal.ModeChat)
+			ctx = llminternal.WithBoundMode(ctx, r.rootAgent.Name(), rootMode)
 
 			hasTaskSubAgent := func() bool {
 				for _, subAgent := range r.rootAgent.SubAgents() {

--- a/runner/runner.go
+++ b/runner/runner.go
@@ -590,7 +590,12 @@ func (r *Runner) Run(ctx context.Context, userID, sessionID string, msg *genai.C
 			// placement that resolves a mode and then keeps it to itself,
 			// which is how a later reader would come to be right about graph
 			// nodes and wrong about roots.
-			ctx = llminternal.WithBoundMode(ctx, r.rootAgent.Name(), llmInternalState, rootMode)
+			//
+			// Kept in a local rather than assigned back to ctx: ctx is this
+			// closure's captured parameter, and this branch is the only writer of
+			// it, so writing it would make the returned iterator stateful for a
+			// caller that ranges it twice.
+			rootCtx := llminternal.WithBoundMode(ctx, r.rootAgent.Name(), llmInternalState, rootMode)
 
 			hasTaskSubAgent := func() bool {
 				for _, subAgent := range r.rootAgent.SubAgents() {
@@ -620,7 +625,7 @@ func (r *Runner) Run(ctx context.Context, userID, sessionID string, msg *genai.C
 				}
 			}
 
-			r.runNode(ctx, storedSession, agentToRun, msg, cfg, options, yield)
+			r.runNode(rootCtx, storedSession, agentToRun, msg, cfg, options, yield)
 			return
 		}
 

--- a/runner/runner.go
+++ b/runner/runner.go
@@ -591,12 +591,11 @@ func (r *Runner) Run(ctx context.Context, userID, sessionID string, msg *genai.C
 			// which is how a later reader would come to be right about graph
 			// nodes and wrong about roots.
 			//
-			// Kept in a local rather than assigned back to ctx, which is this
-			// closure's captured parameter. Re-deriving the binding on a second
-			// range would be harmless in itself — same key, same value — but
-			// the sibling branch below already assigns four wrappers back onto
-			// ctx, so this iterator is stateful for a re-range whatever this
-			// line does. Not adding a fifth is the whole claim.
+			// Kept in a local rather than assigned back to ctx, this closure's
+			// captured parameter, so ranging the returned iterator twice cannot
+			// accumulate wrappers. The non-LlmAgent path below does assign back,
+			// but this branch returns before reaching it, so on this path the
+			// iterator really is clean for a re-range.
 			rootCtx := llminternal.WithBoundMode(ctx, r.rootAgent.Name(), llmInternalState, rootMode)
 
 			hasTaskSubAgent := func() bool {

--- a/runner/runner.go
+++ b/runner/runner.go
@@ -592,9 +592,8 @@ func (r *Runner) Run(ctx context.Context, userID, sessionID string, msg *genai.C
 			// nodes and wrong about roots.
 			//
 			// Kept in a local rather than assigned back to ctx: ctx is this
-			// closure's captured parameter, and this branch is the only writer of
-			// it, so writing it would make the returned iterator stateful for a
-			// caller that ranges it twice.
+			// closure's captured parameter, and writing it would make the returned
+			// iterator stateful for a caller that ranges it twice.
 			rootCtx := llminternal.WithBoundMode(ctx, r.rootAgent.Name(), llmInternalState, rootMode)
 
 			hasTaskSubAgent := func() bool {

--- a/runner/runner.go
+++ b/runner/runner.go
@@ -591,9 +591,12 @@ func (r *Runner) Run(ctx context.Context, userID, sessionID string, msg *genai.C
 			// which is how a later reader would come to be right about graph
 			// nodes and wrong about roots.
 			//
-			// Kept in a local rather than assigned back to ctx: ctx is this
-			// closure's captured parameter, and writing it would make the returned
-			// iterator stateful for a caller that ranges it twice.
+			// Kept in a local rather than assigned back to ctx, which is this
+			// closure's captured parameter. Re-deriving the binding on a second
+			// range would be harmless in itself — same key, same value — but
+			// the sibling branch below already assigns four wrappers back onto
+			// ctx, so this iterator is stateful for a re-range whatever this
+			// line does. Not adding a fifth is the whole claim.
 			rootCtx := llminternal.WithBoundMode(ctx, r.rootAgent.Name(), llmInternalState, rootMode)
 
 			hasTaskSubAgent := func() bool {

--- a/runner/runner.go
+++ b/runner/runner.go
@@ -590,7 +590,7 @@ func (r *Runner) Run(ctx context.Context, userID, sessionID string, msg *genai.C
 			// placement that resolves a mode and then keeps it to itself,
 			// which is how a later reader would come to be right about graph
 			// nodes and wrong about roots.
-			ctx = llminternal.WithBoundMode(ctx, r.rootAgent.Name(), rootMode)
+			ctx = llminternal.WithBoundMode(ctx, r.rootAgent.Name(), llmInternalState, rootMode)
 
 			hasTaskSubAgent := func() bool {
 				for _, subAgent := range r.rootAgent.SubAgents() {

--- a/workflow/agent_node.go
+++ b/workflow/agent_node.go
@@ -90,8 +90,12 @@ func (n *AgentNode) Run(ctx agent.Context, input any) iter.Seq2[*session.Event, 
 		}
 
 		// A graph node is a one-shot placement: an agent that declares no
-		// mode runs single_turn here.
-		ctx = ctx.WithAgentContext(llminternal.WithPlacementMode(ctx, llminternal.ModeSingleTurn))
+		// mode runs single_turn here. Bound under the agent's own name so it
+		// cannot govern a peer this agent later transfers to.
+		if llmA, ok := n.agent.(llminternal.Agent); ok {
+			mode := llminternal.ResolveMode(llminternal.Reveal(llmA).Mode, llminternal.ModeSingleTurn)
+			ctx = ctx.WithAgentContext(llminternal.WithBoundMode(ctx, n.agent.Name(), mode))
+		}
 
 		// Use existing agent context instead of implementing a new one.
 		// Branch is inherited from ctx so the agent runs under the

--- a/workflow/agent_node.go
+++ b/workflow/agent_node.go
@@ -50,13 +50,6 @@ func newAgentNodeWithSchemasTyped[Input, Output any](a agent.Agent, inputSchema,
 		return nil, fmt.Errorf("resolving output schema for agent %q: %w", a.Name(), err)
 	}
 
-	if llmA, ok := a.(llminternal.Agent); ok {
-		state := llminternal.Reveal(llmA)
-		if state.Mode == llminternal.ModeUnset {
-			state.Mode = llminternal.ModeSingleTurn
-		}
-	}
-
 	// The wrapped agent's Run already emits an invoke_agent span, so
 	// the scheduler must not add a redundant invoke_node wrapper —
 	// whether this node is activated by a static edge or delegated to
@@ -95,6 +88,10 @@ func (n *AgentNode) Run(ctx agent.Context, input any) iter.Seq2[*session.Event, 
 			yield(nil, err)
 			return
 		}
+
+		// A graph node is a one-shot placement: an agent that declares no
+		// mode runs single_turn here.
+		ctx = ctx.WithAgentContext(llminternal.WithPlacementMode(ctx, llminternal.ModeSingleTurn))
 
 		// Use existing agent context instead of implementing a new one.
 		// Branch is inherited from ctx so the agent runs under the

--- a/workflow/agent_node.go
+++ b/workflow/agent_node.go
@@ -15,6 +15,7 @@
 package workflow
 
 import (
+	"context"
 	"encoding/json"
 	"fmt"
 	"iter"
@@ -92,9 +93,21 @@ func (n *AgentNode) Run(ctx agent.Context, input any) iter.Seq2[*session.Event, 
 		// A graph node is a one-shot placement: an agent that declares no
 		// mode runs single_turn here. Bound under the agent's own name so it
 		// cannot govern a peer this agent later transfers to.
-		if llmA, ok := n.agent.(llminternal.Agent); ok {
+		//
+		// The binding goes into the context this function passes DOWN, not back
+		// into ctx. Routing it through ctx.WithAgentContext would be the obvious
+		// shape and is a crash: that method returns nil for a tool context and
+		// for a callback context, both of which log and carry on, and the nil is
+		// dereferenced a few lines below. Nothing in this repository drives a
+		// node from inside a tool, but every symbol on that path is exported.
+		// Guarding the nil and keeping the old ctx is not the fix either — the
+		// binding only reaches the request processors through the context handed
+		// downstream, so dropping it would run an undeclared agent as chat at a
+		// single_turn node.
+		bound := context.Context(ctx)
+		if llmA, ok := n.agent.(llminternal.Agent); ok && llmA != nil {
 			mode := llminternal.ResolveMode(llminternal.Reveal(llmA).Mode, llminternal.ModeSingleTurn)
-			ctx = ctx.WithAgentContext(llminternal.WithBoundMode(ctx, n.agent.Name(), mode))
+			bound = llminternal.WithBoundMode(ctx, n.agent.Name(), mode)
 		}
 
 		// Use existing agent context instead of implementing a new one.
@@ -114,7 +127,7 @@ func (n *AgentNode) Run(ctx agent.Context, input any) iter.Seq2[*session.Event, 
 			EndInvocation:  ctx.Ended(),
 			InvocationID:   ctx.InvocationID(),
 		}
-		agentCtx := internalcontext.NewInvocationContext(ctx, params)
+		agentCtx := internalcontext.NewInvocationContext(bound, params)
 		exCtx := agent.NewContext(agentCtx)
 
 		type NodeRunner interface {

--- a/workflow/agent_node.go
+++ b/workflow/agent_node.go
@@ -84,19 +84,20 @@ func NewAgentNode(a agent.Agent, cfg NodeConfig) (*AgentNode, error) {
 // Run implements the Node interface.
 func (n *AgentNode) Run(ctx agent.Context, input any) iter.Seq2[*session.Event, error] {
 	return func(yield func(*session.Event, error) bool) {
-		// Resolving the mode reads ctx, so a nil one is rejected before that
-		// rather than dereferenced. Exported, and RunLLMAgentAsNode — the other
-		// exported entry point that resolves a mode — rejects it the same way.
-		// The merge base panicked on a nil ctx too, a few lines lower while
-		// building params, so this turns a crash into an error rather than
-		// changing behaviour.
-		if ctx == nil {
-			yield(nil, fmt.Errorf("AgentNode.Run: nil context for agent %q", n.agent.Name()))
-			return
-		}
 		userContent, err := nodeInputToContent(input)
 		if err != nil {
 			yield(nil, err)
+			return
+		}
+		// Resolving the mode reads ctx, so a nil one is rejected before that
+		// rather than dereferenced further down. Exported, and RunLLMAgentAsNode
+		// — the other exported entry point that resolves a mode — rejects it the
+		// same way. Placed after nodeInputToContent, which never touches ctx, so
+		// an unmarshalable input still reports the marshaling error the merge
+		// base reported for it. Untyped nil only: a typed-nil agent.Context
+		// still panics, as it does everywhere else in these packages.
+		if ctx == nil {
+			yield(nil, fmt.Errorf("AgentNode.Run: nil context for agent %q", n.agent.Name()))
 			return
 		}
 

--- a/workflow/agent_node.go
+++ b/workflow/agent_node.go
@@ -99,8 +99,11 @@ func (n *AgentNode) Run(ctx agent.Context, input any) iter.Seq2[*session.Event, 
 		// into ctx. Routing it through ctx.WithAgentContext would be the obvious
 		// shape and is a crash: that method returns nil for a tool context and
 		// for a callback context, both of which log and carry on, and the nil is
-		// dereferenced a few lines below. Nothing in this repository drives a
-		// node from inside a tool, but every symbol on that path is exported.
+		// dereferenced a few lines below. No tool context reaches this function:
+		// SingleTurnTool does drive a node from inside a tool, but workflow.RunNode
+		// uses the caller's context only to fetch its SubScheduler, and the child
+		// context comes from the scheduler's own parent. Every symbol on that path
+		// is exported, so an out-of-tree caller can still arrive here with one.
 		// Guarding the nil and keeping the old ctx is not the fix either — the
 		// binding only reaches the request processors through the context handed
 		// downstream, so dropping it would run an undeclared agent as chat at a

--- a/workflow/agent_node.go
+++ b/workflow/agent_node.go
@@ -84,6 +84,16 @@ func NewAgentNode(a agent.Agent, cfg NodeConfig) (*AgentNode, error) {
 // Run implements the Node interface.
 func (n *AgentNode) Run(ctx agent.Context, input any) iter.Seq2[*session.Event, error] {
 	return func(yield func(*session.Event, error) bool) {
+		// Resolving the mode reads ctx, so a nil one is rejected before that
+		// rather than dereferenced. Exported, and RunLLMAgentAsNode — the other
+		// exported entry point that resolves a mode — rejects it the same way.
+		// The merge base panicked on a nil ctx too, a few lines lower while
+		// building params, so this turns a crash into an error rather than
+		// changing behaviour.
+		if ctx == nil {
+			yield(nil, fmt.Errorf("AgentNode.Run: nil context for agent %q", n.agent.Name()))
+			return
+		}
 		userContent, err := nodeInputToContent(input)
 		if err != nil {
 			yield(nil, err)

--- a/workflow/agent_node.go
+++ b/workflow/agent_node.go
@@ -99,11 +99,11 @@ func (n *AgentNode) Run(ctx agent.Context, input any) iter.Seq2[*session.Event, 
 		// into ctx. Routing it through ctx.WithAgentContext would be the obvious
 		// shape and is a crash: that method returns nil for a tool context and
 		// for a callback context, both of which log and carry on, and the nil is
-		// dereferenced a few lines below. No tool context reaches this function:
+		// dereferenced a few lines below. Neither wrapper reaches this function:
 		// SingleTurnTool does drive a node from inside a tool, but workflow.RunNode
 		// uses the caller's context only to fetch its SubScheduler, and the child
 		// context comes from the scheduler's own parent. Every symbol on that path
-		// is exported, so an out-of-tree caller can still arrive here with one.
+		// is exported, so an out-of-tree caller can still arrive here with either.
 		// Guarding the nil and keeping the old ctx is not the fix either — the
 		// binding only reaches the request processors through the context handed
 		// downstream, so dropping it would run an undeclared agent as chat at a

--- a/workflow/agent_node.go
+++ b/workflow/agent_node.go
@@ -106,8 +106,9 @@ func (n *AgentNode) Run(ctx agent.Context, input any) iter.Seq2[*session.Event, 
 		// single_turn node.
 		bound := context.Context(ctx)
 		if llmA, ok := n.agent.(llminternal.Agent); ok && llmA != nil {
-			mode := llminternal.ResolveMode(llminternal.Reveal(llmA).Mode, llminternal.ModeSingleTurn)
-			bound = llminternal.WithBoundMode(ctx, n.agent.Name(), mode)
+			state := llminternal.Reveal(llmA)
+			mode := llminternal.ResolveMode(state.Mode, llminternal.ModeSingleTurn)
+			bound = llminternal.WithBoundMode(ctx, n.agent.Name(), state, mode)
 		}
 
 		// Use existing agent context instead of implementing a new one.

--- a/workflow/agent_node.go
+++ b/workflow/agent_node.go
@@ -91,8 +91,9 @@ func (n *AgentNode) Run(ctx agent.Context, input any) iter.Seq2[*session.Event, 
 		}
 
 		// A graph node is a one-shot placement: an agent that declares no
-		// mode runs single_turn here. Bound under the agent's own name so it
-		// cannot govern a peer this agent later transfers to.
+		// mode runs single_turn here. Bound under this agent's own key — its
+		// name and its identity — so it cannot govern a peer this agent later
+		// transfers to, nor a same-named agent nested beneath it.
 		//
 		// The binding goes into the context this function passes DOWN, not back
 		// into ctx. Routing it through ctx.WithAgentContext would be the obvious

--- a/workflow/agent_node_mode_mutation_test.go
+++ b/workflow/agent_node_mode_mutation_test.go
@@ -1,0 +1,151 @@
+// Copyright 2026 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package workflow_test
+
+import (
+	"slices"
+	"sync"
+	"testing"
+
+	"google.golang.org/adk/v2/agent"
+	"google.golang.org/adk/v2/agent/llmagent"
+	"google.golang.org/adk/v2/internal/llminternal"
+	"google.golang.org/adk/v2/workflow"
+)
+
+// coordinatorToolNames returns the tools a chat coordinator installed for
+// its sub-agents. Which tool a sub-agent gets (single_turn vs task) is
+// derived from that sub-agent's mode, so this is the user-visible
+// consequence of mode resolution.
+func coordinatorToolNames(t *testing.T, a agent.Agent) []string {
+	t.Helper()
+	llmA, ok := a.(llminternal.Agent)
+	if !ok {
+		t.Fatalf("agent %q is not an LlmAgent", a.Name())
+	}
+	var names []string
+	for _, tl := range llminternal.Reveal(llmA).Tools {
+		names = append(names, tl.Name())
+	}
+	slices.Sort(names)
+	return names
+}
+
+func declaredMode(t *testing.T, a agent.Agent) llminternal.Mode {
+	t.Helper()
+	llmA, ok := a.(llminternal.Agent)
+	if !ok {
+		t.Fatalf("agent %q is not an LlmAgent", a.Name())
+	}
+	return llminternal.Reveal(llmA).Mode
+}
+
+// Adapting an agent into a graph node must not rewrite the agent's own
+// declaration. The node's placement is a property of the graph, not of
+// the agent, and the same agent instance may be placed elsewhere.
+func TestNewAgentNode_DoesNotMutateAgentMode(t *testing.T) {
+	t.Parallel()
+
+	a, err := llmagent.New(llmagent.Config{Name: "worker"})
+	if err != nil {
+		t.Fatalf("llmagent.New: %v", err)
+	}
+	if got := declaredMode(t, a); got != llminternal.ModeUnset {
+		t.Fatalf("precondition: declared mode = %q, want unset", got)
+	}
+
+	if _, err := workflow.NewAgentNode(a, workflow.NodeConfig{}); err != nil {
+		t.Fatalf("NewAgentNode: %v", err)
+	}
+
+	if got := declaredMode(t, a); got != llminternal.ModeUnset {
+		t.Errorf("declared mode after NewAgentNode = %q, want unset (wrapping must not mutate the agent)", got)
+	}
+}
+
+// An agent with no declared mode resolves by placement. Resolving one
+// placement must not leak into another: a coordinator's view of its
+// sub-agent must not depend on whether that sub-agent was wrapped as a
+// graph node first.
+func TestLlmAgent_SubAgentModeResolution_IsConstructionOrderIndependent(t *testing.T) {
+	t.Parallel()
+
+	newWorker := func(t *testing.T) agent.Agent {
+		t.Helper()
+		sub, err := llmagent.New(llmagent.Config{Name: "worker"})
+		if err != nil {
+			t.Fatalf("llmagent.New(worker): %v", err)
+		}
+		return sub
+	}
+
+	// Order A: the coordinator is built first, then the same agent
+	// instance is also placed in a graph.
+	subA := newWorker(t)
+	coordA, err := llmagent.New(llmagent.Config{
+		Name:      "coordinator",
+		Mode:      llmagent.ModeChat,
+		SubAgents: []agent.Agent{subA},
+	})
+	if err != nil {
+		t.Fatalf("llmagent.New(coordinator): %v", err)
+	}
+	if _, err := workflow.NewAgentNode(subA, workflow.NodeConfig{}); err != nil {
+		t.Fatalf("NewAgentNode: %v", err)
+	}
+
+	// Order B: the graph placement happens first.
+	subB := newWorker(t)
+	if _, err := workflow.NewAgentNode(subB, workflow.NodeConfig{}); err != nil {
+		t.Fatalf("NewAgentNode: %v", err)
+	}
+	coordB, err := llmagent.New(llmagent.Config{
+		Name:      "coordinator",
+		Mode:      llmagent.ModeChat,
+		SubAgents: []agent.Agent{subB},
+	})
+	if err != nil {
+		t.Fatalf("llmagent.New(coordinator): %v", err)
+	}
+
+	gotA, gotB := coordinatorToolNames(t, coordA), coordinatorToolNames(t, coordB)
+	if !slices.Equal(gotA, gotB) {
+		t.Errorf("coordinator tools depend on construction order:\n  coordinator-first = %v\n  node-first        = %v", gotA, gotB)
+	}
+}
+
+// The same agent instance is documented to serve many concurrent
+// invocations, so placement resolution must not write to state shared
+// across them. Run with -race.
+func TestNewAgentNode_ConcurrentWrappingIsRaceFree(t *testing.T) {
+	t.Parallel()
+
+	a, err := llmagent.New(llmagent.Config{Name: "worker"})
+	if err != nil {
+		t.Fatalf("llmagent.New: %v", err)
+	}
+
+	var wg sync.WaitGroup
+	for range 8 {
+		wg.Add(1)
+		go func() {
+			defer wg.Done()
+			if _, err := workflow.NewAgentNode(a, workflow.NodeConfig{}); err != nil {
+				t.Errorf("NewAgentNode: %v", err)
+			}
+		}()
+	}
+	wg.Wait()
+}

--- a/workflow/agent_node_mode_mutation_test.go
+++ b/workflow/agent_node_mode_mutation_test.go
@@ -15,13 +15,18 @@
 package workflow_test
 
 import (
+	"context"
+	"iter"
 	"slices"
 	"sync"
 	"testing"
 
+	"google.golang.org/genai"
+
 	"google.golang.org/adk/v2/agent"
 	"google.golang.org/adk/v2/agent/llmagent"
 	"google.golang.org/adk/v2/internal/llminternal"
+	"google.golang.org/adk/v2/model"
 	"google.golang.org/adk/v2/workflow"
 )
 
@@ -150,6 +155,61 @@ func TestNewAgentNode_ConcurrentWrappingIsRaceFree(t *testing.T) {
 			defer wg.Done()
 			if _, err := workflow.NewAgentNode(a, workflow.NodeConfig{}); err != nil {
 				t.Errorf("NewAgentNode: %v", err)
+			}
+		}()
+	}
+	wg.Wait()
+}
+
+// raceFreeLLM holds no mutable state, so a race the detector reports under
+// the test below is on the agent, not on the model double.
+type raceFreeLLM struct{}
+
+func (*raceFreeLLM) Name() string { return "race-free" }
+
+func (*raceFreeLLM) GenerateContent(context.Context, *model.LLMRequest, bool) iter.Seq2[*model.LLMResponse, error] {
+	return func(yield func(*model.LLMResponse, error) bool) {
+		yield(&model.LLMResponse{Content: &genai.Content{
+			Role:  "model",
+			Parts: []*genai.Part{{Text: "answer"}},
+		}}, nil)
+	}
+}
+
+// The wrapping test above covers only the write that construction used to
+// make. Placement is resolved again on every run, so build the nodes
+// single-threaded and race the runs instead: the write this replaces lived on
+// the run path, where it raced the contents processor's read. Run with -race.
+func TestOneAgentInstance_ConcurrentInvocationsAreRaceFree(t *testing.T) {
+	t.Parallel()
+
+	a, err := llmagent.New(llmagent.Config{Name: "worker", Model: &raceFreeLLM{}})
+	if err != nil {
+		t.Fatalf("llmagent.New: %v", err)
+	}
+	var wfs []*workflow.Workflow
+	for range 16 {
+		node, err := workflow.NewAgentNode(a, workflow.NodeConfig{})
+		if err != nil {
+			t.Fatalf("NewAgentNode: %v", err)
+		}
+		wf, err := workflow.New("wf", workflow.Chain(workflow.Start, node))
+		if err != nil {
+			t.Fatalf("workflow.New: %v", err)
+		}
+		wfs = append(wfs, wf)
+	}
+
+	var wg sync.WaitGroup
+	for _, wf := range wfs {
+		wg.Add(1)
+		go func() {
+			defer wg.Done()
+			for _, err := range wf.Run(newModeTestCtx(t, a)) {
+				if err != nil {
+					t.Errorf("workflow.Run: %v", err)
+					return
+				}
 			}
 		}()
 	}

--- a/workflow/agent_node_mode_mutation_test.go
+++ b/workflow/agent_node_mode_mutation_test.go
@@ -120,9 +120,15 @@ func TestLlmAgent_SubAgentModeResolution_IsConstructionOrderIndependent(t *testi
 		t.Fatalf("llmagent.New(coordinator): %v", err)
 	}
 
+	// An undeclared sub-agent is a chat peer in both orders, reached by
+	// transfer, so the coordinator installs no delegation tool for it.
+	var want []string
 	gotA, gotB := coordinatorToolNames(t, coordA), coordinatorToolNames(t, coordB)
 	if !slices.Equal(gotA, gotB) {
 		t.Errorf("coordinator tools depend on construction order:\n  coordinator-first = %v\n  node-first        = %v", gotA, gotB)
+	}
+	if !slices.Equal(gotA, want) {
+		t.Errorf("coordinator tools = %v, want %v", gotA, want)
 	}
 }
 

--- a/workflow/agent_node_mode_mutation_test.go
+++ b/workflow/agent_node_mode_mutation_test.go
@@ -16,6 +16,7 @@ package workflow_test
 
 import (
 	"context"
+	"fmt"
 	"iter"
 	"slices"
 	"sync"
@@ -87,22 +88,29 @@ func TestNewAgentNode_DoesNotMutateAgentMode(t *testing.T) {
 func TestLlmAgent_SubAgentModeResolution_IsConstructionOrderIndependent(t *testing.T) {
 	t.Parallel()
 
-	newWorker := func(t *testing.T) agent.Agent {
+	// Two sub-agents, because an all-undeclared coordinator installs no tools
+	// at all and "no tools" compares equal to "no tools" however the resolution
+	// went. The declared one gives the comparison something to be wrong about.
+	newSubAgents := func(t *testing.T) (undeclared, declared agent.Agent) {
 		t.Helper()
 		sub, err := llmagent.New(llmagent.Config{Name: "worker"})
 		if err != nil {
 			t.Fatalf("llmagent.New(worker): %v", err)
 		}
-		return sub
+		dec, err := llmagent.New(llmagent.Config{Name: "declared_worker", Mode: llmagent.ModeSingleTurn})
+		if err != nil {
+			t.Fatalf("llmagent.New(declared_worker): %v", err)
+		}
+		return sub, dec
 	}
 
 	// Order A: the coordinator is built first, then the same agent
 	// instance is also placed in a graph.
-	subA := newWorker(t)
+	subA, decA := newSubAgents(t)
 	coordA, err := llmagent.New(llmagent.Config{
 		Name:      "coordinator",
 		Mode:      llmagent.ModeChat,
-		SubAgents: []agent.Agent{subA},
+		SubAgents: []agent.Agent{subA, decA},
 	})
 	if err != nil {
 		t.Fatalf("llmagent.New(coordinator): %v", err)
@@ -112,22 +120,23 @@ func TestLlmAgent_SubAgentModeResolution_IsConstructionOrderIndependent(t *testi
 	}
 
 	// Order B: the graph placement happens first.
-	subB := newWorker(t)
+	subB, decB := newSubAgents(t)
 	if _, err := workflow.NewAgentNode(subB, workflow.NodeConfig{}); err != nil {
 		t.Fatalf("NewAgentNode: %v", err)
 	}
 	coordB, err := llmagent.New(llmagent.Config{
 		Name:      "coordinator",
 		Mode:      llmagent.ModeChat,
-		SubAgents: []agent.Agent{subB},
+		SubAgents: []agent.Agent{subB, decB},
 	})
 	if err != nil {
 		t.Fatalf("llmagent.New(coordinator): %v", err)
 	}
 
 	// An undeclared sub-agent is a chat peer in both orders, reached by
-	// transfer, so the coordinator installs no delegation tool for it.
-	var want []string
+	// transfer, so the coordinator installs no delegation tool for it. The
+	// declared single_turn one gets a tool in both orders.
+	want := []string{"declared_worker"}
 	gotA, gotB := coordinatorToolNames(t, coordA), coordinatorToolNames(t, coordB)
 	if !slices.Equal(gotA, gotB) {
 		t.Errorf("coordinator tools depend on construction order:\n  coordinator-first = %v\n  node-first        = %v", gotA, gotB)
@@ -135,6 +144,62 @@ func TestLlmAgent_SubAgentModeResolution_IsConstructionOrderIndependent(t *testi
 	if !slices.Equal(gotA, want) {
 		t.Errorf("coordinator tools = %v, want %v", gotA, want)
 	}
+}
+
+// The order test above can only see a difference BETWEEN the two orders, so it
+// cannot catch a write that both orders make. Building a coordinator must not
+// write a mode onto a sub-agent at all: the instance is shared, and a second
+// coordinator over the same sub-agent would race this write.
+func TestLlmAgent_New_DoesNotMutateSubAgentMode(t *testing.T) {
+	t.Parallel()
+
+	sub, err := llmagent.New(llmagent.Config{Name: "worker"})
+	if err != nil {
+		t.Fatalf("llmagent.New(worker): %v", err)
+	}
+	if got := declaredMode(t, sub); got != llminternal.ModeUnset {
+		t.Fatalf("precondition: declared mode = %q, want unset", got)
+	}
+
+	if _, err := llmagent.New(llmagent.Config{
+		Name:      "coordinator",
+		Mode:      llmagent.ModeChat,
+		SubAgents: []agent.Agent{sub},
+	}); err != nil {
+		t.Fatalf("llmagent.New(coordinator): %v", err)
+	}
+
+	if got := declaredMode(t, sub); got != llminternal.ModeUnset {
+		t.Errorf("declared mode after being adopted as a sub-agent = %q, want unset "+
+			"(building a coordinator must not write to the sub-agent)", got)
+	}
+}
+
+// The same shared-instance write, raced. Two coordinators built concurrently
+// over one sub-agent must not write to it. Run with -race.
+func TestLlmAgent_New_ConcurrentCoordinatorsOverOneSubAgent(t *testing.T) {
+	t.Parallel()
+
+	sub, err := llmagent.New(llmagent.Config{Name: "worker"})
+	if err != nil {
+		t.Fatalf("llmagent.New(worker): %v", err)
+	}
+
+	var wg sync.WaitGroup
+	for i := range 8 {
+		wg.Add(1)
+		go func() {
+			defer wg.Done()
+			if _, err := llmagent.New(llmagent.Config{
+				Name:      fmt.Sprintf("coordinator-%d", i),
+				Mode:      llmagent.ModeChat,
+				SubAgents: []agent.Agent{sub},
+			}); err != nil {
+				t.Errorf("llmagent.New(coordinator): %v", err)
+			}
+		}()
+	}
+	wg.Wait()
 }
 
 // The same agent instance is documented to serve many concurrent

--- a/workflow/agent_node_mode_mutation_test.go
+++ b/workflow/agent_node_mode_mutation_test.go
@@ -20,6 +20,7 @@ import (
 	"iter"
 	"slices"
 	"sync"
+	"sync/atomic"
 	"testing"
 
 	"google.golang.org/genai"
@@ -228,11 +229,12 @@ func TestNewAgentNode_ConcurrentWrappingIsRaceFree(t *testing.T) {
 
 // raceFreeLLM holds no mutable state, so a race the detector reports under
 // the test below is on the agent, not on the model double.
-type raceFreeLLM struct{}
+type raceFreeLLM struct{ calls atomic.Int64 }
 
 func (*raceFreeLLM) Name() string { return "race-free" }
 
-func (*raceFreeLLM) GenerateContent(context.Context, *model.LLMRequest, bool) iter.Seq2[*model.LLMResponse, error] {
+func (m *raceFreeLLM) GenerateContent(context.Context, *model.LLMRequest, bool) iter.Seq2[*model.LLMResponse, error] {
+	m.calls.Add(1)
 	return func(yield func(*model.LLMResponse, error) bool) {
 		yield(&model.LLMResponse{Content: &genai.Content{
 			Role:  "model",
@@ -248,12 +250,20 @@ func (*raceFreeLLM) GenerateContent(context.Context, *model.LLMRequest, bool) it
 func TestOneAgentInstance_ConcurrentInvocationsAreRaceFree(t *testing.T) {
 	t.Parallel()
 
-	a, err := llmagent.New(llmagent.Config{Name: "worker", Model: &raceFreeLLM{}})
+	const runs = 16
+
+	llm := &raceFreeLLM{}
+	a, err := llmagent.New(llmagent.Config{Name: "worker", Model: llm})
 	if err != nil {
 		t.Fatalf("llmagent.New: %v", err)
 	}
+	// Both the workflows and the contexts are built here rather than inside the
+	// goroutines: newModeTestCtx calls t.Fatalf, which is only valid on the test
+	// goroutine, and a fixture failure in a worker would otherwise be reported
+	// as something other than a failure.
 	var wfs []*workflow.Workflow
-	for range 16 {
+	var ctxs []agent.Context
+	for range runs {
 		node, err := workflow.NewAgentNode(a, workflow.NodeConfig{})
 		if err != nil {
 			t.Fatalf("NewAgentNode: %v", err)
@@ -263,14 +273,15 @@ func TestOneAgentInstance_ConcurrentInvocationsAreRaceFree(t *testing.T) {
 			t.Fatalf("workflow.New: %v", err)
 		}
 		wfs = append(wfs, wf)
+		ctxs = append(ctxs, newModeTestCtx(t, a))
 	}
 
 	var wg sync.WaitGroup
-	for _, wf := range wfs {
+	for i, wf := range wfs {
 		wg.Add(1)
 		go func() {
 			defer wg.Done()
-			for _, err := range wf.Run(newModeTestCtx(t, a)) {
+			for _, err := range wf.Run(ctxs[i]) {
 				if err != nil {
 					t.Errorf("workflow.Run: %v", err)
 					return
@@ -279,4 +290,10 @@ func TestOneAgentInstance_ConcurrentInvocationsAreRaceFree(t *testing.T) {
 		}()
 	}
 	wg.Wait()
+
+	// Without this the test would stay green if the runs short-circuited before
+	// reaching the contents processor, having opened no race window at all.
+	if got := llm.calls.Load(); got != runs {
+		t.Errorf("model was called %d time(s), want %d — the runs did not reach the code this races", got, runs)
+	}
 }

--- a/workflow/agent_node_mode_mutation_test.go
+++ b/workflow/agent_node_mode_mutation_test.go
@@ -227,8 +227,12 @@ func TestNewAgentNode_ConcurrentWrappingIsRaceFree(t *testing.T) {
 	wg.Wait()
 }
 
-// raceFreeLLM holds no mutable state, so a race the detector reports under
-// the test below is on the agent, not on the model double.
+// raceFreeLLM holds one atomic counter and nothing else, so a race the detector
+// reports under the test below is on the agent, not on the model double. The
+// counter is what lets the test prove it reached the model at all. Note that
+// atomics order the goroutines that touch them, so a conflicting access placed
+// AFTER the model call could be masked by it — the write this replaces happened
+// before, and is unaffected.
 type raceFreeLLM struct{ calls atomic.Int64 }
 
 func (*raceFreeLLM) Name() string { return "race-free" }

--- a/workflow/agent_node_mode_mutation_test.go
+++ b/workflow/agent_node_mode_mutation_test.go
@@ -29,7 +29,6 @@ import (
 	"google.golang.org/adk/v2/agent"
 	"google.golang.org/adk/v2/agent/llmagent"
 	"google.golang.org/adk/v2/internal/llminternal"
-	"google.golang.org/adk/v2/internal/testutil"
 	"google.golang.org/adk/v2/model"
 	"google.golang.org/adk/v2/runner"
 	"google.golang.org/adk/v2/session"
@@ -312,51 +311,6 @@ func TestOneAgentInstance_ConcurrentInvocationsAreRaceFree(t *testing.T) {
 	// reaching the contents processor, having opened no race window at all.
 	if got := llm.calls.Load(); got != runs {
 		t.Errorf("model was called %d time(s), want %d — the runs did not reach the code this races", got, runs)
-	}
-}
-
-// The last of the five removed writes, and the only one nothing else can see
-// gone. runner.Run used to stamp ModeChat onto an undeclared root's shared
-// State. Every reader treats chat and unset alike, so no value assertion
-// anywhere can tell the write from its absence, and no concurrent test drives
-// runner.Run — restoring it would ship green. This asserts the agent object is
-// unchanged by a run, which is the property #1137 is about.
-func TestRunner_Run_DoesNotMutateTheRootAgentsMode(t *testing.T) {
-	t.Parallel()
-
-	root, err := llmagent.New(llmagent.Config{
-		Name:  "root",
-		Model: &testutil.MockModel{Responses: []*genai.Content{genai.NewContentFromText("done", "model")}},
-	})
-	if err != nil {
-		t.Fatalf("llmagent.New: %v", err)
-	}
-	if got := declaredMode(t, root); got != llminternal.ModeUnset {
-		t.Fatalf("precondition: declared mode = %q, want unset", got)
-	}
-
-	r, err := runner.New(runner.Config{
-		AppName:           "app",
-		Agent:             root,
-		SessionService:    session.InMemoryService(),
-		AutoCreateSession: true,
-	})
-	if err != nil {
-		t.Fatalf("runner.New: %v", err)
-	}
-	var events int
-	for _, err := range r.Run(t.Context(), "u", "s1", genai.NewContentFromText("hi", genai.RoleUser), agent.RunConfig{}) {
-		if err != nil {
-			t.Fatalf("Run: %v", err)
-		}
-		events++
-	}
-	if events == 0 {
-		t.Fatal("the run produced no events, so it may not have reached the root bind")
-	}
-
-	if got := declaredMode(t, root); got != llminternal.ModeUnset {
-		t.Errorf("declared mode after runner.Run = %q, want unset (a run must not mutate the agent)", got)
 	}
 }
 

--- a/workflow/agent_node_mode_mutation_test.go
+++ b/workflow/agent_node_mode_mutation_test.go
@@ -28,7 +28,10 @@ import (
 	"google.golang.org/adk/v2/agent"
 	"google.golang.org/adk/v2/agent/llmagent"
 	"google.golang.org/adk/v2/internal/llminternal"
+	"google.golang.org/adk/v2/internal/testutil"
 	"google.golang.org/adk/v2/model"
+	"google.golang.org/adk/v2/runner"
+	"google.golang.org/adk/v2/session"
 	"google.golang.org/adk/v2/workflow"
 )
 
@@ -299,5 +302,50 @@ func TestOneAgentInstance_ConcurrentInvocationsAreRaceFree(t *testing.T) {
 	// reaching the contents processor, having opened no race window at all.
 	if got := llm.calls.Load(); got != runs {
 		t.Errorf("model was called %d time(s), want %d — the runs did not reach the code this races", got, runs)
+	}
+}
+
+// The last of the five removed writes, and the only one nothing else can see
+// gone. runner.Run used to stamp ModeChat onto an undeclared root's shared
+// State. Every reader treats chat and unset alike, so no value assertion
+// anywhere can tell the write from its absence, and no concurrent test drives
+// runner.Run — restoring it would ship green. This asserts the agent object is
+// unchanged by a run, which is the property #1137 is about.
+func TestRunner_Run_DoesNotMutateTheRootAgentsMode(t *testing.T) {
+	t.Parallel()
+
+	root, err := llmagent.New(llmagent.Config{
+		Name:  "root",
+		Model: &testutil.MockModel{Responses: []*genai.Content{genai.NewContentFromText("done", "model")}},
+	})
+	if err != nil {
+		t.Fatalf("llmagent.New: %v", err)
+	}
+	if got := declaredMode(t, root); got != llminternal.ModeUnset {
+		t.Fatalf("precondition: declared mode = %q, want unset", got)
+	}
+
+	r, err := runner.New(runner.Config{
+		AppName:           "app",
+		Agent:             root,
+		SessionService:    session.InMemoryService(),
+		AutoCreateSession: true,
+	})
+	if err != nil {
+		t.Fatalf("runner.New: %v", err)
+	}
+	var events int
+	for _, err := range r.Run(t.Context(), "u", "s1", genai.NewContentFromText("hi", genai.RoleUser), agent.RunConfig{}) {
+		if err != nil {
+			t.Fatalf("Run: %v", err)
+		}
+		events++
+	}
+	if events == 0 {
+		t.Fatal("the run produced no events, so it may not have reached the root bind")
+	}
+
+	if got := declaredMode(t, root); got != llminternal.ModeUnset {
+		t.Errorf("declared mode after runner.Run = %q, want unset (a run must not mutate the agent)", got)
 	}
 }

--- a/workflow/agent_node_mode_mutation_test.go
+++ b/workflow/agent_node_mode_mutation_test.go
@@ -54,6 +54,15 @@ func coordinatorToolNames(t *testing.T, a agent.Agent) []string {
 	return names
 }
 
+func declaredIncludeContents(t *testing.T, a agent.Agent) string {
+	t.Helper()
+	llmA, ok := a.(llminternal.Agent)
+	if !ok {
+		t.Fatalf("agent %q is not an LlmAgent", a.Name())
+	}
+	return llminternal.Reveal(llmA).IncludeContents
+}
+
 func declaredMode(t *testing.T, a agent.Agent) llminternal.Mode {
 	t.Helper()
 	llmA, ok := a.(llminternal.Agent)
@@ -423,5 +432,50 @@ func TestLlmAgent_TransferTargets_AreConstructionOrderIndependent(t *testing.T) 
 	}
 	if coordFirst != nodeFirst {
 		t.Errorf("the coordinator's transfer targets depend on construction order:\n coordinator-first = %q\n node-first        = %q", coordFirst, nodeFirst)
+	}
+}
+
+// CONTRACT 1 covers State.IncludeContents as well as State.Mode, and until now
+// only the Mode half was asserted. The wrapper used to write
+// state.IncludeContents = "none" onto the shared agent when it ran a
+// single_turn placement, which is why a second placement of the same instance
+// then hid history everywhere. A guarded reintroduction of that write —
+// only when the field is still empty — changes no behaviour the history tests
+// observe, because they set IncludeContents explicitly, so nothing but this
+// assertion or the race detector would catch it.
+func TestAgentNode_Run_DoesNotMutateTheAgentsIncludeContents(t *testing.T) {
+	t.Parallel()
+
+	llm := &capturingLLM{}
+	a, err := llmagent.New(llmagent.Config{Name: "worker", Model: llm})
+	if err != nil {
+		t.Fatalf("llmagent.New: %v", err)
+	}
+	if got := declaredIncludeContents(t, a); got != "" {
+		t.Fatalf("precondition: IncludeContents = %q, want empty", got)
+	}
+
+	node, err := workflow.NewAgentNode(a, workflow.NodeConfig{})
+	if err != nil {
+		t.Fatalf("NewAgentNode: %v", err)
+	}
+	wf, err := workflow.New("wf", []workflow.Edge{{From: workflow.Start, To: node}})
+	if err != nil {
+		t.Fatalf("workflow.New: %v", err)
+	}
+	for _, err := range wf.Run(newModeTestCtx(t, a)) {
+		if err != nil {
+			t.Fatalf("wf.Run: %v", err)
+		}
+	}
+	if llm.got == nil {
+		t.Fatal("the model was never called, so the single_turn placement was not exercised")
+	}
+
+	if got := declaredIncludeContents(t, a); got != "" {
+		t.Errorf("IncludeContents after a single_turn placement = %q, want empty (a run must not mutate the agent)", got)
+	}
+	if got := declaredMode(t, a); got != llminternal.ModeUnset {
+		t.Errorf("declared mode after a single_turn placement = %q, want unset", got)
 	}
 }

--- a/workflow/agent_node_mode_mutation_test.go
+++ b/workflow/agent_node_mode_mutation_test.go
@@ -443,3 +443,64 @@ func TestAgentNode_Run_DoesNotMutateTheAgentsIncludeContents(t *testing.T) {
 		t.Errorf("declared mode after a single_turn placement = %q, want unset", got)
 	}
 }
+
+// The whole change, in the shape a user meets it: one placement must not decide
+// what the agent is for every placement after it.
+//
+// An undeclared agent is run at a graph node, then the SAME instance is used as
+// a runner root. On the merge base the node run stamped it — Mode became
+// single_turn and IncludeContents became "none", permanently, on the object —
+// so the runner then rejected it with "root agent %q must be a chat LlmAgent,
+// but has mode single_turn". Measured both ways: the base errors, this runs.
+//
+// The individual writes are pinned field by field elsewhere. This pins the
+// consequence, which is the thing the PR description promises and the only
+// place the two placements are exercised in order on one instance.
+func TestOneInstance_ANodeRunDoesNotDecideItsNextPlacement(t *testing.T) {
+	t.Parallel()
+
+	a, err := llmagent.New(llmagent.Config{
+		Name: "worker", Description: "w", Model: &raceFreeLLM{}, Instruction: "OWN",
+	})
+	if err != nil {
+		t.Fatalf("llmagent.New: %v", err)
+	}
+
+	node, err := workflow.NewAgentNode(a, workflow.NodeConfig{})
+	if err != nil {
+		t.Fatalf("NewAgentNode: %v", err)
+	}
+	ctx := newModeTestCtx(t, a)
+	for _, err := range node.Run(ctx, nil) {
+		if err != nil {
+			t.Fatalf("node.Run: %v", err)
+		}
+	}
+
+	// Nothing the run did may be visible on the agent itself.
+	state := llminternal.Reveal(a.(llminternal.Agent))
+	if state.Mode != llminternal.ModeUnset {
+		t.Errorf("Mode after a node run = %q, want unset", state.Mode)
+	}
+	if state.IncludeContents != "" {
+		t.Errorf("IncludeContents after a node run = %q, want empty", state.IncludeContents)
+	}
+
+	// And the consequence: the same instance is still usable as a chat root.
+	r, err := runner.New(runner.Config{
+		AppName: "app", Agent: a,
+		SessionService: session.InMemoryService(), AutoCreateSession: true,
+	})
+	if err != nil {
+		t.Fatalf("runner.New after a node run: %v", err)
+	}
+	var runErr error
+	for _, err := range r.Run(t.Context(), "u", "s1", genai.NewContentFromText("hello", "user"), agent.RunConfig{}) {
+		if err != nil {
+			runErr = err
+		}
+	}
+	if runErr != nil {
+		t.Errorf("running the same instance as a chat root after a node run: %v", runErr)
+	}
+}

--- a/workflow/agent_node_mode_mutation_test.go
+++ b/workflow/agent_node_mode_mutation_test.go
@@ -314,7 +314,8 @@ func TestOneAgentInstance_ConcurrentInvocationsAreRaceFree(t *testing.T) {
 	}
 }
 
-// The sibling of the test above, for the dimension it cannot see. Construction
+// The sibling of TestLlmAgent_SubAgentModeResolution_IsConstructionOrderIndependent,
+// for the dimension that test cannot see. Construction
 // order moved two things on the merge base, not one: which delegation tool the
 // coordinator installed, and whether the sub-agent was a transfer TARGET.
 // Node-first stamped the undeclared agent single_turn, and isUntransferableMode

--- a/workflow/agent_node_mode_mutation_test.go
+++ b/workflow/agent_node_mode_mutation_test.go
@@ -19,6 +19,7 @@ import (
 	"fmt"
 	"iter"
 	"slices"
+	"strings"
 	"sync"
 	"sync/atomic"
 	"testing"
@@ -347,5 +348,80 @@ func TestRunner_Run_DoesNotMutateTheRootAgentsMode(t *testing.T) {
 
 	if got := declaredMode(t, root); got != llminternal.ModeUnset {
 		t.Errorf("declared mode after runner.Run = %q, want unset (a run must not mutate the agent)", got)
+	}
+}
+
+// The sibling of the test above, for the dimension it cannot see. Construction
+// order moved two things on the merge base, not one: which delegation tool the
+// coordinator installed, and whether the sub-agent was a transfer TARGET.
+// Node-first stamped the undeclared agent single_turn, and isUntransferableMode
+// reads the declaration, so it dropped off the target list entirely. That list
+// is assembled in the request processor rather than in state.Tools, so no
+// assertion on tool names can observe it.
+func TestLlmAgent_TransferTargets_AreConstructionOrderIndependent(t *testing.T) {
+	t.Parallel()
+
+	// coordinatorInstruction builds a chat coordinator over one undeclared
+	// sub-agent, optionally placing that sub-agent at a graph node first, runs
+	// it, and returns the system instruction the coordinator's model saw.
+	coordinatorInstruction := func(t *testing.T, nodeFirst bool) string {
+		t.Helper()
+		sub, err := llmagent.New(llmagent.Config{Name: "worker", Description: "does the work"})
+		if err != nil {
+			t.Fatalf("llmagent.New(worker): %v", err)
+		}
+		if nodeFirst {
+			if _, err := workflow.NewAgentNode(sub, workflow.NodeConfig{}); err != nil {
+				t.Fatalf("NewAgentNode: %v", err)
+			}
+		}
+		llm := &capturingLLM{}
+		coord, err := llmagent.New(llmagent.Config{
+			Name:      "coordinator",
+			Mode:      llmagent.ModeChat,
+			Model:     llm,
+			SubAgents: []agent.Agent{sub},
+		})
+		if err != nil {
+			t.Fatalf("llmagent.New(coordinator): %v", err)
+		}
+		if !nodeFirst {
+			if _, err := workflow.NewAgentNode(sub, workflow.NodeConfig{}); err != nil {
+				t.Fatalf("NewAgentNode: %v", err)
+			}
+		}
+		r, err := runner.New(runner.Config{
+			AppName:           "app",
+			Agent:             coord,
+			SessionService:    session.InMemoryService(),
+			AutoCreateSession: true,
+		})
+		if err != nil {
+			t.Fatalf("runner.New: %v", err)
+		}
+		for _, err := range r.Run(t.Context(), "u", "s1", genai.NewContentFromText("hi", genai.RoleUser), agent.RunConfig{}) {
+			if err != nil {
+				t.Fatalf("Run: %v", err)
+			}
+		}
+		if llm.got == nil {
+			t.Fatal("the coordinator's model was never called, so this pins nothing")
+		}
+		return llm.systemInstruction()
+	}
+
+	coordFirst := coordinatorInstruction(t, false)
+	nodeFirst := coordinatorInstruction(t, true)
+
+	// Guard against both orders being empty, which would satisfy the equality
+	// below while proving nothing.
+	if !strings.Contains(coordFirst, "transfer_to_agent") {
+		t.Fatalf("no transfer instructions in either order, so the comparison is vacuous; got %q", coordFirst)
+	}
+	if !strings.Contains(coordFirst, "worker") {
+		t.Errorf("the undeclared sub-agent is not a transfer target when the coordinator is built first; got %q", coordFirst)
+	}
+	if coordFirst != nodeFirst {
+		t.Errorf("the coordinator's transfer targets depend on construction order:\n coordinator-first = %q\n node-first        = %q", coordFirst, nodeFirst)
 	}
 }

--- a/workflow/agent_node_mode_mutation_test.go
+++ b/workflow/agent_node_mode_mutation_test.go
@@ -263,6 +263,15 @@ func (m *raceFreeLLM) GenerateContent(context.Context, *model.LLMRequest, bool) 
 // make. Placement is resolved again on every run, so build the nodes
 // single-threaded and race the runs instead: the write this replaces lived on
 // the run path, where it raced the contents processor's read. Run with -race.
+//
+// Scope, because "one instance, concurrent invocations" sounds broader than
+// what this races. The agent has no Tools and no Toolsets, so a run never
+// enters the tool processor, whose append onto the agent's own Tools slice is a
+// separate shared-state hazard this change does not touch. Every goroutine gets
+// its own node, workflow and session, so the only objects shared are the agent
+// and the model. And all sixteen placements are the same one — an instance
+// under a runner-root chat placement and a graph-node single_turn placement at
+// the same time is not raced anywhere.
 func TestOneAgentInstance_ConcurrentInvocationsAreRaceFree(t *testing.T) {
 	t.Parallel()
 

--- a/workflow/agent_node_mode_mutation_test.go
+++ b/workflow/agent_node_mode_mutation_test.go
@@ -265,9 +265,10 @@ func (m *raceFreeLLM) GenerateContent(context.Context, *model.LLMRequest, bool) 
 // the run path, where it raced the contents processor's read. Run with -race.
 //
 // Scope, because "one instance, concurrent invocations" sounds broader than
-// what this races. The agent has no Tools and no Toolsets, so a run never
-// enters the tool processor, whose append onto the agent's own Tools slice is a
-// separate shared-state hazard this change does not touch. Every goroutine gets
+// what this races. The agent has no Tools and no Toolsets, so although every
+// run does enter the tool processor, it appends nothing there — and that
+// append onto the agent's own Tools slice is a separate shared-state hazard
+// this change does not touch, so it stays unexercised here. Every goroutine gets
 // its own node, workflow and session, so the only objects shared are the agent
 // and the model. And all sixteen placements are the same one — an instance
 // under a runner-root chat placement and a graph-node single_turn placement at
@@ -447,11 +448,12 @@ func TestAgentNode_Run_DoesNotMutateTheAgentsIncludeContents(t *testing.T) {
 // The whole change, in the shape a user meets it: one placement must not decide
 // what the agent is for every placement after it.
 //
-// An undeclared agent is run at a graph node, then the SAME instance is used as
-// a runner root. On the merge base the node run stamped it — Mode became
-// single_turn and IncludeContents became "none", permanently, on the object —
-// so the runner then rejected it with "root agent %q must be a chat LlmAgent,
-// but has mode single_turn". Measured both ways: the base errors, this runs.
+// An undeclared agent is wrapped in a graph node and run, then the SAME instance
+// is used as a runner root. On the merge base those were two separate writes:
+// NewAgentNode stamped Mode=single_turn at construction, and the run then
+// stamped IncludeContents=none. Both were permanent, on the object, so the
+// runner rejected it with "root agent worker must be a chat LlmAgent, but has
+// mode single_turn". Measured both ways: the base errors, this runs.
 //
 // The individual writes are pinned field by field elsewhere. This pins the
 // consequence, which is the thing the PR description promises and the only
@@ -459,8 +461,9 @@ func TestAgentNode_Run_DoesNotMutateTheAgentsIncludeContents(t *testing.T) {
 func TestOneInstance_ANodeRunDoesNotDecideItsNextPlacement(t *testing.T) {
 	t.Parallel()
 
+	llm := &raceFreeLLM{}
 	a, err := llmagent.New(llmagent.Config{
-		Name: "worker", Description: "w", Model: &raceFreeLLM{}, Instruction: "OWN",
+		Name: "worker", Description: "w", Model: llm, Instruction: "OWN",
 	})
 	if err != nil {
 		t.Fatalf("llmagent.New: %v", err)
@@ -477,7 +480,13 @@ func TestOneInstance_ANodeRunDoesNotDecideItsNextPlacement(t *testing.T) {
 		}
 	}
 
-	// Nothing the run did may be visible on the agent itself.
+	// Guard against a vacuous pass: if nothing ran, the absences below prove
+	// nothing. Every sibling in this file carries the same check.
+	if llm.calls.Load() == 0 {
+		t.Fatal("the model was never called, so the node run did not happen")
+	}
+
+	// Nothing the construction or the run did may be visible on the agent.
 	state := llminternal.Reveal(a.(llminternal.Agent))
 	if state.Mode != llminternal.ModeUnset {
 		t.Errorf("Mode after a node run = %q, want unset", state.Mode)

--- a/workflow/agent_node_mode_placement_test.go
+++ b/workflow/agent_node_mode_placement_test.go
@@ -253,3 +253,52 @@ func TestAgentNode_DeclaredSingleTurn_DropsHistory(t *testing.T) {
 		}
 	}
 }
+
+// Asking for history explicitly beats the node's single_turn placement, the
+// way adk-python only forces include_contents="none" when the caller left the
+// field unset.
+func TestAgentNode_ExplicitIncludeContents_BeatsPlacement(t *testing.T) {
+	t.Parallel()
+
+	llm := &capturingLLM{}
+	a, err := llmagent.New(llmagent.Config{
+		Name:            "worker",
+		Model:           llm,
+		IncludeContents: llmagent.IncludeContentsDefault,
+	})
+	if err != nil {
+		t.Fatalf("llmagent.New: %v", err)
+	}
+	node, err := workflow.NewAgentNode(a, workflow.NodeConfig{})
+	if err != nil {
+		t.Fatalf("NewAgentNode: %v", err)
+	}
+	wf, err := workflow.New("wf", workflow.Chain(workflow.Start, node))
+	if err != nil {
+		t.Fatalf("workflow.New: %v", err)
+	}
+
+	prior := &session.Event{
+		Author:      "user",
+		LLMResponse: model.LLMResponse{Content: genai.NewContentFromText("EARLIER_TURN", "user")},
+	}
+	for _, err := range wf.Run(newModeTestCtx(t, a, prior)) {
+		if err != nil {
+			t.Fatalf("workflow.Run: %v", err)
+		}
+	}
+	if llm.got == nil {
+		t.Fatal("model was never called")
+	}
+	var sawHistory bool
+	for _, c := range llm.got.Contents {
+		for _, p := range c.Parts {
+			if p != nil && strings.Contains(p.Text, "EARLIER_TURN") {
+				sawHistory = true
+			}
+		}
+	}
+	if !sawHistory {
+		t.Errorf("explicit IncludeContentsDefault was overridden by the placement; contents = %v", llm.got.Contents)
+	}
+}

--- a/workflow/agent_node_mode_placement_test.go
+++ b/workflow/agent_node_mode_placement_test.go
@@ -178,11 +178,17 @@ func TestAgentNode_DeclaredChat_BeatsNodeDefault(t *testing.T) {
 		t.Fatalf("workflow.New: %v", err)
 	}
 
-	prior := &session.Event{
-		Author:      "user",
-		LLMResponse: model.LLMResponse{Content: genai.NewContentFromText("EARLIER_TURN", "user")},
+	// A chat agent is not seeded with a synthetic turn the way a single_turn
+	// one is, so the history has to supply the current turn itself. It also has
+	// to end on a user turn: the backward scan that isolates the current turn
+	// skips this agent's own events, so a history ending on one pivots at index
+	// 0 and returns everything whether or not history is being hidden.
+	prior := []*session.Event{
+		{Author: "user", LLMResponse: model.LLMResponse{Content: genai.NewContentFromText("EARLIER_TURN", "user")}},
+		{Author: "coordinator", LLMResponse: model.LLMResponse{Content: genai.NewContentFromText("earlier answer", "model")}},
+		{Author: "user", LLMResponse: model.LLMResponse{Content: genai.NewContentFromText("current question", "user")}},
 	}
-	ic := newModeTestCtx(t, coord, prior)
+	ic := newModeTestCtx(t, coord, prior...)
 	for _, err := range wf.Run(ic) {
 		if err != nil {
 			t.Fatalf("workflow.Run: %v", err)

--- a/workflow/agent_node_mode_placement_test.go
+++ b/workflow/agent_node_mode_placement_test.go
@@ -1,0 +1,255 @@
+// Copyright 2026 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package workflow_test
+
+import (
+	"context"
+	"iter"
+	"strings"
+	"testing"
+
+	"google.golang.org/genai"
+
+	"google.golang.org/adk/v2/agent"
+	"google.golang.org/adk/v2/agent/llmagent"
+	"google.golang.org/adk/v2/internal/agent/runconfig"
+	icontext "google.golang.org/adk/v2/internal/context"
+	"google.golang.org/adk/v2/model"
+	"google.golang.org/adk/v2/session"
+	"google.golang.org/adk/v2/workflow"
+)
+
+// capturingLLM records the first request it is asked to serve.
+type capturingLLM struct{ got *model.LLMRequest }
+
+func (*capturingLLM) Name() string { return "capturing" }
+
+func (c *capturingLLM) GenerateContent(_ context.Context, r *model.LLMRequest, _ bool) iter.Seq2[*model.LLMResponse, error] {
+	if c.got == nil {
+		c.got = r
+	}
+	return func(yield func(*model.LLMResponse, error) bool) {
+		yield(&model.LLMResponse{Content: &genai.Content{
+			Role:  "model",
+			Parts: []*genai.Part{{Text: "answer"}},
+		}}, nil)
+	}
+}
+
+func (c *capturingLLM) systemInstruction() string {
+	if c.got == nil || c.got.Config == nil || c.got.Config.SystemInstruction == nil {
+		return ""
+	}
+	var b strings.Builder
+	for _, p := range c.got.Config.SystemInstruction.Parts {
+		if p != nil {
+			b.WriteString(p.Text)
+		}
+	}
+	return b.String()
+}
+
+func newModeTestCtx(t *testing.T, a agent.Agent, prior ...*session.Event) agent.Context {
+	t.Helper()
+	svc := session.InMemoryService()
+	resp, err := svc.Create(t.Context(), &session.CreateRequest{AppName: "app", UserID: "u"})
+	if err != nil {
+		t.Fatalf("create session: %v", err)
+	}
+	for _, ev := range prior {
+		if err := svc.AppendEvent(t.Context(), resp.Session, ev); err != nil {
+			t.Fatalf("AppendEvent: %v", err)
+		}
+	}
+	stdCtx := runconfig.ToContext(t.Context(), &runconfig.RunConfig{
+		StreamingMode: runconfig.StreamingModeNone,
+	})
+	ic := icontext.NewInvocationContext(stdCtx, icontext.InvocationContextParams{
+		Agent:        a,
+		Session:      resp.Session,
+		UserContent:  genai.NewContentFromText("current question", "user"),
+		InvocationID: "inv-mode-test",
+	})
+	return agent.NewContext(ic)
+}
+
+// An LlmAgent that declares no mode runs single_turn at a graph node, and every
+// request processor must agree on that: no identity preamble, no transfer
+// tooling, no conversation history. Without the node's mode binding the agent
+// would look undeclared to those processors and get all three.
+func TestAgentNode_UnsetMode_RunsAsSingleTurnEverywhere(t *testing.T) {
+	t.Parallel()
+
+	llm := &capturingLLM{}
+	peer, err := llmagent.New(llmagent.Config{Name: "peer", Model: &capturingLLM{}})
+	if err != nil {
+		t.Fatalf("llmagent.New(peer): %v", err)
+	}
+	// A sub-agent makes transfer wiring reachable, so the transfer
+	// suppression is actually exercised rather than vacuously absent.
+	a, err := llmagent.New(llmagent.Config{
+		Name:        "worker",
+		Description: "does the work",
+		Model:       llm,
+		Instruction: "WORKER_INSTRUCTION",
+		SubAgents:   []agent.Agent{peer},
+	})
+	if err != nil {
+		t.Fatalf("llmagent.New(with sub): %v", err)
+	}
+
+	node, err := workflow.NewAgentNode(a, workflow.NodeConfig{})
+	if err != nil {
+		t.Fatalf("NewAgentNode: %v", err)
+	}
+	wf, err := workflow.New("wf", workflow.Chain(workflow.Start, node))
+	if err != nil {
+		t.Fatalf("workflow.New: %v", err)
+	}
+
+	prior := &session.Event{
+		Author:      "user",
+		LLMResponse: model.LLMResponse{Content: genai.NewContentFromText("EARLIER_TURN", "user")},
+	}
+	ic := newModeTestCtx(t, a, prior)
+	for _, err := range wf.Run(ic) {
+		if err != nil {
+			t.Fatalf("workflow.Run: %v", err)
+		}
+	}
+
+	if llm.got == nil {
+		t.Fatal("model was never called")
+	}
+	si := llm.systemInstruction()
+	if strings.Contains(si, "You are an agent. Your internal name is") {
+		t.Errorf("single_turn node got the identity preamble; system instruction:\n%s", si)
+	}
+	if strings.Contains(si, "transfer_to_agent") {
+		t.Errorf("single_turn node got transfer instructions; system instruction:\n%s", si)
+	}
+	// The transfer_to_agent DECLARATION still ships here, as it does before
+	// this change: only the instruction was ever gated on the mode. Asserting
+	// its absence would pin behaviour this change does not claim to alter.
+	for _, c := range llm.got.Contents {
+		for _, p := range c.Parts {
+			if p != nil && strings.Contains(p.Text, "EARLIER_TURN") {
+				t.Errorf("single_turn node saw conversation history; contents = %v", llm.got.Contents)
+			}
+		}
+	}
+}
+
+// A mode resolved for one agent must not govern another. A chat-declared
+// coordinator at a graph node must not push single_turn onto the agent it
+// transfers to, and a declared mode must beat anything the context carries.
+func TestAgentNode_BoundMode_DoesNotLeakToAnotherAgent(t *testing.T) {
+	t.Parallel()
+
+	coordLLM := &capturingLLM{}
+	coord, err := llmagent.New(llmagent.Config{
+		Name:        "coordinator",
+		Model:       coordLLM,
+		Mode:        llmagent.ModeChat,
+		Instruction: "COORD_INSTRUCTION",
+	})
+	if err != nil {
+		t.Fatalf("llmagent.New: %v", err)
+	}
+
+	node, err := workflow.NewAgentNode(coord, workflow.NodeConfig{})
+	if err != nil {
+		t.Fatalf("NewAgentNode: %v", err)
+	}
+	wf, err := workflow.New("wf", workflow.Chain(workflow.Start, node))
+	if err != nil {
+		t.Fatalf("workflow.New: %v", err)
+	}
+
+	prior := &session.Event{
+		Author:      "user",
+		LLMResponse: model.LLMResponse{Content: genai.NewContentFromText("EARLIER_TURN", "user")},
+	}
+	ic := newModeTestCtx(t, coord, prior)
+	for _, err := range wf.Run(ic) {
+		if err != nil {
+			t.Fatalf("workflow.Run: %v", err)
+		}
+	}
+
+	if coordLLM.got == nil {
+		t.Fatal("model was never called")
+	}
+	// The declaration wins over the node's single_turn default, so the
+	// coordinator keeps its history and its identity.
+	var sawHistory bool
+	for _, c := range coordLLM.got.Contents {
+		for _, p := range c.Parts {
+			if p != nil && strings.Contains(p.Text, "EARLIER_TURN") {
+				sawHistory = true
+			}
+		}
+	}
+	if !sawHistory {
+		t.Errorf("chat-declared agent at a node lost its history; contents = %v", coordLLM.got.Contents)
+	}
+	if si := coordLLM.systemInstruction(); !strings.Contains(si, "You are an agent. Your internal name is") {
+		t.Errorf("chat-declared agent at a node lost its identity preamble; system instruction:\n%s", si)
+	}
+}
+
+// A declared single_turn agent is seeded with one synthetic turn at a graph
+// node, so it must not also see the conversation history.
+func TestAgentNode_DeclaredSingleTurn_DropsHistory(t *testing.T) {
+	t.Parallel()
+
+	llm := &capturingLLM{}
+	a, err := llmagent.New(llmagent.Config{
+		Name:  "worker",
+		Model: llm,
+		Mode:  llmagent.ModeSingleTurn,
+	})
+	if err != nil {
+		t.Fatalf("llmagent.New: %v", err)
+	}
+	node, err := workflow.NewAgentNode(a, workflow.NodeConfig{})
+	if err != nil {
+		t.Fatalf("NewAgentNode: %v", err)
+	}
+	wf, err := workflow.New("wf", workflow.Chain(workflow.Start, node))
+	if err != nil {
+		t.Fatalf("workflow.New: %v", err)
+	}
+
+	prior := &session.Event{
+		Author:      "user",
+		LLMResponse: model.LLMResponse{Content: genai.NewContentFromText("EARLIER_TURN", "user")},
+	}
+	for _, err := range wf.Run(newModeTestCtx(t, a, prior)) {
+		if err != nil {
+			t.Fatalf("workflow.Run: %v", err)
+		}
+	}
+	if llm.got == nil {
+		t.Fatal("model was never called")
+	}
+	for _, c := range llm.got.Contents {
+		for _, p := range c.Parts {
+			if p != nil && strings.Contains(p.Text, "EARLIER_TURN") {
+				t.Errorf("single_turn node saw history; contents = %v", llm.got.Contents)
+			}
+		}
+	}
+}

--- a/workflow/agent_node_mode_placement_test.go
+++ b/workflow/agent_node_mode_placement_test.go
@@ -142,7 +142,7 @@ func TestAgentNode_UnsetMode_RunsAsSingleTurnEverywhere(t *testing.T) {
 	}
 	// The transfer_to_agent DECLARATION still ships here, as it does before
 	// this change: only the instruction was ever gated on the mode. Asserting
-	// its absence would pin behaviour this change does not claim to alter.
+	// its absence would pin behavior this change does not claim to alter.
 	for _, c := range llm.got.Contents {
 		for _, p := range c.Parts {
 			if p != nil && strings.Contains(p.Text, "EARLIER_TURN") {
@@ -152,10 +152,10 @@ func TestAgentNode_UnsetMode_RunsAsSingleTurnEverywhere(t *testing.T) {
 	}
 }
 
-// A mode resolved for one agent must not govern another. A chat-declared
-// coordinator at a graph node must not push single_turn onto the agent it
-// transfers to, and a declared mode must beat anything the context carries.
-func TestAgentNode_BoundMode_DoesNotLeakToAnotherAgent(t *testing.T) {
+// A declared mode beats the node's default: a chat coordinator placed at a
+// graph node stays a chat coordinator, keeping its history and its identity
+// rather than being demoted to the single_turn a bare node implies.
+func TestAgentNode_DeclaredChat_BeatsNodeDefault(t *testing.T) {
 	t.Parallel()
 
 	coordLLM := &capturingLLM{}
@@ -300,5 +300,101 @@ func TestAgentNode_ExplicitIncludeContents_BeatsPlacement(t *testing.T) {
 	}
 	if !sawHistory {
 		t.Errorf("explicit IncludeContentsDefault was overridden by the placement; contents = %v", llm.got.Contents)
+	}
+}
+
+// The same override, for an agent that DECLARES single_turn rather than
+// leaving the mode to its placement. Before this change the node forced
+// IncludeContents="none" onto it, so the request went out without the
+// conversation whatever the caller had asked for.
+func TestAgentNode_DeclaredSingleTurnWithExplicitIncludeContents_KeepsHistory(t *testing.T) {
+	t.Parallel()
+
+	llm := &capturingLLM{}
+	a, err := llmagent.New(llmagent.Config{
+		Name:            "worker",
+		Model:           llm,
+		Mode:            llmagent.ModeSingleTurn,
+		IncludeContents: llmagent.IncludeContentsDefault,
+	})
+	if err != nil {
+		t.Fatalf("llmagent.New: %v", err)
+	}
+	node, err := workflow.NewAgentNode(a, workflow.NodeConfig{})
+	if err != nil {
+		t.Fatalf("NewAgentNode: %v", err)
+	}
+	wf, err := workflow.New("wf", workflow.Chain(workflow.Start, node))
+	if err != nil {
+		t.Fatalf("workflow.New: %v", err)
+	}
+
+	prior := &session.Event{
+		Author:      "user",
+		LLMResponse: model.LLMResponse{Content: genai.NewContentFromText("EARLIER_TURN", "user")},
+	}
+	for _, err := range wf.Run(newModeTestCtx(t, a, prior)) {
+		if err != nil {
+			t.Fatalf("workflow.Run: %v", err)
+		}
+	}
+	if llm.got == nil {
+		t.Fatal("model was never called")
+	}
+	var sawHistory bool
+	for _, c := range llm.got.Contents {
+		for _, p := range c.Parts {
+			if p != nil && strings.Contains(p.Text, "EARLIER_TURN") {
+				sawHistory = true
+			}
+		}
+	}
+	if !sawHistory {
+		t.Errorf("declared single_turn with explicit IncludeContentsDefault lost its history; contents = %v", llm.got.Contents)
+	}
+}
+
+// Config.Name is documented as required but nothing rejects an empty one, and
+// the binding is keyed by name. A nameless agent must still be placed by its
+// node rather than quietly falling back to chat and carrying the whole
+// transcript into a one-shot node.
+func TestAgentNode_UnnamedAgent_IsStillPlacedSingleTurn(t *testing.T) {
+	t.Parallel()
+
+	llm := &capturingLLM{}
+	a, err := llmagent.New(llmagent.Config{Model: llm})
+	if err != nil {
+		t.Fatalf("llmagent.New: %v", err)
+	}
+	if a.Name() != "" {
+		t.Fatalf("precondition: agent name = %q, want empty", a.Name())
+	}
+	node, err := workflow.NewAgentNode(a, workflow.NodeConfig{})
+	if err != nil {
+		t.Fatalf("NewAgentNode: %v", err)
+	}
+	wf, err := workflow.New("wf", workflow.Chain(workflow.Start, node))
+	if err != nil {
+		t.Fatalf("workflow.New: %v", err)
+	}
+
+	prior := &session.Event{
+		Author:      "user",
+		LLMResponse: model.LLMResponse{Content: genai.NewContentFromText("EARLIER_TURN", "user")},
+	}
+	for _, err := range wf.Run(newModeTestCtx(t, a, prior)) {
+		if err != nil {
+			t.Fatalf("workflow.Run: %v", err)
+		}
+	}
+	if llm.got == nil {
+		t.Fatal("model was never called")
+	}
+	for _, c := range llm.got.Contents {
+		for _, p := range c.Parts {
+			if p != nil && strings.Contains(p.Text, "EARLIER_TURN") {
+				t.Errorf("nameless agent at a single_turn node saw conversation history; contents = %v", llm.got.Contents)
+			}
+		}
 	}
 }

--- a/workflow/agent_node_mode_placement_test.go
+++ b/workflow/agent_node_mode_placement_test.go
@@ -361,6 +361,59 @@ func TestAgentNode_DeclaredSingleTurnWithExplicitIncludeContents_KeepsHistory(t 
 	}
 }
 
+// IncludeContents is an unvalidated string, so a typo must not be read as an
+// explicit request for history. Only the real IncludeContentsDefault opts out of
+// the placement; anything unrecognised falls back to it, as the merge base did by
+// forcing "none". Getting this wrong hands a one-shot node the whole transcript.
+func TestAgentNode_UnrecognisedIncludeContents_DoesNotDefeatThePlacement(t *testing.T) {
+	t.Parallel()
+
+	for _, bad := range []llmagent.IncludeContents{"None", "defualt", "DEFAULT"} {
+		t.Run(string(bad), func(t *testing.T) {
+			t.Parallel()
+
+			llm := &capturingLLM{}
+			a, err := llmagent.New(llmagent.Config{
+				Name:            "worker",
+				Model:           llm,
+				IncludeContents: bad,
+			})
+			if err != nil {
+				t.Fatalf("llmagent.New: %v", err)
+			}
+			node, err := workflow.NewAgentNode(a, workflow.NodeConfig{})
+			if err != nil {
+				t.Fatalf("NewAgentNode: %v", err)
+			}
+			wf, err := workflow.New("wf", workflow.Chain(workflow.Start, node))
+			if err != nil {
+				t.Fatalf("workflow.New: %v", err)
+			}
+
+			prior := &session.Event{
+				Author:      "user",
+				LLMResponse: model.LLMResponse{Content: genai.NewContentFromText("EARLIER_TURN", "user")},
+			}
+			for _, err := range wf.Run(newModeTestCtx(t, a, prior)) {
+				if err != nil {
+					t.Fatalf("workflow.Run: %v", err)
+				}
+			}
+			if llm.got == nil {
+				t.Fatal("model was never called")
+			}
+			for _, c := range llm.got.Contents {
+				for _, p := range c.Parts {
+					if p != nil && strings.Contains(p.Text, "EARLIER_TURN") {
+						t.Errorf("IncludeContents=%q defeated the single_turn placement and leaked history; contents = %v",
+							bad, llm.got.Contents)
+					}
+				}
+			}
+		})
+	}
+}
+
 // Config.Name is documented as required but nothing rejects an empty one, and
 // the binding is keyed by name. A nameless agent must still be placed by its
 // node rather than quietly falling back to chat and carrying the whole

--- a/workflow/agent_node_mode_placement_test.go
+++ b/workflow/agent_node_mode_placement_test.go
@@ -24,6 +24,7 @@ import (
 
 	"google.golang.org/adk/v2/agent"
 	"google.golang.org/adk/v2/agent/llmagent"
+	"google.golang.org/adk/v2/internal/agent/parentmap"
 	"google.golang.org/adk/v2/internal/agent/runconfig"
 	icontext "google.golang.org/adk/v2/internal/context"
 	"google.golang.org/adk/v2/model"
@@ -402,5 +403,150 @@ func TestAgentNode_UnnamedAgent_IsStillPlacedSingleTurn(t *testing.T) {
 				t.Errorf("nameless agent at a single_turn node saw conversation history; contents = %v", llm.got.Contents)
 			}
 		}
+	}
+}
+
+// roundTripLLM replies from a per-agent script, identifying the caller by the
+// marker its instruction plants in the system instruction, and records every
+// request it served.
+type roundTripLLM struct {
+	script map[string][]*genai.Content
+	seen   []string
+	si     []string
+	conts  [][]*genai.Content
+}
+
+func (*roundTripLLM) Name() string { return "scripted" }
+
+func (m *roundTripLLM) GenerateContent(_ context.Context, r *model.LLMRequest, _ bool) iter.Seq2[*model.LLMResponse, error] {
+	var si strings.Builder
+	if r.Config != nil && r.Config.SystemInstruction != nil {
+		for _, p := range r.Config.SystemInstruction.Parts {
+			if p != nil {
+				si.WriteString(p.Text)
+			}
+		}
+	}
+	who := "worker"
+	if strings.Contains(si.String(), "MARKER_HELPER") {
+		who = "helper"
+	}
+	n := 0
+	for _, s := range m.seen {
+		if s == who {
+			n++
+		}
+	}
+	m.seen = append(m.seen, who)
+	m.si = append(m.si, si.String())
+	m.conts = append(m.conts, r.Contents)
+
+	out := &genai.Content{Role: "model", Parts: []*genai.Part{{Text: "done"}}}
+	if replies := m.script[who]; n < len(replies) {
+		out = replies[n]
+	}
+	return func(yield func(*model.LLMResponse, error) bool) {
+		yield(&model.LLMResponse{Content: out}, nil)
+	}
+}
+
+func roundTripTransferTo(name string) *genai.Content {
+	return &genai.Content{Role: "model", Parts: []*genai.Part{{
+		FunctionCall: &genai.FunctionCall{Name: "transfer_to_agent", Args: map[string]any{"agent_name": name}},
+	}}}
+}
+
+// A single_turn graph node must stay single_turn for the whole activation,
+// including after an agent it transferred to transfers back. The return hop is
+// a fresh activation on the callee's context rather than a return to the outer
+// frame, so the node's binding has to still be findable there.
+//
+// Reported by karolpiotrowicz in review of #1267, with this reproduction.
+func TestAgentNode_PlacementSurvivesATransferRoundTrip(t *testing.T) {
+	m := &roundTripLLM{script: map[string][]*genai.Content{
+		"worker": {roundTripTransferTo("helper")},
+		"helper": {roundTripTransferTo("worker")},
+	}}
+
+	helper, err := llmagent.New(llmagent.Config{
+		Name: "helper", Description: "helps", Model: m, Instruction: "MARKER_HELPER",
+	})
+	if err != nil {
+		t.Fatalf("llmagent.New(helper): %v", err)
+	}
+	// worker declares no mode, so the graph node decides it: single_turn.
+	worker, err := llmagent.New(llmagent.Config{
+		Name: "worker", Description: "works", Model: m, Instruction: "MARKER_WORKER",
+		SubAgents: []agent.Agent{helper},
+	})
+	if err != nil {
+		t.Fatalf("llmagent.New(worker): %v", err)
+	}
+
+	node, err := workflow.NewAgentNode(worker, workflow.NodeConfig{})
+	if err != nil {
+		t.Fatalf("NewAgentNode: %v", err)
+	}
+	wf, err := workflow.New("wf", workflow.Chain(workflow.Start, node))
+	if err != nil {
+		t.Fatalf("workflow.New: %v", err)
+	}
+	parents, err := parentmap.New(worker)
+	if err != nil {
+		t.Fatalf("parentmap.New: %v", err)
+	}
+
+	svc := session.InMemoryService()
+	resp, err := svc.Create(t.Context(), &session.CreateRequest{AppName: "app", UserID: "u"})
+	if err != nil {
+		t.Fatalf("session.Create: %v", err)
+	}
+	prior := &session.Event{
+		Author:      "user",
+		LLMResponse: model.LLMResponse{Content: genai.NewContentFromText("EARLIER_TURN", "user")},
+	}
+	if err := svc.AppendEvent(t.Context(), resp.Session, prior); err != nil {
+		t.Fatalf("AppendEvent: %v", err)
+	}
+
+	std := runconfig.ToContext(t.Context(), &runconfig.RunConfig{StreamingMode: runconfig.StreamingModeNone})
+	std = parentmap.ToContext(std, parents)
+	ic := icontext.NewInvocationContext(std, icontext.InvocationContextParams{
+		Agent: worker, Session: resp.Session,
+		UserContent:  genai.NewContentFromText("current question", "user"),
+		InvocationID: "inv-1",
+	})
+	for _, err := range wf.Run(agent.NewContext(ic)) {
+		if err != nil {
+			t.Fatalf("wf.Run: %v", err)
+		}
+	}
+
+	// Find worker's second request.
+	var idx []int
+	for i, who := range m.seen {
+		if who == "worker" {
+			idx = append(idx, i)
+		}
+	}
+	if len(idx) < 2 {
+		t.Fatalf("worker was called %d time(s), want 2; call order = %v", len(idx), m.seen)
+	}
+	i := idx[1]
+
+	identity := strings.Contains(m.si[i], "You are an agent. Your internal name is")
+	transfer := strings.Contains(m.si[i], "You have a list of other agents to transfer to")
+	history := false
+	for _, c := range m.conts[i] {
+		for _, p := range c.Parts {
+			if p != nil && strings.Contains(p.Text, "EARLIER_TURN") {
+				history = true
+			}
+		}
+	}
+	if identity || transfer || history {
+		t.Errorf("after a transfer round trip the node's agent is no longer single_turn: "+
+			"identityPreamble=%v transferInstructions=%v sawHistory=%v, want all false",
+			identity, transfer, history)
 	}
 }

--- a/workflow/agent_node_mode_placement_test.go
+++ b/workflow/agent_node_mode_placement_test.go
@@ -550,3 +550,48 @@ func TestAgentNode_PlacementSurvivesATransferRoundTrip(t *testing.T) {
 			identity, transfer, history)
 	}
 }
+
+// AgentNode.Run must tolerate a tool context. agent.Context.WithAgentContext
+// returns nil for the tool and callback wrappers rather than erroring, so
+// routing the placement back through ctx crashes here on a path where every
+// symbol is exported. The merge base drained events for such a caller and this
+// must keep doing so.
+func TestAgentNode_Run_AcceptsAToolContext(t *testing.T) {
+	t.Parallel()
+
+	llm := &capturingLLM{}
+	a, err := llmagent.New(llmagent.Config{
+		Name: "c", Description: "c", Model: llm, Mode: llmagent.ModeChat,
+	})
+	if err != nil {
+		t.Fatalf("llmagent.New: %v", err)
+	}
+	node, err := workflow.NewAgentNode(a, workflow.NodeConfig{})
+	if err != nil {
+		t.Fatalf("NewAgentNode: %v", err)
+	}
+
+	svc := session.InMemoryService()
+	resp, err := svc.Create(t.Context(), &session.CreateRequest{AppName: "app", UserID: "u"})
+	if err != nil {
+		t.Fatalf("session.Create: %v", err)
+	}
+	std := runconfig.ToContext(t.Context(), &runconfig.RunConfig{StreamingMode: runconfig.StreamingModeNone})
+	ic := icontext.NewInvocationContext(std, icontext.InvocationContextParams{
+		Agent: a, Session: resp.Session,
+		UserContent:  genai.NewContentFromText("hi", "user"),
+		InvocationID: "inv-tool-ctx",
+	})
+	toolCtx := agent.NewToolContext(ic, "fc-1", &session.EventActions{}, nil)
+
+	got := 0
+	for _, err := range node.Run(toolCtx, "hello") {
+		if err != nil {
+			t.Fatalf("node.Run: %v", err)
+		}
+		got++
+	}
+	if got == 0 {
+		t.Error("node.Run over a tool context produced no events")
+	}
+}

--- a/workflow/agent_node_mode_placement_test.go
+++ b/workflow/agent_node_mode_placement_test.go
@@ -591,6 +591,13 @@ func TestAgentNode_PlacementSurvivesATransferRoundTrip(t *testing.T) {
 	}
 	i := idx[1]
 
+	// Two of the three checks below are absences, so guard against a request
+	// whose system instruction was never assembled at all — every sibling test
+	// in this file carries the same guard.
+	if !strings.Contains(m.si[i], "MARKER_WORKER") {
+		t.Fatalf("worker's own instruction is missing, so the absences below prove nothing; si = %q", m.si[i])
+	}
+
 	identity := strings.Contains(m.si[i], "You are an agent. Your internal name is")
 	transfer := strings.Contains(m.si[i], "You have a list of other agents to transfer to")
 	history := false
@@ -683,6 +690,36 @@ func TestAgentNode_Run_AcceptsAToolContext(t *testing.T) {
 	}
 }
 
+// AgentNode.Run is exported and now resolves a mode, which reads ctx. It must
+// reject a nil context rather than dereference it, the way RunLLMAgentAsNode
+// does. The merge base panicked on a nil ctx too — a few lines lower, building
+// params — so this turns a crash into an error rather than changing behaviour.
+func TestAgentNode_Run_NilContext_Errors(t *testing.T) {
+	t.Parallel()
+
+	a, err := llmagent.New(llmagent.Config{Name: "c", Description: "c", Model: &capturingLLM{}})
+	if err != nil {
+		t.Fatalf("llmagent.New: %v", err)
+	}
+	node, err := workflow.NewAgentNode(a, workflow.NodeConfig{})
+	if err != nil {
+		t.Fatalf("NewAgentNode: %v", err)
+	}
+
+	var gotErr error
+	for _, err := range node.Run(nil, nil) {
+		if err != nil {
+			gotErr = err
+		}
+	}
+	if gotErr == nil {
+		t.Fatal("expected an error for a nil context; got nil")
+	}
+	if !strings.Contains(gotErr.Error(), "nil context") {
+		t.Errorf("err = %q, want it to mention a nil context", gotErr.Error())
+	}
+}
+
 // The mode binding is keyed by agent NAME, and names are only unique across
 // SubAgents(). A graph node's agent is not in SubAgents(), so a nested agent
 // can share a name with one that already holds a binding, and runner.New does
@@ -695,6 +732,12 @@ func TestAgentNode_Run_AcceptsAToolContext(t *testing.T) {
 // agent it was resolved for, this child read the root's chat binding and was
 // handed the identity preamble and transfer instructions the merge base
 // correctly withheld.
+//
+// This test's power depends on the runner's root bind existing. Delete that
+// bind and there is no binding for the child to read, so a name-only key
+// passes too and this stops discriminating. The bind is inert to every reader
+// — that is why removing it survives the mutation battery — but it is not
+// inert to this test, so do not delete it on the strength of that survivor.
 func TestAgentNode_ASameNamedNestedAgentKeepsItsOwnDeclaration(t *testing.T) {
 	t.Parallel()
 

--- a/workflow/agent_node_mode_placement_test.go
+++ b/workflow/agent_node_mode_placement_test.go
@@ -661,8 +661,9 @@ func TestAgentNode_Run_AcceptsAToolContext(t *testing.T) {
 // Here a chat root named "coordinator" transfers to a workflow whose node wraps
 // a SequentialAgent — a composite, so the node binds nothing — whose child is a
 // DIFFERENT agent, also named "coordinator", declaring single_turn. That child
-// must still run single_turn. Before PlacedMode it read the root's chat binding
-// and was handed the identity preamble and transfer instructions the merge base
+// must still run single_turn. Before the binding carried the identity of the
+// agent it was resolved for, this child read the root's chat binding and was
+// handed the identity preamble and transfer instructions the merge base
 // correctly withheld.
 func TestAgentNode_ASameNamedNestedAgentKeepsItsOwnDeclaration(t *testing.T) {
 	t.Parallel()
@@ -840,5 +841,118 @@ func TestAgentNode_ASameNamedUndeclaredNestedAgentIsUnaffectedByTheRootBind(t *t
 
 	if colliding != renamed {
 		t.Errorf("the root's binding changed what a same-named UNDECLARED agent sees.\n colliding = %q\n renamed   = %q", colliding, renamed)
+	}
+}
+
+// The other direction of the same-name collision, and the one the earlier
+// declaration-based compensation could not catch: the nested agent declares
+// NOTHING, so there is no declaration to contradict.
+//
+// A graph node binds single_turn for an outer agent named "worker". That agent
+// transfers into a workflow whose node wraps a composite — so nothing rebinds —
+// and the composite's child is a DIFFERENT agent, also named "worker", also
+// undeclared. Being a composite's child with no placement of its own, it is a
+// chat agent and must be given the identity preamble and transfer tooling. The
+// merge base gave it both, because it read that agent's own State.
+func TestAgentNode_ASingleTurnPlacementDoesNotReachASameNamedUndeclaredDescendant(t *testing.T) {
+	t.Parallel()
+
+	innerLLM := &capturingLLM{}
+	innerPeer, err := llmagent.New(llmagent.Config{Name: "innerpeer", Model: &capturingLLM{}, Description: "inner peer"})
+	if err != nil {
+		t.Fatalf("llmagent.New(innerpeer): %v", err)
+	}
+	inner, err := llmagent.New(llmagent.Config{
+		Name:        "worker", // same name as the placed agent below, deliberately
+		Model:       innerLLM,
+		Instruction: "INNER_INSTRUCTION",
+		SubAgents:   []agent.Agent{innerPeer},
+	})
+	if err != nil {
+		t.Fatalf("llmagent.New(inner): %v", err)
+	}
+	seq, err := sequentialagent.New(sequentialagent.Config{
+		AgentConfig: agent.Config{Name: "seq", SubAgents: []agent.Agent{inner}},
+	})
+	if err != nil {
+		t.Fatalf("sequentialagent.New: %v", err)
+	}
+	innerNode, err := workflow.NewAgentNode(seq, workflow.NodeConfig{})
+	if err != nil {
+		t.Fatalf("NewAgentNode(inner): %v", err)
+	}
+	innerWf, err := workflowagent.New(workflowagent.Config{
+		Name: "innerwf", Description: "inner workflow",
+		Edges: []workflow.Edge{{From: workflow.Start, To: innerNode}},
+	})
+	if err != nil {
+		t.Fatalf("workflowagent.New(inner): %v", err)
+	}
+	// Placed at a graph node while declaring nothing, so it binds single_turn.
+	outer, err := llmagent.New(llmagent.Config{
+		Name: "worker",
+		Model: &testutil.MockModel{Responses: []*genai.Content{
+			genai.NewContentFromFunctionCall("transfer_to_agent",
+				map[string]any{"agent_name": "innerwf"}, "model"),
+			genai.NewContentFromText("outer done", "model"),
+		}},
+		SubAgents: []agent.Agent{innerWf},
+	})
+	if err != nil {
+		t.Fatalf("llmagent.New(outer): %v", err)
+	}
+	outerNode, err := workflow.NewAgentNode(outer, workflow.NodeConfig{})
+	if err != nil {
+		t.Fatalf("NewAgentNode(outer): %v", err)
+	}
+	wf, err := workflowagent.New(workflowagent.Config{
+		Name: "wf", Description: "outer workflow",
+		Edges: []workflow.Edge{{From: workflow.Start, To: outerNode}},
+	})
+	if err != nil {
+		t.Fatalf("workflowagent.New(outer): %v", err)
+	}
+	root, err := llmagent.New(llmagent.Config{
+		Name: "coordinator",
+		Model: &testutil.MockModel{Responses: []*genai.Content{
+			genai.NewContentFromFunctionCall("transfer_to_agent",
+				map[string]any{"agent_name": "wf"}, "model"),
+			genai.NewContentFromText("done", "model"),
+		}},
+		SubAgents: []agent.Agent{wf},
+	})
+	if err != nil {
+		t.Fatalf("llmagent.New(root): %v", err)
+	}
+	r, err := runner.New(runner.Config{
+		AppName:           "app",
+		Agent:             root,
+		SessionService:    session.InMemoryService(),
+		AutoCreateSession: true,
+	})
+	if err != nil {
+		t.Fatalf("runner.New rejected two same-named agents; the collision this pins is gone: %v", err)
+	}
+	msg := genai.NewContentFromText("go", genai.RoleUser)
+	for _, err := range r.Run(t.Context(), "u", "s1", msg, agent.RunConfig{}) {
+		if err != nil {
+			t.Fatalf("Run: %v", err)
+		}
+	}
+
+	if innerLLM.got == nil {
+		t.Fatal("the nested agent was never reached, so this test pins nothing")
+	}
+	si := innerLLM.systemInstruction()
+	// The two assertions below are presences, but an empty instruction would
+	// fail them for the wrong reason, so pin the agent's own text first.
+	if !strings.Contains(si, "INNER_INSTRUCTION") {
+		t.Fatalf("the agent's own instruction is missing, so the checks below prove nothing; si = %q", si)
+	}
+	if !strings.Contains(si, "You are an agent") {
+		t.Error("the nested undeclared agent lost its identity preamble; it read the outer agent's single_turn binding")
+	}
+	if !strings.Contains(si, "transfer_to_agent") {
+		t.Error("the nested undeclared agent lost its transfer instructions; it read the outer agent's single_turn binding")
 	}
 }

--- a/workflow/agent_node_mode_placement_test.go
+++ b/workflow/agent_node_mode_placement_test.go
@@ -24,10 +24,14 @@ import (
 
 	"google.golang.org/adk/v2/agent"
 	"google.golang.org/adk/v2/agent/llmagent"
+	"google.golang.org/adk/v2/agent/workflowagent"
+	"google.golang.org/adk/v2/agent/workflowagents/sequentialagent"
 	"google.golang.org/adk/v2/internal/agent/parentmap"
 	"google.golang.org/adk/v2/internal/agent/runconfig"
 	icontext "google.golang.org/adk/v2/internal/context"
+	"google.golang.org/adk/v2/internal/testutil"
 	"google.golang.org/adk/v2/model"
+	"google.golang.org/adk/v2/runner"
 	"google.golang.org/adk/v2/session"
 	"google.golang.org/adk/v2/workflow"
 )
@@ -646,5 +650,94 @@ func TestAgentNode_Run_AcceptsAToolContext(t *testing.T) {
 	}
 	if got == 0 {
 		t.Error("node.Run over a tool context produced no events")
+	}
+}
+
+// The mode binding is keyed by agent NAME, and names are only unique across
+// SubAgents(). A graph node's agent is not in SubAgents(), so a nested agent
+// can share a name with one that already holds a binding, and runner.New does
+// not reject the tree.
+//
+// Here a chat root named "coordinator" transfers to a workflow whose node wraps
+// a SequentialAgent — a composite, so the node binds nothing — whose child is a
+// DIFFERENT agent, also named "coordinator", declaring single_turn. That child
+// must still run single_turn. Before PlacedMode it read the root's chat binding
+// and was handed the identity preamble and transfer instructions the merge base
+// correctly withheld.
+func TestAgentNode_ASameNamedNestedAgentKeepsItsOwnDeclaration(t *testing.T) {
+	t.Parallel()
+
+	innerLLM := &capturingLLM{}
+	peer, err := llmagent.New(llmagent.Config{Name: "peer", Model: &capturingLLM{}, Description: "a peer"})
+	if err != nil {
+		t.Fatalf("llmagent.New(peer): %v", err)
+	}
+	// Same name as the root, declaring the mode the root's binding would override.
+	inner, err := llmagent.New(llmagent.Config{
+		Name:        "coordinator",
+		Model:       innerLLM,
+		Mode:        llmagent.ModeSingleTurn,
+		Instruction: "INNER_INSTRUCTION",
+		SubAgents:   []agent.Agent{peer},
+	})
+	if err != nil {
+		t.Fatalf("llmagent.New(inner): %v", err)
+	}
+	seq, err := sequentialagent.New(sequentialagent.Config{
+		AgentConfig: agent.Config{Name: "seq", SubAgents: []agent.Agent{inner}},
+	})
+	if err != nil {
+		t.Fatalf("sequentialagent.New: %v", err)
+	}
+	node, err := workflow.NewAgentNode(seq, workflow.NodeConfig{})
+	if err != nil {
+		t.Fatalf("NewAgentNode: %v", err)
+	}
+	wf, err := workflowagent.New(workflowagent.Config{
+		Name:        "wf",
+		Description: "the workflow",
+		Edges:       []workflow.Edge{{From: workflow.Start, To: node}},
+	})
+	if err != nil {
+		t.Fatalf("workflowagent.New: %v", err)
+	}
+	root, err := llmagent.New(llmagent.Config{
+		Name: "coordinator",
+		Model: &testutil.MockModel{Responses: []*genai.Content{
+			genai.NewContentFromFunctionCall("transfer_to_agent",
+				map[string]any{"agent_name": "wf"}, "model"),
+			genai.NewContentFromText("done", "model"),
+		}},
+		SubAgents: []agent.Agent{wf},
+	})
+	if err != nil {
+		t.Fatalf("llmagent.New(root): %v", err)
+	}
+
+	r, err := runner.New(runner.Config{
+		AppName:           "app",
+		Agent:             root,
+		SessionService:    session.InMemoryService(),
+		AutoCreateSession: true,
+	})
+	if err != nil {
+		t.Fatalf("runner.New rejected two same-named agents; the collision this pins is gone: %v", err)
+	}
+	msg := genai.NewContentFromText("please do the thing", genai.RoleUser)
+	for _, err := range r.Run(t.Context(), "u", "s1", msg, agent.RunConfig{}) {
+		if err != nil {
+			t.Fatalf("Run: %v", err)
+		}
+	}
+
+	if innerLLM.got == nil {
+		t.Fatal("the nested agent was never reached, so this test pins nothing")
+	}
+	si := innerLLM.systemInstruction()
+	if strings.Contains(si, "You are an agent") {
+		t.Error("the nested single_turn agent got the identity preamble; it read the root's chat binding")
+	}
+	if strings.Contains(si, "transfer_to_agent") {
+		t.Error("the nested single_turn agent got transfer instructions; it read the root's chat binding")
 	}
 }

--- a/workflow/agent_node_mode_placement_test.go
+++ b/workflow/agent_node_mode_placement_test.go
@@ -615,11 +615,11 @@ func TestAgentNode_PlacementSurvivesATransferRoundTrip(t *testing.T) {
 	}
 }
 
-// AgentNode.Run must tolerate a tool context, and must still place the agent
-// while doing so. agent.Context.WithAgentContext returns nil for the tool and
-// callback wrappers rather than erroring, so routing the placement back through
-// ctx crashes here on a path where every symbol is exported. The merge base
-// drained events for such a caller and this must keep doing so.
+// AgentNode.Run must tolerate the two context wrappers whose WithAgentContext
+// returns nil rather than erroring, and must still place the agent while doing
+// so. Routing the placement back through ctx crashes on a path where every
+// symbol is exported. The merge base drained events for such a caller and this
+// must keep doing so.
 //
 // The agent deliberately declares NO mode. A chat declaration would make this
 // test blind to half of what it is for: chat and "no binding" are the same
@@ -627,136 +627,85 @@ func TestAgentNode_PlacementSurvivesATransferRoundTrip(t *testing.T) {
 // panic by dropping the placement — would pass. Undeclared, the placement is
 // the only thing that makes this agent single_turn, and its loss is visible in
 // the system instruction.
-func TestAgentNode_Run_AcceptsAToolContext(t *testing.T) {
-	t.Parallel()
-
-	llm := &capturingLLM{}
-	peer, err := llmagent.New(llmagent.Config{Name: "peer", Model: &capturingLLM{}, Description: "a peer"})
-	if err != nil {
-		t.Fatalf("llmagent.New(peer): %v", err)
-	}
-	a, err := llmagent.New(llmagent.Config{
-		Name: "c", Description: "c", Model: llm,
-		Instruction: "OWN_INSTRUCTION",
-		SubAgents:   []agent.Agent{peer},
-	})
-	if err != nil {
-		t.Fatalf("llmagent.New: %v", err)
-	}
-	node, err := workflow.NewAgentNode(a, workflow.NodeConfig{})
-	if err != nil {
-		t.Fatalf("NewAgentNode: %v", err)
-	}
-
-	svc := session.InMemoryService()
-	resp, err := svc.Create(t.Context(), &session.CreateRequest{AppName: "app", UserID: "u"})
-	if err != nil {
-		t.Fatalf("session.Create: %v", err)
-	}
-	std := runconfig.ToContext(t.Context(), &runconfig.RunConfig{StreamingMode: runconfig.StreamingModeNone})
-	ic := icontext.NewInvocationContext(std, icontext.InvocationContextParams{
-		Agent: a, Session: resp.Session,
-		UserContent:  genai.NewContentFromText("hi", "user"),
-		InvocationID: "inv-tool-ctx",
-	})
-	toolCtx := agent.NewToolContext(ic, "fc-1", &session.EventActions{}, nil)
-
-	// nodeInput must be nil. A non-nil one takes the seeded path, and seeding
-	// under a tool context panics — the context reports no session, which
-	// wrappedSession then wraps. Measured on the merge base as well as here, so
-	// it is not this change's to fix and not this test's to assert.
-	got := 0
-	for _, err := range node.Run(toolCtx, nil) {
-		if err != nil {
-			t.Fatalf("node.Run: %v", err)
-		}
-		got++
-	}
-	if got == 0 {
-		t.Fatal("node.Run over a tool context produced no events")
-	}
-
-	// Draining is only half of it. The placement has to have survived, which is
-	// what a nil guard that keeps the old ctx would quietly lose.
-	si := llm.systemInstruction()
-	if !strings.Contains(si, "OWN_INSTRUCTION") {
-		t.Fatalf("the agent's own instruction is missing, so the absences below prove nothing; si = %q", si)
-	}
-	if strings.Contains(si, "You are an agent") {
-		t.Error("the node's agent got the identity preamble, so the single_turn placement was dropped")
-	}
-	if strings.Contains(si, "transfer_to_agent") {
-		t.Error("the node's agent got transfer instructions, so the single_turn placement was dropped")
-	}
-}
-
-// The callback context is the other wrapper whose WithAgentContext returns nil
-// rather than erroring, and both are named in the comments that shaped this
-// design. For everything AgentNode.Run touches it behaves exactly as the tool
-// context does — Session, Memory and RunConfig nil, IsolationScope empty — so
-// this test pins that the two stay equivalent rather than reaching a new path.
-// It exists because those comments claim the callback context is handled and
-// nothing drove one.
 //
-// As in the tool-context test the agent declares NO mode and carries a peer,
-// so dropping the placement is visible: an unplaced agent would be chat and
-// would collect the identity preamble and the transfer instructions.
-func TestAgentNode_Run_AcceptsACallbackContext(t *testing.T) {
+// The two wrappers are one table rather than two tests because for everything
+// this function touches they behave identically — Session, Memory and RunConfig
+// nil, IsolationScope empty — so the callback row pins that they stay
+// equivalent rather than reaching a path of its own.
+func TestAgentNode_Run_AcceptsAWrapperContext(t *testing.T) {
 	t.Parallel()
 
-	llm := &capturingLLM{}
-	peer, err := llmagent.New(llmagent.Config{Name: "peer", Model: &capturingLLM{}, Description: "a peer"})
-	if err != nil {
-		t.Fatalf("llmagent.New(peer): %v", err)
-	}
-	a, err := llmagent.New(llmagent.Config{
-		Name: "c", Description: "c", Model: llm,
-		Instruction: "OWN_INSTRUCTION",
-		SubAgents:   []agent.Agent{peer},
-	})
-	if err != nil {
-		t.Fatalf("llmagent.New: %v", err)
-	}
-	node, err := workflow.NewAgentNode(a, workflow.NodeConfig{})
-	if err != nil {
-		t.Fatalf("NewAgentNode: %v", err)
-	}
+	for _, tc := range []struct {
+		name string
+		wrap func(agent.InvocationContext) agent.Context
+	}{
+		{"tool", func(ic agent.InvocationContext) agent.Context {
+			return agent.NewToolContext(ic, "fc-1", &session.EventActions{}, nil)
+		}},
+		{"callback", func(ic agent.InvocationContext) agent.Context {
+			return agent.NewCallbackContext(ic, &session.EventActions{})
+		}},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			t.Parallel()
 
-	svc := session.InMemoryService()
-	resp, err := svc.Create(t.Context(), &session.CreateRequest{AppName: "app", UserID: "u"})
-	if err != nil {
-		t.Fatalf("session.Create: %v", err)
-	}
-	std := runconfig.ToContext(t.Context(), &runconfig.RunConfig{StreamingMode: runconfig.StreamingModeNone})
-	ic := icontext.NewInvocationContext(std, icontext.InvocationContextParams{
-		Agent: a, Session: resp.Session,
-		UserContent:  genai.NewContentFromText("hi", "user"),
-		InvocationID: "inv-cb-ctx",
-	})
-	cbCtx := agent.NewCallbackContext(ic, &session.EventActions{})
+			llm := &capturingLLM{}
+			peer, err := llmagent.New(llmagent.Config{Name: "peer", Model: &capturingLLM{}, Description: "a peer"})
+			if err != nil {
+				t.Fatalf("llmagent.New(peer): %v", err)
+			}
+			a, err := llmagent.New(llmagent.Config{
+				Name: "c", Description: "c", Model: llm,
+				Instruction: "OWN_INSTRUCTION",
+				SubAgents:   []agent.Agent{peer},
+			})
+			if err != nil {
+				t.Fatalf("llmagent.New: %v", err)
+			}
+			node, err := workflow.NewAgentNode(a, workflow.NodeConfig{})
+			if err != nil {
+				t.Fatalf("NewAgentNode: %v", err)
+			}
 
-	// nodeInput must be nil, for the same reason as the tool-context test: the
-	// seeded path needs a session and this context reports none.
-	got := 0
-	for _, err := range node.Run(cbCtx, nil) {
-		if err != nil {
-			t.Fatalf("node.Run: %v", err)
-		}
-		got++
-	}
-	if got == 0 {
-		t.Fatal("node.Run over a callback context produced no events")
-	}
+			svc := session.InMemoryService()
+			resp, err := svc.Create(t.Context(), &session.CreateRequest{AppName: "app", UserID: "u"})
+			if err != nil {
+				t.Fatalf("session.Create: %v", err)
+			}
+			std := runconfig.ToContext(t.Context(), &runconfig.RunConfig{StreamingMode: runconfig.StreamingModeNone})
+			ic := icontext.NewInvocationContext(std, icontext.InvocationContextParams{
+				Agent: a, Session: resp.Session,
+				UserContent:  genai.NewContentFromText("hi", "user"),
+				InvocationID: "inv-" + tc.name + "-ctx",
+			})
 
-	si := llm.systemInstruction()
-	if !strings.Contains(si, "OWN_INSTRUCTION") {
-		t.Fatalf("the agent's own instruction is missing, so the absences below prove nothing; si = %q", si)
-	}
-	if strings.Contains(si, "You are an agent") {
-		t.Error("the node's agent got the identity preamble, so the single_turn placement was dropped")
-	}
-	if strings.Contains(si, "transfer_to_agent") {
-		t.Error("the node's agent got transfer instructions, so the single_turn placement was dropped")
+			// nodeInput must be nil. A non-nil one takes the seeded path, which
+			// needs a session neither wrapper reports; that case is the test
+			// below.
+			got := 0
+			for _, err := range node.Run(tc.wrap(ic), nil) {
+				if err != nil {
+					t.Fatalf("node.Run: %v", err)
+				}
+				got++
+			}
+			if got == 0 {
+				t.Fatalf("node.Run over a %s context produced no events", tc.name)
+			}
+
+			// Draining is only half of it. The placement has to have survived,
+			// which is what a nil guard that keeps the old ctx would quietly lose.
+			si := llm.systemInstruction()
+			if !strings.Contains(si, "OWN_INSTRUCTION") {
+				t.Fatalf("the agent's own instruction is missing, so the absences below prove nothing; si = %q", si)
+			}
+			if strings.Contains(si, "You are an agent") {
+				t.Error("the node's agent got the identity preamble, so the single_turn placement was dropped")
+			}
+			if strings.Contains(si, "transfer_to_agent") {
+				t.Error("the node's agent got transfer instructions, so the single_turn placement was dropped")
+			}
+		})
 	}
 }
 

--- a/workflow/agent_node_mode_placement_test.go
+++ b/workflow/agent_node_mode_placement_test.go
@@ -760,6 +760,81 @@ func TestAgentNode_Run_AcceptsACallbackContext(t *testing.T) {
 	}
 }
 
+// The second cell of the round-15 class, found the same way and measured the
+// same way.
+//
+// An undeclared sub-agent ADOPTED by a chat coordinator used to be stamped chat
+// by installTaskTools, and chat ignores nodeInput, so a node driving it from a
+// tool context with a non-nil input never seeded and completed. Nothing stamps
+// it now, so the node places it single_turn, it takes the seeded path, and that
+// path wraps the session — which a tool context reports as nil.
+//
+// The panic underneath predates this change and is out of scope; the set of
+// callers reaching it did not, so the seeded path reports the missing session
+// instead. Measured: the same call completes on the merge base.
+//
+// The unadopted agent is the control. It reaches the same branch on both sides
+// and panicked on both before this guard, so it shows the guard is what changed
+// the outcome rather than the adoption.
+func TestAgentNode_Run_SeededOverAToolContext_ErrorsRatherThanPanics(t *testing.T) {
+	t.Parallel()
+
+	for _, adopted := range []bool{false, true} {
+		t.Run(map[bool]string{false: "unadopted", true: "adoptedByAChatCoordinator"}[adopted], func(t *testing.T) {
+			t.Parallel()
+
+			sub, err := llmagent.New(llmagent.Config{Name: "worker", Description: "w", Model: &capturingLLM{}})
+			if err != nil {
+				t.Fatalf("llmagent.New(sub): %v", err)
+			}
+			if adopted {
+				if _, err := llmagent.New(llmagent.Config{
+					Name: "coord", Description: "c", Mode: llmagent.ModeChat,
+					Model: &capturingLLM{}, SubAgents: []agent.Agent{sub},
+				}); err != nil {
+					t.Fatalf("llmagent.New(coord): %v", err)
+				}
+			}
+			node, err := workflow.NewAgentNode(sub, workflow.NodeConfig{})
+			if err != nil {
+				t.Fatalf("NewAgentNode: %v", err)
+			}
+
+			svc := session.InMemoryService()
+			resp, err := svc.Create(t.Context(), &session.CreateRequest{AppName: "app", UserID: "u"})
+			if err != nil {
+				t.Fatalf("session.Create: %v", err)
+			}
+			std := runconfig.ToContext(t.Context(), &runconfig.RunConfig{StreamingMode: runconfig.StreamingModeNone})
+			ic := icontext.NewInvocationContext(std, icontext.InvocationContextParams{
+				Agent: sub, Session: resp.Session,
+				UserContent:  genai.NewContentFromText("hi", "user"),
+				InvocationID: "inv-seeded-tool-ctx",
+			})
+			toolCtx := agent.NewToolContext(ic, "fc-1", &session.EventActions{}, nil)
+
+			defer func() {
+				if r := recover(); r != nil {
+					t.Fatalf("panicked instead of reporting the missing session: %v", r)
+				}
+			}()
+
+			var gotErr error
+			for _, err := range node.Run(toolCtx, "some input") {
+				if err != nil {
+					gotErr = err
+				}
+			}
+			if gotErr == nil {
+				t.Fatal("expected an error for a seeded run over a tool context; got nil")
+			}
+			if !strings.Contains(gotErr.Error(), "session") {
+				t.Errorf("err = %q, want it to name the missing session", gotErr.Error())
+			}
+		})
+	}
+}
+
 // AgentNode.Run is exported and now resolves a mode, which reads ctx. It must
 // reject a nil context rather than dereference it, the way RunLLMAgentAsNode
 // does. The merge base panicked on a nil ctx too — a few lines lower, building
@@ -896,11 +971,14 @@ func TestAgentNode_ASameNamedNestedAgentKeepsItsOwnDeclaration(t *testing.T) {
 // bind honest. That bind is kept for uniformity on the argument that a chat
 // binding is indistinguishable from no binding.
 //
-// Note what this does and does not establish. It fails if the root binds a mode
-// readers DO distinguish, so it guards against a future reader learning to tell
-// chat from unset. It does NOT fail if the root bind is deleted, because for an
-// undeclared agent chat and absent are the same answer everywhere — so it is a
-// guard, not corroboration that the bind is inert.
+// Note what this does and does not establish. It fails if a same-named nested
+// agent can read the root's binding at all, which is the identity half of the
+// key doing its job. It does NOT fail if the root bind is deleted, because for
+// an undeclared agent chat and absent are the same answer everywhere. Nor does
+// it fail if the root binds some other mode: identity is in the key, so a
+// foreign binding is invisible to this agent whatever its value — an earlier
+// version of this comment claimed that guard, and the design makes it
+// unreachable.
 //
 // Same collision as above, except the nested same-named agent is undeclared. It
 // must come out identical to the same tree with the collision renamed away.

--- a/workflow/agent_node_mode_placement_test.go
+++ b/workflow/agent_node_mode_placement_test.go
@@ -734,10 +734,111 @@ func TestAgentNode_ASameNamedNestedAgentKeepsItsOwnDeclaration(t *testing.T) {
 		t.Fatal("the nested agent was never reached, so this test pins nothing")
 	}
 	si := innerLLM.systemInstruction()
+	// Both assertions below are absences, and systemInstruction returns "" when
+	// the request carries none — so without this the test would still pass if
+	// instruction assembly stopped running altogether.
+	if !strings.Contains(si, "INNER_INSTRUCTION") {
+		t.Fatalf("the agent's own instruction is missing, so the two absences below prove nothing; si = %q", si)
+	}
 	if strings.Contains(si, "You are an agent") {
 		t.Error("the nested single_turn agent got the identity preamble; it read the root's chat binding")
 	}
 	if strings.Contains(si, "transfer_to_agent") {
 		t.Error("the nested single_turn agent got transfer instructions; it read the root's chat binding")
+	}
+}
+
+// The companion to the test above, and the one that keeps the runner's root
+// bind honest. That bind is kept for uniformity on the argument that a chat
+// binding is indistinguishable from no binding — an argument this change has
+// already falsified once, for an agent that DECLARES a mode. The contradiction
+// guard cannot fire for an agent that declares nothing, so the argument has to
+// carry that case on its own, and nothing measured it.
+//
+// Same collision as above, except the nested same-named agent is undeclared. It
+// must come out identical to the same tree with the collision renamed away.
+func TestAgentNode_ASameNamedUndeclaredNestedAgentIsUnaffectedByTheRootBind(t *testing.T) {
+	t.Parallel()
+
+	run := func(t *testing.T, innerName string) string {
+		t.Helper()
+		innerLLM := &capturingLLM{}
+		peer, err := llmagent.New(llmagent.Config{Name: "peer", Model: &capturingLLM{}, Description: "a peer"})
+		if err != nil {
+			t.Fatalf("llmagent.New(peer): %v", err)
+		}
+		inner, err := llmagent.New(llmagent.Config{
+			Name:        innerName,
+			Model:       innerLLM,
+			Instruction: "INNER_INSTRUCTION",
+			SubAgents:   []agent.Agent{peer},
+		})
+		if err != nil {
+			t.Fatalf("llmagent.New(inner): %v", err)
+		}
+		seq, err := sequentialagent.New(sequentialagent.Config{
+			AgentConfig: agent.Config{Name: "seq", SubAgents: []agent.Agent{inner}},
+		})
+		if err != nil {
+			t.Fatalf("sequentialagent.New: %v", err)
+		}
+		node, err := workflow.NewAgentNode(seq, workflow.NodeConfig{})
+		if err != nil {
+			t.Fatalf("NewAgentNode: %v", err)
+		}
+		wf, err := workflowagent.New(workflowagent.Config{
+			Name:        "wf",
+			Description: "the workflow",
+			Edges:       []workflow.Edge{{From: workflow.Start, To: node}},
+		})
+		if err != nil {
+			t.Fatalf("workflowagent.New: %v", err)
+		}
+		root, err := llmagent.New(llmagent.Config{
+			Name: "coordinator",
+			Model: &testutil.MockModel{Responses: []*genai.Content{
+				genai.NewContentFromFunctionCall("transfer_to_agent",
+					map[string]any{"agent_name": "wf"}, "model"),
+				genai.NewContentFromText("done", "model"),
+			}},
+			SubAgents: []agent.Agent{wf},
+		})
+		if err != nil {
+			t.Fatalf("llmagent.New(root): %v", err)
+		}
+		r, err := runner.New(runner.Config{
+			AppName:           "app",
+			Agent:             root,
+			SessionService:    session.InMemoryService(),
+			AutoCreateSession: true,
+		})
+		if err != nil {
+			t.Fatalf("runner.New: %v", err)
+		}
+		msg := genai.NewContentFromText("please do the thing", genai.RoleUser)
+		for _, err := range r.Run(t.Context(), "u", "s1", msg, agent.RunConfig{}) {
+			if err != nil {
+				t.Fatalf("Run: %v", err)
+			}
+		}
+		if innerLLM.got == nil {
+			t.Fatal("the nested agent was never reached, so this test pins nothing")
+		}
+		si := innerLLM.systemInstruction()
+		if !strings.Contains(si, "INNER_INSTRUCTION") {
+			t.Fatalf("the agent's own instruction is missing, so comparing the two runs proves nothing; si = %q", si)
+		}
+		return si
+	}
+
+	// The agent's own name is the variable being varied and it legitimately
+	// appears in the identity preamble, so compare with it substituted out.
+	// Everything else must match exactly.
+	const collidingName, distinctName = "coordinator", "inner-distinct"
+	colliding := strings.ReplaceAll(run(t, collidingName), collidingName, "NAME")
+	renamed := strings.ReplaceAll(run(t, distinctName), distinctName, "NAME")
+
+	if colliding != renamed {
+		t.Errorf("the root's binding changed what a same-named UNDECLARED agent sees.\n colliding = %q\n renamed   = %q", colliding, renamed)
 	}
 }

--- a/workflow/agent_node_mode_placement_test.go
+++ b/workflow/agent_node_mode_placement_test.go
@@ -1029,3 +1029,85 @@ func TestAgentNode_ASingleTurnPlacementDoesNotReachASameNamedUndeclaredDescendan
 		t.Error("the nested undeclared agent lost its transfer instructions; it read the outer agent's single_turn binding")
 	}
 }
+
+// The enumerated behaviour change that had no test: a composite's UNDECLARED
+// child, re-entered as a transfer target, runs chat where the merge base ran
+// single_turn.
+//
+// installTaskTools never sees this agent — its parent is a SequentialAgent, not
+// an LlmAgent — and no node wraps it, so on the base nothing had stamped it and
+// the wrapper stamped single_turn at the re-entry. Head has no binding for it
+// and resolves the chat fallback instead.
+//
+// Measured both ways on this tree. Base: no identity preamble, no transfer
+// block, no history. Head: all three. Those three are the user-visible cost of
+// the flip and are what the PR description enumerates; asserting them here is
+// what makes the enumeration checkable.
+func TestAgentNode_ACompositeChildReenteredByTransferRunsChat(t *testing.T) {
+	m := &roundTripLLM{script: map[string][]*genai.Content{
+		"worker": {roundTripTransferTo("helper")},
+		"helper": {roundTripTransferTo("worker")},
+	}}
+	helper, err := llmagent.New(llmagent.Config{
+		Name: "helper", Description: "helps", Model: m, Instruction: "MARKER_HELPER",
+	})
+	if err != nil {
+		t.Fatalf("llmagent.New(helper): %v", err)
+	}
+	worker, err := llmagent.New(llmagent.Config{
+		Name: "worker", Description: "works", Model: m, Instruction: "MARKER_WORKER",
+		SubAgents: []agent.Agent{helper},
+	})
+	if err != nil {
+		t.Fatalf("llmagent.New(worker): %v", err)
+	}
+	seq, err := sequentialagent.New(sequentialagent.Config{
+		AgentConfig: agent.Config{Name: "seq", Description: "seq", SubAgents: []agent.Agent{worker}},
+	})
+	if err != nil {
+		t.Fatalf("sequentialagent.New: %v", err)
+	}
+	r, err := runner.New(runner.Config{
+		AppName: "app", Agent: seq,
+		SessionService: session.InMemoryService(), AutoCreateSession: true,
+	})
+	if err != nil {
+		t.Fatalf("runner.New: %v", err)
+	}
+	for _, err := range r.Run(t.Context(), "u", "s1", genai.NewContentFromText("EARLIER_TURN", "user"), agent.RunConfig{}) {
+		if err != nil {
+			t.Fatalf("r.Run: %v", err)
+		}
+	}
+
+	var idx []int
+	for i, who := range m.seen {
+		if who == "worker" {
+			idx = append(idx, i)
+		}
+	}
+	if len(idx) < 2 {
+		t.Fatalf("worker was called %d time(s), want 2; call order = %v", len(idx), m.seen)
+	}
+	si := m.si[idx[1]]
+	if !strings.Contains(si, "MARKER_WORKER") {
+		t.Fatalf("worker's own instruction is missing, so the presences below prove nothing; si = %q", si)
+	}
+	if !strings.Contains(si, "You are an agent") {
+		t.Error("no identity preamble on re-entry; an unbound undeclared agent must run chat here")
+	}
+	if !strings.Contains(si, "transfer_to_agent") {
+		t.Error("no transfer instructions on re-entry; an unbound undeclared agent must run chat here")
+	}
+	history := false
+	for _, c := range m.conts[idx[1]] {
+		for _, p := range c.Parts {
+			if p != nil && strings.Contains(p.Text, "EARLIER_TURN") {
+				history = true
+			}
+		}
+	}
+	if !history {
+		t.Error("no conversation history on re-entry; an unbound undeclared agent must run chat here")
+	}
+}

--- a/workflow/agent_node_mode_placement_test.go
+++ b/workflow/agent_node_mode_placement_test.go
@@ -751,10 +751,13 @@ func TestAgentNode_ASameNamedNestedAgentKeepsItsOwnDeclaration(t *testing.T) {
 
 // The companion to the test above, and the one that keeps the runner's root
 // bind honest. That bind is kept for uniformity on the argument that a chat
-// binding is indistinguishable from no binding — an argument this change has
-// already falsified once, for an agent that DECLARES a mode. The contradiction
-// guard cannot fire for an agent that declares nothing, so the argument has to
-// carry that case on its own, and nothing measured it.
+// binding is indistinguishable from no binding.
+//
+// Note what this does and does not establish. It fails if the root binds a mode
+// readers DO distinguish, so it guards against a future reader learning to tell
+// chat from unset. It does NOT fail if the root bind is deleted, because for an
+// undeclared agent chat and absent are the same answer everywhere — so it is a
+// guard, not corroboration that the bind is inert.
 //
 // Same collision as above, except the nested same-named agent is undeclared. It
 // must come out identical to the same tree with the collision renamed away.

--- a/workflow/agent_node_mode_placement_test.go
+++ b/workflow/agent_node_mode_placement_test.go
@@ -691,10 +691,12 @@ func TestAgentNode_Run_AcceptsAToolContext(t *testing.T) {
 }
 
 // The callback context is the other wrapper whose WithAgentContext returns nil
-// rather than erroring, and it is the one the code comments name alongside the
-// tool context. It reaches further than the tool context does: Session,
-// Memory, RunConfig and IsolationScope all return nil for it, so a placement
-// that survives here survives the emptiest context the agent API hands out.
+// rather than erroring, and both are named in the comments that shaped this
+// design. For everything AgentNode.Run touches it behaves exactly as the tool
+// context does — Session, Memory and RunConfig nil, IsolationScope empty — so
+// this test pins that the two stay equivalent rather than reaching a new path.
+// It exists because those comments claim the callback context is handled and
+// nothing drove one.
 //
 // As in the tool-context test the agent declares NO mode and carries a peer,
 // so dropping the placement is visible: an unplaced agent would be chat and

--- a/workflow/agent_node_mode_placement_test.go
+++ b/workflow/agent_node_mode_placement_test.go
@@ -690,6 +690,74 @@ func TestAgentNode_Run_AcceptsAToolContext(t *testing.T) {
 	}
 }
 
+// The callback context is the other wrapper whose WithAgentContext returns nil
+// rather than erroring, and it is the one the code comments name alongside the
+// tool context. It reaches further than the tool context does: Session,
+// Memory, RunConfig and IsolationScope all return nil for it, so a placement
+// that survives here survives the emptiest context the agent API hands out.
+//
+// As in the tool-context test the agent declares NO mode and carries a peer,
+// so dropping the placement is visible: an unplaced agent would be chat and
+// would collect the identity preamble and the transfer instructions.
+func TestAgentNode_Run_AcceptsACallbackContext(t *testing.T) {
+	t.Parallel()
+
+	llm := &capturingLLM{}
+	peer, err := llmagent.New(llmagent.Config{Name: "peer", Model: &capturingLLM{}, Description: "a peer"})
+	if err != nil {
+		t.Fatalf("llmagent.New(peer): %v", err)
+	}
+	a, err := llmagent.New(llmagent.Config{
+		Name: "c", Description: "c", Model: llm,
+		Instruction: "OWN_INSTRUCTION",
+		SubAgents:   []agent.Agent{peer},
+	})
+	if err != nil {
+		t.Fatalf("llmagent.New: %v", err)
+	}
+	node, err := workflow.NewAgentNode(a, workflow.NodeConfig{})
+	if err != nil {
+		t.Fatalf("NewAgentNode: %v", err)
+	}
+
+	svc := session.InMemoryService()
+	resp, err := svc.Create(t.Context(), &session.CreateRequest{AppName: "app", UserID: "u"})
+	if err != nil {
+		t.Fatalf("session.Create: %v", err)
+	}
+	std := runconfig.ToContext(t.Context(), &runconfig.RunConfig{StreamingMode: runconfig.StreamingModeNone})
+	ic := icontext.NewInvocationContext(std, icontext.InvocationContextParams{
+		Agent: a, Session: resp.Session,
+		UserContent:  genai.NewContentFromText("hi", "user"),
+		InvocationID: "inv-cb-ctx",
+	})
+	cbCtx := agent.NewCallbackContext(ic, &session.EventActions{})
+
+	// nodeInput must be nil, for the same reason as the tool-context test: the
+	// seeded path needs a session and this context reports none.
+	got := 0
+	for _, err := range node.Run(cbCtx, nil) {
+		if err != nil {
+			t.Fatalf("node.Run: %v", err)
+		}
+		got++
+	}
+	if got == 0 {
+		t.Fatal("node.Run over a callback context produced no events")
+	}
+
+	si := llm.systemInstruction()
+	if !strings.Contains(si, "OWN_INSTRUCTION") {
+		t.Fatalf("the agent's own instruction is missing, so the absences below prove nothing; si = %q", si)
+	}
+	if strings.Contains(si, "You are an agent") {
+		t.Error("the node's agent got the identity preamble, so the single_turn placement was dropped")
+	}
+	if strings.Contains(si, "transfer_to_agent") {
+		t.Error("the node's agent got transfer instructions, so the single_turn placement was dropped")
+	}
+}
+
 // AgentNode.Run is exported and now resolves a mode, which reads ctx. It must
 // reject a nil context rather than dereference it, the way RunLLMAgentAsNode
 // does. The merge base panicked on a nil ctx too — a few lines lower, building

--- a/workflow/agent_node_mode_placement_test.go
+++ b/workflow/agent_node_mode_placement_test.go
@@ -608,17 +608,30 @@ func TestAgentNode_PlacementSurvivesATransferRoundTrip(t *testing.T) {
 	}
 }
 
-// AgentNode.Run must tolerate a tool context. agent.Context.WithAgentContext
-// returns nil for the tool and callback wrappers rather than erroring, so
-// routing the placement back through ctx crashes here on a path where every
-// symbol is exported. The merge base drained events for such a caller and this
-// must keep doing so.
+// AgentNode.Run must tolerate a tool context, and must still place the agent
+// while doing so. agent.Context.WithAgentContext returns nil for the tool and
+// callback wrappers rather than erroring, so routing the placement back through
+// ctx crashes here on a path where every symbol is exported. The merge base
+// drained events for such a caller and this must keep doing so.
+//
+// The agent deliberately declares NO mode. A chat declaration would make this
+// test blind to half of what it is for: chat and "no binding" are the same
+// answer at every reader, so the guarded-nil-check shape — which silences the
+// panic by dropping the placement — would pass. Undeclared, the placement is
+// the only thing that makes this agent single_turn, and its loss is visible in
+// the system instruction.
 func TestAgentNode_Run_AcceptsAToolContext(t *testing.T) {
 	t.Parallel()
 
 	llm := &capturingLLM{}
+	peer, err := llmagent.New(llmagent.Config{Name: "peer", Model: &capturingLLM{}, Description: "a peer"})
+	if err != nil {
+		t.Fatalf("llmagent.New(peer): %v", err)
+	}
 	a, err := llmagent.New(llmagent.Config{
-		Name: "c", Description: "c", Model: llm, Mode: llmagent.ModeChat,
+		Name: "c", Description: "c", Model: llm,
+		Instruction: "OWN_INSTRUCTION",
+		SubAgents:   []agent.Agent{peer},
 	})
 	if err != nil {
 		t.Fatalf("llmagent.New: %v", err)
@@ -642,14 +655,27 @@ func TestAgentNode_Run_AcceptsAToolContext(t *testing.T) {
 	toolCtx := agent.NewToolContext(ic, "fc-1", &session.EventActions{}, nil)
 
 	got := 0
-	for _, err := range node.Run(toolCtx, "hello") {
+	for _, err := range node.Run(toolCtx, nil) {
 		if err != nil {
 			t.Fatalf("node.Run: %v", err)
 		}
 		got++
 	}
 	if got == 0 {
-		t.Error("node.Run over a tool context produced no events")
+		t.Fatal("node.Run over a tool context produced no events")
+	}
+
+	// Draining is only half of it. The placement has to have survived, which is
+	// what a nil guard that keeps the old ctx would quietly lose.
+	si := llm.systemInstruction()
+	if !strings.Contains(si, "OWN_INSTRUCTION") {
+		t.Fatalf("the agent's own instruction is missing, so the absences below prove nothing; si = %q", si)
+	}
+	if strings.Contains(si, "You are an agent") {
+		t.Error("the node's agent got the identity preamble, so the single_turn placement was dropped")
+	}
+	if strings.Contains(si, "transfer_to_agent") {
+		t.Error("the node's agent got transfer instructions, so the single_turn placement was dropped")
 	}
 }
 

--- a/workflow/agent_node_mode_placement_test.go
+++ b/workflow/agent_node_mode_placement_test.go
@@ -654,6 +654,10 @@ func TestAgentNode_Run_AcceptsAToolContext(t *testing.T) {
 	})
 	toolCtx := agent.NewToolContext(ic, "fc-1", &session.EventActions{}, nil)
 
+	// nodeInput must be nil. A non-nil one takes the seeded path, and seeding
+	// under a tool context panics — the context reports no session, which
+	// wrappedSession then wraps. Measured on the merge base as well as here, so
+	// it is not this change's to fix and not this test's to assert.
 	got := 0
 	for _, err := range node.Run(toolCtx, nil) {
 		if err != nil {

--- a/workflow/agent_node_mode_placement_test.go
+++ b/workflow/agent_node_mode_placement_test.go
@@ -827,11 +827,12 @@ func TestAgentNode_Run_NilContext_Errors(t *testing.T) {
 // handed the identity preamble and transfer instructions the merge base
 // correctly withheld.
 //
-// This test's power depends on the runner's root bind existing. Delete that
-// bind and there is no binding for the child to read, so a name-only key
-// passes too and this stops discriminating. The bind is inert to every reader
-// — that is why removing it survives the mutation battery — but it is not
-// inert to this test, so do not delete it on the strength of that survivor.
+// The binding a name-only key would wrongly hand this child comes from the
+// WRAPPER, which re-binds the outer coordinator under that same name — not from
+// the runner's root bind. Measured: with the root bind removed and identity
+// dropped from the key together, this test still fails. So the root bind is
+// inert to this test as well as to every reader, and an earlier version of this
+// comment that claimed otherwise was wrong.
 func TestAgentNode_ASameNamedNestedAgentKeepsItsOwnDeclaration(t *testing.T) {
 	t.Parallel()
 
@@ -913,107 +914,6 @@ func TestAgentNode_ASameNamedNestedAgentKeepsItsOwnDeclaration(t *testing.T) {
 	}
 	if strings.Contains(si, "transfer_to_agent") {
 		t.Error("the nested single_turn agent got transfer instructions; it read the root's chat binding")
-	}
-}
-
-// The companion to the test above, and the one that keeps the runner's root
-// bind honest. That bind is kept for uniformity on the argument that a chat
-// binding is indistinguishable from no binding.
-//
-// Note what this does and does not establish. It fails if a same-named nested
-// agent can read the root's binding at all, which is the identity half of the
-// key doing its job. It does NOT fail if the root bind is deleted, because for
-// an undeclared agent chat and absent are the same answer everywhere. Nor does
-// it fail if the root binds some other mode: identity is in the key, so a
-// foreign binding is invisible to this agent whatever its value — an earlier
-// version of this comment claimed that guard, and the design makes it
-// unreachable.
-//
-// Same collision as above, except the nested same-named agent is undeclared. It
-// must come out identical to the same tree with the collision renamed away.
-func TestAgentNode_ASameNamedUndeclaredNestedAgentIsUnaffectedByTheRootBind(t *testing.T) {
-	t.Parallel()
-
-	run := func(t *testing.T, innerName string) string {
-		t.Helper()
-		innerLLM := &capturingLLM{}
-		peer, err := llmagent.New(llmagent.Config{Name: "peer", Model: &capturingLLM{}, Description: "a peer"})
-		if err != nil {
-			t.Fatalf("llmagent.New(peer): %v", err)
-		}
-		inner, err := llmagent.New(llmagent.Config{
-			Name:        innerName,
-			Model:       innerLLM,
-			Instruction: "INNER_INSTRUCTION",
-			SubAgents:   []agent.Agent{peer},
-		})
-		if err != nil {
-			t.Fatalf("llmagent.New(inner): %v", err)
-		}
-		seq, err := sequentialagent.New(sequentialagent.Config{
-			AgentConfig: agent.Config{Name: "seq", SubAgents: []agent.Agent{inner}},
-		})
-		if err != nil {
-			t.Fatalf("sequentialagent.New: %v", err)
-		}
-		node, err := workflow.NewAgentNode(seq, workflow.NodeConfig{})
-		if err != nil {
-			t.Fatalf("NewAgentNode: %v", err)
-		}
-		wf, err := workflowagent.New(workflowagent.Config{
-			Name:        "wf",
-			Description: "the workflow",
-			Edges:       []workflow.Edge{{From: workflow.Start, To: node}},
-		})
-		if err != nil {
-			t.Fatalf("workflowagent.New: %v", err)
-		}
-		root, err := llmagent.New(llmagent.Config{
-			Name: "coordinator",
-			Model: &testutil.MockModel{Responses: []*genai.Content{
-				genai.NewContentFromFunctionCall("transfer_to_agent",
-					map[string]any{"agent_name": "wf"}, "model"),
-				genai.NewContentFromText("done", "model"),
-			}},
-			SubAgents: []agent.Agent{wf},
-		})
-		if err != nil {
-			t.Fatalf("llmagent.New(root): %v", err)
-		}
-		r, err := runner.New(runner.Config{
-			AppName:           "app",
-			Agent:             root,
-			SessionService:    session.InMemoryService(),
-			AutoCreateSession: true,
-		})
-		if err != nil {
-			t.Fatalf("runner.New: %v", err)
-		}
-		msg := genai.NewContentFromText("please do the thing", genai.RoleUser)
-		for _, err := range r.Run(t.Context(), "u", "s1", msg, agent.RunConfig{}) {
-			if err != nil {
-				t.Fatalf("Run: %v", err)
-			}
-		}
-		if innerLLM.got == nil {
-			t.Fatal("the nested agent was never reached, so this test pins nothing")
-		}
-		si := innerLLM.systemInstruction()
-		if !strings.Contains(si, "INNER_INSTRUCTION") {
-			t.Fatalf("the agent's own instruction is missing, so comparing the two runs proves nothing; si = %q", si)
-		}
-		return si
-	}
-
-	// The agent's own name is the variable being varied and it legitimately
-	// appears in the identity preamble, so compare with it substituted out.
-	// Everything else must match exactly.
-	const collidingName, distinctName = "coordinator", "inner-distinct"
-	colliding := strings.ReplaceAll(run(t, collidingName), collidingName, "NAME")
-	renamed := strings.ReplaceAll(run(t, distinctName), distinctName, "NAME")
-
-	if colliding != renamed {
-		t.Errorf("the root's binding changed what a same-named UNDECLARED agent sees.\n colliding = %q\n renamed   = %q", colliding, renamed)
 	}
 }
 

--- a/workflow/validation.go
+++ b/workflow/validation.go
@@ -234,8 +234,9 @@ func validateChatModeWiring(edges []Edge) error {
 	return nil
 }
 
-// agentNodeMode returns the LlmAgent mode of node, or ok=false when node
-// is not an AgentNode wrapping an LlmAgent.
+// agentNodeMode returns the mode the LlmAgent wrapped by node runs under
+// as a graph node, or ok=false when node is not an AgentNode wrapping an
+// LlmAgent.
 func agentNodeMode(node Node) (llminternal.Mode, bool) {
 	agentNode, ok := node.(*AgentNode)
 	if !ok {
@@ -245,7 +246,7 @@ func agentNodeMode(node Node) (llminternal.Mode, bool) {
 	if !ok || llmA == nil {
 		return llminternal.ModeUnset, false
 	}
-	return llminternal.Reveal(llmA).Mode, true
+	return llminternal.ResolveMode(llminternal.Reveal(llmA).Mode, llminternal.ModeSingleTurn), true
 }
 
 // validateUniqueEdges checks that there are no duplicate edges in the workflow.

--- a/workflow/validation.go
+++ b/workflow/validation.go
@@ -237,6 +237,13 @@ func validateChatModeWiring(edges []Edge) error {
 // agentNodeMode returns the mode the LlmAgent wrapped by node runs under
 // as a graph node, or ok=false when node is not an AgentNode wrapping an
 // LlmAgent.
+//
+// Resolving rather than reading the declaration makes no difference to either
+// caller today: both compare against task and chat, and resolving only ever
+// turns unset into single_turn. It is written this way because the answer this
+// returns is what the agent runs under at that placement, which is the whole
+// point of the change around it, and because a caller added later that compares
+// against single_turn would otherwise be silently wrong for an undeclared agent.
 func agentNodeMode(node Node) (llminternal.Mode, bool) {
 	agentNode, ok := node.(*AgentNode)
 	if !ok {

--- a/workflow/validation_taskmode_test.go
+++ b/workflow/validation_taskmode_test.go
@@ -87,13 +87,13 @@ func TestValidateNoTaskModeGraphNodes(t *testing.T) {
 		}
 	})
 
-	t.Run("accepts mode-unset (chat) agent as static node", func(t *testing.T) {
+	t.Run("accepts mode-unset (single_turn at a node) agent as static node", func(t *testing.T) {
 		t.Parallel()
 		anyAgent := newAgent(t, "default", llmagent.ModeUnset)
 		if _, err := workflow.New("wf-default", []workflow.Edge{
 			{From: workflow.Start, To: newNode(t, anyAgent)},
 		}); err != nil {
-			t.Errorf("mode-unset (chat) agent should be accepted as static node; got %v", err)
+			t.Errorf("mode-unset agent should be accepted as static node; got %v", err)
 		}
 	})
 }
@@ -165,4 +165,48 @@ func TestValidateChatModeWiring(t *testing.T) {
 			t.Errorf("single_turn agent mid-graph should be accepted; got %v", err)
 		}
 	})
+}
+
+// An undeclared sub-agent of a chat coordinator resolves single_turn at a graph
+// node, so it may sit mid-chain. The merge base rejected the same graph, but
+// only when the coordinator happened to be constructed first: installTaskTools
+// stamped the sub-agent chat, and validateChatModeWiring then saw a chat agent
+// following another node. Which error workflow.New returns is part of a public
+// constructor's surface, and every other subtest here passes an explicit mode,
+// so nothing else would notice this moving.
+func TestValidateChatModeWiring_UndeclaredSubAgentMayFollowANode(t *testing.T) {
+	t.Parallel()
+
+	sub, err := llmagent.New(llmagent.Config{Name: "w"})
+	if err != nil {
+		t.Fatalf("llmagent.New(sub): %v", err)
+	}
+	// Coordinator first, which is the order that used to decide the answer.
+	if _, err := llmagent.New(llmagent.Config{
+		Name:      "coordinator",
+		Mode:      llmagent.ModeChat,
+		SubAgents: []agent.Agent{sub},
+	}); err != nil {
+		t.Fatalf("llmagent.New(coordinator): %v", err)
+	}
+
+	other, err := llmagent.New(llmagent.Config{Name: "other", Mode: llmagent.ModeSingleTurn})
+	if err != nil {
+		t.Fatalf("llmagent.New(other): %v", err)
+	}
+	first, err := workflow.NewAgentNode(other, workflow.NodeConfig{})
+	if err != nil {
+		t.Fatalf("NewAgentNode(other): %v", err)
+	}
+	second, err := workflow.NewAgentNode(sub, workflow.NodeConfig{})
+	if err != nil {
+		t.Fatalf("NewAgentNode(sub): %v", err)
+	}
+
+	if _, err := workflow.New("wf-undeclared-midchain", []workflow.Edge{
+		{From: workflow.Start, To: first},
+		{From: first, To: second},
+	}); err != nil {
+		t.Errorf("an undeclared sub-agent resolves single_turn at a node and may follow one; got %v", err)
+	}
 }


### PR DESCRIPTION
Fixes #1137.

## Problem
An `LlmAgent` that declares no `Mode` takes one from where it is placed: chat as a sub-agent or a runner root, single_turn as a workflow node. That default was written back onto the agent itself — five sites wrote `llminternal.State.Mode` or `State.IncludeContents`, three of them on the run path.

Every write was guarded on the mode still being unset, so the **first placement to be constructed won** and later placements silently inherited it. The same agent instance used both as a graph node and as a chat sub-agent gave the coordinator a different tool set depending on construction order.

The writes were also **permanent and made on the run path**, so one turn decided the next. Measured on the merge base: running an undeclared agent once at a graph node leaves `Mode` at `single_turn` and `IncludeContents` at `none` on the object, and handing that same instance to `runner.New` afterwards then fails with `root agent worker must be a chat LlmAgent, but has mode single_turn`. Here both fields survive the run untouched and the second placement works. `TestOneInstance_ANodeRunDoesNotDecideItsNextPlacement` pins that sequence and reproduces the error when the write is restored.

The run-path writes were also a **data race**. One agent instance is documented to serve many concurrent invocations, and a `ParallelWorker` mapped over an agent node races activations of the same instance.

None of this is cosmetic: the mode decides which tools are installed (`finish_task`, `SingleTurnTool`/`TaskAgentTool`), whether conversation history is visible, and whether the agent is reachable by `transfer_to_agent`.

## Summary
- `State.Mode` is now the agent's own declaration and is never written after construction.
- A placement resolves the mode for **one** agent and records it on the invocation context, keyed by that agent's name **and its identity** (`boundModeKey{agent string, state *State}`).
- **Identity gives every agent its own slot.** A binding cannot be read by an agent it was not resolved for, and cannot be destroyed by a placement for a same-named other agent. That matters because names are unique only across `SubAgents()`, and a graph node's agent is not in `SubAgents()` — so `runner.New` will accept a tree holding two distinct agents with one name.
- The identity token is the `*State` rather than the `agent.Agent`. `Reveal` hands every binder and every reader the same pointer for one agent, a pointer is always comparable, and an `agent.Agent` in a context key would panic on an implementation whose dynamic type is not.
- The name is redundant for lookup — every binder and reader pairs an agent's name with that same agent's state — and is kept as a guard against a future binder or reader that pairs them inconsistently, and because a key naming the agent reads better in a dump than a bare pointer. The code says so.
- Bindings **nest**: re-placing an agent shadows its outer binding, which is what carries a placement across a `transfer_to_agent` round trip.
- The binding travels in the context handed **downstream**, not back into the caller's own `agent.Context`. `Context.WithAgentContext` returns nil for a tool context and for a callback context rather than erroring, so routing it that way crashes a caller holding one. `AgentNode.Run` and the single_turn and task paths of the wrapper therefore never call it. The wrapper's chat path still does, guarded, because `runChat` needs the `agent.Context` itself for the sub-scheduler its task delegations dispatch through.
- Placements bind explicitly: runner root → chat, `AgentNode` → single_turn. The wrapper falls back to chat, which is what an undeclared mode already means to every reader.
- Every reader of the mode moves to the resolved value: the identity preamble, the transfer instructions, the contents processor, and the compaction prompt estimator. Three kinds of reader stay on the declaration on purpose, each for a different reason, set out in the design comment at the top of `internal/llminternal/mode.go`.
- Hiding history and shaping a single turn stay separate concerns, as they were before: history follows a placement made for this agent, so a declared single_turn agent run outside such a placement keeps its conversation. An explicit `IncludeContents` beats the placement either way, matching adk-python. Only the exact string `"default"` opts out — the field is an unvalidated string, and any other value falls back to the placement rather than being read as a request for history.
- An agent with an empty `Name` is bound like any other, and two nameless agents do not share a binding.
- No public API change (`apidiff` clean).

### What the tests pin
Twenty-six mutations, each removing or corrupting one part of the mechanism, run against `./agent/... ./internal/llminternal/... ./runner/... ./workflow/...`. **Twenty-three fail the suite**: removing any of the three binds, dropping either component of the context key, collapsing the identity to a constant, removing the `ModeUnset` bind guard, reverting any of the five migrated readers, making `BoundMode` report nothing, making `ModeFor` ignore the binding, restoring either `WithAgentContext` shape that crashes on a tool context, either half of the `IncludeContents` gate, and **restoring any one of the five removed writes**. Each of those five is caught by a test in the package that owns the write, so `go test ./<that package>/` sees it come back, not only a full-suite run.

Two survive, and not for the same reason:

- **The root bind in `runner.Run` is inert.** It runs after the check that rejects any root but chat, and a chat binding and no binding are the same answer to every reader. No test depends on it either — measured by removing the bind and dropping identity from the key together, under which the same-name collision test still fails, because the binding it would wrongly read comes from the wrapper re-binding the outer coordinator rather than from the root. It is kept so the runner is not the one placement that resolves a mode and then keeps it to itself.
- **Writing the rebound context back into the captured `ctx` is untested rather than harmless.** Sequentially it is value-equivalent, since re-ranging re-derives the same key with the same value. What the local variable actually prevents is two goroutines ranging one returned iterator, which is a write/write race. Nothing ranges a returned iterator twice, so no test separates the two shapes.

A third survivor was carried here for several rounds — the chat branch's nil guard, justified as unobservable because a chat run over a tool context died either way. Review showed the interesting input was not a chat run but an **undeclared** agent, which the merge base ran as single_turn over that same context successfully. That is the regression described below, and fixing it made the mutant killable.

### Behavior changes worth noting for release
**Construction order no longer decides a coordinator's tool list.** Wrapping an agent in an `AgentNode` before handing it to a coordinator used to stamp it single_turn, so the coordinator got a `SingleTurnTool` for it. It now declares `transfer_to_agent` and names the agent as a target instead. That is what the merge base already produced when the coordinator was built first, so the outcome becomes deterministic rather than new, but a program written against the other construction order will see its tool list change.

**Construction order no longer decides whether a sub-agent is reachable by transfer.** The same write did two things, and the tool list was only the visible one. Wrapping an undeclared agent in an `AgentNode` before building its coordinator stamped it single_turn, and `isUntransferableMode` reads the declaration, so the agent dropped off the coordinator's `transfer_to_agent` target list entirely — the coordinator's whole transfer block disappeared. Both construction orders now produce the same target list. Pinned by `TestLlmAgent_TransferTargets_AreConstructionOrderIndependent`, which fails on the merge base.

**`runner.Run` no longer rejects an undeclared root that was previously wrapped in an `AgentNode`.** On the merge base, wrapping stamped the agent single_turn, so using that same instance as a runner root failed with `root agent a must be a chat LlmAgent, but has mode single_turn`. It now resolves chat and runs. This is an error becoming a success at a public entry point, and it is the intended consequence of removing the write — the old error existed only because one placement had leaked into another.

**An undeclared agent driven through `RunLLMAgentAsNode` runs chat, where it ran single_turn.** The wrapper used to default any unset mode to single_turn. It now resolves chat, because that is what an undeclared mode means everywhere else and only a placement can say otherwise. This reaches more than out-of-module callers: the runner's own agent node drives the wrapper, so an undeclared `LlmAgent` it selects — one nested under a non-`LlmAgent` composite, which `installTaskTools` skips — also moves from single_turn to chat. That is also reachable through a transfer round trip, where a composite's undeclared child is re-entered as a transfer target. Measured on that tree, the re-entered agent now receives **the whole conversation, the identity preamble and the transfer instruction block**, where the merge base gave it none of the three — that is the visible cost, and `TestAgentNode_ACompositeChildReenteredByTransferRunsChat` asserts all three. Two quieter costs come with it: `runSingleTurn` calls `ProcessLLMAgentOutput` and `runChat` does not, so `Event.Output` and `NodeInfo.MessageAsOutput` stop being set for that agent (`runner/run_node.go` and `workflow/agent_node.go` both key on them), and an `OutputSchema` on it stops being validated on that reply. Declare the mode on such an agent if you depend on any of that. Making the fallback single_turn when `nodeInput` is non-nil was tried and rejected: `runner/agent_node.go` passes the user message as `nodeInput` on every non-resume turn, so it would flip every transfer-selected sub-agent to single_turn, which is the case adk-python's `build_node` also resolves to chat.

**`workflow.New` accepts a graph it used to reject.** An undeclared sub-agent of a chat coordinator resolves single_turn at a graph node and may therefore sit mid-chain. The merge base rejected that with `Agent "w" has mode='chat' and cannot follow node "other"`, but only when the coordinator happened to be constructed first, because `installTaskTools` had stamped the sub-agent chat. This is the same order-dependence being removed everywhere else, so the new answer is the right one — but it is a public constructor's error surface changing.

**A parented undeclared sub-agent at a graph node resolves to single_turn, where adk-python gives it chat.** Python's `build_node` picks by whether the agent has a parent — parented gets chat, standalone gets single_turn — while this change gives every undeclared agent at a node single_turn. The merge base matched Python only when the coordinator happened to be constructed first, so there was no order-independent behavior here to preserve, and one of the two had to be chosen. Flagging it because adk-python is the parity reference and this is a real divergence for that one topology, not because the old behavior was better.

**Setting `IncludeContents` to `IncludeContentsDefault` explicitly now means something the merge base had no way to express.** The base forced `IncludeContents = "none"` onto any single_turn agent, so an explicit `"default"` was overwritten and a one-shot node never saw history. It now keeps the history even at a single_turn placement, which is how adk-python reads an explicitly set value. Leaving the field unset is unchanged. The constant's own doc says this.

**An undeclared agent driven from a tool or callback context now reports an error where the merge base ran it.** This is the sharp edge of the chat fallback above, and the one place it is not free. The base stamped such an agent single_turn, and that branch builds its own `InvocationContext`, which a tool context survives — so the call worked. Resolving to chat instead sends it to `runChat`, which needs the `agent.Context` itself, and `WithAgentContext` returns nil for that wrapper. Rather than carry on into a nil dereference several frames down, the branch reports it. A caller that needs this agent over a tool context must declare single_turn or place it at a node. Pinned by `TestRunLLMAgentAsNode_UndeclaredOverAToolContext_ErrorsRatherThanPanics`.

**A nil `agent.Context` produces an error where it used to panic.** `RunLLMAgentAsNode`, `PrepareLLMAgentInput` and `AgentNode.Run` resolve a mode, which reads the context, so each rejects a nil one up front. All three panicked on the merge base, a few lines further in.

**`PrepareLLMAgentInput` now reads the context for every agent, so a partial test fake that panics on `Value` panics here.** The merge base tested the declaration first and returned nil for any non-single_turn agent without touching the context. Resolving a mode has to read it. Measured with a fake built the way `agent.StrictContextMock` documents — embed it, override only what the test uses, leave `Ctx` nil — the same call returns nil on the base and panics on head for chat, task and undeclared agents alike. Out-of-module tests using such a fake need to stub `Value`. Production contexts are unaffected.

**`PrepareLLMAgentInput` returns nil for an undeclared agent that no placement bound, where the merge base returned a seed event.** Wrapping an agent in an `AgentNode` used to stamp it single_turn, so a caller that wrapped it and then called this function on an ordinary context got a first-turn seed. Nothing is stamped now, and a plain context carries no binding, so there is no placement to seed for. This is the intended shape — a seed belongs to a placement — but it is silent: the caller gets nil rather than an error. Callers that build their own node wrapper should either declare the mode or bind one. Pinned by the two undeclared rows of `TestPrepareLLMAgentInput`.

### Known, and deliberately not fixed here
Defects that reproduce identically on the merge base, so none is this change's to fix. They are being filed separately.

- A declared single_turn agent selected by `runner.findAgentToRun` fails with `ErrMultipleOutputs` before producing anything, because `runLlmAgentBody` both emits an event carrying `Output` and returns the same value.
- `RunLLMAgentAsNode` cannot be driven from a tool or callback context at all: such a context reports no session, so a seeded single_turn run wraps that nil in a `wrappedSession` and panics in telemetry, and a chat run panics in `agent.go`.
- `RunLLMAgentAsNode` panics on a nil `agent.Agent`, before the nil-context guard it does have.
- The compaction prompt estimator hardcodes `buildContentsDefault`, so it counts history that a single_turn placement hides.
- `IncludeContents` is never validated, so an unrecognised value is fail-open for an agent with no placement.
- `sequentialagent.RunLive` appends to a shared sub-agent's `Tools` and `Instruction` on a run path — the same class of shared-state write as #1137, in a different field.
- `toolProcessor` appends toolset tools onto the agent's own `Tools` slice rather than a copy, so when that slice has spare capacity the append writes into the shared backing array. Measured: a coordinator built with two tools and a single_turn sub-agent ends at `len=3 cap=4`, and two concurrent invocations both write index 3, leaving one invocation's tool list holding the other's tool. Same class as #1137 again, and for a per-request toolset it crosses invocations.
- `workflowNode.Run` assigns its cancellable context back onto the closure's captured parameter, under a `defer cancel()`. A caller that ranges the returned iterator a second time derives from an already-cancelled parent and gets `context.Canceled` instead of a run. This is the shape three comments in this change explain that they avoid.
- `SingleTurnTool` and `TaskAgentTool` build one `*genai.FunctionDeclaration` at construction and hand that same pointer to every request, while `plugin/functioncallmodifier` writes into `decl.Parameters.Properties` and `decl.Description` in place. Two concurrent invocations of one coordinator therefore write one map with no synchronisation, which is a fatal runtime throw rather than a recoverable panic, and even a single-threaded run appends the description override once per model call. The tools these two types wrap are installed by `installTaskTools`, which this change edits, but the caching and the in-place write both predate it.
- The workflow scheduler drops each per-node `CancelFunc` without calling it: `handleCompletion` deletes the map entry first, and `cancelAll` only reaches entries still in the map. A run that completes normally therefore cancels nothing, so a graph with loop-back routing leaves one live child context per activation, plus an undismissed timer for every node configured with a timeout. `go vet`'s `lostcancel` cannot see it, because the cancel is stored in a map rather than discarded.
- A declared single_turn agent run with no placement keeps its conversation while still receiving the single-turn nudge.
