### PR TITLE
feat(examples): add OrcaRouter model integration example

### DIFF
--- a/examples/orcarouter/README.md
+++ b/examples/orcarouter/README.md
@@ -1,0 +1,76 @@
+# OrcaRouter model integration
+
+Runs an ordinary ADK `llmagent` — with a tool — on an **OrcaRouter** model
+instead of Gemini. OrcaRouter is an OpenAI-compatible AI gateway that routes to
+many models behind a single base URL, using the `google.golang.org/adk/v2/model/openai`
+package (the `openaimodel.NewModel` constructor). Because OrcaRouter serves the
+OpenAI **Responses API**, this sample shares the exact same `model.LLM` wiring as
+the [OpenAI example](../openai/README.md); the only difference is the client
+config, which points at OrcaRouter's endpoint.
+
+- **Concept:** Swap `gemini.NewModel(...)` for `openaimodel.NewModel(...)` with OrcaRouter's base URL; agents, tools, the runner, and the launcher are unchanged.
+- **Needs LLM?** Yes (OrcaRouter API key)
+
+## Goal
+
+Show that ADK is model-agnostic beyond the providers it ships constructors for:
+OrcaRouter plugs into the exact same `llmagent.New` / launcher wiring as the
+[quickstart](../quickstart) and the [OpenAI example](../openai). The only
+difference is the constructor —
+
+```go
+model, err := openaimodel.NewModel(ctx, "orcarouter/free", &openaimodel.ClientConfig{
+    APIKey:  os.Getenv("ORCAROUTER_API_KEY"),
+    BaseURL: "https://api.orcarouter.ai/v1",
+})
+```
+
+— and everything downstream stays identical. The sample also registers a
+`get_weather` function tool to demonstrate that OrcaRouter tool calling flows
+through ADK's normal `functiontool` path.
+
+## Configuration
+
+| Variable            | Required            | Default            | Purpose                          |
+| ------------------- | ------------------- | ------------------ | -------------------------------- |
+| `ORCAROUTER_API_KEY`| Yes                 | —                  | Your OrcaRouter API key (`sk-orca-...`). |
+| `ORCAROUTER_MODEL`  | No                  | `orcarouter/free`  | Model name to serve.             |
+
+Any model ID on the gateway works — for example `orcarouter/fusion`,
+`openai/gpt-4.1`, `anthropic/claude-opus-4.5`, or `deepseek/deepseek-v4-pro`.
+
+## Running the sample
+
+```bash
+export ORCAROUTER_API_KEY=sk-orca-...
+go run ./examples/orcarouter/ console
+```
+
+To pick a different model:
+
+```bash
+export ORCAROUTER_MODEL=orcarouter/fusion
+go run ./examples/orcarouter/ console
+```
+
+The console streams tokens by default; add `-streaming_mode none` for
+block-at-a-time output.
+
+## Example session
+
+The model calls `get_weather` and relays the result (exact wording varies):
+
+```text
+User -> what's the weather in Paris?
+Agent -> It is currently 22°C and sunny in Paris.
+```
+
+## Notes
+
+The sample targets the [Responses API]. `Temperature`, `TopP`,
+`MaxOutputTokens`, structured output (JSON schema), and system instructions all
+work as usual. A few Gemini-style `GenerateContentConfig` knobs are not supported
+and return a descriptive error if set: `TopK`, `StopSequences`, multiple
+candidates, frequency/presence penalties, request labels, and safety settings.
+
+[Responses API]: https://platform.openai.com/docs/api-reference/responses

