### PR TITLE
fix(memory): tokenize on punctuation and all whitespace in extractWords

### DIFF
--- a/memory/inmemory.go
+++ b/memory/inmemory.go
@@ -20,6 +20,7 @@ import (
 	"strings"
 	"sync"
 	"time"
+	"unicode"
 
 	"google.golang.org/genai"
 
@@ -167,12 +168,19 @@ func checkMapsIntersect(m1, m2 map[string]struct{}) bool {
 func extractWords(text string) map[string]struct{} {
 	res := make(map[string]struct{})
 
-	for s := range strings.SplitSeq(text, " ") {
-		if s == "" {
-			continue
-		}
+	// Split on runs of non-word characters so that punctuation and non-space
+	// whitespace are not folded into a token: without this, "great!" is stored
+	// as-is and a search for "great" misses it. This mirrors the `\w+`
+	// tokenization used by adk-python's in-memory memory service.
+	for _, s := range strings.FieldsFunc(text, isNotWord) {
 		res[strings.ToLower(s)] = struct{}{}
 	}
 
 	return res
+}
+
+// isNotWord reports whether r separates two words, i.e. whether it is neither a
+// letter, a digit nor an underscore.
+func isNotWord(r rune) bool {
+	return !unicode.IsLetter(r) && !unicode.IsNumber(r) && r != '_'
 }

--- a/memory/inmemory_test.go
+++ b/memory/inmemory_test.go
@@ -91,6 +91,102 @@ func Test_inMemoryService_SearchMemory(t *testing.T) {
 			},
 		},
 		{
+			name: "find events next to punctuation",
+			initSessions: []session.Session{
+				makeSession(t, "app1", "user1", "sess1", []*session.Event{
+					{
+						ID:          "event1",
+						Author:      "test-bot",
+						LLMResponse: model.LLMResponse{Content: genai.NewContentFromText("The agent works great!", genai.RoleModel)},
+						Timestamp:   must(time.Parse(time.RFC3339, "2023-10-01T10:00:00Z")),
+					},
+					{
+						ID:          "event2",
+						Author:      "test-bot",
+						LLMResponse: model.LLMResponse{Content: genai.NewContentFromText("regions: us-east1,us-west1", genai.RoleModel)},
+						Timestamp:   must(time.Parse(time.RFC3339, "2023-10-02T10:00:00Z")),
+					},
+				}),
+			},
+			req: &memory.SearchRequest{
+				AppName: "app1",
+				UserID:  "user1",
+				Query:   "great us-west1",
+			},
+			wantResp: &memory.SearchResponse{
+				Memories: []memory.Entry{
+					{
+						ID:        "event1",
+						Content:   genai.NewContentFromText("The agent works great!", genai.RoleModel),
+						Author:    "test-bot",
+						Timestamp: must(time.Parse(time.RFC3339, "2023-10-01T10:00:00Z")),
+					},
+					{
+						ID:        "event2",
+						Content:   genai.NewContentFromText("regions: us-east1,us-west1", genai.RoleModel),
+						Author:    "test-bot",
+						Timestamp: must(time.Parse(time.RFC3339, "2023-10-02T10:00:00Z")),
+					},
+				},
+			},
+		},
+		{
+			name: "find events separated by non-space whitespace",
+			initSessions: []session.Session{
+				makeSession(t, "app1", "user1", "sess1", []*session.Event{
+					{
+						ID:          "event1",
+						Author:      "test-bot",
+						LLMResponse: model.LLMResponse{Content: genai.NewContentFromText("first line\nsecond\tline", genai.RoleModel)},
+						Timestamp:   must(time.Parse(time.RFC3339, "2023-10-01T10:00:00Z")),
+					},
+				}),
+			},
+			req: &memory.SearchRequest{
+				AppName: "app1",
+				UserID:  "user1",
+				Query:   "second",
+			},
+			wantResp: &memory.SearchResponse{
+				Memories: []memory.Entry{
+					{
+						ID:        "event1",
+						Content:   genai.NewContentFromText("first line\nsecond\tline", genai.RoleModel),
+						Author:    "test-bot",
+						Timestamp: must(time.Parse(time.RFC3339, "2023-10-01T10:00:00Z")),
+					},
+				},
+			},
+		},
+		{
+			name: "find events for a query containing punctuation",
+			initSessions: []session.Session{
+				makeSession(t, "app1", "user1", "sess1", []*session.Event{
+					{
+						ID:          "event1",
+						Author:      "test-bot",
+						LLMResponse: model.LLMResponse{Content: genai.NewContentFromText("the deploy step timed out", genai.RoleModel)},
+						Timestamp:   must(time.Parse(time.RFC3339, "2023-10-01T10:00:00Z")),
+					},
+				}),
+			},
+			req: &memory.SearchRequest{
+				AppName: "app1",
+				UserID:  "user1",
+				Query:   "Why timed-out?",
+			},
+			wantResp: &memory.SearchResponse{
+				Memories: []memory.Entry{
+					{
+						ID:        "event1",
+						Content:   genai.NewContentFromText("the deploy step timed out", genai.RoleModel),
+						Author:    "test-bot",
+						Timestamp: must(time.Parse(time.RFC3339, "2023-10-01T10:00:00Z")),
+					},
+				},
+			},
+		},
+		{
 			name: "no leakage for different appName",
 			initSessions: []session.Session{
 				makeSession(t, "app1", "user1", "sess3", []*session.Event{


### PR DESCRIPTION
## What

`extractWords` in `memory/inmemory.go` now splits text on runs of non-word runes (`strings.FieldsFunc`) instead of on the literal space character, so punctuation and non-space whitespace no longer become part of an indexed token.

Fixes #569

## Why

`extractWords` builds the keyword index for `InMemoryService` and also tokenizes the incoming query, so both sides were affected:

1. **Punctuation stayed glued to the word.** `"The agent works great!"` indexed the token `great!`, so `SearchMemory` with query `great` returned nothing.
2. **Tabs and newlines were never split on.** `"first line\nsecond\tline"` indexed the single token `line\nsecond\tline`, making every word after the first newline unreachable. Multi-line model responses are the common case here.
3. **Punctuated queries failed symmetrically** — a query of `"Why timed-out?"` produced the token `timed-out?`, which matched nothing.

## Implementation note

The issue proposed `strings.Fields` + `strings.TrimFunc`. I used `strings.FieldsFunc` with a non-word separator predicate instead, for two reasons:

- `TrimFunc` only strips punctuation from the **ends** of a token, so the comma-separated case the issue lists as affected would still break: `regions: us-east1,us-west1` stays one token. `FieldsFunc` handles it.
- It mirrors adk-python's tokenizer, `re.findall(r'\w+', text)` in `in_memory_memory_service.py`, keeping the two implementations aligned per the Alignment with adk-python guidance in CONTRIBUTING.md. The predicate accepts Unicode letters, Unicode digits and `_`, matching Python 3's `\w`.

Happy to switch to the `TrimFunc` approach if maintainers prefer to keep hyphenated and comma-joined tokens intact.

`FieldsFunc` never yields empty strings, so the old `if s == "" { continue }` guard is now dead code and was removed.

## Testing plan

Three cases added to the existing `Test_inMemoryService_SearchMemory` table, one per failure mode above:

- `find events next to punctuation` — covers `great!` and `regions: us-east1,us-west1`
- `find events separated by non-space whitespace` — covers `\n` and `\t`
- `find events for a query containing punctuation` — covers query-side normalization

Each was verified to **fail against the unfixed `extractWords`** before the fix was applied, so they are genuine regression tests rather than tests written to match new behavior:

```
--- FAIL: Test_inMemoryService_SearchMemory
    --- FAIL: Test_inMemoryService_SearchMemory/find_events_next_to_punctuation
    --- FAIL: Test_inMemoryService_SearchMemory/find_events_separated_by_non-space_whitespace
    --- FAIL: Test_inMemoryService_SearchMemory/find_events_for_a_query_containing_punctuation
```

With the fix applied, the full package passes, including the pre-existing `find events` and concurrency tests:

```
--- PASS: Test_inMemoryService_SearchMemory (0.00s)
    --- PASS: Test_inMemoryService_SearchMemory/find_events (0.00s)
    --- PASS: Test_inMemoryService_SearchMemory/find_events_next_to_punctuation (0.00s)
    --- PASS: Test_inMemoryService_SearchMemory/find_events_separated_by_non-space_whitespace (0.00s)
    --- PASS: Test_inMemoryService_SearchMemory/find_events_for_a_query_containing_punctuation (0.00s)
    --- PASS: Test_inMemoryService_SearchMemory/no_leakage_for_different_appName (0.00s)
    --- PASS: Test_inMemoryService_SearchMemory/no_leakage_for_different_user (0.00s)
    --- PASS: Test_inMemoryService_SearchMemory/no_matches (0.00s)
    --- PASS: Test_inMemoryService_SearchMemory/lookup_on_empty_store (0.00s)
--- PASS: Test_inMemoryService_SearchMemory_Concurrent (0.00s)
PASS
```

Also run locally: `go build ./...` (whole module, clean), `go vet ./memory/` (clean), `gofmt` (clean). `extractWords` is unexported and referenced only within the `memory` package, so the change is self-contained.

I could not run `go test -race` locally — it requires cgo and there is no C toolchain on my machine. The change introduces no new concurrency, and the existing `Test_inMemoryService_SearchMemory_Concurrent` passes without race enabled; relying on CI for the race run.