### PR TITLE
internal: require explicit ack for -httprecord directives that claim a whole package

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -162,7 +162,11 @@ See [Multi-Module Development](CONTRIBUTING.md#multi-module-development) in
 - To re-record a whole package, run `go generate ./<pkg>/...`; each package's
   `//go:generate go test -httprecord=…` directives are scoped so that every
   cassette is recorded exactly once (enforced by
-  `TestHTTPRecordDirectivesPartitionCassettes` in `internal`).
+  `TestHTTPRecordDirectivesPartitionCassettes` in `internal`). If a directive
+  intentionally claims every cassette in a package that has more than one
+  (nothing to partition, e.g. one recording directive per package), that same
+  test requires a `// httprecord:whole-package` comment directly above it —
+  add one rather than narrowing the pattern.
 - Prefer table-driven tests; shared helpers live in `internal/testutil`.
 
 ## Boundaries

--- a/agent/remoteagent/v2/a2a_e2e_test.go
+++ b/agent/remoteagent/v2/a2a_e2e_test.go
@@ -14,6 +14,8 @@
 
 package remoteagent
 
+// httprecord:whole-package -- one directive, one small e2e test file; there
+// is nothing here to partition (see internal/httprr_directives_test.go).
 //go:generate go test -httprecord=.*
 
 import (

--- a/internal/httprr_directives_test.go
+++ b/internal/httprr_directives_test.go
@@ -29,7 +29,7 @@ import (
 //
 // The -httprecord flag is a regexp matched against the cassette's file path
 // (see httprr.Recording in internal/httprr), not a -run test-name filter. That
-// makes two failure modes possible, and both are silent:
+// makes three failure modes possible, all silent:
 //
 //   - Two directives in one package match the same cassette, so
 //     `go generate ./<pkg>/...` re-records it twice against a live model in a
@@ -37,9 +37,20 @@ import (
 //     ones.
 //   - A directive matches none of its cassettes, so `go generate` appears to
 //     succeed while recording nothing.
+//   - A single directive matches every cassette in a package that has more
+//     than one, so refreshing one recording re-records the whole package.
+//     This is not always wrong -- a package with one directive per test file
+//     has nothing to partition -- but it must be a deliberate choice, not an
+//     accident (see #1330, reopened after #1362 fixed only the first failure
+//     mode above: five packages still had this at the time, unreviewed).
 //
-// Requiring exactly one directive per cassette rules out the first, and at
-// least one cassette per directive rules out the second.
+// Requiring exactly one directive per cassette rules out the first failure
+// mode, at least one cassette per directive rules out the second, and a
+// `httprecord:whole-package` acknowledgment comment immediately above any
+// directive that claims every cassette in a multi-cassette package rules out
+// the third -- it does not change behavior, only forces the choice to be
+// visible in the diff that makes it, and readable at the directive itself
+// rather than only in an issue thread.
 func TestHTTPRecordDirectivesPartitionCassettes(t *testing.T) {
 	// Start test from the parent directory, root of the module.
 	t.Chdir("..")
@@ -51,11 +62,15 @@ func TestHTTPRecordDirectivesPartitionCassettes(t *testing.T) {
 		"vendor": true,
 	}
 
+	const wholePackageAck = "httprecord:whole-package"
+
 	type directive struct {
-		file    string
-		pattern string
-		re      *regexp.Regexp
-		claims  int // cassettes in the same package this directive matched
+		file       string
+		pattern    string
+		re         *regexp.Regexp
+		claims     int  // cassettes in the same package this directive matched
+		acked      bool // preceding line carries the wholePackageAck marker
+		lineForAck string
 	}
 	byPkg := make(map[string][]directive)
 	total := 0
@@ -77,8 +92,9 @@ func TestHTTPRecordDirectivesPartitionCassettes(t *testing.T) {
 		if err != nil {
 			return err
 		}
-		for _, line := range strings.Split(string(content), "\n") {
-			line = strings.TrimSpace(line)
+		lines := strings.Split(string(content), "\n")
+		for i, raw := range lines {
+			line := strings.TrimSpace(raw)
 			if !strings.HasPrefix(line, "//go:generate") || !strings.Contains(line, "-httprecord") {
 				continue
 			}
@@ -101,7 +117,30 @@ func TestHTTPRecordDirectivesPartitionCassettes(t *testing.T) {
 				t.Errorf("%s: -httprecord=%s is not a valid regexp: %v", path, pattern, err)
 				continue
 			}
-			byPkg[filepath.Dir(path)] = append(byPkg[filepath.Dir(path)], directive{file: path, pattern: pattern, re: re})
+			// The marker must be in a comment line above the directive, never
+			// appended to the //go:generate line itself -- go:generate treats
+			// everything after the directive name as the shell command to
+			// run, so trailing text there would be passed to `go test` as
+			// bogus extra arguments instead of being a comment. It can be
+			// anywhere in the contiguous `//`-comment block directly above
+			// the directive (walking up through consecutive plain "//" lines,
+			// stopping at the first blank or non-comment line), not only the
+			// single line touching the directive, so an explanation can
+			// precede the marker within the same block.
+			acked := false
+			for j := i - 1; j >= 0; j-- {
+				prev := strings.TrimSpace(lines[j])
+				if !strings.HasPrefix(prev, "//") || strings.HasPrefix(prev, "//go:generate") {
+					break
+				}
+				if strings.Contains(prev, wholePackageAck) {
+					acked = true
+					break
+				}
+			}
+			byPkg[filepath.Dir(path)] = append(byPkg[filepath.Dir(path)], directive{
+				file: path, pattern: pattern, re: re, acked: acked, lineForAck: line,
+			})
 			total++
 		}
 		return nil
@@ -147,10 +186,27 @@ func TestHTTPRecordDirectivesPartitionCassettes(t *testing.T) {
 		// A directive that claims nothing is a dead pattern: `go generate` runs
 		// it, records nothing, and reports success. The per-cassette check above
 		// misses this whenever a sibling directive already covers every cassette.
+		//
+		// A directive that claims EVERY cassette in a package with more than
+		// one is the opposite problem (#1330): `go generate ./<pkg>/...`
+		// silently re-records the whole package, against live models whose
+		// responses differ run to run, whenever someone means to refresh just
+		// one. Not necessarily wrong -- a package with one directive covering
+		// one test file has nothing to partition -- so this does not forbid
+		// it, only requires the `httprecord:whole-package` comment directly
+		// above the directive, so the breadth is a visible, deliberate choice
+		// in the diff that introduces or keeps it, not a silent default.
 		for _, d := range directives {
 			if d.claims == 0 {
 				t.Errorf("%s: -httprecord=%s claims none of the %d cassettes in %s/testdata; `go generate` would record nothing",
 					d.file, d.pattern, len(cassettes), pkg)
+				continue
+			}
+			if d.claims == len(cassettes) && len(cassettes) > 1 && !d.acked {
+				t.Errorf("%s: -httprecord=%s claims all %d cassettes in %s/testdata, re-recording any one re-records "+
+					"the whole package -- if that's intended, add a `// %s` comment directly above the directive "+
+					"(see TestHTTPRecordDirectivesPartitionCassettes); if not, narrow the pattern:\n\t%s",
+					d.file, d.pattern, len(cassettes), pkg, wholePackageAck, d.lineForAck)
 			}
 		}
 	}

--- a/model/gemini/gemini_test.go
+++ b/model/gemini/gemini_test.go
@@ -32,6 +32,9 @@ import (
 	"google.golang.org/adk/v2/model"
 )
 
+// httprecord:whole-package -- this is the only recording directive in the
+// package, so there is nothing to partition (see
+// internal/httprr_directives_test.go).
 //go:generate go test -httprecord=testdata/.*\.httprr
 
 func TestModel_Generate(t *testing.T) {

--- a/plugin/functioncallmodifier/integration_test.go
+++ b/plugin/functioncallmodifier/integration_test.go
@@ -35,6 +35,9 @@ import (
 	"google.golang.org/adk/v2/tool/functiontool"
 )
 
+// httprecord:whole-package -- this is the only recording directive in the
+// package (plugin_test.go records nothing), so there is nothing to
+// partition (see internal/httprr_directives_test.go).
 //go:generate go test -v -httprecord=testdata/.*\.httprr
 
 func TestPluginCallbackIntegration(t *testing.T) {

--- a/tool/mcptoolset/set_test.go
+++ b/tool/mcptoolset/set_test.go
@@ -60,6 +60,9 @@ func weatherFunc(ctx context.Context, req *mcp.CallToolRequest, input Input) (*m
 
 const modelName = "gemini-2.5-flash"
 
+// httprecord:whole-package -- this is the only recording directive in the
+// package (transport_config_test.go records nothing), so there is nothing
+// to partition (see internal/httprr_directives_test.go).
 //go:generate go test -v -httprecord=.*
 
 func TestMCPToolSet(t *testing.T) {


### PR DESCRIPTION
### Link to Issue or Description of Change

**1. Link to an existing issue (if applicable):**

- Addresses (not `Closes:`, per the issue's own reopening comment — see below): #1330

**Problem:**

#1330 was reopened after #1362 fixed the double-recording failure mode (two directives claiming the same cassette). The reopening comment (@baptmont) pinned a second, still-silent failure mode: `TestHTTPRecordDirectivesPartitionCassettes` enforces *partition*, not *narrowness* — a single `-httprecord` directive matching every cassette in its package passes the guard cleanly. Five packages still had this at the time:

| directive | package | cassettes |
| --- | --- | --- |
| `-httprecord=.*` | `tool/mcptoolset` | 11 |
| `-httprecord=.*` | `agent/remoteagent/v2` | 4 |
| `-httprecord=testdata/.*\.httprr` | `model/gemini` | 4 |
| `-httprecord=testdata/.*\.httprr` | `plugin/functioncallmodifier` | 3 |

(`tool/functiontool` has only 1 cassette, so its `-httprecord=.*` isn't a partition problem — nothing to partition.)

`go generate ./tool/mcptoolset/...` still re-records all 11 against a live model whenever the intent was to refresh one.

**Solution:**

The issue itself lists three options and explicitly leaves the choice open. This implements the second: *"Teach the guard to flag a directive that claims every cassette in a package with more than one recorded test, so the pattern is at least forced to be deliberate."*

`TestHTTPRecordDirectivesPartitionCassettes` now also fails when a single directive claims every cassette in a package with more than one, **unless** a `// httprecord:whole-package` comment sits in the contiguous `//`-comment block directly above the directive. This doesn't narrow or otherwise change any of the five directives — per the issue's own reasoning, a package with one recording directive has nothing to partition — it only makes that breadth a visible, deliberate choice in the diff that introduces or keeps it, rather than a silent default discoverable only by reading this issue thread. All five directives now carry that comment, each explaining why (single/only recording directive in the package). `AGENTS.md` documents the convention alongside the existing `-httprecord` guidance.

I did not attempt option 1 (closing the issue outright) since that's a maintainer call about intent, not a mechanical fix, and not option 3 (removing the `-httprecord` regexp class of bug entirely) since the issue itself calls that out as by far the largest change.

### Testing Plan

- `go test ./internal/ -run TestHTTPRecordDirectivesPartitionCassettes -v`: fails on all four multi-cassette directives with the ack comment removed (confirmed locally by temporarily deleting each), passes with all five in place (`checked 8 -httprecord directives across 6 packages`).
- `gofmt -l` and `go vet ./internal/... ./agent/remoteagent/v2/... ./model/gemini/... ./plugin/functioncallmodifier/... ./tool/mcptoolset/...`: clean.
- No behavioral change to any `-httprecord` pattern or recorded cassette — this PR only adds a test-time check and doc comments.