### PR TITLE
fix(configurable): config loader panics on non string args

### DIFF
--- a/internal/configurable/configurable_utils.go
+++ b/internal/configurable/configurable_utils.go
@@ -220,11 +220,19 @@ func init() {
 		}
 		serverArgsStr := make([]string, len(serverArgs))
 		for i, arg := range serverArgs {
-			serverArgsStr[i] = arg.(string)
+			s, ok := arg.(string)
+			if !ok {
+				return nil, fmt.Errorf("server_params.args[%d]: expected string, got %T (%v)", i, arg, arg)
+			}
+			serverArgsStr[i] = s
 		}
 		toolFilterStr := make([]string, len(toolFilter))
 		for i, t := range toolFilter {
-			toolFilterStr[i] = t.(string)
+			s, ok := t.(string)
+			if !ok {
+				return nil, fmt.Errorf("tool_filter[%d]: expected string, got %T (%v)", i, t, t)
+			}
+			toolFilterStr[i] = s
 		}
 
 		mcpSet, err := mcptoolset.New(mcptoolset.Config{

--- a/internal/configurable/configurable_utils_test.go
+++ b/internal/configurable/configurable_utils_test.go
@@ -138,8 +138,8 @@ func TestResolveToolReferenceMcpToolsetNonStringArgs(t *testing.T) {
 	}{
 		{
 			name:    "non-string in server args",
-			args:    newArgs([]any{1, 2, 3}, []any{"a"}),
-			wantErr: "server_params.args[0]",
+			args:    newArgs([]any{"a", 1, 2}, []any{"a"}),
+			wantErr: "server_params.args[1]",
 		},
 		{
 			name:    "non-string in tool filter",

--- a/internal/configurable/configurable_utils_test.go
+++ b/internal/configurable/configurable_utils_test.go
@@ -114,6 +114,69 @@ func TestResolveAgentReferenceAllowsPathsInsideAgentDir(t *testing.T) {
 	}
 }
 
+// TestResolveToolReferenceMcpToolsetNonStringArgs reproduces the bug where a
+// non-string element in the McpToolset "args" or "tool_filter" lists triggered
+// an unchecked type assertion that panicked and killed the process. The factory
+// must now return a descriptive error instead of crashing.
+func TestResolveToolReferenceMcpToolsetNonStringArgs(t *testing.T) {
+	newArgs := func(serverArgs, toolFilter []any) map[string]any {
+		return map[string]any{
+			"stdio_connection_params": map[string]any{
+				"server_params": map[string]any{
+					"command": "echo",
+					"args":    serverArgs,
+				},
+			},
+			"tool_filter": toolFilter,
+		}
+	}
+
+	tests := []struct {
+		name    string
+		args    map[string]any
+		wantErr string // empty means a valid config is expected
+	}{
+		{
+			name:    "non-string in server args",
+			args:    newArgs([]any{1, 2, 3}, []any{"a"}),
+			wantErr: "server_params.args[0]",
+		},
+		{
+			name:    "non-string in tool filter",
+			args:    newArgs([]any{"a"}, []any{true}),
+			wantErr: "tool_filter[0]",
+		},
+		{
+			name:    "all strings is valid",
+			args:    newArgs([]any{"a", "b"}, []any{"t1"}),
+			wantErr: "",
+		},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			// A non-string element previously triggered a panic; the call must
+			// return normally (with or without an error), never crash.
+			_, toolset, err := ResolveToolReference(context.Background(), "McpToolset", tc.args)
+			if tc.wantErr == "" {
+				if err != nil {
+					t.Fatalf("ResolveToolReference(McpToolset) = %v, want no error", err)
+				}
+				if toolset == nil {
+					t.Fatal("ResolveToolReference(McpToolset) returned a nil toolset, want non-nil")
+				}
+				return
+			}
+			if err == nil {
+				t.Fatalf("ResolveToolReference(McpToolset) succeeded, want error containing %q", tc.wantErr)
+			}
+			if !strings.Contains(err.Error(), tc.wantErr) {
+				t.Errorf("ResolveToolReference(McpToolset) = %v, want error containing %q", err, tc.wantErr)
+			}
+		})
+	}
+}
+
 // TestResolveAgentReferenceRelativeParentPath covers a parent path that is not
 // absolute, which the containment check must normalise before comparing.
 func TestResolveAgentReferenceRelativeParentPath(t *testing.T) {


### PR DESCRIPTION
## Problem

The config loader (the `McpToolset` toolset factory) panics
when a `root_agent.yaml` has a non-string value where a string is expected. The
loops over `serverArgs` and `toolFilter` in `internal/configurable/configurable_utils.go:223,227`
use bare type assertions (`arg.(string)`), which panic if the YAML element is not
a string (e.g. a number). Loading a bad config should return a clear error, not
panic.

## Solution

Replace the two unchecked type assertions with the checked "comma-ok" form and
return a descriptive non-nil error on a type mismatch, matching how the sibling
params are already handled (e.g. `:209`). The error propagates out of
`FromConfig` and is handled gracefully by `cmd/internal/adkcli/main.go`.

## Testing plan

- Reproduced the bug with custom yaml config
- Added a meaningful test reproducing the bug:
  `TestResolveToolReferenceMcpToolsetNonStringArgs` (non-string `args` /
  `tool_filter` now error instead of panicking; valid config still loads).
- Ran `go test -race -mod=readonly -count=1 -shuffle=on work`

