### PR TITLE
fix(loadartifactstool): support load_artifacts when combined with other tool calls

### DIFF
--- a/tool/loadartifactstool/load_artifacts_tool.go
+++ b/tool/loadartifactstool/load_artifacts_tool.go
@@ -162,14 +162,18 @@ func (t *artifactsTool) processLoadArtifactsFunctionCall(ctx agent.Context, req 
 	if lastContent == nil || len(lastContent.Parts) == 0 {
 		return nil
 	}
-	firstPart := lastContent.Parts[0]
-	if firstPart.FunctionResponse == nil {
-		return nil
+	var functionResponse *genai.FunctionResponse
+	// Iterate over all parts in the last content turn to find load_artifacts responses.
+	// Note: adk-python only checks parts[0]; scanning all parts is intentional in Go to
+	// support parallel/multi-tool turns where load_artifacts may not be the first part.
+	for _, part := range lastContent.Parts {
+		if part != nil && part.FunctionResponse != nil && part.FunctionResponse.Name == "load_artifacts" {
+			functionResponse = part.FunctionResponse
+			// Keep only the first load_artifacts response if multiple exist in one turn.
+			break
+		}
 	}
-
-	functionResponse := firstPart.FunctionResponse
-
-	if functionResponse.Name != "load_artifacts" {
+	if functionResponse == nil {
 		return nil
 	}
 	artifactNamesRaw, ok := functionResponse.Response["artifact_names"]

--- a/tool/loadartifactstool/load_artifacts_tool.go
+++ b/tool/loadartifactstool/load_artifacts_tool.go
@@ -159,14 +159,14 @@ func (t *artifactsTool) processLoadArtifactsFunctionCall(ctx agent.Context, req 
 	if lastContent == nil || len(lastContent.Parts) == 0 {
 		return nil
 	}
-	firstPart := lastContent.Parts[0]
-	if firstPart.FunctionResponse == nil {
-		return nil
+	var functionResponse *genai.FunctionResponse
+	for _, part := range lastContent.Parts {
+		if part != nil && part.FunctionResponse != nil && part.FunctionResponse.Name == "load_artifacts" {
+			functionResponse = part.FunctionResponse
+			break
+		}
 	}
-
-	functionResponse := firstPart.FunctionResponse
-
-	if functionResponse.Name != "load_artifacts" {
+	if functionResponse == nil {
 		return nil
 	}
 	artifactNamesRaw, ok := functionResponse.Response["artifact_names"]

--- a/tool/loadartifactstool/load_artifacts_tool_test.go
+++ b/tool/loadartifactstool/load_artifacts_tool_test.go
@@ -408,6 +408,95 @@ func TestLoadArtifactsTool_ProcessRequest_NilArtifacts_WithFunctionCall(t *testi
 	}
 }
 
+func TestLoadArtifactsTool_ProcessRequest_Artifacts_MultiPartFunctionResponse(t *testing.T) {
+	otherFR := &genai.FunctionResponse{
+		Name: "other_function",
+		Response: map[string]any{
+			"status": "ok",
+		},
+	}
+	loadArtifactsFR := &genai.FunctionResponse{
+		Name: "load_artifacts",
+		Response: map[string]any{
+			"artifact_names": []string{"doc1.txt"},
+		},
+	}
+
+	tests := []struct {
+		name  string
+		parts []*genai.Part
+	}{
+		{
+			name: "load_artifacts after other function",
+			parts: []*genai.Part{
+				genai.NewPartFromFunctionResponse(otherFR.Name, otherFR.Response),
+				genai.NewPartFromFunctionResponse(loadArtifactsFR.Name, loadArtifactsFR.Response),
+			},
+		},
+		{
+			name: "load_artifacts before other function",
+			parts: []*genai.Part{
+				genai.NewPartFromFunctionResponse(loadArtifactsFR.Name, loadArtifactsFR.Response),
+				genai.NewPartFromFunctionResponse(otherFR.Name, otherFR.Response),
+			},
+		},
+		{
+			name: "nil part alongside load_artifacts",
+			parts: []*genai.Part{
+				nil,
+				genai.NewPartFromFunctionResponse(loadArtifactsFR.Name, loadArtifactsFR.Response),
+			},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			loadArtifactsTool := loadartifactstool.New()
+			tc := createToolContext(t)
+			if _, err := tc.Artifacts().Save(t.Context(), "doc1.txt", &genai.Part{Text: "This is the content of doc1.txt"}); err != nil {
+				t.Fatalf("Failed to save artifact: %v", err)
+			}
+
+			llmRequest := &model.LLMRequest{
+				Contents: []*genai.Content{
+					{
+						Role:  genai.RoleUser,
+						Parts: tt.parts,
+					},
+				},
+			}
+
+			requestProcessor, ok := loadArtifactsTool.(toolinternal.RequestProcessor)
+			if !ok {
+				t.Fatal("loadArtifactsTool does not implement RequestProcessor")
+			}
+
+			err := requestProcessor.ProcessRequest(tc, llmRequest)
+			if err != nil {
+				t.Fatalf("ProcessRequest failed: %v", err)
+			}
+
+			if len(llmRequest.Contents) != 2 {
+				t.Fatalf("Expected 2 contents, but got: %v", len(llmRequest.Contents))
+			}
+
+			appendedContent := llmRequest.Contents[1]
+			if appendedContent.Role != genai.RoleUser {
+				t.Errorf("Appended Content Role: got %v, want %v", appendedContent.Role, genai.RoleUser)
+			}
+			if len(appendedContent.Parts) != 2 {
+				t.Fatalf("Expected 2 parts in appended content, but got: %v", len(appendedContent.Parts))
+			}
+			if appendedContent.Parts[0].Text != "Artifact doc1.txt is:" {
+				t.Errorf("First part of appended content: got %v, want 'Artifact doc1.txt is:'", appendedContent.Parts[0].Text)
+			}
+			if appendedContent.Parts[1].Text != "This is the content of doc1.txt" {
+				t.Errorf("Second part of appended content: got %v, want 'This is the content of doc1.txt'", appendedContent.Parts[1].Text)
+			}
+		})
+	}
+}
+
 func createToolContext(t *testing.T) agent.Context {
 	t.Helper()
 

--- a/tool/loadartifactstool/load_artifacts_tool_test.go
+++ b/tool/loadartifactstool/load_artifacts_tool_test.go
@@ -339,6 +339,73 @@ func TestLoadArtifactsTool_ProcessRequest_Artifacts_OtherFunctionCall(t *testing
 	}
 }
 
+func TestLoadArtifactsTool_ProcessRequest_Artifacts_MultiPartFunctionResponse(t *testing.T) {
+	loadArtifactsTool := loadartifactstool.New()
+
+	tc := createToolContext(t)
+	artifacts := map[string]*genai.Part{
+		"doc1.txt": {Text: "This is the content of doc1.txt"},
+	}
+	for name, part := range artifacts {
+		_, err := tc.Artifacts().Save(t.Context(), name, part)
+		if err != nil {
+			t.Fatalf("Failed to save artifact %s: %v", name, err)
+		}
+	}
+
+	otherFR := &genai.FunctionResponse{
+		Name: "other_function",
+		Response: map[string]any{
+			"status": "ok",
+		},
+	}
+	loadArtifactsFR := &genai.FunctionResponse{
+		Name: "load_artifacts",
+		Response: map[string]any{
+			"artifact_names": []string{"doc1.txt"},
+		},
+	}
+	llmRequest := &model.LLMRequest{
+		Contents: []*genai.Content{
+			{
+				Role: "model",
+				Parts: []*genai.Part{
+					genai.NewPartFromFunctionResponse(otherFR.Name, otherFR.Response),
+					genai.NewPartFromFunctionResponse(loadArtifactsFR.Name, loadArtifactsFR.Response),
+				},
+			},
+		},
+	}
+
+	requestProcessor, ok := loadArtifactsTool.(toolinternal.RequestProcessor)
+	if !ok {
+		t.Fatal("loadArtifactsTool does not implement RequestProcessor")
+	}
+
+	err := requestProcessor.ProcessRequest(tc, llmRequest)
+	if err != nil {
+		t.Fatalf("ProcessRequest failed: %v", err)
+	}
+
+	if len(llmRequest.Contents) != 2 {
+		t.Fatalf("Expected 2 contents, but got: %v", len(llmRequest.Contents))
+	}
+
+	appendedContent := llmRequest.Contents[1]
+	if appendedContent.Role != "user" {
+		t.Errorf("Appended Content Role: got %v, want 'user'", appendedContent.Role)
+	}
+	if len(appendedContent.Parts) != 2 {
+		t.Fatalf("Expected 2 parts in appended content, but got: %v", len(appendedContent.Parts))
+	}
+	if appendedContent.Parts[0].Text != "Artifact doc1.txt is:" {
+		t.Errorf("First part of appended content: got %v, want 'Artifact doc1.txt is:'", appendedContent.Parts[0].Text)
+	}
+	if appendedContent.Parts[1].Text != "This is the content of doc1.txt" {
+		t.Errorf("Second part of appended content: got %v, want 'This is the content of doc1.txt'", appendedContent.Parts[1].Text)
+	}
+}
+
 func createToolContext(t *testing.T) agent.Context {
 	t.Helper()
 


### PR DESCRIPTION
Closes #1319

## Summary

- Add multi-part `FunctionResponse` traversal in `processLoadArtifactsFunctionCall` (`tool/loadartifactstool/load_artifacts_tool.go`) to find `load_artifacts` responses across all parts in `req.Contents[last].Parts`
- Add unit test coverage `TestLoadArtifactsTool_ProcessRequest_Artifacts_MultiPartFunctionResponse` in `tool/loadartifactstool/load_artifacts_tool_test.go` asserting multi-part tool execution correctly loads artifact content

## Why

When an LLM executes multiple tool calls in a single turn (e.g. `[other_tool, load_artifacts]`), the function response for `load_artifacts` is placed at `Parts[1]` or later in `req.Contents[last].Parts`. Previously, `processLoadArtifactsFunctionCall` checked only `Parts[0]` (`firstPart := lastContent.Parts[0]`), returning early if `Parts[0]` was a response to a different function. As a result, `load_artifacts` was silently ignored and requested artifact contents were never loaded into context. Iterating over all parts in `lastContent.Parts` locates `load_artifacts` wherever it appears in the response array.

## Test Plan

- [x] Unit tests pass: `go test -race -v ./tool/loadartifactstool/...`
- [x] Linter & Mod Tidy check pass: `go mod tidy -diff`
- [x] Empirical verification: Confirmed `TestLoadArtifactsTool_ProcessRequest_Artifacts_MultiPartFunctionResponse` fails on `main` without the fix (`Expected 2 contents, but got: 1`) and passes cleanly with this fix
- [x] No regressions: All existing `loadartifactstool` test cases pass cleanly

/cc @hyangah @kdroste-google @dpasiukevich @karolpiotrowicz @wolo-lab