### PR TITLE
fix(session/database): auto-populate update_time for app/user state rows (#1177)

### DIFF
--- a/session/database/service_test.go
+++ b/session/database/service_test.go
@@ -159,6 +159,65 @@ func emptyService(t *testing.T) *databaseService {
 	return dbservice
 }
 
+// TestDatabaseService_StateTablesPopulateUpdateTime guards against writing a
+// zero update_time to the app_states/user_states tables. MySQL rejects the zero
+// value under strict mode (NO_ZERO_DATE), which surfaces as Error 1292 whenever
+// app- or user-scoped state is persisted. The update_time columns are maintained
+// on insert and update, mirroring adk-python's auto-updated ORM columns.
+func TestDatabaseService_StateTablesPopulateUpdateTime(t *testing.T) {
+	ctx := t.Context()
+	s := emptyService(t)
+
+	createResp, err := s.Create(ctx, &session.CreateRequest{
+		AppName: "app1",
+		UserID:  "user1",
+		State: map[string]any{
+			"app:config": "v1",
+			"user:pref":  "x",
+		},
+	})
+	if err != nil {
+		t.Fatalf("Create() error = %v", err)
+	}
+
+	// After Create with app-/user-scoped initial state, both rows must carry a
+	// real update_time.
+	var appState storageAppState
+	if err := s.db.First(&appState, "app_name = ?", "app1").Error; err != nil {
+		t.Fatalf("failed to load app state: %v", err)
+	}
+	if appState.UpdateTime.IsZero() {
+		t.Errorf("storageAppState.UpdateTime is zero after Create; want it populated")
+	}
+
+	var userState storageUserState
+	if err := s.db.First(&userState, "app_name = ? AND user_id = ?", "app1", "user1").Error; err != nil {
+		t.Fatalf("failed to load user state: %v", err)
+	}
+	if userState.UpdateTime.IsZero() {
+		t.Errorf("storageUserState.UpdateTime is zero after Create; want it populated")
+	}
+
+	// Appending an event that carries a state delta must refresh the row's time.
+	event := &session.Event{
+		ID:        "event1",
+		Timestamp: time.Now(),
+		Actions: session.EventActions{
+			StateDelta: map[string]any{"user:pref": "y"},
+		},
+	}
+	if err := s.AppendEvent(ctx, createResp.Session, event); err != nil {
+		t.Fatalf("AppendEvent() error = %v", err)
+	}
+
+	if err := s.db.First(&userState, "app_name = ? AND user_id = ?", "app1", "user1").Error; err != nil {
+		t.Fatalf("failed to reload user state after AppendEvent: %v", err)
+	}
+	if userState.UpdateTime.IsZero() {
+		t.Errorf("storageUserState.UpdateTime is zero after AppendEvent; want it refreshed")
+	}
+}
+
 func TestDatabaseService_AppendEvent_PreservesInputEventTempState(t *testing.T) {
 	ctx := t.Context()
 	s := emptyService(t)

--- a/session/database/storage_session.go
+++ b/session/database/storage_session.go
@@ -366,7 +366,7 @@ func createEventFromStorageEvent(se *storageEvent) (*session.Event, error) {
 type storageAppState struct {
 	AppName    string `gorm:"primaryKey;"`
 	State      stateMap
-	UpdateTime time.Time `gorm:"precision:6"`
+	UpdateTime time.Time `gorm:"precision:6;autoUpdateTime:micro"`
 }
 
 // TableName explicitly sets the table name for the AppState struct.
@@ -379,7 +379,7 @@ type storageUserState struct {
 	AppName    string `gorm:"primaryKey;"`
 	UserID     string `gorm:"primaryKey;"`
 	State      stateMap
-	UpdateTime time.Time `gorm:"precision:6"`
+	UpdateTime time.Time `gorm:"precision:6;autoUpdateTime:micro"`
 }
 
 // TableName explicitly sets the table name for the UserState struct.


### PR DESCRIPTION
## What

Fixes #1177 — persisting app- or user-scoped state via `session/database` fails on MySQL with default strict mode:

```
Error 1292 (22007): Incorrect datetime value: '0000-00-00' for column 'update_time' at row 1
```

`storageAppState` / `storageUserState` declare `UpdateTime` without any auto-update tag, and neither write path (`Create`, `AppendEvent`) assigns it, so GORM writes Go's zero `time.Time` explicitly. MySQL's `NO_ZERO_DATE`/`STRICT_TRANS_TABLES` rejects that value. SQLite, PostgreSQL and Spanner happen to accept it, which is why the bug only shows up on MySQL.

## Fix

Tag both state models with `autoUpdateTime` (mirroring adk-python, whose `StorageAppState.update_time` uses `default=func.now(), onupdate=func.now()`):

```go
UpdateTime time.Time `gorm:"precision:6;autoUpdateTime:micro"`
```

GORM then fills the column with the current time on both INSERT (new app/user row) and UPDATE (state delta on an existing row), covering every save path instead of just the two call sites. `precision:6` is preserved, so the DDL is unchanged (`datetime(6)`).

## Testing

- New regression test `TestDatabaseService_StateTablesPopulateUpdateTime` verifies `update_time` is populated after `Create` (app + user state) and refreshed after `AppendEvent` with a state delta. Confirmed it **fails before** the fix (zero `update_time`) and **passes after**.
- `go test ./session/database/...` — all green.
- `go test ./session/...` — `session`, `session/database`, `session/sessiontestsuite` green; `session/vertexai` is not runnable in this environment (requires live gRPC/Vertex AI network access).
- `go build -mod=readonly work` — passes.
- `go mod tidy -diff` — no changes.

A note on `-race`: the race detector fails to start in this Windows sandbox (`exit status 0xc0000139`, missing runtime entry point), so `-race` runs are not available here; the change is limited to GORM struct tags and a test, with no new concurrency.