### PR TITLE
fix: backport data-race and live-connection lifecycle fixes (#1139, #1172, #1167, #1261)

### DIFF
--- a/artifact/gcsartifact/gcs_client.go
+++ b/artifact/gcsartifact/gcs_client.go
@@ -39,6 +39,9 @@ type gcsObject interface {
 	newReader(ctx context.Context) (io.ReadCloser, error)
 	delete(ctx context.Context) error
 	attrs(ctx context.Context) (*storage.ObjectAttrs, error)
+	// ifNotExist returns a handle whose write succeeds only if the object does
+	// not already exist; writing over an existing object fails with HTTP 412.
+	ifNotExist() gcsObject
 }
 
 // gcsObjectIterator
@@ -95,6 +98,11 @@ type gcsObjectWrapper struct {
 // NewWriter implements the gcsObject interface for gcsObjectWrapper.
 func (w *gcsObjectWrapper) newWriter(ctx context.Context) gcsWriter {
 	return &gcsWriterWrapper{w: w.object.NewWriter(ctx)}
+}
+
+// ifNotExist implements the gcsObject interface for gcsObjectWrapper.
+func (w *gcsObjectWrapper) ifNotExist() gcsObject {
+	return &gcsObjectWrapper{object: w.object.If(storage.Conditions{DoesNotExist: true})}
 }
 
 // NewReader implements the gcsObject interface for gcsObjectWrapper.

--- a/artifact/gcsartifact/gcs_client_test.go
+++ b/artifact/gcsartifact/gcs_client_test.go
@@ -1,0 +1,82 @@
+// Copyright 2025 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package gcsartifact
+
+import (
+	"io"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+
+	"cloud.google.com/go/storage"
+	"google.golang.org/api/option"
+)
+
+// TestObjectWrapperIfNotExist checks that the wrapper puts the does-not-exist
+// precondition on the wire. Everything else in this package tests against the
+// fake, so without this a wrapper that dropped the condition would still pass
+// while Save silently degraded to last-writer-wins. The client sends it as the
+// ifGenerationMatch=0 query parameter on the upload URL.
+func TestObjectWrapperIfNotExist(t *testing.T) {
+	for _, tc := range []struct {
+		name        string
+		conditional bool
+		want        string
+	}{
+		{"conditional", true, "0"},
+		{"unconditional", false, ""},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			var got string
+			srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+				got = r.URL.Query().Get("ifGenerationMatch")
+				if _, err := io.Copy(io.Discard, r.Body); err != nil {
+					t.Errorf("draining request body failed: %v", err)
+				}
+				w.Header().Set("Content-Type", "application/json")
+				if _, err := io.WriteString(w, `{"bucket":"bucket","name":"obj","generation":"1"}`); err != nil {
+					t.Errorf("writing response failed: %v", err)
+				}
+			}))
+			defer srv.Close()
+
+			client, err := storage.NewClient(t.Context(), option.WithEndpoint(srv.URL), option.WithoutAuthentication())
+			if err != nil {
+				t.Fatalf("storage.NewClient() failed: %v", err)
+			}
+			t.Cleanup(func() {
+				if err := client.Close(); err != nil {
+					t.Errorf("client.Close() failed: %v", err)
+				}
+			})
+
+			obj := (&gcsClientWrapper{client: client}).bucket("bucket").object("obj")
+			if tc.conditional {
+				obj = obj.ifNotExist()
+			}
+			w := obj.newWriter(t.Context())
+			if _, err := w.Write([]byte("data")); err != nil {
+				t.Fatalf("Write() failed: %v", err)
+			}
+			if err := w.Close(); err != nil {
+				t.Fatalf("Close() failed: %v", err)
+			}
+
+			if got != tc.want {
+				t.Errorf("ifGenerationMatch = %q, want %q", got, tc.want)
+			}
+		})
+	}
+}

--- a/artifact/gcsartifact/gcs_test.go
+++ b/artifact/gcsartifact/gcs_test.go
@@ -17,29 +17,44 @@ package gcsartifact
 import (
 	"bytes"
 	"context"
+	"errors"
+	"fmt"
 	"io"
 	"io/fs"
+	"net/http"
+	"slices"
 	"strings"
 	"sync"
 	"testing"
 	"time"
 
 	"cloud.google.com/go/storage"
+	"github.com/google/go-cmp/cmp"
+	"google.golang.org/api/googleapi"
 	"google.golang.org/api/iterator"
+	"google.golang.org/genai"
+	"google.golang.org/grpc/codes"
+	"google.golang.org/grpc/status"
 
 	"google.golang.org/adk/artifact"
 	"google.golang.org/adk/internal/artifact/tests"
 )
 
