### PR TITLE
fix(artifact): reject path separators in appName/userID/sessionID

### DIFF
--- a/artifact/request_validation_test.go
+++ b/artifact/request_validation_test.go
@@ -122,6 +122,42 @@ func TestSaveRequest_Validate(t *testing.T) {
 			wantErr:    true,
 			wantErrMsg: "invalid name: filename cannot contain path separators",
 		},
+		{
+			name: "AppName with path separator",
+			req: &SaveRequest{
+				AppName:   "My/App",
+				UserID:    "user-123",
+				SessionID: "sess-abc",
+				FileName:  "file.txt",
+				Part:      genai.NewPartFromText("data"),
+			},
+			wantErr:    true,
+			wantErrMsg: "invalid AppName: cannot contain path separators",
+		},
+		{
+			name: "UserID with path separator",
+			req: &SaveRequest{
+				AppName:   "MyApp",
+				UserID:    "user/123",
+				SessionID: "sess-abc",
+				FileName:  "file.txt",
+				Part:      genai.NewPartFromText("data"),
+			},
+			wantErr:    true,
+			wantErrMsg: "invalid UserID: cannot contain path separators",
+		},
+		{
+			name: "SessionID with backslash separator",
+			req: &SaveRequest{
+				AppName:   "MyApp",
+				UserID:    "user-123",
+				SessionID: `sess\abc`,
+				FileName:  "file.txt",
+				Part:      genai.NewPartFromText("data"),
+			},
+			wantErr:    true,
+			wantErrMsg: "invalid SessionID: cannot contain path separators",
+		},
 	}
 	executeValidatorTestCases(t, "SaveRequest", testCases)
 }
@@ -174,6 +210,39 @@ func TestLoadRequest_Validate(t *testing.T) {
 			},
 			wantErr:    true,
 			wantErrMsg: "invalid name: filename cannot contain path separators",
+		},
+		{
+			name: "AppName with path separator",
+			req: &LoadRequest{
+				AppName:   "My/App",
+				UserID:    "user-123",
+				SessionID: "sess-abc",
+				FileName:  "file.txt",
+			},
+			wantErr:    true,
+			wantErrMsg: "invalid AppName: cannot contain path separators",
+		},
+		{
+			name: "UserID with path separator",
+			req: &LoadRequest{
+				AppName:   "MyApp",
+				UserID:    "user/123",
+				SessionID: "sess-abc",
+				FileName:  "file.txt",
+			},
+			wantErr:    true,
+			wantErrMsg: "invalid UserID: cannot contain path separators",
+		},
+		{
+			name: "SessionID with backslash separator",
+			req: &LoadRequest{
+				AppName:   "MyApp",
+				UserID:    "user-123",
+				SessionID: `sess\abc`,
+				FileName:  "file.txt",
+			},
+			wantErr:    true,
+			wantErrMsg: "invalid SessionID: cannot contain path separators",
 		},
 	}
 	executeValidatorTestCases(t, "LoadRequest", testCases)
@@ -228,6 +297,39 @@ func TestDeleteRequest_Validate(t *testing.T) {
 			wantErr:    true,
 			wantErrMsg: "invalid name: filename cannot contain path separators",
 		},
+		{
+			name: "AppName with path separator",
+			req: &DeleteRequest{
+				AppName:   "My/App",
+				UserID:    "user-123",
+				SessionID: "sess-abc",
+				FileName:  "file.txt",
+			},
+			wantErr:    true,
+			wantErrMsg: "invalid AppName: cannot contain path separators",
+		},
+		{
+			name: "UserID with path separator",
+			req: &DeleteRequest{
+				AppName:   "MyApp",
+				UserID:    "user/123",
+				SessionID: "sess-abc",
+				FileName:  "file.txt",
+			},
+			wantErr:    true,
+			wantErrMsg: "invalid UserID: cannot contain path separators",
+		},
+		{
+			name: "SessionID with backslash separator",
+			req: &DeleteRequest{
+				AppName:   "MyApp",
+				UserID:    "user-123",
+				SessionID: `sess\abc`,
+				FileName:  "file.txt",
+			},
+			wantErr:    true,
+			wantErrMsg: "invalid SessionID: cannot contain path separators",
+		},
 	}
 	executeValidatorTestCases(t, "DeleteRequest", testCases)
 }
