### PR TITLE
fix: backport tool-confirmation ordering and wrapper fixes (#1053, #1169, #1130, #1128, #1247)

### DIFF
--- a/internal/llminternal/functions.go
+++ b/internal/llminternal/functions.go
@@ -43,16 +43,18 @@ func generateRequestConfirmationEvent(
 
 	parts := []*genai.Part{}
 	longRunningToolIDs := []string{}
-	functionCallParts := make(map[string]*genai.Part, len(functionCallEvent.Content.Parts))
-	for _, part := range functionCallEvent.Content.Parts {
-		if part.FunctionCall != nil {
-			functionCallParts[part.FunctionCall.ID] = part
-		}
-	}
 
-	for funcID, confirmation := range functionResponseEvent.Actions.RequestedToolConfirmations {
-		originalPart, ok := functionCallParts[funcID]
-		if !ok || originalPart.FunctionCall == nil {
+	// Emit confirmations in the order their function calls appear in the model
+	// response, mirroring adk-python. Iterating Content.Parts (an ordered slice)
+	// rather than ranging RequestedToolConfirmations (a map, whose iteration
+	// order Go randomizes) keeps the emitted order deterministic and aligned
+	// with execution flow.
+	for _, originalPart := range functionCallEvent.Content.Parts {
+		if originalPart.FunctionCall == nil {
+			continue
+		}
+		confirmation, ok := functionResponseEvent.Actions.RequestedToolConfirmations[originalPart.FunctionCall.ID]
+		if !ok {
 			continue
 		}
 

--- a/internal/llminternal/functions_test.go
+++ b/internal/llminternal/functions_test.go
@@ -298,6 +298,103 @@ func TestGenerateRequestConfirmationEventPreservesThoughtSignature(t *testing.T)
 	}
 }
 
+// TestGenerateRequestConfirmationEventResponseOrder verifies that the emitted
+// confirmation parts (and the parallel LongRunningToolIDs slice) follow the
+// order of the function calls in the model response (Content.Parts), regardless
+// of the (randomized) Go map iteration order of RequestedToolConfirmations, and
+// that repeated calls produce an identical order.
+func TestGenerateRequestConfirmationEventResponseOrder(t *testing.T) {
+	ctx := &mockInvocationContext{
+		invocationID: "inv_1",
+		agentName:    "agent_1",
+		branch:       "main",
+	}
+
+	// Confirmations are emitted in the order their function calls appear in the
+	// model response (Content.Parts), independent of funcID string order or map
+	// insertion order. responseOrder is deliberately not sorted.
+	responseOrder := []string{"call_c", "call_a", "call_d", "call_b"}
+
+	functionCallParts := make([]*genai.Part, 0, len(responseOrder))
+	requestedConfirmations := make(map[string]toolconfirmation.ToolConfirmation, len(responseOrder))
+	for _, id := range responseOrder {
+		functionCallParts = append(functionCallParts, &genai.Part{
+			FunctionCall: &genai.FunctionCall{
+				ID:   id,
+				Name: "test_tool",
+				Args: map[string]any{"arg": id},
+			},
+		})
+		requestedConfirmations[id] = toolconfirmation.ToolConfirmation{
+			Hint: "confirm " + id,
+		}
+	}
+
+	functionCallEvent := &session.Event{
+		LLMResponse: model.LLMResponse{
+			Content: &genai.Content{
+				Parts: functionCallParts,
+			},
+		},
+	}
+	functionResponseEvent := &session.Event{
+		Actions: session.EventActions{
+			RequestedToolConfirmations: requestedConfirmations,
+		},
+	}
+
+	// orderOf returns the originating funcIDs in the order the parts were
+	// emitted, by reading back the originalFunctionCall arg of each generated
+	// adk_request_confirmation call.
+	orderOf := func(t *testing.T, ev *session.Event) []string {
+		t.Helper()
+		if ev == nil || ev.Content == nil {
+			t.Fatalf("expected non-nil event with content, got %#v", ev)
+		}
+		if got, want := len(ev.Content.Parts), len(responseOrder); got != want {
+			t.Fatalf("got %d parts, want %d", got, want)
+		}
+		if got, want := len(ev.LongRunningToolIDs), len(responseOrder); got != want {
+			t.Fatalf("got %d LongRunningToolIDs, want %d", got, want)
+		}
+		ids := make([]string, 0, len(ev.Content.Parts))
+		for i, part := range ev.Content.Parts {
+			if part.FunctionCall == nil {
+				t.Fatalf("part %d has nil FunctionCall", i)
+			}
+			if got, want := part.FunctionCall.Name, toolconfirmation.FunctionCallName; got != want {
+				t.Fatalf("part %d FunctionCall.Name = %q, want %q", i, got, want)
+			}
+			orig, ok := part.FunctionCall.Args["originalFunctionCall"].(*genai.FunctionCall)
+			if !ok {
+				t.Fatalf("part %d missing originalFunctionCall arg, got %#v", i, part.FunctionCall.Args["originalFunctionCall"])
+			}
+			ids = append(ids, orig.ID)
+
+			// LongRunningToolIDs must be the generated request-confirmation
+			// call ID at the same index (parallel slices).
+			if got, want := ev.LongRunningToolIDs[i], part.FunctionCall.ID; got != want {
+				t.Errorf("LongRunningToolIDs[%d] = %q, want %q (the request-confirmation call ID)", i, got, want)
+			}
+		}
+		return ids
+	}
+
+	first := generateRequestConfirmationEvent(ctx, functionCallEvent, functionResponseEvent)
+	gotOrder := orderOf(t, first)
+	if diff := cmp.Diff(responseOrder, gotOrder); diff != "" {
+		t.Errorf("parts not in model-response order (-want +got):\n%s", diff)
+	}
+
+	// Repeated calls must produce an identical ordering.
+	for i := 0; i < 10; i++ {
+		next := generateRequestConfirmationEvent(ctx, functionCallEvent, functionResponseEvent)
+		if diff := cmp.Diff(gotOrder, orderOf(t, next)); diff != "" {
+			t.Errorf("ordering not stable on call %d (-first +next):\n%s", i, diff)
+		}
+	}
+}
+
 func TestGenerateRequestConfirmationEventNoThoughtSignature(t *testing.T) {
 	ctx := &mockInvocationContext{
 		invocationID: "inv_1",

--- a/internal/llminternal/request_confirmation_processor.go
+++ b/internal/llminternal/request_confirmation_processor.go
@@ -115,6 +115,13 @@ func RequestConfirmationRequestProcessor(ctx agent.InvocationContext, req *model
 				continue
 			}
 			toolsToResumeByFunctionCallID := map[string]*confirmedCall{}
+			// Record the order the confirmation requests appear in the event so we
+			// can re-dispatch the resumed calls in that same order below. Ranging
+			// over the map directly would use Go's randomized map iteration order,
+			// which makes the re-dispatched function calls, the assembled response,
+			// and the resulting StateDelta last-writer-wins merge all
+			// non-deterministic across runs.
+			var resumeOrder []string
 			for _, functionCall := range calls {
 				confirmation, ok := confirmationResponses[functionCall.ID]
 				if !ok {
@@ -125,6 +132,14 @@ func RequestConfirmationRequestProcessor(ctx agent.InvocationContext, req *model
 					continue
 				}
 
+				// Record each original call ID in resumeOrder only once: two
+				// confirmation requests in the same event can resolve to the same
+				// originalFunctionCall.ID, and the resumed tool must be dispatched
+				// once, not once per confirmation.
+				_, seen := toolsToResumeByFunctionCallID[originalFunctionCall.ID]
+				if !seen {
+					resumeOrder = append(resumeOrder, originalFunctionCall.ID)
+				}
 				toolsToResumeByFunctionCallID[originalFunctionCall.ID] = &confirmedCall{
 					confirmation: &confirmation,
 					call:         *originalFunctionCall,
@@ -154,9 +169,18 @@ func RequestConfirmationRequestProcessor(ctx agent.InvocationContext, req *model
 				continue
 			}
 
-			parts := make([]*genai.Part, 0)
+			// Re-dispatch in request order (resumeOrder), so the parts slice and the
+			// downstream response/StateDelta merge are deterministic.
+			parts := make([]*genai.Part, 0, len(toolsToResumeByFunctionCallID))
 			toolsToResumeConfirmation := make(map[string]*toolconfirmation.ToolConfirmation, len(toolsToResumeByFunctionCallID))
-			for callID, cc := range toolsToResumeByFunctionCallID {
+			for _, callID := range resumeOrder {
+				cc, ok := toolsToResumeByFunctionCallID[callID]
+				if !ok {
+					// Skip calls whose response is already present in this event
+					// snapshot (removed by the delete pass above); re-dispatching such
+					// a call would run its tool a second time within this resume.
+					continue
+				}
 				parts = append(parts, &genai.Part{FunctionCall: &cc.call})
 				toolsToResumeConfirmation[callID] = cc.confirmation
 			}

--- a/internal/llminternal/request_confirmation_processor_test.go
+++ b/internal/llminternal/request_confirmation_processor_test.go
@@ -282,3 +282,346 @@ func TestRequestConfirmationRequestProcessor(t *testing.T) {
 		})
 	}
 }
+
+// TestRequestConfirmationResumeOrderIsStable verifies that when a user resumes
+// several tool confirmations in a single message, the confirmed tool calls are
+// re-dispatched in the order their confirmation requests appear in the
+// confirmation-request event, deterministically across runs. The IDs are
+// deliberately out of sorted order so a sort-based implementation would also
+// fail the test.
+func TestRequestConfirmationResumeOrderIsStable(t *testing.T) {
+	// Request order intentionally differs from sorted order.
+	wantOrder := []string{"call_c3", "call_c1", "call_c5", "call_c2", "call_c6", "call_c4"}
+
+	confirmationCallID := func(originalCallID string) string {
+		return "confirmation_" + originalCallID
+	}
+
+	// One agent event carrying all six confirmation requests.
+	var confirmationParts []*genai.Part
+	for _, callID := range wantOrder {
+		confirmationParts = append(confirmationParts, &genai.Part{
+			FunctionCall: &genai.FunctionCall{
+				Name: toolconfirmation.FunctionCallName,
+				ID:   confirmationCallID(callID),
+				Args: map[string]any{
+					"originalFunctionCall": map[string]any{
+						"name": mockToolName,
+						"args": map[string]any{"param1": "test"},
+						"id":   callID,
+					},
+					"toolConfirmation": toolconfirmation.ToolConfirmation{Confirmed: false, Hint: "test hint"},
+				},
+			},
+		})
+	}
+
+	// One user event approving all six confirmations in the same message. The
+	// responses are assembled in a DIFFERENT order than the requests
+	// (responseOrder != wantOrder). The processor keys confirmations by ID (a
+	// map lookup) and derives re-dispatch order solely from the
+	// confirmation-request event, so the output must track request order
+	// regardless of the order the responses arrive in. Scrambling here makes the
+	// test fail an implementation that (incorrectly) ordered by response arrival.
+	// responseOrder is wantOrder reversed.
+	responseOrder := []string{"call_c4", "call_c6", "call_c2", "call_c5", "call_c1", "call_c3"}
+	userConfirmationJSON, err := json.Marshal(toolconfirmation.ToolConfirmation{Confirmed: true})
+	if err != nil {
+		t.Fatalf("error marshalling user confirmation: %v", err)
+	}
+	var responseParts []*genai.Part
+	for _, callID := range responseOrder {
+		responseParts = append(responseParts, &genai.Part{
+			FunctionResponse: &genai.FunctionResponse{
+				Name:     toolconfirmation.FunctionCallName,
+				ID:       confirmationCallID(callID),
+				Response: map[string]any{"response": string(userConfirmationJSON)},
+			},
+		})
+	}
+
+	events := []*session.Event{
+		{
+			Author: "agent",
+			LLMResponse: model.LLMResponse{
+				Content: &genai.Content{Parts: confirmationParts},
+			},
+		},
+		{
+			Author: "user",
+			LLMResponse: model.LLMResponse{
+				Content: &genai.Content{Parts: responseParts},
+			},
+		},
+	}
+
+	// Go randomizes map iteration order, so repeat the run to catch any
+	// map-order dependence in the re-dispatch path. Both constants are
+	// load-bearing. Go's small-map iteration randomizes a start offset within a
+	// bucket group, so the reachable orders are rotations of insertion order, not
+	// arbitrary permutations: at six entries the identity (already-sorted) order
+	// comes up about 3/8 of the time, so an unordered implementation still
+	// diverges the other ~5/8, and 10 iterations shrinks the blind spot to
+	// roughly 1 in 18,000. At two tools the identity order would come up ~7/8 per
+	// iteration and this same 10-iteration test would pass on the *unfixed* code
+	// about 26% of the time — so do not trim this to two calls or a single
+	// iteration.
+	for run := 0; run < 10; run++ {
+		agnt, tools, err := newMockLlmAgent()
+		if err != nil {
+			t.Fatalf("error creating mock llmagent: %v", err)
+		}
+
+		invocationContext := createInvocationContext(t, agnt, &fakeSession{events: events})
+		llmRequest := &model.LLMRequest{}
+
+		iter := llminternal.RequestConfirmationRequestProcessor(invocationContext, llmRequest, &llminternal.Flow{Tools: tools})
+
+		var gotEvents []*session.Event
+		for event, err := range iter {
+			if err != nil {
+				t.Fatalf("run %d: RequestConfirmationRequestProcessor() unexpected error: %v", run, err)
+			}
+			gotEvents = append(gotEvents, event)
+		}
+
+		if len(gotEvents) != 1 {
+			t.Fatalf("run %d: RequestConfirmationRequestProcessor() got %d events, want 1", run, len(gotEvents))
+		}
+		if gotEvents[0] == nil || gotEvents[0].Content == nil {
+			t.Fatalf("run %d: re-dispatch event or its content is nil", run)
+		}
+
+		var gotOrder []string
+		for _, part := range gotEvents[0].Content.Parts {
+			if part.FunctionResponse != nil {
+				gotOrder = append(gotOrder, part.FunctionResponse.ID)
+			}
+		}
+		if diff := cmp.Diff(wantOrder, gotOrder); diff != "" {
+			t.Errorf("run %d: re-dispatched function call order diff (-want +got):\n%s", run, diff)
+		}
+	}
+}
+
+// TestRequestConfirmationResumeSkipsAlreadyAnsweredCalls exercises the
+// "already answered" skip branch: when the user confirms several tool calls in
+// one message but one of those calls has already been answered (a
+// FunctionResponse for it exists in a later event), that call must NOT be
+// re-dispatched, while the still-pending calls are re-dispatched in request
+// order. Without the skip branch this would double-run (or panic on) the
+// already-answered call.
+func TestRequestConfirmationResumeSkipsAlreadyAnsweredCalls(t *testing.T) {
+	// Request order is intentionally unsorted; "call_a" is the one that has
+	// already been answered and must be skipped, leaving "call_b" and "call_c".
+	requestOrder := []string{"call_b", "call_a", "call_c"}
+	const alreadyAnswered = "call_a"
+	wantOrder := []string{"call_b", "call_c"}
+
+	confirmationCallID := func(originalCallID string) string {
+		return "confirmation_" + originalCallID
+	}
+
+	// One agent event carrying all three confirmation requests.
+	var confirmationParts []*genai.Part
+	for _, callID := range requestOrder {
+		confirmationParts = append(confirmationParts, &genai.Part{
+			FunctionCall: &genai.FunctionCall{
+				Name: toolconfirmation.FunctionCallName,
+				ID:   confirmationCallID(callID),
+				Args: map[string]any{
+					"originalFunctionCall": map[string]any{
+						"name": mockToolName,
+						"args": map[string]any{"param1": "test"},
+						"id":   callID,
+					},
+					"toolConfirmation": toolconfirmation.ToolConfirmation{Confirmed: false, Hint: "test hint"},
+				},
+			},
+		})
+	}
+
+	// One user event approving all three confirmations in the same message.
+	userConfirmationJSON, err := json.Marshal(toolconfirmation.ToolConfirmation{Confirmed: true})
+	if err != nil {
+		t.Fatalf("error marshalling user confirmation: %v", err)
+	}
+	var responseParts []*genai.Part
+	for _, callID := range requestOrder {
+		responseParts = append(responseParts, &genai.Part{
+			FunctionResponse: &genai.FunctionResponse{
+				Name:     toolconfirmation.FunctionCallName,
+				ID:       confirmationCallID(callID),
+				Response: map[string]any{"response": string(userConfirmationJSON)},
+			},
+		})
+	}
+
+	events := []*session.Event{
+		{
+			Author: "agent",
+			LLMResponse: model.LLMResponse{
+				Content: &genai.Content{Parts: confirmationParts},
+			},
+		},
+		{
+			Author: "user",
+			LLMResponse: model.LLMResponse{
+				Content: &genai.Content{Parts: responseParts},
+			},
+		},
+		// A later, agent-authored event that already carries the result for
+		// "call_a". Author is not "user", so it is not mistaken for the
+		// confirmation-response event, but the delete pass still removes call_a
+		// from the resume set — driving the skip branch on re-dispatch.
+		{
+			Author: "testAgent",
+			LLMResponse: model.LLMResponse{
+				Content: &genai.Content{
+					Parts: []*genai.Part{
+						{
+							FunctionResponse: &genai.FunctionResponse{
+								Name:     mockToolName,
+								ID:       alreadyAnswered,
+								Response: map[string]any{"result": "already answered"},
+							},
+						},
+					},
+				},
+			},
+		},
+	}
+
+	agnt, tools, err := newMockLlmAgent()
+	if err != nil {
+		t.Fatalf("error creating mock llmagent: %v", err)
+	}
+
+	invocationContext := createInvocationContext(t, agnt, &fakeSession{events: events})
+	llmRequest := &model.LLMRequest{}
+
+	iter := llminternal.RequestConfirmationRequestProcessor(invocationContext, llmRequest, &llminternal.Flow{Tools: tools})
+
+	var gotEvents []*session.Event
+	for event, err := range iter {
+		if err != nil {
+			t.Fatalf("RequestConfirmationRequestProcessor() unexpected error: %v", err)
+		}
+		gotEvents = append(gotEvents, event)
+	}
+
+	if len(gotEvents) != 1 {
+		t.Fatalf("RequestConfirmationRequestProcessor() got %d events, want 1", len(gotEvents))
+	}
+	if gotEvents[0] == nil || gotEvents[0].Content == nil {
+		t.Fatalf("re-dispatch event or its content is nil")
+	}
+
+	var gotOrder []string
+	for _, part := range gotEvents[0].Content.Parts {
+		if part.FunctionResponse != nil {
+			gotOrder = append(gotOrder, part.FunctionResponse.ID)
+		}
+	}
+	if diff := cmp.Diff(wantOrder, gotOrder); diff != "" {
+		t.Errorf("re-dispatched function call order diff (-want +got):\n%s", diff)
+	}
+}
+
+// TestRequestConfirmationResumeDedupesDuplicateOriginalID pins the "seen"
+// guard: when a single confirmation event carries two confirmation requests
+// that resolve to the same originalFunctionCall.ID, the resumed tool must be
+// dispatched exactly once, not once per confirmation. Without the guard the ID
+// would be appended to resumeOrder twice and the tool would run twice within
+// one re-dispatch.
+func TestRequestConfirmationResumeDedupesDuplicateOriginalID(t *testing.T) {
+	const duplicateCallID = "call_dup"
+
+	// Two distinct confirmation requests (distinct confirmation IDs) that both
+	// point at the same original function call.
+	confirmationIDs := []string{"confirmation_a", "confirmation_b"}
+
+	var confirmationParts []*genai.Part
+	for _, confID := range confirmationIDs {
+		confirmationParts = append(confirmationParts, &genai.Part{
+			FunctionCall: &genai.FunctionCall{
+				Name: toolconfirmation.FunctionCallName,
+				ID:   confID,
+				Args: map[string]any{
+					"originalFunctionCall": map[string]any{
+						"name": mockToolName,
+						"args": map[string]any{"param1": "test"},
+						"id":   duplicateCallID,
+					},
+					"toolConfirmation": toolconfirmation.ToolConfirmation{Confirmed: false, Hint: "test hint"},
+				},
+			},
+		})
+	}
+
+	// One user event approving both confirmations.
+	userConfirmationJSON, err := json.Marshal(toolconfirmation.ToolConfirmation{Confirmed: true})
+	if err != nil {
+		t.Fatalf("error marshalling user confirmation: %v", err)
+	}
+	var responseParts []*genai.Part
+	for _, confID := range confirmationIDs {
+		responseParts = append(responseParts, &genai.Part{
+			FunctionResponse: &genai.FunctionResponse{
+				Name:     toolconfirmation.FunctionCallName,
+				ID:       confID,
+				Response: map[string]any{"response": string(userConfirmationJSON)},
+			},
+		})
+	}
+
+	events := []*session.Event{
+		{
+			Author: "agent",
+			LLMResponse: model.LLMResponse{
+				Content: &genai.Content{Parts: confirmationParts},
+			},
+		},
+		{
+			Author: "user",
+			LLMResponse: model.LLMResponse{
+				Content: &genai.Content{Parts: responseParts},
+			},
+		},
+	}
+
+	agnt, tools, err := newMockLlmAgent()
+	if err != nil {
+		t.Fatalf("error creating mock llmagent: %v", err)
+	}
+
+	invocationContext := createInvocationContext(t, agnt, &fakeSession{events: events})
+	llmRequest := &model.LLMRequest{}
+
+	iter := llminternal.RequestConfirmationRequestProcessor(invocationContext, llmRequest, &llminternal.Flow{Tools: tools})
+
+	var gotEvents []*session.Event
+	for event, err := range iter {
+		if err != nil {
+			t.Fatalf("RequestConfirmationRequestProcessor() unexpected error: %v", err)
+		}
+		gotEvents = append(gotEvents, event)
+	}
+
+	if len(gotEvents) != 1 {
+		t.Fatalf("RequestConfirmationRequestProcessor() got %d events, want 1", len(gotEvents))
+	}
+	if gotEvents[0] == nil || gotEvents[0].Content == nil {
+		t.Fatalf("re-dispatch event or its content is nil")
+	}
+
+	var gotOrder []string
+	for _, part := range gotEvents[0].Content.Parts {
+		if part.FunctionResponse != nil {
+			gotOrder = append(gotOrder, part.FunctionResponse.ID)
+		}
+	}
+	if diff := cmp.Diff([]string{duplicateCallID}, gotOrder); diff != "" {
+		t.Errorf("expected the duplicated original call to be dispatched exactly once (-want +got):\n%s", diff)
+	}
+}

--- a/session/database/service_test.go
+++ b/session/database/service_test.go
@@ -110,3 +110,54 @@ func emptyService(t *testing.T) *databaseService {
 
 	return dbservice
 }
+
+func TestDatabaseService_AppendEvent_PreservesInputEventTempState(t *testing.T) {
+	ctx := t.Context()
+	s := emptyService(t)
+
+	createResp, err := s.Create(ctx, &session.CreateRequest{
+		AppName: "testapp",
+		UserID:  "testuser",
+	})
+	if err != nil {
+		t.Fatalf("Create() error = %v", err)
+	}
+
+	event := &session.Event{
+		ID:        "event1",
+		Timestamp: time.Now(),
+		Actions: session.EventActions{
+			StateDelta: map[string]any{
+				"temp:k1": "v1",
+				"sk":      "v2",
+			},
+		},
+	}
+
+	if err := s.AppendEvent(ctx, createResp.Session, event); err != nil {
+		t.Fatalf("AppendEvent failed: %v", err)
+	}
+
+	// Verify that the input event pointer's StateDelta map was not mutated in place.
+	if _, exists := event.Actions.StateDelta["temp:k1"]; !exists {
+		t.Errorf("expected temp:k1 to be preserved on input event after AppendEvent, but it was removed: %v", event.Actions.StateDelta)
+	}
+	if event.Actions.StateDelta["sk"] != "v2" {
+		t.Errorf("expected non-temp key sk to remain in input event, got: %v", event.Actions.StateDelta)
+	}
+
+	// Verify that the stored event in the session has temp keys stripped.
+	var storedEvent *session.Event
+	for ev := range createResp.Session.Events().All() {
+		storedEvent = ev
+	}
+	if storedEvent == nil {
+		t.Fatalf("expected stored event in session, got nil")
+	}
+	if _, exists := storedEvent.Actions.StateDelta["temp:k1"]; exists {
+		t.Errorf("expected temp:k1 to be stripped from stored event, but it still exists: %v", storedEvent.Actions.StateDelta)
+	}
+	if storedEvent.Actions.StateDelta["sk"] != "v2" {
+		t.Errorf("expected non-temp key sk on stored event, got: %v", storedEvent.Actions.StateDelta)
+	}
+}

--- a/session/database/session.go
+++ b/session/database/session.go
@@ -162,10 +162,16 @@ func trimTempDeltaState(event *session.Event) *session.Event {
 		}
 	}
 
-	// Replace the old map with the newly filtered one.
-	event.Actions.StateDelta = filteredStateDelta
+	// If no keys were filtered out, return the original event without copying.
+	if len(filteredStateDelta) == len(event.Actions.StateDelta) {
+		return event
+	}
 
-	return event
+	// Create a copy of the event to avoid mutating the original.
+	eventCopy := *event
+	eventCopy.Actions.StateDelta = filteredStateDelta
+
+	return &eventCopy
 }
 
 // updateSessionState updates the session state based on the event state delta.

--- a/session/inmemory.go
+++ b/session/inmemory.go
@@ -439,10 +439,16 @@ func trimTempDeltaState(event *Event) *Event {
 		}
 	}
 
-	// Replace the old map with the newly filtered one.
-	event.Actions.StateDelta = filteredStateDelta
+	// If no keys were filtered out, return the original event without copying.
+	if len(filteredStateDelta) == len(event.Actions.StateDelta) {
+		return event
+	}
 
-	return event
+	// Create a copy of the event to avoid mutating the original.
+	eventCopy := *event
+	eventCopy.Actions.StateDelta = filteredStateDelta
+
+	return &eventCopy
 }
 
 // updateSessionState updates the session state based on the event state delta.

--- a/session/inmemory_test.go
+++ b/session/inmemory_test.go
@@ -132,3 +132,54 @@ func TestInMemorySession_AppendEvent_Deadlock(t *testing.T) {
 	// If it doesn't hang, the test passes (meaning no deadlock)
 	t.Log("AppendEvent did not deadlock")
 }
+
+func TestInMemoryService_AppendEvent_PreservesInputEventTempState(t *testing.T) {
+	ctx := t.Context()
+	service := session.InMemoryService()
+
+	createResp, err := service.Create(ctx, &session.CreateRequest{
+		AppName: "testapp",
+		UserID:  "testuser",
+	})
+	if err != nil {
+		t.Fatalf("Failed to create session: %v", err)
+	}
+
+	event := &session.Event{
+		ID:        "event1",
+		Timestamp: time.Now(),
+		Actions: session.EventActions{
+			StateDelta: map[string]any{
+				"temp:k1": "v1",
+				"sk":      "v2",
+			},
+		},
+	}
+
+	if err := service.AppendEvent(ctx, createResp.Session, event); err != nil {
+		t.Fatalf("AppendEvent failed: %v", err)
+	}
+
+	// Verify that the input event pointer's StateDelta map was not mutated in place.
+	if _, exists := event.Actions.StateDelta["temp:k1"]; !exists {
+		t.Errorf("expected temp:k1 to be preserved on input event after AppendEvent, but it was removed: %v", event.Actions.StateDelta)
+	}
+	if event.Actions.StateDelta["sk"] != "v2" {
+		t.Errorf("expected non-temp key sk to remain in input event, got: %v", event.Actions.StateDelta)
+	}
+
+	// Verify that the stored event in the session has temp keys stripped.
+	var storedEvent *session.Event
+	for ev := range createResp.Session.Events().All() {
+		storedEvent = ev
+	}
+	if storedEvent == nil {
+		t.Fatalf("expected stored event in session, got nil")
+	}
+	if _, exists := storedEvent.Actions.StateDelta["temp:k1"]; exists {
+		t.Errorf("expected temp:k1 to be stripped from stored event, but it still exists: %v", storedEvent.Actions.StateDelta)
+	}
+	if storedEvent.Actions.StateDelta["sk"] != "v2" {
+		t.Errorf("expected non-temp key sk on stored event, got: %v", storedEvent.Actions.StateDelta)
+	}
+}

--- a/session/vertexai/service_test.go
+++ b/session/vertexai/service_test.go
@@ -224,3 +224,30 @@ func sanitizeFilename(name string) string {
 	safe = strings.ReplaceAll(safe, "/", "-")
 	return safe + ".replay"
 }
+
+func Test_trimTempDeltaState_PreservesInputEvent(t *testing.T) {
+	event := &session.Event{
+		ID: "event1",
+		Actions: session.EventActions{
+			StateDelta: map[string]any{
+				"temp:k1": "v1",
+				"sk":      "v2",
+			},
+		},
+	}
+
+	trimmed := trimTempDeltaState(event)
+
+	if trimmed == event {
+		t.Errorf("expected trimTempDeltaState to return a new event copy when stripping temp keys, got original pointer")
+	}
+	if _, exists := event.Actions.StateDelta["temp:k1"]; !exists {
+		t.Errorf("expected temp:k1 to be preserved on input event, but it was removed: %v", event.Actions.StateDelta)
+	}
+	if _, exists := trimmed.Actions.StateDelta["temp:k1"]; exists {
+		t.Errorf("expected temp:k1 to be stripped from trimmed event copy, but it still exists: %v", trimmed.Actions.StateDelta)
+	}
+	if trimmed.Actions.StateDelta["sk"] != "v2" {
+		t.Errorf("expected non-temp key sk on trimmed event, got: %v", trimmed.Actions.StateDelta)
+	}
+}

--- a/session/vertexai/session.go
+++ b/session/vertexai/session.go
@@ -162,10 +162,16 @@ func trimTempDeltaState(event *session.Event) *session.Event {
 		}
 	}
 
-	// Replace the old map with the newly filtered one.
-	event.Actions.StateDelta = filteredStateDelta
+	// If no keys were filtered out, return the original event without copying.
+	if len(filteredStateDelta) == len(event.Actions.StateDelta) {
+		return event
+	}
 
-	return event
+	// Create a copy of the event to avoid mutating the original.
+	eventCopy := *event
+	eventCopy.Actions.StateDelta = filteredStateDelta
+
+	return &eventCopy
 }
 
 // updateSessionState updates the session state based on the event state delta.

