### PR TITLE
fix(model/openaimodel): pin function tools to non-strict validation

### DIFF
--- a/model/openaimodel/doc.go
+++ b/model/openaimodel/doc.go
@@ -21,6 +21,14 @@
 // providers that expose the OpenAI Responses API surface. This package
 // allows for easy integration of OpenAI's language models into applications.
 //
+// Function tools are declared with strict parameter validation disabled, and
+// that is not configurable, so tool call arguments are best effort rather than
+// guaranteed to match the declared parameter schema: validate them in the tool.
+// Optional arguments stay optional as a result, but a tool whose parameters
+// already met the strict requirements, as functiontool.New produces unless the
+// argument struct uses omitempty or omitzero, was previously upgraded to strict
+// mode by the API and no longer is.
+//
 // Clients construct a ClientConfig and pass it to NewModel:
 //
 //	ctx := context.Background()

--- a/model/openaimodel/doc.go
+++ b/model/openaimodel/doc.go
@@ -21,6 +21,15 @@
 // providers that expose the OpenAI Responses API surface. This package
 // allows for easy integration of OpenAI's language models into applications.
 //
+// Function tools are declared with strict parameter validation disabled, and
+// that is not configurable, so tool call arguments are best effort rather than
+// guaranteed to match the declared parameter schema: validate them in the tool.
+// Optional arguments stay optional as a result: the API used to rewrite the
+// schema to make every argument required, then enforce that. The cost is that
+// tools whose parameters already qualified for strict mode are no longer
+// enforced — functiontool.New produces those unless the argument struct uses
+// omitempty, omitzero or a map-typed field.
+//
 // Clients construct a ClientConfig and pass it to NewModel:
 //
 //	ctx := context.Background()

--- a/model/openaimodel/request_test.go
+++ b/model/openaimodel/request_test.go
@@ -15,6 +15,7 @@
 package openaimodel
 
 import (
+	"encoding/json"
 	"errors"
 	"reflect"
 	"strings"
@@ -117,6 +118,54 @@ func TestBuildOpenAIParams_JSONSchema(t *testing.T) {
 	}
 	if got := params.Text.Format.OfJSONSchema.Schema["type"]; got != "object" {
 		t.Fatalf("schema mismatch got=%v", got)
+	}
+}
+
+// TestBuildOpenAIParams_ToolsPinStrictOff checks the strict flag on the request
+// body rather than on the converted tool, because that is what decides the
+// validation mode. The declaration below is already strict-compatible, which is
+// the case the Responses API would otherwise normalize into strict mode.
+func TestBuildOpenAIParams_ToolsPinStrictOff(t *testing.T) {
+	req := &model.LLMRequest{
+		Contents: []*genai.Content{genai.NewContentFromText("weather?", genai.RoleUser)},
+		Config: &genai.GenerateContentConfig{
+			Tools: []*genai.Tool{{
+				FunctionDeclarations: []*genai.FunctionDeclaration{{
+					Name: "get_weather",
+					ParametersJsonSchema: map[string]any{
+						"type":                 "object",
+						"properties":           map[string]any{"city": map[string]any{"type": "string"}},
+						"required":             []any{"city"},
+						"additionalProperties": false,
+					},
+				}},
+			}},
+		},
+	}
+	params, err := buildOpenAIParams("fallback", req)
+	if err != nil {
+		t.Fatalf("buildOpenAIParams() err = %v", err)
+	}
+	data, err := json.Marshal(params)
+	if err != nil {
+		t.Fatalf("json.Marshal() err = %v", err)
+	}
+	var payload struct {
+		Tools []struct {
+			Strict *bool `json:"strict"`
+		} `json:"tools"`
+	}
+	if err := json.Unmarshal(data, &payload); err != nil {
+		t.Fatalf("json.Unmarshal() err = %v", err)
+	}
+	if len(payload.Tools) != 1 {
+		t.Fatalf("tools = %d, want 1: %s", len(payload.Tools), data)
+	}
+	if payload.Tools[0].Strict == nil {
+		t.Fatalf("strict missing from the request body: %s", data)
+	}
+	if *payload.Tools[0].Strict {
+		t.Errorf("strict = true, want false")
 	}
 }
 

