### PR TITLE
Update go version to 1.26.6

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -1,6 +1,6 @@
 module google.golang.org/adk/v2
 
-go 1.26.5
+go 1.26.6
 
 require (
 	cloud.google.com/go v0.123.0


### PR DESCRIPTION
Upgrading to 1.26.6 due to vulnerabilities found by govulncheck (https://github.com/google/adk-go/actions/runs/31765233084)