### PR TITLE
fix(llmagent): scope -httprecord directives so one cassette re-records alone

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -143,9 +143,19 @@ See [Multi-Module Development](CONTRIBUTING.md#multi-module-development) in
 - Tests run **offline by default**: LLM HTTP traffic is replayed from
   `testdata/*.httprr` via `internal/httprr`. Never add live model or network
   calls to tests.
-- To (re)record a package's traffic, supply real credentials (e.g.
-  `GOOGLE_API_KEY`) and run `go generate ./<pkg>/...` (it runs
-  `go test -httprecord=…`); commit the updated `testdata/*.httprr`.
+- `-httprecord` takes a **regexp matched against the cassette's file path**,
+  not a `-run` test-name filter. Keep it as narrow as the set of cassettes you
+  mean to replace: recording against a live model produces a different response
+  every time, so a broad pattern rewrites unrelated cassettes and buries the
+  intended change.
+- To re-record **one** cassette — the normal case — supply real credentials
+  (e.g. `GOOGLE_API_KEY`) and name it in both flags:
+  `go test ./<pkg>/ -run TestFoo -httprecord='TestFoo\.httprr$'`.
+  Commit only that `testdata/*.httprr`.
+- To re-record a whole package, run `go generate ./<pkg>/...`; each package's
+  `//go:generate go test -httprecord=…` directives are scoped so that every
+  cassette is recorded exactly once (enforced by
+  `TestHTTPRecordDirectivesPartitionCassettes` in `internal`).
 - Prefer table-driven tests; shared helpers live in `internal/testutil`.
 
 ## Boundaries

--- a/agent/llmagent/llmagent_delegation_test.go
+++ b/agent/llmagent/llmagent_delegation_test.go
@@ -22,9 +22,14 @@
 // changing an Instruction, tool declaration, or agent shape, delete
 // the corresponding .httprr file and run:
 //
-//	GEMINI_API_KEY=... go test ./agent/llmagent/ -httprecord=TestDelegation_NN
+//	GEMINI_API_KEY=... go test ./agent/llmagent/ -run TestDelegation_NN \
+//	    -httprecord='TestDelegation_NN.*\.httprr$'
 //
-// To re-record everything: -httprecord=TestDelegation.
+// -httprecord is a regexp matched against the cassette's file path, not a
+// test-name filter, so keep it as narrow as the set of cassettes you mean to
+// replace. The go:generate directive below re-records every delegation
+// cassette and nothing else; `go generate ./agent/llmagent/...` also runs the
+// directive in llmagent_test.go, so it re-records the whole package.
 //
 // The tests generate *.events.yaml file to visualize delegation and overall
 // flow of execution.
