### PR TITLE
test(remoteagent): de-flake the A2A cleanup propagation tests (#1131, #1145)

### DIFF
--- a/agent/remoteagent/a2a_agent_compat_test.go
+++ b/agent/remoteagent/a2a_agent_compat_test.go
@@ -18,6 +18,8 @@ import (
 	"context"
 	"iter"
 	"net/http/httptest"
+	"strings"
+	"sync"
 	"testing"
 	"time"
 
@@ -33,6 +35,7 @@ import (
 	"google.golang.org/adk/agent"
 	"google.golang.org/adk/agent/llmagent"
 	icontext "google.golang.org/adk/internal/context"
+	"google.golang.org/adk/internal/testutil"
 	"google.golang.org/adk/internal/utils"
 	"google.golang.org/adk/model"
 	"google.golang.org/adk/runner"
@@ -679,9 +682,11 @@ func newRootAgent(name string, subAgent agent.Agent) agent.Agent {
 }
 
 func TestCompat_A2ACleanupPropagation(t *testing.T) {
+	remoteTaskIDChan, remoteCleanupCalledChan := make(chan legacyA2A.TaskID, 1), make(chan struct{}, 2)
+	// Artifact text the mock subagent streams; the cancel step keys off it.
+	const remoteArtifactText = "remote-subagent-working"
 	// Remote A2A server publishes a submitted task and start generating artifact updates
 	// until it detects a context cancelation
-	remoteTaskIDChan, remoteCleanupCalledChan := make(chan legacyA2A.TaskID, 1), make(chan struct{}, 2)
 	serverB := startLegacyA2AServer(t, &mockLegacyExecutor{
 		cancelFn: func(ctx context.Context, reqCtx *legacyASrv.RequestContext, queue legacyEQ.Queue) error {
 			event := legacyA2A.NewStatusUpdateEvent(reqCtx, legacyA2A.TaskStateCanceled, nil)
@@ -694,7 +699,7 @@ func TestCompat_A2ACleanupPropagation(t *testing.T) {
 				return err
 			}
 			for ctx.Err() == nil {
-				if err := queue.Write(ctx, legacyA2A.NewArtifactEvent(reqCtx, legacyA2A.TextPart{Text: "foo"})); err != nil {
+				if err := queue.Write(ctx, legacyA2A.NewArtifactEvent(reqCtx, legacyA2A.TextPart{Text: remoteArtifactText})); err != nil {
 					return err
 				}
 				time.Sleep(1 * time.Millisecond)
@@ -731,27 +736,44 @@ func TestCompat_A2ACleanupPropagation(t *testing.T) {
 
 	client := newLegacyA2AClient(t, serverA)
 
-	// Send a streaming message in a detached goroutine, passing status update through chan
+	// Join the detached streaming/cancel goroutines before teardown; a late
+	// t.Errorf from an in-flight RPC on a finished test would panic.
+	var wg sync.WaitGroup
+	t.Cleanup(wg.Wait)
+
+	// remoteStreamingChan closes when the subagent's own output first reaches the client.
 	statusUpdateEventChan := make(chan legacyA2A.Event, 10)
+	remoteStreamingChan := make(chan struct{})
+	wg.Add(1)
 	go func() {
+		defer wg.Done()
 		defer close(statusUpdateEventChan)
+		remoteStreaming := false
 		msg := legacyA2A.NewMessage(legacyA2A.MessageRoleUser, legacyA2A.TextPart{Text: "work"})
 		for event, err := range client.SendStreamingMessage(t.Context(), &legacyA2A.MessageSendParams{Message: msg}) {
 			if err != nil {
 				t.Errorf("client.SendStreamingMessage() error = %v", err)
 				return
 			}
-			if _, ok := event.(*legacyA2A.TaskArtifactUpdateEvent); ok {
+			if tau, ok := event.(*legacyA2A.TaskArtifactUpdateEvent); ok {
+				if !remoteStreaming && artifactContainsText(tau, remoteArtifactText) {
+					remoteStreaming = true
+					close(remoteStreamingChan)
+				}
 				continue
 			}
 			statusUpdateEventChan <- event
 		}
 	}()
 
-	// Issue a task cancellation request
+	// Cancel only after the subagent's output reaches the client: before that the
+	// parent doesn't know the subagent task ID, so cancellation can't propagate.
 	taskID := (<-statusUpdateEventChan).TaskInfo().TaskID
+	testutil.AwaitN(t, remoteStreamingChan, 1, "remote subagent streaming")
 	cancelResultChan := make(chan *legacyA2A.Task, 1)
+	wg.Add(1)
 	go func() {
+		defer wg.Done()
 		defer close(cancelResultChan)
 		task, err := client.CancelTask(t.Context(), &legacyA2A.TaskIDParams{ID: taskID})
 		if err != nil {
@@ -775,29 +797,16 @@ func TestCompat_A2ACleanupPropagation(t *testing.T) {
 	}
 
 	// Check subagent task got cancelled when the parent task was cancelled.
-	// Reads from channel twice because cleanup gets called both for cancelation and execution.
-	timeout := time.After(5 * time.Second)
-	for range 2 {
-		select {
-		case <-remoteCleanupCalledChan:
-		case <-timeout:
-			t.Fatalf("remote cleanup was not called")
-		}
-	}
+	// Subagent cleanup fires twice: once for cancelation, once for execution.
+	// A generous per-wait deadline avoids flaking under CPU contention.
+	testutil.AwaitN(t, remoteCleanupCalledChan, 2, "remote cleanup")
 	var remoteTaskID legacyA2A.TaskID
 	select {
 	case remoteTaskID = <-remoteTaskIDChan:
 	case <-time.After(1 * time.Second):
 		t.Fatal("server B was never reached; remoteTaskIDChan is empty")
 	}
-
-	for range 2 {
-		select {
-		case <-executorCleanupCalledChan:
-		case <-timeout:
-			t.Fatalf("executor cleanup was not called")
-		}
-	}
+	testutil.AwaitN(t, executorCleanupCalledChan, 2, "executor cleanup")
 
 	remoteClient := newLegacyA2AClient(t, serverB)
 	remoteTask, err := remoteClient.GetTask(t.Context(), &legacyA2A.TaskQueryParams{ID: remoteTaskID})
@@ -807,4 +816,19 @@ func TestCompat_A2ACleanupPropagation(t *testing.T) {
 	if remoteTask.Status.State != legacyA2A.TaskStateCanceled {
 		t.Errorf("remoteTask.Status.State = %q, want %q", remoteTask.Status.State, legacyA2A.TaskStateCanceled)
 	}
+
+	// Join the cancel RPC so it can't log on t after the test returns.
+	testutil.AwaitN(t, cancelResultChan, 1, "cancel task")
+}
+
+func artifactContainsText(tau *legacyA2A.TaskArtifactUpdateEvent, substr string) bool {
+	if tau.Artifact == nil {
+		return false
+	}
+	for _, p := range tau.Artifact.Parts {
+		if tp, ok := p.(legacyA2A.TextPart); ok && strings.Contains(tp.Text, substr) {
+			return true
+		}
+	}
+	return false
 }

--- a/agent/remoteagent/v2/a2a_e2e_test.go
+++ b/agent/remoteagent/v2/a2a_e2e_test.go
@@ -26,6 +26,7 @@ import (
 	"net/http"
 	"path/filepath"
 	"strings"
+	"sync"
 	"testing"
 	"time"
 
@@ -377,9 +378,11 @@ func TestA2AMultiHopInputRequired(t *testing.T) {
 }
 
 func TestA2ACleanupPropagation(t *testing.T) {
+	remoteTaskIDChan, remoteCleanupCalledChan := make(chan a2a.TaskID, 1), make(chan struct{}, 2)
+	// Artifact text the mock subagent streams; the cancel step keys off it.
+	const remoteArtifactText = "remote-subagent-working"
 	// Remote A2A server publishes a submitted task and start generating artifact updates
 	// until it detects a context cancelation
-	remoteTaskIDChan, remoteCleanupCalledChan := make(chan a2a.TaskID, 1), make(chan struct{}, 2)
 	serverB := startA2AServer(&mockA2AExecutor{
 		cancelFn: func(ctx context.Context, reqCtx *a2asrv.ExecutorContext) iter.Seq2[a2a.Event, error] {
 			return func(yield func(a2a.Event, error) bool) {
@@ -393,7 +396,7 @@ func TestA2ACleanupPropagation(t *testing.T) {
 					return
 				}
 				for ctx.Err() == nil {
-					if !yield(a2a.NewArtifactEvent(reqCtx, a2a.NewTextPart("foo")), nil) {
+					if !yield(a2a.NewArtifactEvent(reqCtx, a2a.NewTextPart(remoteArtifactText)), nil) {
 						return
 					}
 					time.Sleep(1 * time.Millisecond)
@@ -427,27 +430,44 @@ func TestA2ACleanupPropagation(t *testing.T) {
 
 	client := newA2AClient(t, serverA)
 
-	// Send a streaming message in a detached goroutine, passing status update through chan
+	// Join the detached streaming/cancel goroutines before teardown; a late
+	// t.Errorf from an in-flight RPC on a finished test would panic.
+	var wg sync.WaitGroup
+	t.Cleanup(wg.Wait)
+
+	// remoteStreamingChan closes when the subagent's own output first reaches the client.
 	statusUpdateEventChan := make(chan a2a.Event, 10)
+	remoteStreamingChan := make(chan struct{})
+	wg.Add(1)
 	go func() {
+		defer wg.Done()
 		defer close(statusUpdateEventChan)
+		remoteStreaming := false
 		msg := a2a.NewMessage(a2a.MessageRoleUser, a2a.NewTextPart("work"))
 		for event, err := range client.SendStreamingMessage(t.Context(), &a2a.SendMessageRequest{Message: msg}) {
 			if err != nil {
 				t.Errorf("client.SendStreamingMessage() error = %v", err)
 				return
 			}
-			if _, ok := event.(*a2a.TaskArtifactUpdateEvent); ok {
+			if tau, ok := event.(*a2a.TaskArtifactUpdateEvent); ok {
+				if !remoteStreaming && artifactContainsText(tau, remoteArtifactText) {
+					remoteStreaming = true
+					close(remoteStreamingChan)
+				}
 				continue
 			}
 			statusUpdateEventChan <- event
 		}
 	}()
 
-	// Issue a task cancellation request
+	// Cancel only after the subagent's output reaches the client: before that the
+	// parent doesn't know the subagent task ID, so cancellation can't propagate.
 	taskID := (<-statusUpdateEventChan).TaskInfo().TaskID
+	awaitN(t, remoteStreamingChan, 1, "remote subagent streaming")
 	cancelResultChan := make(chan *a2a.Task, 1)
+	wg.Add(1)
 	go func() {
+		defer wg.Done()
 		defer close(cancelResultChan)
 		task, err := client.CancelTask(t.Context(), &a2a.CancelTaskRequest{ID: taskID})
 		if err != nil {
@@ -470,25 +490,12 @@ func TestA2ACleanupPropagation(t *testing.T) {
 		t.Fatalf("type(lastStreamingUpdate) = %T, want *a2a.TaskStatusUpdateEvent", lastStreamingUpdate)
 	}
 
-	// Check subagent task got cancelled when the parent task was cancelled.
-	// Reads from channel twice because cleanup gets called both for cancelation and execution.
-	timeout := time.After(5 * time.Second)
-	for range 2 {
-		select {
-		case <-remoteCleanupCalledChan:
-		case <-timeout:
-			t.Fatalf("remote cleanup was not called")
-		}
-	}
+	// Subagent cleanup fires twice: once for cancelation, once for execution.
+	// A generous per-wait deadline avoids flaking under CPU contention.
+	awaitN(t, remoteCleanupCalledChan, 2, "remote cleanup")
 	remoteTaskID := <-remoteTaskIDChan
+	awaitN(t, executorCleanupCalledChan, 2, "executor cleanup")
 
-	for range 2 {
-		select {
-		case <-executorCleanupCalledChan:
-		case <-timeout:
-			t.Fatalf("executor cleanup was not called")
-		}
-	}
 	remoteClient := newA2AClient(t, serverB)
 	remoteTask, err := remoteClient.GetTask(t.Context(), &a2a.GetTaskRequest{ID: remoteTaskID})
 	if err != nil {
@@ -497,6 +504,35 @@ func TestA2ACleanupPropagation(t *testing.T) {
 	if remoteTask.Status.State != a2a.TaskStateCanceled {
 		t.Errorf("remoteTask.Status.State = %q, want %q", remoteTask.Status.State, a2a.TaskStateCanceled)
 	}
+
+	// Join the cancel RPC so it can't log on t after the test returns.
+	awaitN(t, cancelResultChan, 1, "cancel task")
+}
+
+// awaitN receives n values from ch or fails the test after a generous, contention-
+// tolerant deadline. A closed channel counts as a receive, so it also joins a
+// goroutine that closed ch without sending.
+func awaitN[T any](t *testing.T, ch <-chan T, n int, what string) {
+	t.Helper()
+	const deadline = 30 * time.Second
+	timer := time.NewTimer(deadline)
+	defer timer.Stop()
+	for i := range n {
+		select {
+		case <-ch:
+		case <-timer.C:
+			t.Fatalf("%s: got %d of %d within %v", what, i, n, deadline)
+		}
+	}
+}
+
+func artifactContainsText(tau *a2a.TaskArtifactUpdateEvent, substr string) bool {
+	for _, p := range tau.Artifact.Parts {
+		if strings.Contains(p.Text(), substr) {
+			return true
+		}
+	}
+	return false
 }
 
 func TestA2ASingleHopFinalResponse(t *testing.T) {

--- a/agent/remoteagent/v2/a2a_e2e_test.go
+++ b/agent/remoteagent/v2/a2a_e2e_test.go
@@ -463,7 +463,7 @@ func TestA2ACleanupPropagation(t *testing.T) {
 	// Cancel only after the subagent's output reaches the client: before that the
 	// parent doesn't know the subagent task ID, so cancellation can't propagate.
 	taskID := (<-statusUpdateEventChan).TaskInfo().TaskID
-	awaitN(t, remoteStreamingChan, 1, "remote subagent streaming")
+	testutil.AwaitN(t, remoteStreamingChan, 1, "remote subagent streaming")
 	cancelResultChan := make(chan *a2a.Task, 1)
 	wg.Add(1)
 	go func() {
@@ -492,9 +492,9 @@ func TestA2ACleanupPropagation(t *testing.T) {
 
 	// Subagent cleanup fires twice: once for cancelation, once for execution.
 	// A generous per-wait deadline avoids flaking under CPU contention.
-	awaitN(t, remoteCleanupCalledChan, 2, "remote cleanup")
+	testutil.AwaitN(t, remoteCleanupCalledChan, 2, "remote cleanup")
 	remoteTaskID := <-remoteTaskIDChan
-	awaitN(t, executorCleanupCalledChan, 2, "executor cleanup")
+	testutil.AwaitN(t, executorCleanupCalledChan, 2, "executor cleanup")
 
 	remoteClient := newA2AClient(t, serverB)
 	remoteTask, err := remoteClient.GetTask(t.Context(), &a2a.GetTaskRequest{ID: remoteTaskID})
@@ -506,24 +506,7 @@ func TestA2ACleanupPropagation(t *testing.T) {
 	}
 
 	// Join the cancel RPC so it can't log on t after the test returns.
-	awaitN(t, cancelResultChan, 1, "cancel task")
-}
-
-// awaitN receives n values from ch or fails the test after a generous, contention-
-// tolerant deadline. A closed channel counts as a receive, so it also joins a
-// goroutine that closed ch without sending.
-func awaitN[T any](t *testing.T, ch <-chan T, n int, what string) {
-	t.Helper()
-	const deadline = 30 * time.Second
-	timer := time.NewTimer(deadline)
-	defer timer.Stop()
-	for i := range n {
-		select {
-		case <-ch:
-		case <-timer.C:
-			t.Fatalf("%s: got %d of %d within %v", what, i, n, deadline)
-		}
-	}
+	testutil.AwaitN(t, cancelResultChan, 1, "cancel task")
 }
 
 func artifactContainsText(tau *a2a.TaskArtifactUpdateEvent, substr string) bool {

--- a/internal/testutil/test_agent_runner.go
+++ b/internal/testutil/test_agent_runner.go
@@ -20,6 +20,7 @@ import (
 	"fmt"
 	"iter"
 	"testing"
+	"time"
 
 	"google.golang.org/genai"
 
@@ -257,4 +258,22 @@ func CollectTextParts(stream iter.Seq2[*session.Event, error]) ([]string, error)
 		}
 	}
 	return texts, nil
+}
+
+// AwaitN receives n values from ch, or fails the test via t.Fatalf if they do
+// not all arrive within a generous, contention-tolerant deadline. A closed
+// channel counts as a receive, so AwaitN also joins a goroutine that closed ch
+// without sending.
+func AwaitN[T any](t *testing.T, ch <-chan T, n int, what string) {
+	t.Helper()
+	const deadline = 30 * time.Second
+	timer := time.NewTimer(deadline)
+	defer timer.Stop()
+	for i := range n {
+		select {
+		case <-ch:
+		case <-timer.C:
+			t.Fatalf("%s: got %d of %d within %v", what, i, n, deadline)
+		}
+	}
 }


### PR DESCRIPTION
## Problem

`TestA2ACleanupPropagation` and `TestCompat_A2ACleanupPropagation` are flaky on `v1`:
`go test -count=20 ./agent/remoteagent/...` fails 3 times out of 20 on a pristine
checkout. Both tests trigger the remote cleanup off the first artifact event they
observe, but that event is not necessarily the remote sub-agent's own output, and the
detached streaming goroutines can call `t.Errorf` after the test has finished, which
panics.

This blocks the rest of the v1.6.0 backport series: every PR targeting `v1` inherits
that failure rate, so CI goes red for reasons unrelated to the change under review.

## Summary

Backports #1131 and #1145 from `main`; both are test-only.

- Key the cancel step off the remote sub-agent's specific artifact text instead of any
  artifact event, so the test no longer races against server A's own output.
- Join the detached streaming/cancel goroutines through a `sync.WaitGroup` registered
  with `t.Cleanup`, so an in-flight RPC cannot report on a finished test.
- Move the shared runner helper into `internal/testutil` so the compat test and the v2
  e2e test drive it the same way.

With both applied the same 20-run stress passes 0/20 failures.