--- a/model/openaimodel/tools.go
+++ b/model/openaimodel/tools.go
@@ -67,6 +67,20 @@ func ensureFunctionToolOnly(idx int, tool *genai.Tool) error {
 // converts it into an OpenAI-specific responses.FunctionToolParam. We handle
 // the function's name, description, and importantly, convert its parameters
 // from a generic schema format to a map[string]any that the OpenAI API expects.
+//
+// Strict parameter validation is pinned off so the mode does not depend on the
+// caller's schema. Left unset, the API picks it from the schema shape, reports
+// the choice only on the response tool, which this package discards, and does
+// not merely accept or reject: given additionalProperties:false with only some
+// properties in required, it rewrites required to name them all and runs strict,
+// forcing a value into an argument the caller made optional.
+//
+// Pinning on is the breaking direction. Strict needs every property in
+// required, so an optional one must be nullable ("type": ["string", "null"]):
+// functiontool.New emits that for pointer fields, but omitempty and omitzero
+// fields are left out of required, and genai.Schema emits "nullable": true,
+// which strict rejects. Strict also demands additionalProperties:false on every
+// object; a map-typed field emits a schema there.
 func convertFunctionDeclaration(fn *genai.FunctionDeclaration) (*responses.FunctionToolParam, error) {
 	if fn == nil {
 		return nil, fmt.Errorf("openai: nil function declaration")
@@ -97,6 +111,7 @@ func convertFunctionDeclaration(fn *genai.FunctionDeclaration) (*responses.Funct
 		Name:       fn.Name,
 		Type:       constant.Function("function"),
 		Parameters: paramsMap,
+		Strict:     param.NewOpt(false),
 	}
 	if fn.Description != "" {
 		fnParam.Description = param.NewOpt(fn.Description)

--- a/model/openaimodel/tools.go
+++ b/model/openaimodel/tools.go
@@ -67,6 +67,16 @@ func ensureFunctionToolOnly(idx int, tool *genai.Tool) error {
 // converts it into an OpenAI-specific responses.FunctionToolParam. We handle
 // the function's name, description, and importantly, convert its parameters
 // from a generic schema format to a map[string]any that the OpenAI API expects.
+//
+// Strict parameter validation is pinned off so the mode does not depend on the
+// caller's schema. Left unset, the Responses API normalizes the parameters into
+// strict mode when it can and silently falls back when it cannot, reporting the
+// mode it chose on the response tool, which this package does not surface. That
+// makes the pin a real change for tools whose schema already qualified, as
+// functiontool.New produces unless the argument struct uses omitempty or
+// omitzero; pinning it on instead is the breaking direction, because strict
+// requires every property in required, so an optional argument would have to be
+// declared nullable ("type": ["string", "null"]) and listed there anyway.
 func convertFunctionDeclaration(fn *genai.FunctionDeclaration) (*responses.FunctionToolParam, error) {
 	if fn == nil {
 		return nil, fmt.Errorf("openai: nil function declaration")
@@ -97,6 +107,7 @@ func convertFunctionDeclaration(fn *genai.FunctionDeclaration) (*responses.Funct
 		Name:       fn.Name,
 		Type:       constant.Function("function"),
 		Parameters: paramsMap,
+		Strict:     param.NewOpt(false),
 	}
 	if fn.Description != "" {
 		fnParam.Description = param.NewOpt(fn.Description)

--- a/model/openaimodel/tools_test.go
+++ b/model/openaimodel/tools_test.go
@@ -15,6 +15,7 @@
 package openaimodel
 
 import (
+	"encoding/json"
 	"reflect"
 	"strings"
 	"testing"
@@ -88,6 +89,15 @@ func TestConvertTools(t *testing.T) {
 			}
 			if len(tools) > 0 && (tools[0].OfFunction == nil || tools[0].OfFunction.Name != "fn1") {
 				t.Fatalf("unexpected tool: %+v", tools[0])
+			}
+			for i, tool := range tools {
+				if tool.OfFunction == nil {
+					t.Errorf("tool %d is not a function tool: %+v", i, tool)
+					continue
+				}
+				if !tool.OfFunction.Strict.Valid() || tool.OfFunction.Strict.Value {
+					t.Errorf("tool %d Strict = %+v, want an explicit false", i, tool.OfFunction.Strict)
+				}
 			}
 		})
 	}
@@ -195,6 +205,114 @@ func TestConvertFunctionDeclaration(t *testing.T) {
 				}
 			}
 		})
+	}
+}
+
+// TestConvertFunctionDeclarationPinsStrictOff covers every parameter path,
+// because the Responses API decides the validation mode from the schema shape
+// when strict is absent. Pinning it makes the mode independent of the schema.
+func TestConvertFunctionDeclarationPinsStrictOff(t *testing.T) {
+	tests := []struct {
+		name string
+		decl *genai.FunctionDeclaration
+	}{
+		{
+			name: "no parameters",
+			decl: &genai.FunctionDeclaration{Name: "fn"},
+		},
+		{
+			name: "genai schema parameters",
+			decl: &genai.FunctionDeclaration{
+				Name: "fn",
+				Parameters: &genai.Schema{
+					Type:       genai.TypeObject,
+					Properties: map[string]*genai.Schema{"city": {Type: genai.TypeString}},
+					Required:   []string{"city"},
+				},
+			},
+		},
+		{
+			// A hand-written schema can be strict-compatible, which is exactly
+			// the case where an absent strict flag would flip the API into
+			// strict mode without the caller asking for it.
+			name: "strict-compatible ParametersJsonSchema",
+			decl: &genai.FunctionDeclaration{
+				Name: "fn",
+				ParametersJsonSchema: map[string]any{
+					"type":                 "object",
+					"properties":           map[string]any{"city": map[string]any{"type": "string"}},
+					"required":             []any{"city"},
+					"additionalProperties": false,
+				},
+			},
+		},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			fn, err := convertFunctionDeclaration(tc.decl)
+			if err != nil {
+				t.Fatalf("convertFunctionDeclaration() error = %v", err)
+			}
+			if !fn.Strict.Valid() {
+				t.Fatal("Strict is unset; the Responses API would choose the validation mode from the schema shape")
+			}
+			if fn.Strict.Value {
+				t.Errorf("Strict = true, want false")
+			}
+		})
+	}
+}
+
+// TestConvertFunctionDeclarationMarshalsStrict guards the wire format. Strict is
+// tagged omitzero, so leaving it at its zero value drops the key from the
+// payload entirely rather than sending false.
+func TestConvertFunctionDeclarationMarshalsStrict(t *testing.T) {
+	fn, err := convertFunctionDeclaration(&genai.FunctionDeclaration{Name: "fn"})
+	if err != nil {
+		t.Fatalf("convertFunctionDeclaration() error = %v", err)
+	}
+	data, err := json.Marshal(fn)
+	if err != nil {
+		t.Fatalf("json.Marshal() error = %v", err)
+	}
+	var payload map[string]any
+	if err := json.Unmarshal(data, &payload); err != nil {
+		t.Fatalf("json.Unmarshal() error = %v", err)
+	}
+	strict, ok := payload["strict"]
+	if !ok {
+		t.Fatalf("strict missing from payload %s", data)
+	}
+	if strict != false {
+		t.Errorf("strict = %v, want false", strict)
+	}
+}
+
+// TestConvertFunctionDeclarationKeepsOptionalParameters pins the constraint that
+// rules out simply reusing enforceStrictOpenAISchema here: it rewrites required
+// to list every property, which would make optional tool arguments mandatory.
+func TestConvertFunctionDeclarationKeepsOptionalParameters(t *testing.T) {
+	fn, err := convertFunctionDeclaration(&genai.FunctionDeclaration{
+		Name: "fn",
+		Parameters: &genai.Schema{
+			Type: genai.TypeObject,
+			Properties: map[string]*genai.Schema{
+				"city":  {Type: genai.TypeString},
+				"units": {Type: genai.TypeString},
+			},
+			Required: []string{"city"},
+		},
+	})
+	if err != nil {
+		t.Fatalf("convertFunctionDeclaration() error = %v", err)
+	}
+	want := []any{"city"}
+	if got := fn.Parameters["required"]; !reflect.DeepEqual(got, want) {
+		t.Errorf("required = %v, want %v", got, want)
+	}
+	if _, ok := fn.Parameters["additionalProperties"]; ok {
+		t.Errorf("additionalProperties was injected into %v", fn.Parameters)
 	}
 }
 

