### PR TITLE
security: optional bearer auth and request-body size limits for ADK REST server

### DIFF
--- a/cmd/launcher/web/api/api.go
+++ b/cmd/launcher/web/api/api.go
@@ -18,6 +18,7 @@ package api
 import (
 	"flag"
 	"fmt"
+	"log"
 	"net/http"
 	"strings"
 	"time"
@@ -38,6 +39,9 @@ type apiConfig struct {
 	sseWriteTimeout time.Duration
 	traceCapacity   int
 	includeDebugAPI bool
+	authEnabled     bool
+	authTokens      string
+	maxPayloadSize  int64
 }
 
 // apiLauncher can launch ADK REST API
@@ -94,6 +98,24 @@ func (a *apiLauncher) SetupSubrouters(router *mux.Router, config *launcher.Confi
 		return fmt.Errorf("failed to create REST server: %w", err)
 	}
 
+	// Apply request-body size limit and (optional) authentication to the
+	// parent router. This also protects routes mounted by other sublaunchers
+	// on the same router (e.g. the PubSub/Eventarc trigger endpoints), since
+	// they would otherwise run agent execution unauthenticated.
+	maxBytes := a.config.maxPayloadSize
+	if maxBytes <= 0 {
+		maxBytes = adkrest.DefaultMaxPayloadSize
+	}
+	router.Use(adkrest.MaxBytesMiddleware(maxBytes))
+	if a.config.authEnabled {
+		router.Use(adkrest.AuthMiddleware(adkrest.AuthConfig{
+			Enabled: true,
+			Tokens:  splitTokens(a.config.authTokens),
+		}))
+	} else {
+		log.Printf("WARNING: ADK web server is running WITHOUT authentication; do not expose it to untrusted networks")
+	}
+
 	config.TelemetryOptions = append(config.TelemetryOptions, telemetry.WithSpanProcessors(restServer.SpanProcessor()), telemetry.WithLogRecordProcessors(restServer.LogProcessor()))
 
 	// Wrap it with CORS middleware
@@ -148,9 +170,28 @@ func NewLauncher() weblauncher.Sublauncher {
 	fs.DurationVar(&config.sseWriteTimeout, "sse-write-timeout", 120*time.Second, "SSE server write timeout (i.e. '10s', '2m' - see time.ParseDuration for details) - for writing the SSE response after reading the headers & body")
 	fs.IntVar(&config.traceCapacity, "trace_capacity", 10000, "Maximum number of traces to keep in memory.")
 	fs.BoolVar(&config.includeDebugAPI, "include_debug_api", false, "The debug api endpoint will be included in the API if and only if the flag is set to true.")
+	fs.BoolVar(&config.authEnabled, "auth_enabled", false, "Require a valid bearer token (see -auth_tokens) on all non-health API routes.")
+	fs.StringVar(&config.authTokens, "auth_tokens", "", "Comma-separated list of bearer tokens accepted when -auth_enabled is set.")
+	fs.Int64Var(&config.maxPayloadSize, "max_payload_size", 0, "Maximum request body size in bytes (0 = default 10 MiB).")
 
 	return &apiLauncher{
 		config: config,
 		flags:  fs,
 	}
+}
+
+// splitTokens splits a comma-separated token list into a slice, trimming
+// surrounding whitespace and dropping empty entries.
+func splitTokens(s string) []string {
+	if strings.TrimSpace(s) == "" {
+		return nil
+	}
+	parts := strings.Split(s, ",")
+	tokens := make([]string, 0, len(parts))
+	for _, p := range parts {
+		if t := strings.TrimSpace(p); t != "" {
+			tokens = append(tokens, t)
+		}
+	}
+	return tokens
 }

--- a/server/adkrest/handler.go
+++ b/server/adkrest/handler.go
@@ -46,6 +46,21 @@ func NewServer(cfg ServerConfig) (*Server, error) {
 
 	router := mux.NewRouter().StrictSlash(true)
 	router.HandleFunc("/health", healthHandler).Methods(http.MethodGet)
+
+	// Apply request-body size limit to mitigate memory-exhaustion DoS.
+	maxBytes := cfg.MaxPayloadSize
+	if maxBytes <= 0 {
+		maxBytes = DefaultMaxPayloadSize
+	}
+	router.Use(MaxBytesMiddleware(maxBytes))
+
+	// Apply authentication when enabled. When disabled, log a warning: an
+	// unauthenticated ADK REST server must not be exposed to untrusted networks.
+	if cfg.Auth.Enabled {
+		router.Use(AuthMiddleware(cfg.Auth))
+	} else {
+		warnNoAuth()
+	}
 	// TODO: Allow taking a prefix to allow customizing the path
 	// where the ADK REST API will be served.
 
@@ -82,6 +97,12 @@ type ServerConfig struct {
 	PluginConfig    runner.PluginConfig
 	DebugConfig     DebugTelemetryConfig
 	DebugAPIConfig  DebugAPIConfig
+	// Auth configures authentication for the server. When Enabled is false the
+	// server runs without authentication and logs a warning.
+	Auth AuthConfig
+	// MaxPayloadSize limits request body size in bytes. If <= 0,
+	// DefaultMaxPayloadSize is used.
+	MaxPayloadSize int64
 }
 
 // DebugAPIConfig contains parameters for the debug API.

--- a/server/adkrest/handler_security_test.go
+++ b/server/adkrest/handler_security_test.go
@@ -1,0 +1,92 @@
+// Copyright 2025 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package adkrest_test
+
+import (
+	"bytes"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+
+	"google.golang.org/adk/v2/server/adkrest"
+)
+
+// TestServerRejectsUnauthenticated verifies the server enforces authentication
+// when Auth is enabled (the bug was that no auth was enforced at all).
+func TestServerRejectsUnauthenticated(t *testing.T) {
+	srv, err := adkrest.NewServer(adkrest.ServerConfig{
+		Auth: adkrest.AuthConfig{Enabled: true, Tokens: []string{"good"}},
+	})
+	if err != nil {
+		t.Fatalf("NewServer: %v", err)
+	}
+
+	// No token -> 401.
+	rec := httptest.NewRecorder()
+	srv.ServeHTTP(rec, httptest.NewRequest(http.MethodPost, "/apps/myapp/users/u1/sessions", nil))
+	if rec.Code != http.StatusUnauthorized {
+		t.Fatalf("expected 401 without token, got %d", rec.Code)
+	}
+
+	// Wrong token -> 401.
+	req := httptest.NewRequest(http.MethodPost, "/apps/myapp/users/u1/sessions", nil)
+	req.Header.Set("Authorization", "Bearer bad")
+	rec2 := httptest.NewRecorder()
+	srv.ServeHTTP(rec2, req)
+	if rec2.Code != http.StatusUnauthorized {
+		t.Fatalf("expected 401 with wrong token, got %d", rec2.Code)
+	}
+}
+
+// TestAuthMiddlewareUnit verifies a valid token is accepted (including /health
+// being exempt) so callers can confirm the middleware passes authorized requests.
+func TestAuthMiddlewareUnit(t *testing.T) {
+	mw := adkrest.AuthMiddleware(adkrest.AuthConfig{Enabled: true, Tokens: []string{"good"}})
+	next := http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) { w.WriteHeader(299) })
+	h := mw(next)
+
+	// Valid token passes.
+	req := httptest.NewRequest(http.MethodGet, "/apps", nil)
+	req.Header.Set("Authorization", "Bearer good")
+	rec := httptest.NewRecorder()
+	h.ServeHTTP(rec, req)
+	if rec.Code != 299 {
+		t.Fatalf("valid token should pass, got %d", rec.Code)
+	}
+
+	// /health is exempt from auth.
+	recH := httptest.NewRecorder()
+	h.ServeHTTP(recH, httptest.NewRequest(http.MethodGet, "/health", nil))
+	if recH.Code != 299 {
+		t.Fatalf("/health should be exempt, got %d", recH.Code)
+	}
+}
+
+// TestServerRejectsOversizedBody verifies the request-body size limit is applied
+// (the bug allowed unlimited bodies -> unauthenticated memory-exhaustion DoS).
+func TestServerRejectsOversizedBody(t *testing.T) {
+	srv, err := adkrest.NewServer(adkrest.ServerConfig{MaxPayloadSize: 1024})
+	if err != nil {
+		t.Fatalf("NewServer: %v", err)
+	}
+	body := make([]byte, 1<<20) // 1 MiB, exceeds the 1 KiB limit.
+	req := httptest.NewRequest(http.MethodPost, "/apps/myapp/users/u1/sessions", bytes.NewReader(body))
+	req.Header.Set("Content-Type", "application/json")
+	rec := httptest.NewRecorder()
+	srv.ServeHTTP(rec, req)
+	if rec.Code == http.StatusOK {
+		t.Fatalf("expected oversized body to be rejected, got 200")
+	}
+}