@@ -63,7 +68,7 @@ import (
 
 const delegationModelName = "gemini-3.5-flash"
 
-//go:generate go test -httprecord=TestDelegation
+//go:generate go test -httprecord=^testdata[/\\]TestDelegation_.*\.httprr$
 
 // newDelegationModel returns a Gemini model whose HTTP transport is
 // the httprr record/replay wrapper, scoped to a trace file derived

--- a/agent/llmagent/llmagent_test.go
+++ b/agent/llmagent/llmagent_test.go
@@ -45,7 +45,7 @@ const (
 	message   = "Handle the requests as specified in the System Instruction."
 )
 
-//go:generate go test -httprecord=Test
+//go:generate go test -httprecord=^testdata[/\\]Test(FunctionTool|LLMAgent|ToolCallback).*\.httprr$
 
 func TestLLMAgent(t *testing.T) {
 	errNoNetwork := errors.New("no network")

--- a/internal/httprr_directives_test.go
+++ b/internal/httprr_directives_test.go
@@ -1,0 +1,159 @@
+// Copyright 2026 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package internal_test
+
+import (
+	"os"
+	"path/filepath"
+	"regexp"
+	"strings"
+	"testing"
+)
+
+// TestHTTPRecordDirectivesPartitionCassettes checks that in every package which
+// declares at least one `//go:generate go test -httprecord=…` directive, each
+// of the package's testdata/*.httprr cassettes is claimed by exactly one
+// directive.
+//
+// The -httprecord flag is a regexp matched against the cassette's file path
+// (see httprr.Recording in internal/httprr), not a -run test-name filter. That
+// makes two failure modes possible, and both are silent:
+//
+//   - Two directives in one package match the same cassette, so
+//     `go generate ./<pkg>/...` re-records it twice against a live model in a
+//     single invocation, and re-recording any one cassette rewrites unrelated
+//     ones.
+//   - A directive matches none of its cassettes, so `go generate` appears to
+//     succeed while recording nothing.
+//
+// Requiring exactly one directive per cassette rules out the first, and at
+// least one cassette per directive rules out the second.
+func TestHTTPRecordDirectivesPartitionCassettes(t *testing.T) {
+	// Start test from the parent directory, root of the module.
+	t.Chdir("..")
+
+	ignore := map[string]bool{
+		// Copied from golang.org/x/oscar; defines the flag, does not use it.
+		"internal/httprr": true,
+		// Contains vendored dependencies.
+		"vendor": true,
+	}
+
+	type directive struct {
+		file    string
+		pattern string
+		re      *regexp.Regexp
+		claims  int // cassettes in the same package this directive matched
+	}
+	byPkg := make(map[string][]directive)
+	total := 0
+
+	err := filepath.Walk(".", func(path string, info os.FileInfo, err error) error {
+		if err != nil {
+			return err
+		}
+		if info.IsDir() {
+			if ignore[path] {
+				return filepath.SkipDir
+			}
+			return nil
+		}
+		if !strings.HasSuffix(path, "_test.go") {
+			return nil
+		}
+		content, err := os.ReadFile(path)
+		if err != nil {
+			return err
+		}
+		for _, line := range strings.Split(string(content), "\n") {
+			line = strings.TrimSpace(line)
+			if !strings.HasPrefix(line, "//go:generate") || !strings.Contains(line, "-httprecord") {
+				continue
+			}
+			pattern := ""
+			for _, field := range strings.Fields(line) {
+				if p, ok := strings.CutPrefix(field, "-httprecord="); ok {
+					pattern = p
+					break
+				}
+			}
+			if pattern == "" {
+				// Not `-httprecord=<regexp>`: either an empty pattern (which
+				// disables recording) or a form this test cannot read, in which
+				// case the checks below would pass vacuously.
+				t.Errorf("%s: cannot read -httprecord pattern from directive: %s", path, line)
+				continue
+			}
+			re, err := regexp.Compile(pattern)
+			if err != nil {
+				t.Errorf("%s: -httprecord=%s is not a valid regexp: %v", path, pattern, err)
+				continue
+			}
+			byPkg[filepath.Dir(path)] = append(byPkg[filepath.Dir(path)], directive{file: path, pattern: pattern, re: re})
+			total++
+		}
+		return nil
+	})
+	if err != nil {
+		t.Fatalf("walking module: %v", err)
+	}
+	if total == 0 {
+		t.Fatal("no //go:generate -httprecord directives found; this test is no longer checking anything")
+	}
+
+	for pkg, directives := range byPkg {
+		cassettes, err := filepath.Glob(filepath.Join(pkg, "testdata", "*.httprr"))
+		if err != nil {
+			t.Errorf("globbing cassettes in %s: %v", pkg, err)
+			continue
+		}
+		for _, cassette := range cassettes {
+			// The path httprr matches against is the one the test passes to
+			// httprr.Open, which is filepath.Join("testdata", <name>.httprr)
+			// relative to the package directory. Checked in slash form only:
+			// on Windows that path uses a backslash, and directives written as
+			// `testdata/…` would not match it, but no cassette in this repo has
+			// ever been recorded on Windows. Directives added by this change use
+			// `testdata[/\\]…` so they work either way.
+			rel := filepath.ToSlash(filepath.Join("testdata", filepath.Base(cassette)))
+			var matched []string
+			for i := range directives {
+				if directives[i].re.MatchString(rel) {
+					directives[i].claims++
+					matched = append(matched, directives[i].file+": -httprecord="+directives[i].pattern)
+				}
+			}
+			switch {
+			case len(matched) == 0:
+				t.Errorf("%s/%s is claimed by no -httprecord directive; `go generate ./%s/...` will not re-record it", pkg, rel, pkg)
+			case len(matched) > 1:
+				t.Errorf("%s/%s is claimed by %d -httprecord directives, want exactly 1:\n\t%s",
+					pkg, rel, len(matched), strings.Join(matched, "\n\t"))
+			}
+		}
+
+		// A directive that claims nothing is a dead pattern: `go generate` runs
+		// it, records nothing, and reports success. The per-cassette check above
+		// misses this whenever a sibling directive already covers every cassette.
+		for _, d := range directives {
+			if d.claims == 0 {
+				t.Errorf("%s: -httprecord=%s claims none of the %d cassettes in %s/testdata; `go generate` would record nothing",
+					d.file, d.pattern, len(cassettes), pkg)
+			}
+		}
+	}
+
+	t.Logf("checked %d -httprecord directives across %d packages", total, len(byPkg))
+}


### PR DESCRIPTION
### Link to Issue or Description of Change

**1. Link to an existing issue (if applicable):**

- Closes: #1330

**Problem:**

`-httprecord` is a regexp matched against the cassette's file path, not a `-run` test-name filter. `agent/llmagent` declares two of them: `-httprecord=Test` in `llmagent_test.go` matches all 20 cassettes in the package, and `-httprecord=TestDelegation` in `llmagent_delegation_test.go` matches 10 of those same 20. So the documented `go generate ./agent/llmagent/...` re-records the entire package and records the 10 delegation cassettes twice in one invocation.

Anyone refreshing one cassette gets a diff touching every recorded interaction in the package, against live models whose responses differ run to run. The intended change is unreadable next to the churn, and an unrelated test can start failing because its cassette was silently replaced with a different model response. `AGENTS.md` presents that whole-package command as the way to re-record, so the wrong thing to run is the documented thing.

**Solution:**

Scope each directive to the cassettes its own file owns, anchored on the `testdata/` prefix and the `.httprr` suffix so no name matches as a substring:

```
llmagent_test.go:            -httprecord=^testdata[/\\]Test(FunctionTool|LLMAgent|ToolCallback).*\.httprr$
llmagent_delegation_test.go: -httprecord=^testdata[/\\]TestDelegation_.*\.httprr$
```

Rewrite the recording section of `AGENTS.md`: re-recording a single cassette is the normal case and needs the name in both `-run` and `-httprecord`, `-httprecord` matches file paths rather than test names, and `go generate` on a package is safe because its directives no longer overlap.

Add `TestHTTPRecordDirectivesPartitionCassettes` (`internal/httprr_directives_test.go`) so the property is enforced rather than just fixed. It walks the module, groups every `//go:generate go test -httprecord=…` by package, and requires that each `testdata/*.httprr` is claimed by exactly one directive and each directive claims at least one cassette. The second half catches the quieter failure: a pattern that has drifted away from its cassettes, where `go generate` appears to succeed while recording nothing.

### Testing Plan

**Unit Tests:**

- [x] I have added or updated unit tests for my change.
- [x] All unit tests pass locally.

`go test -count=1 ./internal/ ./agent/llmagent/` passes; the new test reports 7 directives checked across 6 packages. Putting the two old patterns back makes it fail on each of the 10 doubly-claimed delegation cassettes, naming both directives that claim it.

**Manual End-to-End (E2E) Tests:**

Not run, and it should not be: recording needs live credentials and would rewrite the committed cassettes, which is the problem this fixes. The directives are `go:generate` comments, so nothing here can change replay behavior, and `agent/llmagent` still passes offline against the unchanged cassettes.

### Checklist

- [x] I have read the [CONTRIBUTING.md](./CONTRIBUTING.md) document.
- [x] I have performed a self-review of my own code.
- [x] I have commented my code, particularly in hard-to-understand areas.
- [x] I have added tests that prove my fix is effective or that my feature works.
- [x] New and existing unit tests pass locally with my changes.
- [ ] I have manually tested my changes end-to-end.
- [x] Any dependent changes have been merged and published in downstream modules.

### Additional context

The single-directive packages (`agent/remoteagent/v2`, `model/gemini`) keep patterns that match all of their cassettes. For a package with one directive that already partitions, so the new test accepts them and this change leaves them alone; re-recording one cassette there still means naming it on the command line instead of running `go generate`.
