### PR TITLE
fix: backport web launcher h2c, deploy and documentation fixes (#826, #919, #786, #1212, #1162)

### DIFF
--- a/README.md
+++ b/README.md
@@ -18,7 +18,9 @@
       <a href="https://google.github.io/adk-docs/">Docs</a> &
       <a href="https://github.com/google/adk-go/tree/main/examples">Samples</a> &
       <a href="https://github.com/google/adk-python">Python ADK</a> &
-      <a href="https://github.com/google/adk-java">Java ADK</a> & 
+      <a href="https://github.com/google/adk-java">Java ADK</a> &
+      <a href="https://github.com/google/adk-kotlin">Kotlin ADK</a> &
+      <a href="https://github.com/google/adk-js">TypeScript ADK</a> &
       <a href="https://github.com/google/adk-web">ADK Web</a>.
     </h3>
 </html>

--- a/agent/llmagent/llmagent.go
+++ b/agent/llmagent/llmagent.go
@@ -254,8 +254,10 @@ type Config struct {
 	InputSchema *genai.Schema
 	// The output schema when agent replies.
 	//
-	// NOTE: when this is set, agent can only reply and cannot use any tools,
-	// such as function tools, RAGs, agent transfer, etc.
+	// When OutputSchema is set, the framework transparently injects a
+	// set_model_response tool so the model can still invoke other tools
+	// (function tools, RAG, agent transfer, etc.) while producing structured
+	// output. See internal/llminternal/outputschema_processor.go for details.
 	OutputSchema *genai.Schema
 
 	// Callbacks are executed in the order they are provided.

--- a/cmd/adkgo/internal/deploy/agentengine/agentengine.go
+++ b/cmd/adkgo/internal/deploy/agentengine/agentengine.go
@@ -280,9 +280,6 @@ func (f *deployAgentEngineFlags) gcloudDeployToAgentEngine() error {
 								{Name: "GOOGLE_CLOUD_AGENT_ENGINE_ENABLE_TELEMETRY", Value: "true"},
 								{Name: "OTEL_INSTRUMENTATION_GENAI_CAPTURE_MESSAGE_CONTENT", Value: "true"},
 							},
-							SecretEnv: []*aiplatformpb.SecretEnvVar{
-								{Name: "GOOGLE_API_KEY", SecretRef: &aiplatformpb.SecretRef{Secret: "GOOGLE_API_KEY", Version: "latest"}},
-							},
 						},
 						ClassMethods: methods,
 					},

--- a/cmd/launcher/web/web.go
+++ b/cmd/launcher/web/web.go
@@ -42,6 +42,7 @@ type webConfig struct {
 	idleTimeout     time.Duration
 	shutdownTimeout time.Duration
 	otelToCloud     bool
+	useH2C          bool
 }
 
 // webLauncher can launch web server
@@ -182,13 +183,7 @@ func (w *webLauncher) Run(ctx context.Context, config *launcher.Config) error {
 	}
 	log.Println()
 
-	srv := http.Server{
-		Addr:         fmt.Sprintf(":%v", fmt.Sprint(w.config.port)),
-		WriteTimeout: w.config.writeTimeout,
-		ReadTimeout:  w.config.readTimeout,
-		IdleTimeout:  w.config.idleTimeout,
-		Handler:      router,
-	}
+	srv := w.buildHTTPServer(router)
 
 	errChan := make(chan error, 1)
 	go func() {
@@ -219,6 +214,29 @@ func (w *webLauncher) Run(ctx context.Context, config *launcher.Config) error {
 	}
 }
 