--- a/tool/functiontool/streaming_function_test.go
+++ b/tool/functiontool/streaming_function_test.go
@@ -1,0 +1,189 @@
+// Copyright 2026 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package functiontool_test
+
+import (
+	"errors"
+	"fmt"
+	"iter"
+	"strings"
+	"testing"
+
+	"google.golang.org/adk/agent"
+	icontext "google.golang.org/adk/internal/context"
+	"google.golang.org/adk/internal/toolinternal"
+	"google.golang.org/adk/session"
+	"google.golang.org/adk/tool"
+	"google.golang.org/adk/tool/functiontool"
+	"google.golang.org/adk/tool/toolconfirmation"
+)
+
+type streamingArgs struct {
+	Value string `json:"value"`
+}
+
+func newStreamingToolContext(t *testing.T, actions *session.EventActions, confirmation *toolconfirmation.ToolConfirmation) agent.ToolContext {
+	t.Helper()
+	invocationContext := icontext.NewInvocationContext(t.Context(), icontext.InvocationContextParams{})
+	return agent.NewToolContext(invocationContext, "call-id", actions, confirmation)
+}
+
+func requireStreamingTool(t *testing.T, cfg functiontool.Config, handler functiontool.StreamingFunc[streamingArgs]) toolinternal.StreamingFunctionTool {
+	t.Helper()
+	got, err := functiontool.NewStreaming(cfg, handler)
+	if err != nil {
+		t.Fatalf("NewStreaming() failed: %v", err)
+	}
+	streamingTool, ok := got.(toolinternal.StreamingFunctionTool)
+	if !ok {
+		t.Fatalf("NewStreaming() returned %T, want toolinternal.StreamingFunctionTool", got)
+	}
+	return streamingTool
+}
+
+func TestStreamingFunctionToolConfirmation(t *testing.T) {
+	tests := []struct {
+		name                 string
+		confirmation         *toolconfirmation.ToolConfirmation
+		wantErr              error
+		wantHandlerCall      bool
+		wantConfirmationCall bool
+	}{
+		{
+			name:         "rejected",
+			confirmation: &toolconfirmation.ToolConfirmation{Confirmed: false},
+			wantErr:      tool.ErrConfirmationRejected,
+		},
+		{
+			name:            "confirmed",
+			confirmation:    &toolconfirmation.ToolConfirmation{Confirmed: true},
+			wantHandlerCall: true,
+		},
+		{
+			name:                 "confirmation requested",
+			wantErr:              tool.ErrConfirmationRequired,
+			wantConfirmationCall: true,
+		},
+	}
+
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			actions := &session.EventActions{}
+			handlerCalled := false
+			streamingTool := requireStreamingTool(t, functiontool.Config{
+				Name:                "streaming_tool",
+				RequireConfirmation: true,
+			}, func(_ agent.ToolContext, args streamingArgs) iter.Seq2[string, error] {
+				handlerCalled = true
+				return func(yield func(string, error) bool) {
+					yield("handled "+args.Value, nil)
+				}
+			})
+
+			var values []string
+			var gotErr error
+			ctx := newStreamingToolContext(t, actions, test.confirmation)
+			for value, err := range streamingTool.RunStream(ctx, map[string]any{"value": "request"}) {
+				values = append(values, value)
+				gotErr = err
+			}
+
+			if !errors.Is(gotErr, test.wantErr) {
+				t.Errorf("RunStream() error = %v, want %v", gotErr, test.wantErr)
+			}
+			if handlerCalled != test.wantHandlerCall {
+				t.Errorf("handler called = %t, want %t", handlerCalled, test.wantHandlerCall)
+			}
+			if test.wantHandlerCall {
+				if len(values) != 1 || values[0] != "handled request" {
+					t.Errorf("RunStream() values = %v, want [handled request]", values)
+				}
+			}
+
+			confirmation, requested := actions.RequestedToolConfirmations["call-id"]
+			if requested != test.wantConfirmationCall {
+				t.Fatalf("confirmation requested = %t, want %t", requested, test.wantConfirmationCall)
+			}
+			if test.wantConfirmationCall {
+				if !actions.SkipSummarization {
+					t.Error("SkipSummarization = false, want true")
+				}
+				if !strings.Contains(confirmation.Hint, "streaming_tool()") {
+					t.Errorf("confirmation hint = %q, want tool name", confirmation.Hint)
+				}
+			}
+		})
+	}
+}
+
+func TestNewStreamingRequireConfirmationProviderValidation(t *testing.T) {
+	tests := []struct {
+		name     string
+		provider any
+		wantErr  bool
+	}{
+		{name: "nil", provider: nil},
+		{name: "valid", provider: func(streamingArgs) bool { return true }},
+		{name: "not a function", provider: struct{}{}, wantErr: true},
+		{name: "wrong argument", provider: func(string) bool { return true }, wantErr: true},
+		{name: "wrong result", provider: func(streamingArgs) int { return 1 }, wantErr: true},
+	}
+
+	handler := func(agent.ToolContext, streamingArgs) iter.Seq2[string, error] {
+		return func(func(string, error) bool) {}
+	}
+	wantError := fmt.Sprintf("error RequireConfirmationProvider must be a function with signature func(%T) bool", streamingArgs{})
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			got, err := functiontool.NewStreaming[streamingArgs](functiontool.Config{
+				RequireConfirmationProvider: test.provider,
+			}, handler)
+			if test.wantErr {
+				if err == nil || !strings.Contains(err.Error(), wantError) {
+					t.Fatalf("NewStreaming() error = %v, want error containing %q", err, wantError)
+				}
+				return
+			}
+			if err != nil {
+				t.Fatalf("NewStreaming() failed: %v", err)
+			}
+			if got == nil {
+				t.Fatal("NewStreaming() returned nil tool")
+			}
+		})
+	}
+}
+
+func TestStreamingFunctionToolStopsHandlerWhenConsumerStops(t *testing.T) {
+	cleanedUp := false
+	streamingTool := requireStreamingTool(t, functiontool.Config{Name: "streaming_tool"}, func(_ agent.ToolContext, _ streamingArgs) iter.Seq2[string, error] {
+		return func(yield func(string, error) bool) {
+			defer func() { cleanedUp = true }()
+			if !yield("first", nil) {
+				return
+			}
+			yield("second", nil)
+		}
+	})
+
+	ctx := newStreamingToolContext(t, &session.EventActions{}, nil)
+	for range streamingTool.RunStream(ctx, map[string]any{"value": "request"}) {
+		break
+	}
+
+	if !cleanedUp {
+		t.Error("handler cleanup did not run after the consumer stopped")
+	}
+}