-// newGCSArtifactServiceForTesting creates a gcsService for the specified bucket using a mocked inmemory client
-func newGCSArtifactServiceForTesting(bucketName string) (artifact.Service, error) {
+// newGCSServiceForTesting creates a *gcsService backed by the in-memory fake. It
+// stubs out the retry backoff so retry-heavy tests stay fast.
+func newGCSServiceForTesting(bucketName string) *gcsService {
 	client := newFakeClient()
-	s := &gcsService{
+	return &gcsService{
 		bucketName:    bucketName,
 		storageClient: client,
 		bucket:        client.bucket(bucketName),
+		sleep:         func(ctx context.Context, _ time.Duration) error { return ctx.Err() },
 	}
-	return s, nil
+}
+
+// newGCSArtifactServiceForTesting creates a gcsService for the specified bucket using a mocked inmemory client
+func newGCSArtifactServiceForTesting(bucketName string) (artifact.Service, error) {
+	return newGCSServiceForTesting(bucketName), nil
 }
 
 func TestGCSArtifactService(t *testing.T) {
@@ -47,6 +62,204 @@ func TestGCSArtifactService(t *testing.T) {
 		return newGCSArtifactServiceForTesting("new")
 	}
 	tests.TestArtifactService(t, "GCS", factory)
+}
+
+// TestGCSArtifactServiceConcurrentSave checks that concurrent saves of the same
+// artifact get distinct versions and none is overwritten. Pre-fix, colliding
+// savers picked the same version and clobbered each other.
+func TestGCSArtifactServiceConcurrentSave(t *testing.T) {
+	srv, err := newGCSArtifactServiceForTesting("concurrent")
+	if err != nil {
+		t.Fatalf("failed to set up service: %v", err)
+	}
+
+	// Must stay <= maxSaveAttempts: a maximally-unlucky saver can lose one race
+	// per other writer, so it may need up to savers attempts to land a version.
+	const savers = 10
+
+	var wg sync.WaitGroup
+	gotVersions := make([]int64, savers)
+	errs := make([]error, savers)
+	for i := range savers {
+		wg.Add(1)
+		go func() {
+			defer wg.Done()
+			resp, err := srv.Save(t.Context(), saveReq())
+			if err != nil {
+				errs[i] = err
+				return
+			}
+			gotVersions[i] = resp.Version
+		}()
+	}
+	wg.Wait()
+
+	for i, err := range errs {
+		if err != nil {
+			// Fail fast: a saver error leaves zeroed versions, which would make
+			// the version diffs below noisy and misleading.
+			t.Fatalf("saver %d: Save() failed: %v", i, err)
+		}
+	}
+
+	slices.Sort(gotVersions)
+	want := make([]int64, savers)
+	for i := range want {
+		want[i] = int64(i + 1)
+	}
+	if diff := cmp.Diff(want, gotVersions); diff != "" {
+		t.Errorf("returned versions mismatch (-want +got):\n%s", diff)
+	}
+
+	// The stored versions must match what Save reported (nothing overwritten).
+	resp, err := srv.Versions(t.Context(), &artifact.VersionsRequest{
+		AppName: "app", UserID: "user", SessionID: "session", FileName: "file",
+	})
+	if err != nil {
+		t.Fatalf("Versions() failed: %v", err)
+	}
+	stored := resp.Versions
+	slices.Sort(stored)
+	if diff := cmp.Diff(want, stored); diff != "" {
+		t.Errorf("stored versions mismatch (-want +got):\n%s", diff)
+	}
+}
+
+// TestSaveReturnsWriteErrorWithoutRetry checks that a non-precondition write
+// error is surfaced as-is and not retried.
+func TestSaveReturnsWriteErrorWithoutRetry(t *testing.T) {
+	svc := newGCSServiceForTesting("errtest")
+	fb := svc.bucket.(*fakeBucket)
+	wantErr := &googleapi.Error{Code: http.StatusInternalServerError, Message: "boom"}
+	fb.closeErr = wantErr
+
+	if _, err := svc.Save(t.Context(), saveReq()); !errors.Is(err, wantErr) {
+		t.Fatalf("Save() err = %v, want %v", err, wantErr)
+	}
+	if got := fb.closeCalls; got != 1 {
+		t.Errorf("write attempts = %d, want 1 (no retry on non-precondition error)", got)
+	}
+}
+
+// TestSaveExhaustsRetriesOnPersistentConflict checks that Save gives up with
+// ErrVersionConflict after maxSaveAttempts when every write hits a precondition
+// failure.
+func TestSaveExhaustsRetriesOnPersistentConflict(t *testing.T) {
+	svc := newGCSServiceForTesting("errtest")
+	fb := svc.bucket.(*fakeBucket)
+	fb.closeErr = &googleapi.Error{Code: http.StatusPreconditionFailed}
+
+	if _, err := svc.Save(t.Context(), saveReq()); !errors.Is(err, ErrVersionConflict) {
+		t.Fatalf("Save() err = %v, want ErrVersionConflict", err)
+	}
+	if got := fb.closeCalls; got != maxSaveAttempts {
+		t.Errorf("write attempts = %d, want %d", got, maxSaveAttempts)
+	}
+}
+
+// TestSaveZeroByteArtifact checks that an empty payload still creates a real,
+// listable version. SaveRequest.Validate only requires Part.InlineData, so this
+// is reachable through the public API, and treating "no bytes" as "no object"
+// would make the second save overwrite the first.
+func TestSaveZeroByteArtifact(t *testing.T) {
+	svc := newGCSServiceForTesting("zerobyte")
+	req := func() *artifact.SaveRequest {
+		return &artifact.SaveRequest{
+			AppName: "app", UserID: "user", SessionID: "session", FileName: "file",
+			Part: genai.NewPartFromBytes([]byte{}, "application/octet-stream"),
+		}
+	}
+
+	for want := int64(1); want <= 2; want++ {
+		resp, err := svc.Save(t.Context(), req())
+		if err != nil {
+			t.Fatalf("Save() failed: %v", err)
+		}
+		if resp.Version != want {
+			t.Errorf("Save() version = %d, want %d", resp.Version, want)
+		}
+	}
+
+	versions, err := svc.Versions(t.Context(), &artifact.VersionsRequest{
+		AppName: "app", UserID: "user", SessionID: "session", FileName: "file",
+	})
+	if err != nil {
+		t.Fatalf("Versions() failed: %v", err)
+	}
+	slices.Sort(versions.Versions)
+	if diff := cmp.Diff([]int64{1, 2}, versions.Versions); diff != "" {
+		t.Errorf("stored versions mismatch (-want +got):\n%s", diff)
+	}
+
+	loaded, err := svc.Load(t.Context(), &artifact.LoadRequest{
+		AppName: "app", UserID: "user", SessionID: "session", FileName: "file",
+	})
+	if err != nil {
+		t.Fatalf("Load() failed: %v", err)
+	}
+	if got := loaded.Part.InlineData.Data; len(got) != 0 {
+		t.Errorf("Load() data = %q, want empty", got)
+	}
+}
+
+// TestBackoffDelayBounds checks the jittered backoff stays within [0, saveRetryMaxDelay].
+func TestBackoffDelayBounds(t *testing.T) {
+	for attempt := range maxSaveAttempts {
+		if d := backoffDelay(attempt); d < 0 || d > saveRetryMaxDelay {
+			t.Errorf("backoffDelay(%d) = %v, want within [0, %v]", attempt, d, saveRetryMaxDelay)
+		}
+	}
+}
+
+// TestIsPreconditionFailed covers both transports (HTTP *googleapi.Error and
+// gRPC status), raw and wrapped, since Save's retry hinges on this detection.
+func TestIsPreconditionFailed(t *testing.T) {
+	for _, tc := range []struct {
+		name string
+		err  error
+		want bool
+	}{
+		{"nil", nil, false},
+		{"generic", errors.New("boom"), false},
+		{"http 412", &googleapi.Error{Code: http.StatusPreconditionFailed}, true},
+		{"http 412 wrapped", fmt.Errorf("save: %w", &googleapi.Error{Code: http.StatusPreconditionFailed}), true},
+		{"http 500", &googleapi.Error{Code: http.StatusInternalServerError}, false},
+		{"grpc failed precondition", status.Error(codes.FailedPrecondition, "cond"), true},
+		{"grpc failed precondition wrapped", fmt.Errorf("save: %w", status.Error(codes.FailedPrecondition, "cond")), true},
+		{"grpc not found", status.Error(codes.NotFound, "nf"), false},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			if got := isPreconditionFailed(tc.err); got != tc.want {
+				t.Errorf("isPreconditionFailed(%v) = %v, want %v", tc.err, got, tc.want)
+			}
+		})
+	}
+}
+
+// TestSleepContext checks that sleepContext honors a non-positive duration, an
+// already-cancelled context, and a normal short wait.
+func TestSleepContext(t *testing.T) {
+	if err := sleepContext(t.Context(), 0); err != nil {
+		t.Errorf("sleepContext(_, 0) = %v, want nil", err)
+	}
+
+	cancelled, cancel := context.WithCancel(t.Context())
+	cancel()
+	if err := sleepContext(cancelled, time.Hour); !errors.Is(err, context.Canceled) {
+		t.Errorf("sleepContext(cancelled, 1h) = %v, want context.Canceled", err)
+	}
+
+	if err := sleepContext(t.Context(), time.Millisecond); err != nil {
+		t.Errorf("sleepContext(_, 1ms) = %v, want nil", err)
+	}
+}
+
+// saveReq returns a minimal valid SaveRequest for the fixed test artifact.
+func saveReq() *artifact.SaveRequest {
+	return &artifact.SaveRequest{
+		AppName: "app", UserID: "user", SessionID: "session", FileName: "file",
+		Part: genai.NewPartFromBytes([]byte("data"), "text/plain"),
+	}
 }
 
 // ---------------------------------- Mock Implementations -----------------------------------
