### PR TITLE
fix(cmd/launcher/web): initialize telemetry before starting HTTP server (#1350)

### DIFF
--- a/cmd/launcher/web/web.go
+++ b/cmd/launcher/web/web.go
@@ -186,6 +186,11 @@ func (w *webLauncher) Run(ctx context.Context, config *launcher.Config) error {
 	}
 	log.Println()
 
+	telemetryService, err := telemetry.InitAndSetGlobalOtelProviders(ctx, config, w.config.otelToCloud)
+	if err != nil {
+		return fmt.Errorf("telemetry initialization failed: %v", err)
+	}
+
 	srv := w.buildHTTPServer(router)
 
 	errChan := make(chan error, 1)
@@ -195,11 +200,6 @@ func (w *webLauncher) Run(ctx context.Context, config *launcher.Config) error {
 		}
 		close(errChan)
 	}()
-
-	telemetryService, err := telemetry.InitAndSetGlobalOtelProviders(ctx, config, w.config.otelToCloud)
-	if err != nil {
-		return fmt.Errorf("telemetry initialization failed: %v", err)
-	}
 
 	select {
 	case <-ctx.Done():

--- a/cmd/launcher/web/web.go
+++ b/cmd/launcher/web/web.go
@@ -183,6 +183,11 @@ func (w *webLauncher) Run(ctx context.Context, config *launcher.Config) error {
 	}
 	log.Println()
 
+	telemetryService, err := telemetry.InitAndSetGlobalOtelProviders(ctx, config, w.config.otelToCloud)
+	if err != nil {
+		return fmt.Errorf("telemetry initialization failed: %v", err)
+	}
+
 	srv := w.buildHTTPServer(router)
 
 	errChan := make(chan error, 1)
@@ -192,11 +197,6 @@ func (w *webLauncher) Run(ctx context.Context, config *launcher.Config) error {
 		}
 		close(errChan)
 	}()
-
-	telemetryService, err := telemetry.InitAndSetGlobalOtelProviders(ctx, config, w.config.otelToCloud)
-	if err != nil {
-		return fmt.Errorf("telemetry initialization failed: %v", err)
-	}
 
 	select {
 	case <-ctx.Done():

--- a/cmd/launcher/web/web_test.go
+++ b/cmd/launcher/web/web_test.go
@@ -15,10 +15,19 @@
 package web
 
 import (
+	"context"
+	"fmt"
 	"io"
 	"net"
 	"net/http"
 	"testing"
+	"time"
+
+	"github.com/gorilla/mux"
+	"go.opentelemetry.io/otel/sdk/resource"
+
+	"google.golang.org/adk/v2/cmd/launcher"
+	"google.golang.org/adk/v2/telemetry"
 )
 
 func TestH2CFlag(t *testing.T) {
@@ -118,5 +127,57 @@ func assertProtocol(t *testing.T, client *http.Client, url string, wantMajor int
 	}
 	if resp.ProtoMajor != wantMajor {
 		t.Errorf("response protocol = %q, want HTTP/%d", resp.Proto, wantMajor)
+	}
+}
+
+type telemetryFailSublauncher struct{}
+
+func (telemetryFailSublauncher) Keyword() string { return "repro" }
+
+func (telemetryFailSublauncher) Parse(args []string) ([]string, error)             { return args, nil }
+func (telemetryFailSublauncher) CommandLineSyntax() string                         { return "" }
+func (telemetryFailSublauncher) SimpleDescription() string                         { return "" }
+func (telemetryFailSublauncher) UserMessage(webURL string, printer func(v ...any)) {}
+func (telemetryFailSublauncher) SetupSubrouters(r *mux.Router, c *launcher.Config) error {
+	return nil
+}
+
+// TestRunDoesNotLeakListenerWhenTelemetryInitFails covers issue #1350: when
+// telemetry initialization fails, Run must not leave an HTTP listener bound.
+func TestRunDoesNotLeakListenerWhenTelemetryInitFails(t *testing.T) {
+	ln, err := net.Listen("tcp", "127.0.0.1:0")
+	if err != nil {
+		t.Fatalf("net.Listen() failed: %v", err)
+	}
+	port := ln.Addr().(*net.TCPAddr).Port
+	if err := ln.Close(); err != nil {
+		t.Fatalf("listener Close() failed: %v", err)
+	}
+
+	l := NewLauncher(telemetryFailSublauncher{}).(*webLauncher)
+	if _, err := l.Parse([]string{"--port", fmt.Sprint(port), "repro"}); err != nil {
+		t.Fatalf("Parse() failed: %v", err)
+	}
+
+	// A resource whose schema URL conflicts with resource.Default()'s makes
+	// resource.Merge fail, so telemetry init fails without touching the network.
+	bad := resource.NewWithAttributes("https://conflicting.invalid/schema/v1")
+	config := &launcher.Config{
+		TelemetryOptions: []telemetry.Option{telemetry.WithResource(bad)},
+	}
+
+	if err := l.Run(context.Background(), config); err == nil {
+		t.Fatalf("Run() succeeded, want telemetry initialization failure")
+	}
+
+	addr := fmt.Sprintf("127.0.0.1:%d", port)
+	deadline := time.Now().Add(3 * time.Second)
+	for time.Now().Before(deadline) {
+		conn, err := net.DialTimeout("tcp", addr, 100*time.Millisecond)
+		if err == nil {
+			_ = conn.Close()
+			t.Fatalf("port %d still bound after Run() returned an error: listener leaked", port)
+		}
+		time.Sleep(10 * time.Millisecond)
 	}
 }


### PR DESCRIPTION
### Link to Issue or Description of Change

- Closes: #1350

### Problem

In `webLauncher.Run`, `srv.ListenAndServe()` was previously spawned in a background goroutine prior to initializing telemetry providers. If telemetry setup failed, `Run` returned immediately without shutting down `srv`, leaking the listening socket and background goroutine.

### Solution

Reorder `telemetry.InitAndSetGlobalOtelProviders` to run before starting the `srv.ListenAndServe()` background goroutine, ensuring that no socket is bound or background goroutine spawned if telemetry initialization fails.

### Testing Plan

- [x] Tested web launcher and subrouters locally.
- [x] All repository verification commands pass:
  ```text
  go test -v -race -count=1 ./cmd/launcher/web/...
  go build -mod=readonly work
  golangci-lint run
  go mod tidy -diff
  ```

### Checklist

- [x] I have read the [CONTRIBUTING.md](./CONTRIBUTING.md) document.
- [x] I have performed a self-review of my own code.
- [x] I have commented my code, particularly in hard-to-understand areas.
- [x] I have added tests that prove my fix is effective or that my feature works.
- [x] New and existing unit tests pass locally with my changes.
- [x] I have manually tested my changes end-to-end.
- [x] Any dependent changes have been merged and published in downstream modules.