--- a/model/openaimodel/tools_test.go
+++ b/model/openaimodel/tools_test.go
@@ -15,6 +15,7 @@
 package openaimodel
 
 import (
+	"encoding/json"
 	"reflect"
 	"strings"
 	"testing"
@@ -88,6 +89,15 @@ func TestConvertTools(t *testing.T) {
 			}
 			if len(tools) > 0 && (tools[0].OfFunction == nil || tools[0].OfFunction.Name != "fn1") {
 				t.Fatalf("unexpected tool: %+v", tools[0])
+			}
+			for i, tool := range tools {
+				if tool.OfFunction == nil {
+					t.Errorf("tool %d is not a function tool: %+v", i, tool)
+					continue
+				}
+				if !tool.OfFunction.Strict.Valid() || tool.OfFunction.Strict.Value {
+					t.Errorf("tool %d Strict = %+v, want an explicit false", i, tool.OfFunction.Strict)
+				}
 			}
 		})
 	}
@@ -193,6 +203,157 @@ func TestConvertFunctionDeclaration(t *testing.T) {
 				if err == nil || !strings.Contains(err.Error(), tc.wantErr) {
 					t.Fatalf("expected error containing %q, got: %v", tc.wantErr, err)
 				}
+			}
+		})
+	}
+}
+
+// TestConvertFunctionDeclarationPinsStrictOff covers every parameter path,
+// because the Responses API decides the validation mode from the schema shape
+// when strict is absent. Pinning it makes the mode independent of the schema.
+func TestConvertFunctionDeclarationPinsStrictOff(t *testing.T) {
+	tests := []struct {
+		name string
+		decl *genai.FunctionDeclaration
+	}{
+		{
+			name: "no parameters",
+			decl: &genai.FunctionDeclaration{Name: "fn"},
+		},
+		{
+			name: "genai schema parameters",
+			decl: &genai.FunctionDeclaration{
+				Name: "fn",
+				Parameters: &genai.Schema{
+					Type:       genai.TypeObject,
+					Properties: map[string]*genai.Schema{"city": {Type: genai.TypeString}},
+					Required:   []string{"city"},
+				},
+			},
+		},
+		{
+			// A hand-written schema can be strict-compatible, which is exactly
+			// the case where an absent strict flag would flip the API into
+			// strict mode without the caller asking for it.
+			name: "strict-compatible ParametersJsonSchema",
+			decl: &genai.FunctionDeclaration{
+				Name: "fn",
+				ParametersJsonSchema: map[string]any{
+					"type":                 "object",
+					"properties":           map[string]any{"city": map[string]any{"type": "string"}},
+					"required":             []any{"city"},
+					"additionalProperties": false,
+				},
+			},
+		},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			fn, err := convertFunctionDeclaration(tc.decl)
+			if err != nil {
+				t.Fatalf("convertFunctionDeclaration() error = %v", err)
+			}
+			if !fn.Strict.Valid() {
+				t.Fatal("Strict is unset; the Responses API would choose the validation mode from the schema shape")
+			}
+			if fn.Strict.Value {
+				t.Errorf("Strict = true, want false")
+			}
+		})
+	}
+}
+
+// TestConvertFunctionDeclarationMarshalsStrict guards the wire format. Strict is
+// tagged omitzero, so leaving it at its zero value drops the key from the
+// payload entirely rather than sending false.
+func TestConvertFunctionDeclarationMarshalsStrict(t *testing.T) {
+	fn, err := convertFunctionDeclaration(&genai.FunctionDeclaration{Name: "fn"})
+	if err != nil {
+		t.Fatalf("convertFunctionDeclaration() error = %v", err)
+	}
+	data, err := json.Marshal(fn)
+	if err != nil {
+		t.Fatalf("json.Marshal() error = %v", err)
+	}
+	var payload map[string]any
+	if err := json.Unmarshal(data, &payload); err != nil {
+		t.Fatalf("json.Unmarshal() error = %v", err)
+	}
+	strict, ok := payload["strict"]
+	if !ok {
+		t.Fatalf("strict missing from payload %s", data)
+	}
+	if strict != false {
+		t.Errorf("strict = %v, want false", strict)
+	}
+}
+
+// TestConvertFunctionDeclarationKeepsOptionalParameters pins the constraint that
+// rules out simply reusing enforceStrictOpenAISchema here: it rewrites required
+// to list every property, which would make optional tool arguments mandatory.
+//
+// Both paths are covered: ParametersJsonSchema is the one functiontool.New
+// takes, and its schema is already strict-shaped apart from required, so a
+// rewrite there is invisible unless the fixture omits a property from required.
+func TestConvertFunctionDeclarationKeepsOptionalParameters(t *testing.T) {
+	tests := []struct {
+		name string
+		decl *genai.FunctionDeclaration
+		// Value the key must still hold after conversion; nil means absent.
+		wantAdditionalProperties any
+	}{
+		{
+			// genai.Schema carries no additionalProperties; it must not be injected.
+			name: "genai schema parameters",
+			decl: &genai.FunctionDeclaration{
+				Name: "fn",
+				Parameters: &genai.Schema{
+					Type: genai.TypeObject,
+					Properties: map[string]*genai.Schema{
+						"city":  {Type: genai.TypeString},
+						"units": {Type: genai.TypeString},
+					},
+					Required: []string{"city"},
+				},
+			},
+			wantAdditionalProperties: nil,
+		},
+		{
+			// What functiontool.New emits for an omitempty/omitzero field.
+			name: "ParametersJsonSchema with an optional property",
+			decl: &genai.FunctionDeclaration{
+				Name: "fn",
+				ParametersJsonSchema: map[string]any{
+					"type": "object",
+					"properties": map[string]any{
+						"city":  map[string]any{"type": "string"},
+						"units": map[string]any{"type": "string"},
+					},
+					"required":             []any{"city"},
+					"additionalProperties": false,
+				},
+			},
+			wantAdditionalProperties: false,
+		},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			fn, err := convertFunctionDeclaration(tc.decl)
+			if err != nil {
+				t.Fatalf("convertFunctionDeclaration() error = %v", err)
+			}
+			want := []any{"city"}
+			if got := fn.Parameters["required"]; !reflect.DeepEqual(got, want) {
+				t.Errorf("required = %v, want %v", got, want)
+			}
+			got, ok := fn.Parameters["additionalProperties"]
+			if !ok {
+				got = nil
+			}
+			if !reflect.DeepEqual(got, tc.wantAdditionalProperties) {
+				t.Errorf("additionalProperties = %v, want %v, in %v", got, tc.wantAdditionalProperties, fn.Parameters)
 			}
 		})
 	}