@@ -267,6 +369,36 @@ func TestListRequest_Validate(t *testing.T) {
 			req:        &ListRequest{},
 			wantErr:    true,
 			wantErrMsg: "invalid list request: missing required fields: AppName, UserID, SessionID",
+		},
+		{
+			name: "AppName with path separator",
+			req: &ListRequest{
+				AppName:   "My/App",
+				UserID:    "user-123",
+				SessionID: "sess-abc",
+			},
+			wantErr:    true,
+			wantErrMsg: "invalid AppName: cannot contain path separators",
+		},
+		{
+			name: "UserID with path separator",
+			req: &ListRequest{
+				AppName:   "MyApp",
+				UserID:    "user/123",
+				SessionID: "sess-abc",
+			},
+			wantErr:    true,
+			wantErrMsg: "invalid UserID: cannot contain path separators",
+		},
+		{
+			name: "SessionID with backslash separator",
+			req: &ListRequest{
+				AppName:   "MyApp",
+				UserID:    "user-123",
+				SessionID: `sess\abc`,
+			},
+			wantErr:    true,
+			wantErrMsg: "invalid SessionID: cannot contain path separators",
 		},
 	}
 	executeValidatorTestCases(t, "ListRequest", testCases)
@@ -321,6 +453,39 @@ func TestVersionsRequest_Validate(t *testing.T) {
 			wantErr:    true,
 			wantErrMsg: "invalid name: filename cannot contain path separators",
 		},
+		{
+			name: "AppName with path separator",
+			req: &VersionsRequest{
+				AppName:   "My/App",
+				UserID:    "user-123",
+				SessionID: "sess-abc",
+				FileName:  "file.txt",
+			},
+			wantErr:    true,
+			wantErrMsg: "invalid AppName: cannot contain path separators",
+		},
+		{
+			name: "UserID with path separator",
+			req: &VersionsRequest{
+				AppName:   "MyApp",
+				UserID:    "user/123",
+				SessionID: "sess-abc",
+				FileName:  "file.txt",
+			},
+			wantErr:    true,
+			wantErrMsg: "invalid UserID: cannot contain path separators",
+		},
+		{
+			name: "SessionID with backslash separator",
+			req: &VersionsRequest{
+				AppName:   "MyApp",
+				UserID:    "user-123",
+				SessionID: `sess\abc`,
+				FileName:  "file.txt",
+			},
+			wantErr:    true,
+			wantErrMsg: "invalid SessionID: cannot contain path separators",
+		},
 	}
 	executeValidatorTestCases(t, "VersionsRequest", testCases)
 }
@@ -373,6 +538,39 @@ func TestGetArtifactVersionRequest_Validate(t *testing.T) {
 			},
 			wantErr:    true,
 			wantErrMsg: "invalid name: filename cannot contain path separators",
+		},
+		{
+			name: "AppName with path separator",
+			req: &GetArtifactVersionRequest{
+				AppName:   "My/App",
+				UserID:    "user-123",
+				SessionID: "sess-abc",
+				FileName:  "file.txt",
+			},
+			wantErr:    true,
+			wantErrMsg: "invalid AppName: cannot contain path separators",
+		},
+		{
+			name: "UserID with path separator",
+			req: &GetArtifactVersionRequest{
+				AppName:   "MyApp",
+				UserID:    "user/123",
+				SessionID: "sess-abc",
+				FileName:  "file.txt",
+			},
+			wantErr:    true,
+			wantErrMsg: "invalid UserID: cannot contain path separators",
+		},
+		{
+			name: "SessionID with backslash separator",
+			req: &GetArtifactVersionRequest{
+				AppName:   "MyApp",
+				UserID:    "user-123",
+				SessionID: `sess\abc`,
+				FileName:  "file.txt",
+			},
+			wantErr:    true,
+			wantErrMsg: "invalid SessionID: cannot contain path separators",
 		},
 	}
 	executeValidatorTestCases(t, "GetArtifactVersionRequest", testCases)
