### PR TITLE
fix(llminternal): pair every function call with a result in request contents

### DIFF
--- a/internal/llminternal/contents_processor.go
+++ b/internal/llminternal/contents_processor.go
@@ -240,6 +240,10 @@ func buildContentsDefault(agentName, invocationBranch, isolationScope string, ev
 		contents = append(contents, content)
 	}
 
+	// Ids are read after the conversion so a stripped call id is answered by a
+	// response with the same stripped id.
+	contents = pairUnansweredFunctionCalls(contents, pendingCallIDs(filtered))
+
 	// For scoped agents (task / single_turn), prepend a synthetic user
 	// content built from the originating FC's args. The FC lives in an
 	// UNSCOPED parent event (e.g. the coordinator's task-delegation FC)

--- a/internal/llminternal/contents_processor.go
+++ b/internal/llminternal/contents_processor.go
@@ -236,13 +236,17 @@ func buildContentsDefault(agentName, invocationBranch, isolationScope string, ev
 			continue
 		}
 
-		utils.RemoveClientFunctionCallID(content)
 		contents = append(contents, content)
 	}
 
-	// Ids are read after the conversion so a stripped call id is answered by a
-	// response with the same stripped id.
+	// Calls are paired while they still carry the ids ADK generated, because
+	// LongRunningToolIDs holds those ids and a turn with several calls can only
+	// be matched to its results by id. The strip that follows blanks a
+	// synthesized response id together with the call id it answers.
 	contents = pairUnansweredFunctionCalls(contents, pendingCallIDs(filtered))
+	for _, content := range contents {
+		utils.RemoveClientFunctionCallID(content)
+	}
 
 	// For scoped agents (task / single_turn), prepend a synthetic user
 	// content built from the originating FC's args. The FC lives in an

--- a/internal/llminternal/contents_processor_test.go
+++ b/internal/llminternal/contents_processor_test.go
@@ -178,6 +178,12 @@ func TestContentsRequestProcessor_IncludeContents(t *testing.T) {
 					Role: "user",
 				},
 				genai.NewContentFromFunctionCall("func1", nil, "model"),