--- a/tool/tool.go
+++ b/tool/tool.go
@@ -47,7 +47,7 @@ type Tool interface {
 
 // Context is an alias for agent.ToolContext.
 //
-// Deprecated: use agent.Context directly. This alias exists only to
+// Deprecated: use agent.ToolContext directly. This alias exists only to
 // minimize churn during the migration and will be removed in a future
 // release.
 type Context = agent.ToolContext
@@ -197,6 +197,20 @@ func (t *confirmationTool) Declaration() *genai.FunctionDeclaration {
 }
 
 func (t *confirmationTool) ProcessRequest(ctx agent.ToolContext, req *model.LLMRequest) error {
+	if rp, ok := t.runnableTool.(interface {
+		ProcessRequest(ctx agent.ToolContext, req *model.LLMRequest) error
+	}); ok {
+		_, existedBefore := req.Tools[t.Name()]
+		if err := rp.ProcessRequest(ctx, req); err != nil {
+			return err
+		}
+		// If the inner tool packed itself into req.Tools during ProcessRequest,
+		// replace it with the confirmation wrapper so confirmationTool.Run is invoked.
+		if !existedBefore && req.Tools != nil && req.Tools[t.Name()] != nil {
+			req.Tools[t.Name()] = t
+			return nil
+		}
+	}
 	return toolutils.PackTool(req, t)
 }
 

--- a/tool/tool_test.go
+++ b/tool/tool_test.go
@@ -16,6 +16,7 @@ package tool_test
 
 import (
 	"context"
+	"errors"
 	"strings"
 	"testing"
 
@@ -23,7 +24,10 @@ import (
 
 	"google.golang.org/adk/agent"
 	"google.golang.org/adk/internal/toolinternal"
+	"google.golang.org/adk/internal/toolinternal/toolutils"
+	"google.golang.org/adk/internal/utils"
 	"google.golang.org/adk/memory"
+	"google.golang.org/adk/model"
 	"google.golang.org/adk/session"
 	"google.golang.org/adk/tool"
 	"google.golang.org/adk/tool/agenttool"
@@ -275,5 +279,144 @@ func TestWithConfirmation(t *testing.T) {
 				t.Errorf("toolRan = %v, want %v", toolRan, tt.wantToolRan)
 			}
 		})
+	}
+}
+
+type mockCustomRequestTool struct {
+	tool.Tool
+	decl                 *genai.FunctionDeclaration
+	processRequestCalled *bool
+}
+
+func (m *mockCustomRequestTool) Declaration() *genai.FunctionDeclaration { return m.decl }
+func (m *mockCustomRequestTool) Run(ctx agent.ToolContext, args any) (map[string]any, error) {
+	return map[string]any{}, nil
+}
+
+func (m *mockCustomRequestTool) ProcessRequest(ctx agent.ToolContext, req *model.LLMRequest) error {
+	*m.processRequestCalled = true
+	utils.AppendInstructions(req, "custom tool system instruction")
+	return nil
+}
+
+func TestWithConfirmation_ProcessRequest(t *testing.T) {
+	processRequestCalled := false
+	baseTool, err := functiontool.New(functiontool.Config{Name: "customReqTool"}, func(ctx agent.ToolContext, input struct{}) (struct{}, error) {
+		return struct{}{}, nil
+	})
+	if err != nil {
+		t.Fatalf("functiontool.New() failed: %v", err)
+	}
+
+	customTool := &mockCustomRequestTool{
+		Tool:                 baseTool,
+		decl:                 &genai.FunctionDeclaration{Name: "customReqTool"},
+		processRequestCalled: &processRequestCalled,
+	}
+
+	ts := &testToolset{tools: []tool.Tool{customTool}}
+	cts := tool.WithConfirmation(ts, true, nil)
+
+	tools, err := cts.Tools(nil)
+	if err != nil {
+		t.Fatalf("cts.Tools() failed: %v", err)
+	}
+	if len(tools) != 1 {
+		t.Fatalf("cts.Tools() returned %d tools, want 1", len(tools))
+	}
+
+	processor, ok := tools[0].(toolinternal.RequestProcessor)
+	if !ok {
+		t.Fatalf("wrapped tool does not implement RequestProcessor")
+	}
+
+	req := &model.LLMRequest{}
+	if err := processor.ProcessRequest(nil, req); err != nil {
+		t.Fatalf("ProcessRequest() failed: %v", err)
+	}
+
+	if !processRequestCalled {
+		t.Errorf("expected wrapped tool's ProcessRequest to be called, but it was not")
+	}
+	if req.Config == nil || req.Config.SystemInstruction == nil || len(req.Config.SystemInstruction.Parts) == 0 {
+		t.Fatalf("expected SystemInstruction to be set on req.Config, got nil/empty")
+	}
+	if got := req.Config.SystemInstruction.Parts[0].Text; got != "custom tool system instruction" {
+		t.Errorf("SystemInstruction text = %q, want %q", got, "custom tool system instruction")
+	}
+}
+
+type mockCustomRequestPackingTool struct {
+	tool.Tool
+	decl                 *genai.FunctionDeclaration
+	processRequestCalled *bool
+}
+
+func (m *mockCustomRequestPackingTool) Declaration() *genai.FunctionDeclaration { return m.decl }
+func (m *mockCustomRequestPackingTool) Run(ctx agent.ToolContext, args any) (map[string]any, error) {
+	return map[string]any{}, nil
+}
+
+func (m *mockCustomRequestPackingTool) ProcessRequest(ctx agent.ToolContext, req *model.LLMRequest) error {
+	*m.processRequestCalled = true
+	return toolutils.PackTool(req, m)
+}
+
+func TestWithConfirmation_ProcessRequest_Packing(t *testing.T) {
+	processRequestCalled := false
+	baseTool, err := functiontool.New(functiontool.Config{Name: "customPackingTool"}, func(ctx agent.ToolContext, input struct{}) (struct{}, error) {
+		return struct{}{}, nil
+	})
+	if err != nil {
+		t.Fatalf("functiontool.New() failed: %v", err)
+	}
+
+	customTool := &mockCustomRequestPackingTool{
+		Tool:                 baseTool,
+		decl:                 &genai.FunctionDeclaration{Name: "customPackingTool"},
+		processRequestCalled: &processRequestCalled,
+	}
+
+	ts := &testToolset{tools: []tool.Tool{customTool}}
+	cts := tool.WithConfirmation(ts, true, nil)
+
+	tools, err := cts.Tools(nil)
+	if err != nil {
+		t.Fatalf("cts.Tools() failed: %v", err)
+	}
+	if len(tools) != 1 {
+		t.Fatalf("cts.Tools() returned %d tools, want 1", len(tools))
+	}
+
+	processor, ok := tools[0].(toolinternal.RequestProcessor)
+	if !ok {
+		t.Fatalf("wrapped tool does not implement RequestProcessor")
+	}
+
+	req := &model.LLMRequest{}
+	if err := processor.ProcessRequest(nil, req); err != nil {
+		t.Fatalf("ProcessRequest() failed: %v", err)
+	}
+
+	if !processRequestCalled {
+		t.Errorf("expected wrapped tool's ProcessRequest to be called, but it was not")
+	}
+
+	if req.Tools["customPackingTool"] != tools[0] {
+		t.Errorf("expected req.Tools[%q] to be the confirmation wrapper %T, got %T", "customPackingTool", tools[0], req.Tools["customPackingTool"])
+	}
+
+	packedTool, ok := req.Tools["customPackingTool"].(toolinternal.FunctionTool)
+	if !ok {
+		t.Fatalf("expected packed tool to implement toolinternal.FunctionTool, got %T", req.Tools["customPackingTool"])
+	}
+
+	ctx := &testContext{Context: context.Background()}
+	_, err = packedTool.Run(ctx, map[string]any{})
+	if !errors.Is(err, tool.ErrConfirmationRequired) {
+		t.Errorf("expected Run() to return ErrConfirmationRequired, got %v", err)
+	}
+	if !ctx.requestConfirmationCalled {
+		t.Errorf("expected RequestConfirmation to be called on ctx, but it was not")
 	}
 }