@@ -441,6 +639,54 @@ func TestValidateRequiredStrings(t *testing.T) {
 			got := validateRequiredStrings(tc.input)
 			if !reflect.DeepEqual(got, tc.want) {
 				t.Errorf("validateRequiredStrings() = %v, want %v", got, tc.want)
+			}
+		})
+	}
+}
+
+func TestValidatePathSegments(t *testing.T) {
+	testCases := []struct {
+		name                       string
+		appName, userID, sessionID string
+		wantErrMsg                 string // "" means no error
+	}{
+		{
+			name:    "all clean",
+			appName: "MyApp", userID: "user-123", sessionID: "sess-abc",
+		},
+		{
+			name:    "forward slash in appName",
+			appName: "My/App", userID: "user-123", sessionID: "sess-abc",
+			wantErrMsg: "invalid AppName: cannot contain path separators",
+		},
+		{
+			name:    "forward slash in userID",
+			appName: "MyApp", userID: "user/123", sessionID: "sess-abc",
+			wantErrMsg: "invalid UserID: cannot contain path separators",
+		},
+		{
+			name:    "backslash in sessionID",
+			appName: "MyApp", userID: "user-123", sessionID: `sess\abc`,
+			wantErrMsg: "invalid SessionID: cannot contain path separators",
+		},
+		{
+			name:    "appName reported before userID when both are bad",
+			appName: "a/b", userID: "c/d", sessionID: "sess-abc",
+			wantErrMsg: "invalid AppName: cannot contain path separators",
+		},
+	}
+
+	for _, tc := range testCases {
+		t.Run(tc.name, func(t *testing.T) {
+			err := validatePathSegments(tc.appName, tc.userID, tc.sessionID)
+			if tc.wantErrMsg == "" {
+				if err != nil {
+					t.Errorf("validatePathSegments() = %v, want nil", err)
+				}
+				return
+			}
+			if err == nil || err.Error() != tc.wantErrMsg {
+				t.Errorf("validatePathSegments() = %v, want %q", err, tc.wantErrMsg)
 			}
 		})
 	}

--- a/artifact/service.go
+++ b/artifact/service.go
@@ -108,6 +108,10 @@ func (req *SaveRequest) Validate() error {
 		return fmt.Errorf("invalid save request: Part.InlineData or Part.Text has to be set")
 	}
 
+	// Validate that the key segments don't contain path separators
+	if err := validatePathSegments(req.AppName, req.UserID, req.SessionID); err != nil {
+		return err
+	}
 	// Validate that FileName doesn't contain path separators
 	if err := validateFileName(req.FileName); err != nil {
 		return err
@@ -118,6 +122,21 @@ func (req *SaveRequest) Validate() error {
 func validateFileName(name string) error {
 	if strings.Contains(name, "/") || strings.Contains(name, "\\") {
 		return fmt.Errorf("invalid name: filename cannot contain path separators")
+	}
+	return nil
+}
+
+// validatePathSegments rejects appName, userID, or sessionID values that contain
+// a path separator ('/' or '\').
+func validatePathSegments(appName, userID, sessionID string) error {
+	for _, f := range []requiredField{
+		{Name: "AppName", Value: appName},
+		{Name: "UserID", Value: userID},
+		{Name: "SessionID", Value: sessionID},
+	} {
+		if strings.Contains(f.Value, "/") || strings.Contains(f.Value, "\\") {
+			return fmt.Errorf("invalid %s: cannot contain path separators", f.Name)
+		}
 	}
 	return nil
 }
@@ -153,6 +172,10 @@ func (req *LoadRequest) Validate() error {
 		return fmt.Errorf("invalid load request: missing required fields: %s", strings.Join(missingFields, ", "))
 	}
 
+	// Validate that the key segments don't contain path separators
+	if err := validatePathSegments(req.AppName, req.UserID, req.SessionID); err != nil {
+		return err
+	}
 	// Validate that FileName doesn't contain path separators
 	if err := validateFileName(req.FileName); err != nil {
 		return err
@@ -193,6 +216,10 @@ func (req *DeleteRequest) Validate() error {
 		return fmt.Errorf("invalid delete request: missing required fields: %s", strings.Join(missingFields, ", "))
 	}
 
+	// Validate that the key segments don't contain path separators
+	if err := validatePathSegments(req.AppName, req.UserID, req.SessionID); err != nil {
+		return err
+	}
 	// Validate that FileName doesn't contain path separators
 	if err := validateFileName(req.FileName); err != nil {
 		return err
@@ -222,7 +249,9 @@ func (req *ListRequest) Validate() error {
 	if len(missingFields) > 0 {
 		return fmt.Errorf("invalid list request: missing required fields: %s", strings.Join(missingFields, ", "))
 	}
-	return nil
+
+	// Validate that the key segments don't contain path separators
+	return validatePathSegments(req.AppName, req.UserID, req.SessionID)
 }
 
 // ListResponse is the return type of [ArtifactService.List].
@@ -253,6 +282,10 @@ func (req *VersionsRequest) Validate() error {
 		return fmt.Errorf("invalid versions request: missing required fields: %s", strings.Join(missingFields, ", "))
 	}
 
+	// Validate that the key segments don't contain path separators
+	if err := validatePathSegments(req.AppName, req.UserID, req.SessionID); err != nil {
+		return err
+	}
 	// Validate that FileName doesn't contain path separators
 	if err := validateFileName(req.FileName); err != nil {
 		return err
@@ -301,6 +334,10 @@ func (req *GetArtifactVersionRequest) Validate() error {
 		return fmt.Errorf("invalid get artifact version request: missing required fields: %s", strings.Join(missingFields, ", "))
 	}
 
+	// Validate that the key segments don't contain path separators
+	if err := validatePathSegments(req.AppName, req.UserID, req.SessionID); err != nil {
+		return err
+	}
 	// Validate that FileName doesn't contain path separators
 	if err := validateFileName(req.FileName); err != nil {
 		return err


### PR DESCRIPTION
## Problem
Path to the GCS object is built by concatenating fields appName/userID/sessionID/fileName/version to one string: `fmt.Sprintf("%s/%s/%s/%s/%d", appName, userID, sessionID, fileName, version)`. Because the key is a single flat string, a `/` in any segment moves the boundaries. Example:
For GCS artifact service, if one app has appName = `app/u1`, userID = `u2` and another has appName = `app`, userID = `u1/u2`, then for the same sessionID both resolve to the same session prefix: `app/u1/u2/<sessionID>`.
Identical prefixes allow artifacts to leak across apps/users (read, list, overwrite, delete).

Examples:
- one artifact overwritten with another one coming from different app / user (so e.g. latest version of the artifact is artifact from another app / user) 
- session which can see artifacts from different apps

Important caveat: REST router in the adk server can't feed a decoded "/" into a path segment, but one could use the Gcs Artifact Service independently (e.g. as an agent tool) where it would be doable.

## Solution
Add segment validation (for appName, userID, sessionID) similarily to existing `validateFileName`.

## Testing plan
- `golangci-lint run` - 0 issues
- `go build -mod=readonly work` passed
- `go test -race -mod=readonly -count=1 -shuffle=on work` green

## Potential improvements
- refactor: it could be possible to merge `validatePathSegments` with already existing `validateFileName` into one function
- all `Validate` methods accross `artifact/service.go` have very similar structure, and we might introduce helper function which could be reused across all `Validate` implementations to not duplicate redundant code