### PR TITLE
fix(agentengine): base64-encode byte slices in ConvertSnake

### DIFF
--- a/server/agentengine/internal/helper/encode.go
+++ b/server/agentengine/internal/helper/encode.go
@@ -15,6 +15,7 @@
 package helper
 
 import (
+	"encoding/base64"
 	"fmt"
 	"log"
 	"reflect"
@@ -120,6 +121,14 @@ func convertSnake(path, indent string, o any) (any, error) {
 		}
 		return m, nil
 	case reflect.Slice:
+		// A byte slice is a byte string, not a list of numbers. encoding/json
+		// base64-encodes it and the JSON convention follows. Converting element by
+		// element would send every byte through this type switch and fail on
+		// reflect.Uint8, which fails the whole containing struct. genai.Part's
+		// ThoughtSignature is the field that hits this in practice.
+		if v.Type().Elem().Kind() == reflect.Uint8 {
+			return base64.StdEncoding.EncodeToString(v.Bytes()), nil
+		}
 		res := []any{}
 		for i := 0; i < v.Len(); i++ {
 			elem, err := convertSnake(path+".[]", indent+"    ", v.Index(i).Interface())

--- a/server/agentengine/internal/helper/encode_test.go
+++ b/server/agentengine/internal/helper/encode_test.go
@@ -15,6 +15,7 @@
 package helper
 
 import (
+	"encoding/base64"
 	"testing"
 
 	"github.com/google/go-cmp/cmp"
@@ -249,5 +250,88 @@ func TestOmitEmpty(t *testing.T) {
 			t.Errorf("convertSnake() = %v, want %v, diff: \n%v", got, tc.want, diff)
 		}
 
+	}
+}
+
+func TestByteSlice(t *testing.T) {
+	type withBytes struct {
+		Signature []byte `json:"signature,omitempty"`
+		Name      string `json:"name,omitempty"`
+	}
+
+	tests := []struct {
+		name  string
+		input withBytes
+		want  map[string]any
+	}{
+		{
+			name:  "non-empty byte slice is base64 encoded",
+			input: withBytes{Signature: []byte{0x01, 0x02, 0x03}, Name: "a"},
+			want:  map[string]any{"signature": "AQID", "name": "a"},
+		},
+		{
+			name:  "empty byte slice is dropped by omitempty",
+			input: withBytes{Signature: []byte{}, Name: "a"},
+			want:  map[string]any{"name": "a"},
+		},
+		{
+			name:  "nil byte slice is dropped by omitempty",
+			input: withBytes{Name: "a"},
+			want:  map[string]any{"name": "a"},
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got, err := convertSnake("", "", tt.input)
+			if err != nil {
+				t.Fatalf("convertSnake() failed: %v", err)
+			}
+			if diff := cmp.Diff(tt.want, got); diff != "" {
+				t.Errorf("convertSnake() mismatch (-want +got):\n%s", diff)
+			}
+		})
+	}
+}
+
+func TestThoughtSignature(t *testing.T) {
+	// A thought signature is what thinking models put on a part in practice, and
+	// before byte slices were handled it failed conversion of the whole event.
+	signature := []byte("thought-signature-bytes")
+	event := session.Event{
+		ID: "1",
+		LLMResponse: model.LLMResponse{
+			Content: &genai.Content{
+				Role: "model",
+				Parts: []*genai.Part{
+					{Text: "hello", ThoughtSignature: signature},
+				},
+			},
+		},
+	}
+
+	got, err := convertSnake("", "", event)
+	if err != nil {
+		t.Fatalf("convertSnake() failed: %v", err)
+	}
+
+	m, ok := got.(map[string]any)
+	if !ok {
+		t.Fatalf("convertSnake() returned %T, want map[string]any", got)
+	}
+	content, ok := m["content"].(map[string]any)
+	if !ok {
+		t.Fatalf("content is %T, want map[string]any", m["content"])
+	}
+	parts, ok := content["parts"].([]any)
+	if !ok || len(parts) != 1 {
+		t.Fatalf("parts is %#v, want a slice of one element", content["parts"])
+	}
+	part, ok := parts[0].(map[string]any)
+	if !ok {
+		t.Fatalf("parts[0] is %T, want map[string]any", parts[0])
+	}
+	want := base64.StdEncoding.EncodeToString(signature)
+	if part["thought_signature"] != want {
+		t.Errorf("thought_signature = %v, want %v", part["thought_signature"], want)
 	}
 }