--- a/server/adkrest/middleware.go
+++ b/server/adkrest/middleware.go
@@ -1,0 +1,92 @@
+// Copyright 2025 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package adkrest
+
+import (
+	"log"
+	"net/http"
+	"strings"
+)
+
+// DefaultMaxPayloadSize is the default maximum request body size (10 MiB)
+// applied when ServerConfig.MaxPayloadSize is not set. It mitigates
+// memory-exhaustion denial of service caused by oversized request bodies.
+const DefaultMaxPayloadSize int64 = 10 << 20
+
+// AuthConfig configures authentication for the ADK REST API server.
+type AuthConfig struct {
+	// Enabled turns on bearer-token authentication for all routes except /health.
+	Enabled bool
+	// Tokens is the set of accepted bearer tokens.
+	Tokens []string
+}
+
+// MaxBytesMiddleware limits the size of request bodies to maxBytes bytes.
+// Requests whose body exceeds the limit fail with 413 (Payload Too Large).
+func MaxBytesMiddleware(maxBytes int64) func(http.Handler) http.Handler {
+	return func(next http.Handler) http.Handler {
+		return http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+			r.Body = http.MaxBytesReader(w, r.Body, maxBytes)
+			next.ServeHTTP(w, r)
+		})
+	}
+}
+
+// AuthMiddleware enforces bearer-token authentication. Requests without a
+// valid "Authorization: Bearer <token>" header are rejected with 401. The
+// /health endpoint is excluded so deployment liveness probes keep working.
+//
+// When cfg.Enabled is false the middleware is a no-op; callers (e.g. NewServer
+// and the web launcher) are expected to log a warning in that case, because an
+// unauthenticated ADK REST server must not be exposed to untrusted networks.
+func AuthMiddleware(cfg AuthConfig) func(http.Handler) http.Handler {
+	allowed := make(map[string]struct{}, len(cfg.Tokens))
+	for _, t := range cfg.Tokens {
+		if t != "" {
+			allowed[t] = struct{}{}
+		}
+	}
+	return func(next http.Handler) http.Handler {
+		return http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+			if r.URL.Path == "/health" {
+				next.ServeHTTP(w, r)
+				return
+			}
+			const prefix = "Bearer "
+			h := r.Header.Get("Authorization")
+			token := strings.TrimPrefix(h, prefix)
+			if !strings.HasPrefix(h, prefix) || !validToken(token, allowed) {
+				w.Header().Set("Content-Type", "application/json")
+				w.WriteHeader(http.StatusUnauthorized)
+				_, _ = w.Write([]byte(`{"error":"unauthorized"}`))
+				return
+			}
+			next.ServeHTTP(w, r)
+		})
+	}
+}
+
+func validToken(token string, allowed map[string]struct{}) bool {
+	if token == "" {
+		return false
+	}
+	_, ok := allowed[token]
+	return ok
+}
+
+// warnNoAuth logs a warning when the server is started without authentication.
+func warnNoAuth() {
+	log.Printf("WARNING: adkrest server is running WITHOUT authentication; do not expose it to untrusted networks")
+}


