### PR TITLE
fix(llm): ignore sibling branches for current turn

### DIFF
--- a/internal/llminternal/contents_processor.go
+++ b/internal/llminternal/contents_processor.go
@@ -533,6 +533,13 @@ func buildContentsCurrentTurnContextOnly(agentName, branch, isolationScope strin
 	// Find the latest event that starts the current turn and process from there
 	for i := len(events) - 1; i >= 0; i-- {
 		event := events[i]
+		// Events from a sibling branch are not part of this agent's
+		// current turn. In parallel delegations, a sibling may append its
+		// response after this agent's user input; treating that response as
+		// the pivot would slice the input out of the request.
+		if !eventBelongsToBranch(branch, event) {
+			continue
+		}
 		// An out-of-scope event cannot start this agent's turn: it is
 		// invisible to the agent, so skip it as a pivot (matching
 		// adk-python's _should_include_event_in_context gate here).

--- a/internal/llminternal/contents_processor_test.go
+++ b/internal/llminternal/contents_processor_test.go
@@ -296,6 +296,51 @@ func TestContentsRequestProcessor_IncludeContentsNone_IsolationScopePivot(t *tes
 	}
 }
 
+func TestContentsRequestProcessor_IncludeContentsNone_IgnoresSiblingBranchPivot(t *testing.T) {
+	t.Parallel()
+
+	const branch = "coordinator.translator_es"
+	events := []*session.Event{
+		{
+			Author: "user",
+			Branch: branch,
+			LLMResponse: model.LLMResponse{
+				Content: genai.NewContentFromText("good morning", genai.RoleUser),
+			},
+		},
+		{
+			Author: "translator_fr",
+			Branch: "coordinator.translator_fr",
+			LLMResponse: model.LLMResponse{
+				Content: genai.NewContentFromText("Bonjour", genai.RoleModel),
+			},
+		},
+	}
+
+	a := utils.Must(llmagent.New(llmagent.Config{
+		Name:            "translator_es",
+		Model:           &testModel{},
+		Mode:            llmagent.ModeSingleTurn,
+		IncludeContents: "none",
+	}))
+	ctx := icontext.NewInvocationContext(t.Context(), icontext.InvocationContextParams{
+		Agent:   a,
+		Branch:  branch,
+		Session: &fakeSession{events: events},
+	})
+	req := &model.LLMRequest{}
+	for _, err := range llminternal.ContentsRequestProcessor(ctx, req, &llminternal.Flow{}) {
+		if err != nil {
+			t.Fatalf("contentsRequestProcessor failed: %v", err)
+		}
+	}
+
+	want := []*genai.Content{genai.NewContentFromText("good morning", genai.RoleUser)}
+	if diff := cmp.Diff(want, req.Contents); diff != "" {
+		t.Errorf("contents mismatch (-want +got):\n%s", diff)
+	}
+}
+
 // TestContentsRequestProcessor_StrictIsolationFilterExcludesForeignScope
 // verifies that the contents from the different scope are not included
 // in the content for LLM.


### PR DESCRIPTION
### Link to Issue or Description of Change

- Closes: #1313

`include_contents="none"` finds the latest event that starts an agent's current
turn. It already ignored events from a different isolation scope, but it did not
ignore events from sibling branches. During parallel delegation, one translator
could therefore append its response while the other translator was building its
request. The sibling response became the current-turn pivot and sliced the
second translator's seeded input out of the request, causing the intermittent
HTTP replay miss.

This change applies the existing branch-membership check while finding the
current-turn pivot. A regression test covers a sibling response arriving after
the current branch's user input.

### Testing Plan

**Unit Tests:**

- [x] I have added or updated unit tests for my change.
- [x] All unit tests pass locally.

Passed locally:

- `go build ./...`
- `go test ./...`
- `go test ./internal/llminternal -run 'TestContentsRequestProcessor_IncludeContentsNone_(IsolationScopePivot|IgnoresSiblingBranchPivot)$'`
- `go test -count=500 ./agent/llmagent -run '^TestDelegation_04_ChatToTwoSingleTurnParallel$'`
- `go test -race -count=100 ./agent/llmagent -run '^TestDelegation_04_ChatToTwoSingleTurnParallel$'`
- `go mod tidy -diff`
- `git diff --check`

`golangci-lint run` was not run locally because `golangci-lint` is not installed
in this environment; the repository CI lint job remains the source of truth.

For comparison, the unmodified test failed during a 200-run loop with the
reported cassette miss and a request containing no `contents`.

**Manual End-to-End (E2E) Tests:**

The existing delegation test exercises the full coordinator-to-two-translators
flow against the checked-in replay cassette. The 500-run normal and 100-run race
stress checks above completed without a replay miss.

### Checklist

- [x] I have read the [CONTRIBUTING.md](./CONTRIBUTING.md) document.
- [x] I have performed a self-review of my own code.
- [x] I have commented my code, particularly in hard-to-understand areas.
- [x] I have added tests that prove my fix is effective or that my feature works.
- [x] New and existing unit tests pass locally with my changes.
- [x] I have manually tested my changes end-to-end.
- [ ] Any dependent changes have been merged and published in downstream modules.

No downstream dependency changes are required.