+func (w *webLauncher) buildHTTPServer(handler http.Handler) *http.Server {
+	srv := &http.Server{
+		Addr:         fmt.Sprintf(":%v", fmt.Sprint(w.config.port)),
+		WriteTimeout: w.config.writeTimeout,
+		ReadTimeout:  w.config.readTimeout,
+		IdleTimeout:  w.config.idleTimeout,
+		Handler:      handler,
+	}
+
+	if w.config.useH2C {
+		// Enable both HTTP/1 and cleartext HTTP/2 on the same listener. Existing
+		// REST, Web UI, A2A, and trigger routes continue to work over HTTP/1.1,
+		// while custom web sublaunchers can register HTTP/2-capable handlers,
+		// such as Connect handlers.
+		protocols := new(http.Protocols)
+		protocols.SetHTTP1(true)
+		protocols.SetUnencryptedHTTP2(true)
+		srv.Protocols = protocols
+	}
+
+	return srv
+}
+
 // SimpleDescription implements launcher.SubLauncher.
 func (w *webLauncher) SimpleDescription() string {
 	return "starts web server with additional sub-servers specified by sublaunchers"
@@ -236,6 +254,7 @@ func NewLauncher(sublaunchers ...Sublauncher) launcher.SubLauncher {
 	fs.DurationVar(&config.idleTimeout, "idle-timeout", 60*time.Second, "Server idle timeout (i.e. '10s', '2m' - see time.ParseDuration for details) - for waiting for the next request (only when keep-alive is enabled)")
 	fs.DurationVar(&config.shutdownTimeout, "shutdown-timeout", 15*time.Second, "Server shutdown timeout (i.e. '10s', '2m' - see time.ParseDuration for details) - for waiting for active requests to finish during shutdown")
 	fs.BoolVar(&config.otelToCloud, "otel_to_cloud", false, "Enables/disables OpenTelemetry export to GCP: telemetry.googleapis.com. See adk-go/telemetry package for details about supported options, credentials and environment variables.")
+	fs.BoolVar(&config.useH2C, "h2c", false, "Enable prior-knowledge cleartext HTTP/2 (h2c; no HTTP/1.1 Upgrade) on the web server listener. Cleartext is insecure; do not expose it to untrusted networks. Long-lived streaming responses may require increasing --write-timeout.")
 
 	return &webLauncher{
 		config:       config,

--- a/cmd/launcher/web/web_test.go
+++ b/cmd/launcher/web/web_test.go
@@ -1,0 +1,122 @@
+// Copyright 2026 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package web
+
+import (
+	"io"
+	"net"
+	"net/http"
+	"testing"
+)
+
+func TestH2CFlag(t *testing.T) {
+	for _, tc := range []struct {
+		name    string
+		args    []string
+		wantH2C bool
+	}{
+		{
+			name: "disabled by default",
+		},
+		{
+			name:    "enabled",
+			args:    []string{"--h2c"},
+			wantH2C: true,
+		},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			launcher := NewLauncher().(*webLauncher)
+			if _, err := launcher.Parse(tc.args); err != nil {
+				t.Fatalf("Parse(%v) failed: %v", tc.args, err)
+			}
+
+			srv := launcher.buildHTTPServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+				w.Header().Set("X-Request-Protocol", r.Proto)
+				w.WriteHeader(http.StatusNoContent)
+			}))
+			listener, err := net.Listen("tcp", "127.0.0.1:0")
+			if err != nil {
+				t.Fatalf("net.Listen() failed: %v", err)
+			}
+			serveErr := make(chan error, 1)
+			go func() {
+				serveErr <- srv.Serve(listener)
+			}()
+			t.Cleanup(func() {
+				if err := srv.Close(); err != nil {
+					t.Errorf("server Close() failed: %v", err)
+				}
+				if err := <-serveErr; err != http.ErrServerClosed {
+					t.Errorf("server Serve() error = %v, want %v", err, http.ErrServerClosed)
+				}
+			})
+
+			url := "http://" + listener.Addr().String()
+			assertProtocol(t, http.DefaultClient, url, 1)
+
+			h2cProtocols := new(http.Protocols)
+			h2cProtocols.SetUnencryptedHTTP2(true)
+			h2cClient := &http.Client{
+				Transport: &http.Transport{Protocols: h2cProtocols},
+			}
+			t.Cleanup(h2cClient.CloseIdleConnections)
+
+			resp, err := h2cClient.Get(url)
+			if !tc.wantH2C {
+				if err == nil {
+					if closeErr := resp.Body.Close(); closeErr != nil {
+						t.Errorf("response body Close() failed: %v", closeErr)
+					}
+					t.Fatalf("h2c request unexpectedly succeeded with protocol %q", resp.Proto)
+				}
+				return
+			}
+			if err != nil {
+				t.Fatalf("h2c request failed: %v", err)
+			}
+			defer func() {
+				if err := resp.Body.Close(); err != nil {
+					t.Errorf("response body Close() failed: %v", err)
+				}
+			}()
+			if resp.ProtoMajor != 2 {
+				t.Errorf("h2c response protocol = %q, want HTTP/2", resp.Proto)
+			}
+			if got := resp.Header.Get("X-Request-Protocol"); got != "HTTP/2.0" {
+				t.Errorf("handler request protocol = %q, want %q", got, "HTTP/2.0")
+			}
+		})
+	}
+}
+
+func assertProtocol(t *testing.T, client *http.Client, url string, wantMajor int) {
+	t.Helper()
+
+	resp, err := client.Get(url)
+	if err != nil {
+		t.Fatalf("HTTP request failed: %v", err)
+	}
+	defer func() {
+		if err := resp.Body.Close(); err != nil {
+			t.Errorf("response body Close() failed: %v", err)
+		}
+	}()
+	if _, err := io.Copy(io.Discard, resp.Body); err != nil {
+		t.Fatalf("reading response body failed: %v", err)
+	}
+	if resp.ProtoMajor != wantMajor {
+		t.Errorf("response protocol = %q, want HTTP/%d", resp.Proto, wantMajor)
+	}
+}

