### PR TITLE
Adding opt-in option for the debug endpoint in ADK REST API

### DIFF
--- a/cmd/adkgo/internal/deploy/cloudrun/cloudrun.go
+++ b/cmd/adkgo/internal/deploy/cloudrun/cloudrun.go
@@ -48,8 +48,8 @@ type cloudRunServiceFlags struct {
 	serverPort      int
 	a2aAgentCardURL string
 	a2a             bool // enable a2a or not
-	api             bool // enable api or not
-	debugApi        bool // enable debug api or not
+	api             bool // enable REST API or not
+	debugAPI        bool // enable debug in REST API or not
 	webui           bool // enable webui or not
 	pubsub          bool // enable pubsub trigger or not
 	pubsubTrigger   triggerConfigFlags
@@ -110,7 +110,7 @@ func init() {
 	cloudrunCmd.PersistentFlags().BoolVar(&flags.cloudRun.a2a, "a2a", true, "Enable A2A")
 	cloudrunCmd.PersistentFlags().StringVarP(&flags.cloudRun.a2aAgentCardURL, "a2a_agent_url", "a", "http://127.0.0.1:8081", "A2A agent card URL as advertised in the public agent card")
 	cloudrunCmd.PersistentFlags().BoolVar(&flags.cloudRun.api, "api", true, "Enable API")
-	cloudrunCmd.PersistentFlags().BoolVar(&flags.cloudRun.debugApi, "debug_api", false, "Enable Debug API (if API is enabled)")
+	cloudrunCmd.PersistentFlags().BoolVar(&flags.cloudRun.debugAPI, "debug_api", false, "Enable Debug API - requires '-api'")
 	cloudrunCmd.PersistentFlags().BoolVar(&flags.cloudRun.webui, "webui", true, "Enable Web UI")
 	cloudrunCmd.PersistentFlags().BoolVar(&flags.cloudRun.pubsub, "pubsub", false, "Enable PubSub subrouter")
 	cloudrunCmd.PersistentFlags().IntVar(&flags.cloudRun.pubsubTrigger.maxRetries, "pubsub_max_retries", 3, "Maximum retries for HTTP 429 errors from PubSub triggers")
@@ -128,6 +128,10 @@ func init() {
 func (f *deployCloudRunFlags) computeFlags() error {
 	return util.LogStartStop("Computing flags & preparing temp",
 		func(p util.Printer) error {
+			if f.cloudRun.debugAPI && !f.cloudRun.api {
+				return fmt.Errorf("cannot enable Debug API without having enabled API")
+			}
+
 			absp, err := filepath.Abs(flags.source.entryPointPath)
 			if err != nil {
 				return fmt.Errorf("cannot make an absolute path from '%v': %w", f.source.entryPointPath, err)
@@ -160,10 +164,6 @@ func (f *deployCloudRunFlags) computeFlags() error {
 				f.build.execPath = path.Join(f.build.tempDir, exec)
 			}
 			f.build.dockerfileBuildPath = path.Join(f.build.tempDir, "Dockerfile")
-
-			if f.cloudRun.debugApi && !f.cloudRun.api {
-				return fmt.Errorf("cannot enable Debug API without having enabled API")
-			}
 
 			return nil
 		})
@@ -217,7 +217,7 @@ CMD ["/app/` + f.build.execFile + `", "web", "-port", "` + strconv.Itoa(flags.cl
 			if flags.cloudRun.api {
 				b.WriteString(`, "api", "-webui_address", "127.0.0.1:` + strconv.Itoa(f.proxy.port) + `"`)
 
-				if flags.cloudRun.debugApi {
+				if flags.cloudRun.debugAPI {
 					b.WriteString(`, "-include_debug_api"`)
 				}
 			}

--- a/cmd/adkgo/internal/deploy/cloudrun/cloudrun.go
+++ b/cmd/adkgo/internal/deploy/cloudrun/cloudrun.go
@@ -110,7 +110,7 @@ func init() {
 	cloudrunCmd.PersistentFlags().BoolVar(&flags.cloudRun.a2a, "a2a", true, "Enable A2A")
 	cloudrunCmd.PersistentFlags().StringVarP(&flags.cloudRun.a2aAgentCardURL, "a2a_agent_url", "a", "http://127.0.0.1:8081", "A2A agent card URL as advertised in the public agent card")
 	cloudrunCmd.PersistentFlags().BoolVar(&flags.cloudRun.api, "api", true, "Enable API")
-	cloudrunCmd.PersistentFlags().BoolVar(&flags.cloudRun.debugAPI, "debug_api", false, "Enable Debug API - requires '-api'")
+	cloudrunCmd.PersistentFlags().BoolVar(&flags.cloudRun.debugAPI, "debug_api", false, "Enable Debug API - requires '--api'")
 	cloudrunCmd.PersistentFlags().BoolVar(&flags.cloudRun.webui, "webui", true, "Enable Web UI")
 	cloudrunCmd.PersistentFlags().BoolVar(&flags.cloudRun.pubsub, "pubsub", false, "Enable PubSub subrouter")
 	cloudrunCmd.PersistentFlags().IntVar(&flags.cloudRun.pubsubTrigger.maxRetries, "pubsub_max_retries", 3, "Maximum retries for HTTP 429 errors from PubSub triggers")

--- a/cmd/adkgo/internal/deploy/cloudrun/cloudrun.go
+++ b/cmd/adkgo/internal/deploy/cloudrun/cloudrun.go
@@ -49,6 +49,7 @@ type cloudRunServiceFlags struct {
 	a2aAgentCardURL string
 	a2a             bool // enable a2a or not
 	api             bool // enable api or not
+	debugApi        bool // enable debug api or not
 	webui           bool // enable webui or not
 	pubsub          bool // enable pubsub trigger or not
 	pubsubTrigger   triggerConfigFlags
@@ -109,6 +110,7 @@ func init() {
 	cloudrunCmd.PersistentFlags().BoolVar(&flags.cloudRun.a2a, "a2a", true, "Enable A2A")
 	cloudrunCmd.PersistentFlags().StringVarP(&flags.cloudRun.a2aAgentCardURL, "a2a_agent_url", "a", "http://127.0.0.1:8081", "A2A agent card URL as advertised in the public agent card")
 	cloudrunCmd.PersistentFlags().BoolVar(&flags.cloudRun.api, "api", true, "Enable API")
+	cloudrunCmd.PersistentFlags().BoolVar(&flags.cloudRun.debugApi, "debug_api", false, "Enable Debug API (if API is enabled)")
 	cloudrunCmd.PersistentFlags().BoolVar(&flags.cloudRun.webui, "webui", true, "Enable Web UI")
 	cloudrunCmd.PersistentFlags().BoolVar(&flags.cloudRun.pubsub, "pubsub", false, "Enable PubSub subrouter")
 	cloudrunCmd.PersistentFlags().IntVar(&flags.cloudRun.pubsubTrigger.maxRetries, "pubsub_max_retries", 3, "Maximum retries for HTTP 429 errors from PubSub triggers")
@@ -158,6 +160,10 @@ func (f *deployCloudRunFlags) computeFlags() error {
 				f.build.execPath = path.Join(f.build.tempDir, exec)
 			}
 			f.build.dockerfileBuildPath = path.Join(f.build.tempDir, "Dockerfile")
+
+			if f.cloudRun.debugApi && !f.cloudRun.api {
+				return fmt.Errorf("cannot enable Debug API without having enabled API")
+			}
 
 			return nil
 		})
@@ -210,6 +216,10 @@ CMD ["/app/` + f.build.execFile + `", "web", "-port", "` + strconv.Itoa(flags.cl
 
 			if flags.cloudRun.api {
 				b.WriteString(`, "api", "-webui_address", "127.0.0.1:` + strconv.Itoa(f.proxy.port) + `"`)
+
+				if flags.cloudRun.debugApi {
+					b.WriteString(`, "-include_debug_api"`)
+				}
 			}
 			if flags.cloudRun.a2a {
 				b.WriteString(`, "a2a", "--a2a_agent_url", "` + flags.cloudRun.a2aAgentCardURL + `"`)

--- a/cmd/launcher/web/api/api.go
+++ b/cmd/launcher/web/api/api.go
@@ -86,7 +86,7 @@ func (a *apiLauncher) SetupSubrouters(router *mux.Router, config *launcher.Confi
 		DebugConfig: adkrest.DebugTelemetryConfig{
 			TraceCapacity: a.config.traceCapacity,
 		},
-		DebugApiConfig: adkrest.DebugApiConfig{
+		DebugApiConfig: adkrest.DebugAPIConfig{
 			IncludeDebugAPI: a.config.includeDebugAPI,
 		},
 	})

--- a/cmd/launcher/web/api/api.go
+++ b/cmd/launcher/web/api/api.go
@@ -83,9 +83,11 @@ func (a *apiLauncher) SetupSubrouters(router *mux.Router, config *launcher.Confi
 		ArtifactService: config.ArtifactService,
 		SSEWriteTimeout: a.config.sseWriteTimeout,
 		PluginConfig:    config.PluginConfig,
-		DebugConfig: adkrest.DebugConfig{
-			IncludeDebugAPI:        a.config.includeDebugAPI,
+		DebugConfig: adkrest.DebugTelemetryConfig{
 			TelemetryTraceCapacity: a.config.traceCapacity,
+		},
+		DebugApiConfig: adkrest.DebugApiConfig{
+			IncludeDebugAPI: a.config.includeDebugAPI,
 		},
 	})
 	if err != nil {

--- a/cmd/launcher/web/api/api.go
+++ b/cmd/launcher/web/api/api.go
@@ -37,6 +37,7 @@ type apiConfig struct {
 	pathPrefix      string
 	sseWriteTimeout time.Duration
 	traceCapacity   int
+	includeDebugAPI bool
 }
 
 // apiLauncher can launch ADK REST API
@@ -82,8 +83,9 @@ func (a *apiLauncher) SetupSubrouters(router *mux.Router, config *launcher.Confi
 		ArtifactService: config.ArtifactService,
 		SSEWriteTimeout: a.config.sseWriteTimeout,
 		PluginConfig:    config.PluginConfig,
-		DebugConfig: adkrest.DebugTelemetryConfig{
-			TraceCapacity: a.config.traceCapacity,
+		DebugConfig: adkrest.DebugConfig{
+			IncludeDebugAPI:        a.config.includeDebugAPI,
+			TelemetryTraceCapacity: a.config.traceCapacity,
 		},
 	})
 	if err != nil {
@@ -143,6 +145,7 @@ func NewLauncher() weblauncher.Sublauncher {
 	fs.StringVar(&config.pathPrefix, "path_prefix", "/api", "ADK REST API path prefix. Default is '/api'.")
 	fs.DurationVar(&config.sseWriteTimeout, "sse-write-timeout", 120*time.Second, "SSE server write timeout (i.e. '10s', '2m' - see time.ParseDuration for details) - for writing the SSE response after reading the headers & body")
 	fs.IntVar(&config.traceCapacity, "trace_capacity", 10000, "Maximum number of traces to keep in memory.")
+	fs.BoolVar(&config.includeDebugAPI, "include_debug_api", false, "The debug api endpoint will be included in the API if and only if the flag is set to true.")
 
 	return &apiLauncher{
 		config: config,

--- a/cmd/launcher/web/api/api.go
+++ b/cmd/launcher/web/api/api.go
@@ -84,7 +84,7 @@ func (a *apiLauncher) SetupSubrouters(router *mux.Router, config *launcher.Confi
 		SSEWriteTimeout: a.config.sseWriteTimeout,
 		PluginConfig:    config.PluginConfig,
 		DebugConfig: adkrest.DebugTelemetryConfig{
-			TelemetryTraceCapacity: a.config.traceCapacity,
+			TraceCapacity: a.config.traceCapacity,
 		},
 		DebugApiConfig: adkrest.DebugApiConfig{
 			IncludeDebugAPI: a.config.includeDebugAPI,

--- a/cmd/launcher/web/api/api.go
+++ b/cmd/launcher/web/api/api.go
@@ -86,7 +86,7 @@ func (a *apiLauncher) SetupSubrouters(router *mux.Router, config *launcher.Confi
 		DebugConfig: adkrest.DebugTelemetryConfig{
 			TraceCapacity: a.config.traceCapacity,
 		},
-		DebugApiConfig: adkrest.DebugAPIConfig{
+		DebugAPIConfig: adkrest.DebugAPIConfig{
 			IncludeDebugAPI: a.config.includeDebugAPI,
 		},
 	})

--- a/server/adkrest/handler.go
+++ b/server/adkrest/handler.go
@@ -38,7 +38,7 @@ import (
 // NewServer creates a new ADK REST API server which implements [http.Handler] interface.
 func NewServer(cfg ServerConfig) (*Server, error) {
 	debugTelemetry, err := services.NewDebugTelemetryWithConfig(&services.DebugTelemetryConfig{
-		TraceCapacity: cfg.DebugConfig.TraceCapacity,
+		TraceCapacity: cfg.DebugConfig.TelemetryTraceCapacity,
 	})
 	if err != nil {
 		return nil, fmt.Errorf("failed to create debug telemetry service: %w", err)
@@ -48,14 +48,19 @@ func NewServer(cfg ServerConfig) (*Server, error) {
 	router.HandleFunc("/health", healthHandler).Methods(http.MethodGet)
 	// TODO: Allow taking a prefix to allow customizing the path
 	// where the ADK REST API will be served.
-	setupRouter(router,
+
+	subrouters := []routers.Router{
 		routers.NewSessionsAPIRouter(controllers.NewSessionsAPIController(cfg.SessionService)),
 		routers.NewRuntimeAPIRouter(controllers.NewRuntimeAPIController(cfg.SessionService, cfg.MemoryService, cfg.AgentLoader, cfg.ArtifactService, cfg.SSEWriteTimeout, cfg.PluginConfig, false)),
 		routers.NewAppsAPIRouter(controllers.NewAppsAPIController(cfg.AgentLoader)),
-		routers.NewDebugAPIRouter(controllers.NewDebugAPIController(cfg.SessionService, cfg.AgentLoader, debugTelemetry)),
 		routers.NewArtifactsAPIRouter(controllers.NewArtifactsAPIController(cfg.ArtifactService)),
 		&routers.EvalAPIRouter{},
-	)
+	}
+	if cfg.DebugConfig.IncludeDebugAPI {
+		subrouters = append(subrouters, routers.NewDebugAPIRouter(controllers.NewDebugAPIController(cfg.SessionService, cfg.AgentLoader, debugTelemetry)))
+	}
+
+	setupRouter(router, subrouters...)
 	return &Server{
 		router:         router,
 		telemetryStore: debugTelemetry,
@@ -75,14 +80,16 @@ type ServerConfig struct {
 	ArtifactService artifact.Service
 	SSEWriteTimeout time.Duration
 	PluginConfig    runner.PluginConfig
-	DebugConfig     DebugTelemetryConfig
+	DebugConfig     DebugConfig
 }
 
-// DebugTelemetryConfig contains parameters for the debug telemetry.
-type DebugTelemetryConfig struct {
+// DebugConfig contains parameters for the debug telemetry.
+type DebugConfig struct {
+	IncludeDebugAPI bool
+
 	// Maximum number of traces to keep in memory.
 	// If <= 0, the default capacity 10_000 is used.
-	TraceCapacity int
+	TelemetryTraceCapacity int
 }
 
 // Server is an HTTP server that serves the ADK REST API.

--- a/server/adkrest/handler.go
+++ b/server/adkrest/handler.go
@@ -56,7 +56,7 @@ func NewServer(cfg ServerConfig) (*Server, error) {
 		routers.NewArtifactsAPIRouter(controllers.NewArtifactsAPIController(cfg.ArtifactService)),
 		&routers.EvalAPIRouter{},
 	}
-	if cfg.DebugApiConfig.IncludeDebugAPI {
+	if cfg.DebugAPIConfig.IncludeDebugAPI {
 		subrouters = append(subrouters, routers.NewDebugAPIRouter(controllers.NewDebugAPIController(cfg.SessionService, cfg.AgentLoader, debugTelemetry)))
 	}
 
@@ -81,7 +81,7 @@ type ServerConfig struct {
 	SSEWriteTimeout time.Duration
 	PluginConfig    runner.PluginConfig
 	DebugConfig     DebugTelemetryConfig
-	DebugApiConfig  DebugAPIConfig
+	DebugAPIConfig  DebugAPIConfig
 }
 
 // DebugAPIConfig contains parameters for the debug API.

--- a/server/adkrest/handler.go
+++ b/server/adkrest/handler.go
@@ -81,11 +81,11 @@ type ServerConfig struct {
 	SSEWriteTimeout time.Duration
 	PluginConfig    runner.PluginConfig
 	DebugConfig     DebugTelemetryConfig
-	DebugApiConfig  DebugApiConfig
+	DebugApiConfig  DebugAPIConfig
 }
 
-// DebugApiConfig contains parameters for the debug api.
-type DebugApiConfig struct {
+// DebugAPIConfig contains parameters for the debug API.
+type DebugAPIConfig struct {
 	IncludeDebugAPI bool
 }
 

--- a/server/adkrest/handler.go
+++ b/server/adkrest/handler.go
@@ -38,7 +38,7 @@ import (
 // NewServer creates a new ADK REST API server which implements [http.Handler] interface.
 func NewServer(cfg ServerConfig) (*Server, error) {
 	debugTelemetry, err := services.NewDebugTelemetryWithConfig(&services.DebugTelemetryConfig{
-		TraceCapacity: cfg.DebugConfig.TelemetryTraceCapacity,
+		TraceCapacity: cfg.DebugConfig.TraceCapacity,
 	})
 	if err != nil {
 		return nil, fmt.Errorf("failed to create debug telemetry service: %w", err)
@@ -84,16 +84,16 @@ type ServerConfig struct {
 	DebugApiConfig  DebugApiConfig
 }
 
+// DebugApiConfig contains parameters for the debug api.
 type DebugApiConfig struct {
 	IncludeDebugAPI bool
 }
 
 // DebugTelemetryConfig contains parameters for the debug telemetry.
 type DebugTelemetryConfig struct {
-
 	// Maximum number of traces to keep in memory.
 	// If <= 0, the default capacity 10_000 is used.
-	TelemetryTraceCapacity int
+	TraceCapacity int
 }
 
 // Server is an HTTP server that serves the ADK REST API.

--- a/server/adkrest/handler.go
+++ b/server/adkrest/handler.go
@@ -86,6 +86,7 @@ type ServerConfig struct {
 
 // DebugAPIConfig contains parameters for the debug API.
 type DebugAPIConfig struct {
+	// Controls if [routers.NewDebugAPIRouter] is included
 	IncludeDebugAPI bool
 }
 

--- a/server/adkrest/handler.go
+++ b/server/adkrest/handler.go
@@ -56,7 +56,7 @@ func NewServer(cfg ServerConfig) (*Server, error) {
 		routers.NewArtifactsAPIRouter(controllers.NewArtifactsAPIController(cfg.ArtifactService)),
 		&routers.EvalAPIRouter{},
 	}
-	if cfg.DebugConfig.IncludeDebugAPI {
+	if cfg.DebugApiConfig.IncludeDebugAPI {
 		subrouters = append(subrouters, routers.NewDebugAPIRouter(controllers.NewDebugAPIController(cfg.SessionService, cfg.AgentLoader, debugTelemetry)))
 	}
 
@@ -80,12 +80,16 @@ type ServerConfig struct {
 	ArtifactService artifact.Service
 	SSEWriteTimeout time.Duration
 	PluginConfig    runner.PluginConfig
-	DebugConfig     DebugConfig
+	DebugConfig     DebugTelemetryConfig
+	DebugApiConfig  DebugApiConfig
 }
 
-// DebugConfig contains parameters for the debug telemetry.
-type DebugConfig struct {
+type DebugApiConfig struct {
 	IncludeDebugAPI bool
+}
+
+// DebugTelemetryConfig contains parameters for the debug telemetry.
+type DebugTelemetryConfig struct {
 
 	// Maximum number of traces to keep in memory.
 	// If <= 0, the default capacity 10_000 is used.

--- a/server/adkrest/handler_test.go
+++ b/server/adkrest/handler_test.go
@@ -18,6 +18,9 @@ import (
 	"net/http"
 	"net/http/httptest"
 	"testing"
+
+	"google.golang.org/adk/v2/agent"
+	"google.golang.org/adk/v2/session"
 )
 
 func TestServerHealth(t *testing.T) {
@@ -38,5 +41,49 @@ func TestServerHealth(t *testing.T) {
 	}
 	if got, want := recorder.Body.String(), "{\"status\":\"ok\"}\n"; got != want {
 		t.Errorf("GET /health body = %q, want %q", got, want)
+	}
+}
+
+// debugRoutes are every route owned by the debug API router, including the
+// event graph route, whose path does not contain "debug".
+var debugRoutes = []string{
+	"/debug/trace/evt1",
+	"/debug/trace/session/sess1",
+	"/apps/app1/users/user1/sessions/sess1/events/evt1/graph",
+}
+
+// muxNotFound is what gorilla/mux writes when no route matches. A registered
+// handler that happens to answer 404 writes its own body, so the body is what
+// distinguishes "not routed" from "routed and rejected".
+const muxNotFound = "404 page not found\n"
+
+func TestNewServerDebugAPIGate(t *testing.T) {
+	for _, tc := range []struct {
+		name       string
+		include    bool
+		wantRouted bool
+	}{
+		{name: "omitted by default", include: false, wantRouted: false},
+		{name: "included when opted in", include: true, wantRouted: true},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			srv, err := NewServer(ServerConfig{
+				SessionService: session.InMemoryService(),
+				AgentLoader:    agent.NewSingleLoader(nil),
+				DebugAPIConfig: DebugAPIConfig{IncludeDebugAPI: tc.include},
+			})
+			if err != nil {
+				t.Fatalf("NewServer() error = %v", err)
+			}
+			for _, route := range debugRoutes {
+				rr := httptest.NewRecorder()
+				srv.ServeHTTP(rr, httptest.NewRequest(http.MethodGet, route, nil))
+				routed := rr.Body.String() != muxNotFound
+				if routed != tc.wantRouted {
+					t.Errorf("GET %s: routed = %v, want %v (code %d, body %q)",
+						route, routed, tc.wantRouted, rr.Code, rr.Body.String())
+				}
+			}
+		})
 	}
 }


### PR DESCRIPTION
**Problem:**
Debug endpoint in api was unconditionally exposed. 

**Solution:**
Opt-in option to include debug api to `web api`. Includes Opt-in for cloudrun deployment. 

### Testing Plan
Manual tests

**Manual End-to-End (E2E) Tests:**

 - local run with/without the -include_debug_api flag
 - cloudrun deployment with/without ` --debug_api` flag

### Checklist

- [X] I have read the [CONTRIBUTING.md](./CONTRIBUTING.md) document.
- [X] I have performed a self-review of my own code.
- [X] I have commented my code, particularly in hard-to-understand areas.
- [N/A] I have added tests that prove my fix is effective or that my feature works.
- [X] New and existing unit tests pass locally with my changes.
- [X] I have manually tested my changes end-to-end.
- [X] Any dependent changes have been merged and published in downstream modules.


