### PR TITLE
ci: backport workflow hardening and build-cache keying (#1250, #1199, #1288)

### DIFF
--- a/.github/actions/setup/action.yml
+++ b/.github/actions/setup/action.yml
@@ -22,5 +22,11 @@ runs:
         path: |
           ~/.cache/go-build
           ~/go/pkg/mod
-        key: ${{ runner.os }}-go-build-${{ hashFiles('**/go.mod', '**/go.sum') }}
-        restore-keys: ${{ runner.os }}-go-build-
+        # The Go version has to be part of the key. The build cache holds export
+        # data written by the toolchain that produced it, and a bare restore-keys
+        # prefix will happily restore a cache written by an older Go. Analyses
+        # that read stdlib facts then work from stale data: staticcheck stops
+        # seeing the runtime.Goexit behind t.Fatal and reports SA5011 nil
+        # dereferences throughout the tests.
+        key: ${{ runner.os }}-go-${{ steps.setup-go.outputs.go-version }}-build-${{ hashFiles('**/go.mod', '**/go.sum') }}
+        restore-keys: ${{ runner.os }}-go-${{ steps.setup-go.outputs.go-version }}-build-

--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -16,3 +16,10 @@ updates:
     allow:
       - dependency-name: "google.golang.org/genai"
     open-pull-requests-limit: 10
+    # Let a release age before we adopt it, so regressions and compromised
+    # releases have time to surface. Security updates ignore cooldown.
+    cooldown:
+      default-days: 7
+      semver-patch-days: 7
+      semver-minor-days: 7
+      semver-major-days: 14

--- a/.github/workflows/go.yml
+++ b/.github/workflows/go.yml
@@ -18,6 +18,12 @@ concurrency:
   group: ${{ github.workflow }}-${{ github.head_ref || github.ref }}
   cancel-in-progress: true
 
+# Every job here only reads the repository: it checks out, builds, tests and
+# lints. Declaring that once at the top keeps each job from inheriting the
+# broader default token.
+permissions:
+  contents: read
+
 jobs:
   test:
     runs-on: ubuntu-latest

--- a/.github/workflows/go.yml
+++ b/.github/workflows/go.yml
@@ -55,3 +55,9 @@ jobs:
       with:
         install-mode: goinstall
         version: 5256574b81bcedfbcae9099f745f6aee9335da10 # v2.3.1
+        # golangci-lint's analysis cache stores the facts analyzers derive about
+        # dependencies, and its key does not track the toolchain. Restoring one
+        # written by an older Go leaves staticcheck without the runtime.Goexit
+        # inside testing.(*common).FailNow, so it stops treating t.Fatal as
+        # terminating and reports SA5011 nil dereferences throughout the tests.
+        skip-cache: true

--- a/.github/workflows/nightly.yml
+++ b/.github/workflows/nightly.yml
@@ -6,6 +6,11 @@ on:
 
   workflow_dispatch:
 
+# Both jobs only read the repository: they check out, test and scan for known
+# vulnerabilities.
+permissions:
+  contents: read
+
 jobs:
   test:
     runs-on: ubuntu-latest


### PR DESCRIPTION
## Problem

`v1` never received the CI hardening main has picked up since the branch cut, and
two of the gaps make PRs targeting it fail for reasons unrelated to their own
diff.

The org GitHub Actions Scan audits the workflow files that differ between a PR's
branch and main, and neither `go.yml` nor `nightly.yml` declares a `permissions`
block, so their jobs run on the default token — zizmor 1.25.2 reports 6 Medium
`excessive-permissions` findings across the two files. #1281 and #1282 go red on
`zizmor-output` today without touching `.github` at all.

Separately, the Go build cache key does not track the toolchain version, so an
entry written by an older Go leaves staticcheck without the `runtime.Goexit`
behind `t.Fatal` and it reports SA5011 nil dereferences throughout the tests,
failing lint on code that is fine.

## Summary

Backports the CI hardening main already has:

- `permissions: contents: read` at the top of `go.yml` and `nightly.yml` — every
  job in both only reads the repository. Adapted from #1250 (`go.yml`) and #1288
  (`nightly.yml`); `v1` has no multi-module matrix, so Nightly is two jobs here
  rather than three.
- The build cache keyed on the toolchain version, plus `skip-cache` for
  golangci-lint's own analysis cache, from #1250.
- A Dependabot cooldown, from #1199. This one fixes no finding and has no runtime
  effect on the branch — the scan does not audit `dependabot.yml`, and Dependabot
  reads its config from the default branch only. It is here purely to stop `v1`
  drifting further from main; making the cooldown actually apply to `v1` needs a
  `target-branch: "v1"` entry on main's config.

Verified with zizmor 1.25.2: 9 Medium findings before, 3 after — all six
`excessive-permissions` gone. The remaining `artipacked` findings are suppressed
by the org config.

Also restores the trailing newline at end of `nightly.yml`.