--- a/examples/agentengine/main.go
+++ b/examples/agentengine/main.go
@@ -82,7 +82,7 @@ func main() {
 	location := os.Getenv("GOOGLE_CLOUD_AGENT_ENGINE_LOCATION")
 	agentEngineID := os.Getenv("GOOGLE_CLOUD_AGENT_ENGINE_ID")
 
-	model, err := gemini.NewModel(ctx, "gemini-2.5-flash", &genai.ClientConfig{
+	model, err := gemini.NewModel(ctx, "gemini-3.5-flash", &genai.ClientConfig{
 		Backend:  genai.BackendVertexAI,
 		Project:  projectID,
 		Location: location,

--- a/tool/skilltoolset/instruction_test.go
+++ b/tool/skilltoolset/instruction_test.go
@@ -1,0 +1,46 @@
+// Copyright 2026 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package skilltoolset
+
+import (
+	"reflect"
+	"strings"
+	"testing"
+
+	"google.golang.org/adk/tool/skilltoolset/internal/skilltool"
+)
+
+// TestDefaultInstructionMatchesLoadSkillSchema guards against the default
+// system instruction documenting a parameter name for the load_skill tool that
+// does not match its input schema. The instruction previously told the model to
+// call load_skill with skill_name="<SKILL_NAME>", but LoadSkillArgs marshals its
+// field as "name", so the first call was rejected for an unknown field.
+func TestDefaultInstructionMatchesLoadSkillSchema(t *testing.T) {
+	field, ok := reflect.TypeOf(skilltool.LoadSkillArgs{}).FieldByName("Name")
+	if !ok {
+		t.Fatal("LoadSkillArgs has no Name field")
+	}
+	paramName := strings.Split(field.Tag.Get("json"), ",")[0]
+	if paramName == "" {
+		t.Fatal("LoadSkillArgs.Name has no json tag")
+	}
+
+	if !strings.Contains(defaultSkillSystemInstruction, "`load_skill` tool with `"+paramName+"=") {
+		t.Errorf("default instruction should document load_skill with %q=, got:\n%s", paramName, defaultSkillSystemInstruction)
+	}
+	if strings.Contains(defaultSkillSystemInstruction, "`load_skill` tool with `skill_name=") {
+		t.Error("default instruction still documents skill_name= for load_skill, which is not a valid load_skill parameter")
+	}
+}

--- a/tool/skilltoolset/toolset.go
+++ b/tool/skilltoolset/toolset.go
@@ -39,7 +39,7 @@ Skills are folders of instructions and resources that extend your capabilities f
 This is very important:
 
 ` +
-		"1. If a skill seems relevant to the current user query, you MUST use the `load_skill` tool with `skill_name=\"<SKILL_NAME>\"` to read its full instructions before proceeding.\n" +
+		"1. If a skill seems relevant to the current user query, you MUST use the `load_skill` tool with `name=\"<SKILL_NAME>\"` to read its full instructions before proceeding.\n" +
 		"2. Once you have read the instructions, follow them exactly as documented before replying to the user. For example, If the instruction lists multiple steps, please make sure you complete all of them in order.\n" +
 		"3. The `load_skill_resource` tool is for viewing files within a skill's directory (e.g., `references/*`, `assets/*`, `scripts/*`). Do NOT use other tools to access these files.\n"
 )


### PR DESCRIPTION
## Problem

A group of small user-visible defects still present on `v1`:

- The web launcher listener speaks HTTP/1 only, so a custom `web.Sublauncher` cannot
  mount an HTTP/2-aware handler (a native gRPC server, for instance) without standing up
  a second server.
- `adkgo deploy agentengine` hardcodes a `GOOGLE_API_KEY` secret env var, so the deploy
  fails for anyone who has not created that secret.
- The `load_skill` tool documents its parameter as `skill_name`; the actual parameter is
  `name`.
- The `OutputSchema` doc comment claims tools stop working, which is wrong — they still
  work via `set_model_response`.
- The README does not list the Kotlin and TypeScript ADK implementations.
- The `examples/agentengine` sample still pins `gemini-2.5-flash`, behind the rest of the
  v1 examples (`gemini-3.1-flash-lite`).
- The web launcher listener serves HTTP/1 only, so a custom `web.Sublauncher` cannot mount
  an HTTP/2-aware handler (a native gRPC/Connect server) without a second listener.


## Summary

Backports #826, #1162, #919, #786 and #1212 from `main`.

- Enable h2c on the web launcher listener so HTTP/1 and cleartext HTTP/2 share it, with
  no change to the public launcher APIs.
- Drop the hardcoded `GOOGLE_API_KEY` secret from the Agent Engine deploy path.
- Correct the `load_skill` parameter name and the `OutputSchema` comment.
- List the Kotlin and TypeScript implementations in the README.
- Drop the hardcoded `GOOGLE_API_KEY` secret from the Agent Engine deploy path and bump the
  `examples/agentengine` model from `gemini-2.5-flash` to `gemini-3.5-flash`. On `main` the
  same commit went `gemini-flash-latest` → `gemini-3.5-flash`; on `v1` the base is older, so
  it is a two-generation jump for the example. The end state matches `main`.
- Add an opt-in `-h2c` flag (default false) enabling prior-knowledge cleartext HTTP/2
  alongside HTTP/1 on the web launcher listener. No Go API change; the CLI grows one flag