### PR TITLE
fix(gcsartifact): recognize wrapped storage.ErrObjectNotExist

### DIFF
--- a/artifact/gcsartifact/gcs_test.go
+++ b/artifact/gcsartifact/gcs_test.go
@@ -202,6 +202,53 @@ func TestSaveZeroByteArtifact(t *testing.T) {
 	}
 }
 
+// TestNotFoundIsWrappedSentinel checks that Load and GetArtifactVersion
+// recognize storage.ErrObjectNotExist even when the storage client wraps it,
+// which is how cloud.google.com/go/storage actually returns it in production
+// (see storage.formatObjectErr, which always wraps NotFound as
+// fmt.Errorf("%w: %w", ErrObjectNotExist, err)). A caller checking
+// errors.Is(err, fs.ErrNotExist) must still get a match.
+func TestNotFoundIsWrappedSentinel(t *testing.T) {
+	wrapped := fmt.Errorf("%w: %w", storage.ErrObjectNotExist, errors.New("googleapi: Error 404: Not Found"))
+
+	for _, tc := range []struct {
+		name string
+		call func(svc *gcsService) error
+	}{
+		{
+			name: "Load",
+			call: func(svc *gcsService) error {
+				_, err := svc.Load(t.Context(), &artifact.LoadRequest{
+					AppName: "app", UserID: "user", SessionID: "session", FileName: "file",
+					Version: 1,
+				})
+				return err
+			},
+		},
+		{
+			name: "GetArtifactVersion",
+			call: func(svc *gcsService) error {
+				_, err := svc.GetArtifactVersion(t.Context(), &artifact.GetArtifactVersionRequest{
+					AppName: "app", UserID: "user", SessionID: "session", FileName: "file",
+					Version: 1,
+				})
+				return err
+			},
+		},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			svc := newGCSServiceForTesting("wrapped-not-exist")
+			fb := svc.bucket.(*fakeBucket)
+			fb.attrsErr = wrapped
+
+			err := tc.call(svc)
+			if !errors.Is(err, fs.ErrNotExist) {
+				t.Errorf("err = %v, want errors.Is(err, fs.ErrNotExist) = true", err)
+			}
+		})
+	}
+}
+
 // TestBackoffDelayBounds checks the jittered backoff stays within [0, saveRetryMaxDelay].
 func TestBackoffDelayBounds(t *testing.T) {
 	for attempt := range maxSaveAttempts {
@@ -290,6 +337,12 @@ type fakeBucket struct {
 	// return it (a simulated write failure); closeCalls counts Close calls.
 	closeErr   error
 	closeCalls int
+
+	// attrsErr, when set, is returned by every object's attrs() call in place
+	// of the default not-found/found behavior. Used to simulate the GCS
+	// client library's wrapped storage.ErrObjectNotExist (see
+	// TestNotFoundIsWrappedSentinel).
+	attrsErr error
 }
 
 // object returns a handle to the named blob, creating an empty backing store on
@@ -358,6 +411,14 @@ func (o *fakeObject) ifNotExist() gcsObject {
 
 // attrs returns fake attributes for the object.
 func (o *fakeObject) attrs(ctx context.Context) (*storage.ObjectAttrs, error) {
+	if o.bucket != nil {
+		o.bucket.mu.Lock()
+		forced := o.bucket.attrsErr
+		o.bucket.mu.Unlock()
+		if forced != nil {
+			return nil, forced
+		}
+	}
 	b := o.blob
 	b.mu.Lock()
 	defer b.mu.Unlock()

--- a/artifact/gcsartifact/service.go
+++ b/artifact/gcsartifact/service.go
@@ -298,7 +298,7 @@ func (s *gcsService) Load(ctx context.Context, req *artifact.LoadRequest) (_ *ar
 	// Check if the blob exists before trying to read it
 	attrs, err := blob.attrs(ctx)
 	if err != nil {
-		if err == storage.ErrObjectNotExist {
+		if errors.Is(err, storage.ErrObjectNotExist) {
 			return nil, fmt.Errorf("artifact '%s' not found: %w", blobName, fs.ErrNotExist)
 		}
 		return nil, fmt.Errorf("could not get blob attributes: %w", err)
@@ -474,7 +474,7 @@ func (s *gcsService) GetArtifactVersion(ctx context.Context, req *artifact.GetAr
 
 	attrs, err := blob.attrs(ctx)
 	if err != nil {
-		if err == storage.ErrObjectNotExist {
+		if errors.Is(err, storage.ErrObjectNotExist) {
 			return nil, fmt.Errorf("artifact '%s' not found: %w", blobName, fs.ErrNotExist)
 		}
 		return nil, fmt.Errorf("could not get blob attributes: %w", err)


### PR DESCRIPTION
### Link to Issue or Description of Change

**2. Or, if no issue exists, describe the change:**

**Problem:**

`artifact/gcsartifact/service.go` has two identical checks (`Load` and `GetArtifactVersion`) that compare the error from `blob.attrs(ctx)` against `storage.ErrObjectNotExist` with `==`:

```go
attrs, err := blob.attrs(ctx)
if err != nil {
    if err == storage.ErrObjectNotExist {
        return nil, fmt.Errorf("artifact '%s' not found: %w", blobName, fs.ErrNotExist)
    }
    return nil, fmt.Errorf("could not get blob attributes: %w", err)
}
```

The pinned `cloud.google.com/go/storage v1.64.0` always wraps this sentinel. `ObjectHandle.Attrs` routes through `httpStorageClient.GetObject` → `formatObjectErr`:

```go
func formatObjectErr(err error) error {
    var e *googleapi.Error
    if s, ok := status.FromError(err); (ok && s.Code() == codes.NotFound) ||
        (errors.As(err, &e) && e.Code == http.StatusNotFound) {
        return fmt.Errorf("%w: %w", ErrObjectNotExist, err)
    }
    return err
}
```

So in production `err == storage.ErrObjectNotExist` is always `false`, and the `fs.ErrNotExist` translation is dead code. A caller doing `errors.Is(err, fs.ErrNotExist)` after a real not-found gets a generic "could not get blob attributes" error instead of a not-found signal.

This package already documents the fix for this exact class of bug two functions up, on `ErrVersionConflict`:

> `// ErrVersionConflict ... It is always wrapped, so test for it with [errors.Is]`

This PR applies that same rule to `storage.ErrObjectNotExist` at both call sites.

**Solution:**

Change both `err == storage.ErrObjectNotExist` checks to `errors.Is(err, storage.ErrObjectNotExist)`. Both `errors` and `storage` were already imported. No other behavior changes — one concern only.

### Testing Plan

**Unit Tests:**

- [x] I have added or updated unit tests for my change.
- [x] All unit tests pass locally.

Added `TestNotFoundIsWrappedSentinel` in `artifact/gcsartifact/gcs_test.go`, covering both `Load` and `GetArtifactVersion`. It adds a small `attrsErr` hook to the existing in-memory fake (`fakeBucket`/`fakeObject`) so `attrs()` can return a *wrapped* `storage.ErrObjectNotExist` — mirroring what the real client actually returns — instead of the fake's previous bare-sentinel behavior, which never exercised this bug.

Confirmed RED on the pre-fix code (test added, fix withheld):

```
=== RUN   TestNotFoundIsWrappedSentinel/Load
    gcs_test.go:246: err = could not get blob attributes: storage: object doesn't exist: googleapi: Error 404: Not Found, want errors.Is(err, fs.ErrNotExist) = true
--- FAIL: TestNotFoundIsWrappedSentinel/Load (0.00s)
=== RUN   TestNotFoundIsWrappedSentinel/GetArtifactVersion
    gcs_test.go:246: err = could not get blob attributes: storage: object doesn't exist: googleapi: Error 404: Not Found, want errors.Is(err, fs.ErrNotExist) = true
--- FAIL: TestNotFoundIsWrappedSentinel/GetArtifactVersion (0.00s)
FAIL
```

GREEN after the fix, along with the full existing package suite:

```
go test -race -mod=readonly -count=1 -shuffle=on ./artifact/... ./artifact/gcsartifact/...
ok  	google.golang.org/adk/v2/artifact	1.028s
ok  	google.golang.org/adk/v2/artifact/gcsartifact	1.043s
```

Also ran, all clean:
- `golangci-lint run ./artifact/...` — 0 issues
- `golangci-lint fmt ./artifact/...` — no changes
- `go mod tidy -diff` — empty
- `go build -mod=readonly work` — succeeds

**Manual End-to-End (E2E) Tests:**

Not applicable — this is a pure error-classification fix inside `gcsService.Load`/`GetArtifactVersion`, fully covered by the unit test above; no UI, runner, or live-GCS surface is touched.

### Checklist

- [x] I have read the CONTRIBUTING.md document.
- [x] I have performed a self-review of my own code.
- [x] I have commented my code, particularly in hard-to-understand areas.
- [x] I have added tests that prove my fix is effective or that my feature works.
- [x] New and existing unit tests pass locally with my changes.
- [ ] I have manually tested my changes end-to-end. (not applicable — see above)
- [x] Any dependent changes have been merged and published in downstream modules.