+				// The turn ended before the tool result was recorded, so the
+				// call reaches the model with a placeholder result.
+				functionResponseContent(&genai.FunctionResponse{
+					Name:     "func1",
+					Response: map[string]any{"result": missingResult},
+				}),
 			},
 		},
 		{
@@ -193,6 +199,12 @@ func TestContentsRequestProcessor_IncludeContents(t *testing.T) {
 					Role: "user",
 				},
 				genai.NewContentFromFunctionCall("func1", nil, "model"),
+				// The turn ended before the tool result was recorded, so the
+				// call reaches the model with a placeholder result.
+				functionResponseContent(&genai.FunctionResponse{
+					Name:     "func1",
+					Response: map[string]any{"result": missingResult},
+				}),
 			},
 		},
 		{

--- a/internal/llminternal/tool_pairing.go
+++ b/internal/llminternal/tool_pairing.go
@@ -1,0 +1,155 @@
+// Copyright 2026 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package llminternal
+
+import (
+	"google.golang.org/genai"
+
+	"google.golang.org/adk/v2/internal/utils"
+	"google.golang.org/adk/v2/session"
+)
+
+// missingFunctionResult stands in for a result that was never recorded. It
+// names no cause, because there is none to name: the turn may have been
+// interrupted, or the process may have died between the two events.
+const missingFunctionResult = "No response available for this function call."
+
+// pendingFunctionResult stands in for a call ADK is deliberately holding open:
+// a long-running tool, a human approval, or a request for user input. No
+// function response exists for these until the answer arrives, so the call is
+// pending rather than lost. The distinction changes what the model does next:
+// told a tool returned nothing, it reissues the call or proceeds without it;
+// told the call is still awaiting a response, it can wait.
+const pendingFunctionResult = "This call is awaiting a response and has not completed yet."
+
+// pendingCallIDs returns the ids of the calls ADK is holding open.
+// LongRunningToolIDs lives on the event and does not survive the conversion to
+// contents, so it is read here.
+func pendingCallIDs(events []*session.Event) map[string]bool {
+	pending := make(map[string]bool)
+	for _, event := range events {
+		if event == nil {
+			continue
+		}
+		for _, id := range event.LongRunningToolIDs {
+			pending[id] = true
+		}
+	}
+	return pending
+}
+
+// pairUnansweredFunctionCalls gives every function call a function response in
+// the immediately following content.
+//
+// A call and its result are two separate session events. When a turn ends
+// between them (a restart, an OOM kill, a disconnect, a cancellation), the
+// session keeps a function call that no function response answers. That
+// history is replayed on every later turn, and a provider that requires strict
+// pairing then rejects the whole conversation: Anthropic answers "tool_use ids
+// were found without tool_result blocks immediately after", and the session
+// stays unusable until it is deleted.
+//
+// The repair runs on the request rather than the stored events, so recorded
+// history stays intact and a session that is already broken heals on its next
+// turn without a migration. It also sits above the session service, so it
+// applies to every store.
+//
+// Pairing is checked positionally, against the immediately following content,
+// because that is the invariant the provider enforces. A conversation whose
+// calls are all answered is returned unchanged, and any conversation this does
+// change is one the provider would have rejected.
+func pairUnansweredFunctionCalls(contents []*genai.Content, pending map[string]bool) []*genai.Content {
+	paired := make([]*genai.Content, 0, len(contents))
+	for index, content := range contents {
+		paired = append(paired, content)
+
+		calls := utils.FunctionCalls(content)
+		if len(calls) == 0 {
+			continue
+		}
+
+		var following *genai.Content
+		if index+1 < len(contents) {
+			following = contents[index+1]
+		}
+		answered := responseIDs(following)
+		unanswered := unansweredCalls(calls, answered)
+		if len(unanswered) == 0 {
+			continue
+		}
+
+		parts := make([]*genai.Part, 0, len(unanswered))
+		for _, call := range unanswered {
+			parts = append(parts, &genai.Part{
+				FunctionResponse: &genai.FunctionResponse{
+					ID:       call.ID,
+					Name:     call.Name,
+					Response: map[string]any{"result": placeholderFor(call, pending)},
+				},
+			})
+		}
+
+		// Join a turn that already answers this call event, so the results stay
+		// in one message; otherwise the results need a turn of their own,
+		// before whatever currently follows.
+		if len(answered) > 0 {
+			following.Parts = append(following.Parts, parts...)
+			continue
+		}
+		paired = append(paired, &genai.Content{Role: genai.RoleUser, Parts: parts})
+	}
+	return paired
+}
+
+func placeholderFor(call *genai.FunctionCall, pending map[string]bool) string {
+	if call.ID != "" && pending[call.ID] {
+		return pendingFunctionResult
+	}
+	return missingFunctionResult
+}
+
+// unansweredCalls returns the calls that answered does not account for. Ids are
+// consumed one at a time rather than matched through a set, so a turn that
+// carries several calls without an id (Gemini omits them, and ADK strips its
+// own client ids before the request is built) does not have a single response
+// silently answer all of them.
+func unansweredCalls(calls []*genai.FunctionCall, answered []string) []*genai.FunctionCall {
+	remaining := make([]string, len(answered))
+	copy(remaining, answered)
+
+	var unanswered []*genai.FunctionCall
+	for _, call := range calls {
+		matched := false
+		for i, id := range remaining {
+			if id == call.ID {
+				remaining = append(remaining[:i], remaining[i+1:]...)
+				matched = true
+				break
+			}
+		}
+		if !matched {
+			unanswered = append(unanswered, call)
+		}
+	}
+	return unanswered
+}
+
+func responseIDs(content *genai.Content) []string {
+	var ids []string
+	for _, response := range utils.FunctionResponses(content) {
+		ids = append(ids, response.ID)
+	}
+	return ids
+}

--- a/internal/llminternal/tool_pairing.go
+++ b/internal/llminternal/tool_pairing.go
@@ -57,9 +57,10 @@ func pendingCallIDs(events []*session.Event) map[string]bool {
 // between them (a restart, an OOM kill, a disconnect, a cancellation), the
 // session keeps a function call that no function response answers. That
 // history is replayed on every later turn, and a provider that requires strict
-// pairing then rejects the whole conversation: Anthropic answers "tool_use ids
-// were found without tool_result blocks immediately after", and the session
-// stays unusable until it is deleted.
+// pairing then rejects the whole conversation, so the session stays unusable
+// until it is deleted. The OpenAI Responses API rejects a function call item
+// that no function call output answers, and Anthropic answers "tool_use ids
+// were found without tool_result blocks immediately after".
 //
 // The repair runs on the request rather than the stored events, so recorded
 // history stays intact and a session that is already broken heals on its next
@@ -105,7 +106,7 @@ func pairUnansweredFunctionCalls(contents []*genai.Content, pending map[string]b
 		// in one message; otherwise the results need a turn of their own,
 		// before whatever currently follows.
 		if len(answered) > 0 {
-			following.Parts = append(following.Parts, parts...)
+			following.Parts = withResultsInserted(following.Parts, parts)
 			continue
 		}
 		paired = append(paired, &genai.Content{Role: genai.RoleUser, Parts: parts})
@@ -152,4 +153,22 @@ func responseIDs(content *genai.Content) []string {
 		ids = append(ids, response.ID)
 	}
 	return ids
+}
+
+// withResultsInserted returns parts with results added to its leading run of
+// responses. Anthropic requires every tool result to precede any other block in
+// the message that carries it, so a placeholder appended after a trailing text
+// part would be rejected for the same reason the missing result was.
+func withResultsInserted(parts, results []*genai.Part) []*genai.Part {
+	insertIndex := len(parts)
+	for i, part := range parts {
+		if part == nil || part.FunctionResponse == nil {
+			insertIndex = i
+			break
+		}
+	}
+	joined := make([]*genai.Part, 0, len(parts)+len(results))
+	joined = append(joined, parts[:insertIndex]...)
+	joined = append(joined, results...)
+	return append(joined, parts[insertIndex:]...)
 }

--- a/internal/llminternal/tool_pairing.go
+++ b/internal/llminternal/tool_pairing.go
@@ -123,9 +123,8 @@ func placeholderFor(call *genai.FunctionCall, pending map[string]bool) string {
 
 // unansweredCalls returns the calls that answered does not account for. Ids are
 // consumed one at a time rather than matched through a set, so a turn that
-// carries several calls without an id (Gemini omits them, and ADK strips its
-// own client ids before the request is built) does not have a single response
-// silently answer all of them.
+// carries several calls without an id (an event recorded outside the flow may
+// carry none) does not have a single response silently answer all of them.
 func unansweredCalls(calls []*genai.FunctionCall, answered []string) []*genai.FunctionCall {
 	remaining := make([]string, len(answered))
 	copy(remaining, answered)
@@ -155,20 +154,23 @@ func responseIDs(content *genai.Content) []string {
 	return ids
 }
 
-// withResultsInserted returns parts with results added to its leading run of
-// responses. Anthropic requires every tool result to precede any other block in
-// the message that carries it, so a placeholder appended after a trailing text
-// part would be rejected for the same reason the missing result was.
+// withResultsInserted returns parts with every function response, existing and
+// added, ahead of every other part. Anthropic requires every tool result to
+// precede any other block in the message that carries it, so a result left
+// after a text part would be rejected for the same reason the missing result
+// was.
 func withResultsInserted(parts, results []*genai.Part) []*genai.Part {
-	insertIndex := len(parts)
-	for i, part := range parts {
-		if part == nil || part.FunctionResponse == nil {
-			insertIndex = i
-			break
+	joined := make([]*genai.Part, 0, len(parts)+len(results))
+	for _, part := range parts {
+		if part != nil && part.FunctionResponse != nil {
+			joined = append(joined, part)
 		}
 	}
-	joined := make([]*genai.Part, 0, len(parts)+len(results))
-	joined = append(joined, parts[:insertIndex]...)
 	joined = append(joined, results...)
-	return append(joined, parts[insertIndex:]...)
+	for _, part := range parts {
+		if part == nil || part.FunctionResponse == nil {
+			joined = append(joined, part)
+		}
+	}
+	return joined
 }

--- a/internal/llminternal/tool_pairing_test.go
+++ b/internal/llminternal/tool_pairing_test.go
@@ -1,0 +1,278 @@
+// Copyright 2026 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package llminternal_test
+
+import (
+	"testing"
+
+	"github.com/google/go-cmp/cmp"
+	"google.golang.org/genai"
+
+	"google.golang.org/adk/v2/agent/llmagent"
+	icontext "google.golang.org/adk/v2/internal/context"
+	"google.golang.org/adk/v2/internal/llminternal"
+	"google.golang.org/adk/v2/internal/utils"
+	"google.golang.org/adk/v2/model"
+	"google.golang.org/adk/v2/session"
+)
+
+// The placeholders the request processor supplies. Repeated here so a change to
+// the text of either one has to be made deliberately.
+const (
+	missingResult = "No response available for this function call."
+	pendingResult = "This call is awaiting a response and has not completed yet."
+)
+
+func functionCallContent(calls ...*genai.FunctionCall) *genai.Content {
+	parts := make([]*genai.Part, 0, len(calls))
+	for _, call := range calls {
+		parts = append(parts, &genai.Part{FunctionCall: call})
+	}
+	return &genai.Content{Role: genai.RoleModel, Parts: parts}
+}
+
+func functionResponseContent(responses ...*genai.FunctionResponse) *genai.Content {
+	parts := make([]*genai.Part, 0, len(responses))
+	for _, response := range responses {
+		parts = append(parts, &genai.Part{FunctionResponse: response})
+	}
+	return &genai.Content{Role: genai.RoleUser, Parts: parts}
+}
+
+// TestContentsRequestProcessor_PairUnansweredFunctionCalls covers the history a
+// turn that ended between a function call and its result leaves behind. Every
+// call must reach the model with a result in the immediately following content,
+// because that is the pairing a provider such as Anthropic enforces.
+func TestContentsRequestProcessor_PairUnansweredFunctionCalls(t *testing.T) {
+	const agentName = "test_agent"
+
+	fcSearch := &genai.FunctionCall{ID: "call_1", Name: "search_tool", Args: map[string]any{"query": "test"}}
+	fcFetch := &genai.FunctionCall{ID: "call_2", Name: "fetch_tool", Args: map[string]any{"url": "http://example.com"}}
+	frSearch := &genai.FunctionResponse{ID: "call_1", Name: "search_tool", Response: map[string]any{"results": "item1"}}
+
+	fcAsk := &genai.FunctionCall{ID: "lro_call_1", Name: "ask_user", Args: map[string]any{"question": "proceed?"}}
+	frAsk := &genai.FunctionResponse{ID: "lro_call_1", Name: "ask_user", Response: map[string]any{"answer": "yes"}}
+
+	fcNoIDFirst := &genai.FunctionCall{Name: "search_tool", Args: map[string]any{"query": "a"}}
+	fcNoIDSecond := &genai.FunctionCall{Name: "search_tool", Args: map[string]any{"query": "b"}}
+	frNoID := &genai.FunctionResponse{Name: "search_tool", Response: map[string]any{"results": "item1"}}
+
+	userEvent := func(text string) *session.Event {
+		return &session.Event{
+			Author:      "user",
+			LLMResponse: model.LLMResponse{Content: genai.NewContentFromText(text, genai.RoleUser)},
+		}
+	}
+	callEvent := func(longRunningIDs []string, calls ...*genai.FunctionCall) *session.Event {
+		parts := make([]*genai.Part, 0, len(calls))
+		for _, call := range calls {
+			parts = append(parts, &genai.Part{FunctionCall: call})
+		}
+		return &session.Event{
+			Author:             agentName,
+			LongRunningToolIDs: longRunningIDs,
+			LLMResponse:        model.LLMResponse{Content: &genai.Content{Role: genai.RoleModel, Parts: parts}},
+		}
+	}
+	responseEvent := func(responses ...*genai.FunctionResponse) *session.Event {
+		return &session.Event{
+			Author:      "user",
+			LLMResponse: model.LLMResponse{Content: functionResponseContent(responses...)},
+		}
+	}
+
+	testCases := []struct {
+		name   string
+		events []*session.Event
+		want   []*genai.Content
+	}{
+		{
+			name: "interrupted call at the end of the history",
+			events: []*session.Event{
+				userEvent("search for test"),
+				callEvent(nil, fcSearch),
+			},
+			want: []*genai.Content{
+				genai.NewContentFromText("search for test", genai.RoleUser),
+				functionCallContent(fcSearch),
+				functionResponseContent(&genai.FunctionResponse{
+					ID:       "call_1",
+					Name:     "search_tool",
+					Response: map[string]any{"result": missingResult},
+				}),
+			},
+		},
+		{
+			name: "interrupted call in the middle of the history",
+			events: []*session.Event{
+				userEvent("search for test"),
+				callEvent(nil, fcSearch),
+				userEvent("are you still there?"),
+			},
+			want: []*genai.Content{
+				genai.NewContentFromText("search for test", genai.RoleUser),
+				functionCallContent(fcSearch),
+				functionResponseContent(&genai.FunctionResponse{
+					ID:       "call_1",
+					Name:     "search_tool",
+					Response: map[string]any{"result": missingResult},
+				}),
+				genai.NewContentFromText("are you still there?", genai.RoleUser),
+			},
+		},
+		{
+			name: "partially answered turn keeps the results in one content",
+			events: []*session.Event{
+				userEvent("search and fetch"),
+				callEvent(nil, fcSearch, fcFetch),
+				responseEvent(frSearch),
+			},
+			want: []*genai.Content{
+				genai.NewContentFromText("search and fetch", genai.RoleUser),
+				functionCallContent(fcSearch, fcFetch),
+				functionResponseContent(
+					frSearch,
+					&genai.FunctionResponse{
+						ID:       "call_2",
+						Name:     "fetch_tool",
+						Response: map[string]any{"result": missingResult},
+					},
+				),
+			},
+		},
+		{
+			name: "call held open reports that it awaits a response",
+			events: []*session.Event{
+				userEvent("do the thing"),
+				callEvent([]string{"lro_call_1"}, fcAsk),
+			},
+			want: []*genai.Content{
+				genai.NewContentFromText("do the thing", genai.RoleUser),
+				functionCallContent(fcAsk),
+				functionResponseContent(&genai.FunctionResponse{
+					ID:       "lro_call_1",
+					Name:     "ask_user",
+					Response: map[string]any{"result": pendingResult},
+				}),
+			},
+		},
+		{
+			name: "answered call held open keeps its own result",
+			events: []*session.Event{
+				userEvent("do the thing"),
+				callEvent([]string{"lro_call_1"}, fcAsk),
+				responseEvent(frAsk),
+			},
+			want: []*genai.Content{
+				genai.NewContentFromText("do the thing", genai.RoleUser),
+				functionCallContent(fcAsk),
+				functionResponseContent(frAsk),
+			},
+		},
+		{
+			name: "one result does not answer two calls without an id",
+			events: []*session.Event{
+				userEvent("search twice"),
+				callEvent(nil, fcNoIDFirst, fcNoIDSecond),
+				responseEvent(frNoID),
+			},
+			want: []*genai.Content{
+				genai.NewContentFromText("search twice", genai.RoleUser),
+				functionCallContent(fcNoIDFirst, fcNoIDSecond),
+				functionResponseContent(
+					frNoID,
+					&genai.FunctionResponse{
+						Name:     "search_tool",
+						Response: map[string]any{"result": missingResult},
+					},
+				),
+			},
+		},
+		{
+			name: "history whose calls are all answered is left alone",
+			events: []*session.Event{
+				userEvent("search for test"),
+				callEvent(nil, fcSearch),
+				responseEvent(frSearch),
+			},
+			want: []*genai.Content{
+				genai.NewContentFromText("search for test", genai.RoleUser),
+				functionCallContent(fcSearch),
+				functionResponseContent(frSearch),
+			},
+		},
+	}
+
+	for _, tc := range testCases {
+		t.Run(tc.name, func(t *testing.T) {
+			testAgent := utils.Must(llmagent.New(llmagent.Config{
+				Name:  agentName,
+				Model: &testModel{},
+			}))
+			ctx := icontext.NewInvocationContext(t.Context(), icontext.InvocationContextParams{
+				Agent:   testAgent,
+				Session: &fakeSession{events: tc.events},
+			})
+
+			req := &model.LLMRequest{}
+			for _, err := range llminternal.ContentsRequestProcessor(ctx, req, &llminternal.Flow{}) {
+				if err != nil {
+					t.Fatalf("ContentsRequestProcessor failed: %v", err)
+				}
+			}
+
+			if diff := cmp.Diff(tc.want, req.Contents); diff != "" {
+				t.Errorf("Contents mismatch (-want +got):\n%s", diff)
+			}
+			assertCallsAreAnswered(t, req.Contents)
+		})
+	}
+}
+
+// assertCallsAreAnswered checks the invariant the provider enforces: the
+// content that follows a call answers every call it carries.
+func assertCallsAreAnswered(t *testing.T, contents []*genai.Content) {
+	t.Helper()
+	for i, content := range contents {
+		calls := utils.FunctionCalls(content)
+		if len(calls) == 0 {
+			continue
+		}
+		var following *genai.Content
+		if i+1 < len(contents) {
+			following = contents[i+1]
+		}
+		if got, want := len(utils.FunctionResponses(following)), len(calls); got != want {
+			t.Errorf("content %d: got %d results for %d calls, want one each", i, got, want)
+		}
+	}
+}
+
+// TestContentsRequestProcessor_UnpairedHistoryFailsTheCheck guards
+// assertCallsAreAnswered: the same check must reject a history that was never
+// repaired, otherwise it would pass on any input.
+func TestContentsRequestProcessor_UnpairedHistoryFailsTheCheck(t *testing.T) {
+	unpaired := []*genai.Content{
+		genai.NewContentFromText("search for test", genai.RoleUser),
+		genai.NewContentFromFunctionCall("search_tool", map[string]any{"query": "test"}, genai.RoleModel),
+		genai.NewContentFromText("are you still there?", genai.RoleUser),
+	}
+
+	recorder := &testing.T{}
+	assertCallsAreAnswered(recorder, unpaired)
+	if !recorder.Failed() {
+		t.Error("assertCallsAreAnswered accepted a history with an unanswered call")
+	}
+}

--- a/internal/llminternal/tool_pairing_test.go
+++ b/internal/llminternal/tool_pairing_test.go
@@ -153,6 +153,36 @@ func TestContentsRequestProcessor_PairUnansweredFunctionCalls(t *testing.T) {
 			},
 		},
 		{
+			name: "placeholder stays ahead of a trailing text part",
+			events: []*session.Event{
+				userEvent("search and fetch"),
+				callEvent(nil, fcSearch, fcFetch),
+				{
+					Author: "user",
+					LLMResponse: model.LLMResponse{Content: &genai.Content{
+						Role: genai.RoleUser,
+						Parts: []*genai.Part{
+							{FunctionResponse: frSearch},
+							{Text: "and please hurry"},
+						},
+					}},
+				},
+			},
+			want: []*genai.Content{
+				genai.NewContentFromText("search and fetch", genai.RoleUser),
+				functionCallContent(fcSearch, fcFetch),
+				{Role: genai.RoleUser, Parts: []*genai.Part{
+					{FunctionResponse: frSearch},
+					{FunctionResponse: &genai.FunctionResponse{
+						ID:       "call_2",
+						Name:     "fetch_tool",
+						Response: map[string]any{"result": missingResult},
+					}},
+					{Text: "and please hurry"},
+				}},
+			},
+		},
+		{
 			name: "call held open reports that it awaits a response",
 			events: []*session.Event{
 				userEvent("do the thing"),

--- a/internal/llminternal/tool_pairing_test.go
+++ b/internal/llminternal/tool_pairing_test.go
@@ -15,6 +15,7 @@
 package llminternal_test
 
 import (
+	"slices"
 	"testing"
 
 	"github.com/google/go-cmp/cmp"
@@ -66,8 +67,17 @@ func TestContentsRequestProcessor_PairUnansweredFunctionCalls(t *testing.T) {
 	frAsk := &genai.FunctionResponse{ID: "lro_call_1", Name: "ask_user", Response: map[string]any{"answer": "yes"}}
 
 	fcNoIDFirst := &genai.FunctionCall{Name: "search_tool", Args: map[string]any{"query": "a"}}
-	fcNoIDSecond := &genai.FunctionCall{Name: "search_tool", Args: map[string]any{"query": "b"}}
+	fcNoIDSecond := &genai.FunctionCall{Name: "fetch_tool", Args: map[string]any{"url": "http://example.com"}}
 	frNoID := &genai.FunctionResponse{Name: "search_tool", Response: map[string]any{"results": "item1"}}
+
+	// Ids ADK generates for a provider that omits them. They are stripped from
+	// the request, so the contents reaching the model carry an empty id.
+	fcGenSearch := &genai.FunctionCall{ID: "adk-AAAA", Name: "search_tool", Args: map[string]any{"query": "test"}}
+	fcGenFetch := &genai.FunctionCall{ID: "adk-BBBB", Name: "fetch_tool", Args: map[string]any{"url": "http://example.com"}}
+	frGenFetch := &genai.FunctionResponse{ID: "adk-BBBB", Name: "fetch_tool", Response: map[string]any{"body": "<html/>"}}
+	stripped := func(call *genai.FunctionCall) *genai.FunctionCall {
+		return &genai.FunctionCall{Name: call.Name, Args: call.Args}
+	}
 
 	userEvent := func(text string) *session.Event {
 		return &session.Event{
@@ -224,10 +234,74 @@ func TestContentsRequestProcessor_PairUnansweredFunctionCalls(t *testing.T) {
 				functionResponseContent(
 					frNoID,
 					&genai.FunctionResponse{
-						Name:     "search_tool",
+						Name:     "fetch_tool",
 						Response: map[string]any{"result": missingResult},
 					},
 				),
+			},
+		},
+		{
+			name: "call held open under a generated id reports that it awaits a response",
+			events: []*session.Event{
+				userEvent("search for test"),
+				callEvent([]string{"adk-AAAA"}, fcGenSearch),
+			},
+			want: []*genai.Content{
+				genai.NewContentFromText("search for test", genai.RoleUser),
+				functionCallContent(stripped(fcGenSearch)),
+				functionResponseContent(&genai.FunctionResponse{
+					Name:     "search_tool",
+					Response: map[string]any{"result": pendingResult},
+				}),
+			},
+		},
+		{
+			name: "call held open under a generated id next to an answered call",
+			events: []*session.Event{
+				userEvent("do both"),
+				callEvent([]string{"adk-AAAA"}, fcGenSearch, fcGenFetch),
+				responseEvent(frGenFetch),
+			},
+			want: []*genai.Content{
+				genai.NewContentFromText("do both", genai.RoleUser),
+				functionCallContent(stripped(fcGenSearch), stripped(fcGenFetch)),
+				functionResponseContent(
+					&genai.FunctionResponse{Name: "fetch_tool", Response: frGenFetch.Response},
+					&genai.FunctionResponse{
+						Name:     "search_tool",
+						Response: map[string]any{"result": pendingResult},
+					},
+				),
+			},
+		},
+		{
+			name: "results are hoisted ahead of a leading text part",
+			events: []*session.Event{
+				userEvent("search and fetch"),
+				callEvent(nil, fcSearch, fcFetch),
+				{
+					Author: "user",
+					LLMResponse: model.LLMResponse{Content: &genai.Content{
+						Role: genai.RoleUser,
+						Parts: []*genai.Part{
+							{Text: "here is what I found"},
+							{FunctionResponse: frSearch},
+						},
+					}},
+				},
+			},
+			want: []*genai.Content{
+				genai.NewContentFromText("search and fetch", genai.RoleUser),
+				functionCallContent(fcSearch, fcFetch),
+				{Role: genai.RoleUser, Parts: []*genai.Part{
+					{FunctionResponse: frSearch},
+					{FunctionResponse: &genai.FunctionResponse{
+						ID:       "call_2",
+						Name:     "fetch_tool",
+						Response: map[string]any{"result": missingResult},
+					}},
+					{Text: "here is what I found"},
+				}},
 			},
 		},
 		{
@@ -272,7 +346,9 @@ func TestContentsRequestProcessor_PairUnansweredFunctionCalls(t *testing.T) {
 }
 
 // assertCallsAreAnswered checks the invariant the provider enforces: the
-// content that follows a call answers every call it carries.
+// content that follows a call answers every call it carries, once. A call is
+// matched to a response by id, or by name when the id is empty, and each
+// response answers a single call.
 func assertCallsAreAnswered(t *testing.T, contents []*genai.Content) {
 	t.Helper()
 	for i, content := range contents {
@@ -284,8 +360,22 @@ func assertCallsAreAnswered(t *testing.T, contents []*genai.Content) {
 		if i+1 < len(contents) {
 			following = contents[i+1]
 		}
-		if got, want := len(utils.FunctionResponses(following)), len(calls); got != want {
-			t.Errorf("content %d: got %d results for %d calls, want one each", i, got, want)
+		remaining := utils.FunctionResponses(following)
+		for _, call := range calls {
+			matched := slices.IndexFunc(remaining, func(response *genai.FunctionResponse) bool {
+				if call.ID != "" {
+					return response.ID == call.ID
+				}
+				return response.ID == "" && response.Name == call.Name
+			})
+			if matched < 0 {
+				t.Errorf("content %d: call %s (id %q) has no result in the following content", i, call.Name, call.ID)
+				continue
+			}
+			remaining = slices.Delete(remaining, matched, matched+1)
+		}
+		for _, response := range remaining {
+			t.Errorf("content %d: result for %s (id %q) answers no call", i+1, response.Name, response.ID)
 		}
 	}
 }
@@ -304,5 +394,21 @@ func TestContentsRequestProcessor_UnpairedHistoryFailsTheCheck(t *testing.T) {
 	assertCallsAreAnswered(recorder, unpaired)
 	if !recorder.Failed() {
 		t.Error("assertCallsAreAnswered accepted a history with an unanswered call")
+	}
+
+	fetch := &genai.FunctionResponse{Name: "fetch_tool", Response: map[string]any{"body": "<html/>"}}
+	doubled := []*genai.Content{
+		genai.NewContentFromText("do both", genai.RoleUser),
+		functionCallContent(
+			&genai.FunctionCall{Name: "search_tool", Args: map[string]any{"query": "test"}},
+			&genai.FunctionCall{Name: "fetch_tool", Args: map[string]any{"url": "http://example.com"}},
+		),
+		functionResponseContent(fetch, fetch),
+	}
+
+	recorder = &testing.T{}
+	assertCallsAreAnswered(recorder, doubled)
+	if !recorder.Failed() {
+		t.Error("assertCallsAreAnswered accepted two results for one call and none for the other")
 	}
 }


### PR DESCRIPTION
## Problem

A function call and its result are two separate session events. When a turn ends between them (a restart, an OOM kill, a client disconnect, a cancellation), the session keeps a function call that no function response answers.

That history is replayed on every later turn, so the session does not recover on its own, and a provider that requires strict pairing rejects the whole conversation. The OpenAI Responses path in this repo sends the dangling call as a `function_call` item with no `function_call_output`, which the API rejects. Anthropic, used through a custom model, answers `tool_use ids were found without tool_result blocks immediately after`. Either way the session stays unusable until it is deleted.

No issue exists for the Go side. The same failure is reported against adk-python in google/adk-python#5856, #3971 and #6582.

## Change

Pair every function call with a result while the request contents are assembled, in `buildContentsDefault`. A call the immediately following content does not answer gets a placeholder result there.

- The stored events are untouched, so recorded history stays intact and a session that is already broken heals on its next turn with no migration.
- It sits above the session service, so one implementation covers every store and every provider.
- Ids are read after the conversion, so a call whose client id was stripped is answered by a response with the same stripped id.
- Pairing is checked positionally, against the immediately following content, because that is the invariant the provider enforces.
- On a turn that is already partly answered, the placeholder joins the leading run of responses. Anthropic requires the results to precede any other block in the message, so appending after a trailing text part would be rejected for the same reason the missing result was.

A call the framework holds open (a long-running tool, an approval, a request for user input) is described as awaiting a response, not as having returned nothing. The difference changes what the model does next: told a tool returned nothing, it reissues the call or proceeds without it; told the call is still awaiting a response, it can wait. Those ids come from `LongRunningToolIDs`, which lives on the event and does not survive the conversion to contents.

A conversation whose calls are all answered is returned unchanged.

The mirror change for adk-python is google/adk-python#6914.

## Testing plan

- `go test ./... -count=1` — 158 packages, all pass.
- `go build ./...`, `go vet ./internal/llminternal/`, `gofmt -l`.

`internal/llminternal/tool_pairing_test.go` drives the request processor over eight histories: the interrupted turn at the end of the history and in the middle, the partially answered parallel turn, the same turn with a trailing text part, the call held open in both directions, calls without an id, and a healthy history that must come back unchanged. Each case also asserts the provider invariant, that the content after a call answers every call it carries; a guard test asserts the same check rejects unrepaired input.

Two `TestContentsRequestProcessor_IncludeContents/agentTransfer` fixtures end on an unanswered call. They now expect the placeholder result instead of the synthetic continuation turn.


The placeholder content is user-role, so a history that previously ended on a model turn carrying an unanswered call now ends on a user turn. The synthetic "Continue processing previous requests..." user content is therefore no longer appended in that case; the two agentTransfer fixtures in `contents_processor_test.go` record this.
