### PR TITLE
fix(ci): restrict the nightly workflow to a read-only token

### DIFF
--- a/.github/workflows/nightly.yml
+++ b/.github/workflows/nightly.yml
@@ -6,6 +6,12 @@ on:
 
   workflow_dispatch:
 
+# Every job here only reads the repository: it checks out, tests and runs
+# govulncheck. Declaring that once at the top keeps each job from inheriting the
+# broader default token, which on a scheduled run is write-capable.
+permissions:
+  contents: read
+
 jobs:
   discover:
     runs-on: ubuntu-latest


### PR DESCRIPTION
## Problem

`.github/workflows/nightly.yml` declares no `permissions` block, so all three of
its jobs inherit the default token — which on a scheduled run is write-capable,
even though every job only checks out, tests and runs govulncheck. zizmor 1.25.2
reports 4 Medium `excessive-permissions` findings on the file: the workflow
itself plus each of `discover`, `test` and `vulncheck`.

`go.yml` got the same treatment in #1250 (second commit, despite the PR title);
Nightly was missed. The gap is latent today because the org Actions Scan only
audits workflow files in a PR's diff — the first PR that touches this one goes
red.

## Summary

Declare `permissions: contents: read` once at the top rather than per job.
Verified with zizmor 1.25.2: 4 findings before, 0 after. The remaining
`artipacked` findings are suppressed by the org config.

Also restores the trailing newline at end of file.