### PR TITLE
docs: fix typos in examples

### DIFF
--- a/examples/bidi/streamingtool/main.go
+++ b/examples/bidi/streamingtool/main.go
@@ -110,7 +110,7 @@ func main() {
 	a, err := llmagent.New(llmagent.Config{
 		Name:        "bidi-demo",
 		Model:       model,
-		Instruction: "You are a helpful assistant with a streaming tool 'count_to'. Always use it when asked to count. Wait for the tool results, and when you recieve them you should say the number, if it is divisible by 3 you should not say the number and instead say Fizz and if it is divisible by 5 you should say Buzz, if it is divisible by both 3 and 5 you should say FizzBuzz. Always use the check_divisible tool",
+		Instruction: "You are a helpful assistant with a streaming tool 'count_to'. Always use it when asked to count. Wait for the tool results, and when you receive them you should say the number, if it is divisible by 3 you should not say the number and instead say Fizz and if it is divisible by 5 you should say Buzz, if it is divisible by both 3 and 5 you should say FizzBuzz. Always use the check_divisible tool",
 		Tools:       []tool.Tool{counterTool, stopTool, checkDivisibleTool},
 	})
 	if err != nil {

--- a/examples/toolconfirmation/main.go
+++ b/examples/toolconfirmation/main.go
@@ -13,7 +13,7 @@
 // limitations under the License.
 
 // Package provides an example console app for tool confirmation.
-// The example shows requestVacationDays func which requires user confirmation. It uses ctx.ToolConfirmation() and ctx.RequestConfirmation() to define the confimation process.
+// The example shows requestVacationDays func which requires user confirmation. It uses ctx.ToolConfirmation() and ctx.RequestConfirmation() to define the confirmation process.
 // This is the example for most advanced scenario which gives the full control how to define confirmation flow.
 // For simpler setup use `RequireConfirmation` or `RequireConfirmationProvider` in [functiontool.Config].
 package main

--- a/examples/web/agents/image_generator.go
+++ b/examples/web/agents/image_generator.go
@@ -12,7 +12,7 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-// Package agents contains sample agents to demonstate ADK Web Capabilities.
+// Package agents contains sample agents to demonstrate ADK Web Capabilities.
 package agents
 
 import (


### PR DESCRIPTION
### Link to Issue or Description of Change

**Problem:**

Three example files contain spelling mistakes in user-facing instructions and package comments.

**Solution:**

Correct `recieve`, `confimation`, and `demonstate` without changing behavior.

### Testing Plan

- `go test ./examples/bidi/streamingtool ./examples/toolconfirmation ./examples/web/agents`
- `go build -mod=readonly work`
- `golangci-lint run --new-from-rev=origin/main` for the affected example packages
- `git diff --check`

### Checklist

- [x] I have read the `CONTRIBUTING.md` document.
- [x] I have performed a self-review of my changes.
- [x] No tests were added because this is a typo-only documentation change.