### PR TITLE
fix(llminternal): merge ArtifactDelta across parallel function responses

### DIFF
--- a/internal/llminternal/base_flow.go
+++ b/internal/llminternal/base_flow.go
@@ -1406,6 +1406,9 @@ func mergeEventActions(base, other *session.EventActions) *session.EventActions 
 	if other.StateDelta != nil {
 		base.StateDelta = deepMergeMap(base.StateDelta, other.StateDelta)
 	}
+	if other.ArtifactDelta != nil {
+		base.ArtifactDelta = mergeArtifactDelta(base.ArtifactDelta, other.ArtifactDelta)
+	}
 	// TODO add similar logic for state
 	if other.RequestedToolConfirmations != nil {
 		if base.RequestedToolConfirmations == nil {
@@ -1414,6 +1417,23 @@ func mergeEventActions(base, other *session.EventActions) *session.EventActions 
 		maps.Copy(base.RequestedToolConfirmations, other.RequestedToolConfirmations)
 	}
 	return base
+}
+
+// mergeArtifactDelta merges src into dst, keeping the highest version for each
+// artifact name. Artifact versions are monotonically increasing per file, so the
+// larger value is always the more recent write. Merging by max rather than
+// last-write-wins means a parallel tool call that saved an older version cannot
+// mask a newer one recorded by a sibling call in the same turn.
+func mergeArtifactDelta(dst, src map[string]int64) map[string]int64 {
+	if dst == nil {
+		dst = make(map[string]int64, len(src))
+	}
+	for name, version := range src {
+		if existing, ok := dst[name]; !ok || version > existing {
+			dst[name] = version
+		}
+	}
+	return dst
 }
 
 func deepMergeMap(dst, src map[string]any) map[string]any {

--- a/internal/llminternal/base_flow_test.go
+++ b/internal/llminternal/base_flow_test.go
@@ -813,3 +813,70 @@ func TestCallLLMStreamingModeWithoutContextRunConfig(t *testing.T) {
 		t.Errorf("GenerateContent received stream=%v, want true for SSE streaming mode", m.stream)
 	}
 }
+
+func TestMergeEventActionsArtifactDelta(t *testing.T) {
+	tests := []struct {
+		name  string
+		base  *session.EventActions
+		other *session.EventActions
+		want  map[string]int64
+	}{
+		{
+			name:  "base has no artifact delta",
+			base:  &session.EventActions{},
+			other: &session.EventActions{ArtifactDelta: map[string]int64{"a.txt": 1}},
+			want:  map[string]int64{"a.txt": 1},
+		},
+		{
+			name:  "disjoint artifacts are both preserved",
+			base:  &session.EventActions{ArtifactDelta: map[string]int64{"a.txt": 1}},
+			other: &session.EventActions{ArtifactDelta: map[string]int64{"b.txt": 4}},
+			want:  map[string]int64{"a.txt": 1, "b.txt": 4},
+		},
+		{
+			name:  "same artifact keeps the higher version",
+			base:  &session.EventActions{ArtifactDelta: map[string]int64{"a.txt": 3}},
+			other: &session.EventActions{ArtifactDelta: map[string]int64{"a.txt": 2}},
+			want:  map[string]int64{"a.txt": 3},
+		},
+		{
+			name:  "same artifact takes a newer version from other",
+			base:  &session.EventActions{ArtifactDelta: map[string]int64{"a.txt": 1}},
+			other: &session.EventActions{ArtifactDelta: map[string]int64{"a.txt": 5}},
+			want:  map[string]int64{"a.txt": 5},
+		},
+		{
+			name:  "nil other leaves base untouched",
+			base:  &session.EventActions{ArtifactDelta: map[string]int64{"a.txt": 2}},
+			other: nil,
+			want:  map[string]int64{"a.txt": 2},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got := mergeEventActions(tt.base, tt.other)
+			if diff := cmp.Diff(tt.want, got.ArtifactDelta); diff != "" {
+				t.Errorf("mergeEventActions() ArtifactDelta mismatch (-want +got):\n%s", diff)
+			}
+		})
+	}
+}
+
+// TestMergeParallelFunctionResponseEventsArtifactDelta reproduces issue #493:
+// when several tool calls in one turn each save an artifact, every delta must
+// survive the merge, not just the first.
+func TestMergeParallelFunctionResponseEventsArtifactDelta(t *testing.T) {
+	base := &session.EventActions{ArtifactDelta: map[string]int64{"first.txt": 1}}
+	for _, other := range []*session.EventActions{
+		{ArtifactDelta: map[string]int64{"second.txt": 1}},
+		{ArtifactDelta: map[string]int64{"third.txt": 1}},
+		{ArtifactDelta: map[string]int64{"first.txt": 3}},
+	} {
+		base = mergeEventActions(base, other)
+	}
+	want := map[string]int64{"first.txt": 3, "second.txt": 1, "third.txt": 1}
+	if diff := cmp.Diff(want, base.ArtifactDelta); diff != "" {
+		t.Errorf("merged ArtifactDelta mismatch (-want +got):\n%s", diff)
+	}
+}


### PR DESCRIPTION
**Please ensure you have read the [contribution guide](./CONTRIBUTING.md) before creating a pull request.**

### Link to Issue or Description of Change

