### PR TITLE
fix: backport load_artifacts, streaming usage and artifact-delta fixes (#670, #1257, #904)

### DIFF
--- a/internal/artifact/tests/service_suite.go
+++ b/internal/artifact/tests/service_suite.go
@@ -56,6 +56,15 @@ func TestArtifactService(t *testing.T, name string, factory func(t *testing.T) (
 		}
 		testArtifactService_UserScoped(ctx, t, srv, name)
 	})
+	t.Run(fmt.Sprintf("Test%sArtifactService_GetArtifactVersion", name), func(t *testing.T) {
+		ctx := t.Context()
+		// Create the service using the factory for this sub-test.
+		srv, err := factory(t)
+		if err != nil {
+			t.Fatalf("Failed to set up service: %v", err)
+		}
+		testArtifactService_GetArtifactVersion(ctx, t, srv, name)
+	})
 }
 
 func testArtifactService(ctx context.Context, t *testing.T, srv artifact.Service, testSuffix string) {
@@ -408,4 +417,82 @@ func testArtifactService_Empty(ctx context.Context, t *testing.T, srv artifact.S
 			t.Fatalf("Versions() = (%v, %v), want error(%v)", got, err, fs.ErrNotExist)
 		}
 	})
+	t.Run(fmt.Sprintf("GetArtifactVersion_%s", testSuffix), func(t *testing.T) {
+		got, err := srv.GetArtifactVersion(ctx, &artifact.GetArtifactVersionRequest{
+			AppName: "app", UserID: "user", SessionID: "session", FileName: "file1",
+		})
+		if !errors.Is(err, fs.ErrNotExist) {
+			t.Fatalf("GetArtifactVersion() = (%v, %v), want error(%v)", got, err, fs.ErrNotExist)
+		}
+	})
+}
+
+func testArtifactService_GetArtifactVersion(ctx context.Context, t *testing.T, srv artifact.Service, testSuffix string) {
+	appName := "testapp"
+	userID := "testuser"
+	sessionID := "testsession"
+	fileName := "verfile"
+
+	for i, data := range []*genai.Part{
+		genai.NewPartFromBytes([]byte("v1"), "text/plain"),
+		genai.NewPartFromBytes([]byte("v2"), "text/plain"),
+		genai.NewPartFromBytes([]byte("v3"), "text/plain"),
+	} {
+		wantVersion := int64(i + 1)
+		got, err := srv.Save(ctx, &artifact.SaveRequest{
+			AppName: appName, UserID: userID, SessionID: sessionID, FileName: fileName,
+			Part: data,
+		})
+		if err != nil || got.Version != wantVersion {
+			t.Fatalf("[%d] Save() = (%v, %v), want (%v, nil)", i, got.Version, err, wantVersion)
+		}
+	}
+
+	for _, tc := range []struct {
+		name        string
+		version     int64
+		wantVersion int64
+	}{
+		{name: "latest", wantVersion: 3},
+		{name: "specific", version: 2, wantVersion: 2},
+	} {
+		t.Run(fmt.Sprintf("GetArtifactVersion_%s_%s", tc.name, testSuffix), func(t *testing.T) {
+			resp, err := srv.GetArtifactVersion(ctx, &artifact.GetArtifactVersionRequest{
+				AppName: appName, UserID: userID, SessionID: sessionID, FileName: fileName, Version: tc.version,
+			})
+			if err != nil {
+				t.Fatalf("GetArtifactVersion(%d) failed: %v", tc.version, err)
+			}
+			if got := resp.ArtifactVersion.Version; got != tc.wantVersion {
+				t.Errorf("GetArtifactVersion(%d).Version = %d, want %d", tc.version, got, tc.wantVersion)
+			}
+			if got := resp.ArtifactVersion.MimeType; got != "text/plain" {
+				t.Errorf("GetArtifactVersion(%d).MimeType = %q, want %q", tc.version, got, "text/plain")
+			}
+		})
+	}
+
+	t.Run(fmt.Sprintf("GetArtifactVersion_nonexistent-version_%s", testSuffix), func(t *testing.T) {
+		got, err := srv.GetArtifactVersion(ctx, &artifact.GetArtifactVersionRequest{
+			AppName: appName, UserID: userID, SessionID: sessionID, FileName: fileName, Version: 99,
+		})
+		if !errors.Is(err, fs.ErrNotExist) {
+			t.Fatalf("GetArtifactVersion(99) = (%v, %v), want error(%v)", got, err, fs.ErrNotExist)
+		}
+	})
+	t.Run(fmt.Sprintf("GetArtifactVersion_nonexistent-file_%s", testSuffix), func(t *testing.T) {
+		got, err := srv.GetArtifactVersion(ctx, &artifact.GetArtifactVersionRequest{
+			AppName: appName, UserID: userID, SessionID: sessionID, FileName: "does-not-exist",
+		})
+		if !errors.Is(err, fs.ErrNotExist) {
+			t.Fatalf("GetArtifactVersion(missing file) = (%v, %v), want error(%v)", got, err, fs.ErrNotExist)
+		}
+	})
+
+	// Clean up.
+	if err := srv.Delete(ctx, &artifact.DeleteRequest{
+		AppName: appName, UserID: userID, SessionID: sessionID, FileName: fileName,
+	}); err != nil {
+		t.Fatalf("Delete(%s) failed: %v", fileName, err)
+	}
 }

