### PR TITLE
fix(agentengine): base64-encode []byte fields instead of failing thei…

### DIFF
--- a/server/agentengine/internal/helper/encode.go
+++ b/server/agentengine/internal/helper/encode.go
@@ -15,6 +15,8 @@
 package helper
 
 import (
+	"encoding/base64"
+	"encoding/json"
 	"fmt"
 	"log"
 	"reflect"
@@ -120,6 +122,15 @@ func convertSnake(path, indent string, o any) (any, error) {
 		}
 		return m, nil
 	case reflect.Slice:
+		if rm, ok := o.(json.RawMessage); ok {
+			if len(rm) == 0 {
+				return nil, nil
+			}
+			return rm, nil
+		}
+		if v.Type().Elem().Kind() == reflect.Uint8 {
+			return base64.StdEncoding.EncodeToString(v.Bytes()), nil
+		}
 		res := []any{}
 		for i := 0; i < v.Len(); i++ {
 			elem, err := convertSnake(path+".[]", indent+"    ", v.Index(i).Interface())

--- a/server/agentengine/internal/helper/encode.go
+++ b/server/agentengine/internal/helper/encode.go
@@ -15,6 +15,7 @@
 package helper
 
 import (
+	"encoding/base64"
 	"fmt"
 	"log"
 	"reflect"
@@ -120,6 +121,9 @@ func convertSnake(path, indent string, o any) (any, error) {
 		}
 		return m, nil
 	case reflect.Slice:
+		if v.Type().Elem().Kind() == reflect.Uint8 {
+			return base64.StdEncoding.EncodeToString(v.Bytes()), nil
+		}
 		res := []any{}
 		for i := 0; i < v.Len(); i++ {
 			elem, err := convertSnake(path+".[]", indent+"    ", v.Index(i).Interface())

--- a/server/agentengine/internal/helper/encode_test.go
+++ b/server/agentengine/internal/helper/encode_test.go
@@ -163,6 +163,62 @@ func TestEventLogProbs(t *testing.T) {
 	}
 }
 
+func TestByteSlice(t *testing.T) {
+	event := session.Event{
+		ID: "1",
+		LLMResponse: model.LLMResponse{
+			Content: &genai.Content{
+				Parts: []*genai.Part{
+					{
+						Text:             "hi",
+						ThoughtSignature: []byte{0xDE, 0xAD, 0xBE, 0xEF},
+					},
+				},
+			},
+		},
+	}
+	o, err := convertSnake("", "", event)
+	if err != nil {
+		t.Fatalf("convertSnake() failed: %v", err)
+	}
+	m, ok := o.(map[string]any)
+	if !ok {
+		t.Fatalf("o is not a map: %T", o)
+	}
+	content, ok := m["content"].(map[string]any)
+	if !ok {
+		t.Fatalf("content is not a map: %T", m["content"])
+	}
+	parts, ok := content["parts"].([]any)
+	if !ok || len(parts) != 1 {
+		t.Fatalf("parts is not a 1-element slice: %v", content["parts"])
+	}
+	part, ok := parts[0].(map[string]any)
+	if !ok {
+		t.Fatalf("part is not a map: %T", parts[0])
+	}
+	want := "3q2+7w=="
+	if got, _ := part["thought_signature"].(string); got != want {
+		t.Errorf("thought_signature = %q, want %q", got, want)
+	}
+}
+
+func TestByteSliceOmitEmpty(t *testing.T) {
+	type A struct {
+		Sig []byte `json:"sig,omitempty"`
+	}
+	got, err := convertSnake("", "", A{})
+	if err != nil {
+		t.Fatalf("convertSnake() failed: %v", err)
+	}
+	m, ok := got.(map[string]any)
+	if !ok {
+		t.Fatalf("got is not a map: %T", got)
+	}
+	if _, present := m["sig"]; present {
+		t.Errorf("sig should be omitted for an empty []byte, got: %v", m["sig"])
+	}
+}
 func TestEmbedded(t *testing.T) {
 	type A struct {
 		anInteger int

--- a/server/agentengine/internal/helper/encode_test.go
+++ b/server/agentengine/internal/helper/encode_test.go
@@ -15,6 +15,7 @@
 package helper
 
 import (
+	"encoding/json"
 	"testing"
 
 	"github.com/google/go-cmp/cmp"
@@ -160,6 +161,99 @@ func TestEventLogProbs(t *testing.T) {
 		}
 	} else {
 		t.Errorf("o is not a map")
+	}
+}
+
+func TestByteSlice(t *testing.T) {
+	event := session.Event{
+		ID: "1",
+		LLMResponse: model.LLMResponse{
+			Content: &genai.Content{
+				Parts: []*genai.Part{
+					{
+						Text:             "hi",
+						ThoughtSignature: []byte{0xDE, 0xAD, 0xBE, 0xEF},
+					},
+				},
+			},
+		},
+	}
+	o, err := convertSnake("", "", event)
+	if err != nil {
+		t.Fatalf("convertSnake() failed: %v", err)
+	}
+	m, ok := o.(map[string]any)
+	if !ok {
+		t.Fatalf("o is not a map: %T", o)
+	}
+	content, ok := m["content"].(map[string]any)
+	if !ok {
+		t.Fatalf("content is not a map: %T", m["content"])
+	}
+	parts, ok := content["parts"].([]any)
+	if !ok || len(parts) != 1 {
+		t.Fatalf("parts is not a 1-element slice: %v", content["parts"])
+	}
+	part, ok := parts[0].(map[string]any)
+	if !ok {
+		t.Fatalf("part is not a map: %T", parts[0])
+	}
+	want := "3q2+7w=="
+	if got, _ := part["thought_signature"].(string); got != want {
+		t.Errorf("thought_signature = %q, want %q", got, want)
+	}
+}
+
+func TestByteSliceOmitEmpty(t *testing.T) {
+	type A struct {
+		Sig []byte `json:"sig,omitempty"`
+	}
+	got, err := convertSnake("", "", A{})
+	if err != nil {
+		t.Fatalf("convertSnake() failed: %v", err)
+	}
+	m, ok := got.(map[string]any)
+	if !ok {
+		t.Fatalf("got is not a map: %T", got)
+	}
+	if _, present := m["sig"]; present {
+		t.Errorf("sig should be omitted for an empty []byte, got: %v", m["sig"])
+	}
+}
+
+func TestRawMessage(t *testing.T) {
+	type A struct {
+		Default json.RawMessage `json:"default,omitempty"`
+	}
+	a := A{Default: json.RawMessage(`{"approved":false}`)}
+	got, err := convertSnake("", "", a)
+	if err != nil {
+		t.Fatalf("convertSnake() failed: %v", err)
+	}
+	b, err := json.Marshal(got)
+	if err != nil {
+		t.Fatalf("json.Marshal() failed: %v", err)
+	}
+	want := `{"default":{"approved":false}}`
+	if string(b) != want {
+		t.Errorf("marshaled output = %s, want %s", b, want)
+	}
+}
+
+func TestRawMessageOmitEmpty(t *testing.T) {
+	type A struct {
+		Default json.RawMessage `json:"default,omitempty"`
+	}
+	got, err := convertSnake("", "", A{})
+	if err != nil {
+		t.Fatalf("convertSnake() failed: %v", err)
+	}
+	m, ok := got.(map[string]any)
+	if !ok {
+		t.Fatalf("got is not a map: %T", got)
+	}
+	if _, present := m["default"]; present {
+		t.Errorf("default should be omitted for an empty json.RawMessage, got: %v", m["default"])
 	}
 }
 


### PR DESCRIPTION
### Link to Issue or Description of Change

**1. Link to an existing issue (if applicable):**

- Closes: #1386

### Testing Plan

**Unit Tests:**

- [x] I have added or updated unit tests for my change.
- [x] All unit tests pass locally.

Added two tests to `encode_test.go`, following the existing file's conventions:

- `TestByteSlice` - a `session.Event` with a non-empty
  `Content.Parts[0].ThoughtSignature` now converts successfully, and the
  resulting `thought_signature` key holds the expected base64 string
  (`{0xDE, 0xAD, 0xBE, 0xEF}` -> `"3q2+7w=="`, matching what
  `encoding/json` produces for the same bytes).
- `TestByteSliceOmitEmpty` - confirms `omitempty` is unaffected: an empty
  `[]byte` is still correctly omitted, not encoded as an empty string.

Ran the full existing package suite alongside the new tests - zero regressions:

```
$ go test ./server/agentengine/...
ok      google.golang.org/adk/v2/server/agentengine/controllers/method  0.972s
ok      google.golang.org/adk/v2/server/agentengine/internal/helper     0.491s
$ go vet ./server/agentengine/...
(clean)
```

**Manual End-to-End (E2E) Tests:**

Ran the real `agentengine` launcher (`web agentengine` - the same launcher
composition `agentengine.NewLauncher` uses in production) locally against a
real deployed, Vertex AI Sessions-backed Reasoning Engine resource, using
`gemini-3.6-flash` (emits a non-empty `ThoughtSignature` on essentially
every turn, not just tool calls - the worst case observed). Sent the exact
`async_stream_query` request shape Gemini Enterprise uses:

```
curl -s -X POST -H "Content-Type: application/json" \
  "http://localhost:8080/api/stream_reasoning_engine" \
  -d '{"class_method": "async_stream_query", "input": {"user_id": "verify", "message": {"role": "user", "parts": [{"text": "hi"}]}}}'
```

- Before the fix: every signature-bearing event logged `Failed to convert:
  ... err: unsupported type: uint8` and shipped to the client in raw
  Go/camelCase field names (`thoughtSignature`, `finishReason`,
  `invocationId`) mixed into an otherwise snake_case stream.
- After the fix: zero `Failed to convert` log lines. The event now
  serializes correctly, e.g. `"thought_signature": "AY89a1..."`, with
  consistent snake_case throughout (`finish_reason`, `invocation_id`, etc).

Also confirmed this is not model- or version-specific: the same missing
`reflect.Uint8` case is present identically in all three published
`adk/v2` releases (v2.0.0, v2.1.0, v2.2.0), and the bug reproduces on
`gemini-2.5-flash` too on any function-calling turn (just not on every
turn, unlike `gemini-3.6-flash`). Full details, including the live Gemini
Enterprise retry-into-dead-session cascade this caused in production, are
in #1386.

### Checklist

- [x] I have read the [CONTRIBUTING.md](./CONTRIBUTING.md) document.
- [x] I have performed a self-review of my own code.
- [x] I have commented my code, particularly in hard-to-understand areas.
- [x] I have added tests that prove my fix is effective or that my feature works.
- [x] New and existing unit tests pass locally with my changes.
- [x] I have manually tested my changes end-to-end.

### Additional context

`convertSnake`'s type switch only ever handled signed integers
(`Int`/`Int8`/`Int16`/`Int32`/`Int64`) - there was no case for `Uint8` or
any other `Uint*` kind. A `[]byte` field is a `reflect.Slice`, so it fell
into the generic per-element loop, and each individual byte (a bare
`uint8`) hit the `default: unsupported type` branch, failing conversion of
the *entire containing struct*. `encoding/json.Marshal` already solves
this correctly (base64-encodes `[]byte` automatically) - this fix just
applies the same, standard approach instead of reinventing a worse version
of it for one specific hand-rolled converter.