### PR TITLE
docs(examples/agentregistry): add an A2A publish-and-resolve sample

### DIFF
--- a/examples/agentregistry/README.md
+++ b/examples/agentregistry/README.md
@@ -20,7 +20,7 @@ export GOOGLE_CLOUD_PROJECT=your-project
 
 You probably don't have to register anything to try the samples: enabling a supported Google Cloud API auto-registers its **remote MCP server** in your registry. A fresh project typically already lists `run.googleapis.com`, `logging.googleapis.com`, `compute.googleapis.com`, and friends — all of which `bind` can consume as-is.
 
-The client authenticates with ADC and bills the quota project (`GOOGLE_CLOUD_QUOTA_PROJECT`, then the credentials' `quota_project_id` on the ADC path, then `Config.ProjectID` — which these samples take from `GOOGLE_CLOUD_PROJECT`). `gcloud` picks its quota project separately, so pass `--billing-project` to it or an unrelated default can deny the call with `USER_PROJECT_DENIED`.
+The client authenticates with ADC and bills the quota project (`GOOGLE_CLOUD_QUOTA_PROJECT`, the credentials' `quota_project_id`, then `GOOGLE_CLOUD_PROJECT`, in that order). `gcloud` picks its quota project separately, so pass `--billing-project` to it or an unrelated default can deny the call with `USER_PROJECT_DENIED`.
 
 To see what is registered without running any Go code:
 
@@ -33,7 +33,7 @@ Reference: [Agent Registry overview](https://docs.cloud.google.com/agent-registr
 
 ### If you get `403 PERMISSION_DENIED`
 
-Check which project you are actually hitting — `echo $GOOGLE_CLOUD_PROJECT`. A shell profile or a previous `gcloud config set` often leaves a default pointing at a project without the API enabled or without the viewer role, and the resource in the error names the project the call actually went to:
+Check which project you are actually hitting — `echo $GOOGLE_CLOUD_PROJECT`. A shell profile or a previous `gcloud config set` often leaves a default pointing at a project without the API enabled or without the viewer role, and the samples print the project they used on their first line:
 
 ```text
 Failed to list agents: HTTP 403 — PERMISSION_DENIED: Permission 'agentregistry.agents.list'
@@ -41,7 +41,7 @@ denied on resource '//agentregistry.googleapis.com/projects/some-other-project/l
 Grant roles/agentregistry.viewer on this project, or point GOOGLE_CLOUD_PROJECT at one where you have it.
 ```
 
-The message names the exact permission and resource; either grant it or set `GOOGLE_CLOUD_PROJECT` for the run. Both samples condense the API's error envelope like this by unwrapping `*agentregistry.APIError` — see `explain` in either `main.go`.
+The message names the exact permission and resource; either grant it or set `GOOGLE_CLOUD_PROJECT` for the run. `discover` and `bind` condense the API's error envelope like this by unwrapping `*agentregistry.APIError` — see `explain` in either `main.go`.
 
 ## Examples
 
@@ -49,8 +49,9 @@ The message names the exact permission and resource; either grant it or set `GOO
 |---|---|---|
 | [`discover`](./discover) | Browse the catalog: `AllAgents` / `AllMCPServers` / `AllEndpoints` with a server-side filter and automatic paging | No |
 | [`bind`](./bind) | Bind an agent to a *capability*: find the MCP server that declares the tool you need, then `MCPToolset` it | Yes |
+| [`a2a`](./a2a) | Publish an agent of your own, resolve it back with `RemoteAgent`, and talk to it over A2A | No |
 
-Start with `discover` to see what your project has; `bind` then needs no resource names at all.
+Start with `discover` to see what your project has; `bind` then needs no resource names at all. `a2a` is the only one that registers anything, and it is the only place `RemoteAgent` is exercised.
 
 ## How the pieces fit
 
@@ -76,25 +77,9 @@ The dotted line is the point of the whole thing: **the registry is a catalog, ne
 
 ## Registering your own agent
 
-The registry's write surface is the `Service` resource. You create a `Service`; the registry *projects* read-only `Agent` and `McpServer` resources from it — those are what the client reads, and they carry generated IDs like `agentregistry-00000000-0000-0000-630f-070a9d06e171`, not the ID you chose. Get the projected name from `services describe`:
+The registry's write surface is the `Service` resource. You create a `Service`; the registry *projects* read-only `Agent` and `McpServer` resources from it — those are what the client reads, and they carry generated IDs like `agentregistry-00000000-0000-0000-630f-070a9d06e171`, not the ID you chose, so read the projected name back with `services describe --format='value(registryResource)'`.
 
-```bash
-gcloud agent-registry services create my-agent \
-  --location=global --project=$GOOGLE_CLOUD_PROJECT --billing-project=$GOOGLE_CLOUD_PROJECT \
-  --display-name="My Agent" \
-  --agent-spec-type=a2a-agent-card \
-  --agent-spec-content="$(cat agent-card.json)"
-
-gcloud agent-registry services describe my-agent \
-  --location=global --project=$GOOGLE_CLOUD_PROJECT --billing-project=$GOOGLE_CLOUD_PROJECT \
-  --format='value(registryResource)'
-```
-
-Three traps worth knowing before you spend an afternoon on them:
-
-- **Use `--agent-spec-type=a2a-agent-card`, not `no-spec`.** `a2a-agent-card` embeds the card `RemoteAgent` reads. `no-spec` leaves the record with neither a card nor an `A2A_AGENT` protocol, so resolution falls through to the protocol lookup and fails with `A2A connection URI not found`.
-- **The card's `skills` must be non-empty**, each with `id`/`name`/`description`/`tags`, or the create call is rejected.
-- **The card's `protocolBinding` must match how your server actually serves** — `HTTP+JSON` for `a2asrv.NewRESTHandler`, `JSONRPC` for `a2asrv.NewJSONRPCHandler`. A mismatch only shows up as an empty reply at the first message. (The registry stores the binding as `HTTP_JSON`; the client maps that to A2A's `HTTP+JSON`. Both spellings are correct in their own domain.)
+The [`a2a`](./a2a) sample walks the whole loop with a working card, and its notes cover the traps that cost the most time: `a2a-agent-card` versus `no-spec`, the non-empty `skills` requirement, and keeping the card's `protocolBinding` in step with the handler you serve.
 
 ## Core concepts at a glance
 

--- a/examples/agentregistry/README.md
+++ b/examples/agentregistry/README.md
@@ -1,15 +1,15 @@
 # Agent Registry examples
 
-Runnable samples for the **Google Cloud Agent Registry** client (`google.golang.org/adk/v2/agentregistry`) — a governed catalog of A2A agents, MCP servers, and model endpoints. One sample browses the catalog; the other builds an agent out of what it finds.
+Runnable samples for the **Google Cloud Agent Registry** client (`google.golang.org/adk/v2/agentregistry`) — a governed catalog of A2A agents, MCP servers, and model endpoints. One browses the catalog, one builds an agent out of what it finds, one publishes an agent and reaches it back through the catalog.
 
 Every example has its own README with a Mermaid diagram, a goal, run instructions, and an example session.
 
 ## Prerequisites
 
-Both samples talk to the real `agentregistry.googleapis.com`. You need:
+All three samples talk to the real `agentregistry.googleapis.com`. You need:
 
 - a project with the Agent Registry API enabled,
-- `roles/agentregistry.viewer` on it (reading is enough here — without it every call fails with `403 PERMISSION_DENIED`),
+- `roles/agentregistry.viewer` on it — enough for `discover` and `bind`; `a2a` also registers a `Service`, so it needs create and delete permission on top. Without the read role every call fails with `403 PERMISSION_DENIED`,
 - Application Default Credentials.
 
 ```bash
@@ -20,7 +20,7 @@ export GOOGLE_CLOUD_PROJECT=your-project
 
 You probably don't have to register anything to try the samples: enabling a supported Google Cloud API auto-registers its **remote MCP server** in your registry. A fresh project typically already lists `run.googleapis.com`, `logging.googleapis.com`, `compute.googleapis.com`, and friends — all of which `bind` can consume as-is.
 
-The client authenticates with ADC and bills the quota project (`GOOGLE_CLOUD_QUOTA_PROJECT`, the credentials' `quota_project_id`, then `GOOGLE_CLOUD_PROJECT`, in that order). `gcloud` picks its quota project separately, so pass `--billing-project` to it or an unrelated default can deny the call with `USER_PROJECT_DENIED`.
+The client authenticates with ADC and bills the quota project (`GOOGLE_CLOUD_QUOTA_PROJECT`, then the credentials' `quota_project_id` on the ADC path, then `Config.ProjectID` — which these samples take from `GOOGLE_CLOUD_PROJECT`). `gcloud` picks its quota project separately, so pass `--billing-project` to it or an unrelated default can deny the call with `USER_PROJECT_DENIED`.
 
 To see what is registered without running any Go code:
 
@@ -33,7 +33,7 @@ Reference: [Agent Registry overview](https://docs.cloud.google.com/agent-registr
 
 ### If you get `403 PERMISSION_DENIED`
 
-Check which project you are actually hitting — `echo $GOOGLE_CLOUD_PROJECT`. A shell profile or a previous `gcloud config set` often leaves a default pointing at a project without the API enabled or without the viewer role, and the samples print the project they used on their first line:
+Check which project you are actually hitting — `echo $GOOGLE_CLOUD_PROJECT`. A shell profile or a previous `gcloud config set` often leaves a default pointing at a project without the API enabled or without the viewer role, and the resource in the error names the project the call actually went to:
 
 ```text
 Failed to list agents: HTTP 403 — PERMISSION_DENIED: Permission 'agentregistry.agents.list'
@@ -79,7 +79,7 @@ The dotted line is the point of the whole thing: **the registry is a catalog, ne
 
 The registry's write surface is the `Service` resource. You create a `Service`; the registry *projects* read-only `Agent` and `McpServer` resources from it — those are what the client reads, and they carry generated IDs like `agentregistry-00000000-0000-0000-630f-070a9d06e171`, not the ID you chose, so read the projected name back with `services describe --format='value(registryResource)'`.
 
-The [`a2a`](./a2a) sample walks the whole loop with a working card, and its notes cover the traps that cost the most time: `a2a-agent-card` versus `no-spec`, the non-empty `skills` requirement, and keeping the card's `protocolBinding` in step with the handler you serve.
+The [`a2a`](./a2a) sample walks the whole loop with a working card, and its notes cover the traps that cost the most time: `a2a-agent-card` versus `no-spec`, the non-empty `skills` requirement, and keeping the card's `protocolBinding` in step with the handler you serve. Registering is also the one thing here that needs more than the viewer role.
 
 ## Core concepts at a glance
 

--- a/examples/agentregistry/README.md
+++ b/examples/agentregistry/README.md
@@ -41,7 +41,7 @@ denied on resource '//agentregistry.googleapis.com/projects/some-other-project/l
 Grant roles/agentregistry.viewer on this project, or point GOOGLE_CLOUD_PROJECT at one where you have it.
 ```
 
-The message names the exact permission and resource; either grant it or set `GOOGLE_CLOUD_PROJECT` for the run. `discover` and `bind` condense the API's error envelope like this by unwrapping `*agentregistry.APIError` — see `explain` in either `main.go`.
+The message names the exact permission and resource; either grant it or set `GOOGLE_CLOUD_PROJECT` for the run. All three samples condense the API's error envelope like this by unwrapping `*agentregistry.APIError` — see `explain` in any `main.go`.
 
 ## Examples
 

--- a/examples/agentregistry/a2a/README.md
+++ b/examples/agentregistry/a2a/README.md
@@ -21,21 +21,38 @@ In production those are separate deployments. Only the publisher half moves; the
 
 ```mermaid
 sequenceDiagram
-    participant You as Setup (one-time)
+    autonumber
+    actor You as You
     participant AR as Agent Registry
-    participant C as agentregistry.Client
-    participant RA as RemoteAgent
-    participant S as Local A2A server
+    participant Main as main()<br/>consumer half
+    participant Srv as A2A server<br/>localhost:8765
+    participant Echo as registry_echo<br/>(your agent)
 
-    You->>AR: services create (embedded A2A card,<br/>url = http://localhost:8765)
-    AR-->>You: projected agent name
-    Note over AR: the registry stores the card.<br/>It never calls the URL.
-    C->>AR: GetAgent(name)
-    AR-->>C: card + protocols
-    C->>RA: build A2A client from the card
-    RA->>S: sendMessage (HTTP+JSON, direct)
-    S-->>RA: "echo: ..."
+    rect rgb(238,245,255)
+    Note over You,AR: Setup — once, before the sample runs
+    You->>AR: services create — card with url http://localhost:8765
+    AR-->>You: projects/.../agents/agentregistry-...
+    end
+    Note over AR: The registry stores the card.<br/>It never calls the URL inside it.
+
+    Main->>Srv: serve() — expose registry_echo over A2A
+
+    rect rgb(255,249,230)
+    Note over Main,AR: Resolve — the only time the registry is read
+    Main->>AR: RemoteAgent(name), which fetches the record
+    AR-->>Main: card: registry_echo, http://localhost:8765, HTTP+JSON
+    end
+
+    rect rgb(236,252,238)
+    Note over Main,Echo: Exchange — straight to the card's URL, registry not involved
+    Main->>Srv: sendMessage "Hello from the registry!"
+    Srv->>Echo: invoke, UserContent = "Hello from the registry!"
+    Echo-->>Srv: "echo: Hello from the registry!"
+    Srv-->>Main: session.Event
+    end
 ```
+
+The right-hand pair is the same agent seen twice: `registry_echo` is what this process publishes, and `registry_echo` is the name the consumer half learns from the catalog. The message text is what makes the loop legible — it leaves `main()`, reaches your `agent.New` as `UserContent`, and comes back prefixed.
 
 ## Setup
 

--- a/examples/agentregistry/a2a/README.md
+++ b/examples/agentregistry/a2a/README.md
@@ -97,8 +97,9 @@ That prints the name in project-number form; the client accepts either that or t
 
 ## Running the sample
 
+Setup already exported `GOOGLE_CLOUD_PROJECT` and `REGISTRY_AGENT`, so nothing else is needed:
+
 ```bash
-export GOOGLE_CLOUD_LOCATION=global
 go run ./examples/agentregistry/a2a/
 ```
 

--- a/examples/agentregistry/a2a/README.md
+++ b/examples/agentregistry/a2a/README.md
@@ -1,0 +1,123 @@
+# Publishing an agent and reaching it through the registry
+
+Register an agent of your own, then resolve it back out of the catalog and talk to it over A2A. This is the other factory helper: [`bind`](../bind) covers `MCPToolset`, this covers `Client.RemoteAgent`.
+
+- **Concept:** the registry hands you a card and a URL; the A2A conversation is yours alone.
+- **Needs LLM?** No — the published agent is a canned echo, so all you need is ADC.
+- **Needs a registry?** Yes, plus a one-time registration — see [Setup](#setup).
+
+## Goal
+
+Show the fact that surprises people first: **the registry is a catalog, not a proxy.** It stores your agent card and never calls the URL inside it. So the card can point at `http://localhost:8765`, and the loop closes with nothing deployed — no Cloud Run service, no tunnel, no public endpoint.
+
+The sample plays both roles in one process so it runs in one terminal:
+
+- the **publisher** serves an agent over A2A at that address,
+- the **consumer** knows only a registry resource name, and gets the URL, the transport, and the agent's identity from the catalog.
+
+In production those are separate deployments. Only the publisher half moves; the consumer half is exactly what any caller writes.
+
+## Workflow
+
+```mermaid
+sequenceDiagram
+    participant You as Setup (one-time)
+    participant AR as Agent Registry
+    participant C as agentregistry.Client
+    participant RA as RemoteAgent
+    participant S as Local A2A server
+
+    You->>AR: services create (embedded A2A card,<br/>url = http://localhost:8765)
+    AR-->>You: projected agent name
+    Note over AR: the registry stores the card.<br/>It never calls the URL.
+    C->>AR: GetAgent(name)
+    AR-->>C: card + protocols
+    C->>RA: build A2A client from the card
+    RA->>S: sendMessage (HTTP+JSON, direct)
+    S-->>RA: "echo: ..."
+```
+
+## Setup
+
+Register the agent once. The card's `url` must match where the sample serves, and its `protocolBinding` must match the handler the sample uses (`HTTP+JSON` ↔ `a2asrv.NewRESTHandler`).
+
+```bash
+export GOOGLE_CLOUD_PROJECT=your-project
+
+cat > /tmp/card.json <<'EOF'
+{
+  "name": "registry_echo",
+  "description": "Echo agent published from a local process.",
+  "version": "1.0.0",
+  "supportedInterfaces": [
+    { "url": "http://localhost:8765", "protocolBinding": "HTTP+JSON", "protocolVersion": "1.0" }
+  ],
+  "capabilities": { "streaming": true },
+  "defaultInputModes": ["text/plain"],
+  "defaultOutputModes": ["text/plain"],
+  "skills": [
+    { "id": "echo", "name": "Echo", "description": "Repeats the message back.", "tags": ["demo"] }
+  ]
+}
+EOF
+
+gcloud agent-registry services create adk-a2a-demo \
+  --location=global --project=$GOOGLE_CLOUD_PROJECT --billing-project=$GOOGLE_CLOUD_PROJECT \
+  --display-name="ADK A2A sample" \
+  --agent-spec-type=a2a-agent-card \
+  --agent-spec-content=@/tmp/card.json
+```
+
+The `Service` you created projects a read-only `Agent`, and that projection is what the client reads. Ask for its name:
+
+```bash
+export REGISTRY_AGENT=$(gcloud agent-registry services describe adk-a2a-demo \
+  --location=global --project=$GOOGLE_CLOUD_PROJECT --billing-project=$GOOGLE_CLOUD_PROJECT \
+  --format='value(registryResource)')
+```
+
+That prints the name in project-number form; the client accepts either that or the project-ID form.
+
+## Running the sample
+
+```bash
+export GOOGLE_CLOUD_LOCATION=global
+go run ./examples/agentregistry/a2a/
+```
+
+| Variable | Required | Meaning |
+|---|---|---|
+| `GOOGLE_CLOUD_PROJECT` | yes | Project whose registry is read |
+| `GOOGLE_CLOUD_LOCATION` | no | Registry location, defaults to `global` |
+| `REGISTRY_AGENT` | yes | Resource name of the projected agent |
+| `A2A_ADDR` | no | Where to serve, defaults to `localhost:8765`; must match the card |
+
+## Example session
+
+```text
+Serving an agent over A2A at http://localhost:8765
+Resolved "registry_echo" from the registry; the URL and transport came from its card
+
+>>> Hello from the registry!
+
+<<< echo: Hello from the registry!
+```
+
+`registry_echo` is the name from the **card**, not from the local `agent.New` — proof the identity came out of the catalog. The reply carries the request text back, so both directions of the exchange are covered.
+
+## Cleaning up
+
+```bash
+gcloud agent-registry services delete adk-a2a-demo \
+  --location=global --project=$GOOGLE_CLOUD_PROJECT --billing-project=$GOOGLE_CLOUD_PROJECT
+```
+
+Deleting the `Service` removes the projected agent from the catalog.
+
+## Notes
+
+- **`--agent-spec-type=a2a-agent-card`, not `no-spec`.** `RemoteAgent` looks for a protocol of type `A2A_AGENT`; `no-spec` registers a `CUSTOM` one, and resolution fails with `A2A connection URI not found`.
+- **`skills` must be non-empty**, each with `id`/`name`/`description`/`tags`, or the create call is rejected.
+- **Egress auth is yours.** Nothing here needs it because localhost is not behind IAM. A published agent that is behind IAM needs `WithA2AHTTPClient` — and the right scopes for *that* agent, which are not always `cloud-platform`.
+- **A failed A2A call is quiet.** It arrives as an event with `LLMResponse.ErrorMessage` set and no content, which reads as an empty answer if you only look at content; `ask` checks for it explicitly.
+- **No embedded card? Still fine.** When a record has no `A2A_AGENT_CARD`, `RemoteAgent` synthesizes one from the record's protocols. Both paths end in the same `agent.Agent`.

--- a/examples/agentregistry/a2a/README.md
+++ b/examples/agentregistry/a2a/README.md
@@ -4,7 +4,7 @@ Register an agent of your own, then resolve it back out of the catalog and talk 
 
 - **Concept:** the registry hands you a card and a URL; the A2A conversation is yours alone.
 - **Needs LLM?** No — the published agent is a canned echo, so all you need is ADC.
-- **Needs a registry?** Yes, plus a one-time registration — see [Setup](#setup).
+- **Needs a registry?** Yes, plus a one-time registration — see [Prerequisites](../README.md#prerequisites) and [Setup](#setup).
 
 ## Goal
 
@@ -56,6 +56,8 @@ sequenceDiagram
 
 ## Setup
 
+On top of the [shared prerequisites](../README.md#prerequisites) this sample **writes** to the registry, so `roles/agentregistry.viewer` is not enough: you need create and delete permission on Agent Registry `Services`.
+
 Register the agent once. The card's `url` must match where the sample serves, and its `protocolBinding` must match the handler the sample uses (`HTTP+JSON` ↔ `a2asrv.NewRESTHandler`).
 
 ```bash
@@ -82,7 +84,7 @@ gcloud agent-registry services create adk-a2a-demo \
   --location=global --project=$GOOGLE_CLOUD_PROJECT --billing-project=$GOOGLE_CLOUD_PROJECT \
   --display-name="ADK A2A sample" \
   --agent-spec-type=a2a-agent-card \
-  --agent-spec-content=@/tmp/card.json
+  --agent-spec-content=/tmp/card.json
 ```
 
 The `Service` you created projects a read-only `Agent`, and that projection is what the client reads. Ask for its name:
@@ -105,9 +107,9 @@ go run ./examples/agentregistry/a2a/
 
 | Variable | Required | Meaning |
 |---|---|---|
-| `GOOGLE_CLOUD_PROJECT` | yes | Project whose registry is read |
-| `GOOGLE_CLOUD_LOCATION` | no | Registry location, defaults to `global` |
-| `REGISTRY_AGENT` | yes | Resource name of the projected agent |
+| `GOOGLE_CLOUD_PROJECT` | yes | Quota project billed for the registry calls — the project *read* comes from `REGISTRY_AGENT` |
+| `GOOGLE_CLOUD_LOCATION` | no | Client location, defaults to `global`; only the value inside `REGISTRY_AGENT` selects what is read |
+| `REGISTRY_AGENT` | yes | Resource name of the projected agent; being absolute, it carries its own project and location |
 | `A2A_ADDR` | no | Where to serve, defaults to `localhost:8765`; must match the card |
 
 ## Example session
@@ -121,7 +123,7 @@ Resolved "registry_echo" from the registry; the URL and transport came from its 
 <<< echo: Hello from the registry!
 ```
 
-`registry_echo` is the name from the **card**, not from the local `agent.New` — proof the identity came out of the catalog. The reply carries the request text back, so both directions of the exchange are covered.
+`registry_echo` is the name the client read from the **card** — though the local `agent.New` uses that name too, so it is the code, not the line, that shows where it came from: the consuming half never names the agent. The reply carries the request text back, so both directions of the exchange are covered.
 
 ## Cleaning up
 
@@ -134,8 +136,9 @@ Deleting the `Service` removes the projected agent from the catalog.
 
 ## Notes
 
-- **`--agent-spec-type=a2a-agent-card`, not `no-spec`.** `RemoteAgent` looks for a protocol of type `A2A_AGENT`; `no-spec` registers a `CUSTOM` one, and resolution fails with `A2A connection URI not found`.
+- **`--agent-spec-type=a2a-agent-card`, not `no-spec`.** `a2a-agent-card` embeds the card the client reads. `no-spec` leaves the record with neither a card nor an `A2A_AGENT` protocol, so resolution falls through to the protocol lookup and fails with `A2A connection URI not found`.
 - **`skills` must be non-empty**, each with `id`/`name`/`description`/`tags`, or the create call is rejected.
+- **Keep `protocolBinding` in step with the handler you serve** — `HTTP+JSON` for `a2asrv.NewRESTHandler`, `JSONRPC` for `a2asrv.NewJSONRPCHandler`. A mismatch only shows up as an empty reply at the first message. Write the A2A spelling in the card even though `agents describe` reads the binding back as `HTTP_JSON`: the client maps the registry's wire value for you, but a card that *contains* `HTTP_JSON` is unmarshalled verbatim and matches no transport, which fails with `no compatible transports found`.
 - **Egress auth is yours.** Nothing here needs it because localhost is not behind IAM. A published agent that is behind IAM needs `WithA2AHTTPClient` — and the right scopes for *that* agent, which are not always `cloud-platform`.
-- **A failed A2A call is quiet.** It arrives as an event with `LLMResponse.ErrorMessage` set and no content, which reads as an empty answer if you only look at content; `ask` checks for it explicitly.
-- **No embedded card? Still fine.** When a record has no `A2A_AGENT_CARD`, `RemoteAgent` synthesizes one from the record's protocols. Both paths end in the same `agent.Agent`.
+- **A failed A2A call is quiet.** It arrives as an event with `LLMResponse.ErrorMessage` set — and, from an ADK-served agent, no content at all — so it reads as an empty answer if you only look at content. `ask` checks for it explicitly, and likewise skips partial events, because a streaming agent sends its text once in chunks and again as one aggregated event.
+- **No embedded card? Still fine.** When a record has no `A2A_AGENT_CARD`, `RemoteAgent` synthesizes one from the record's protocols. Both paths produce an `agent.Agent`, but not an identical one: the synthesized card takes its name from the record's display name and defaults its input and output modes to text.

--- a/examples/agentregistry/a2a/README.md
+++ b/examples/agentregistry/a2a/README.md
@@ -12,10 +12,10 @@ Show the fact that surprises people first: **the registry is a catalog, not a pr
 
 The sample plays both roles in one process so it runs in one terminal:
 
-- the **publisher** serves an agent over A2A at that address,
-- the **consumer** knows only a registry resource name, and gets the URL, the transport, and the agent's identity from the catalog.
+- as **publisher** it serves an agent over A2A at that address,
+- as **consumer** it knows only a registry resource name, and gets the URL, the transport, and the agent's identity from the catalog.
 
-In production those are separate deployments. Only the publisher half moves; the consumer half is exactly what any caller writes.
+In production these are separate programs. The consuming code is unchanged — it is what any caller writes; the publishing code is what the agent's owner deploys.
 
 ## Workflow
 
@@ -24,7 +24,7 @@ sequenceDiagram
     autonumber
     actor You as You
     participant AR as Agent Registry
-    participant Main as main()<br/>consumer half
+    participant Main as main()
     participant Srv as A2A server<br/>localhost:8765
     participant Echo as registry_echo<br/>(your agent)
 
@@ -52,7 +52,7 @@ sequenceDiagram
     end
 ```
 
-The right-hand pair is the same agent seen twice: `registry_echo` is what this process publishes, and `registry_echo` is the name the consumer half learns from the catalog. The message text is what makes the loop legible — it leaves `main()`, reaches your `agent.New` as `UserContent`, and comes back prefixed.
+`main()` appears once because it is one process: step 3 is it publishing, steps 4-9 are it consuming. And `registry_echo` is the same agent seen twice — the name this process serves under, and the name that comes back out of the catalog at resolve time. The message text is what makes the loop legible: it leaves `main()`, reaches your `agent.New` as `UserContent`, and comes back prefixed.
 
 ## Setup
 

--- a/examples/agentregistry/a2a/README.md
+++ b/examples/agentregistry/a2a/README.md
@@ -114,7 +114,10 @@ go run ./examples/agentregistry/a2a/
 
 ## Example session
 
+No model runs here, so with the card from [Setup](#setup) the output is exactly this:
+
 ```text
+$ go run ./examples/agentregistry/a2a/
 Serving an agent over A2A at http://localhost:8765
 Resolved "registry_echo" from the registry; the URL and transport came from its card
 
@@ -123,7 +126,7 @@ Resolved "registry_echo" from the registry; the URL and transport came from its 
 <<< echo: Hello from the registry!
 ```
 
-`registry_echo` is the name the client read from the **card** — though the local `agent.New` uses that name too, so it is the code, not the line, that shows where it came from: the consuming half never names the agent. The reply carries the request text back, so both directions of the exchange are covered.
+`registry_echo` came off the **card**, not out of the consuming code, which never names the agent. The line alone cannot show that, because the local `agent.New` serves under the same name — the code is where it is visible. The reply carries the request text back, so both directions of the exchange are covered.
 
 ## Cleaning up
 

--- a/examples/agentregistry/a2a/main.go
+++ b/examples/agentregistry/a2a/main.go
@@ -1,0 +1,173 @@
+// Copyright 2026 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+// Package main closes the Agent Registry loop for A2A: it serves an agent over
+// A2A, resolves that same agent back out of the registry, and exchanges a
+// message with it.
+//
+// One process plays both roles so the loop runs in one terminal. In production
+// they are separate deployments, and only the publishing half moves — the
+// consuming half below is what any caller writes.
+package main
+
+import (
+	"cmp"
+	"context"
+	"fmt"
+	"iter"
+	"log"
+	"net/http"
+	"os"
+	"strings"
+	"time"
+
+	"github.com/a2aproject/a2a-go/v2/a2asrv"
+	"google.golang.org/genai"
+
+	"google.golang.org/adk/v2/agent"
+	"google.golang.org/adk/v2/agentregistry"
+	"google.golang.org/adk/v2/model"
+	"google.golang.org/adk/v2/runner"
+	adka2a "google.golang.org/adk/v2/server/adka2a/v2"
+	"google.golang.org/adk/v2/session"
+)
+
+func main() {
+	ctx := context.Background()
+
+	project := os.Getenv("GOOGLE_CLOUD_PROJECT")
+	if project == "" {
+		log.Fatal("GOOGLE_CLOUD_PROJECT must be set")
+	}
+	location := cmp.Or(os.Getenv("GOOGLE_CLOUD_LOCATION"), "global")
+	name := os.Getenv("REGISTRY_AGENT")
+	if name == "" {
+		log.Fatal("REGISTRY_AGENT must be set to the agent resource name from registration; see the README")
+	}
+	// Must match the URL in the card that was registered.
+	addr := cmp.Or(os.Getenv("A2A_ADDR"), "localhost:8765")
+
+	// Publisher half.
+	srv, err := serve(addr)
+	if err != nil {
+		log.Fatalf("Failed to start the A2A server: %v", err)
+	}
+	defer func() { _ = srv.Close() }()
+	log.Printf("Serving an agent over A2A at http://%s", addr)
+
+	// Consumer half: everything below only knows the registry resource name.
+	client, err := agentregistry.New(ctx, agentregistry.Config{
+		ProjectID: project,
+		Location:  location,
+	})
+	if err != nil {
+		log.Fatalf("Failed to create the registry client: %v", err)
+	}
+
+	// No egress options: the registered card points at localhost, which is not
+	// behind IAM. An agent that is needs WithA2AHTTPClient.
+	remote, err := client.RemoteAgent(ctx, name)
+	if err != nil {
+		log.Fatalf("Failed to resolve %q: %v", name, err)
+	}
+	log.Printf("Resolved %q from the registry; the URL and transport came from its card", remote.Name())
+
+	reply, err := ask(ctx, remote, "Hello from the registry!")
+	if err != nil {
+		log.Fatalf("Failed to reach the agent over A2A: %v", err)
+	}
+	fmt.Printf("\n<<< %s\n", reply)
+}
+
+// ask runs one turn against the agent and returns its text.
+func ask(ctx context.Context, a agent.Agent, prompt string) (string, error) {
+	r, err := runner.New(runner.Config{
+		AppName:           a.Name(),
+		Agent:             a,
+		SessionService:    session.InMemoryService(),
+		AutoCreateSession: true,
+	})
+	if err != nil {
+		return "", err
+	}
+	fmt.Printf("\n>>> %s\n", prompt)
+
+	var reply strings.Builder
+	for event, err := range r.Run(ctx, "user", "session", genai.NewContentFromText(prompt, genai.RoleUser), agent.RunConfig{}) {
+		if err != nil {
+			return "", err
+		}
+		// A failed A2A call arrives as an event carrying an error and no
+		// content, which would otherwise read as a silent empty answer.
+		if event.LLMResponse.ErrorMessage != "" {
+			return "", fmt.Errorf("remote agent: %s", event.LLMResponse.ErrorMessage)
+		}
+		if event.LLMResponse.Content != nil {
+			for _, part := range event.LLMResponse.Content.Parts {
+				reply.WriteString(part.Text)
+			}
+		}
+	}
+	if reply.Len() == 0 {
+		return "", fmt.Errorf("empty reply")
+	}
+	return reply.String(), nil
+}
+
+// serve exposes a canned agent over A2A. It echoes the request so a successful
+// run proves both directions of the exchange, and needs no model credentials.
+func serve(addr string) (*http.Server, error) {
+	echo, err := agent.New(agent.Config{
+		Name: "registry_echo",
+		Run: func(ictx agent.InvocationContext) iter.Seq2[*session.Event, error] {
+			return func(yield func(*session.Event, error) bool) {
+				var got strings.Builder
+				if c := ictx.UserContent(); c != nil {
+					for _, part := range c.Parts {
+						got.WriteString(part.Text)
+					}
+				}
+				yield(&session.Event{LLMResponse: model.LLMResponse{
+					Content: genai.NewContentFromText("echo: "+got.String(), genai.RoleModel),
+				}}, nil)
+			}
+		},
+	})
+	if err != nil {
+		return nil, err
+	}
+
+	handler := a2asrv.NewHandler(adka2a.NewExecutor(adka2a.ExecutorConfig{
+		RunnerConfig: runner.Config{
+			AppName:        echo.Name(),
+			Agent:          echo,
+			SessionService: session.InMemoryService(),
+		},
+	}))
+	// The card registered for this agent declares HTTP+JSON, so serve REST.
+	srv := &http.Server{Addr: addr, Handler: a2asrv.NewRESTHandler(handler)}
+
+	failed := make(chan error, 1)
+	go func() {
+		if err := srv.ListenAndServe(); err != nil && err != http.ErrServerClosed {
+			failed <- err
+		}
+	}()
+	select {
+	case err := <-failed:
+		return nil, err
+	case <-time.After(300 * time.Millisecond):
+		return srv, nil
+	}
+}

--- a/examples/agentregistry/a2a/main.go
+++ b/examples/agentregistry/a2a/main.go
@@ -16,9 +16,10 @@
 // A2A, resolves that same agent back out of the registry, and exchanges a
 // message with it.
 //
-// One process plays both roles so the loop runs in one terminal. In production
-// they are separate deployments, and only the publishing half moves — the
-// consuming half below is what any caller writes.
+// One process plays both roles so the loop runs in one terminal: it publishes
+// the agent, then consumes it through the registry. In production those are
+// separate programs, and the consuming code below is unchanged — it is what any
+// caller writes.
 package main
 
 import (
@@ -58,7 +59,7 @@ func main() {
 	// Must match the URL in the card that was registered.
 	addr := cmp.Or(os.Getenv("A2A_ADDR"), "localhost:8765")
 
-	// Publisher half.
+	// Publishing: in production this is the agent owner's deployment.
 	srv, err := serve(addr)
 	if err != nil {
 		log.Fatalf("Failed to start the A2A server: %v", err)
@@ -66,7 +67,7 @@ func main() {
 	defer func() { _ = srv.Close() }()
 	log.Printf("Serving an agent over A2A at http://%s", addr)
 
-	// Consumer half: everything below only knows the registry resource name.
+	// Consuming: everything below knows only the registry resource name.
 	client, err := agentregistry.New(ctx, agentregistry.Config{
 		ProjectID: project,
 		Location:  location,

--- a/examples/agentregistry/a2a/main.go
+++ b/examples/agentregistry/a2a/main.go
@@ -25,9 +25,12 @@ package main
 import (
 	"cmp"
 	"context"
+	"encoding/json"
+	"errors"
 	"fmt"
 	"iter"
 	"log"
+	"net"
 	"net/http"
 	"os"
 	"strings"
@@ -45,16 +48,23 @@ import (
 )
 
 func main() {
-	ctx := context.Background()
+	// Output here is a transcript, not a log: the timestamp prefix is noise.
+	log.SetFlags(0)
+	// run owns the listener; log.Fatal inside it would skip the deferred close.
+	if err := run(context.Background()); err != nil {
+		log.Fatal(err)
+	}
+}
 
+func run(ctx context.Context) error {
 	project := os.Getenv("GOOGLE_CLOUD_PROJECT")
 	if project == "" {
-		log.Fatal("GOOGLE_CLOUD_PROJECT must be set")
+		return errors.New("GOOGLE_CLOUD_PROJECT must be set")
 	}
 	location := cmp.Or(os.Getenv("GOOGLE_CLOUD_LOCATION"), "global")
 	name := os.Getenv("REGISTRY_AGENT")
 	if name == "" {
-		log.Fatal("REGISTRY_AGENT must be set to the agent resource name from registration; see the README")
+		return errors.New("REGISTRY_AGENT must be set to the agent resource name from registration; see the README")
 	}
 	// Must match the URL in the card that was registered.
 	addr := cmp.Or(os.Getenv("A2A_ADDR"), "localhost:8765")
@@ -62,7 +72,7 @@ func main() {
 	// Publishing: in production this is the agent owner's deployment.
 	srv, err := serve(addr)
 	if err != nil {
-		log.Fatalf("Failed to start the A2A server: %v", err)
+		return fmt.Errorf("failed to start the A2A server: %w", err)
 	}
 	defer func() { _ = srv.Close() }()
 	log.Printf("Serving an agent over A2A at http://%s", addr)
@@ -73,22 +83,23 @@ func main() {
 		Location:  location,
 	})
 	if err != nil {
-		log.Fatalf("Failed to create the registry client: %v", err)
+		return fmt.Errorf("failed to create the registry client: %w", err)
 	}
 
 	// No egress options: the registered card points at localhost, which is not
 	// behind IAM. An agent that is needs WithA2AHTTPClient.
 	remote, err := client.RemoteAgent(ctx, name)
 	if err != nil {
-		log.Fatalf("Failed to resolve %q: %v", name, err)
+		return fmt.Errorf("failed to resolve %q: %s", name, explain(err))
 	}
 	log.Printf("Resolved %q from the registry; the URL and transport came from its card", remote.Name())
 
 	reply, err := ask(ctx, remote, "Hello from the registry!")
 	if err != nil {
-		log.Fatalf("Failed to reach the agent over A2A: %v", err)
+		return fmt.Errorf("failed to reach the agent over A2A: %w", err)
 	}
 	fmt.Printf("\n<<< %s\n", reply)
+	return nil
 }
 
 // ask runs one turn against the agent and returns its text.
@@ -109,10 +120,16 @@ func ask(ctx context.Context, a agent.Agent, prompt string) (string, error) {
 		if err != nil {
 			return "", err
 		}
-		// A failed A2A call arrives as an event carrying an error and no
-		// content, which would otherwise read as a silent empty answer.
+		// A failed A2A call arrives as an event carrying an error, which would
+		// otherwise read as the agent simply having nothing to say.
 		if event.LLMResponse.ErrorMessage != "" {
 			return "", fmt.Errorf("remote agent: %s", event.LLMResponse.ErrorMessage)
+		}
+		// A streaming agent sends each chunk as a partial event and then the
+		// whole text again in one non-partial event; progress notes arrive as
+		// partials too. Summing both would return the answer twice.
+		if event.LLMResponse.Partial {
+			continue
 		}
 		if event.LLMResponse.Content != nil {
 			for _, part := range event.LLMResponse.Content.Parts {
@@ -121,7 +138,7 @@ func ask(ctx context.Context, a agent.Agent, prompt string) (string, error) {
 		}
 	}
 	if reply.Len() == 0 {
-		return "", fmt.Errorf("empty reply")
+		return "", errors.New("empty reply")
 	}
 	return reply.String(), nil
 }
@@ -156,19 +173,53 @@ func serve(addr string) (*http.Server, error) {
 			SessionService: session.InMemoryService(),
 		},
 	}))
-	// The card registered for this agent declares HTTP+JSON, so serve REST.
-	srv := &http.Server{Addr: addr, Handler: a2asrv.NewRESTHandler(handler)}
+	srv := &http.Server{
+		// The card registered for this agent declares HTTP+JSON, so serve REST.
+		Handler: a2asrv.NewRESTHandler(handler),
+		// Only localhost here, but readers copy sample servers into deployments.
+		ReadHeaderTimeout: 10 * time.Second,
+	}
 
-	failed := make(chan error, 1)
+	// Bind before returning: net.Listen either takes the port or says why not,
+	// so the caller never races a server that has not come up yet.
+	ln, err := net.Listen("tcp", addr)
+	if err != nil {
+		return nil, err
+	}
 	go func() {
-		if err := srv.ListenAndServe(); err != nil && err != http.ErrServerClosed {
-			failed <- err
+		if err := srv.Serve(ln); err != nil && !errors.Is(err, http.ErrServerClosed) {
+			log.Printf("A2A server stopped: %v", err)
 		}
 	}()
-	select {
-	case err := <-failed:
-		return nil, err
-	case <-time.After(300 * time.Millisecond):
-		return srv, nil
+	return srv, nil
+}
+
+// explain renders a registry failure as something a human can act on. The
+// service reports a denial as a screenful of JSON, so unwrap the typed
+// [agentregistry.APIError] and keep the parts that identify the fix.
+//
+// It returns text, not an error: wrapping the result back into one with %w
+// would re-append the envelope it exists to suppress.
+func explain(err error) string {
+	var apiErr *agentregistry.APIError
+	if !errors.As(err, &apiErr) {
+		return err.Error()
 	}
+	var envelope struct {
+		Error struct {
+			Message string `json:"message"`
+			Status  string `json:"status"`
+		} `json:"error"`
+	}
+	detail := apiErr.Body
+	if json.Unmarshal([]byte(apiErr.Body), &envelope) == nil && envelope.Error.Message != "" {
+		detail = envelope.Error.Message
+		if envelope.Error.Status != "" {
+			detail = envelope.Error.Status + ": " + detail
+		}
+	}
+	if apiErr.StatusCode == http.StatusForbidden {
+		detail += "\nGrant roles/agentregistry.viewer on this project, or point GOOGLE_CLOUD_PROJECT at one where you have it."
+	}
+	return fmt.Sprintf("HTTP %d — %s", apiErr.StatusCode, detail)
 }


### PR DESCRIPTION
## Problem

Stacked on #1266.

That PR covers discovery and `MCPToolset`, but leaves `RemoteAgent` documented
and never exercised. The reason is that the only A2A agent in a stock registry
is Google-managed, and calling it needs that product's own OAuth scopes — an
ADC token scoped to `cloud-platform` comes back with
`403 PERMISSION_DENIED: Request had insufficient authentication scopes`. So the
half of the client that resolves agents had no runnable example, and the setup
that would make one work was undocumented.

## Summary

Adds `examples/agentregistry/a2a/`, which registers an agent of your own and
then reaches it back through the catalog.

The sample turns on one property of the service: **the registry stores the card
and never calls the URL inside it.** So the card can point at
`http://localhost:8765` and the whole loop closes with nothing deployed — no
Cloud Run service, no tunnel, no public endpoint. The published agent is a
canned echo, so the sample needs no model credentials either; ADC is enough.

- One process plays both roles — it serves the agent over A2A and consumes it
  through the registry — so the loop runs in one terminal. The consuming half
  only ever knows a resource name; the URL, the transport and the agent's
  identity all come out of the card.
- The echo replies with the request text, so a green run covers both directions
  rather than just proving something came back.
- `ask` fails loudly on `LLMResponse.ErrorMessage`. A rejected A2A call arrives
  as an event with an error and no content, which otherwise reads as the agent
  simply having nothing to say.
- The README carries the one-time `gcloud services create` recipe, the
  `services describe --format='value(registryResource)'` step for the projected
  agent name, and a delete command to clean up.
- The index's registration section shrinks to the `Service` → projection
  concept and defers to the sample for the working card, so the traps are
  documented once instead of twice.

Verified against a live Agent Registry: the exact card JSON in the README was
registered, the sample run against it, and the pasted session is its real
output. Both the project-number form that `gcloud` prints and the project-ID
form resolve. The throwaway `Service` was deleted afterwards and the catalog
confirmed clean.