### PR TITLE
fix(openaimodel): serialize assistant history as text

### DIFF
--- a/model/openaimodel/request.go
+++ b/model/openaimodel/request.go
@@ -159,6 +159,28 @@ func newMessage(role genai.Role, texts []string) (*responses.EasyInputMessagePar
 	if err != nil {
 		return nil, err
 	}
+	if msgRole == responses.EasyInputMessageRoleAssistant {
+		var content strings.Builder
+		for _, txt := range texts {
+			if strings.TrimSpace(txt) == "" {
+				continue
+			}
+			if content.Len() > 0 {
+				content.WriteByte('\n')
+			}
+			content.WriteString(txt)
+		}
+		if content.Len() == 0 {
+			return nil, nil
+		}
+		return &responses.EasyInputMessageParam{
+			Role: msgRole,
+			Type: responses.EasyInputMessageTypeMessage,
+			Content: responses.EasyInputMessageContentUnionParam{
+				OfString: param.NewOpt(content.String()),
+			},
+		}, nil
+	}
 	contentList := make(responses.ResponseInputMessageContentListParam, 0, len(texts))
 	for _, txt := range texts {
 		if strings.TrimSpace(txt) == "" {

--- a/model/openaimodel/request_test.go
+++ b/model/openaimodel/request_test.go
@@ -56,6 +56,40 @@ func TestBuildOpenAIParams_Text(t *testing.T) {
 	}
 }
 
+func TestBuildOpenAIParams_AssistantHistory(t *testing.T) {
+	req := &model.LLMRequest{
+		Contents: []*genai.Content{
+			genai.NewContentFromText("first question", genai.RoleUser),
+			{
+				Role: string(genai.RoleModel),
+				Parts: []*genai.Part{
+					{Text: "first"},
+					{Text: "answer"},
+				},
+			},
+			genai.NewContentFromText("follow-up question", genai.RoleUser),
+		},
+	}
+	params, err := buildOpenAIParams("gpt-4o-mini", req)
+	if err != nil {
+		t.Fatalf("buildOpenAIParams() err = %v", err)
+	}
+	items := params.Input.OfInputItemList
+	if len(items) != 3 || items[1].OfMessage == nil {
+		t.Fatalf("unexpected input items: %+v", items)
+	}
+	message := items[1].OfMessage
+	if got, want := message.Role, responses.EasyInputMessageRoleAssistant; got != want {
+		t.Fatalf("assistant role got=%q want=%q", got, want)
+	}
+	if got, want := message.Content.OfString.Value, "first\nanswer"; got != want {
+		t.Fatalf("assistant content got=%q want=%q", got, want)
+	}
+	if !param.IsOmitted(message.Content.OfInputItemContentList) {
+		t.Fatalf("assistant content must be a string: %+v", message.Content)
+	}
+}
+
 func TestBuildOpenAIParams_FunctionCall(t *testing.T) {
 	req := &model.LLMRequest{
 		Contents: []*genai.Content{


### PR DESCRIPTION
### Link to Issue or Description of Change

**Problem:**

`openaimodel` serializes every text message as an `input_text` content part. On a follow-up turn, model history is normalized to the `assistant` role, but the OpenAI Responses API rejects `input_text` for assistant content:

```text
HTTP 400
code="invalid_value"
param="input[1].content[0]"
```

This makes the first model turn succeed and the second turn fail.

**Solution:**

Serialize assistant history through `EasyInputMessage` string content. User, system, and developer messages keep their existing typed input content. This uses the SDK's role-aware easy-message representation without inventing response item IDs or statuses.

### Testing Plan

**Unit Tests:**

- [x] Added `TestBuildOpenAIParams_AssistantHistory`, covering user → assistant → user history and asserting assistant string content.
- [x] `go test -race ./model/openaimodel -count=1`
- [x] `go test -race -mod=readonly -count=1 -shuffle=on work` — 73 packages passed; 83 packages had no tests.
- [x] `go build -mod=readonly work`
- [x] `golangci-lint run` in the root module — 0 findings.
- [x] `go mod tidy -diff` in the root and `plugin/agentanalytics` modules — no diff.

**Manual End-to-End (E2E) Tests:**

A temporary local harness called `NewModel` against the OpenAI Responses API with user → assistant → user contents:

```text
go test ./model/openaimodel -run '^TestLiveAssistantHistory$' -count=1 -timeout=60s
ok google.golang.org/adk/v2/model/openaimodel 1.795s
```

The same two-turn flow was then exercised through a downstream live meeting agent: both model turns completed and the agent remained connected. No prompts, responses, credentials, or meeting content are included here.

### Checklist

- [x] I have read the `CONTRIBUTING.md` document.
- [x] I have performed a self-review of my own code.
- [x] I have commented my code where needed.
- [x] I have added tests that prove the fix is effective.
- [x] New and existing unit tests pass locally with my changes.
- [x] I have manually tested the change end-to-end.
- [x] No dependent downstream-module changes are required.

### Additional context

No matching open issue or pull request was found. The unrelated `plugin/agentanalytics` lint currently reports the existing `reflect.Ptr should be inlined` finding at `json_formatter.go:103`; this branch does not modify that module.