### PR TITLE
fix(session/vertexai): treat nil function args as an empty struct

### DIFF
--- a/session/vertexai/vertexai_client.go
+++ b/session/vertexai/vertexai_client.go
@@ -919,10 +919,18 @@ func createGroundingMetadata(metadata *aiplatformpb.GroundingMetadata) *genai.Gr
 // It uses JSON marshaling as an intermediary step to safely serialize
 // the input data before constructing the *structpb.Struct.
 // Returns an error if any part of the JSON round-trip or conversion fails.
+//
+// A nil value marshals to the JSON literal "null", which structpb rejects.
+// Such a value is treated as an empty Struct, matching structpb.NewStruct(nil)
+// and keeping callers that pass an absent map (for example a function call
+// that takes no arguments) from failing.
 func toStructPB(value any) (*structpb.Struct, error) {
 	data, err := json.Marshal(value)
 	if err != nil {
 		return nil, fmt.Errorf("failed to marshal value: %w", err)
+	}
+	if string(data) == "null" {
+		return &structpb.Struct{}, nil
 	}
 	res := &structpb.Struct{}
 	if err := res.UnmarshalJSON(data); err != nil {

--- a/session/vertexai/vertexai_test.go
+++ b/session/vertexai/vertexai_test.go
@@ -477,6 +477,29 @@ func TestToStructPB(t *testing.T) {
 			expectError: true,
 		},
 		{
+			// A tool that takes no arguments leaves FunctionCall.Args nil, which
+			// marshals to the JSON literal "null". That must convert to an empty
+			// Struct rather than an error, as structpb.NewStruct(nil) did.
+			name:        "nil map converts to an empty struct",
+			input:       map[string]any(nil),
+			expectError: false,
+			validate: func(t *testing.T, s *structpb.Struct) {
+				if got := len(s.GetFields()); got != 0 {
+					t.Errorf("len(fields) = %d, want 0", got)
+				}
+			},
+		},
+		{
+			name:        "untyped nil converts to an empty struct",
+			input:       nil,
+			expectError: false,
+			validate: func(t *testing.T, s *structpb.Struct) {
+				if got := len(s.GetFields()); got != 0 {
+					t.Errorf("len(fields) = %d, want 0", got)
+				}
+			},
+		},
+		{
 			name: "custom struct representing possible state delta",
 			input: struct {
 				StringValue string
@@ -569,6 +592,38 @@ func TestCreateAiplatformpbContent(t *testing.T) {
 							genai.NewPartFromFunctionCall("tool", map[string]any{
 								"city": "Stockholm",
 							}),
+						},
+						Role: genai.RoleUser,
+					},
+				},
+			},
+			expectError: false,
+		},
+		{
+			// Regression: a tool declaring no parameters yields a FunctionCall
+			// with nil Args. This must persist rather than fail the AppendEvent.
+			name: "function call with nil args",
+			event: &session.Event{
+				LLMResponse: model.LLMResponse{
+					Content: &genai.Content{
+						Parts: []*genai.Part{
+							{FunctionCall: &genai.FunctionCall{ID: "call-1", Name: "get_time"}},
+						},
+						Role: genai.RoleModel,
+					},
+				},
+			},
+			expectError: false,
+		},
+		{
+			// Regression: a tool returning no payload yields a FunctionResponse
+			// with nil Response.
+			name: "function response with nil response",
+			event: &session.Event{
+				LLMResponse: model.LLMResponse{
+					Content: &genai.Content{
+						Parts: []*genai.Part{
+							{FunctionResponse: &genai.FunctionResponse{ID: "call-1", Name: "get_time"}},
 						},
 						Role: genai.RoleUser,
 					},


### PR DESCRIPTION
### Link to Issue or Description of Change

- Fixes: #1321

### Problem

`session/vertexai` fails to persist any event containing a function call with nil `Args`, or a function response with nil `Response`. That is the normal shape for a tool declaring no parameters (`get_time`, `list_items`, …) or a tool returning no payload — `genai` leaves the field nil when the model emits a function call with no `args`.

`createAiplatformpbContent` converts both fields with `toStructPB`, which marshals to JSON and hands the result to `structpb.Struct.UnmarshalJSON`. A nil map marshals to the literal `null`, which `structpb` rejects. The error propagates out of `AppendEvent`, so the event is never written:

```
failed to add event to session: failed to append event: error creating content:
failed to convert function call to structpb: failed to unmarshal JSON data to structpb:
proto: syntax error (line 1:1): unexpected token null
```

These conversions previously used `structpb.NewStruct`, which returns an empty `Struct` for a nil map. The move to the JSON-based helper was needed to support values `structpb.NewStruct` cannot handle (typed slices such as `[]string`, #668), but it also turned the nil case from "empty struct" into an error:

```go
structpb.NewStruct(map[string]any(nil))  // -> &structpb.Struct{}, nil
toStructPB(map[string]any(nil))          // -> nil, "unexpected token null"
```

Last unaffected release is v1.4.0; present in v1.5.0, v1.5.1, v1.6.0, v2.0.0, v2.1.0 and v2.2.0.

### Solution

Treat a `null` marshaling as an empty `Struct` inside `toStructPB`.

Fixing the helper rather than guarding the two call sites keeps all five callers consistent and restores the exact prior `structpb.NewStruct` semantics. The three other call sites (lines 74, 458, 686) already guard with `len(...) > 0` or `!= nil`, so this is a no-op for them; only the two function-call sites were unguarded.

### Testing Plan

- [x] `TestToStructPB`: added `nil map converts to an empty struct` and `untyped nil converts to an empty struct`.
- [x] `TestCreateAiplatformpbContent`: added `function call with nil args` and `function response with nil response`, covering the failure at the level users hit it.
- [x] Confirmed all four new cases fail without the fix and pass with it.
- [x] Existing tests in the package unchanged and green.

```sh
go build -mod=readonly ./...
go test -race -count=1 -shuffle=on ./session/...
gofmt -l session/
go mod tidy -diff
```

### Alignment with adk-python

A tool with no parameters is a first-class case across ADK implementations; persisting its call event should not depend on whether the model emitted an empty `args` object or omitted the field.
