### PR TITLE
feat: Implement a contextual trace stack and manager to dynamically trace nested execution and spans

### DIFF
--- a/plugin/agentanalytics/bigquery_agent_analytics_plugin.go
+++ b/plugin/agentanalytics/bigquery_agent_analytics_plugin.go
@@ -102,6 +102,10 @@ func NewBigQueryAgentAnalyticsPluginWithClients(
 		}
 		err = tableRef.Create(ctx, &bq.TableMetadata{
 			Schema: EventsSchema(),
+			TimePartitioning: &bq.TimePartitioning{
+				Field: "timestamp",
+				Type:  bq.DayPartitioningType,
+			},
 			Clustering: &bq.Clustering{
 				Fields: config.ClusteringFields,
 			},

--- a/plugin/agentanalytics/bigquery_agent_analytics_plugin.go
+++ b/plugin/agentanalytics/bigquery_agent_analytics_plugin.go
@@ -603,4 +603,3 @@ func (s *spanStack) getStartTime(spanID string) time.Time {
 	}
 	return time.Time{}
 }
-

--- a/plugin/agentanalytics/bigquery_agent_analytics_plugin.go
+++ b/plugin/agentanalytics/bigquery_agent_analytics_plugin.go
@@ -18,7 +18,11 @@ package agentanalytics
 import (
 	"context"
 	"fmt"
+	"strings"
+	"sync"
 	"time"
+
+	"github.com/google/uuid"
 
 	bq "cloud.google.com/go/bigquery"
 	bqstorage "cloud.google.com/go/bigquery/storage/apiv1"
@@ -137,6 +141,7 @@ func NewBigQueryAgentAnalyticsPluginWithClients(
 		row["timestamp"] = time.Now()
 		row["event_type"] = eventType
 
+		var invocationID string
 		if rCtx, ok := ctx.(agent.ReadonlyContext); ok {
 			if rCtx.AgentName() != "" {
 				row["agent"] = rCtx.AgentName()
@@ -145,6 +150,7 @@ func NewBigQueryAgentAnalyticsPluginWithClients(
 				row["session_id"] = rCtx.SessionID()
 			}
 			row["invocation_id"] = rCtx.InvocationID()
+			invocationID = rCtx.InvocationID()
 			row["user_id"] = rCtx.UserID()
 		} else if iCtx, ok := ctx.(agent.InvocationContext); ok {
 			if iCtx.Agent() != nil && iCtx.Agent().Name() != "" {
@@ -157,6 +163,7 @@ func NewBigQueryAgentAnalyticsPluginWithClients(
 				row["user_id"] = iCtx.Session().UserID()
 			}
 			row["invocation_id"] = iCtx.InvocationID()
+			invocationID = iCtx.InvocationID()
 		}
 
 		isTruncated := false
@@ -208,11 +215,30 @@ func NewBigQueryAgentAnalyticsPluginWithClients(
 		}
 		row["is_truncated"] = isTruncated
 
-		// Add trace info dynamically resolving the context span
-		spanCtx := trace.SpanContextFromContext(ctx)
-		if spanCtx.IsValid() {
-			row["trace_id"] = spanCtx.TraceID().String()
-			row["span_id"] = spanCtx.SpanID().String()
+		stack := tm.getStack(invocationID)
+		if stack != nil {
+			tID, sID, pID := stack.getCurrentSpan(ctx)
+			if overrideSpanID, ok := extraAttrs["span_id_override"].(string); ok && overrideSpanID != "" {
+				sID = overrideSpanID
+			}
+			if overrideParentSpanID, ok := extraAttrs["parent_span_id_override"].(string); ok && overrideParentSpanID != "" {
+				pID = overrideParentSpanID
+			}
+
+			if tID != "" {
+				row["trace_id"] = tID
+				row["span_id"] = sID
+				if pID != "" {
+					row["parent_span_id"] = pID
+				}
+			}
+		} else {
+			// Fallback to ambient context
+			spanCtx := trace.SpanContextFromContext(ctx)
+			if spanCtx.IsValid() {
+				row["trace_id"] = spanCtx.TraceID().String()
+				row["span_id"] = spanCtx.SpanID().String()
+			}
 		}
 
 		processor.Append(row)
@@ -227,12 +253,24 @@ func NewBigQueryAgentAnalyticsPluginWithClients(
 			return msg, nil
 		},
 		BeforeRunCallback: func(ctx agent.InvocationContext) (*genai.Content, error) {
+			// Initialize stack and push root span
+			stack := tm.getStack(ctx.InvocationID())
+			stack.pushSpan(ctx, "invocation_root")
+
 			logEvent(ctx, "INVOCATION_START", nil, nil)
 			return nil, nil
 		},
 		AfterRunCallback: func(ctx agent.InvocationContext) {
 			logEvent(ctx, "INVOCATION_END", nil, nil)
+
+			// Pop the root span
+			stack := tm.getStack(ctx.InvocationID())
+			stack.popSpan()
+
 			processor.flush() // flush queue synchronously
+
+			// Clean up stack map to prevent memory leaks
+			tm.removeStack(ctx.InvocationID())
 		},
 		OnEventCallback: func(ctx agent.InvocationContext, ev *session.Event) (*session.Event, error) {
 			attrs := map[string]any{"event_author": ev.Author}
@@ -250,6 +288,9 @@ func NewBigQueryAgentAnalyticsPluginWithClients(
 		},
 
 		BeforeModelCallback: func(ctx agent.Context, req *model.LLMRequest) (*model.LLMResponse, error) {
+			stack := tm.getStack(ctx.InvocationID())
+			stack.pushSpan(ctx, "llm_request")
+
 			attrs := map[string]any{"model": "unknown"}
 			if req.Model != "" {
 				attrs["model"] = req.Model
@@ -258,34 +299,128 @@ func NewBigQueryAgentAnalyticsPluginWithClients(
 			return nil, nil
 		},
 		AfterModelCallback: func(ctx agent.Context, res *model.LLMResponse, err error) (*model.LLMResponse, error) {
-			attrs := map[string]any{}
+			stack := tm.getStack(ctx.InvocationID())
+			_, spanID, parentSpanID := stack.getCurrentSpan(ctx)
+
+			var durationMs float64
+			var ttftMs float64
+
+			if res != nil && res.Partial {
+				// Streaming chunk - do NOT pop span yet
+				if spanID != "" {
+					stack.recordFirstToken(spanID)
+					startTime := stack.getStartTime(spanID)
+					firstToken := stack.getFirstTokenTime(spanID)
+					if !startTime.IsZero() {
+						durationMs = float64(time.Since(startTime).Nanoseconds()) / 1e6
+					}
+					if !startTime.IsZero() && !firstToken.IsZero() {
+						ttftMs = float64(firstToken.Sub(startTime).Nanoseconds()) / 1e6
+					}
+				}
+			} else {
+				// Final response - pop span
+				if spanID != "" {
+					stack.recordFirstToken(spanID)
+					startTime := stack.getStartTime(spanID)
+					firstToken := stack.getFirstTokenTime(spanID)
+					if !startTime.IsZero() && !firstToken.IsZero() {
+						ttftMs = float64(firstToken.Sub(startTime).Nanoseconds()) / 1e6
+					}
+				}
+				poppedSpanID, poppedDurationMs := stack.popSpan()
+				if poppedSpanID != "" {
+					spanID = poppedSpanID
+					durationMs = poppedDurationMs
+				}
+			}
+
+			attrs := map[string]any{
+				"span_id_override":        spanID,
+				"parent_span_id_override": parentSpanID,
+			}
 			if res != nil && res.UsageMetadata != nil {
 				attrs["usage_metadata"] = res.UsageMetadata
 			}
+
+			// Calculate latency_ms JSON
+			latencyMap := make(map[string]any)
+			if durationMs > 0 {
+				latencyMap["total_ms"] = int64(durationMs)
+			}
+			if ttftMs > 0 {
+				latencyMap["time_to_first_token_ms"] = int64(ttftMs)
+			}
+			if len(latencyMap) > 0 {
+				latencyRaw, _, _ := SmartTruncate(latencyMap, config.MaxContentLen)
+				attrs["latency_ms"] = string(latencyRaw)
+			}
+
 			logEvent(ctx, "MODEL_RESPONSE", res, attrs)
 			return nil, nil
 		},
 		OnModelErrorCallback: func(ctx agent.Context, req *model.LLMRequest, err error) (*model.LLMResponse, error) {
-			attrs := map[string]any{"error_message": err.Error()}
+			stack := tm.getStack(ctx.InvocationID())
+			poppedSpanID, durationMs := stack.popSpan()
+
+			attrs := map[string]any{
+				"error_message":           err.Error(),
+				"span_id_override":        poppedSpanID,
+				"parent_span_id_override": "",
+			}
+
+			latencyMap := map[string]any{"total_ms": int64(durationMs)}
+			latencyRaw, _, _ := SmartTruncate(latencyMap, config.MaxContentLen)
+			attrs["latency_ms"] = string(latencyRaw)
+
 			logEvent(ctx, "MODEL_ERROR", nil, attrs)
 			return nil, nil
 		},
 
 		BeforeToolCallback: func(ctx agent.Context, t tool.Tool, args map[string]any) (map[string]any, error) {
-			attrs := map[string]any{"tool_name": t.Name()}
+			stack := tm.getStack(ctx.InvocationID())
+			stack.pushSpan(ctx, t.Name())
+
+			attrs := map[string]any{
+				"tool_name": t.Name(),
+			}
 			logEvent(ctx, "TOOL_START", args, attrs)
 			return nil, nil
 		},
 		AfterToolCallback: func(ctx agent.Context, t tool.Tool, args, res map[string]any, err error) (map[string]any, error) {
-			attrs := map[string]any{"tool_name": t.Name()}
+			stack := tm.getStack(ctx.InvocationID())
+			_, _, parentSpanID := stack.getCurrentSpan(ctx)
+			poppedSpanID, durationMs := stack.popSpan()
+
+			attrs := map[string]any{
+				"tool_name":               t.Name(),
+				"span_id_override":        poppedSpanID,
+				"parent_span_id_override": parentSpanID,
+			}
+
+			latencyMap := map[string]any{"total_ms": int64(durationMs)}
+			latencyRaw, _, _ := SmartTruncate(latencyMap, config.MaxContentLen)
+			attrs["latency_ms"] = string(latencyRaw)
+
 			logEvent(ctx, "TOOL_END", res, attrs)
 			return nil, nil
 		},
 		OnToolErrorCallback: func(ctx agent.Context, t tool.Tool, args map[string]any, err error) (map[string]any, error) {
+			stack := tm.getStack(ctx.InvocationID())
+			_, _, parentSpanID := stack.getCurrentSpan(ctx)
+			poppedSpanID, durationMs := stack.popSpan()
+
 			attrs := map[string]any{
-				"tool_name":     t.Name(),
-				"error_message": err.Error(),
+				"tool_name":               t.Name(),
+				"error_message":           err.Error(),
+				"span_id_override":        poppedSpanID,
+				"parent_span_id_override": parentSpanID,
 			}
+
+			latencyMap := map[string]any{"total_ms": int64(durationMs)}
+			latencyRaw, _, _ := SmartTruncate(latencyMap, config.MaxContentLen)
+			attrs["latency_ms"] = string(latencyRaw)
+
 			logEvent(ctx, "TOOL_ERROR", nil, attrs)
 			return nil, nil
 		},
@@ -301,3 +436,171 @@ func NewBigQueryAgentAnalyticsPluginWithClients(
 
 	return baseplugin.New(cfg)
 }
+
+type spanRecord struct {
+	spanID         string
+	parentSpanID   string
+	traceID        string
+	startTime      time.Time
+	ownsSpan       bool
+	firstTokenTime time.Time
+}
+
+type spanStack struct {
+	mu    sync.Mutex
+	spans []*spanRecord
+}
+
+type traceManager struct {
+	mu     sync.RWMutex
+	stacks map[string]*spanStack
+}
+
+var tm = &traceManager{
+	stacks: make(map[string]*spanStack),
+}
+
+func (m *traceManager) getStack(invocationID string) *spanStack {
+	if invocationID == "" {
+		return nil
+	}
+	m.mu.RLock()
+	stack, exists := m.stacks[invocationID]
+	m.mu.RUnlock()
+
+	if exists {
+		return stack
+	}
+
+	m.mu.Lock()
+	stack, exists = m.stacks[invocationID]
+	if !exists {
+		stack = &spanStack{}
+		m.stacks[invocationID] = stack
+	}
+	m.mu.Unlock()
+	return stack
+}
+
+func (m *traceManager) removeStack(invocationID string) {
+	if invocationID == "" {
+		return
+	}
+	m.mu.Lock()
+	delete(m.stacks, invocationID)
+	m.mu.Unlock()
+}
+
+func (s *spanStack) pushSpan(ctx context.Context, spanName string) string {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+
+	spanID := strings.ReplaceAll(uuid.NewString(), "-", "")[:16]
+
+	var parentSpanID string
+	var traceID string
+
+	if len(s.spans) > 0 {
+		parent := s.spans[len(s.spans)-1]
+		parentSpanID = parent.spanID
+	}
+
+	// Check ambient context trace
+	ambientSpan := trace.SpanContextFromContext(ctx)
+	if ambientSpan.IsValid() {
+		traceID = ambientSpan.TraceID().String()
+		if parentSpanID == "" {
+			parentSpanID = ambientSpan.SpanID().String()
+		}
+	} else if len(s.spans) > 0 {
+		traceID = s.spans[0].traceID
+	} else {
+		// Generate fallback trace ID
+		traceID = strings.ReplaceAll(uuid.NewString(), "-", "")
+	}
+
+	record := &spanRecord{
+		spanID:       spanID,
+		parentSpanID: parentSpanID,
+		traceID:      traceID,
+		startTime:    time.Now(),
+		ownsSpan:     true,
+	}
+	s.spans = append(s.spans, record)
+	return spanID
+}
+
+func (s *spanStack) popSpan() (string, float64) {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+
+	if len(s.spans) == 0 {
+		return "", 0
+	}
+
+	idx := len(s.spans) - 1
+	record := s.spans[idx]
+	s.spans = s.spans[:idx]
+
+	durationMs := float64(time.Since(record.startTime).Nanoseconds()) / 1e6
+	return record.spanID, durationMs
+}
+
+func (s *spanStack) getCurrentSpan(ctx context.Context) (traceID, spanID, parentSpanID string) {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+
+	if len(s.spans) > 0 {
+		record := s.spans[len(s.spans)-1]
+		return record.traceID, record.spanID, record.parentSpanID
+	}
+
+	// Fallback to ambient context
+	ambientSpan := trace.SpanContextFromContext(ctx)
+	if ambientSpan.IsValid() {
+		return ambientSpan.TraceID().String(), ambientSpan.SpanID().String(), ""
+	}
+
+	return "", "", ""
+}
+
+func (s *spanStack) recordFirstToken(spanID string) bool {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+
+	for _, r := range s.spans {
+		if r.spanID == spanID {
+			if r.firstTokenTime.IsZero() {
+				r.firstTokenTime = time.Now()
+				return true
+			}
+			return false
+		}
+	}
+	return false
+}
+
+func (s *spanStack) getFirstTokenTime(spanID string) time.Time {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+
+	for _, r := range s.spans {
+		if r.spanID == spanID {
+			return r.firstTokenTime
+		}
+	}
+	return time.Time{}
+}
+
+func (s *spanStack) getStartTime(spanID string) time.Time {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+
+	for _, r := range s.spans {
+		if r.spanID == spanID {
+			return r.startTime
+		}
+	}
+	return time.Time{}
+}
+

--- a/plugin/agentanalytics/bigquery_agent_analytics_plugin_test.go
+++ b/plugin/agentanalytics/bigquery_agent_analytics_plugin_test.go
@@ -427,3 +427,96 @@ func TestNewBigQueryAgentAnalyticsPlugin_CreateTable_WithPartitioning(t *testing
 		t.Errorf("Expected partitioning field to be 'timestamp', got request body: %s", requestBody)
 	}
 }
+
+func TestContextualTraceStacking(t *testing.T) {
+	p, _, mCtx := setupTestPlugin(t)
+
+	beforeRunCb := p.BeforeRunCallback()
+	if beforeRunCb == nil {
+		t.Fatal("BeforeRunCallback is nil")
+	}
+
+	// 1. Trigger BeforeRunCallback to push root span
+	_, err := beforeRunCb(mCtx)
+	if err != nil {
+		t.Fatalf("BeforeRunCallback error: %v", err)
+	}
+
+	stack := tm.getStack(mCtx.InvocationID())
+	if stack == nil {
+		t.Fatal("Expected stack to be initialized, got nil")
+	}
+
+	stack.mu.Lock()
+	spansLen := len(stack.spans)
+	stack.mu.Unlock()
+	if spansLen != 1 {
+		t.Errorf("Expected 1 span in stack, got %d", spansLen)
+	}
+
+	stack.mu.Lock()
+	rootSpanID := stack.spans[0].spanID
+	stack.mu.Unlock()
+	if rootSpanID == "" {
+		t.Error("Expected non-empty root span ID")
+	}
+
+	// 2. Trigger BeforeModelCallback to push nested span
+	beforeModelCb := p.BeforeModelCallback()
+	if beforeModelCb == nil {
+		t.Fatal("BeforeModelCallback is nil")
+	}
+
+	_, err = beforeModelCb(mCtx, &model.LLMRequest{Model: "test-model"})
+	if err != nil {
+		t.Fatalf("BeforeModelCallback error: %v", err)
+	}
+
+	stack.mu.Lock()
+	spansLen = len(stack.spans)
+	stack.mu.Unlock()
+	if spansLen != 2 {
+		t.Errorf("Expected 2 spans in stack after model start, got %d", spansLen)
+	}
+
+	stack.mu.Lock()
+	nestedSpan := stack.spans[1]
+	stack.mu.Unlock()
+	if nestedSpan.parentSpanID != rootSpanID {
+		t.Errorf("Expected nested span parent ID to be %s, got %s", rootSpanID, nestedSpan.parentSpanID)
+	}
+
+	// 3. Trigger AfterModelCallback to pop nested span
+	afterModelCb := p.AfterModelCallback()
+	if afterModelCb == nil {
+		t.Fatal("AfterModelCallback is nil")
+	}
+
+	_, err = afterModelCb(mCtx, &model.LLMResponse{}, nil)
+	if err != nil {
+		t.Fatalf("AfterModelCallback error: %v", err)
+	}
+
+	stack.mu.Lock()
+	spansLen = len(stack.spans)
+	stack.mu.Unlock()
+	if spansLen != 1 {
+		t.Errorf("Expected 1 span in stack after model end, got %d", spansLen)
+	}
+
+	// 4. Trigger AfterRunCallback to pop root span and cleanup
+	afterRunCb := p.AfterRunCallback()
+	if afterRunCb == nil {
+		t.Fatal("AfterRunCallback is nil")
+	}
+
+	afterRunCb(mCtx)
+
+	tm.mu.RLock()
+	_, exists := tm.stacks[mCtx.InvocationID()]
+	tm.mu.RUnlock()
+	if exists {
+		t.Error("Expected stack to be cleaned up and removed from traceManager, but it still exists")
+	}
+}
+

--- a/plugin/agentanalytics/bigquery_agent_analytics_plugin_test.go
+++ b/plugin/agentanalytics/bigquery_agent_analytics_plugin_test.go
@@ -519,4 +519,3 @@ func TestContextualTraceStacking(t *testing.T) {
 		t.Error("Expected stack to be cleaned up and removed from traceManager, but it still exists")
 	}
 }
-

--- a/plugin/agentanalytics/bigquery_agent_analytics_plugin_test.go
+++ b/plugin/agentanalytics/bigquery_agent_analytics_plugin_test.go
@@ -15,6 +15,7 @@
 package agentanalytics
 
 import (
+	"bytes"
 	"context"
 	"errors"
 	"io"
@@ -340,5 +341,89 @@ func TestLogEvent_ExtractsTraceInfo(t *testing.T) {
 		}
 	case <-time.After(5 * time.Second):
 		t.Error("Timed out waiting for request")
+	}
+}
+
+func TestNewBigQueryAgentAnalyticsPlugin_CreateTable_WithPartitioning(t *testing.T) {
+	ctx := context.Background()
+	config := DefaultConfig()
+	config.Enabled = true
+	config.ProjectID = "test-project"
+	config.DatasetID = "test-dataset"
+	config.TableName = "test-table"
+
+	createCalled := false
+	var requestBody string
+
+	mockTransport := &mockTransport{
+		roundTrip: func(r *http.Request) (*http.Response, error) {
+			// Table metadata request: returns 404 Not Found to trigger creation
+			if r.Method == "GET" && strings.Contains(r.URL.Path, "/datasets/test-dataset/tables/test-table") {
+				return &http.Response{
+					StatusCode: http.StatusNotFound,
+					Body:       io.NopCloser(strings.NewReader(`{"error":{"code":404,"message":"Not found"}}`)),
+				}, nil
+			}
+			// Table creation request
+			if r.Method == "POST" && strings.Contains(r.URL.Path, "/datasets/test-dataset/tables") {
+				createCalled = true
+				bodyBytes, _ := io.ReadAll(r.Body)
+				requestBody = string(bodyBytes)
+				r.Body = io.NopCloser(bytes.NewBuffer(bodyBytes))
+
+				return &http.Response{
+					StatusCode: http.StatusOK,
+					Body:       io.NopCloser(strings.NewReader("{}")),
+				}, nil
+			}
+			return &http.Response{
+				StatusCode: http.StatusOK,
+				Body:       io.NopCloser(strings.NewReader("{}")),
+			}, nil
+		},
+	}
+	httpClient := &http.Client{Transport: mockTransport}
+	bqClient, err := bq.NewClient(ctx, config.ProjectID, option.WithHTTPClient(httpClient))
+	if err != nil {
+		t.Fatalf("Failed to create bigquery client: %v", err)
+	}
+
+	lis, err := net.Listen("tcp", "localhost:0")
+	if err != nil {
+		t.Fatalf("failed to listen: %v", err)
+	}
+	gSrv := grpc.NewServer()
+	storagepb.RegisterBigQueryWriteServer(gSrv, &fakeBigQueryWriteServer{})
+	go func() { _ = gSrv.Serve(lis) }()
+	t.Cleanup(gSrv.Stop)
+
+	conn, err := grpc.NewClient(lis.Addr().String(), grpc.WithTransportCredentials(insecure.NewCredentials()))
+	if err != nil {
+		t.Fatalf("failed to dial test server: %v", err)
+	}
+	t.Cleanup(func() { _ = conn.Close() })
+
+	writeClient, err := bqstorage.NewBigQueryWriteClient(ctx, option.WithGRPCConn(conn))
+	if err != nil {
+		t.Fatalf("Failed to create BigQuery write client: %v", err)
+	}
+
+	_, err = NewBigQueryAgentAnalyticsPluginWithClients(ctx, config, bqClient, writeClient)
+	if err != nil {
+		t.Fatalf("Plugin initialization error: %v", err)
+	}
+
+	if !createCalled {
+		t.Error("Expected table creation to be called")
+	}
+
+	if !strings.Contains(requestBody, "timePartitioning") {
+		t.Errorf("Expected request body to contain 'timePartitioning', got: %s", requestBody)
+	}
+	if !strings.Contains(requestBody, "DAY") {
+		t.Errorf("Expected partitioning type to be 'DAY', got request body: %s", requestBody)
+	}
+	if !strings.Contains(requestBody, "timestamp") {
+		t.Errorf("Expected partitioning field to be 'timestamp', got request body: %s", requestBody)
 	}
 }


### PR DESCRIPTION
**Please ensure you have read the [contribution guide](./CONTRIBUTING.md) before creating a pull request.**

### Link to Issue or Description of Change

**1. Link to an existing issue (if applicable):**

- Closes: N/A
- Related: https://github.com/google/adk-go/issues/738

**2. Or, if no issue exists, describe the change:**

**Problem:**
In concurrent or asynchronous agent execution flows, standard flat context logs lack parent-child span structure, making it incredibly difficult to trace nested execution layers (e.g., which agent invocation triggered which tool or LLM call).

**Solution:**
Implement a thread-safe in-memory contextual trace stack (`spanStack` and `traceManager`) inside `bigquery_agent_analytics_plugin.go`. Push nested execution span contexts (`spanRecord`) onto the invocation's trace stack at execution boundaries (Runs, Models, Tools), linking children to parents via `parentSpanID`. Retrieve trace context when logging events, and ensure safe cleanup upon run completion.

### Testing Plan

Added a complete integration unit test `TestContextualTraceStacking` which triggers `BeforeRunCallback`, `BeforeModelCallback`, `AfterModelCallback`, and `AfterRunCallback` sequentially, verifying that:
1. A root span is correctly pushed.
2. Nested spans are linked to the root span as `parentSpanID`.
3. Stack sizes update correctly as spans are popped.
4. The invocation's trace stack is properly cleaned up and removed on execution end.

### Checklist

- [x] I have read the [CONTRIBUTING.md](./CONTRIBUTING.md) document.
- [x] I have performed a self-review of my own code.
- [x] I have commented my code, particularly in hard-to-understand areas.
- [x] I have added tests that prove my fix is effective or that my feature works.
- [x] New and existing unit tests pass locally with my changes.
- [x] I have manually tested my changes end-to-end.