### PR DESCRIPTION
**Problem:**

`convertFunctionDeclaration` never set `FunctionToolParam.Strict`. openai-go
tags that field `json:"strict,omitzero"`, so leaving it unset drops the key from
the request body entirely, and the Responses API reads an absent `strict` as
"attempt strict mode; if the schema cannot be made compatible, fall back to
non-strict, best-effort function calling". The validation mode a tool runs under
was therefore inferred by the server from the shape of whatever parameter schema
the caller happened to produce, rather than chosen by this package.

That makes the mode inconsistent and invisible. Tools built with
`functiontool.New` get `additionalProperties:false` and a full `required` list
from jsonschema-go, so they ran strict; tools declared with a hand-written
`genai.Schema` emit no `additionalProperties` and never did. Adding `omitempty`
to a single Go struct field silently flipped that tool from validated to best
effort. The API reports the mode it settled on on the response tool, which this
package discards, so there was no way to tell which you got.

**Solution:**

Pin `Strict` to `false`, making the mode this package's decision rather than an
emergent property of the caller's struct tags. This matches adk-python's
Responses path. Pinning it *on* is the breaking direction: strict requires every
property to appear in `required`, so an optional argument would have to be
declared nullable (`"type": ["string", "null"]`) and listed there anyway,
changing what existing agents send. The trade is that tools whose schema already
qualified lose strict validation and drop to best effort; the package doc and
the conversion site record this and tell callers to validate arguments in the
tool.

### Testing Plan

**Unit Tests:** added `TestConvertFunctionDeclarationPinsStrictOff` (all three
parameter paths), `TestConvertFunctionDeclarationMarshalsStrict` (guards the
`omitzero` wire format), `TestConvertFunctionDeclarationKeepsOptionalParameters`
(pins that `enforceStrictOpenAISchema` is not applied to tool parameters),
`TestBuildOpenAIParams_ToolsPinStrictOff` (asserts on the marshalled request
body), plus a strict assertion in `TestConvertTools`.

    $ go test -race -count=1 ./model/openaimodel/
    ok  google.golang.org/adk/v2/model/openaimodel  1.391s