### PR TITLE
fix(compaction): stop tail retention paying a model call every turn

### DIFF
--- a/internal/compactioninternal/tail_retention.go
+++ b/internal/compactioninternal/tail_retention.go
@@ -147,6 +147,40 @@ func TailRetention(ctx context.Context, cfg *compaction.Config, sess session.Ses
 		return nil, noop, nil
 	}
 
+	// The same futility as the gate above, but across turns, which that gate
+	// cannot see: its state lives on the compaction runtime, which is built per
+	// invocation, so every turn arrives with it cleared. A standing summary
+	// already larger than the threshold puts the prompt back over the line the
+	// moment compaction finishes, so left alone this is one summarizer call
+	// every turn for the life of the session, and not one of them can succeed.
+	//
+	// Declining outright is not the answer either, because the uncovered tail
+	// would then grow without limit, which is what this strategy exists to
+	// prevent. The work is amortized instead: once the summary alone cannot
+	// fit, wait until enough new material has accumulated to be worth a call.
+	// The prompt stays bounded, by the summary plus a fraction of the threshold
+	// plus the retained tail, at a fraction of the calls.
+	//
+	// Measured on the window rather than by subtracting from the prompt count,
+	// because the two are not always on the same footing: the prompt count
+	// prefers an observed usage reading, which includes the materialized
+	// summary, but falls back to an estimate over raw events, where a
+	// compaction event renders as nothing. Subtracting would then be comparing
+	// a number that includes the summary against one that does not.
+	if standing, ok := standingSummaryTokens(events, scope, estimate); ok && standing >= cfg.TokenThreshold {
+		if fresh := window; estimate != nil {
+			// The seed is the previous summary, not new material.
+			if len(fresh) > 0 && hasCompaction(fresh[0]) {
+				fresh = fresh[1:]
+			}
+			if estimate(fresh) < cfg.TokenThreshold/rearmDivisor {
+				traceDeclined(ctx, cfg, sess, telemetry.CompactionTriggerTokenThreshold,
+					"the standing summary alone exceeds the threshold, and too little has accumulated since to be worth a call")
+				return nil, noop, nil
+			}
+		}
+	}
+
 	summary, finish, err := summarizeTraced(ctx, cfg, sess, scope.InvocationID, telemetry.CompactionTriggerTokenThreshold, window)
 	if err != nil {
 		// The gate is closed here rather than on the Finish callback, because
@@ -504,4 +538,41 @@ func traceDeclined(ctx context.Context, cfg *compaction.Config, sess session.Ses
 		id = sess.ID()
 	}
 	telemetry.TraceCompactionDeclined(ctx, spanParams(cfg, id, latestInvocationID(sess), trigger, 0), reason)
+}
+
+// rearmDivisor sets how much new material must accumulate before tail
+// retention runs again, once the standing summary alone has been shown not to
+// fit under the threshold.
+//
+// A quarter of the threshold. Small enough that the prompt stays close to the
+// ceiling the strategy promises, large enough that the summarizer is not called
+// to fold in a turn or two. The exact fraction matters less than that one
+// exists: without it the call rate is one per turn regardless of how little
+// changed.
+const rearmDivisor = 4
+
+// standingSummaryTokens estimates the size of the newest visible summary on its
+// own, which is the part of the prompt no further compaction can remove.
+//
+// Reported separately from the prompt count because the two answer different
+// questions. The prompt count says whether the prompt is too large; this says
+// whether compacting could do anything about it.
+func standingSummaryTokens(events []*session.Event, scope TurnScope, estimate TokenCounter) (int, bool) {
+	if estimate == nil {
+		return 0, false
+	}
+	for i := len(events) - 1; i >= 0; i-- {
+		ev := events[i]
+		if !scope.visible(ev) || !HasUsableSummary(ev) {
+			continue
+		}
+		// Measured through the same estimator as everything else, on an event
+		// shaped like the one tail retention seeds a window with, so the number
+		// is comparable to the prompt count it is subtracted from.
+		probe := &session.Event{
+			LLMResponse: model.LLMResponse{Content: ev.Actions.Compaction.CompactedContent},
+		}
+		return estimate([]*session.Event{probe}), true
+	}
+	return 0, false
 }

