### PR TITLE
fix(workflow): report every graph validation violation at once

### DIFF
--- a/workflow/graph.go
+++ b/workflow/graph.go
@@ -14,6 +14,11 @@
 
 package workflow
 
+import (
+	"slices"
+	"strings"
+)
+
 // graph is the precomputed structural view of a workflow's edges.
 // Built once at workflow construction; queried by the engine at
 // dispatch time.
@@ -37,13 +42,23 @@ func newGraph(edges []Edge) *graph {
 	return &graph{successors: succ, predecessors: pred}
 }
 
-// allEdges returns all edges in the graph.
+// allEdges returns all edges in the graph, grouped by source node in
+// name order.
 func (g *graph) allEdges() []Edge {
 	var edges []Edge
-	for _, succs := range g.successors {
-		edges = append(edges, succs...)
+	for _, n := range g.sortedNodes() {
+		edges = append(edges, g.successors[n]...)
 	}
 	return edges
+}
+
+// sortedNodes returns all nodes ordered by name. Callers that report
+// findings to the user (graph validation) use it so the output does not
+// inherit Go's randomized map iteration order.
+func (g *graph) sortedNodes() []Node {
+	nodes := g.allNodes()
+	slices.SortFunc(nodes, func(a, b Node) int { return strings.Compare(a.Name(), b.Name()) })
+	return nodes
 }
 
 // successorsOf returns the outgoing edges for a node.

--- a/workflow/validation.go
+++ b/workflow/validation.go
@@ -19,6 +19,7 @@ import (
 	"encoding/json"
 	"errors"
 	"fmt"
+	"iter"
 	"slices"
 	"strings"
 
@@ -64,73 +65,98 @@ var ErrSubWorkflowNameCollision = errors.New("sub-workflow name collision")
 // safely. Use a JoinNode to converge multiple branches.
 var ErrUnsupportedFanIn = errors.New("non-JoinNode fan-in is not yet supported")
 
-// validateNodes executes a set of edges validation checks.
+// validateNodes executes a set of edges validation checks. Every check
+// runs and all violations are reported together, so a caller with
+// several mistakes can fix them in one pass.
 func validateNodes(edges []Edge) error {
-	if err := validateUniqueNames(edges); err != nil {
-		return err
+	return joinViolations(
+		validateUniqueNames(edges),
+		validateStartNodePresent(edges),
+		validateStartNodeNoIncoming(edges),
+		validateNoTaskModeGraphNodes(edges),
+		validateChatModeWiring(edges),
+	)
+}
+
+// joinViolations reports errs as a single error, skipping nils and
+// messages already reported (two edges violating one rule the same way
+// read as one problem to the user). A lone violation is returned as-is,
+// unjoined, so it keeps the exact identity and message it had before
+// validation started aggregating.
+func joinViolations(errs ...error) error {
+	var kept []error
+	seen := make(map[string]bool)
+	for _, err := range errs {
+		if err == nil || seen[err.Error()] {
+			continue
+		}
+		seen[err.Error()] = true
+		kept = append(kept, err)
 	}
-	if err := validateStartNodePresent(edges); err != nil {
-		return err
+	if len(kept) == 1 {
+		return kept[0]
 	}
-	if err := validateStartNodeNoIncoming(edges); err != nil {
-		return err
+	return errors.Join(kept...)
+}
+
+// distinctNodes yields each node of edges once, in first-appearance
+// order, so validation reports violations in the order the caller
+// declared them.
+func distinctNodes(edges []Edge) iter.Seq[Node] {
+	return func(yield func(Node) bool) {
+		seen := make(map[Node]bool)
+		for _, edge := range edges {
+			for _, node := range [2]Node{edge.From, edge.To} {
+				if seen[node] {
+					continue
+				}
+				seen[node] = true
+				if !yield(node) {
+					return
+				}
+			}
+		}
 	}
-	if err := validateNoTaskModeGraphNodes(edges); err != nil {
-		return err
-	}
-	if err := validateChatModeWiring(edges); err != nil {
-		return err
-	}
-	return nil
 }
 
 // validateSubWorkflowNames checks that no sub-workflow has the same name as the parent workflow.
 func validateSubWorkflowNames(workflowName string, edges []Edge) error {
-	for _, edge := range edges {
-		if err := checkSubWorkflowName(edge.From, workflowName); err != nil {
-			return err
-		}
-		if err := checkSubWorkflowName(edge.To, workflowName); err != nil {
-			return err
+	var errs []error
+	for node := range distinctNodes(edges) {
+		if err := checkSubWorkflowName(node, workflowName); err != nil {
+			errs = append(errs, err)
 		}
 	}
-	return nil
+	return joinViolations(errs...)
 }
 
 // checkSubWorkflowName checks if the node is a WorkflowNode and if its sub-workflow has the same name as the parent workflow.
 func checkSubWorkflowName(node Node, workflowName string) error {
 	if wfNode, ok := node.(*WorkflowNode); ok {
 		if wfNode.subWorkflow.Name() == workflowName {
-			return fmt.Errorf("%w: %q", ErrSubWorkflowNameCollision, workflowName)
+			return fmt.Errorf("%w: %q (node %q)", ErrSubWorkflowNameCollision, workflowName, node.Name())
 		}
 	}
 	return nil
 }
 
 // validateUniqueNames checks that all nodes in the edge set have unique names.
-// If duplicate node names are found, it returns an error. The equality between
-// nodes is checked by comparing the nodes directly.
+// It reports every duplicated name, once each. The equality between nodes is
+// checked by comparing the nodes directly.
 func validateUniqueNames(edges []Edge) error {
 	names := make(map[string]Node)
-	checkNode := func(node Node) error {
-		if storedNode, ok := names[node.Name()]; ok {
-			if storedNode != node {
-				return fmt.Errorf("%w: %s", ErrDuplicateNodeName, node.Name())
-			}
-		} else {
+	var errs []error
+	for node := range distinctNodes(edges) {
+		storedNode, ok := names[node.Name()]
+		if !ok {
 			names[node.Name()] = node
+			continue
 		}
-		return nil
-	}
-	for _, edge := range edges {
-		if err := checkNode(edge.From); err != nil {
-			return err
-		}
-		if err := checkNode(edge.To); err != nil {
-			return err
+		if storedNode != node {
+			errs = append(errs, fmt.Errorf("%w: %s", ErrDuplicateNodeName, node.Name()))
 		}
 	}
-	return nil
+	return joinViolations(errs...)
 }
 
 // validateStartNodePresent checks that there is at least one edge starting from the start node.
@@ -145,38 +171,27 @@ func validateStartNodePresent(edges []Edge) error {
 
 // validateStartNodeNoIncoming checks that no node points to the start node.
 func validateStartNodeNoIncoming(edges []Edge) error {
+	var errs []error
 	for _, edge := range edges {
 		if edge.To == Start {
-			return fmt.Errorf("%w: %s", ErrNodePointsToStart, edge.From.Name())
+			errs = append(errs, fmt.Errorf("%w: %s", ErrNodePointsToStart, edge.From.Name()))
 		}
 	}
-	return nil
+	return joinViolations(errs...)
 }
 
-// validateWorkflow executes a set of workflow validation checks.
+// validateWorkflow executes a set of workflow validation checks. Every
+// check runs and all violations are reported together.
 func validateWorkflow(workflow *graph, schema *jsonschema.Resolved) error {
-	if err := validateUniqueEdges(workflow); err != nil {
-		return err
-	}
-	if err := validateDefaultRoute(workflow); err != nil {
-		return err
-	}
-	if err := validateConnectivity(workflow); err != nil {
-		return err
-	}
-	if err := validateCycles(workflow); err != nil {
-		return err
-	}
-	if err := validateFanIn(workflow); err != nil {
-		return err
-	}
-	if err := validateStaticSchemas(workflow); err != nil {
-		return err
-	}
-	if err := validateStateSchemaConsistency(workflow, schema); err != nil {
-		return err
-	}
-	return nil
+	return joinViolations(
+		validateUniqueEdges(workflow),
+		validateDefaultRoute(workflow),
+		validateConnectivity(workflow),
+		validateCycles(workflow),
+		validateFanIn(workflow),
+		validateStaticSchemas(workflow),
+		validateStateSchemaConsistency(workflow, schema),
+	)
 }
 
 // validateNoTaskModeGraphNodes rejects task-mode LlmAgents that appear
@@ -195,23 +210,17 @@ func validateWorkflow(workflow *graph, schema *jsonschema.Resolved) error {
 //   - dispatched dynamically via workflow.RunNode from a function/
 //     dynamic node — never as static graph nodes.
 func validateNoTaskModeGraphNodes(edges []Edge) error {
-	allNodes := make(map[Node]bool)
-	for _, e := range edges {
-		allNodes[e.From] = true
-		allNodes[e.To] = true
-	}
-
-	for node := range allNodes {
+	var errs []error
+	for node := range distinctNodes(edges) {
 		if mode, ok := agentNodeMode(node); ok && mode == llminternal.ModeTask {
-			return fmt.Errorf(
+			errs = append(errs, fmt.Errorf(
 				"Agent %q has mode='task' and cannot be used as a workflow graph node. Use a chat coordinator with task sub-agents, or "+
 					"dispatch dynamically via RunNode from a function node",
 				node.Name(),
-			)
+			))
 		}
 	}
-
-	return nil
+	return joinViolations(errs...)
 }
 
 // validateChatModeWiring rejects a chat-mode LlmAgent that is reached from
@@ -220,18 +229,19 @@ func validateNoTaskModeGraphNodes(edges []Edge) error {
 // down an edge, so feeding it from a predecessor silently drops that
 // predecessor's output. Mirrors adk-python's _validate_chat_agent_wiring.
 func validateChatModeWiring(edges []Edge) error {
+	var errs []error
 	for _, e := range edges {
 		if e.From == Start {
 			continue
 		}
 		if mode, ok := agentNodeMode(e.To); ok && mode == llminternal.ModeChat {
-			return fmt.Errorf(
+			errs = append(errs, fmt.Errorf(
 				"Agent %q has mode='chat' and cannot follow node %q: chat agents rely on conversation history and cannot consume a predecessor's node input. Use mode='single_turn', or wire the agent directly from Start",
 				e.To.Name(), e.From.Name(),
-			)
+			))
 		}
 	}
-	return nil
+	return joinViolations(errs...)
 }
 
 // agentNodeMode returns the LlmAgent mode of node, or ok=false when node
@@ -252,31 +262,35 @@ func agentNodeMode(node Node) (llminternal.Mode, bool) {
 // Two edges with the same (From, To) are rejected regardless of Route; use
 // MultiRoute to express alternatives to the same target.
 func validateUniqueEdges(workflow *graph) error {
-	for node, edges := range workflow.successors {
-		uniqueEdges := make(map[Node]struct{})
-		for _, edge := range edges {
-			if _, ok := uniqueEdges[edge.To]; ok {
-				return fmt.Errorf("%w: from %q to %q", ErrDuplicateEdge, node.Name(), edge.To.Name())
+	var errs []error
+	for _, node := range workflow.sortedNodes() {
+		seen := make(map[Node]bool)
+		for _, edge := range workflow.successorsOf(node) {
+			if seen[edge.To] {
+				errs = append(errs, fmt.Errorf("%w: from %q to %q", ErrDuplicateEdge, node.Name(), edge.To.Name()))
+				continue
 			}
-			uniqueEdges[edge.To] = struct{}{}
+			seen[edge.To] = true
 		}
 	}
-	return nil
+	return joinViolations(errs...)
 }
 
 // validateDefaultRoute checks that there are no multiple default routes for one node.
 func validateDefaultRoute(workflow *graph) error {
-	for node, edges := range workflow.successors {
-		hasDefault := false
-		for _, edge := range edges {
-			if edge.Route == Default && !hasDefault {
-				hasDefault = true
-			} else if edge.Route == Default && hasDefault {
-				return fmt.Errorf("%w: %q", ErrMultipleDefaultRoutes, node.Name())
+	var errs []error
+	for _, node := range workflow.sortedNodes() {
+		defaults := 0
+		for _, edge := range workflow.successorsOf(node) {
+			if edge.Route == Default {
+				defaults++
 			}
 		}
+		if defaults > 1 {
+			errs = append(errs, fmt.Errorf("%w: %q", ErrMultipleDefaultRoutes, node.Name()))
+		}
 	}
-	return nil
+	return joinViolations(errs...)
 }
 
 // validateConnectivity checks that all nodes in the edge set are reachable from the start node.
@@ -320,42 +334,44 @@ func validateConnectivity(workflow *graph) error {
 // and are ignored during unconditional cycle detection.
 func validateCycles(workflow *graph) error {
 	visited := make(map[Node]struct{})
+	reported := make(map[Node]struct{})
+	var errs []error
 
-	var traverse func(n Node, inStack map[Node]struct{}) error
-	traverse = func(n Node, inStack map[Node]struct{}) error {
+	var traverse func(n Node, inStack map[Node]struct{})
+	traverse = func(n Node, inStack map[Node]struct{}) {
 		if _, ok := inStack[n]; ok {
-			return fmt.Errorf("%w: %q", ErrUnconditionalCycle, n.Name())
+			// One error per node a cycle closes on: a dense graph has
+			// O(edges) back-edges, and repeating them helps nobody.
+			if _, done := reported[n]; !done {
+				reported[n] = struct{}{}
+				errs = append(errs, fmt.Errorf("%w: %q", ErrUnconditionalCycle, n.Name()))
+			}
+			return
 		}
 
 		if _, ok := visited[n]; ok {
-			return nil
+			return
 		}
 
 		inStack[n] = struct{}{}
 		visited[n] = struct{}{}
 
-		for _, edge := range workflow.successors[n] {
+		for _, edge := range workflow.successorsOf(n) {
 			if edge.Route == nil {
-				if err := traverse(edge.To, inStack); err != nil {
-					return err
-				}
+				traverse(edge.To, inStack)
 			}
 		}
 
 		delete(inStack, n)
-		return nil
 	}
 
-	for node := range workflow.successors {
+	for _, node := range workflow.sortedNodes() {
 		if _, ok := visited[node]; !ok {
-			inStack := make(map[Node]struct{})
-			if err := traverse(node, inStack); err != nil {
-				return err
-			}
+			traverse(node, make(map[Node]struct{}))
 		}
 	}
 
-	return nil
+	return joinViolations(errs...)
 }
 
 // validateFanIn rejects a non-JoinNode target that has two or more
@@ -367,22 +383,23 @@ func validateCycles(workflow *graph) error {
 // back-edges — where the predecessors don't all fire together — are not
 // rejected.
 func validateFanIn(workflow *graph) error {
-	for node, edges := range workflow.predecessors {
+	var errs []error
+	for _, node := range workflow.sortedNodes() {
 		if _, isJoin := node.(*JoinNode); isJoin {
 			continue
 		}
 		unconditional := 0
-		for _, edge := range edges {
+		for _, edge := range workflow.predecessorsOf(node) {
 			if edge.Route == nil {
 				unconditional++
 			}
 		}
 		if unconditional > 1 {
-			return fmt.Errorf("%w: node %q has %d unconditional incoming edges; "+
-				"use a JoinNode to converge branches", ErrUnsupportedFanIn, node.Name(), unconditional)
+			errs = append(errs, fmt.Errorf("%w: node %q has %d unconditional incoming edges; "+
+				"use a JoinNode to converge branches", ErrUnsupportedFanIn, node.Name(), unconditional))
 		}
 	}
-	return nil
+	return joinViolations(errs...)
 }
 
 // defaultValidateInput validates data against schema. When data is a
@@ -454,7 +471,8 @@ func validateStateSchemaConsistency(g *graph, schema *jsonschema.Resolved) error
 	}
 	schemaFields := extractFieldNames(schema)
 
-	for _, n := range g.allNodes() {
+	var errs []error
+	for _, n := range g.sortedNodes() {
 		spa, ok := n.(StateParamsAware)
 		if !ok {
 			continue
@@ -466,11 +484,11 @@ func validateStateSchemaConsistency(g *graph, schema *jsonschema.Resolved) error
 				continue
 			}
 			if !slices.Contains(schemaFields, fieldName) {
-				return fmt.Errorf("node %q references state field %q which is not declared in StateSchema (declared: %v)", n.Name(), fieldName, schemaFields)
+				errs = append(errs, fmt.Errorf("node %q references state field %q which is not declared in StateSchema (declared: %v)", n.Name(), fieldName, schemaFields))
 			}
 		}
 	}
-	return nil
+	return joinViolations(errs...)
 }
 
 func extractFieldNames(schema *jsonschema.Resolved) []string {
@@ -485,6 +503,7 @@ func extractFieldNames(schema *jsonschema.Resolved) []string {
 }
 
 func validateStaticSchemas(g *graph) error {
+	var errs []error
 	for _, edge := range g.allEdges() {
 		outResolved := edge.From.OutputSchema()
 		inResolved := edge.To.InputSchema()
@@ -493,15 +512,16 @@ func validateStaticSchemas(g *graph) error {
 		}
 		eq, err := schemasEqualCanonical(outResolved.Schema(), inResolved.Schema())
 		if err != nil {
-			return fmt.Errorf("comparing schemas on edge %s->%s: %w",
-				edge.From.Name(), edge.To.Name(), err)
+			errs = append(errs, fmt.Errorf("comparing schemas on edge %s->%s: %w",
+				edge.From.Name(), edge.To.Name(), err))
+			continue
 		}
 		if !eq {
-			return fmt.Errorf("graph validation failed: schema mismatch on edge %s -> %s",
-				edge.From.Name(), edge.To.Name())
+			errs = append(errs, fmt.Errorf("graph validation failed: schema mismatch on edge %s -> %s",
+				edge.From.Name(), edge.To.Name()))
 		}
 	}
-	return nil
+	return joinViolations(errs...)
 }
 
 func schemasEqualCanonical(a, b *jsonschema.Schema) (bool, error) {

--- a/workflow/validation_test.go
+++ b/workflow/validation_test.go
@@ -16,6 +16,7 @@ package workflow
 
 import (
 	"errors"
+	"fmt"
 	"strings"
 	"testing"
 
@@ -447,6 +448,163 @@ func TestValidateFanIn(t *testing.T) {
 				t.Errorf("expected no error, got %v", err)
 			}
 		})
+	}
+}
+
+// violations flattens a validation error into the individual findings
+// it carries. A phase joins the results of its checks, each of which is
+// itself a join, so the tree has to be walked to the leaves — unwrapping
+// one level would count failing checks, not violations.
+func violations(err error) []error {
+	if err == nil {
+		return nil
+	}
+	multi, ok := err.(interface{ Unwrap() []error })
+	if !ok {
+		return []error{err}
+	}
+	var leaves []error
+	for _, e := range multi.Unwrap() {
+		leaves = append(leaves, violations(e)...)
+	}
+	return leaves
+}
+
+func violationMessages(err error) []string {
+	var msgs []string
+	for _, e := range violations(err) {
+		msgs = append(msgs, e.Error())
+	}
+	return msgs
+}
+
+func TestValidateNodes_ReportsEveryViolation(t *testing.T) {
+	// Two pairs of same-named nodes and two edges back into Start:
+	// two checks, each with two findings, all from one call.
+	a1, a2 := newDummyNode("A"), newDummyNode("A")
+	b1, b2 := newDummyNode("B"), newDummyNode("B")
+	c, d := newDummyNode("C"), newDummyNode("D")
+	err := validateNodes([]Edge{
+		{From: Start, To: a1},
+		{From: a1, To: a2},
+		{From: a2, To: b1},
+		{From: b1, To: b2},
+		{From: c, To: Start},
+		{From: d, To: Start},
+	})
+	want := []string{
+		"duplicate node name: A",
+		"duplicate node name: B",
+		"node points to start node: C",
+		"node points to start node: D",
+	}
+	if diff := cmp.Diff(want, violationMessages(err)); diff != "" {
+		t.Errorf("validateNodes() violations mismatch (-want +got):\n%s", diff)
+	}
+	for _, sentinel := range []error{ErrDuplicateNodeName, ErrNodePointsToStart} {
+		if !errors.Is(err, sentinel) {
+			t.Errorf("validateNodes() = %v, want it to match %v", err, sentinel)
+		}
+	}
+}
+
+// A single violation must come back exactly as it did before validation
+// started aggregating: unjoined, one line, same message.
+func TestNew_SingleViolationUnchanged(t *testing.T) {
+	a, b := newDummyNode("A"), newDummyNode("B")
+	_, err := New("wf", []Edge{{From: a, To: b}})
+	if !errors.Is(err, ErrNoStartNode) {
+		t.Fatalf("New() = %v, want it to match ErrNoStartNode", err)
+	}
+	if got, want := err.Error(), ErrNoStartNode.Error(); got != want {
+		t.Errorf("New() error = %q, want %q (a lone violation must not be wrapped)", got, want)
+	}
+}
+
+// Every back-edge into a node closing a cycle used to add a line, so a
+// dense graph produced O(edges) identical findings.
+func TestValidateCycles_OneFindingPerNode(t *testing.T) {
+	// Complete graph: every node is on an unconditional cycle.
+	const n = 20
+	nodes := make([]Node, n)
+	for i := range nodes {
+		nodes[i] = newDummyNode(fmt.Sprintf("N%02d", i))
+	}
+	var edges []Edge
+	for i, from := range nodes {
+		for j, to := range nodes {
+			if i != j {
+				edges = append(edges, Edge{From: from, To: to})
+			}
+		}
+	}
+	got := len(violations(validateCycles(newGraph(edges))))
+	if got == 0 || got > n {
+		t.Errorf("validateCycles() reported %d findings for a %d-node complete graph, want 1..%d", got, n, n)
+	}
+}
+
+func TestValidateWorkflow_ReportsEveryViolation(t *testing.T) {
+	a, b, c := newDummyNode("A"), newDummyNode("B"), newDummyNode("C")
+	d, e := newDummyNode("D"), newDummyNode("E")
+	g := newGraph([]Edge{
+		{From: Start, To: a},
+		{From: a, To: b, Route: Default},
+		{From: a, To: c, Route: Default}, // two default routes out of A
+		{From: d, To: e},                 // unreachable pair, unconditionally cyclic
+		{From: e, To: d},
+	})
+	err := validateWorkflow(g, nil)
+	for _, want := range []error{ErrMultipleDefaultRoutes, ErrNodesNotReachable, ErrUnconditionalCycle} {
+		if !errors.Is(err, want) {
+			t.Errorf("validateWorkflow() = %v, want it to match %v", err, want)
+		}
+	}
+	if got, want := len(violations(err)), 3; got != want {
+		t.Errorf("validateWorkflow() reported %d violations, want %d: %v", got, want, err)
+	}
+}
+
+// A failing phase stops the next one: later phases assume the earlier
+// ones hold, so their findings would be noise.
+func TestNew_StopsAfterFailingPhase(t *testing.T) {
+	a1, a2, b := newDummyNode("A"), newDummyNode("A"), newDummyNode("B")
+	_, err := New("wf", []Edge{
+		{From: Start, To: a1},
+		{From: a1, To: a2},
+		{From: a1, To: b},
+		{From: a1, To: b}, // duplicate edge: a later-phase violation
+	})
+	if !errors.Is(err, ErrDuplicateNodeName) {
+		t.Fatalf("New() = %v, want it to match ErrDuplicateNodeName", err)
+	}
+	if errors.Is(err, ErrDuplicateEdge) {
+		t.Errorf("New() = %v, want no graph-phase findings while the node phase fails", err)
+	}
+}
+
+// Graph-level checks walk maps, so they sort by node name; without that
+// the reported order (and for New, the error string) would vary per run.
+func TestValidateWorkflow_StableViolationOrder(t *testing.T) {
+	var edges []Edge
+	for _, name := range []string{"C", "A", "D", "B"} {
+		src := newDummyNode(name)
+		edges = append(edges,
+			Edge{From: src, To: newDummyNode(name + "1"), Route: Default},
+			Edge{From: src, To: newDummyNode(name + "2"), Route: Default},
+		)
+	}
+	want := []string{
+		`node has more than one default route: "A"`,
+		`node has more than one default route: "B"`,
+		`node has more than one default route: "C"`,
+		`node has more than one default route: "D"`,
+	}
+	for range 50 {
+		got := violationMessages(validateDefaultRoute(newGraph(edges)))
+		if diff := cmp.Diff(want, got); diff != "" {
+			t.Fatalf("validateDefaultRoute() violations mismatch (-want +got):\n%s", diff)
+		}
 	}
 }
 

--- a/workflow/workflow.go
+++ b/workflow/workflow.go
@@ -227,6 +227,14 @@ func WithStateSchema(s *jsonschema.Resolved) Option {
 //
 // Optional Option values configure engine behaviour
 // (concurrency cap, etc.); see WithMaxConcurrency.
+//
+// Validation runs in phases. Each phase reports every violation it
+// finds so a caller can fix them all in one pass; two or more are
+// combined with errors.Join, and errors.Is still matches the individual
+// sentinels (ErrDuplicateNodeName, ErrMultipleDefaultRoutes, …). A
+// failing phase stops the rest, because later phases assume the earlier
+// ones hold — there is no point checking routing on a graph whose node
+// names collide.
 func New(name string, edges []Edge, opts ...Option) (*Workflow, error) {
 	if err := validateNodes(edges); err != nil {
 		return nil, err


### PR DESCRIPTION
## Problem

`workflow.New` validates a graph with 13 checks, grouped into three
sequential phases (`validateNodes` → `validateSubWorkflowNames` →
`validateWorkflow`). Every check returned the *first* violation it found, and
every phase returned the first failing check. A caller with three mistakes in
their edge list therefore needed three fix-recompile cycles to see all three —
each run revealed exactly one of them.

Which violation surfaced was also non-deterministic: six of the checks iterate
`graph.successors` / `predecessors` / `allNodes`, so on a graph with more than
one violation of the same kind, Go's randomized map iteration decided what the
user was told to fix.

## Summary

- Each phase now runs all of its checks, and each check collects all of its own
  findings; they come back combined with `errors.Join`. Phases still
  short-circuit each other — a later phase assumes the earlier ones hold, and
  there is no point checking routing on a graph whose node names collide.
- Not a breaking change: `errors.Is` matches through joined errors, so code
  keying off `ErrDuplicateNodeName`, `ErrMultipleDefaultRoutes`, … keeps
  working. A lone violation is returned unjoined, so the single-violation case
  is byte-identical to before (including direct `==` against a sentinel).
- Checks that walked a map now iterate nodes in name order, so the reported
  order — and with aggregation, the whole error string — is stable across runs.
- `validateCycles` reports one finding per node that closes a cycle rather than
  one per back-edge. On a complete 400-node graph that is 399 lines / 14 KB
  instead of 79 800 lines / 3 MB.
- `joinViolations` drops repeated identical messages, so two edges breaking one
  rule the same way read as one problem.
- `ErrSubWorkflowNameCollision` now names the offending node; without it,
  multiple collisions produced indistinguishable duplicate lines.

Example, a graph with three mistakes:

```
node has more than one default route: "A" nodes not reachable from start node: "D, E" unconditional cycle detected: "D"
```