@@ -58,7 +271,7 @@ type fakeClient struct {
 func newFakeClient() gcsClient {
 	return &fakeClient{
 		inMemoryBucket: &fakeBucket{
-			objectsMap: make(map[string]*fakeObject),
+			blobs: make(map[string]*fakeBlob),
 		},
 	}
 }
@@ -70,90 +283,112 @@ func (c *fakeClient) bucket(name string) gcsBucket {
 
 // fakeBucket implements the gcsBucket interface for testing.
 type fakeBucket struct {
-	mu         sync.Mutex
-	objectsMap map[string]*fakeObject
+	mu    sync.Mutex
+	blobs map[string]*fakeBlob
+
+	// Test hooks (guarded by mu): closeErr, when set, makes every writer Close
+	// return it (a simulated write failure); closeCalls counts Close calls.
+	closeErr   error
+	closeCalls int
 }
 
-// Object returns a fake object from the in-memory store.
+// object returns a handle to the named blob, creating an empty backing store on
+// first use so repeat handles to the same name share state.
 func (f *fakeBucket) object(name string) gcsObject {
 	f.mu.Lock()
 	defer f.mu.Unlock()
-	if _, ok := f.objectsMap[name]; !ok {
-		f.objectsMap[name] = &fakeObject{name: name}
+	b, ok := f.blobs[name]
+	if !ok {
+		b = &fakeBlob{name: name}
+		f.blobs[name] = b
 	}
-	return f.objectsMap[name]
+	return &fakeObject{blob: b, bucket: f}
 }
 
-// Objects simulates iterating over objects with a prefix.
+// objects iterates the existing (written, not deleted) blobs matching the
+// prefix, snapshotting attributes at call time like a real GCS listing so a
+// later delete can't retroactively change what this iterator returns.
 func (f *fakeBucket) objects(ctx context.Context, q *storage.Query) gcsObjectIterator {
 	f.mu.Lock()
 	defer f.mu.Unlock()
 
-	var matchingObjects []*fakeObject
-	for name, obj := range f.objectsMap {
+	var attrs []*storage.ObjectAttrs
+	for name, b := range f.blobs {
 		if q != nil && q.Prefix != "" && !strings.HasPrefix(name, q.Prefix) {
 			continue
 		}
-		if !obj.deleted {
-			matchingObjects = append(matchingObjects, obj)
+		b.mu.Lock()
+		if b.exists {
+			attrs = append(attrs, &storage.ObjectAttrs{Name: b.name, ContentType: b.contentType})
 		}
+		b.mu.Unlock()
 	}
-
-	// This is the key change. We return a custom type that has a `Next` method
-	// that manages its own state and returns the correct values.
-	return &fakeObjectIterator{
-		objects: matchingObjects,
-		index:   0,
-	}
+	return &fakeObjectIterator{attrs: attrs}
 }
 
-// fakeObject implements the gcsObject interface for testing.
-type fakeObject struct {
-	mu          sync.Mutex
-	name        string
+// fakeBlob is the shared backing store for one object name; handles reference it
+// by pointer so concurrent writers to the same name exercise the precondition.
+type fakeBlob struct {
+	mu   sync.Mutex
+	name string
+	// exists tracks presence separately from data: a handle can be taken
+	// without creating an object, and a zero-byte artifact does exist (real GCS
+	// creates and lists one).
+	exists      bool
 	data        []byte
-	deleted     bool
 	contentType string
 }
 
-// NewWriter returns a fake writer that stores data in memory.
-func (f *fakeObject) newWriter(ctx context.Context) gcsWriter {
-	f.mu.Lock()
-	defer f.mu.Unlock()
-	f.deleted = false // A write operation "undeletes" the object
-	f.data = nil      // Clear existing data
-	return &fakeWriter{obj: f, buffer: &bytes.Buffer{}}
+// fakeObject is a handle to a fakeBlob, optionally carrying a does-not-exist
+// precondition (mirrors storage.ObjectHandle.If(Conditions{DoesNotExist: true})).
+type fakeObject struct {
+	blob         *fakeBlob
+	bucket       *fakeBucket
+	mustNotExist bool
 }
 
-// Attrs returns fake attributes for the object.
-func (f *fakeObject) attrs(ctx context.Context) (*storage.ObjectAttrs, error) {
-	f.mu.Lock()
-	defer f.mu.Unlock()
-	if f.deleted || f.data == nil {
+// newWriter returns a fake writer that commits data to the blob on Close.
+func (o *fakeObject) newWriter(ctx context.Context) gcsWriter {
+	return &fakeWriter{obj: o, buffer: &bytes.Buffer{}}
+}
+
+func (o *fakeObject) ifNotExist() gcsObject {
+	return &fakeObject{blob: o.blob, bucket: o.bucket, mustNotExist: true}
+}
+
+// attrs returns fake attributes for the object.
+func (o *fakeObject) attrs(ctx context.Context) (*storage.ObjectAttrs, error) {
+	b := o.blob
+	b.mu.Lock()
+	defer b.mu.Unlock()
+	if !b.exists {
 		return nil, storage.ErrObjectNotExist
 	}
-	return &storage.ObjectAttrs{Name: f.name, Created: time.Now(), ContentType: f.contentType}, nil
+	return &storage.ObjectAttrs{Name: b.name, Created: time.Now(), ContentType: b.contentType}, nil
 }
 
-// Delete marks the object as deleted in memory.
-func (f *fakeObject) delete(ctx context.Context) error {
-	f.mu.Lock()
-	defer f.mu.Unlock()
-	f.deleted = true
+// delete removes the object from the in-memory store.
+func (o *fakeObject) delete(ctx context.Context) error {
+	b := o.blob
+	b.mu.Lock()
+	defer b.mu.Unlock()
+	b.exists = false
+	b.data = nil
 	return nil
 }
 
-// NewReader returns a reader for the in-memory data.
-func (f *fakeObject) newReader(ctx context.Context) (io.ReadCloser, error) {
-	f.mu.Lock()
-	defer f.mu.Unlock()
-	if f.deleted || f.data == nil {
+// newReader returns a reader for the in-memory data.
+func (o *fakeObject) newReader(ctx context.Context) (io.ReadCloser, error) {
+	b := o.blob
+	b.mu.Lock()
+	defer b.mu.Unlock()
+	if !b.exists {
 		return nil, fs.ErrNotExist
 	}
-	return io.NopCloser(bytes.NewReader(f.data)), nil
+	return io.NopCloser(bytes.NewReader(b.data)), nil
 }
 
-// fakeWriter is a helper type to simulate an *storage.Writer
+// fakeWriter is a helper type to simulate an *storage.Writer.
 type fakeWriter struct {
 	obj         *fakeObject
 	buffer      *bytes.Buffer
@@ -164,11 +399,29 @@ func (w *fakeWriter) Write(p []byte) (n int, err error) {
 	return w.buffer.Write(p)
 }
 
+// Close commits the buffered data under the blob lock, so a conditional write
+// that loses the race sees the winner's data and returns HTTP 412 like GCS. A
+// bucket-level closeErr hook lets tests force a write failure.
 func (w *fakeWriter) Close() error {
-	w.obj.mu.Lock()
-	defer w.obj.mu.Unlock()
-	w.obj.data = w.buffer.Bytes()
-	w.obj.contentType = w.contentType
+	if bkt := w.obj.bucket; bkt != nil {
+		bkt.mu.Lock()
+		bkt.closeCalls++
+		forced := bkt.closeErr
+		bkt.mu.Unlock()
+		if forced != nil {
+			return forced
+		}
+	}
+
+	b := w.obj.blob
+	b.mu.Lock()
+	defer b.mu.Unlock()
+	if w.obj.mustNotExist && b.exists {
+		return &googleapi.Error{Code: http.StatusPreconditionFailed, Message: "conditionNotMet"}
+	}
+	b.data = w.buffer.Bytes()
+	b.contentType = w.contentType
+	b.exists = true
 	return nil
 }
 
@@ -177,22 +430,20 @@ func (w *fakeWriter) SetContentType(cType string) {
 	w.contentType = cType
 }
 
-// fakeObjectIterator is a fake iterator that returns attributes from a slice.
-// This type is the key to solving the 'unknown field' error.
+// fakeObjectIterator returns attribute snapshots taken at list time.
 type fakeObjectIterator struct {
-	objects []*fakeObject
-	index   int
+	attrs []*storage.ObjectAttrs
+	index int
 }
 
-// Next implements the iterator pattern.
-// It returns the next object in the slice or an iterator.Done error.
+// next returns the next object's attributes or an iterator.Done error.
 func (i *fakeObjectIterator) next() (*storage.ObjectAttrs, error) {
-	if i.index >= len(i.objects) {
+	if i.index >= len(i.attrs) {
 		return nil, iterator.Done
 	}
-	obj := i.objects[i.index]
+	a := i.attrs[i.index]
 	i.index++
-	return &storage.ObjectAttrs{Name: obj.name, ContentType: obj.contentType}, nil
+	return a, nil
 }
 
 var (

--- a/artifact/gcsartifact/service.go
+++ b/artifact/gcsartifact/service.go
@@ -21,20 +21,27 @@ package gcsartifact
 
 import (
 	"context"
+	"errors"
 	"fmt"
 	"io"
 	"io/fs"
 	"maps"
+	"math/rand/v2"
+	"net/http"
 	"slices"
 	"sort"
 	"strconv"
 	"strings"
+	"time"
 
 	"cloud.google.com/go/storage"
 	"golang.org/x/sync/errgroup"
+	"google.golang.org/api/googleapi"
 	"google.golang.org/api/iterator"
 	"google.golang.org/api/option"
 	"google.golang.org/genai"
+	"google.golang.org/grpc/codes"
+	"google.golang.org/grpc/status"
 
 	"google.golang.org/adk/artifact"
 )
@@ -44,6 +51,9 @@ type gcsService struct {
 	bucketName    string
 	storageClient gcsClient
 	bucket        gcsBucket
+	// sleep waits for d or until ctx is done; a field so tests can stub out the
+	// Save retry backoff. Never nil: every construction site sets it.
+	sleep func(ctx context.Context, d time.Duration) error
 }
 
 // NewService creates a Google Cloud Storage service for the specified bucket.
@@ -58,6 +68,7 @@ func NewService(ctx context.Context, bucketName string, opts ...option.ClientOpt
 		bucketName:    bucketName,
 		storageClient: clientWrapper,
 		bucket:        clientWrapper.bucket(bucketName),
+		sleep:         sleepContext,
 	}
 	return s, nil
 }
@@ -90,50 +101,138 @@ func buildUserPrefix(appName, userID string) string {
 	return fmt.Sprintf("%s/%s/user/", appName, userID)
 }
 
-// Save implements [artifact.Service]
-func (s *gcsService) Save(ctx context.Context, req *artifact.SaveRequest) (_ *artifact.SaveResponse, err error) {
-	err = req.Validate()
-	if err != nil {
+const (
+	// maxSaveAttempts caps Save's retries; each retry means a concurrent writer
+	// took the version we picked, so this is how many colliding writers we
+	// tolerate before returning [ErrVersionConflict].
+	maxSaveAttempts = 16
+	// saveRetryBaseDelay and saveRetryMaxDelay bound the jittered backoff Save
+	// waits between those retries.
+	saveRetryBaseDelay = 10 * time.Millisecond
+	saveRetryMaxDelay  = 1 * time.Second
+)
+
+// ErrVersionConflict is returned by Save when it cannot claim a new version
+// within its retry budget because concurrent writers keep taking the version it
+// picks. It is always wrapped, so test for it with [errors.Is]; a caller seeing
+// it can safely retry the save.
+var ErrVersionConflict = errors.New("artifact version conflict")
+
+// Save implements [artifact.Service].
+//
+// GCS can't list-then-write atomically, so versions are assigned optimistically:
+// Save writes version max+1 with a does-not-exist precondition and, if another
+// writer already took that version, backs off and retries with a fresh one (up
+// to [maxSaveAttempts]). It returns [ErrVersionConflict] if that budget is
+// exhausted rather than overwriting an existing version. Each attempt costs one
+// listing plus one upload.
+//
+// The scheme only holds if every writer uses the precondition: a bucket also
+// written by a client that assigns versions unconditionally can still lose one.
+func (s *gcsService) Save(ctx context.Context, req *artifact.SaveRequest) (*artifact.SaveResponse, error) {
+	if err := req.Validate(); err != nil {
 		return nil, fmt.Errorf("request validation failed: %w", err)
 	}
 	appName, userID, sessionID, fileName := req.AppName, req.UserID, req.SessionID, req.FileName
-	newArtifact := req.Part
 
-	nextVersion := int64(1)
+	var lastErr error
+	for attempt := range maxSaveAttempts {
+		response, err := s.versions(ctx, &artifact.VersionsRequest{
+			AppName: appName, UserID: userID, SessionID: sessionID, FileName: fileName,
+		})
+		if err != nil {
+			return nil, fmt.Errorf("failed to list artifact versions: %w", err)
+		}
+		nextVersion := int64(1)
+		if len(response.Versions) > 0 {
+			nextVersion = slices.Max(response.Versions) + 1
+		}
 
-	// TODO race condition, could use mutex but it's a remote resource so the issue would still occurs
-	// with multiple consumers, and gcs does not have transactions spanning several operations
-	response, err := s.versions(ctx, &artifact.VersionsRequest{
-		AppName: req.AppName, UserID: req.UserID, SessionID: req.SessionID, FileName: req.FileName,
-	})
-	if err != nil {
-		return nil, fmt.Errorf("failed to list artifact versions: %w", err)
+		blobName := buildBlobName(appName, userID, sessionID, fileName, nextVersion)
+		obj := s.bucket.object(blobName).ifNotExist()
+		err = writeArtifact(ctx, obj, req.Part)
+		if err == nil {
+			return &artifact.SaveResponse{Version: nextVersion}, nil
+		}
+		if !isPreconditionFailed(err) {
+			return nil, fmt.Errorf("failed to save artifact: %w", err)
+		}
+		lastErr = err
+		// Lost the race for this version. Back off (skip after the final attempt)
+		// and retry with a fresh version.
+		if attempt < maxSaveAttempts-1 {
+			if err := s.sleep(ctx, backoffDelay(attempt)); err != nil {
+				return nil, fmt.Errorf("failed to save artifact %q: %w", fileName, err)
+			}
+		}
 	}
-	if len(response.Versions) > 0 {
-		nextVersion = slices.Max(response.Versions) + 1
-	}
+	return nil, fmt.Errorf("failed to save artifact %q after %d attempts (last error: %v): %w", fileName, maxSaveAttempts, lastErr, ErrVersionConflict)
+}
 
-	blobName := buildBlobName(appName, userID, sessionID, fileName, nextVersion)
-	writer := s.bucket.object(blobName).newWriter(ctx)
+// backoffDelay returns a full-jitter backoff for the given zero-based retry
+// attempt, capped at saveRetryMaxDelay.
+func backoffDelay(attempt int) time.Duration {
+	d := saveRetryMaxDelay
+	if attempt < 63 {
+		if scaled := saveRetryBaseDelay << attempt; scaled > 0 && scaled < d {
+			d = scaled
+		}
+	}
+	return time.Duration(rand.Int64N(int64(d) + 1))
+}
+
+// sleepContext waits for d or until ctx is done, returning ctx.Err() if ctx is
+// done first.
+func sleepContext(ctx context.Context, d time.Duration) error {
+	if err := ctx.Err(); err != nil {
+		return err
+	}
+	if d <= 0 {
+		return nil
+	}
+	t := time.NewTimer(d)
+	defer t.Stop()
+	select {
+	case <-ctx.Done():
+		return ctx.Err()
+	case <-t.C:
+		return nil
+	}
+}
+
+// writeArtifact streams part to obj. A precondition on obj surfaces as an error
+// from Close, not Write.
+func writeArtifact(ctx context.Context, obj gcsObject, part *genai.Part) (err error) {
+	writer := obj.newWriter(ctx)
 	defer func() {
 		if closeErr := writer.Close(); closeErr != nil && err == nil {
 			err = fmt.Errorf("failed to close blob writer: %w", closeErr)
 		}
 	}()
 
-	if newArtifact.InlineData != nil {
-		writer.SetContentType(newArtifact.InlineData.MIMEType)
-		if _, err := writer.Write(newArtifact.InlineData.Data); err != nil {
-			return nil, fmt.Errorf("failed to write blob to GCS: %w", err)
+	if part.InlineData != nil {
+		writer.SetContentType(part.InlineData.MIMEType)
+		if _, err := writer.Write(part.InlineData.Data); err != nil {
+			return fmt.Errorf("failed to write blob to GCS: %w", err)
 		}
 	} else {
 		writer.SetContentType("text/plain")
-		if _, err := writer.Write([]byte(newArtifact.Text)); err != nil {
-			return nil, fmt.Errorf("failed to write text to GCS: %w", err)
+		if _, err := writer.Write([]byte(part.Text)); err != nil {
+			return fmt.Errorf("failed to write text to GCS: %w", err)
 		}
 	}
+	return nil
+}
 
-	return &artifact.SaveResponse{Version: nextVersion}, nil
+// isPreconditionFailed reports whether err is a GCS precondition failure: HTTP
+// 412 (*googleapi.Error) on the JSON API, or codes.FailedPrecondition on the
+// gRPC transport. Both status.FromError and errors.As unwrap wrapped errors.
+func isPreconditionFailed(err error) bool {
+	var apiErr *googleapi.Error
+	if errors.As(err, &apiErr) {
+		return apiErr.Code == http.StatusPreconditionFailed
+	}
+	return status.Code(err) == codes.FailedPrecondition
 }
 
 // Delete implements [artifact.Service]

--- a/artifact/service.go
+++ b/artifact/service.go
@@ -32,6 +32,9 @@ type Service interface {
 	// Save saves an artifact to the artifact service storage.
 	// The artifact is a file identified by the app name, user ID, session ID, and fileName.
 	// After saving the artifact, a revision ID is returned to identify the artifact version.
+	// Implementations that assign versions optimistically may fail to claim one
+	// while other writers save the same artifact; that failure is transient and
+	// the call can be retried.
 	Save(ctx context.Context, req *SaveRequest) (*SaveResponse, error)
 	// Load loads an artifact from the storage.
 	// The artifact is a file identified by the appName, userID, sessionID and fileName.

--- a/internal/llminternal/base_flow.go
+++ b/internal/llminternal/base_flow.go
@@ -368,6 +368,9 @@ func (f *Flow) RunLive(ctx agent.InvocationContext) (agent.LiveSession, iter.Seq
 			}
 
 			eventsChan := make(chan *session.Event)
+			// Producers must guard sends with connCtx: once a reconnect (or any
+			// teardown) abandons this unbuffered channel, cleanup's cancelConn is
+			// what unblocks them (issue #1152).
 			errChan := make(chan error)
 
 			// Send preprocessed content directly to model if any exists after early preprocessing
@@ -384,7 +387,10 @@ func (f *Flow) RunLive(ctx agent.InvocationContext) (agent.LiveSession, iter.Seq
 				for {
 					resp, err := liveConn.Recv(connCtx)
 					if err != nil {
-						errChan <- err
+						select {
+						case errChan <- err:
+						case <-connCtx.Done():
+						}
 						return
 					}
 					if resp != nil {
@@ -425,7 +431,10 @@ func (f *Flow) RunLive(ctx agent.InvocationContext) (agent.LiveSession, iter.Seq
 						}
 						if req.Content != nil {
 							if err := liveConn.SendContent(connCtx, req.Content); err != nil {
-								errChan <- err
+								select {
+								case errChan <- err:
+								case <-connCtx.Done():
+								}
 								return
 							}
 						}
@@ -434,7 +443,10 @@ func (f *Flow) RunLive(ctx agent.InvocationContext) (agent.LiveSession, iter.Seq
 								sess.audioMgr.CacheInput(ctx, blob.Data, blob.MIMEType)
 							}
 							if err := liveConn.SendRealtime(connCtx, req.RealtimeInput); err != nil {
-								errChan <- err
+								select {
+								case errChan <- err:
+								case <-connCtx.Done():
+								}
 								return
 							}
 						}

--- a/internal/llminternal/base_flow.go
+++ b/internal/llminternal/base_flow.go
@@ -378,6 +378,12 @@ func (f *Flow) RunLive(ctx agent.InvocationContext) (agent.LiveSession, iter.Seq
 				if err := liveConn.SendHistory(ctx, nreq.Contents); err != nil {
 					log.Printf("failed to send history: %v\n", err)
 					sess.pushError(err)
+					// cleanup, not a bare return: genai dials the live socket
+					// with a context-less websocket.DefaultDialer.Dial, and
+					// nothing in the SDK watches a context, so only an explicit
+					// Close releases it. Returning without cleanup strands the
+					// connection for the life of the process.
+					cleanup()
 					return
 				}
 			}

--- a/internal/llminternal/base_flow_live_test.go
+++ b/internal/llminternal/base_flow_live_test.go
@@ -16,7 +16,10 @@ package llminternal
 
 import (
 	"context"
+	"errors"
 	"iter"
+	"math"
+	"net"
 	"net/http"
 	"net/http/httptest"
 	"runtime"
@@ -391,4 +394,95 @@ func TestRunLiveNoGoroutineLeak(t *testing.T) {
 			assertNoRunLiveLeak(t, baseline)
 		})
 	}
+}
+
+// liveHistoryProcessor populates req.Contents with a turn the SDK cannot
+// marshal, so RunLive's SendHistory call fails on the client side.
+//
+// The failure has to be client-side: a broken socket would also fail the send,
+// but then there would be no live connection left to observe. json.Marshal
+// rejects NaN, so the send fails while the websocket stays healthy.
+func liveHistoryProcessor(ctx agent.InvocationContext, req *model.LLMRequest, f *Flow) iter.Seq2[*session.Event, error] {
+	req.Config = &genai.GenerateContentConfig{}
+	req.Contents = []*genai.Content{{
+		Role: "user",
+		Parts: []*genai.Part{{
+			FunctionCall: &genai.FunctionCall{
+				Name: "unmarshalable",
+				Args: map[string]any{"nan": math.NaN()},
+			},
+		}},
+	}}
+	return func(yield func(*session.Event, error) bool) {}
+}
+
+// TestRunLiveClosesConnectionOnSendHistoryFailure pins the cleanup discipline
+// on RunLive's one early-return path.
+//
+// Every other return in RunLive's own body releases the attempt through
+// cleanup (or cancelConn, before the connection exists). The SendHistory
+// failure path returns without either, so the websocket is never closed.
+// Cancelling the context would not help: genai dials with
+// websocket.DefaultDialer.Dial, which takes no context, and nothing in the SDK
+// watches one — only an explicit Close releases that socket. So the connection
+// survives for the lifetime of the process, not just the invocation.
+func TestRunLiveClosesConnectionOnSendHistoryFailure(t *testing.T) {
+	// How long the fake server waits for the client's close before concluding
+	// the socket was abandoned. Only paid on failure.
+	const closeWait = 3 * time.Second
+
+	baseline, _ := runLiveStacks()
+
+	// clientClosed reports whether the client tore the connection down, as
+	// opposed to leaving the server parked until its read deadline expired.
+	clientClosed := make(chan bool, 1)
+	client, connCount := startFakeLiveServer(t, func(connNum int, conn *websocket.Conn) {
+		_ = conn.SetReadDeadline(time.Now().Add(closeWait))
+		_, _, err := conn.ReadMessage()
+		var netErr net.Error
+		clientClosed <- !(errors.As(err, &netErr) && netErr.Timeout())
+	})
+
+	f := &Flow{
+		Model:             &fakeLiveModel{client: client},
+		RequestProcessors: []func(ctx agent.InvocationContext, req *model.LLMRequest, f *Flow) iter.Seq2[*session.Event, error]{liveHistoryProcessor},
+	}
+	ctx, cancel := newLiveInvocationContext(t)
+	defer cancel()
+
+	_, seq, err := f.RunLive(ctx)
+	if err != nil {
+		t.Fatalf("RunLive failed: %v", err)
+	}
+
+	// RunLive pushes the SendHistory error and returns. Stop iterating at that
+	// error: nothing closes the session, so ranging further would block.
+	var gotErr error
+	for _, e := range seq {
+		if e != nil {
+			gotErr = e
+			break
+		}
+	}
+	if gotErr == nil {
+		t.Fatal("expected the SendHistory failure to surface through the iterator")
+	}
+	if !strings.Contains(gotErr.Error(), "history") {
+		t.Errorf("surfaced error = %v, want it to mention the history send", gotErr)
+	}
+	if got := connCount.Load(); got != 1 {
+		t.Errorf("connection count = %d, want 1", got)
+	}
+
+	select {
+	case closed := <-clientClosed:
+		if !closed {
+			t.Error("RunLive returned without closing the live connection: the socket " +
+				"is leaked for the life of the process (missing cleanup on the SendHistory path)")
+		}
+	case <-time.After(closeWait + 2*time.Second):
+		t.Fatal("fake server never reported a connection outcome")
+	}
+
+	assertNoRunLiveLeak(t, baseline)
 }

--- a/internal/llminternal/base_flow_live_test.go
+++ b/internal/llminternal/base_flow_live_test.go
@@ -1,0 +1,394 @@
+// Copyright 2026 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package llminternal
+
+import (
+	"context"
+	"iter"
+	"net/http"
+	"net/http/httptest"
+	"runtime"
+	"strings"
+	"sync/atomic"
+	"testing"
+	"time"
+
+	"github.com/gorilla/websocket"
+	"google.golang.org/genai"
+
+	"google.golang.org/adk/agent"
+	"google.golang.org/adk/internal/agent/runconfig"
+	icontext "google.golang.org/adk/internal/context"
+	"google.golang.org/adk/model"
+	"google.golang.org/adk/session"
+)
+
+// fakeLiveModel implements model.LLM plus the Client() accessor RunLive
+// type-asserts on, backed by a genai client pointed at a fake websocket server.
+type fakeLiveModel struct {
+	client *genai.Client
+}
+
+func (m *fakeLiveModel) Name() string { return "test-live-model" }
+
+func (m *fakeLiveModel) GenerateContent(ctx context.Context, req *model.LLMRequest, stream bool) iter.Seq2[*model.LLMResponse, error] {
+	return func(yield func(*model.LLMResponse, error) bool) {}
+}
+
+func (m *fakeLiveModel) Client() *genai.Client { return m.client }
+
+const serverContentPong = `{"serverContent":{"modelTurn":{"parts":[{"text":"pong"}],"role":"model"},"turnComplete":true}}`
+
+// startFakeLiveServer runs a Gemini Live wire-protocol fake: it upgrades the
+// websocket, consumes the client's setup frame, replies {"setupComplete":{}},
+// then hands the connection to serveConn with a 1-based connection number.
+// When serveConn returns, the connection is hard-closed (no close handshake).
+func startFakeLiveServer(t *testing.T, serveConn func(connNum int, conn *websocket.Conn)) (*genai.Client, *atomic.Int32) {
+	t.Helper()
+	var upgrader websocket.Upgrader
+	var connCount atomic.Int32
+	ts := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		conn, err := upgrader.Upgrade(w, r, nil)
+		if err != nil {
+			t.Errorf("websocket upgrade failed: %v", err)
+			return
+		}
+		defer func() { _ = conn.Close() }()
+		// Count before the setup exchange: a client that saw setupComplete is
+		// then guaranteed to observe this connection in the count.
+		connNum := int(connCount.Add(1))
+		if _, _, err := conn.ReadMessage(); err != nil {
+			t.Errorf("reading setup frame failed: %v", err)
+			return
+		}
+		if err := conn.WriteMessage(websocket.TextMessage, []byte(`{"setupComplete":{}}`)); err != nil {
+			t.Errorf("writing setupComplete failed: %v", err)
+			return
+		}
+		serveConn(connNum, conn)
+	}))
+	t.Cleanup(ts.Close)
+
+	client, err := genai.NewClient(t.Context(), &genai.ClientConfig{
+		Backend:     genai.BackendGeminiAPI,
+		APIKey:      "test-api-key",
+		HTTPOptions: genai.HTTPOptions{BaseURL: strings.Replace(ts.URL, "http", "ws", 1)},
+	})
+	if err != nil {
+		t.Fatalf("NewClient failed: %v", err)
+	}
+	return client, &connCount
+}
+
+// blockUntilClientCloses parks the fake connection until the client tears it
+// down, so an idle server never triggers a spurious reconnect.
+func blockUntilClientCloses(conn *websocket.Conn) {
+	for {
+		if _, _, err := conn.ReadMessage(); err != nil {
+			return
+		}
+	}
+}
+
+// runLiveStacks returns the goroutine stacks still parked inside RunLive's
+// producer/consumer closures, and their count.
+func runLiveStacks() (int, string) {
+	// runtime.Stack silently truncates when the dump outgrows buf, which would
+	// hide leaked goroutines and turn this helper into a false pass. Grow until
+	// the whole dump fits.
+	buf := make([]byte, 1<<20)
+	var n int
+	for {
+		n = runtime.Stack(buf, true)
+		if n < len(buf) {
+			break
+		}
+		buf = make([]byte, 2*len(buf))
+	}
+	var leaked []string
+	for g := range strings.SplitSeq(string(buf[:n]), "\n\n") {
+		if strings.Contains(g, "llminternal.(*Flow).RunLive") {
+			leaked = append(leaked, g)
+		}
+	}
+	return len(leaked), strings.Join(leaked, "\n\n")
+}
+
+// assertNoRunLiveLeak fails if this test left more RunLive goroutines behind
+// than existed at its start. The baseline keeps a leak (a permanently blocked
+// goroutine) in one subtest from failing every subsequent subtest too.
+func assertNoRunLiveLeak(t *testing.T, baseline int) {
+	t.Helper()
+	deadline := time.Now().Add(5 * time.Second)
+	var count int
+	var stacks string
+	for time.Now().Before(deadline) {
+		count, stacks = runLiveStacks()
+		if count <= baseline {
+			return
+		}
+		time.Sleep(20 * time.Millisecond)
+	}
+	t.Fatalf("leaked %d RunLive goroutines (baseline %d):\n%s", count-baseline, baseline, stacks)
+}
+
+func newLiveInvocationContext(t *testing.T) (agent.InvocationContext, context.CancelFunc) {
+	t.Helper()
+	testAgent, err := agent.New(agent.Config{Name: "test-live-agent"})
+	if err != nil {
+		t.Fatalf("agent.New failed: %v", err)
+	}
+	baseCtx, cancel := context.WithCancel(t.Context())
+	ctx := icontext.NewInvocationContext(
+		runconfig.ToContext(baseCtx, &runconfig.RunConfig{
+			StreamingMode: runconfig.StreamingModeBidi,
+			Live:          &agent.LiveRunConfig{},
+		}),
+		icontext.InvocationContextParams{Agent: testAgent},
+	)
+	return ctx, cancel
+}
+
+// liveConfigProcessor is the minimal request processor RunLive needs: it
+// populates req.Config, which RunLive dereferences to build the connect config.
+func liveConfigProcessor(ctx agent.InvocationContext, req *model.LLMRequest, f *Flow) iter.Seq2[*session.Event, error] {
+	req.Config = &genai.GenerateContentConfig{}
+	return func(yield func(*session.Event, error) bool) {}
+}
+
+func TestRunLiveNoGoroutineLeak(t *testing.T) {
+	tests := []struct {
+		name string
+		// serveConn scripts the fake server per connection (post setup-complete).
+		serveConn func(connNum int, conn *websocket.Conn)
+		// drive consumes the event iterator and steers the session; it must
+		// return only when the iterator is exhausted.
+		drive     func(t *testing.T, sess agent.LiveSession, seq iter.Seq2[*session.Event, error], cancel context.CancelFunc)
+		wantConns int32
+	}{
+		{
+			// Connection 1 dies with an abrupt close (a resumable error).
+			// RunLive must reconnect, serve a turn on connection 2, and tear
+			// down without stranding either connection's producer goroutines.
+			name: "reader resumable error reconnects without leak",
+			serveConn: func(connNum int, conn *websocket.Conn) {
+				if connNum == 1 {
+					return // hard close right after setup => resumable 1006 on the client
+				}
+				if err := conn.WriteMessage(websocket.TextMessage, []byte(serverContentPong)); err != nil {
+					return
+				}
+				blockUntilClientCloses(conn)
+			},
+			drive: func(t *testing.T, sess agent.LiveSession, seq iter.Seq2[*session.Event, error], cancel context.CancelFunc) {
+				sawTurn := false
+				for ev, err := range seq {
+					if err != nil {
+						continue // the post-cancel context.Canceled error is expected
+					}
+					if ev != nil && ev.LLMResponse.Content != nil {
+						sawTurn = true
+						cancel() // got the post-reconnect turn; tear the session down
+					}
+				}
+				if !sawTurn {
+					t.Error("never received the post-reconnect model turn")
+				}
+			},
+			wantConns: 2,
+		},
+		{
+			// Connection 1 dies before the client sends anything. The sender
+			// goroutine that picks up the queued Send may hit a dead
+			// connection; its error must be discarded, not strand the sender,
+			// and a retried Send must succeed on connection 2.
+			name: "sender error after connection loss does not leak",
+			serveConn: func(connNum int, conn *websocket.Conn) {
+				if connNum == 1 {
+					return
+				}
+				for {
+					if _, _, err := conn.ReadMessage(); err != nil {
+						return
+					}
+					if err := conn.WriteMessage(websocket.TextMessage, []byte(serverContentPong)); err != nil {
+						return
+					}
+				}
+			},
+			drive: func(t *testing.T, sess agent.LiveSession, seq iter.Seq2[*session.Event, error], cancel context.CancelFunc) {
+				stop := make(chan struct{})
+				go func() {
+					for range 200 {
+						select {
+						case <-stop:
+							return
+						default:
+						}
+						if err := sess.Send(agent.LiveRequest{Content: genai.NewContentFromText("ping", "user")}); err != nil {
+							return
+						}
+						time.Sleep(5 * time.Millisecond)
+					}
+				}()
+				sawTurn := false
+				for ev, err := range seq {
+					if err != nil {
+						continue
+					}
+					if ev != nil && ev.LLMResponse.Content != nil && !sawTurn {
+						sawTurn = true
+						close(stop)
+						cancel()
+					}
+				}
+				if !sawTurn {
+					t.Error("never received a model turn for the retried send")
+				}
+			},
+			wantConns: 2,
+		},
+		{
+			// Same connection-loss shape as the case above, but the queued
+			// request carries RealtimeInput rather than Content, so the sender
+			// fails inside SendRealtime — the third errChan send site. Without
+			// its guard the sender strands just as it does for SendContent.
+			name: "realtime sender error after connection loss does not leak",
+			serveConn: func(connNum int, conn *websocket.Conn) {
+				if connNum == 1 {
+					return
+				}
+				for {
+					if _, _, err := conn.ReadMessage(); err != nil {
+						return
+					}
+					if err := conn.WriteMessage(websocket.TextMessage, []byte(serverContentPong)); err != nil {
+						return
+					}
+				}
+			},
+			drive: func(t *testing.T, sess agent.LiveSession, seq iter.Seq2[*session.Event, error], cancel context.CancelFunc) {
+				stop := make(chan struct{})
+				go func() {
+					for range 200 {
+						select {
+						case <-stop:
+							return
+						default:
+						}
+						// A fresh Blob per send: SendRealtime fills in an empty
+						// MIMEType, so a shared value would be mutated in place.
+						req := agent.LiveRequest{RealtimeInput: &genai.Blob{
+							Data:     []byte{0x00, 0x01, 0x02, 0x03},
+							MIMEType: "audio/pcm",
+						}}
+						if err := sess.Send(req); err != nil {
+							return
+						}
+						time.Sleep(5 * time.Millisecond)
+					}
+				}()
+				sawTurn := false
+				for ev, err := range seq {
+					if err != nil {
+						continue
+					}
+					if ev != nil && ev.LLMResponse.Content != nil && !sawTurn {
+						sawTurn = true
+						close(stop)
+						cancel()
+					}
+				}
+				if !sawTurn {
+					t.Error("never received a model turn for the retried realtime send")
+				}
+			},
+			wantConns: 2,
+		},
+		{
+			// A close frame with a non-resumable code must surface as an error
+			// to the caller and terminate the flow after a single connection.
+			//
+			// This case passes with or without the errChan guards: the sender
+			// exits through the existing connCtx.Done() arm, so nothing is
+			// stranded. It pins the terminal-path behaviour; it is not a
+			// regression guard for the leak.
+			name: "non-resumable error terminates after one connection",
+			serveConn: func(connNum int, conn *websocket.Conn) {
+				deadline := time.Now().Add(time.Second)
+				_ = conn.WriteControl(websocket.CloseMessage,
+					websocket.FormatCloseMessage(websocket.CloseProtocolError, "fatal"), deadline)
+			},
+			drive: func(t *testing.T, sess agent.LiveSession, seq iter.Seq2[*session.Event, error], cancel context.CancelFunc) {
+				sawErr := false
+				for _, err := range seq {
+					if err != nil && strings.Contains(err.Error(), "1002") {
+						sawErr = true
+					}
+				}
+				if !sawErr {
+					t.Error("expected the close-1002 error to surface through the iterator")
+				}
+			},
+			wantConns: 1,
+		},
+		{
+			// Cancelling the invocation context while the reader is blocked in
+			// Recv is the everyday teardown path: cleanup closes the
+			// connection, the reader's Recv fails, and its error send must not
+			// block forever on the abandoned channel.
+			name: "parent ctx cancel exits cleanly",
+			serveConn: func(connNum int, conn *websocket.Conn) {
+				blockUntilClientCloses(conn)
+			},
+			drive: func(t *testing.T, sess agent.LiveSession, seq iter.Seq2[*session.Event, error], cancel context.CancelFunc) {
+				// Cancel only after the first event (the setup-complete
+				// acknowledgement) so the reader is parked in Recv when
+				// cleanup tears the connection down.
+				first := true
+				for range seq {
+					if first {
+						first = false
+						cancel()
+					}
+				}
+			},
+			wantConns: 1,
+		},
+	}
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			baseline, _ := runLiveStacks()
+			client, connCount := startFakeLiveServer(t, tc.serveConn)
+			f := &Flow{
+				Model:             &fakeLiveModel{client: client},
+				RequestProcessors: []func(ctx agent.InvocationContext, req *model.LLMRequest, f *Flow) iter.Seq2[*session.Event, error]{liveConfigProcessor},
+			}
+			ctx, cancel := newLiveInvocationContext(t)
+			defer cancel()
+
+			sess, seq, err := f.RunLive(ctx)
+			if err != nil {
+				t.Fatalf("RunLive failed: %v", err)
+			}
+			tc.drive(t, sess, seq, cancel)
+
+			if got := connCount.Load(); got != tc.wantConns {
+				t.Errorf("connection count = %d, want %d", got, tc.wantConns)
+			}
+			assertNoRunLiveLeak(t, baseline)
+		})
+	}
+}

--- a/memory/inmemory.go
+++ b/memory/inmemory.go
@@ -114,14 +114,19 @@ func (s *inMemoryService) SearchMemory(ctx context.Context, req *SearchRequest) 
 		userID:  req.UserID,
 	}
 
-	s.mu.RLock()
-	values, ok := s.store[k]
-	s.mu.RUnlock()
-	if !ok {
-		return &SearchResponse{}, nil
-	}
-
 	res := &SearchResponse{}
+
+	// Hold the read lock for the whole scan. AddSessionToMemory writes into the
+	// per-user session map under the write lock, so releasing the lock before
+	// iterating would race with a concurrent write and can panic with
+	// "concurrent map iteration and map write".
+	s.mu.RLock()
+	defer s.mu.RUnlock()
+
+	values, ok := s.store[k]
+	if !ok {
+		return res, nil
+	}
 
 	for _, events := range values {
 		for _, e := range events {

--- a/memory/inmemory_test.go
+++ b/memory/inmemory_test.go
@@ -17,6 +17,8 @@ package memory_test
 import (
 	"iter"
 	"slices"
+	"strconv"
+	"sync"
 	"testing"
 	"time"
 
@@ -225,4 +227,44 @@ func must[V any](v V, err error) V {
 		panic(err)
 	}
 	return v
+}
+
+// Test_inMemoryService_SearchMemory_Concurrent runs SearchMemory and
+// AddSessionToMemory on the same app/user in parallel. The service is
+// documented as thread-safe, so under -race (as CI runs it) the two must not
+// touch the per-user session map without synchronization.
+func Test_inMemoryService_SearchMemory_Concurrent(t *testing.T) {
+	s := memory.InMemoryService()
+	ctx := t.Context()
+
+	// Seed one session so the per-user map is non-empty while searchers iterate.
+	if err := s.AddSessionToMemory(ctx, makeSession(t, "app1", "user1", "seed", nil)); err != nil {
+		t.Fatalf("AddSessionToMemory() error = %v", err)
+	}
+
+	const workers = 8
+	var wg sync.WaitGroup
+	for i := 0; i < workers; i++ {
+		wg.Add(2)
+		go func(i int) {
+			defer wg.Done()
+			for j := 0; j < 50; j++ {
+				id := "s" + strconv.Itoa(i) + "-" + strconv.Itoa(j)
+				if err := s.AddSessionToMemory(ctx, makeSession(t, "app1", "user1", id, nil)); err != nil {
+					t.Errorf("AddSessionToMemory() error = %v", err)
+					return
+				}
+			}
+		}(i)
+		go func() {
+			defer wg.Done()
+			for j := 0; j < 50; j++ {
+				if _, err := s.SearchMemory(ctx, &memory.SearchRequest{AppName: "app1", UserID: "user1", Query: "x"}); err != nil {
+					t.Errorf("SearchMemory() error = %v", err)
+					return
+				}
+			}
+		}()
+	}
+	wg.Wait()
 }


### PR DESCRIPTION
## Problem

Four concurrency and resource-lifecycle bugs present on `v1`:

- `InMemoryService.SearchMemory` reads the per-user session map under the read lock but
  releases it before iterating, while `AddSessionToMemory` writes the same map — a
  concurrent search and add can panic with `concurrent map iteration and map write`,
  despite the service being documented as thread-safe.
- `gcsService.Save` assigns versions non-atomically (list, `max+1`, write). Two
  concurrent saves pick the same version and the second upload silently overwrites the
  first.
- `Flow.RunLive`'s producer goroutines do bare sends on an unbuffered per-attempt
  `errChan`. Once the consumer stops reading it, the producer blocks forever — one
  leaked goroutine per reconnect on long-lived `/run_live` servers.
- The `SendHistory` failure path in `RunLive` is the only return in the function body
  that releases neither `connCtx` nor `liveConn`.

## Summary

Backports #1139, #1172, #1167 and #1261 from `main`.

- Hold the read lock across the whole `SearchMemory` scan. `AddSessionToMemory` replaces
  session slices wholesale, so a read lock is sufficient and searches still run
  concurrently.
- Write the artifact blob with a `DoesNotExist` generation precondition; on the
  resulting 412 re-read the versions and retry with a fresh number, bounded by
  `maxSaveAttempts`. N concurrent saves now yield exactly versions `1..N`.
- Guard the `errChan` sends so an abandoned producer exits instead of blocking.
- Call `cleanup()` on the `SendHistory` failure path.