--- a/internal/compactioninternal/tail_retention.go
+++ b/internal/compactioninternal/tail_retention.go
@@ -173,7 +173,16 @@ func TailRetention(ctx context.Context, cfg *compaction.Config, sess session.Ses
 			if len(fresh) > 0 && hasCompaction(fresh[0]) {
 				fresh = fresh[1:]
 			}
-			if estimate(fresh) < cfg.TokenThreshold/rearmDivisor {
+			// A count as well as a size, because the estimator is a floor. It
+			// counts text, tool calls and tool responses, but not inline data,
+			// so a tail of images reads as almost nothing while costing the
+			// real prompt a great deal -- and holding compaction off on the
+			// strength of that reading would let the prompt grow without
+			// limit, which is worse than the wasted calls this guard exists to
+			// stop. Whichever bound is reached first releases it.
+			enough := estimate(fresh) >= cfg.TokenThreshold/rearmDivisor ||
+				len(fresh) >= rearmMaxPendingEvents*cfg.EventRetentionSize
+			if !enough {
 				traceDeclined(ctx, cfg, sess, telemetry.CompactionTriggerTokenThreshold,
 					"the standing summary alone exceeds the threshold, and too little has accumulated since to be worth a call")
 				return nil, noop, nil
@@ -550,6 +559,15 @@ func traceDeclined(ctx context.Context, cfg *compaction.Config, sess session.Ses
 // exists: without it the call rate is one per turn regardless of how little
 // changed.
 const rearmDivisor = 4
+
+// rearmMaxPendingEvents bounds how many events may pile up behind the amortized
+// gate, as a multiple of the retained tail, regardless of what they estimate to.
+//
+// The size rule above rests on an estimator that is explicitly a floor, so this
+// is the backstop for the case where it reads low and the prompt is growing
+// anyway. Generous on purpose: it should almost never be the rule that fires,
+// only the one that stops "almost never" from meaning "never".
+const rearmMaxPendingEvents = 8
 
 // standingSummaryTokens estimates the size of the newest visible summary on its
 // own, which is the part of the prompt no further compaction can remove.

--- a/internal/compactioninternal/tail_retention_test.go
+++ b/internal/compactioninternal/tail_retention_test.go
@@ -1287,3 +1287,44 @@ func estimateFromEvents(events []*session.Event) int {
 	}
 	return EstimateTokensFromContents(contents)
 }
+
+// TestTailRetentionAmortizationDoesNotStallOnAnUndercountedTail pins the
+// backstop on the amortized gate.
+//
+// The size rule rests on the token estimator, which is documented as a floor:
+// it counts text, tool calls and tool responses, but not inline data. A tail of
+// images therefore reads as almost nothing while costing the real prompt a
+// great deal. Holding compaction off on the strength of that reading would let
+// the prompt grow without limit, which is a worse failure than the wasted calls
+// the gate exists to prevent.
+func TestTailRetentionAmortizationDoesNotStallOnAnUndercountedTail(t *testing.T) {
+	t.Parallel()
+
+	oversized := compactionEvent("s1", 1, 1, 2, strings.Repeat("x", 400))
+
+	// Events the estimator cannot see: inline data only, no text and no tool
+	// traffic. Enough of them to pass the count backstop.
+	events := []*session.Event{oversized}
+	for i := range rearmMaxPendingEvents*2 + 6 {
+		ev := modelTextEvent("blob", "inv2", i+3, "")
+		ev.LLMResponse.Content = &genai.Content{Role: "model", Parts: []*genai.Part{
+			{InlineData: &genai.Blob{MIMEType: "image/png", Data: []byte("payload")}},
+		}}
+		events = append(events, ev)
+	}
+	events = append(events, withUsage(modelTextEvent("last", "inv3", 99, "a"), 5000))
+
+	cfg := &compaction.Config{
+		TokenThreshold:     50,
+		EventRetentionSize: 2,
+		Summarizer:         &fakeSummarizer{summary: "sum"},
+	}
+	got, err := tailRetentionStored(context.Background(), cfg,
+		&staticSession{events: events}, TurnScope{}, estimateFromEvents, &recordingGate{allow: true})
+	if err != nil {
+		t.Fatalf("tailRetentionStored() error = %v", err)
+	}
+	if got == nil {
+		t.Error("compaction never ran behind the amortized gate for a tail the estimator cannot measure, so the prompt would grow without limit")
+	}
+}

--- a/internal/compactioninternal/tail_retention_test.go
+++ b/internal/compactioninternal/tail_retention_test.go
@@ -1198,3 +1198,92 @@ func TestTailRetentionWindowStaysInsideTheTurnsScope(t *testing.T) {
 		t.Errorf("window (-want +got):\n%s", diff)
 	}
 }
+
+// TestTailRetentionAmortizesWhenTheSummaryAloneExceedsTheThreshold pins the
+// across-turn half of the futility check.
+//
+// The ProgressGate covers one invocation. It lives on the compaction runtime,
+// which is built per invocation, so a new turn always arrives with it cleared.
+// A standing summary larger than the threshold therefore re-triggered
+// compaction on every single turn, forever, and none of those calls could
+// succeed: the summary is already over the line before any new events are
+// counted.
+func TestTailRetentionAmortizesWhenTheSummaryAloneExceedsTheThreshold(t *testing.T) {
+	t.Parallel()
+
+	// 400 characters of summary is 100 tokens through the estimator, against a
+	// threshold of 50. Compacting cannot get under that however much it folds
+	// in.
+	oversized := compactionEvent("s1", 1, 1, 2, strings.Repeat("x", 400))
+
+	tests := []struct {
+		name        string
+		tail        []*session.Event
+		wantSummary bool
+	}{
+		{
+			// One short turn since the last compaction. Summarizing it buys a
+			// handful of tokens against a prompt already far over the line.
+			name: "little new material, so no call",
+			tail: []*session.Event{
+				textEvent("a", "inv2", 3, "q"), modelTextEvent("b", "inv2", 4, "a"),
+				textEvent("c", "inv3", 5, "q"),
+				// An observed prompt count, so the threshold is crossed on the
+				// strength of the materialized summary rather than of the tail.
+				// Without this the estimator never sees the summary at all --
+				// a compaction event renders as nothing -- the prompt reads as
+				// a handful of tokens, and the pass declines for being under
+				// the threshold, which would let this case pass with the guard
+				// deleted.
+				withUsage(modelTextEvent("d", "inv3", 6, "a"), 120),
+			},
+			wantSummary: false,
+		},
+		{
+			// Enough has accumulated to be worth folding in, so the strategy
+			// resumes rather than letting the tail grow without limit.
+			name: "enough new material, so it runs",
+			tail: []*session.Event{
+				textEvent("a", "inv2", 3, strings.Repeat("y", 200)),
+				modelTextEvent("b", "inv2", 4, strings.Repeat("y", 200)),
+				textEvent("c", "inv3", 5, "q"),
+				withUsage(modelTextEvent("d", "inv3", 6, "a"), 220),
+			},
+			wantSummary: true,
+		},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			t.Parallel()
+
+			events := append([]*session.Event{oversized}, tc.tail...)
+			cfg := &compaction.Config{
+				TokenThreshold:     50,
+				EventRetentionSize: 2,
+				Summarizer:         &fakeSummarizer{summary: "sum"},
+			}
+			got, err := tailRetentionStored(context.Background(), cfg,
+				&staticSession{events: events}, TurnScope{},
+				estimateFromEvents, &recordingGate{allow: true})
+			if err != nil {
+				t.Fatalf("tailRetentionStored() error = %v", err)
+			}
+			if (got != nil) != tc.wantSummary {
+				t.Errorf("compaction ran = %t, want %t: a standing summary over the threshold must not buy a model call every turn, but must still run once the tail is worth folding in", got != nil, tc.wantSummary)
+			}
+		})
+	}
+}
+
+// estimateFromEvents is a character-based TokenCounter matching the estimator
+// the runner installs, so the proportions in the test above mean what they say.
+func estimateFromEvents(events []*session.Event) int {
+	contents := make([]*genai.Content, 0, len(events))
+	for _, ev := range events {
+		if c := utils.Content(ev); c != nil {
+			contents = append(contents, c)
+		}
+	}
+	return EstimateTokensFromContents(contents)
+}


