### PR TITLE
fix(skilltoolset): accept scalar allowed-tools frontmatter (#1301)

### DIFF
--- a/tool/skilltoolset/skill/filesystem_source_test.go
+++ b/tool/skilltoolset/skill/filesystem_source_test.go
@@ -53,6 +53,25 @@ func TestFileSystemSource_ListFrontmatters(t *testing.T) {
 			},
 		},
 		{
+			name: "Allowed tools formats",
+			source: NewFileSystemSource(plainFS{fstest.MapFS{
+				"spec-skill/SKILL.md": &fstest.MapFile{
+					Data: []byte("---\nname: spec-skill\ndescription: test\nallowed-tools: Bash(git:*) Bash(jq:*) Read\n---\nInstructions."),
+				},
+				"list-skill/SKILL.md": &fstest.MapFile{
+					Data: []byte("---\nname: list-skill\ndescription: test\nallowed-tools:\n  - Bash(git:*)\n  - Bash(jq:*)\n  - Read\n---\nInstructions."),
+				},
+				"other-skill/SKILL.md": &fstest.MapFile{
+					Data: []byte("---\nname: other-skill\ndescription: test\n---\nInstructions."),
+				},
+			}}),
+			want: []*Frontmatter{
+				{Name: "spec-skill", Description: "test", AllowedTools: []string{"Bash(git:*)", "Bash(jq:*)", "Read"}},
+				{Name: "list-skill", Description: "test", AllowedTools: []string{"Bash(git:*)", "Bash(jq:*)", "Read"}},
+				{Name: "other-skill", Description: "test"},
+			},
+		},
+		{
 			name: "Name mismatch",
 			source: NewFileSystemSource(plainFS{fstest.MapFS{
 				"test-skill/SKILL.md": &fstest.MapFile{Data: []byte("---\nname: wrong-skill\ndescription: test\n---\n")},

--- a/tool/skilltoolset/skill/frontmatter.go
+++ b/tool/skilltoolset/skill/frontmatter.go
@@ -23,6 +23,7 @@ import (
 	"io"
 	"slices"
 	"strings"
+	"unicode"
 
 	"gopkg.in/yaml.v3"
 )
@@ -41,6 +42,99 @@ type Frontmatter struct {
 	Compatibility string            `yaml:"compatibility,omitempty"`
 	Metadata      map[string]string `yaml:"metadata,omitempty"`
 	AllowedTools  []string          `yaml:"allowed-tools,omitempty"`
+}
+
+// frontmatterYAML keeps the public Frontmatter representation stable while
+// accepting both the specification's scalar allowed-tools value and the YAML
+// sequence accepted by earlier ADK Go releases.
+type frontmatterYAML struct {
+	Name          string            `yaml:"name"`
+	Description   string            `yaml:"description"`
+	License       string            `yaml:"license,omitempty"`
+	Compatibility string            `yaml:"compatibility,omitempty"`
+	Metadata      map[string]string `yaml:"metadata,omitempty"`
+	AllowedTools  allowedToolsYAML  `yaml:"allowed-tools,omitempty"`
+}
+
+type allowedToolsYAML []string
+
+const allowedToolsFormat = "allowed-tools must be a whitespace- or comma-separated list of Tool or Tool(well-balanced expression)"
+
+func (a *allowedToolsYAML) UnmarshalYAML(node *yaml.Node) error {
+	switch node.Kind {
+	case yaml.SequenceNode:
+		var tools []string
+		if err := node.Decode(&tools); err != nil {
+			return err
+		}
+		*a = tools
+		return nil
+	case yaml.ScalarNode:
+		if node.Tag == "!!null" {
+			*a = nil
+			return nil
+		}
+		if node.Tag != "!!str" {
+			return fmt.Errorf("allowed-tools must be a string or a sequence of strings")
+		}
+		tools, err := splitAllowedTools(node.Value)
+		if err != nil {
+			return err
+		}
+		*a = tools
+		return nil
+	default:
+		return fmt.Errorf("allowed-tools must be a string or a sequence of strings")
+	}
+}
+
+// splitAllowedTools splits tool names or tool expressions separated by
+// whitespace or commas. Separators inside balanced parentheses are preserved.
+func splitAllowedTools(value string) ([]string, error) {
+	var tools []string
+	var current strings.Builder
+	depth := 0
+	flush := func() {
+		if current.Len() == 0 {
+			return
+		}
+		tools = append(tools, current.String())
+		current.Reset()
+	}
+
+	for _, r := range value {
+		switch {
+		case r == '(':
+			depth++
+			current.WriteRune(r)
+		case r == ')':
+			if depth == 0 {
+				return nil, fmt.Errorf("%s: unexpected ')'", allowedToolsFormat)
+			}
+			depth--
+			current.WriteRune(r)
+		case depth == 0 && (unicode.IsSpace(r) || r == ','):
+			flush()
+		default:
+			current.WriteRune(r)
+		}
+	}
+	if depth != 0 {
+		return nil, fmt.Errorf("%s: unclosed '('", allowedToolsFormat)
+	}
+	flush()
+	return tools, nil
+}
+
+func (f *frontmatterYAML) toFrontmatter() *Frontmatter {
+	return &Frontmatter{
+		Name:          f.Name,
+		Description:   f.Description,
+		License:       f.License,
+		Compatibility: f.Compatibility,
+		Metadata:      f.Metadata,
+		AllowedTools:  []string(f.AllowedTools),
+	}
 }
 
 // Parse reads and validates YAML frontmatter from a SKILL.md reader.
@@ -70,16 +164,17 @@ func Parse(r *bufio.Reader) (*Frontmatter, error) {
 		yamlBytes.Write(line)
 	}
 
-	fm := Frontmatter{}
+	fmYAML := frontmatterYAML{}
 	decoder := yaml.NewDecoder(bytes.NewReader(yamlBytes.Bytes()))
 	decoder.KnownFields(true)
-	if err := decoder.Decode(&fm); err != nil {
+	if err := decoder.Decode(&fmYAML); err != nil {
 		return nil, fmt.Errorf("parse frontmatter: %w", err)
 	}
-	if err := Validate(&fm); err != nil {
+	fm := fmYAML.toFrontmatter()
+	if err := Validate(fm); err != nil {
 		return nil, fmt.Errorf("invalid frontmatter: %w", err)
 	}
-	return &fm, nil
+	return fm, nil
 }
 
 // ParseBytes splits and validates YAML frontmatter from SKILL.md content bytes.

--- a/tool/skilltoolset/skill/frontmatter_test.go
+++ b/tool/skilltoolset/skill/frontmatter_test.go
@@ -123,6 +123,26 @@ func TestParse_Valid(t *testing.T) {
 			wantInstruction: "Markdown Body",
 		},
 		{
+			name:  "allowed tools as specification scalar",
+			input: "---\nname: skill\ndescription: skill\nallowed-tools: Bash(git:*) Bash(jq:*) Read\n---\nMarkdown Body",
+			want: &Frontmatter{
+				Name:         "skill",
+				Description:  "skill",
+				AllowedTools: []string{"Bash(git:*)", "Bash(jq:*)", "Read"},
+			},
+			wantInstruction: "Markdown Body",
+		},
+		{
+			name:  "allowed tools comma-separated with spaces inside parentheses",
+			input: "---\nname: skill\ndescription: skill\nallowed-tools: Read, Bash(kubectl get:*)\n---\nMarkdown Body",
+			want: &Frontmatter{
+				Name:         "skill",
+				Description:  "skill",
+				AllowedTools: []string{"Read", "Bash(kubectl get:*)"},
+			},
+			wantInstruction: "Markdown Body",
+		},
+		{
 			name: "valid full frontmatter",
 			input: `---
 name: my-cool-skill
@@ -184,8 +204,9 @@ Body
 
 func TestParse_InvalidFormat(t *testing.T) {
 	tests := []struct {
-		name  string
-		input string
+		name    string
+		input   string
+		wantErr string
 	}{
 		{
 			name:  "missing opening separator",
@@ -223,6 +244,21 @@ func TestParse_InvalidFormat(t *testing.T) {
 			name:  "unknown fields",
 			input: "---\nname: skill\ndescription: skill\nunknown-field: field\n---\n# Markdown\nBody",
 		},
+		{
+			name:    "allowed tools with unexpected closing parenthesis",
+			input:   "---\nname: skill\ndescription: skill\nallowed-tools: Read) Bash\n---\n# Markdown\nBody",
+			wantErr: "allowed-tools must be a whitespace- or comma-separated list of Tool or Tool(well-balanced expression): unexpected ')'",
+		},
+		{
+			name:    "allowed tools with unclosed opening parenthesis",
+			input:   "---\nname: skill\ndescription: skill\nallowed-tools: Bash(git:* Read\n---\n# Markdown\nBody",
+			wantErr: "allowed-tools must be a whitespace- or comma-separated list of Tool or Tool(well-balanced expression): unclosed '('",
+		},
+		{
+			name:    "allowed tools with closing parenthesis before opening parenthesis",
+			input:   "---\nname: skill\ndescription: skill\nallowed-tools: Bash)(git:*)\n---\n# Markdown\nBody",
+			wantErr: "allowed-tools must be a whitespace- or comma-separated list of Tool or Tool(well-balanced expression): unexpected ')'",
+		},
 	}
 	for _, testcase := range tests {
 		t.Run(testcase.name, func(t *testing.T) {
@@ -232,7 +268,10 @@ func TestParse_InvalidFormat(t *testing.T) {
 			_, err := Parse(reader)
 
 			if err == nil {
-				t.Errorf("expected error, got nil")
+				t.Fatal("expected error, got nil")
+			}
+			if testcase.wantErr != "" && !strings.Contains(err.Error(), testcase.wantErr) {
+				t.Errorf("error %q does not contain %q", err, testcase.wantErr)
 			}
 		})
 	}


### PR DESCRIPTION
## Problem

`v1` rejects a skill whose frontmatter gives `allowed-tools` as a single scalar
rather than a list. Authors write the scalar form naturally for a one-tool skill,
and the skill then fails to load.

Landed on `main` as #1301 after the v1.6.0 backport series was assembled, so it
was not part of it.

## Summary

Straight backport of #1301: accept both the scalar and the list form when parsing
the frontmatter. Applies cleanly to `v1`; only the module path differs.