### PR TITLE
feat: Implement automatic schema upgrades for BigQuery logger

### DIFF
--- a/plugin/agentanalytics/bigquery_agent_analytics_plugin.go
+++ b/plugin/agentanalytics/bigquery_agent_analytics_plugin.go
@@ -102,6 +102,10 @@ func NewBigQueryAgentAnalyticsPluginWithClients(
 		}
 		err = tableRef.Create(ctx, &bq.TableMetadata{
 			Schema: EventsSchema(),
+			TimePartitioning: &bq.TimePartitioning{
+				Field: "timestamp",
+				Type:  bq.DayPartitioningType,
+			},
 			Clustering: &bq.Clustering{
 				Fields: config.ClusteringFields,
 			},

--- a/plugin/agentanalytics/bigquery_agent_analytics_plugin.go
+++ b/plugin/agentanalytics/bigquery_agent_analytics_plugin.go
@@ -321,7 +321,7 @@ func NewBigQueryAgentAnalyticsPluginWithClients(
 	return baseplugin.New(cfg)
 }
 
-func schemaFieldsMatch(existing, desired bq.Schema) (newFields bq.Schema, updatedRecords bq.Schema) {
+func schemaFieldsMatch(existing, desired bq.Schema) (newFields, updatedRecords bq.Schema) {
 	existingByName := make(map[string]*bq.FieldSchema)
 	for _, f := range existing {
 		existingByName[f.Name] = f

--- a/plugin/agentanalytics/bigquery_agent_analytics_plugin.go
+++ b/plugin/agentanalytics/bigquery_agent_analytics_plugin.go
@@ -18,11 +18,14 @@ package agentanalytics
 import (
 	"context"
 	"fmt"
+	"net/http"
+	"strings"
 	"time"
 
 	bq "cloud.google.com/go/bigquery"
 	bqstorage "cloud.google.com/go/bigquery/storage/apiv1"
 	"go.opentelemetry.io/otel/trace"
+	"google.golang.org/api/googleapi"
 	"google.golang.org/genai"
 
 	"google.golang.org/adk/v2/agent"
@@ -30,6 +33,11 @@ import (
 	baseplugin "google.golang.org/adk/v2/plugin"
 	"google.golang.org/adk/v2/session"
 	"google.golang.org/adk/v2/tool"
+)
+
+const (
+	schemaVersion         = "1"
+	schemaVersionLabelKey = "adk_schema_version"
 )
 
 // NewBigQueryAgentAnalyticsPlugin creates a newly configured analytics plugin with default config.
@@ -95,24 +103,35 @@ func NewBigQueryAgentAnalyticsPluginWithClients(
 
 	// Ensure table exists (done once per instance)
 	tableRef := bqClient.Dataset(config.DatasetID).Table(config.TableName)
-	_, err := tableRef.Metadata(ctx)
+	meta, err := tableRef.Metadata(ctx)
 	if err != nil {
-		if config.Logger != nil {
-			config.Logger.Printf("Table %s not found. Creating it...", config.TableName)
-		}
-		err = tableRef.Create(ctx, &bq.TableMetadata{
-			Schema: EventsSchema(),
-			TimePartitioning: &bq.TimePartitioning{
-				Field: "timestamp",
-				Type:  bq.DayPartitioningType,
-			},
-			Clustering: &bq.Clustering{
-				Fields: config.ClusteringFields,
-			},
-		})
-		if err != nil {
+		if apiErr, ok := err.(*googleapi.Error); ok && apiErr.Code == http.StatusNotFound {
 			if config.Logger != nil {
-				config.Logger.Printf("Failed to create BigQuery table %v: %v", config.TableName, err)
+				config.Logger.Printf("Table %s not found. Creating it...", config.TableName)
+			}
+			err = tableRef.Create(ctx, &bq.TableMetadata{
+				Schema: EventsSchema(),
+				TimePartitioning: &bq.TimePartitioning{
+					Field: "timestamp",
+					Type:  bq.DayPartitioningType,
+				},
+				Clustering: &bq.Clustering{
+					Fields: config.ClusteringFields,
+				},
+				Labels: map[string]string{
+					schemaVersionLabelKey: schemaVersion,
+				},
+			})
+			if err != nil {
+				return nil, fmt.Errorf("failed to create BigQuery table: %w", err)
+			}
+		} else {
+			return nil, fmt.Errorf("failed to retrieve BigQuery table metadata: %w", err)
+		}
+	} else {
+		if config.AutoSchemaUpgrade {
+			if err := maybeUpgradeSchema(ctx, tableRef, meta, config.Logger); err != nil {
+				return nil, fmt.Errorf("failed to auto-upgrade BigQuery table schema: %w", err)
 			}
 		}
 	}
@@ -303,4 +322,124 @@ func NewBigQueryAgentAnalyticsPluginWithClients(
 	}
 
 	return baseplugin.New(cfg)
+}
+
+func schemaFieldsMatch(existing, desired bq.Schema) (newFields bq.Schema, updatedRecords bq.Schema) {
+	existingByName := make(map[string]*bq.FieldSchema)
+	for _, f := range existing {
+		existingByName[f.Name] = f
+	}
+
+	for _, desiredField := range desired {
+		existingField, exists := existingByName[desiredField.Name]
+		if !exists {
+			newFields = append(newFields, desiredField)
+		} else if desiredField.Type == bq.RecordFieldType && existingField.Type == bq.RecordFieldType && len(desiredField.Schema) > 0 {
+			subNew, subUpdated := schemaFieldsMatch(existingField.Schema, desiredField.Schema)
+			if len(subNew) > 0 || len(subUpdated) > 0 {
+				// Build a merged sub-field list
+				mergedSub := make(bq.Schema, len(existingField.Schema))
+				copy(mergedSub, existingField.Schema)
+
+				updatedNames := make(map[string]bool)
+				for _, f := range subUpdated {
+					updatedNames[f.Name] = true
+				}
+
+				// Replace updated nested records in-place
+				for i, f := range mergedSub {
+					if updatedNames[f.Name] {
+						for _, u := range subUpdated {
+							if u.Name == f.Name {
+								mergedSub[i] = u
+								break
+							}
+						}
+					}
+				}
+
+				// Append entirely new sub-fields
+				mergedSub = append(mergedSub, subNew...)
+
+				// Create updated RECORD field schema
+				updatedField := *existingField
+				updatedField.Schema = mergedSub
+				updatedRecords = append(updatedRecords, &updatedField)
+			}
+		}
+	}
+	return newFields, updatedRecords
+}
+
+func maybeUpgradeSchema(ctx context.Context, existingTable *bq.Table, meta *bq.TableMetadata, logger Logger) error {
+	storedVersion := meta.Labels[schemaVersionLabelKey]
+	if storedVersion == schemaVersion {
+		return nil
+	}
+
+	newFields, updatedRecords := schemaFieldsMatch(meta.Schema, EventsSchema())
+
+	if len(newFields) > 0 || len(updatedRecords) > 0 {
+		updatedNames := make(map[string]bool)
+		for _, f := range updatedRecords {
+			updatedNames[f.Name] = true
+		}
+
+		merged := make(bq.Schema, 0, len(meta.Schema)+len(newFields))
+		for _, f := range meta.Schema {
+			if updatedNames[f.Name] {
+				for _, u := range updatedRecords {
+					if u.Name == f.Name {
+						merged = append(merged, u)
+						break
+					}
+				}
+			} else {
+				merged = append(merged, f)
+			}
+		}
+		merged = append(merged, newFields...)
+
+		// Update schema in metadata update
+		update := bq.TableMetadataToUpdate{
+			Schema: merged,
+		}
+		update.SetLabel(schemaVersionLabelKey, schemaVersion)
+
+		_, err := existingTable.Update(ctx, update, meta.ETag)
+		if err != nil {
+			return fmt.Errorf("failed to update table schema: %w", err)
+		}
+
+		if logger != nil {
+			var changeDesc []string
+			if len(newFields) > 0 {
+				var names []string
+				for _, f := range newFields {
+					names = append(names, f.Name)
+				}
+				changeDesc = append(changeDesc, fmt.Sprintf("new columns %v", names))
+			}
+			if len(updatedRecords) > 0 {
+				var names []string
+				for _, f := range updatedRecords {
+					names = append(names, f.Name)
+				}
+				changeDesc = append(changeDesc, fmt.Sprintf("updated RECORD fields %v", names))
+			}
+			logger.Printf("Auto-upgraded table schema: %s", strings.Join(changeDesc, ", "))
+		}
+	} else {
+		// No schema upgrade needed, just update label if missing or outdated
+		if storedVersion != schemaVersion {
+			update := bq.TableMetadataToUpdate{}
+			update.SetLabel(schemaVersionLabelKey, schemaVersion)
+
+			_, err := existingTable.Update(ctx, update, meta.ETag)
+			if err != nil {
+				return fmt.Errorf("failed to update table labels: %w", err)
+			}
+		}
+	}
+	return nil
 }

--- a/plugin/agentanalytics/bigquery_agent_analytics_plugin.go
+++ b/plugin/agentanalytics/bigquery_agent_analytics_plugin.go
@@ -324,7 +324,7 @@ func NewBigQueryAgentAnalyticsPluginWithClients(
 	return baseplugin.New(cfg)
 }
 
-func schemaFieldsMatch(existing, desired bq.Schema) (newFields bq.Schema, updatedRecords bq.Schema) {
+func schemaFieldsMatch(existing, desired bq.Schema) (newFields, updatedRecords bq.Schema) {
 	existingByName := make(map[string]*bq.FieldSchema)
 	for _, f := range existing {
 		existingByName[f.Name] = f

--- a/plugin/agentanalytics/bigquery_agent_analytics_plugin.go
+++ b/plugin/agentanalytics/bigquery_agent_analytics_plugin.go
@@ -18,11 +18,14 @@ package agentanalytics
 import (
 	"context"
 	"fmt"
+	"net/http"
+	"strings"
 	"time"
 
 	bq "cloud.google.com/go/bigquery"
 	bqstorage "cloud.google.com/go/bigquery/storage/apiv1"
 	"go.opentelemetry.io/otel/trace"
+	"google.golang.org/api/googleapi"
 	"google.golang.org/genai"
 
 	"google.golang.org/adk/v2/agent"
@@ -30,6 +33,11 @@ import (
 	baseplugin "google.golang.org/adk/v2/plugin"
 	"google.golang.org/adk/v2/session"
 	"google.golang.org/adk/v2/tool"
+)
+
+const (
+	schemaVersion         = "1"
+	schemaVersionLabelKey = "adk_schema_version"
 )
 
 // NewBigQueryAgentAnalyticsPlugin creates a newly configured analytics plugin with default config.
@@ -95,24 +103,35 @@ func NewBigQueryAgentAnalyticsPluginWithClients(
 
 	// Ensure table exists (done once per instance)
 	tableRef := bqClient.Dataset(config.DatasetID).Table(config.TableName)
-	_, err := tableRef.Metadata(ctx)
+	meta, err := tableRef.Metadata(ctx)
 	if err != nil {
-		if config.Logger != nil {
-			config.Logger.Printf("Table %s not found. Creating it...", config.TableName)
-		}
-		err = tableRef.Create(ctx, &bq.TableMetadata{
-			Schema: EventsSchema(),
-			TimePartitioning: &bq.TimePartitioning{
-				Field: "timestamp",
-				Type:  bq.DayPartitioningType,
-			},
-			Clustering: &bq.Clustering{
-				Fields: config.ClusteringFields,
-			},
-		})
-		if err != nil {
+		if apiErr, ok := err.(*googleapi.Error); ok && apiErr.Code == http.StatusNotFound {
 			if config.Logger != nil {
-				config.Logger.Printf("Failed to create BigQuery table %v: %v", config.TableName, err)
+				config.Logger.Printf("Table %s not found. Creating it...", config.TableName)
+			}
+			err = tableRef.Create(ctx, &bq.TableMetadata{
+				Schema: EventsSchema(),
+				TimePartitioning: &bq.TimePartitioning{
+					Field: "timestamp",
+					Type:  bq.DayPartitioningType,
+				},
+				Clustering: &bq.Clustering{
+					Fields: config.ClusteringFields,
+				},
+				Labels: map[string]string{
+					schemaVersionLabelKey: schemaVersion,
+				},
+			})
+			if err != nil {
+				return nil, fmt.Errorf("failed to create BigQuery table: %w", err)
+			}
+		} else {
+			return nil, fmt.Errorf("failed to retrieve BigQuery table metadata: %w", err)
+		}
+	} else {
+		if config.AutoSchemaUpgrade {
+			if err := maybeUpgradeSchema(ctx, tableRef, meta, config.Logger); err != nil {
+				return nil, fmt.Errorf("failed to auto-upgrade BigQuery table schema: %w", err)
 			}
 		}
 	}
@@ -300,4 +319,124 @@ func NewBigQueryAgentAnalyticsPluginWithClients(
 	}
 
 	return baseplugin.New(cfg)
+}
+
+func schemaFieldsMatch(existing, desired bq.Schema) (newFields bq.Schema, updatedRecords bq.Schema) {
+	existingByName := make(map[string]*bq.FieldSchema)
+	for _, f := range existing {
+		existingByName[f.Name] = f
+	}
+
+	for _, desiredField := range desired {
+		existingField, exists := existingByName[desiredField.Name]
+		if !exists {
+			newFields = append(newFields, desiredField)
+		} else if desiredField.Type == bq.RecordFieldType && existingField.Type == bq.RecordFieldType && len(desiredField.Schema) > 0 {
+			subNew, subUpdated := schemaFieldsMatch(existingField.Schema, desiredField.Schema)
+			if len(subNew) > 0 || len(subUpdated) > 0 {
+				// Build a merged sub-field list
+				mergedSub := make(bq.Schema, len(existingField.Schema))
+				copy(mergedSub, existingField.Schema)
+
+				updatedNames := make(map[string]bool)
+				for _, f := range subUpdated {
+					updatedNames[f.Name] = true
+				}
+
+				// Replace updated nested records in-place
+				for i, f := range mergedSub {
+					if updatedNames[f.Name] {
+						for _, u := range subUpdated {
+							if u.Name == f.Name {
+								mergedSub[i] = u
+								break
+							}
+						}
+					}
+				}
+
+				// Append entirely new sub-fields
+				mergedSub = append(mergedSub, subNew...)
+
+				// Create updated RECORD field schema
+				updatedField := *existingField
+				updatedField.Schema = mergedSub
+				updatedRecords = append(updatedRecords, &updatedField)
+			}
+		}
+	}
+	return newFields, updatedRecords
+}
+
+func maybeUpgradeSchema(ctx context.Context, existingTable *bq.Table, meta *bq.TableMetadata, logger Logger) error {
+	storedVersion := meta.Labels[schemaVersionLabelKey]
+	if storedVersion == schemaVersion {
+		return nil
+	}
+
+	newFields, updatedRecords := schemaFieldsMatch(meta.Schema, EventsSchema())
+
+	if len(newFields) > 0 || len(updatedRecords) > 0 {
+		updatedNames := make(map[string]bool)
+		for _, f := range updatedRecords {
+			updatedNames[f.Name] = true
+		}
+
+		merged := make(bq.Schema, 0, len(meta.Schema)+len(newFields))
+		for _, f := range meta.Schema {
+			if updatedNames[f.Name] {
+				for _, u := range updatedRecords {
+					if u.Name == f.Name {
+						merged = append(merged, u)
+						break
+					}
+				}
+			} else {
+				merged = append(merged, f)
+			}
+		}
+		merged = append(merged, newFields...)
+
+		// Update schema in metadata update
+		update := bq.TableMetadataToUpdate{
+			Schema: merged,
+		}
+		update.SetLabel(schemaVersionLabelKey, schemaVersion)
+
+		_, err := existingTable.Update(ctx, update, meta.ETag)
+		if err != nil {
+			return fmt.Errorf("failed to update table schema: %w", err)
+		}
+
+		if logger != nil {
+			var changeDesc []string
+			if len(newFields) > 0 {
+				var names []string
+				for _, f := range newFields {
+					names = append(names, f.Name)
+				}
+				changeDesc = append(changeDesc, fmt.Sprintf("new columns %v", names))
+			}
+			if len(updatedRecords) > 0 {
+				var names []string
+				for _, f := range updatedRecords {
+					names = append(names, f.Name)
+				}
+				changeDesc = append(changeDesc, fmt.Sprintf("updated RECORD fields %v", names))
+			}
+			logger.Printf("Auto-upgraded table schema: %s", strings.Join(changeDesc, ", "))
+		}
+	} else {
+		// No schema upgrade needed, just update label if missing or outdated
+		if storedVersion != schemaVersion {
+			update := bq.TableMetadataToUpdate{}
+			update.SetLabel(schemaVersionLabelKey, schemaVersion)
+
+			_, err := existingTable.Update(ctx, update, meta.ETag)
+			if err != nil {
+				return fmt.Errorf("failed to update table labels: %w", err)
+			}
+		}
+	}
+	return nil
 }

--- a/plugin/agentanalytics/bigquery_agent_analytics_plugin_test.go
+++ b/plugin/agentanalytics/bigquery_agent_analytics_plugin_test.go
@@ -15,6 +15,7 @@
 package agentanalytics
 
 import (
+	"bytes"
 	"context"
 	"errors"
 	"io"
@@ -376,5 +377,89 @@ func TestLogEvent_ExtractsTraceInfo(t *testing.T) {
 		}
 	case <-time.After(5 * time.Second):
 		t.Error("Timed out waiting for request")
+	}
+}
+
+func TestNewBigQueryAgentAnalyticsPlugin_CreateTable_WithPartitioning(t *testing.T) {
+	ctx := context.Background()
+	config := DefaultConfig()
+	config.Enabled = true
+	config.ProjectID = "test-project"
+	config.DatasetID = "test-dataset"
+	config.TableName = "test-table"
+
+	createCalled := false
+	var requestBody string
+
+	mockTransport := &mockTransport{
+		roundTrip: func(r *http.Request) (*http.Response, error) {
+			// Table metadata request: returns 404 Not Found to trigger creation
+			if r.Method == "GET" && strings.Contains(r.URL.Path, "/datasets/test-dataset/tables/test-table") {
+				return &http.Response{
+					StatusCode: http.StatusNotFound,
+					Body:       io.NopCloser(strings.NewReader(`{"error":{"code":404,"message":"Not found"}}`)),
+				}, nil
+			}
+			// Table creation request
+			if r.Method == "POST" && strings.Contains(r.URL.Path, "/datasets/test-dataset/tables") {
+				createCalled = true
+				bodyBytes, _ := io.ReadAll(r.Body)
+				requestBody = string(bodyBytes)
+				r.Body = io.NopCloser(bytes.NewBuffer(bodyBytes))
+
+				return &http.Response{
+					StatusCode: http.StatusOK,
+					Body:       io.NopCloser(strings.NewReader("{}")),
+				}, nil
+			}
+			return &http.Response{
+				StatusCode: http.StatusOK,
+				Body:       io.NopCloser(strings.NewReader("{}")),
+			}, nil
+		},
+	}
+	httpClient := &http.Client{Transport: mockTransport}
+	bqClient, err := bq.NewClient(ctx, config.ProjectID, option.WithHTTPClient(httpClient))
+	if err != nil {
+		t.Fatalf("Failed to create bigquery client: %v", err)
+	}
+
+	lis, err := net.Listen("tcp", "localhost:0")
+	if err != nil {
+		t.Fatalf("failed to listen: %v", err)
+	}
+	gSrv := grpc.NewServer()
+	storagepb.RegisterBigQueryWriteServer(gSrv, &fakeBigQueryWriteServer{})
+	go func() { _ = gSrv.Serve(lis) }()
+	t.Cleanup(gSrv.Stop)
+
+	conn, err := grpc.NewClient(lis.Addr().String(), grpc.WithTransportCredentials(insecure.NewCredentials()))
+	if err != nil {
+		t.Fatalf("failed to dial test server: %v", err)
+	}
+	t.Cleanup(func() { _ = conn.Close() })
+
+	writeClient, err := bqstorage.NewBigQueryWriteClient(ctx, option.WithGRPCConn(conn))
+	if err != nil {
+		t.Fatalf("Failed to create BigQuery write client: %v", err)
+	}
+
+	_, err = NewBigQueryAgentAnalyticsPluginWithClients(ctx, config, bqClient, writeClient)
+	if err != nil {
+		t.Fatalf("Plugin initialization error: %v", err)
+	}
+
+	if !createCalled {
+		t.Error("Expected table creation to be called")
+	}
+
+	if !strings.Contains(requestBody, "timePartitioning") {
+		t.Errorf("Expected request body to contain 'timePartitioning', got: %s", requestBody)
+	}
+	if !strings.Contains(requestBody, "DAY") {
+		t.Errorf("Expected partitioning type to be 'DAY', got request body: %s", requestBody)
+	}
+	if !strings.Contains(requestBody, "timestamp") {
+		t.Errorf("Expected partitioning field to be 'timestamp', got request body: %s", requestBody)
 	}
 }

--- a/plugin/agentanalytics/bigquery_agent_analytics_plugin_test.go
+++ b/plugin/agentanalytics/bigquery_agent_analytics_plugin_test.go
@@ -427,3 +427,315 @@ func TestNewBigQueryAgentAnalyticsPlugin_CreateTable_WithPartitioning(t *testing
 		t.Errorf("Expected partitioning field to be 'timestamp', got request body: %s", requestBody)
 	}
 }
+
+func TestSchemaFieldsMatch(t *testing.T) {
+	existing := bq.Schema{
+		{Name: "col1", Type: bq.StringFieldType},
+		{
+			Name: "col_record",
+			Type: bq.RecordFieldType,
+			Schema: bq.Schema{
+				{Name: "sub1", Type: bq.IntegerFieldType},
+			},
+		},
+	}
+
+	desired := bq.Schema{
+		{Name: "col1", Type: bq.StringFieldType},
+		{Name: "col2", Type: bq.BooleanFieldType}, // New top-level col
+		{
+			Name: "col_record",
+			Type: bq.RecordFieldType,
+			Schema: bq.Schema{
+				{Name: "sub1", Type: bq.IntegerFieldType},
+				{Name: "sub2", Type: bq.StringFieldType}, // New sub-field
+			},
+		},
+	}
+
+	newFields, updatedRecords := schemaFieldsMatch(existing, desired)
+
+	if len(newFields) != 1 || newFields[0].Name != "col2" {
+		t.Errorf("Expected 1 new top-level field 'col2', got %v", newFields)
+	}
+
+	if len(updatedRecords) != 1 || updatedRecords[0].Name != "col_record" {
+		t.Fatalf("Expected 1 updated RECORD field 'col_record', got %v", updatedRecords)
+	}
+
+	updatedRecord := updatedRecords[0]
+	if len(updatedRecord.Schema) != 2 {
+		t.Errorf("Expected updated RECORD to have 2 sub-fields, got %d", len(updatedRecord.Schema))
+	}
+	if updatedRecord.Schema[1].Name != "sub2" {
+		t.Errorf("Expected second sub-field of RECORD to be 'sub2', got %s", updatedRecord.Schema[1].Name)
+	}
+}
+
+func TestNewBigQueryAgentAnalyticsPlugin_TableExists(t *testing.T) {
+	ctx := context.Background()
+	config := DefaultConfig()
+	config.Enabled = true
+	config.ProjectID = "test-project"
+	config.DatasetID = "test-dataset"
+	config.TableName = "test-table"
+	config.AutoSchemaUpgrade = false
+
+	mockTransport := &mockTransport{
+		roundTrip: func(r *http.Request) (*http.Response, error) {
+			if r.Method == "GET" && strings.Contains(r.URL.Path, "/datasets/test-dataset/tables/test-table") {
+				return &http.Response{
+					StatusCode: http.StatusOK,
+					Body:       io.NopCloser(strings.NewReader(`{"tableReference":{"projectId":"test-project","datasetId":"test-dataset","tableId":"test-table"}}`)),
+				}, nil
+			}
+			return &http.Response{
+				StatusCode: http.StatusOK,
+				Body:       io.NopCloser(strings.NewReader("{}")),
+			}, nil
+		},
+	}
+	httpClient := &http.Client{Transport: mockTransport}
+	bqClient, err := bq.NewClient(ctx, config.ProjectID, option.WithHTTPClient(httpClient))
+	if err != nil {
+		t.Fatalf("Failed to create bigquery client: %v", err)
+	}
+
+	lis, err := net.Listen("tcp", "localhost:0")
+	if err != nil {
+		t.Fatalf("failed to listen: %v", err)
+	}
+	gSrv := grpc.NewServer()
+	storagepb.RegisterBigQueryWriteServer(gSrv, &fakeBigQueryWriteServer{})
+	go func() { _ = gSrv.Serve(lis) }()
+	t.Cleanup(gSrv.Stop)
+
+	conn, err := grpc.NewClient(lis.Addr().String(), grpc.WithTransportCredentials(insecure.NewCredentials()))
+	if err != nil {
+		t.Fatalf("failed to dial test server: %v", err)
+	}
+	t.Cleanup(func() { _ = conn.Close() })
+
+	writeClient, err := bqstorage.NewBigQueryWriteClient(ctx, option.WithGRPCConn(conn))
+	if err != nil {
+		t.Fatalf("Failed to create BigQuery write client: %v", err)
+	}
+
+	p, err := NewBigQueryAgentAnalyticsPluginWithClients(ctx, config, bqClient, writeClient)
+	if err != nil {
+		t.Fatalf("Expected no error when table exists, got: %v", err)
+	}
+	if p == nil {
+		t.Fatal("Expected plugin to be non-nil")
+	}
+}
+
+func TestNewBigQueryAgentAnalyticsPlugin_TableNotFound_CreateSucceeds(t *testing.T) {
+	ctx := context.Background()
+	config := DefaultConfig()
+	config.Enabled = true
+	config.ProjectID = "test-project"
+	config.DatasetID = "test-dataset"
+	config.TableName = "test-table"
+	config.AutoSchemaUpgrade = false
+
+	createCalled := false
+
+	mockTransport := &mockTransport{
+		roundTrip: func(r *http.Request) (*http.Response, error) {
+			if r.Method == "GET" && strings.Contains(r.URL.Path, "/datasets/test-dataset/tables/test-table") {
+				return &http.Response{
+					StatusCode: http.StatusNotFound,
+					Body:       io.NopCloser(strings.NewReader(`{"error":{"code":404,"message":"Not found"}}`)),
+				}, nil
+			}
+			if r.Method == "POST" && strings.Contains(r.URL.Path, "/datasets/test-dataset/tables") {
+				createCalled = true
+				return &http.Response{
+					StatusCode: http.StatusOK,
+					Body:       io.NopCloser(strings.NewReader("{}")),
+				}, nil
+			}
+			return &http.Response{
+				StatusCode: http.StatusOK,
+				Body:       io.NopCloser(strings.NewReader("{}")),
+			}, nil
+		},
+	}
+	httpClient := &http.Client{Transport: mockTransport}
+	bqClient, err := bq.NewClient(ctx, config.ProjectID, option.WithHTTPClient(httpClient))
+	if err != nil {
+		t.Fatalf("Failed to create bigquery client: %v", err)
+	}
+
+	lis, err := net.Listen("tcp", "localhost:0")
+	if err != nil {
+		t.Fatalf("failed to listen: %v", err)
+	}
+	gSrv := grpc.NewServer()
+	storagepb.RegisterBigQueryWriteServer(gSrv, &fakeBigQueryWriteServer{})
+	go func() { _ = gSrv.Serve(lis) }()
+	t.Cleanup(gSrv.Stop)
+
+	conn, err := grpc.NewClient(lis.Addr().String(), grpc.WithTransportCredentials(insecure.NewCredentials()))
+	if err != nil {
+		t.Fatalf("failed to dial test server: %v", err)
+	}
+	t.Cleanup(func() { _ = conn.Close() })
+
+	writeClient, err := bqstorage.NewBigQueryWriteClient(ctx, option.WithGRPCConn(conn))
+	if err != nil {
+		t.Fatalf("Failed to create BigQuery write client: %v", err)
+	}
+
+	p, err := NewBigQueryAgentAnalyticsPluginWithClients(ctx, config, bqClient, writeClient)
+	if err != nil {
+		t.Fatalf("Expected no error when table is created successfully, got: %v", err)
+	}
+	if p == nil {
+		t.Fatal("Expected plugin to be non-nil")
+	}
+	if !createCalled {
+		t.Error("Expected table creation to be attempted, but it was not called")
+	}
+}
+
+func TestNewBigQueryAgentAnalyticsPlugin_TableNotFound_CreateFails(t *testing.T) {
+	ctx := context.Background()
+	config := DefaultConfig()
+	config.Enabled = true
+	config.ProjectID = "test-project"
+	config.DatasetID = "test-dataset"
+	config.TableName = "test-table"
+	config.AutoSchemaUpgrade = false
+
+	mockTransport := &mockTransport{
+		roundTrip: func(r *http.Request) (*http.Response, error) {
+			if r.Method == "GET" && strings.Contains(r.URL.Path, "/datasets/test-dataset/tables/test-table") {
+				return &http.Response{
+					StatusCode: http.StatusNotFound,
+					Body:       io.NopCloser(strings.NewReader(`{"error":{"code":404,"message":"Not found"}}`)),
+				}, nil
+			}
+			if r.Method == "POST" && strings.Contains(r.URL.Path, "/datasets/test-dataset/tables") {
+				return &http.Response{
+					StatusCode: http.StatusForbidden,
+					Body:       io.NopCloser(strings.NewReader(`{"error":{"code":403,"message":"Permission denied"}}`)),
+				}, nil
+			}
+			return &http.Response{
+				StatusCode: http.StatusOK,
+				Body:       io.NopCloser(strings.NewReader("{}")),
+			}, nil
+		},
+	}
+	httpClient := &http.Client{Transport: mockTransport}
+	bqClient, err := bq.NewClient(ctx, config.ProjectID, option.WithHTTPClient(httpClient))
+	if err != nil {
+		t.Fatalf("Failed to create bigquery client: %v", err)
+	}
+
+	lis, err := net.Listen("tcp", "localhost:0")
+	if err != nil {
+		t.Fatalf("failed to listen: %v", err)
+	}
+	gSrv := grpc.NewServer()
+	storagepb.RegisterBigQueryWriteServer(gSrv, &fakeBigQueryWriteServer{})
+	go func() { _ = gSrv.Serve(lis) }()
+	t.Cleanup(gSrv.Stop)
+
+	conn, err := grpc.NewClient(lis.Addr().String(), grpc.WithTransportCredentials(insecure.NewCredentials()))
+	if err != nil {
+		t.Fatalf("failed to dial test server: %v", err)
+	}
+	t.Cleanup(func() { _ = conn.Close() })
+
+	writeClient, err := bqstorage.NewBigQueryWriteClient(ctx, option.WithGRPCConn(conn))
+	if err != nil {
+		t.Fatalf("Failed to create BigQuery write client: %v", err)
+	}
+
+	p, err := NewBigQueryAgentAnalyticsPluginWithClients(ctx, config, bqClient, writeClient)
+	if err == nil {
+		t.Fatal("Expected error when table creation fails, got nil")
+	}
+	if p != nil {
+		t.Error("Expected plugin to be nil when table creation fails")
+	}
+	if !strings.Contains(err.Error(), "failed to create BigQuery table") {
+		t.Errorf("Expected error message to contain 'failed to create BigQuery table', got: %v", err)
+	}
+}
+
+func TestNewBigQueryAgentAnalyticsPlugin_MetadataError_Non404(t *testing.T) {
+	ctx := context.Background()
+	config := DefaultConfig()
+	config.Enabled = true
+	config.ProjectID = "test-project"
+	config.DatasetID = "test-dataset"
+	config.TableName = "test-table"
+	config.AutoSchemaUpgrade = false
+
+	createAttempted := false
+
+	mockTransport := &mockTransport{
+		roundTrip: func(r *http.Request) (*http.Response, error) {
+			if r.Method == "GET" && strings.Contains(r.URL.Path, "/datasets/test-dataset/tables/test-table") {
+				return &http.Response{
+					StatusCode: http.StatusForbidden,
+					Body:       io.NopCloser(strings.NewReader(`{"error":{"code":403,"message":"Permission denied"}}`)),
+				}, nil
+			}
+			if r.Method == "POST" && strings.Contains(r.URL.Path, "/datasets/test-dataset/tables") {
+				createAttempted = true
+				return &http.Response{
+					StatusCode: http.StatusOK,
+					Body:       io.NopCloser(strings.NewReader("{}")),
+				}, nil
+			}
+			return &http.Response{
+				StatusCode: http.StatusOK,
+				Body:       io.NopCloser(strings.NewReader("{}")),
+			}, nil
+		},
+	}
+	httpClient := &http.Client{Transport: mockTransport}
+	bqClient, err := bq.NewClient(ctx, config.ProjectID, option.WithHTTPClient(httpClient))
+	if err != nil {
+		t.Fatalf("Failed to create bigquery client: %v", err)
+	}
+
+	lis, err := net.Listen("tcp", "localhost:0")
+	if err != nil {
+		t.Fatalf("failed to listen: %v", err)
+	}
+	gSrv := grpc.NewServer()
+	storagepb.RegisterBigQueryWriteServer(gSrv, &fakeBigQueryWriteServer{})
+	go func() { _ = gSrv.Serve(lis) }()
+	t.Cleanup(gSrv.Stop)
+
+	conn, err := grpc.NewClient(lis.Addr().String(), grpc.WithTransportCredentials(insecure.NewCredentials()))
+	if err != nil {
+		t.Fatalf("failed to dial test server: %v", err)
+	}
+	t.Cleanup(func() { _ = conn.Close() })
+
+	writeClient, err := bqstorage.NewBigQueryWriteClient(ctx, option.WithGRPCConn(conn))
+	if err != nil {
+		t.Fatalf("Failed to create BigQuery write client: %v", err)
+	}
+
+	p, err := NewBigQueryAgentAnalyticsPluginWithClients(ctx, config, bqClient, writeClient)
+	if err == nil {
+		t.Fatal("Expected error when metadata retrieval fails with non-404 error, got nil")
+	}
+	if p != nil {
+		t.Error("Expected plugin to be nil when metadata retrieval fails")
+	}
+	if createAttempted {
+		t.Error("Expected table creation NOT to be attempted, but it was called")
+	}
+	if !strings.Contains(err.Error(), "failed to retrieve BigQuery table metadata") {
+		t.Errorf("Expected error message to contain 'failed to retrieve BigQuery table metadata', got: %v", err)
+	}
+}

--- a/plugin/agentanalytics/bigquery_agent_analytics_plugin_test.go
+++ b/plugin/agentanalytics/bigquery_agent_analytics_plugin_test.go
@@ -15,6 +15,7 @@
 package agentanalytics
 
 import (
+	"bytes"
 	"context"
 	"errors"
 	"io"
@@ -340,5 +341,89 @@ func TestLogEvent_ExtractsTraceInfo(t *testing.T) {
 		}
 	case <-time.After(5 * time.Second):
 		t.Error("Timed out waiting for request")
+	}
+}
+
+func TestNewBigQueryAgentAnalyticsPlugin_CreateTable_WithPartitioning(t *testing.T) {
+	ctx := context.Background()
+	config := DefaultConfig()
+	config.Enabled = true
+	config.ProjectID = "test-project"
+	config.DatasetID = "test-dataset"
+	config.TableName = "test-table"
+
+	createCalled := false
+	var requestBody string
+
+	mockTransport := &mockTransport{
+		roundTrip: func(r *http.Request) (*http.Response, error) {
+			// Table metadata request: returns 404 Not Found to trigger creation
+			if r.Method == "GET" && strings.Contains(r.URL.Path, "/datasets/test-dataset/tables/test-table") {
+				return &http.Response{
+					StatusCode: http.StatusNotFound,
+					Body:       io.NopCloser(strings.NewReader(`{"error":{"code":404,"message":"Not found"}}`)),
+				}, nil
+			}
+			// Table creation request
+			if r.Method == "POST" && strings.Contains(r.URL.Path, "/datasets/test-dataset/tables") {
+				createCalled = true
+				bodyBytes, _ := io.ReadAll(r.Body)
+				requestBody = string(bodyBytes)
+				r.Body = io.NopCloser(bytes.NewBuffer(bodyBytes))
+
+				return &http.Response{
+					StatusCode: http.StatusOK,
+					Body:       io.NopCloser(strings.NewReader("{}")),
+				}, nil
+			}
+			return &http.Response{
+				StatusCode: http.StatusOK,
+				Body:       io.NopCloser(strings.NewReader("{}")),
+			}, nil
+		},
+	}
+	httpClient := &http.Client{Transport: mockTransport}
+	bqClient, err := bq.NewClient(ctx, config.ProjectID, option.WithHTTPClient(httpClient))
+	if err != nil {
+		t.Fatalf("Failed to create bigquery client: %v", err)
+	}
+
+	lis, err := net.Listen("tcp", "localhost:0")
+	if err != nil {
+		t.Fatalf("failed to listen: %v", err)
+	}
+	gSrv := grpc.NewServer()
+	storagepb.RegisterBigQueryWriteServer(gSrv, &fakeBigQueryWriteServer{})
+	go func() { _ = gSrv.Serve(lis) }()
+	t.Cleanup(gSrv.Stop)
+
+	conn, err := grpc.NewClient(lis.Addr().String(), grpc.WithTransportCredentials(insecure.NewCredentials()))
+	if err != nil {
+		t.Fatalf("failed to dial test server: %v", err)
+	}
+	t.Cleanup(func() { _ = conn.Close() })
+
+	writeClient, err := bqstorage.NewBigQueryWriteClient(ctx, option.WithGRPCConn(conn))
+	if err != nil {
+		t.Fatalf("Failed to create BigQuery write client: %v", err)
+	}
+
+	_, err = NewBigQueryAgentAnalyticsPluginWithClients(ctx, config, bqClient, writeClient)
+	if err != nil {
+		t.Fatalf("Plugin initialization error: %v", err)
+	}
+
+	if !createCalled {
+		t.Error("Expected table creation to be called")
+	}
+
+	if !strings.Contains(requestBody, "timePartitioning") {
+		t.Errorf("Expected request body to contain 'timePartitioning', got: %s", requestBody)
+	}
+	if !strings.Contains(requestBody, "DAY") {
+		t.Errorf("Expected partitioning type to be 'DAY', got request body: %s", requestBody)
+	}
+	if !strings.Contains(requestBody, "timestamp") {
+		t.Errorf("Expected partitioning field to be 'timestamp', got request body: %s", requestBody)
 	}
 }

--- a/plugin/agentanalytics/bigquery_agent_analytics_plugin_test.go
+++ b/plugin/agentanalytics/bigquery_agent_analytics_plugin_test.go
@@ -463,3 +463,315 @@ func TestNewBigQueryAgentAnalyticsPlugin_CreateTable_WithPartitioning(t *testing
 		t.Errorf("Expected partitioning field to be 'timestamp', got request body: %s", requestBody)
 	}
 }
+
+func TestSchemaFieldsMatch(t *testing.T) {
+	existing := bq.Schema{
+		{Name: "col1", Type: bq.StringFieldType},
+		{
+			Name: "col_record",
+			Type: bq.RecordFieldType,
+			Schema: bq.Schema{
+				{Name: "sub1", Type: bq.IntegerFieldType},
+			},
+		},
+	}
+
+	desired := bq.Schema{
+		{Name: "col1", Type: bq.StringFieldType},
+		{Name: "col2", Type: bq.BooleanFieldType}, // New top-level col
+		{
+			Name: "col_record",
+			Type: bq.RecordFieldType,
+			Schema: bq.Schema{
+				{Name: "sub1", Type: bq.IntegerFieldType},
+				{Name: "sub2", Type: bq.StringFieldType}, // New sub-field
+			},
+		},
+	}
+
+	newFields, updatedRecords := schemaFieldsMatch(existing, desired)
+
+	if len(newFields) != 1 || newFields[0].Name != "col2" {
+		t.Errorf("Expected 1 new top-level field 'col2', got %v", newFields)
+	}
+
+	if len(updatedRecords) != 1 || updatedRecords[0].Name != "col_record" {
+		t.Fatalf("Expected 1 updated RECORD field 'col_record', got %v", updatedRecords)
+	}
+
+	updatedRecord := updatedRecords[0]
+	if len(updatedRecord.Schema) != 2 {
+		t.Errorf("Expected updated RECORD to have 2 sub-fields, got %d", len(updatedRecord.Schema))
+	}
+	if updatedRecord.Schema[1].Name != "sub2" {
+		t.Errorf("Expected second sub-field of RECORD to be 'sub2', got %s", updatedRecord.Schema[1].Name)
+	}
+}
+
+func TestNewBigQueryAgentAnalyticsPlugin_TableExists(t *testing.T) {
+	ctx := context.Background()
+	config := DefaultConfig()
+	config.Enabled = true
+	config.ProjectID = "test-project"
+	config.DatasetID = "test-dataset"
+	config.TableName = "test-table"
+	config.AutoSchemaUpgrade = false
+
+	mockTransport := &mockTransport{
+		roundTrip: func(r *http.Request) (*http.Response, error) {
+			if r.Method == "GET" && strings.Contains(r.URL.Path, "/datasets/test-dataset/tables/test-table") {
+				return &http.Response{
+					StatusCode: http.StatusOK,
+					Body:       io.NopCloser(strings.NewReader(`{"tableReference":{"projectId":"test-project","datasetId":"test-dataset","tableId":"test-table"}}`)),
+				}, nil
+			}
+			return &http.Response{
+				StatusCode: http.StatusOK,
+				Body:       io.NopCloser(strings.NewReader("{}")),
+			}, nil
+		},
+	}
+	httpClient := &http.Client{Transport: mockTransport}
+	bqClient, err := bq.NewClient(ctx, config.ProjectID, option.WithHTTPClient(httpClient))
+	if err != nil {
+		t.Fatalf("Failed to create bigquery client: %v", err)
+	}
+
+	lis, err := net.Listen("tcp", "localhost:0")
+	if err != nil {
+		t.Fatalf("failed to listen: %v", err)
+	}
+	gSrv := grpc.NewServer()
+	storagepb.RegisterBigQueryWriteServer(gSrv, &fakeBigQueryWriteServer{})
+	go func() { _ = gSrv.Serve(lis) }()
+	t.Cleanup(gSrv.Stop)
+
+	conn, err := grpc.NewClient(lis.Addr().String(), grpc.WithTransportCredentials(insecure.NewCredentials()))
+	if err != nil {
+		t.Fatalf("failed to dial test server: %v", err)
+	}
+	t.Cleanup(func() { _ = conn.Close() })
+
+	writeClient, err := bqstorage.NewBigQueryWriteClient(ctx, option.WithGRPCConn(conn))
+	if err != nil {
+		t.Fatalf("Failed to create BigQuery write client: %v", err)
+	}
+
+	p, err := NewBigQueryAgentAnalyticsPluginWithClients(ctx, config, bqClient, writeClient)
+	if err != nil {
+		t.Fatalf("Expected no error when table exists, got: %v", err)
+	}
+	if p == nil {
+		t.Fatal("Expected plugin to be non-nil")
+	}
+}
+
+func TestNewBigQueryAgentAnalyticsPlugin_TableNotFound_CreateSucceeds(t *testing.T) {
+	ctx := context.Background()
+	config := DefaultConfig()
+	config.Enabled = true
+	config.ProjectID = "test-project"
+	config.DatasetID = "test-dataset"
+	config.TableName = "test-table"
+	config.AutoSchemaUpgrade = false
+
+	createCalled := false
+
+	mockTransport := &mockTransport{
+		roundTrip: func(r *http.Request) (*http.Response, error) {
+			if r.Method == "GET" && strings.Contains(r.URL.Path, "/datasets/test-dataset/tables/test-table") {
+				return &http.Response{
+					StatusCode: http.StatusNotFound,
+					Body:       io.NopCloser(strings.NewReader(`{"error":{"code":404,"message":"Not found"}}`)),
+				}, nil
+			}
+			if r.Method == "POST" && strings.Contains(r.URL.Path, "/datasets/test-dataset/tables") {
+				createCalled = true
+				return &http.Response{
+					StatusCode: http.StatusOK,
+					Body:       io.NopCloser(strings.NewReader("{}")),
+				}, nil
+			}
+			return &http.Response{
+				StatusCode: http.StatusOK,
+				Body:       io.NopCloser(strings.NewReader("{}")),
+			}, nil
+		},
+	}
+	httpClient := &http.Client{Transport: mockTransport}
+	bqClient, err := bq.NewClient(ctx, config.ProjectID, option.WithHTTPClient(httpClient))
+	if err != nil {
+		t.Fatalf("Failed to create bigquery client: %v", err)
+	}
+
+	lis, err := net.Listen("tcp", "localhost:0")
+	if err != nil {
+		t.Fatalf("failed to listen: %v", err)
+	}
+	gSrv := grpc.NewServer()
+	storagepb.RegisterBigQueryWriteServer(gSrv, &fakeBigQueryWriteServer{})
+	go func() { _ = gSrv.Serve(lis) }()
+	t.Cleanup(gSrv.Stop)
+
+	conn, err := grpc.NewClient(lis.Addr().String(), grpc.WithTransportCredentials(insecure.NewCredentials()))
+	if err != nil {
+		t.Fatalf("failed to dial test server: %v", err)
+	}
+	t.Cleanup(func() { _ = conn.Close() })
+
+	writeClient, err := bqstorage.NewBigQueryWriteClient(ctx, option.WithGRPCConn(conn))
+	if err != nil {
+		t.Fatalf("Failed to create BigQuery write client: %v", err)
+	}
+
+	p, err := NewBigQueryAgentAnalyticsPluginWithClients(ctx, config, bqClient, writeClient)
+	if err != nil {
+		t.Fatalf("Expected no error when table is created successfully, got: %v", err)
+	}
+	if p == nil {
+		t.Fatal("Expected plugin to be non-nil")
+	}
+	if !createCalled {
+		t.Error("Expected table creation to be attempted, but it was not called")
+	}
+}
+
+func TestNewBigQueryAgentAnalyticsPlugin_TableNotFound_CreateFails(t *testing.T) {
+	ctx := context.Background()
+	config := DefaultConfig()
+	config.Enabled = true
+	config.ProjectID = "test-project"
+	config.DatasetID = "test-dataset"
+	config.TableName = "test-table"
+	config.AutoSchemaUpgrade = false
+
+	mockTransport := &mockTransport{
+		roundTrip: func(r *http.Request) (*http.Response, error) {
+			if r.Method == "GET" && strings.Contains(r.URL.Path, "/datasets/test-dataset/tables/test-table") {
+				return &http.Response{
+					StatusCode: http.StatusNotFound,
+					Body:       io.NopCloser(strings.NewReader(`{"error":{"code":404,"message":"Not found"}}`)),
+				}, nil
+			}
+			if r.Method == "POST" && strings.Contains(r.URL.Path, "/datasets/test-dataset/tables") {
+				return &http.Response{
+					StatusCode: http.StatusForbidden,
+					Body:       io.NopCloser(strings.NewReader(`{"error":{"code":403,"message":"Permission denied"}}`)),
+				}, nil
+			}
+			return &http.Response{
+				StatusCode: http.StatusOK,
+				Body:       io.NopCloser(strings.NewReader("{}")),
+			}, nil
+		},
+	}
+	httpClient := &http.Client{Transport: mockTransport}
+	bqClient, err := bq.NewClient(ctx, config.ProjectID, option.WithHTTPClient(httpClient))
+	if err != nil {
+		t.Fatalf("Failed to create bigquery client: %v", err)
+	}
+
+	lis, err := net.Listen("tcp", "localhost:0")
+	if err != nil {
+		t.Fatalf("failed to listen: %v", err)
+	}
+	gSrv := grpc.NewServer()
+	storagepb.RegisterBigQueryWriteServer(gSrv, &fakeBigQueryWriteServer{})
+	go func() { _ = gSrv.Serve(lis) }()
+	t.Cleanup(gSrv.Stop)
+
+	conn, err := grpc.NewClient(lis.Addr().String(), grpc.WithTransportCredentials(insecure.NewCredentials()))
+	if err != nil {
+		t.Fatalf("failed to dial test server: %v", err)
+	}
+	t.Cleanup(func() { _ = conn.Close() })
+
+	writeClient, err := bqstorage.NewBigQueryWriteClient(ctx, option.WithGRPCConn(conn))
+	if err != nil {
+		t.Fatalf("Failed to create BigQuery write client: %v", err)
+	}
+
+	p, err := NewBigQueryAgentAnalyticsPluginWithClients(ctx, config, bqClient, writeClient)
+	if err == nil {
+		t.Fatal("Expected error when table creation fails, got nil")
+	}
+	if p != nil {
+		t.Error("Expected plugin to be nil when table creation fails")
+	}
+	if !strings.Contains(err.Error(), "failed to create BigQuery table") {
+		t.Errorf("Expected error message to contain 'failed to create BigQuery table', got: %v", err)
+	}
+}
+
+func TestNewBigQueryAgentAnalyticsPlugin_MetadataError_Non404(t *testing.T) {
+	ctx := context.Background()
+	config := DefaultConfig()
+	config.Enabled = true
+	config.ProjectID = "test-project"
+	config.DatasetID = "test-dataset"
+	config.TableName = "test-table"
+	config.AutoSchemaUpgrade = false
+
+	createAttempted := false
+
+	mockTransport := &mockTransport{
+		roundTrip: func(r *http.Request) (*http.Response, error) {
+			if r.Method == "GET" && strings.Contains(r.URL.Path, "/datasets/test-dataset/tables/test-table") {
+				return &http.Response{
+					StatusCode: http.StatusForbidden,
+					Body:       io.NopCloser(strings.NewReader(`{"error":{"code":403,"message":"Permission denied"}}`)),
+				}, nil
+			}
+			if r.Method == "POST" && strings.Contains(r.URL.Path, "/datasets/test-dataset/tables") {
+				createAttempted = true
+				return &http.Response{
+					StatusCode: http.StatusOK,
+					Body:       io.NopCloser(strings.NewReader("{}")),
+				}, nil
+			}
+			return &http.Response{
+				StatusCode: http.StatusOK,
+				Body:       io.NopCloser(strings.NewReader("{}")),
+			}, nil
+		},
+	}
+	httpClient := &http.Client{Transport: mockTransport}
+	bqClient, err := bq.NewClient(ctx, config.ProjectID, option.WithHTTPClient(httpClient))
+	if err != nil {
+		t.Fatalf("Failed to create bigquery client: %v", err)
+	}
+
+	lis, err := net.Listen("tcp", "localhost:0")
+	if err != nil {
+		t.Fatalf("failed to listen: %v", err)
+	}
+	gSrv := grpc.NewServer()
+	storagepb.RegisterBigQueryWriteServer(gSrv, &fakeBigQueryWriteServer{})
+	go func() { _ = gSrv.Serve(lis) }()
+	t.Cleanup(gSrv.Stop)
+
+	conn, err := grpc.NewClient(lis.Addr().String(), grpc.WithTransportCredentials(insecure.NewCredentials()))
+	if err != nil {
+		t.Fatalf("failed to dial test server: %v", err)
+	}
+	t.Cleanup(func() { _ = conn.Close() })
+
+	writeClient, err := bqstorage.NewBigQueryWriteClient(ctx, option.WithGRPCConn(conn))
+	if err != nil {
+		t.Fatalf("Failed to create BigQuery write client: %v", err)
+	}
+
+	p, err := NewBigQueryAgentAnalyticsPluginWithClients(ctx, config, bqClient, writeClient)
+	if err == nil {
+		t.Fatal("Expected error when metadata retrieval fails with non-404 error, got nil")
+	}
+	if p != nil {
+		t.Error("Expected plugin to be nil when metadata retrieval fails")
+	}
+	if createAttempted {
+		t.Error("Expected table creation NOT to be attempted, but it was called")
+	}
+	if !strings.Contains(err.Error(), "failed to retrieve BigQuery table metadata") {
+		t.Errorf("Expected error message to contain 'failed to retrieve BigQuery table metadata', got: %v", err)
+	}
+}

--- a/plugin/agentanalytics/config.go
+++ b/plugin/agentanalytics/config.go
@@ -63,6 +63,9 @@ type Config struct {
 
 	// Retry configuration for appending rows.
 	RetryConfig RetryConfig
+
+	// Automatically add new columns to existing tables when schema evolves.
+	AutoSchemaUpgrade bool
 }
 
 // DefaultConfig returns the default configuration for the agent analytics plugin.
@@ -86,5 +89,6 @@ func DefaultConfig() Config {
 			MaxDelay:     10 * time.Second,
 			Multiplier:   2.0,
 		},
+		AutoSchemaUpgrade: true,
 	}
 }


### PR DESCRIPTION
**Please ensure you have read the [contribution guide](./CONTRIBUTING.md) before creating a pull request.**

### Link to Issue or Description of Change

**1. Link to an existing issue (if applicable):**

- Closes: N/A

**2. Or, if no issue exists, describe the change:**

**Problem:**
As the Go ADK analytics plugin updates its schema over time, users with pre-existing BigQuery tables will experience insertion errors due to missing columns, unless they manually migrate or recreate their tables.

**Solution:**
Implement automatic schema upgrades on initialization. During `NewBigQueryAgentAnalyticsPluginWithClients`, the plugin retrieves the existing table metadata, compares its schema against the latest `EventsSchema()`, and automatically updates the BigQuery table schema to add any missing fields or record sub-fields safely.

### Testing Plan

* `TestSchemaFieldsMatch` validates that the schema comparison algorithm correctly identifies top-level and nested structural differences.
* `TestNewBigQueryAgentAnalyticsPlugin_TableExists` verifies that existing tables are inspected and dynamically updated without throwing insertion errors.

### Checklist

- [x] I have read the [CONTRIBUTING.md](./CONTRIBUTING.md) document.
- [x] I have performed a self-review of my own code.
- [x] I have commented my code, particularly in hard-to-understand areas.
- [x] I have added tests that prove my fix is effective or that my feature works.
- [x] New and existing unit tests pass locally with my changes.
- [x] I have manually tested my changes end-to-end.