### PR TITLE
docs: correct role alternation comment in contents_processor

### DIFF
--- a/internal/llminternal/contents_processor.go
+++ b/internal/llminternal/contents_processor.go
@@ -61,8 +61,10 @@ func ContentsRequestProcessor(ctx agent.InvocationContext, req *model.LLMRequest
 			return
 		}
 		req.Contents = append(req.Contents, contents...)
-		// Gemini API requires role alternation (model turns cannot be consecutive).
-		// If the conversation history concludes on a model turn, inject a synthetic user continuation turn.
+		// If the conversation history concludes on a model turn, inject a synthetic user
+		// continuation turn so the model keeps producing output rather than returning an
+		// empty response. (Mirrors maybeAppendUserContent in model/gemini and
+		// adk-python's _maybe_append_user_content.)
 		if len(req.Contents) > 0 {
 			if last := req.Contents[len(req.Contents)-1]; last != nil && last.Role != "user" {
 				req.Contents = append(req.Contents, genai.NewContentFromText("Continue processing previous requests as instructed. Exit or provide a summary if no more outputs are needed.", "user"))


### PR DESCRIPTION
Fixes #1218

Comment-only change. The previous comment claimed the Gemini API requires role alternation (model turns cannot be consecutive), which is not an API requirement. The injected synthetic user continuation turn is a generation-quality nudge (mirrors `maybeAppendUserContent` in model/gemini and `_maybe_append_user_content` in adk-python). Reworded the comment to describe what the code actually does. No behavior change.