### PR TITLE
feat(runner): bound model calls per invocation with RunConfig.MaxLLMCalls

### DIFF
--- a/agent/run_config.go
+++ b/agent/run_config.go
@@ -14,6 +14,12 @@
 
 package agent
 
+import "errors"
+
+// ErrLLMCallsLimitExceeded is returned when an invocation makes more model
+// calls than RunConfig.MaxLLMCalls allows. Detect it with errors.Is.
+var ErrLLMCallsLimitExceeded = errors.New("max number of llm calls exceeded")
+
 // StreamingMode defines the streaming mode for agent execution.
 type StreamingMode string
 
@@ -32,4 +38,18 @@ type RunConfig struct {
 	// If true, ADK runner will save each part of the user input that is a blob
 	// (e.g., images, files) as an artifact.
 	SaveInputBlobsAsArtifacts bool
+	// MaxLLMCalls bounds the total number of model calls one invocation may
+	// make, across every agent it runs. Exceeding it ends the run with an error
+	// wrapping ErrLLMCallsLimitExceeded.
+	//
+	// Zero, the value a caller gets from agent.RunConfig{}, means the default:
+	// 500, or the value of the ADK_MAX_LLM_CALLS environment variable if it is
+	// set to a valid integer. A negative value means no limit.
+	//
+	// The limit exists because whether a run terminates otherwise depends
+	// entirely on model behaviour: a model that keeps requesting tool calls
+	// appends an event per turn and re-sends a growing history, so token cost
+	// grows quadratically with no exit. Mirrors adk-python's
+	// RunConfig.max_llm_calls.
+	MaxLLMCalls int
 }

--- a/internal/agent/runconfig/limits.go
+++ b/internal/agent/runconfig/limits.go
@@ -1,0 +1,73 @@
+// Copyright 2026 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package runconfig
+
+import (
+	"fmt"
+	"log"
+	"os"
+	"strconv"
+
+	"google.golang.org/adk/v2/agent"
+)
+
+const (
+	// DefaultMaxLLMCalls is the model-call budget an invocation gets when the
+	// caller does not choose one. Matches adk-python's default.
+	DefaultMaxLLMCalls = 500
+
+	// MaxLLMCallsEnvVar overrides DefaultMaxLLMCalls. Matches adk-python.
+	MaxLLMCallsEnvVar = "ADK_MAX_LLM_CALLS"
+)
+
+// ResolveMaxLLMCalls turns the value a caller set on a public run config into
+// the limit to enforce.
+//
+// A positive value is used as given. A negative value means no limit and is
+// passed through. Zero, which is what a caller gets from an empty struct
+// literal, resolves to the environment override if it parses, and to
+// DefaultMaxLLMCalls otherwise.
+func ResolveMaxLLMCalls(v int) int {
+	if v != 0 {
+		return v
+	}
+	raw, ok := os.LookupEnv(MaxLLMCallsEnvVar)
+	if !ok {
+		return DefaultMaxLLMCalls
+	}
+	n, err := strconv.Atoi(raw)
+	if err != nil {
+		log.Printf("adk: invalid %s value %q, using the default %d", MaxLLMCallsEnvVar, raw, DefaultMaxLLMCalls)
+		return DefaultMaxLLMCalls
+	}
+	return n
+}
+
+// IncrementAndEnforceLLMCallsLimit counts one model call against the
+// invocation's budget and reports whether the budget is now exceeded.
+//
+// It counts first and then checks, so a limit of n permits exactly n calls. A
+// nil receiver, which happens when an agent is run directly rather than through
+// the runner, imposes no limit, and so does a non-positive limit.
+func (c *RunConfig) IncrementAndEnforceLLMCallsLimit() error {
+	if c == nil {
+		return nil
+	}
+	calls := c.llmCalls.Add(1)
+	if c.MaxLLMCalls <= 0 || calls <= int64(c.MaxLLMCalls) {
+		return nil
+	}
+	return fmt.Errorf("%w: limit is %d", agent.ErrLLMCallsLimitExceeded, c.MaxLLMCalls)
+}

