### PR TITLE
fix(openaimodel): serialize assistant messages with output_text type (#1197)

### DIFF
--- a/model/openaimodel/request.go
+++ b/model/openaimodel/request.go
@@ -95,12 +95,23 @@ func convertContents(contents []*genai.Content) (responses.ResponseInputParam, e
 			if len(textParts) == 0 {
 				return nil
 			}
-			msg, err := newMessage(curRole, textParts)
-			if err != nil {
-				return err
-			}
-			if msg != nil {
-				items = append(items, responses.ResponseInputItemUnionParam{OfMessage: msg})
+			switch curRole {
+			case genai.RoleModel:
+				out, err := newOutputMessage(textParts)
+				if err != nil {
+					return err
+				}
+				if out != nil {
+					items = append(items, responses.ResponseInputItemUnionParam{OfOutputMessage: out})
+				}
+			default:
+				msg, err := newMessage(curRole, textParts)
+				if err != nil {
+					return err
+				}
+				if msg != nil {
+					items = append(items, responses.ResponseInputItemUnionParam{OfMessage: msg})
+				}
 			}
 			textParts = textParts[:0]
 			return nil
@@ -182,6 +193,22 @@ func newMessage(role genai.Role, texts []string) (*responses.EasyInputMessagePar
 			OfInputItemContentList: contentList,
 		},
 	}, nil
+}
+
+func newOutputMessage(texts []string) (*responses.ResponseOutputMessageParam, error) {
+	content := make([]responses.ResponseOutputMessageContentUnionParam, 0, len(texts))
+	for _, txt := range texts {
+		if strings.TrimSpace(txt) == "" {
+			continue
+		}
+		content = append(content, responses.ResponseOutputMessageContentUnionParam{
+			OfOutputText: &responses.ResponseOutputTextParam{Text: txt},
+		})
+	}
+	if len(content) == 0 {
+		return nil, nil
+	}
+	return &responses.ResponseOutputMessageParam{Content: content}, nil
 }
 
 func normalizeRole(role genai.Role) (responses.EasyInputMessageRole, error) {

--- a/model/openaimodel/request_test.go
+++ b/model/openaimodel/request_test.go
@@ -616,3 +616,40 @@ func TestNewJSONSchemaFormat(t *testing.T) {
 		})
 	}
 }
+
+func TestBuildOpenAIParams_AssistantOutputText(t *testing.T) {
+	req := &model.LLMRequest{
+		Contents: []*genai.Content{
+			genai.NewContentFromText("hello", genai.RoleUser),
+			genai.NewContentFromText("hi there!", genai.RoleModel),
+			genai.NewContentFromText("how are you?", genai.RoleUser),
+		},
+	}
+	params, err := buildOpenAIParams("fallback", req)
+	if err != nil {
+		t.Fatalf("buildOpenAIParams() err = %v", err)
+	}
+	items := params.Input.OfInputItemList
+	if len(items) != 3 {
+		t.Fatalf("expected 3 items, got %d", len(items))
+	}
+	// Item 0: user (message)
+	if items[0].OfMessage == nil {
+		t.Fatalf("item 0 should be OfMessage")
+	}
+	// Item 1: assistant (output message with output_text)
+	if items[1].OfOutputMessage == nil {
+		t.Fatalf("item 1 (assistant turn) should be OfOutputMessage, got %+v", items[1])
+	}
+	outParts := items[1].OfOutputMessage.Content
+	if len(outParts) != 1 || outParts[0].OfOutputText == nil {
+		t.Fatalf("unexpected assistant output content: %+v", outParts)
+	}
+	if got, want := outParts[0].OfOutputText.Text, "hi there!"; got != want {
+		t.Fatalf("assistant text mismatch got=%q want=%q", got, want)
+	}
+	// Item 2: user (message)
+	if items[2].OfMessage == nil {
+		t.Fatalf("item 2 should be OfMessage")
+	}
+}


### PR DESCRIPTION
Fixes #1197

### Summary
The OpenAI model connector () previously serialized every message's content with type `input_text` regardless of role. When a prior assistant turn was replayed in a multi-turn conversation, OpenAI API rejected the request with HTTP 400 because assistant content must use type `output_text`.

### Solution
- Updated `flushText` in `model/openaimodel/request.go` to branch on `genai.RoleModel` and emit `ResponseInputItemUnionParam{OfOutputMessage: ...}` with `output_text` content using a helper `newOutputMessage`.
- Added unit test `TestBuildOpenAIParams_AssistantOutputText` verifying assistant turns are serialized with `output_text` content type.