**1. Link to an existing issue (if applicable):**

- Closes: #493
- Related: #354 (the same defect for `StateDelta`, fixed in #449)

**Problem:**

`mergeEventActions` in `internal/llminternal/base_flow.go` merges `StateDelta`,
`SkipSummarization`, `TransferToAgent`, `Escalate` and `RequestedToolConfirmations`,
but never handled `ArtifactDelta` at all. When several tool calls in one turn each
save an artifact, only the first delta survives into the yielded event — every
subsequent one is silently discarded.

This is the artifact-side twin of #354, which was fixed for state deltas in #449.

**Solution:**

Merge `ArtifactDelta` by **highest version per artifact name**.

`ArtifactDelta` is `map[string]int64` mapping file name to version, and artifact
versions are monotonically increasing per file — `artifact/inmemory.go` `find()`
scans from `math.MaxInt64` downward and returns the first hit as "the latest one".
So the larger value is always the more recent write, and merging by max means a
parallel call that saved an older version cannot mask a newer one recorded by a
sibling call in the same turn.

**Deliberate divergence from the Python ADK, flagged for reviewers:** Python's
`merge_parallel_function_response_events` deep-merges into last-write-wins. For
versioned artifacts that loses information — given writes of `a:1`, `a:3`, `a:2`,
Python yields `a:2` while max-wins yields `a:3`. The issue reporter made this case
explicitly and I agree with it, but it *is* a behavioural difference from Python
parity. If the team prefers strict parity, changing `mergeArtifactDelta` to
unconditional assignment is a one-line change and I'm happy to switch it.

### Testing Plan

**Unit Tests:**

- [x] I have added or updated unit tests for my change.
- [x] All unit tests pass locally.

Two tests added to `internal/llminternal/base_flow_test.go`, alongside the existing
`TestMergeEventActions` introduced by #449:

- `TestMergeEventActionsArtifactDelta` — table test: nil base, disjoint names,
  same name with a lower incoming version, same name with a higher incoming
  version, and nil `other`.
- `TestMergeParallelFunctionResponseEventsArtifactDelta` — reproduces #493
  directly: three sequential merges must retain all three artifacts and keep the
  highest version of the one written twice.

Both were verified to **fail before the fix and pass after it**. Failing output on
unpatched `base_flow.go`, with the test file already in place:

```
--- FAIL: TestMergeEventActionsArtifactDelta (0.00s)
    base_flow_test.go:860: mergeEventActions() ArtifactDelta mismatch (-want +got):
          map[string]int64(
        -     {"a.txt": 1},
        +     nil,
    base_flow_test.go:860: mergeEventActions() ArtifactDelta mismatch (-want +got):
          map[string]int64{
              "a.txt": 1,
        -     "b.txt": 4,
--- FAIL: TestMergeParallelFunctionResponseEventsArtifactDelta (0.00s)
FAIL    google.golang.org/adk/v2/internal/llminternal   0.012s
```

After the fix:

```
--- PASS: TestMergeEventActionsArtifactDelta (0.00s)
--- PASS: TestMergeParallelFunctionResponseEventsArtifactDelta (0.00s)
ok      google.golang.org/adk/v2/internal/llminternal   0.011s
```

Full run across the affected trees, identical to the pre-change baseline on the
same commit (13 packages ok, 0 failures either side):

```
$ go test ./internal/llminternal/... ./session/... ./agent/...
ok  google.golang.org/adk/v2/internal/llminternal
ok  google.golang.org/adk/v2/internal/llminternal/googlellm
ok  google.golang.org/adk/v2/session
ok  google.golang.org/adk/v2/session/database
ok  google.golang.org/adk/v2/session/vertexai
... (13 ok, 0 FAIL)

$ go vet ./internal/llminternal/     # clean
$ gofmt -l internal/llminternal/     # clean
```

**Manual End-to-End (E2E) Tests:**

Not run — this is a pure in-memory merge function with no I/O, and the unit tests
exercise the exact code path the issue describes. Reproducing end-to-end requires a
live model emitting multiple parallel tool calls that each save an artifact; the
issue author reproduced it that way against `gemini-3-flash-preview` and
`gemini-3-pro-preview`.

### Checklist

- [x] I have read the [CONTRIBUTING.md](./CONTRIBUTING.md) document.
- [x] I have performed a self-review of my own code.
- [x] I have commented my code, particularly in hard-to-understand areas.
- [x] I have added tests that prove my fix is effective or that my feature works.
- [x] New and existing unit tests pass locally with my changes.
- [ ] I have manually tested my changes end-to-end. — see note above
- [x] Any dependent changes have been merged and published in downstream modules.

### Additional context

The diff is **20 additions, 0 deletions**. An earlier draft also removed the
`// TODO add similar logic for state` line directly below the `StateDelta` block,
on the assumption this change resolved it. I checked and that comment was added
*after* #449 merged, so it is live rather than stale and I could not prove it
refers to artifacts — it is left untouched. If it does refer to this, it is safe
to drop.

Not addressed here, deliberately: `mergeEventActions` still overwrites
`TransferToAgent` on a last-write-wins basis, which has the same
"parallel calls silently clobber each other" shape. That is a separate concern
with different semantics and belongs in its own issue and PR.
