### PR TITLE
chore: report 1.6.0 as the ADK version

### DIFF
--- a/internal/version/version.go
+++ b/internal/version/version.go
@@ -15,4 +15,4 @@
 package version
 
 // Version exposes the current ADK Go version, used for llm request tagging
-const Version = "1.2.0"
+const Version = "1.6.0"


### PR DESCRIPTION
## Problem

`internal/version.Version` has read `1.2.0` since v1.3.0:

| tag | reported version |
|---|---|
| v1.3.0 | 1.2.0 |
| v1.4.0 | 1.2.0 |
| v1.5.0 | 1.2.0 |
| v1.5.1 | 1.2.0 |

The constant is not cosmetic — it goes out in the `google-adk/<version>` header
sent to Gemini, in the OTel instrumentation version on every trace and log, and
as the MCP client version. Anything attributing usage or traces by SDK version
has been reading a stale number for four releases.

## Summary

Set it to the release being prepared.

