### PR TITLE
chore(version): bump the tagged version constant to 2.3.0

### DIFF
--- a/internal/version/version.go
+++ b/internal/version/version.go
@@ -15,4 +15,4 @@
 package version
 
 // Version exposes the current ADK Go version, used for llm request tagging
-const Version = "2.0.0"
+const Version = "2.3.0"


### PR DESCRIPTION
## Problem

`internal/version/version.go` still declares `2.0.0`. The constant was last bumped for the 2.0 release and was missed for both `v2.1.0` and `v2.2.0`, so every Gemini request since has advertised `google-adk/2.0.0` in `User-Agent` and `x-goog-api-client`, the MCP client has identified itself as `2.0.0`, and OpenTelemetry traces and logs have carried `2.0.0` as their instrumentation version. Usage attributed to the last two releases is therefore indistinguishable from 2.0.

## Summary

Sets the constant to `2.3.0`, the version being tagged for this release. Nothing else reads or asserts an exact version — `model/gemini/gemini_test.go` only checks that the `google-adk/` and `gl-go/` prefixes are present, and no recorded test traffic pins the old string, so replay stays intact.