--- a/internal/agent/runconfig/limits_test.go
+++ b/internal/agent/runconfig/limits_test.go
@@ -1,0 +1,110 @@
+// Copyright 2026 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package runconfig
+
+import (
+	"errors"
+	"sync"
+	"testing"
+
+	"google.golang.org/adk/v2/agent"
+)
+
+func TestResolveMaxLLMCalls(t *testing.T) {
+	tests := []struct {
+		name  string
+		in    int
+		env   string
+		setEn bool
+		want  int
+	}{
+		{name: "zero takes the default", in: 0, want: DefaultMaxLLMCalls},
+		{name: "zero takes the environment override", in: 0, env: "7", setEn: true, want: 7},
+		{name: "zero ignores an unparsable override", in: 0, env: "lots", setEn: true, want: DefaultMaxLLMCalls},
+		{name: "zero honours a negative override", in: 0, env: "-1", setEn: true, want: -1},
+		{name: "an explicit value wins over the environment", in: 5, env: "7", setEn: true, want: 5},
+		{name: "a negative value is passed through", in: -1, want: -1},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			if tt.setEn {
+				t.Setenv(MaxLLMCallsEnvVar, tt.env)
+			}
+			if got := ResolveMaxLLMCalls(tt.in); got != tt.want {
+				t.Errorf("ResolveMaxLLMCalls(%d) = %d, want %d", tt.in, got, tt.want)
+			}
+		})
+	}
+}
+
+func TestIncrementAndEnforceLLMCallsLimit(t *testing.T) {
+	t.Run("a limit of n permits exactly n calls", func(t *testing.T) {
+		c := &RunConfig{MaxLLMCalls: 2}
+		for i := 1; i <= 2; i++ {
+			if err := c.IncrementAndEnforceLLMCallsLimit(); err != nil {
+				t.Fatalf("call %d returned %v, want nil", i, err)
+			}
+		}
+		err := c.IncrementAndEnforceLLMCallsLimit()
+		if !errors.Is(err, agent.ErrLLMCallsLimitExceeded) {
+			t.Errorf("call 3 returned %v, want it to wrap ErrLLMCallsLimitExceeded", err)
+		}
+	})
+
+	t.Run("non-positive limits do not bound", func(t *testing.T) {
+		for _, limit := range []int{0, -1} {
+			c := &RunConfig{MaxLLMCalls: limit}
+			for i := 0; i < 100; i++ {
+				if err := c.IncrementAndEnforceLLMCallsLimit(); err != nil {
+					t.Fatalf("limit %d bounded the run at call %d: %v", limit, i, err)
+				}
+			}
+		}
+	})
+
+	t.Run("a nil run config does not bound", func(t *testing.T) {
+		var c *RunConfig
+		if err := c.IncrementAndEnforceLLMCallsLimit(); err != nil {
+			t.Errorf("nil receiver returned %v, want nil", err)
+		}
+	})
+
+	t.Run("the counter is shared across concurrent agents", func(t *testing.T) {
+		// Sub-agents in one invocation share the run config, so the budget is
+		// for the invocation rather than for each agent.
+		const limit = 50
+		c := &RunConfig{MaxLLMCalls: limit}
+
+		var wg sync.WaitGroup
+		var mu sync.Mutex
+		allowed := 0
+		for i := 0; i < limit*2; i++ {
+			wg.Add(1)
+			go func() {
+				defer wg.Done()
+				if err := c.IncrementAndEnforceLLMCallsLimit(); err == nil {
+					mu.Lock()
+					allowed++
+					mu.Unlock()
+				}
+			}()
+		}
+		wg.Wait()
+
+		if allowed != limit {
+			t.Errorf("allowed %d calls, want %d", allowed, limit)
+		}
+	})
+}

--- a/internal/agent/runconfig/run_config.go
+++ b/internal/agent/runconfig/run_config.go
@@ -16,6 +16,7 @@ package runconfig
 
 import (
 	"context"
+	"sync/atomic"
 
 	"google.golang.org/adk/v2/agent"
 )
