### PR TITLE
fix(agentengine/helper): handle []byte fields in ConvertSnake

### DIFF
--- a/server/agentengine/internal/helper/encode.go
+++ b/server/agentengine/internal/helper/encode.go
@@ -15,6 +15,7 @@
 package helper
 
 import (
+	"encoding/base64"
 	"fmt"
 	"log"
 	"reflect"
@@ -120,6 +121,15 @@ func convertSnake(path, indent string, o any) (any, error) {
 		}
 		return m, nil
 	case reflect.Slice:
+		// A byte slice ([]byte) is a single logical value (e.g. a base64-encoded
+		// blob such as genai.Part.ThoughtSignature), not a list of elements to
+		// recurse into. Without this, each uint8 element hits the default case and
+		// fails conversion with "unsupported type: uint8", which makes the whole
+		// enclosing struct fall back to its raw Go form. Match encoding/json by
+		// emitting a base64-encoded string.
+		if v.Type().Elem().Kind() == reflect.Uint8 {
+			return base64.StdEncoding.EncodeToString(v.Bytes()), nil
+		}
 		res := []any{}
 		for i := 0; i < v.Len(); i++ {
 			elem, err := convertSnake(path+".[]", indent+"    ", v.Index(i).Interface())

--- a/server/agentengine/internal/helper/encode_test.go
+++ b/server/agentengine/internal/helper/encode_test.go
@@ -163,6 +163,24 @@ func TestEventLogProbs(t *testing.T) {
 	}
 }
 
+func TestConvertSnakeByteSlice(t *testing.T) {
+	// Regression test for https://github.com/google/adk-go/issues/1386:
+	// []byte fields (e.g. genai.Part.ThoughtSignature) previously failed
+	// conversion with "unsupported type: uint8", causing the whole enclosing
+	// struct to fall back to its raw Go form instead of snake_case JSON.
+	type payload struct {
+		Data []byte `json:"data"`
+	}
+	got, err := convertSnake("", "", payload{Data: []byte{0x01, 0x02, 0x03}})
+	if err != nil {
+		t.Fatalf("convertSnake() failed: %v", err)
+	}
+	want := map[string]any{"data": "AQID"}
+	if diff := cmp.Diff(got, want); diff != "" {
+		t.Errorf("convertSnake() mismatch (-want +got):\n%s", diff)
+	}
+}
+
 func TestEmbedded(t *testing.T) {
 	type A struct {
 		anInteger int


### PR DESCRIPTION
ConvertSnake failed to convert []byte struct fields (e.g. genai.Part.ThoughtSignature) because the reflect.Slice branch iterated each uint8 element and hit the default "unsupported type: uint8" case. This made the whole enclosing struct fall back to its raw Go form, breaking Agent Engine event JSON (snake_case) for thinking models.

Treat byte slices as a single base64-encoded string, matching encoding/json.Marshal behavior. No schema or consumer changes needed.

Fixes #1386

**Please ensure you have read the [contribution guide](./CONTRIBUTING.md) before creating a pull request.**

### Link to Issue or Description of Change

**1. Link to an existing issue (if applicable):**

- Closes: #_issue_number_
- Related: #_issue_number_

**2. Or, if no issue exists, describe the change:**

_If applicable, please follow the issue templates to provide as much detail as
possible._

**Problem:**
_A clear and concise description of what the problem is._

**Solution:**
_A clear and concise description of what you want to happen and why you choose
this solution._

### Testing Plan

_Please describe the tests that you ran to verify your changes. This is required
for all PRs that are not small documentation or typo fixes._

**Unit Tests:**

- [ ] I have added or updated unit tests for my change.
- [ ] All unit tests pass locally.

_Please include a summary of passed go test results._

**Manual End-to-End (E2E) Tests:**

_Please provide instructions on how to manually test your changes, including any
necessary setup or configuration. Please provide logs or screenshots to help
reviewers better understand the fix._

### Checklist

- [ ] I have read the [CONTRIBUTING.md](./CONTRIBUTING.md) document.
- [ ] I have performed a self-review of my own code.
- [ ] I have commented my code, particularly in hard-to-understand areas.
- [ ] I have added tests that prove my fix is effective or that my feature works.
- [ ] New and existing unit tests pass locally with my changes.
- [ ] I have manually tested my changes end-to-end.
- [ ] Any dependent changes have been merged and published in downstream modules.

### Additional context

_Add any other context or screenshots about the feature request here._