### PR DESCRIPTION
## Problem
Four defects in the tool-confirmation path, all present on `v1`:
- `generateRequestConfirmationEvent` ranges `RequestedToolConfirmations` (a map), so the
  emitted `adk_request_confirmation` parts and the parallel `LongRunningToolIDs` slice
  follow randomized map iteration whenever a response requests more than one
  confirmation.
- `RequestConfirmationRequestProcessor` has the same hazard on the resume side, making
  the re-dispatch order, the assembled `FunctionResponse` parts and `StateDelta`
  last-writer-wins precedence all nondeterministic.
- `tool.WithConfirmation` shadows a custom `ProcessRequest` on the wrapped tool, so the
  inner tool never sees the call.
- `trimTempDeltaState` mutates caller-provided event pointers in place when stripping
  `temp:` state-delta keys.
Separately, and specific to this branch: the deprecation note on the `tool.Context` alias
names `agent.Context` as the replacement, but `v1` has no such type — its `agent` package
exposes only `CallbackContext` and `ToolContext`.

## Summary
Backports #1053, #1169, #1130 and #1128, plus the streaming-confirmation coverage from
#1247.
- Emit confirmations in model-response order by iterating `Content.Parts` and looking up
  each confirmation by call ID, mirroring adk-python.
- Resume confirmed tool calls in request order rather than map order.
- `confirmationTool.ProcessRequest` delegates to the wrapped tool, and if that tool packs
  itself into `req.Tools` the wrapper replaces the entry so confirmation still runs.
- `trimTempDeltaState` shallow-copies the event across `inmemory`, `database` and
  `vertexai`, with an early return when nothing was stripped.
- Point the `tool.Context` deprecation note at `agent.ToolContext`, the type the alias
  resolves to. Not a cherry-pick: `main` has no such alias, so the fix exists only here.
Adapted for `v1`: the wrapper keeps the `agent.ToolContext` signature and the test imports
`toolutils` from `internal/toolinternal`, since `PackTool` is only public on `main` (#1055).