@@ -28,9 +29,22 @@ const (
 	StreamingModeBidi StreamingMode = "bidi"
 )
 
+// RunConfig carries the per-invocation runtime settings that the flow needs but
+// that are not part of any single agent's configuration. It is stored on the Go
+// context by the runner and must be used by pointer: it holds the invocation's
+// model-call counter.
 type RunConfig struct {
 	StreamingMode StreamingMode
 	Live          *agent.LiveRunConfig
+
+	// MaxLLMCalls is the resolved model-call budget for this invocation. See
+	// ResolveMaxLLMCalls. Non-positive means no limit.
+	MaxLLMCalls int
+
+	// llmCalls counts model calls made during this invocation, across every
+	// agent it runs, so one budget covers the whole invocation rather than one
+	// budget per agent.
+	llmCalls atomic.Int64
 }
 
 func ToContext(ctx context.Context, cfg *RunConfig) context.Context {

--- a/internal/llminternal/base_flow.go
+++ b/internal/llminternal/base_flow.go
@@ -838,6 +838,14 @@ func (f *Flow) callLLM(ctx agent.InvocationContext, req *model.LLMRequest, state
 			useStream = rc.StreamingMode == agent.StreamingModeSSE
 		}
 
+		// Count this call against the invocation's budget before making it. The
+		// run config is absent when an agent is run directly rather than through
+		// the runner (issue #586), and that imposes no limit.
+		if err := runconfig.FromContext(ctx).IncrementAndEnforceLLMCallsLimit(); err != nil {
+			yield(nil, err)
+			return
+		}
+
 		for resp, err := range generateContent(ctx, f.Model, req, useStream) {
 			if err != nil {
 				cbResp, cbErr := f.runOnModelErrorCallbacks(ctx, req, stateDelta, artifactDelta, err)

--- a/runner/max_llm_calls_test.go
+++ b/runner/max_llm_calls_test.go
@@ -1,0 +1,172 @@
+// Copyright 2026 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package runner
+
+import (
+	"context"
+	"errors"
+	"iter"
+	"testing"
+
+	"google.golang.org/genai"
+
+	"google.golang.org/adk/v2/agent"
+	"google.golang.org/adk/v2/agent/llmagent"
+	"google.golang.org/adk/v2/model"
+	"google.golang.org/adk/v2/session"
+	"google.golang.org/adk/v2/tool"
+	"google.golang.org/adk/v2/tool/functiontool"
+)
+
+// loopingModel never produces a final answer: every turn asks for the same tool
+// again. Without a budget the flow calls it forever, appending an event per turn
+// and re-sending a growing history.
+type loopingModel struct {
+	model.LLM
+	calls int
+}
+
+func (m *loopingModel) Name() string { return "looping-mock" }
+
+func (m *loopingModel) GenerateContent(ctx context.Context, req *model.LLMRequest, useStream bool) iter.Seq2[*model.LLMResponse, error] {
+	return func(yield func(*model.LLMResponse, error) bool) {
+		m.calls++
+		yield(&model.LLMResponse{
+			Content: &genai.Content{
+				Role: "model",
+				Parts: []*genai.Part{{FunctionCall: &genai.FunctionCall{
+					ID:   "fc",
+					Name: "noop",
+					Args: map[string]any{},
+				}}},
+			},
+		}, nil)
+	}
+}
+
+func noopToolForTest(t *testing.T) tool.Tool {
+	t.Helper()
+	tl, err := functiontool.New(functiontool.Config{Name: "noop"}, func(ctx agent.Context, in struct{}) (struct{}, error) {
+		return struct{}{}, nil
+	})
+	if err != nil {
+		t.Fatalf("functiontool.New() failed: %v", err)
+	}
+	return tl
+}
+
+func runLoopingAgent(t *testing.T, cfg agent.RunConfig) (calls int, err error) {
+	t.Helper()
+
+	m := &loopingModel{}
+	a, aerr := llmagent.New(llmagent.Config{
+		Name:  "looper",
+		Model: m,
+		Tools: []tool.Tool{noopToolForTest(t)},
+	})
+	if aerr != nil {
+		t.Fatalf("llmagent.New() failed: %v", aerr)
+	}
+	r, rerr := New(Config{
+		AppName:           "testApp",
+		Agent:             a,
+		SessionService:    session.InMemoryService(),
+		AutoCreateSession: true,
+	})
+	if rerr != nil {
+		t.Fatalf("runner.New() failed: %v", rerr)
+	}
+
+	msg := genai.NewContentFromText("go", genai.RoleUser)
+	for _, e := range r.Run(t.Context(), "u", "s", msg, cfg) {
+		if e != nil {
+			err = e
+			break
+		}
+	}
+	return m.calls, err
+}
+
+func TestRun_MaxLLMCallsBoundsTheRun(t *testing.T) {
+	calls, err := runLoopingAgent(t, agent.RunConfig{MaxLLMCalls: 3})
+
+	if !errors.Is(err, agent.ErrLLMCallsLimitExceeded) {
+		t.Fatalf("Run() error = %v, want it to wrap ErrLLMCallsLimitExceeded", err)
+	}
+	// The budget is spent, then the next call is refused, so the model is
+	// reached exactly MaxLLMCalls times.
+	if calls != 3 {
+		t.Errorf("model calls = %d, want 3", calls)
+	}
+}
+
+func TestRun_MaxLLMCallsDefaultsToABudget(t *testing.T) {
+	// An empty RunConfig must not mean "unlimited": that is the state this
+	// change exists to remove. Keep the budget small via the environment so the
+	// test does not make 500 calls.
+	t.Setenv("ADK_MAX_LLM_CALLS", "2")
+
+	calls, err := runLoopingAgent(t, agent.RunConfig{})
+
+	if !errors.Is(err, agent.ErrLLMCallsLimitExceeded) {
+		t.Fatalf("Run() error = %v, want it to wrap ErrLLMCallsLimitExceeded", err)
+	}
+	if calls != 2 {
+		t.Errorf("model calls = %d, want 2", calls)
+	}
+}
+
+func TestRun_MaxLLMCallsNegativeMeansUnlimited(t *testing.T) {
+	// Cannot assert "runs forever", so assert the limit is not what stops it:
+	// cancel the context and check the error is the cancellation, not the budget.
+	m := &loopingModel{}
+	a, err := llmagent.New(llmagent.Config{
+		Name:  "looper",
+		Model: m,
+		Tools: []tool.Tool{noopToolForTest(t)},
+	})
+	if err != nil {
+		t.Fatalf("llmagent.New() failed: %v", err)
+	}
+	r, err := New(Config{
+		AppName:           "testApp",
+		Agent:             a,
+		SessionService:    session.InMemoryService(),
+		AutoCreateSession: true,
+	})
+	if err != nil {
+		t.Fatalf("runner.New() failed: %v", err)
+	}
+
+	msg := genai.NewContentFromText("go", genai.RoleUser)
+	const stopAfter = 12
+	var gotErr error
+	for _, e := range r.Run(t.Context(), "u", "s", msg, agent.RunConfig{MaxLLMCalls: -1}) {
+		if e != nil {
+			gotErr = e
+			break
+		}
+		if m.calls >= stopAfter {
+			break
+		}
+	}
+
+	if errors.Is(gotErr, agent.ErrLLMCallsLimitExceeded) {
+		t.Errorf("Run() was stopped by the budget with MaxLLMCalls = -1")
+	}
+	if m.calls < stopAfter {
+		t.Errorf("model calls = %d, want at least %d before the consumer stopped", m.calls, stopAfter)
+	}
+}

--- a/runner/run_node.go
+++ b/runner/run_node.go
@@ -214,6 +214,7 @@ func (r *Runner) newNodeInvocationContext(
 	ctx = parentmap.ToContext(ctx, r.parents)
 	ctx = runconfig.ToContext(ctx, &runconfig.RunConfig{
 		StreamingMode: runconfig.StreamingMode(cfg.StreamingMode),
+		MaxLLMCalls:   runconfig.ResolveMaxLLMCalls(cfg.MaxLLMCalls),
 	})
 	ctx = plugininternal.ToContext(ctx, r.pluginManager)
 

--- a/runner/runner.go
+++ b/runner/runner.go
@@ -255,6 +255,7 @@ func (r *Runner) Run(ctx context.Context, userID, sessionID string, msg *genai.C
 		ctx = parentmap.ToContext(ctx, r.parents)
 		ctx = runconfig.ToContext(ctx, &runconfig.RunConfig{
 			StreamingMode: runconfig.StreamingMode(cfg.StreamingMode),
+			MaxLLMCalls:   runconfig.ResolveMaxLLMCalls(cfg.MaxLLMCalls),
 		})
 		ctx = plugininternal.ToContext(ctx, r.pluginManager)
 


### PR DESCRIPTION
### Link to Issue or Description of Change

**1. Link to an existing issue (if applicable):**

- Closes: #1287
- Related: #1286, which stays open. See Additional context.

**Problem:**

Whether a non-live run terminates depends entirely on model behaviour. `Flow.Run` leaves its loop on a non-thought-only final response, ten consecutive thought-only turns, an error, a partial last event, consumer cancellation, or `EndInvocation()`. A model that keeps requesting tool calls satisfies none of them, so the loop appends an event per turn and re-sends a growing history, and token cost grows quadratically with no exit.

`agent.RunConfig` had two fields, `StreamingMode` and `SaveInputBlobsAsArtifacts`, and neither is a limit. The only limit-shaped field in the codebase, `LiveRunConfig.MaxLLMCalls`, is on the live path and is not reachable from `Flow.Run`.

The analysis is @jjsasha63's, in #1287 and #1286, including the measurement of `events=60 modelCalls=30 and climbing` against a model that only returns function calls. I have followed his design note that the two configs should share one counter rather than growing two divergent limits.

Worth noting that the case for a bound is already made in this repository, in the comment above `maxConsecutiveThoughtOnlyTurns`:

> A model that keeps emitting thoughts without ever surfacing an answer would otherwise spin forever, appending an event per turn and re-sending an ever-growing history.

That reasoning was accepted for the thought-only branch in #1290 and is absent from the function-call branch beside it.

**Solution:**

`agent.RunConfig` gains `MaxLLMCalls int`, with `agent.ErrLLMCallsLimitExceeded` as the sentinel so callers can use `errors.Is`.

Resolution, in `runconfig.ResolveMaxLLMCalls`:

| Value | Meaning |
|---|---|
| `0`, what `agent.RunConfig{}` gives | 500, or `ADK_MAX_LLM_CALLS` if it parses |
| positive | that limit |
| negative | no limit |

The zero value carrying a budget is the point of the change. `agent.RunConfig{}` appears in every example in the repository, including the one in `AGENTS.md`, and "unlimited by default" is the state this is meant to remove. 500 and the environment variable name both match adk-python's `RunConfig.max_llm_calls`, which is the parity target under the alignment rule in `AGENTS.md`.

Three details are deliberate:

- **The counter is per invocation, not per agent.** It lives on the shared `internal/agent/runconfig.RunConfig`, which the runner puts on the context by pointer, so sub-agents and transfers inside one invocation draw on one budget. This is the shared counter #1286 asked for. It is an `atomic.Int64` because `parallelagent` runs sub-agents concurrently.
- **Enforcement sits at the single place the non-live flow reaches a model**, immediately before `generateContent` in `callLLM`, so a `Before` model callback that short-circuits does not spend budget. Counting happens first and the check second, so a limit of n permits exactly n calls, matching `increment_and_enforce_llm_calls_limit` in adk-python.
- **A nil run config imposes no limit.** `runconfig.FromContext` returns nil when an agent is run directly rather than through the runner (#586), and that path is unchanged.

### Testing Plan

**Unit Tests:**

- [x] I have added or updated unit tests for my change.
- [x] All unit tests pass locally.

`internal/agent/runconfig/limits_test.go` covers resolution (default, environment override, unparsable override, negative override, explicit value winning over the environment, negative pass-through) and enforcement (a limit of n permits exactly n calls, non-positive limits do not bound, a nil receiver does not bound, and a concurrency case asserting that 100 goroutines against a limit of 50 get exactly 50 through, which is the shared-counter guarantee).

`runner/max_llm_calls_test.go` is the end-to-end case, driven by a model that only ever returns the same function call:

- `MaxLLMCalls: 3` ends the run with an error wrapping `ErrLLMCallsLimitExceeded` after exactly 3 model calls.
- `agent.RunConfig{}` with `ADK_MAX_LLM_CALLS=2` bounds at 2, which is the assertion that the empty literal is no longer unlimited.
- `MaxLLMCalls: -1` is not stopped by the budget: the consumer stops it after 12 calls instead.

Results:

```
$ go test ./runner/ -run 'TestRun_MaxLLMCalls' -count=1 -v
--- PASS: TestRun_MaxLLMCallsBoundsTheRun (0.00s)
--- PASS: TestRun_MaxLLMCallsDefaultsToABudget (0.00s)
--- PASS: TestRun_MaxLLMCallsNegativeMeansUnlimited (0.00s)
ok  	google.golang.org/adk/v2/runner	0.493s

$ go test ./internal/agent/runconfig/ -count=1 -race
ok  	google.golang.org/adk/v2/internal/agent/runconfig	1.632s

$ go test -race -mod=readonly -count=1 -shuffle=on ./...
EXIT 0, no failures, no races

$ go vet ./agent/ ./runner/ ./internal/agent/runconfig/ ./internal/llminternal/
clean

$ go mod tidy -diff
prints nothing
```

Worth reporting the mutation check, because it is unusual. With the enforcement line removed, `TestRun_MaxLLMCallsBoundsTheRun` does not fail: it hangs until the Go test timeout kills it at 30s with a goroutine dump. That is the bug demonstrating itself, and it is the reason a bound belongs in the framework rather than in each caller.

**Manual End-to-End (E2E) Tests:**

The looping-model test is the end-to-end check and needs no credentials, which is why it is a test rather than a runner transcript. Setup is the standard one from `AGENTS.md`: an `llmagent` with one no-op tool, `runner.New` with an in-memory session service and `AutoCreateSession`, and a model whose every response is the same function call. On `main` that setup does not terminate. On this branch it ends after `MaxLLMCalls` model calls with an error the caller can match with `errors.Is(err, agent.ErrLLMCallsLimitExceeded)`.

### Checklist

- [x] I have read the [CONTRIBUTING.md](./CONTRIBUTING.md) document.
- [x] I have performed a self-review of my own code.
- [x] I have commented my code, particularly in hard-to-understand areas.
- [x] I have added tests that prove my fix is effective or that my feature works.
- [x] New and existing unit tests pass locally with my changes.
- [x] I have manually tested my changes end-to-end.
- [x] Any dependent changes have been merged and published in downstream modules.

### Additional context

**This does not close #1286, and that is deliberate.** The live path holds a bidi connection and does not go through `callLLM`, so what counts as one call there is a decision I did not want to make on the maintainers' behalf. `LiveRunConfig.MaxLLMCalls` is untouched and still inert. Wiring it without enforcing it would recreate exactly the problem #1286 reports, that a present, silently ignored field makes you stop looking. The counter and the enforcement helper are on the shared config so that wiring the live path is a small follow-up rather than a second mechanism.

**On the default being a behaviour change.** An invocation that legitimately makes more than 500 model calls will now stop. That is the same position adk-python has taken since its default was introduced, and the escape hatches are per-run (`MaxLLMCalls: -1`) and per-deployment (`ADK_MAX_LLM_CALLS`). Happy to make the default unlimited instead if you would rather not change existing behaviour on the 2.x line, though I think the safe default is the more useful one and the parity argument supports it.

@jjsasha63, if you would rather take this yourself, say so and I will close it.