### PR DESCRIPTION
Follow-up to #1431 (merged as `cf61116c`). Independent of #1434 and #1438.

Tracking issue: #298.

## The problem

Tail retention already declines to compact when a previous attempt **in the same
turn** failed to bring the prompt under the threshold — summarizing a little more
would leave it just as far over, for the price of a model call.

That gate lives on the compaction runtime, and the runtime is built **per
invocation**. Every new turn arrives with it cleared.

So a summary that is itself larger than `TokenThreshold` re-triggers compaction
on every turn for the life of the session, and none of those calls can succeed:
the prompt is over the line before a single new event is counted.

This is pre-existing, but #1431 makes it easier to reach. The fact-retention
instruction enlarges summaries by design, so a threshold that used to sit
comfortably above the summary may now sit below it. Measured: at a 700-token
threshold, compaction fired on **nearly every turn** — 35 to 38 compactions
across a 40-turn run.

## Why not just decline

Declining outright would trade a cost problem for a correctness one. The
uncovered tail would grow without limit, which is exactly what tail retention
exists to prevent.

So the work is amortized instead. Once the summary alone cannot fit, wait until a
quarter of the threshold in new material has accumulated before calling the
summarizer again. The prompt stays bounded — by the summary, plus that fraction,
plus the retained tail — at a fraction of the calls.