--- a/internal/llminternal/stream_aggregator.go
+++ b/internal/llminternal/stream_aggregator.go
@@ -78,7 +78,9 @@ func (s *streamingResponseAggregator) ProcessResponse(ctx context.Context, genRe
 
 func (s *streamingResponseAggregator) aggregateResponse(llmResponse *model.LLMResponse) *model.LLMResponse {
 	s.response = llmResponse
-	s.usageMetadata = llmResponse.UsageMetadata
+	if llmResponse.UsageMetadata != nil {
+		s.usageMetadata = llmResponse.UsageMetadata
+	}
 	if llmResponse.GroundingMetadata != nil {
 		s.groundingMetadata = llmResponse.GroundingMetadata
 	}

--- a/internal/llminternal/stream_aggregator_test.go
+++ b/internal/llminternal/stream_aggregator_test.go
@@ -1104,6 +1104,50 @@ func TestMetadataOnlyChunkDoesNotAbortStream(t *testing.T) {
 	}
 }
 
+func TestUsageMetadataRetainedWhenLaterChunkHasNoUsageMetadata(t *testing.T) {
+	aggregator := llminternal.NewStreamingResponseAggregator()
+	ctx := t.Context()
+
+	usageMetadata := &genai.GenerateContentResponseUsageMetadata{
+		PromptTokenCount:     3,
+		CandidatesTokenCount: 5,
+		TotalTokenCount:      8,
+	}
+	chunks := []*genai.GenerateContentResponse{
+		{
+			Candidates:    []*genai.Candidate{{Content: genai.NewContentFromText("Hello", "model")}},
+			UsageMetadata: usageMetadata,
+		},
+		{
+			Candidates: []*genai.Candidate{{
+				Content:      genai.NewContentFromText(" world", "model"),
+				FinishReason: genai.FinishReasonStop,
+			}},
+		},
+	}
+
+	for _, chunk := range chunks {
+		for _, err := range aggregator.ProcessResponse(ctx, chunk) {
+			if err != nil {
+				t.Fatalf("unexpected error processing chunk: %v", err)
+			}
+		}
+	}
+
+	finalResponse := aggregator.Close()
+	if finalResponse == nil {
+		t.Fatal("expected a final aggregated response, got nil")
+	}
+	if finalResponse.UsageMetadata == nil {
+		t.Fatal("expected usage metadata in the final aggregated response, got nil")
+	}
+	if finalResponse.UsageMetadata.PromptTokenCount != usageMetadata.PromptTokenCount ||
+		finalResponse.UsageMetadata.CandidatesTokenCount != usageMetadata.CandidatesTokenCount ||
+		finalResponse.UsageMetadata.TotalTokenCount != usageMetadata.TotalTokenCount {
+		t.Errorf("usage metadata was not retained: got %+v, want %+v", finalResponse.UsageMetadata, usageMetadata)
+	}
+}
+
 func TestFinishReasonUnexpectedToolCallPreservesErrorCode(t *testing.T) {
 	aggregator := llminternal.NewStreamingResponseAggregator()
 	ctx := t.Context()

--- a/session/vertexai/vertexai_client.go
+++ b/session/vertexai/vertexai_client.go
@@ -18,6 +18,7 @@ import (
 	"context"
 	"encoding/json"
 	"fmt"
+	"math"
 	"regexp"
 	"strconv"
 	"strings"
@@ -264,14 +265,9 @@ func (c *vertexAiClient) appendEvent(ctx context.Context, appName, sessionID str
 		return err
 	}
 
-	var eventState *aiplatformpb.EventActions
-	// Convert and set the initial state if provided
-	if len(event.Actions.StateDelta) > 0 {
-		sessionState, err := toStructPB(event.Actions.StateDelta)
-		if err != nil {
-			return fmt.Errorf("failed to convert state to structpb: %w", err)
-		}
-		eventState = &aiplatformpb.EventActions{StateDelta: sessionState}
+	eventActions, err := createAiplatformpbEventActions(event)
+	if err != nil {
+		return fmt.Errorf("failed to convert event actions: %w", err)
 	}
 
 	content, err := createAiplatformpbContent(event)
@@ -294,7 +290,7 @@ func (c *vertexAiClient) appendEvent(ctx context.Context, appName, sessionID str
 			Author:        event.Author,
 			InvocationId:  event.InvocationID,
 			Content:       content,
-			Actions:       eventState,
+			Actions:       eventActions,
 			EventMetadata: metadata,
 			ErrorCode:     event.ErrorCode,
 			ErrorMessage:  event.ErrorMessage,
@@ -340,9 +336,7 @@ func (c *vertexAiClient) listSessionEvents(ctx context.Context, appName, session
 			Timestamp:    rpcResp.Timestamp.AsTime(),
 			InvocationID: rpcResp.InvocationId,
 			Author:       rpcResp.Author,
-			Actions: session.EventActions{
-				StateDelta: filterNilValues(rpcResp.Actions.StateDelta.AsMap()),
-			},
+			Actions:      aiplatformToSessionEventActions(rpcResp.Actions),
 			LLMResponse: model.LLMResponse{
 				Content:      content,
 				ErrorCode:    rpcResp.ErrorCode,
@@ -369,6 +363,48 @@ func (c *vertexAiClient) listSessionEvents(ctx context.Context, appName, session
 		return events[len(events)-numRecentEvents:], nil
 	}
 	return events, nil
+}
+
+func createAiplatformpbEventActions(event *session.Event) (*aiplatformpb.EventActions, error) {
+	if len(event.Actions.StateDelta) == 0 && len(event.Actions.ArtifactDelta) == 0 {
+		return nil, nil
+	}
+
+	actions := &aiplatformpb.EventActions{}
+	if len(event.Actions.StateDelta) > 0 {
+		sessionState, err := toStructPB(event.Actions.StateDelta)
+		if err != nil {
+			return nil, fmt.Errorf("failed to convert state to structpb: %w", err)
+		}
+		actions.StateDelta = sessionState
+	}
+	if len(event.Actions.ArtifactDelta) > 0 {
+		actions.ArtifactDelta = make(map[string]int32, len(event.Actions.ArtifactDelta))
+		for name, version := range event.Actions.ArtifactDelta {
+			if version > math.MaxInt32 || version < math.MinInt32 {
+				return nil, fmt.Errorf("artifact %q version %d does not fit in int32", name, version)
+			}
+			actions.ArtifactDelta[name] = int32(version)
+		}
+	}
+	return actions, nil
+}
+
+func aiplatformToSessionEventActions(actions *aiplatformpb.EventActions) session.EventActions {
+	if actions == nil {
+		return session.EventActions{}
+	}
+
+	eventActions := session.EventActions{
+		StateDelta: filterNilValues(actions.StateDelta.AsMap()),
+	}
+	if len(actions.ArtifactDelta) > 0 {
+		eventActions.ArtifactDelta = make(map[string]int64, len(actions.ArtifactDelta))
+		for name, version := range actions.ArtifactDelta {
+			eventActions.ArtifactDelta[name] = int64(version)
+		}
+	}
+	return eventActions
 }
 
 func sessionIdBySessionName(sn string) (string, error) {

--- a/session/vertexai/vertexai_test.go
+++ b/session/vertexai/vertexai_test.go
@@ -15,14 +15,26 @@
 package vertexai
 
 import (
+	"context"
+	"fmt"
+	"math"
+	"net"
 	"testing"
+	"time"
+
+	aiplatformpb "cloud.google.com/go/aiplatform/apiv1beta1/aiplatformpb"
+	"github.com/google/go-cmp/cmp"
 
 	"google.golang.org/adk/model"
 	"google.golang.org/adk/session"
 	"google.golang.org/adk/util/vertexai"
 
-	aiplatformpb "cloud.google.com/go/aiplatform/apiv1beta1/aiplatformpb"
+	"google.golang.org/api/option"
 	"google.golang.org/genai"
+	"google.golang.org/grpc"
+	"google.golang.org/grpc/credentials/insecure"
+	"google.golang.org/grpc/test/bufconn"
+	"google.golang.org/protobuf/proto"
 	"google.golang.org/protobuf/types/known/structpb"
 )
 
@@ -477,4 +489,250 @@ func TestCreateAiplatformpbMetadata(t *testing.T) {
 			}
 		})
 	}
+}
+
+func TestEventActionsConverters(t *testing.T) {
+	tests := []struct {
+		name string
+		run  func(t *testing.T)
+	}{
+		{
+			name: "session to aiplatform includes artifact delta",
+			run: func(t *testing.T) {
+				wantStateDelta := map[string]any{"user:theme": "dark"}
+				wantArtifactDelta := map[string]int32{"chart.html": 3, "table.csv": 7}
+				event := &session.Event{
+					Actions: session.EventActions{
+						StateDelta:    wantStateDelta,
+						ArtifactDelta: map[string]int64{"chart.html": 3, "table.csv": 7},
+					},
+				}
+
+				actions, err := createAiplatformpbEventActions(event)
+				if err != nil {
+					t.Fatalf("createAiplatformpbEventActions() failed: %v", err)
+				}
+				if actions == nil {
+					t.Fatal("createAiplatformpbEventActions() returned nil")
+				}
+				if actions.StateDelta == nil {
+					t.Fatal("actions.StateDelta is nil")
+				}
+				if diff := cmp.Diff(wantStateDelta, actions.StateDelta.AsMap()); diff != "" {
+					t.Errorf("actions.StateDelta mismatch (-want +got):\n%s", diff)
+				}
+				if diff := cmp.Diff(wantArtifactDelta, actions.ArtifactDelta); diff != "" {
+					t.Errorf("actions.ArtifactDelta mismatch (-want +got):\n%s", diff)
+				}
+			},
+		},
+		{
+			name: "session to aiplatform rejects artifact version outside int32",
+			run: func(t *testing.T) {
+				event := &session.Event{
+					Actions: session.EventActions{
+						ArtifactDelta: map[string]int64{"chart.html": int64(math.MaxInt32) + 1},
+					},
+				}
+
+				_, err := createAiplatformpbEventActions(event)
+				if err == nil {
+					t.Fatal("createAiplatformpbEventActions() succeeded, want error")
+				}
+				want := `artifact "chart.html" version 2147483648 does not fit in int32`
+				if got := err.Error(); got != want {
+					t.Errorf("createAiplatformpbEventActions() error = %q, want %q", got, want)
+				}
+			},
+		},
+		{
+			name: "aiplatform to session includes artifact delta",
+			run: func(t *testing.T) {
+				want := session.EventActions{
+					StateDelta:    map[string]any{"user:theme": "dark"},
+					ArtifactDelta: map[string]int64{"chart.html": 3, "table.csv": 7},
+				}
+				stateDelta, err := structpb.NewStruct(map[string]any{"user:theme": "dark"})
+				if err != nil {
+					t.Fatalf("structpb.NewStruct() failed: %v", err)
+				}
+
+				actions := aiplatformToSessionEventActions(&aiplatformpb.EventActions{
+					StateDelta:    stateDelta,
+					ArtifactDelta: map[string]int32{"chart.html": 3, "table.csv": 7},
+				})
+
+				if diff := cmp.Diff(want, actions); diff != "" {
+					t.Errorf("actions mismatch (-want +got):\n%s", diff)
+				}
+			},
+		},
+		{
+			name: "aiplatform to session nil actions",
+			run: func(t *testing.T) {
+				if diff := cmp.Diff(session.EventActions{}, aiplatformToSessionEventActions(nil)); diff != "" {
+					t.Errorf("actions mismatch (-want +got):\n%s", diff)
+				}
+			},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, tt.run)
+	}
+}
+
+func TestVertexAiClientEventActionsRoundTrip(t *testing.T) {
+	tests := []struct {
+		name string
+		in   session.EventActions
+		want session.EventActions
+	}{
+		{
+			name: "artifact delta only",
+			in: session.EventActions{
+				ArtifactDelta: map[string]int64{"chart.html": 1},
+			},
+			want: session.EventActions{
+				StateDelta:    map[string]any{},
+				ArtifactDelta: map[string]int64{"chart.html": 1},
+			},
+		},
+		{
+			name: "state delta only",
+			in: session.EventActions{
+				StateDelta: map[string]any{"user:theme": "dark"},
+			},
+			want: session.EventActions{
+				StateDelta: map[string]any{"user:theme": "dark"},
+			},
+		},
+		{
+			name: "both deltas",
+			in: session.EventActions{
+				StateDelta:    map[string]any{"user:theme": "dark"},
+				ArtifactDelta: map[string]int64{"chart.html": 1},
+			},
+			want: session.EventActions{
+				StateDelta:    map[string]any{"user:theme": "dark"},
+				ArtifactDelta: map[string]int64{"chart.html": 1},
+			},
+		},
+		{
+			name: "empty deltas",
+			in: session.EventActions{
+				StateDelta:    map[string]any{},
+				ArtifactDelta: map[string]int64{},
+			},
+			want: session.EventActions{
+				StateDelta: map[string]any{},
+			},
+		},
+		{
+			name: "no actions at all",
+			in:   session.EventActions{},
+			want: session.EventActions{
+				StateDelta: map[string]any{},
+			},
+		},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			ctx := t.Context()
+			service := &fakeVertexAiSessionService{}
+			client := newFakeVertexAiClient(t, service)
+
+			event := session.NewEvent("invocation-1")
+			event.Author = "agent"
+			event.Actions = tc.in
+
+			if err := client.appendEvent(ctx, "test-app", "session-1", event); err != nil {
+				t.Fatalf("appendEvent() failed: %v", err)
+			}
+			got, err := client.listSessionEvents(ctx, "test-app", "session-1", time.Time{}, 0)
+			if err != nil {
+				t.Fatalf("listSessionEvents() failed: %v", err)
+			}
+			if gotLen := len(got); gotLen != 1 {
+				t.Fatalf("len(got) = %d, want 1", gotLen)
+			}
+			if diff := cmp.Diff(tc.want, got[0].Actions); diff != "" {
+				t.Errorf("Actions mismatch (-want +got):\n%s", diff)
+			}
+		})
+	}
+}
+
+type fakeVertexAiSessionService struct {
+	aiplatformpb.UnimplementedSessionServiceServer
+	events []*aiplatformpb.SessionEvent
+}
+
+func (s *fakeVertexAiSessionService) AppendEvent(ctx context.Context, req *aiplatformpb.AppendEventRequest) (*aiplatformpb.AppendEventResponse, error) {
+	event, ok := proto.Clone(req.Event).(*aiplatformpb.SessionEvent)
+	if !ok {
+		return nil, fmt.Errorf("unexpected event type %T", req.Event)
+	}
+	event.Name = fmt.Sprintf("%s/events/event-%d", req.Name, len(s.events)+1)
+	if event.Actions == nil {
+		// Vertex AI materializes an empty Actions message on read-back.
+		event.Actions = &aiplatformpb.EventActions{}
+	}
+	s.events = append(s.events, event)
+	return &aiplatformpb.AppendEventResponse{}, nil
+}
+
+func (s *fakeVertexAiSessionService) ListEvents(ctx context.Context, req *aiplatformpb.ListEventsRequest) (*aiplatformpb.ListEventsResponse, error) {
+	events := make([]*aiplatformpb.SessionEvent, 0, len(s.events))
+	for _, event := range s.events {
+		cloned, ok := proto.Clone(event).(*aiplatformpb.SessionEvent)
+		if !ok {
+			return nil, fmt.Errorf("unexpected event type %T", event)
+		}
+		events = append(events, cloned)
+	}
+	return &aiplatformpb.ListEventsResponse{SessionEvents: events}, nil
+}
+
+func newFakeVertexAiClient(t *testing.T, service aiplatformpb.SessionServiceServer) *vertexAiClient {
+	t.Helper()
+
+	listener := bufconn.Listen(1024 * 1024)
+	server := grpc.NewServer()
+	aiplatformpb.RegisterSessionServiceServer(server, service)
+	go func() {
+		_ = server.Serve(listener)
+	}()
+	t.Cleanup(func() {
+		server.Stop()
+		_ = listener.Close()
+	})
+
+	conn, err := grpc.NewClient("passthrough:///bufnet",
+		grpc.WithContextDialer(func(context.Context, string) (net.Conn, error) {
+			return listener.Dial()
+		}),
+		grpc.WithTransportCredentials(insecure.NewCredentials()),
+	)
+	if err != nil {
+		t.Fatalf("grpc.NewClient() failed: %v", err)
+	}
+	t.Cleanup(func() {
+		_ = conn.Close()
+	})
+
+	client, err := newVertexAiClient(t.Context(), "us-central1", "test-project", "123",
+		option.WithGRPCConn(conn),
+		option.WithoutAuthentication(),
+	)
+	if err != nil {
+		t.Fatalf("newVertexAiClient() failed: %v", err)
+	}
+	t.Cleanup(func() {
+		if err := client.Close(); err != nil {
+			t.Errorf("client.Close() failed: %v", err)
+		}
+	})
+	return client
 }

--- a/tool/loadartifactstool/load_artifacts_tool.go
+++ b/tool/loadartifactstool/load_artifacts_tool.go
@@ -173,9 +173,21 @@ func (t *artifactsTool) processLoadArtifactsFunctionCall(ctx agent.ToolContext, 
 	if !ok {
 		return nil
 	}
-	artifactNames, ok := artifactNamesRaw.([]string)
-	if !ok {
-		return fmt.Errorf("invalid artifact names type: %T, expected []string", artifactNamesRaw)
+	var artifactNames []string
+	switch names := artifactNamesRaw.(type) {
+	case []string:
+		artifactNames = names
+	case []any:
+		artifactNames = make([]string, len(names))
+		for i, name := range names {
+			s, ok := name.(string)
+			if !ok {
+				return fmt.Errorf("invalid artifact name type at index %d: %T, expected string", i, name)
+			}
+			artifactNames[i] = s
+		}
+	default:
+		return fmt.Errorf("invalid artifact names type: %T, expected []string or []any", artifactNamesRaw)
 	}
 	if len(artifactNames) == 0 {
 		return nil

--- a/tool/loadartifactstool/load_artifacts_tool_test.go
+++ b/tool/loadartifactstool/load_artifacts_tool_test.go
@@ -229,6 +229,68 @@ func TestLoadArtifactsTool_ProcessRequest_Artifacts_LoadArtifactsFunctionCall(t 
 	}
 }
 
+func TestLoadArtifactsTool_ProcessRequest_Artifacts_LoadArtifactsFunctionCall_AnySlice(t *testing.T) {
+	loadArtifactsTool := loadartifactstool.New()
+
+	tc := createToolContext(t)
+	artifacts := map[string]*genai.Part{
+		"doc1.txt": {Text: "This is the content of doc1.txt"},
+	}
+	for name, part := range artifacts {
+		_, err := tc.Artifacts().Save(t.Context(), name, part)
+		if err != nil {
+			t.Fatalf("Failed to save artifact %s: %v", name, err)
+		}
+	}
+
+	// Simulate the function response after a structpb round-trip, where
+	// []string becomes []any ([]interface{}).
+	functionResponse := &genai.FunctionResponse{
+		Name: "load_artifacts",
+		Response: map[string]any{
+			"artifact_names": []any{"doc1.txt"},
+		},
+	}
+	llmRequest := &model.LLMRequest{
+		Contents: []*genai.Content{
+			{
+				Role: "model",
+				Parts: []*genai.Part{
+					genai.NewPartFromFunctionResponse(functionResponse.Name, functionResponse.Response),
+				},
+			},
+		},
+	}
+
+	requestProcessor, ok := loadArtifactsTool.(toolinternal.RequestProcessor)
+	if !ok {
+		t.Fatal("loadArtifactsTool does not implement RequestProcessor")
+	}
+
+	err := requestProcessor.ProcessRequest(tc, llmRequest)
+	if err != nil {
+		t.Fatalf("ProcessRequest failed: %v", err)
+	}
+
+	if len(llmRequest.Contents) != 2 {
+		t.Fatalf("Expected 2 content, but got: %v", llmRequest.Contents)
+	}
+
+	appendedContent := llmRequest.Contents[1]
+	if appendedContent.Role != "user" {
+		t.Errorf("Appended Content Role: got %v, want 'user'", appendedContent.Role)
+	}
+	if len(appendedContent.Parts) != 2 {
+		t.Fatalf("Expected 2 parts in appended content, but got: %v", appendedContent.Parts)
+	}
+	if appendedContent.Parts[0].Text != "Artifact doc1.txt is:" {
+		t.Errorf("First part: got %v, want 'Artifact doc1.txt is:'", appendedContent.Parts[0].Text)
+	}
+	if appendedContent.Parts[1].Text != "This is the content of doc1.txt" {
+		t.Errorf("Second part: got %v, want 'This is the content of doc1.txt'", appendedContent.Parts[1].Text)
+	}
+}
+
 func TestLoadArtifactsTool_ProcessRequest_Artifacts_OtherFunctionCall(t *testing.T) {
 	loadArtifactsTool := loadartifactstool.New()
 


### PR DESCRIPTION
## Problem
Three defects present on `v1`:
- `load_artifacts` silently loads nothing once a session has been persisted and
  reloaded. Session storage carries the function response through JSON, so
  `Response.AsMap()` hands back `[]any` where the tool wrote `[]string`, and
  `processLoadArtifactsFunctionCall` asserted the concrete type:
  `invalid artifact names type: []interface {}, expected []string`.
- Streaming `UsageMetadata` is overwritten by later chunks, so a chunk without usage
  erases usage reported earlier.
- The Vertex AI session client drops `Actions.ArtifactDelta` when appending events and
  does not restore it when listing them; artifact versions that exceed the `int32` wire
  field are silently truncated.

## Summary
Backports #670, #1257 and #904 from `main`, plus the `GetArtifactVersion` coverage from
#1156.
- Accept both `[]string` and `[]any` for `artifact_names` on the read side, and report a
  non-string element by index instead of the type of the whole slice. `Run` keeps
  returning `[]string`: the write path no longer calls `structpb.NewStruct`, `toStructPB`
  round-trips through JSON, and the `[]string` branch has to stay for in-process callers
  anyway.
- Retain non-nil `UsageMetadata` across streaming chunks.
- Include and restore `Actions.ArtifactDelta`, reject out-of-range artifact versions
  instead of truncating, and keep nil `Actions` from panicking while preserving empty
  action messages on the wire.