--- a/examples/orcarouter/main.go
+++ b/examples/orcarouter/main.go
@@ -1,0 +1,109 @@
+// Copyright 2026 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+// Package demonstrates an ADK agent backed by an OrcaRouter model instead of
+// Gemini. OrcaRouter is an OpenAI-compatible AI gateway that exposes many
+// models behind a single base URL (https://api.orcarouter.ai/v1). It talks to
+// OrcaRouter's Responses API, so it plugs into the same model.LLM wiring as the
+// OpenAI example (examples/openai); the only ADK-specific difference is the
+// constructor's client config.
+package main
+
+import (
+	"context"
+	"fmt"
+	"log"
+	"os"
+
+	"google.golang.org/adk/v2/agent"
+	"google.golang.org/adk/v2/agent/llmagent"
+	"google.golang.org/adk/v2/cmd/launcher"
+	"google.golang.org/adk/v2/cmd/launcher/full"
+	openaimodel "google.golang.org/adk/v2/model/openaimodel"
+	"google.golang.org/adk/v2/tool"
+	"google.golang.org/adk/v2/tool/functiontool"
+)
+
+// defaultModel is used when ORCAROUTER_MODEL is unset. orcarouter/free routes
+// to a free model on the gateway and needs no billing details.
+const defaultModel = "orcarouter/free"
+
+type weatherInput struct {
+	City string `json:"city"`
+}
+
+type weatherOutput struct {
+	Report string `json:"report"`
+}
+
+// getWeather is a stand-in for a real weather API so the sample runs offline
+// once the model call returns. It shows a plain Go function surfaced to an
+// OrcaRouter model as a tool via ADK's function-calling support.
+func getWeather(_ agent.Context, in weatherInput) (weatherOutput, error) {
+	return weatherOutput{
+		Report: fmt.Sprintf("It is currently 22°C and sunny in %s.", in.City),
+	}, nil
+}
+
+func main() {
+	ctx := context.Background()
+
+	apiKey := os.Getenv("ORCAROUTER_API_KEY")
+	if apiKey == "" {
+		log.Fatal("set ORCAROUTER_API_KEY (get one at https://www.orcarouter.ai)")
+	}
+
+	modelName := os.Getenv("ORCAROUTER_MODEL")
+	if modelName == "" {
+		modelName = defaultModel
+	}
+
+	model, err := openaimodel.NewModel(ctx, modelName, &openaimodel.ClientConfig{
+		APIKey:  apiKey,
+		BaseURL: "https://api.orcarouter.ai/v1",
+	})
+	if err != nil {
+		log.Fatalf("Failed to create model: %v", err)
+	}
+
+	weatherTool, err := functiontool.New(functiontool.Config{
+		Name:        "get_weather",
+		Description: "Returns the current weather for a given city.",
+	}, getWeather)
+	if err != nil {
+		log.Fatalf("Failed to create tool: %v", err)
+	}
+
+	a, err := llmagent.New(llmagent.Config{
+		Name:        "orcarouter_weather_agent",
+		Model:       model,
+		Description: "Answers weather questions using an OrcaRouter model.",
+		Instruction: "You are a helpful assistant. When asked about the weather in a city, call the get_weather tool and report the result.",
+		Tools: []tool.Tool{
+			weatherTool,
+		},
+	})
+	if err != nil {
+		log.Fatalf("Failed to create agent: %v", err)
+	}
+
+	config := &launcher.Config{
+		AgentLoader: agent.NewSingleLoader(a),
+	}
+
+	l := full.NewLauncher()
+	if err = l.Execute(ctx, config, os.Args[1:]); err != nil {
+		log.Fatalf("Run failed: %v\n\n%s", err, l.CommandLineSyntax())
+	}
+}


### PR DESCRIPTION
## Summary

ADK Go is a model-agnostic, code-first toolkit: the [OpenAI
example](examples/openai) shows that any endpoint implementing the OpenAI
Responses API can back an `llmagent` through the same `model.LLM` wiring as
Gemini. This PR adds a runnable example that points that wiring at
[OrcaRouter](https://www.orcarouter.ai), an OpenAI-compatible AI gateway that
routes to many models behind a single base URL.

OrcaRouter is built for both models and agents. Like OpenRouter, it exposes a
provider/model namespace across many models — but it also combines adaptive
routing, automatic failover, zero-markup inference, observability, guardrails,
and agent-tool governance behind the same endpoint. Adding orcarouter as a
first-class provider means this project's users can use that stack directly,
without treating OrcaRouter as an anonymous custom base URL. It also runs
gateway-level, zero-trust security for AI agents on the same endpoint —
screening every prompt/response and governing every tool call on a
default-deny basis, with no application code changes.

## Changes

- Add `examples/orcarouter/main.go`, mirroring `examples/openai`:
  `openaimodel.NewModel` with `BaseURL: "https://api.orcarouter.ai/v1"`,
  `ORCAROUTER_API_KEY` (env), a `get_weather` function tool, and the same
  launcher wiring — no framework or `openaimodel` changes.
- Add `examples/orcarouter/README.md` with a configuration table, run
  instructions, and the model IDs available on the gateway
  (`orcarouter/free`, `orcarouter/fusion`, `openai/gpt-4.1`, …).
- No new dependencies; no public API surface changes.

## Validation

- `go build -mod=readonly work` — pass
- `go test -mod=readonly -count=1 ./model/... ./examples/orcarouter/` — pass
- `golangci-lint run` — 0 issues
- `go mod tidy -diff` — no changes
- Live check: ran `openaimodel.NewModel` with `BaseURL: "https://api.orcarouter.ai/v1"`
  against the gateway; both non-streaming and streaming `GenerateContent`
  returned model output (HTTP 200) for `orcarouter/fusion-flash`.

## Testing plan

- [x] Unit: existing `model/openaimodel` tests remain green
- [x] Manual E2E: live OrcaRouter call via the example's exact client config
- [x] `go run ./examples/orcarouter/ console` with `ORCAROUTER_API_KEY` set

---

I'm an engineer on the OrcaRouter team.

Discord: discord.gg/YEubt8enRA · X: https://x.com/OrcaRouter
