### PR TITLE
test(artifact): cover version lookup after deletion

### DIFF
--- a/internal/artifact/tests/service_suite.go
+++ b/internal/artifact/tests/service_suite.go
@@ -489,10 +489,17 @@ func testArtifactService_GetArtifactVersion(ctx context.Context, t *testing.T, s
 		}
 	})
 
-	// Clean up.
 	if err := srv.Delete(ctx, &artifact.DeleteRequest{
 		AppName: appName, UserID: userID, SessionID: sessionID, FileName: fileName,
 	}); err != nil {
 		t.Fatalf("Delete(%s) failed: %v", fileName, err)
 	}
+	t.Run(fmt.Sprintf("GetArtifactVersionAfterDelete_%s", testSuffix), func(t *testing.T) {
+		got, err := srv.GetArtifactVersion(ctx, &artifact.GetArtifactVersionRequest{
+			AppName: appName, UserID: userID, SessionID: sessionID, FileName: fileName,
+		})
+		if !errors.Is(err, fs.ErrNotExist) {
+			t.Fatalf("GetArtifactVersion() = (%v, %v), want error(%v)", got, err, fs.ErrNotExist)
+		}
+	})
 }


### PR DESCRIPTION
**Please ensure you have read the [contribution guide](https://github.com/google/adk-go/blob/main/CONTRIBUTING.md) before creating a pull request.**

### Link to Issue or Description of Change

- #681

**Problem:**

The shared artifact service contract suite verifies that `GetArtifactVersion` returns `fs.ErrNotExist` for an empty service, a missing version, and a missing file, but it does not verify the behavior after an existing artifact is deleted.

**Solution:**

Extend the shared service suite with a post-deletion `GetArtifactVersion` assertion. The test runs through the existing in-memory and fake-GCS service implementations and requires an error that matches `fs.ErrNotExist`.

### Testing Plan

**Unit Tests:**

- [x] I have added or updated unit tests for my change.
- [x] All unit tests pass locally.

Passed results:

- `go test -mod=readonly -count=1 -shuffle=on ./artifact/... ./internal/artifact/...`
- `docker run ... golang:1.26.6 go test -race -mod=readonly -count=1 -shuffle=on work` (all workspace packages passed; the Windows worktree was copied to a temporary Linux directory to normalize CRLF before running the repository's copyright-header test)
- `go build -mod=readonly work`
- `go build -mod=readonly ./...` in `plugin/agentanalytics`
- `golangci-lint run --allow-parallel-runners --new-from-rev=HEAD`
- `git diff --check` and `gofmt`

Known local limitations:

- `go mod tidy -diff` reports a CRLF/LF-only diff on the Windows worktree and does not modify any files.
- Full `golangci-lint run` reports pre-existing gofumpt issues in `platform/*.go` and `plugin/agentanalytics/*.go`; the changed file is clean under `--new-from-rev=HEAD`.

**Manual End-to-End (E2E) Tests:**

Not applicable: this is a backend contract test with no user-facing runtime change or external service setup.

### Checklist

- [x] I have read the [CONTRIBUTING.md](https://github.com/google/adk-go/blob/main/CONTRIBUTING.md) document.
- [x] I have performed a self-review of my own code.
- [x] I have commented my code, particularly where needed for this small assertion.
- [x] I have added tests that prove the behavior after deletion.
- [x] New and existing unit tests pass locally in the relevant packages and workspace race run.
- [x] Manual E2E testing is not applicable to this test-only change.
- [x] No dependent changes are required.

### Additional context

No production code or public API behavior is changed.