## One implementation note worth reviewing

New material is measured **on the compaction window**, not by subtracting the
summary from the prompt count. Those two numbers are not always on the same
footing: the prompt count prefers an observed usage reading, which includes the
materialized summary, but falls back to an estimate over raw events, where a
compaction event renders as nothing. Subtracting would compare a number that
includes the summary against one that does not, and would misfire precisely on
the estimator path.

The seed is excluded from that measurement, since the previous summary is not new
material.

**A count releases the gate as well as a size**, whichever comes first. The
estimator is documented as a floor — it counts text, tool calls and tool
responses, but not inline data — so a tail of images reads as almost nothing
while costing the real prompt a great deal. Holding compaction off on that
reading would trade wasted calls for unbounded prompt growth, which is the wrong
way round. At most eight times the retained tail may accumulate regardless of
what it estimates to.

## Testing plan

`go build`, `go test -race -count=1 -shuffle=on`, `golangci-lint run` (v2.3.1)
and `go mod tidy -diff` clean in both modules.

`TestTailRetentionAmortizesWhenTheSummaryAloneExceedsTheThreshold` covers both
directions: no call when little has accumulated, and a call once the tail is
worth folding in.

**Mutation-tested, and the first version of the test failed that check** — worth
knowing if you are reviewing the test rather than the code. Without an observed
prompt count in the fixture, the estimator never sees the summary (a compaction
event renders as nothing), the prompt reads as a handful of tokens, and the pass
declines for being *under* the threshold. The test passed with the guard deleted.
With a usage count in place both mutations fail: removing the guard, and
forgetting to exclude the seed from what counts as new material.

## What this does not do

It does not change any default. `TokenThreshold` has none — 0 disables tail
retention and the application chooses the number. #1434 adds guidance on choosing
it, which is the other half of this: a threshold close to the summary size is the
condition that puts an agent here in the first place.

## Notes for an automated reviewer

**Review this exact commit: `d7901989ea7b9f07fe634227695a075b9d61a229`.** Check out the SHA, not a branch name.
Cut from `main` at `cf61116c`, one commit, confined to
`internal/compactioninternal`.


