### PR TITLE
fix(workflow): make ParallelWorker fail-fast stop new dispatch under maxConcurrency (#1238)

### DIFF
--- a/workflow/parallel_worker.go
+++ b/workflow/parallel_worker.go
@@ -112,16 +112,23 @@ func (n *ParallelWorker) Run(ctx agent.Context, input any) iter.Seq2[*session.Ev
 			if sem != nil {
 				select {
 				case sem <- struct{}{}:
-				case <-ctx.Done():
+				case <-workerCtx.Done():
 					wg.Done()
 					continue
+				}
+				select {
+				case <-workerCtx.Done():
+					<-sem
+					wg.Done()
+					continue
+				default:
 				}
 			}
 
 			itemBranch := deriveSubBranch(parentBranch, wrappedName+"@"+strconv.Itoa(i+1))
 
 			itemCtx := workerCtx.WithDelta(&agent.CommonContextDelta{InvocationContextDelta: &agent.InvocationContextDelta{Branch: &itemBranch}})
-			go n.runWorker(itemCtx, i, item, sem, resCh, &wg)
+			go n.runWorker(itemCtx, i, item, sem, resCh, &wg, cancelFunc)
 		}
 
 		// Goroutine to close channel when all workers are done
@@ -166,7 +173,7 @@ type workerResult struct {
 	err   error
 }
 
-func (n *ParallelWorker) runWorker(ctx agent.Context, idx int, item any, sem chan struct{}, resCh chan<- workerResult, wg *sync.WaitGroup) {
+func (n *ParallelWorker) runWorker(ctx agent.Context, idx int, item any, sem chan struct{}, resCh chan<- workerResult, wg *sync.WaitGroup, cancelFunc func()) {
 	defer wg.Done()
 	defer func() {
 		if sem != nil {
@@ -201,6 +208,7 @@ func (n *ParallelWorker) runWorker(ctx agent.Context, idx int, item any, sem cha
 		}
 
 		// Cannot retry or exhausted attempts
+		cancelFunc()
 		resCh <- workerResult{index: idx, err: runErr}
 		return
 	}

--- a/workflow/parallel_worker_test.go
+++ b/workflow/parallel_worker_test.go
@@ -772,3 +772,30 @@ func TestParallelWorker_RetryEmitsSpanPerAttempt(t *testing.T) {
 		t.Errorf("status multiset = {Error:%d, Unset:%d}, want {Error:1, Unset:1}", errCount, unsetCount)
 	}
 }
+
+func TestParallelWorker_MaxConcurrencyFailFast(t *testing.T) {
+	const nItems = 5
+	var started int32
+
+	wrapped := NewFunctionNode("slow_or_fail", func(ctx agent.Context, input int) (int, error) {
+		if input == 0 {
+			return 0, errors.New("error 0")
+		}
+		atomic.AddInt32(&started, 1)
+		time.Sleep(50 * time.Millisecond)
+		return input, nil
+	}, defaultNodeConfig)
+
+	pw, err := NewParallelWorker("parallel", wrapped, 1, defaultNodeConfig)
+	if err != nil {
+		t.Fatal(err)
+	}
+	exCtx := agent.NewContext(newMockCtx(t))
+
+	for range pw.Run(exCtx, []any{0, 1, 2, 3, 4}) {
+	}
+
+	if got := atomic.LoadInt32(&started); got >= nItems-1 {
+		t.Errorf("started = %d, want fewer than %d items dispatched after fail-fast cancellation", got, nItems-1)
+	}
+}


### PR DESCRIPTION
Fixes #1238

### Summary
`ParallelWorker.Run` documents that a non-retryable error from one item makes the workflow fail fast and cancel other in-flight workers. Under `maxConcurrency > 0` this did not hold: once one item failed, every other item still waiting on the concurrency semaphore got dispatched anyway and ran to completion before the error surfaced.

### Solution
- Checked `workerCtx.Done()` in dispatch loop `select` instead of the root `ctx.Done()`.
- Added a non-blocking check on `workerCtx.Done()` after acquiring the semaphore slot to avoid race conditions.
- Updated `runWorker` to invoke `cancelFunc()` synchronously upon non-retryable worker failure before releasing its semaphore slot.
- Added unit test `TestParallelWorker_MaxConcurrencyFailFast` verifying that items after a fail-fast failure are not dispatched under `maxConcurrency`.