### PR TITLE
fix(session): strip temp: keys from the canonical in-memory record

### DIFF
--- a/session/inmemory.go
+++ b/session/inmemory.go
@@ -223,6 +223,11 @@ func (s *inMemoryService) AppendEvent(ctx context.Context, curSession Session, e
 		return fmt.Errorf("fail to set state on appendEvent: %w", err)
 	}
 
+	// temp: keys are discarded once the event is persisted. sess.appendEvent
+	// trims them on the caller's copy of the session only, so trim again here
+	// instead of cloning the original, untrimmed delta into the canonical record.
+	processedEvent := trimTempDeltaState(event)
+
 	eventCopy := &Event{
 		ID:             event.ID,
 		InvocationID:   event.InvocationID,
@@ -231,7 +236,7 @@ func (s *inMemoryService) AppendEvent(ctx context.Context, curSession Session, e
 		Branch:         event.Branch,
 		IsolationScope: event.IsolationScope,
 		Actions: EventActions{
-			StateDelta:                 maps.Clone(event.Actions.StateDelta),
+			StateDelta:                 maps.Clone(processedEvent.Actions.StateDelta),
 			ArtifactDelta:              maps.Clone(event.Actions.ArtifactDelta),
 			RequestedToolConfirmations: maps.Clone(event.Actions.RequestedToolConfirmations),
 			TransferToAgent:            event.Actions.TransferToAgent,

--- a/session/inmemory_test.go
+++ b/session/inmemory_test.go
@@ -184,6 +184,60 @@ func TestInMemorySession_AppendEvent_Deadlock(t *testing.T) {
 	t.Log("AppendEvent did not deadlock")
 }
 
+func TestInMemoryService_AppendEvent_StripsTempStateFromCanonicalRecord(t *testing.T) {
+	ctx := t.Context()
+	service := session.InMemoryService()
+
+	createResp, err := service.Create(ctx, &session.CreateRequest{
+		AppName: "testapp",
+		UserID:  "testuser",
+	})
+	if err != nil {
+		t.Fatalf("Failed to create session: %v", err)
+	}
+
+	event := &session.Event{
+		ID:        "event1",
+		Timestamp: time.Now(),
+		Actions: session.EventActions{
+			StateDelta: map[string]any{
+				"temp:scratch":   "ephemeral",
+				"persistent_key": "keep",
+			},
+		},
+	}
+
+	if err := service.AppendEvent(ctx, createResp.Session, event); err != nil {
+		t.Fatalf("AppendEvent failed: %v", err)
+	}
+
+	// Read the session back from the service. Create and Get never hand out a
+	// pointer to the canonical record, so this is the only way to see what was
+	// actually stored.
+	getResp, err := service.Get(ctx, &session.GetRequest{
+		AppName:   "testapp",
+		UserID:    "testuser",
+		SessionID: createResp.Session.ID(),
+	})
+	if err != nil {
+		t.Fatalf("Get failed: %v", err)
+	}
+
+	var storedEvent *session.Event
+	for ev := range getResp.Session.Events().All() {
+		storedEvent = ev
+	}
+	if storedEvent == nil {
+		t.Fatalf("expected an event on the session returned by Get, got none")
+	}
+	if _, exists := storedEvent.Actions.StateDelta["temp:scratch"]; exists {
+		t.Errorf("expected temp:scratch to be stripped from the stored event, got: %v", storedEvent.Actions.StateDelta)
+	}
+	if storedEvent.Actions.StateDelta["persistent_key"] != "keep" {
+		t.Errorf("expected persistent_key on the stored event, got: %v", storedEvent.Actions.StateDelta)
+	}
+}
+
 func TestInMemoryService_AppendEvent_PreservesInputEventTempState(t *testing.T) {
 	ctx := t.Context()
 	service := session.InMemoryService()


### PR DESCRIPTION
### Link to Issue or Description of Change

**1. Link to an existing issue (if applicable):**

- Closes: #1354

**Problem:**

`inMemoryService.AppendEvent` computed the temp-stripped `StateDelta` twice, and only one of the two results reached the canonical session record.

`sess.appendEvent(event)` calls `trimTempDeltaState`, but that result lands on the caller's copy of the session only, because `Create()` and `Get()` never hand callers a pointer to the canonical record. Separately, the stored record built its own `eventCopy` with `maps.Clone(event.Actions.StateDelta)`, cloned from the original, untrimmed event.

Until v1.6.0 this was masked by an aliasing side effect: `trimTempDeltaState` mutated the shared `event` in place, so by the time the clone ran the map was already clean. #1128 correctly stopped that mutation and returned a copy instead, which is right in isolation but broke the clone's implicit reliance on it.

The result is that `temp:`-prefixed keys survive into `Get()` and `ListEvents()`, against the documented contract on `KeyPrefixTemp` that they are discarded after the invocation completes. Confirmed clean on v1.5.1 and leaking on v1.6.0.

Session, app and user state are not affected: `sessionutils.ExtractStateDeltas` already drops `temp:` keys, so the leak is limited to the stored event.

**Solution:**

Call `trimTempDeltaState` once in `AppendEvent` and clone the canonical record's `StateDelta` from that result, which is the fix suggested in the issue. It keeps the no-mutation guarantee from #1128 and restores the pre-v1.6.0 behaviour of the stored event.

### Testing Plan

**Unit Tests:**

- [x] I have added or updated unit tests for my change.
- [x] All unit tests pass locally.

Added `TestInMemoryService_AppendEvent_StripsTempStateFromCanonicalRecord`. It appends an event carrying `temp:scratch` and `persistent_key`, reads the session back through `service.Get` rather than reusing the caller's copy, and asserts only `persistent_key` survives. Reading through `Get` is the point: the existing `TestInMemoryService_AppendEvent_PreservesInputEventTempState` checks the caller's copy, which was already correct, so it did not catch this.

The new test fails on `main` and passes with this change:

```
$ git stash -- session/inmemory.go && go test ./session/ -run 'StripsTempState' -count=1
--- FAIL: TestInMemoryService_AppendEvent_StripsTempStateFromCanonicalRecord (0.00s)
    inmemory_test.go:234: expected temp:scratch to be stripped from the stored event, got: map[persistent_key:keep temp:scratch:ephemeral]
FAIL
FAIL	google.golang.org/adk/v2/session	0.416s

$ git stash pop && go test ./session/... -count=1
ok  	google.golang.org/adk/v2/session	0.458s
ok  	google.golang.org/adk/v2/session/database	0.475s
?   	google.golang.org/adk/v2/session/sessiontestsuite	[no test files]
ok  	google.golang.org/adk/v2/session/vertexai	2.111s
```

`go vet ./session/` is clean.

**Manual End-to-End (E2E) Tests:**

The reproduction program in #1354 is the E2E check. Against this branch it prints:

```
StateDelta after Get(): map[string]interface {}{"persistent_key":"keep"}
```

which matches v1.5.1. On `main` it prints the leaked `temp:scratch` key as well.

### Checklist

- [x] I have read the [CONTRIBUTING.md](./CONTRIBUTING.md) document.
- [x] I have performed a self-review of my own code.
- [x] I have commented my code, particularly in hard-to-understand areas.
- [x] I have added tests that prove my fix is effective or that my feature works.
- [x] New and existing unit tests pass locally with my changes.
- [x] I have manually tested my changes end-to-end.
- [x] Any dependent changes have been merged and published in downstream modules.

### Additional context

The change is three lines plus a comment. It deliberately calls `trimTempDeltaState` a second time rather than threading the trimmed event out of `sess.appendEvent`, to keep the change small and leave that method's signature alone. Happy to do it the other way if you prefer.