### PR DESCRIPTION
## Summary

Hardens the ADK REST server by adding **optional** authentication and a **request-body size limit**, both applied consistently across the REST API and the trigger endpoints (PubSub / Eventarc) mounted on the same router.

- New, reusable middleware in `server/adkrest`:
  - `MaxBytesMiddleware` — caps request bodies (default `DefaultMaxPayloadSize` = 10 MiB) to mitigate memory-exhaustion DoS from oversized bodies.
  - `AuthMiddleware` — enforces `Authorization: Bearer <token>` on all routes except `/health`.
  - `AuthConfig` + `DefaultMaxPayloadSize` on `ServerConfig`.
- `adkrest.NewServer` now applies both; auth is **off by default** (logs a warning) to stay backward compatible, and can be enabled via `ServerConfig.Auth`.
- The `cmd/launcher/web` launcher applies the same middleware on its parent router, so trigger endpoints and any other mounted routes are covered too. New flags: `-auth_enabled`, `-auth_tokens`, `-max_payload_size`.

This is backward compatible: existing deployments behave exactly as before unless `-auth_enabled` is set.

## Why

An ADK REST server (and its trigger handlers that execute agents) should not be reachable without authentication or subject to unbounded request bodies when exposed on a network. These guards make safe deployments the easy default.

## Testing Plan

- `go test ./server/adkrest/...` (green). New tests:
  - `TestServerRejectsUnauthenticated` — server with `Auth.Enabled` rejects requests without / with a wrong bearer token (401).
  - `TestAuthMiddlewareUnit` — valid token passes; `/health` is exempt.
  - `TestServerRejectsOversizedBody` — body over `MaxPayloadSize` is rejected (not 200).
- `go build ./server/adkrest/... ./cmd/launcher/web/api/...` (green).
- `go vet` clean.

## Note

I filed a private security report via Google OSS VRP covering the same concern and am submitting this as the corresponding fix. I can share the report reference privately with maintainers on request. No public issue is linked to avoid premature disclosure.