### PR DESCRIPTION
### Link to Issue or Description of Change

**1. Link to an existing issue (if applicable):**

- Closes: #1386

**Problem:**

`convertSnake` has no case for `reflect.Uint8`, and for slices it converts each element individually. Every byte in a `[]byte` therefore reaches the `default` branch and returns `unsupported type: uint8`, which fails conversion of the whole containing struct.

`ConvertSnake` logs that error and returns the original, unconverted Go value, so the affected event is serialized with Go's native struct json tags (camelCase, `LLMResponse`-shaped) inside a stream of otherwise correctly converted snake_case events.

`genai.Part.ThoughtSignature` is the field that hits this in practice, and thinking models populate it routinely. On the `async_stream_query` path the whole event batch is wrapped in one `StreamingAgentRunWithEventsResponse`, so a single thought signature anywhere in the batch breaks conversion of the entire response object rather than one event.

**Solution:**

Treat a byte slice as a byte string rather than a list of numbers and base64-encode it, which is what `encoding/json` already does and what the JSON convention for byte strings is. The check is on the element kind, so named byte-slice types are covered too, and it sits before the element loop so no byte reaches the type switch.

`thoughtSignature` now converts to `"thought_signature": "<base64>"` and the containing event converts to snake_case like every other event.

### Testing Plan

**Unit Tests:**

- [x] I have added or updated unit tests for my change.
- [x] All unit tests pass locally.

Two tests added to `encode_test.go`:

- `TestByteSlice` covers a non-empty byte slice (base64), an empty one and a nil one (both dropped by `omitempty`, matching `encoding/json`).
- `TestThoughtSignature` builds a `session.Event` carrying a `genai.Part` with a `ThoughtSignature` and checks the converted event, which is the shape that actually breaks in production.

Both fail on `main` with the error from the issue:

```
$ git stash -- server/agentengine/internal/helper/encode.go
$ go test ./server/agentengine/internal/helper/ -run 'ByteSlice|ThoughtSignature' -count=1
--- FAIL: TestByteSlice/non-empty_byte_slice_is_base64_encoded
    encode_test.go:287: convertSnake() failed: failed to convert regular struct field with path: .signature err: failed to convert slice element with path: .signature.[] err: unsupported type: uint8
--- FAIL: TestThoughtSignature
    encode_test.go:314: convertSnake() failed: ... err: failed to convert slice element with path: .LLMResponse.content*.parts.[]*.thoughtSignature.[] err: unsupported type: uint8
FAIL
```

and pass with the change:

```
$ go test ./server/agentengine/... -count=1
?   	google.golang.org/adk/v2/server/agentengine	[no test files]
?   	google.golang.org/adk/v2/server/agentengine/controllers	[no test files]
ok  	google.golang.org/adk/v2/server/agentengine/controllers/method	0.441s
ok  	google.golang.org/adk/v2/server/agentengine/internal/helper	0.678s
?   	google.golang.org/adk/v2/server/agentengine/internal/models	[no test files]
?   	google.golang.org/adk/v2/server/agentengine/internal/routers	[no test files]
```

`go vet ./server/agentengine/...` is clean.

**Manual End-to-End (E2E) Tests:**

`helper` is an `internal` package, so the isolated reproduction has to live inside the module, which is what `TestThoughtSignature` does: it goes through the real `session.Event` and `genai.Part` types rather than a stand-in struct. On `main` that event falls back to the unconverted value and the payload comes out camelCase; on this branch it converts to snake_case with `"thought_signature"` holding the base64 string.

### Checklist

- [x] I have read the [CONTRIBUTING.md](./CONTRIBUTING.md) document.
- [x] I have performed a self-review of my own code.
- [x] I have commented my code, particularly in hard-to-understand areas.
- [x] I have added tests that prove my fix is effective or that my feature works.
- [x] New and existing unit tests pass locally with my changes.
- [x] I have manually tested my changes end-to-end.
- [x] Any dependent changes have been merged and published in downstream modules.

### Additional context

The same missing branch means any unsigned integer field, such as a plain `uint64`, still returns `unsupported type` and falls back the same way. I have kept this PR to the byte-slice case reported in #1386 rather than widening it. Happy to raise a separate issue and PR for the unsigned integer kinds if you want that closed too.
