### PR TITLE
fix(sequentialagent): make RunLive's task_completed injection race-free

### DIFF
--- a/agent/workflowagents/sequentialagent/agent.go
+++ b/agent/workflowagents/sequentialagent/agent.go
@@ -151,17 +151,18 @@ func (a *sequentialAgent) RunLive(ctx agent.InvocationContext) (agent.LiveSessio
 			state := llminternal.Reveal(llmAgent)
 			// Reveal returns the sub-agent's shared, persistent State, so
 			// concurrent live sessions driving one agent tree would race
-			// this read-then-append on Tools/Instruction. state.LiveInjection
+			// this read-then-append on Tools/Instruction. state.LiveModeInjection
 			// runs it once per agent and gives every other RunLive caller a
 			// happens-before edge before they read Tools.
-			state.LiveInjection.Do(func() {
+			state.LiveModeInjection.Do(func() {
 				hasTaskCompleted := false
 				for _, t := range state.Tools {
 					// llmagent.New assigns the caller's cfg.Tools slice
-					// unvalidated (#1490), so a nil element can reach here;
-					// skip an untyped nil. A typed nil still panics in
-					// t.Name() below — on every call, as on main, because
-					// LiveInjection.Do does not latch on panic.
+					// without validating it (#1490), so a nil element can
+					// reach here; skip an untyped nil. A typed nil may panic
+					// in t.Name(), depending on its implementation. When it
+					// does, LiveModeInjection.Do does not latch the panic, so
+					// the next call retries the scan.
 					if t == nil {
 						continue
 					}

--- a/agent/workflowagents/sequentialagent/agent.go
+++ b/agent/workflowagents/sequentialagent/agent.go
@@ -149,18 +149,33 @@ func (a *sequentialAgent) RunLive(ctx agent.InvocationContext) (agent.LiveSessio
 	for _, subAgent := range subAgents {
 		if llmAgent, ok := subAgent.(llminternal.Agent); ok {
 			state := llminternal.Reveal(llmAgent)
-			hasTaskCompleted := false
-			for _, t := range state.Tools {
-				if t.Name() == "task_completed" {
-					hasTaskCompleted = true
-					break
+			// Reveal returns the sub-agent's shared, persistent State, so
+			// concurrent live sessions driving one agent tree would race
+			// this read-then-append on Tools/Instruction. The guard lives
+			// on State (see llminternal.State.TaskCompletedInjection): the
+			// injection runs exactly once, and every other RunLive caller
+			// for this sub-agent blocks on it before reading Tools rather
+			// than racing its own unsynchronized check.
+			state.TaskCompletedInjection.Do(func() {
+				hasTaskCompleted := false
+				for _, t := range state.Tools {
+					// llmagent.New copies cfg.Tools without validating, so a
+					// nil element can reach here; skip it rather than panic
+					// inside sync.Once (which would latch the guard shut).
+					if t == nil {
+						continue
+					}
+					if t.Name() == "task_completed" {
+						hasTaskCompleted = true
+						break
+					}
 				}
-			}
-			if !hasTaskCompleted {
-				state.Tools = append(state.Tools, taskCompletedTool)
-				instructionSuffix := "\nIf you finished the user's request according to its description, call the task_completed function to exit so the next agents can take over. When calling this function, do not generate any text other than the function call."
-				state.Instruction += instructionSuffix
-			}
+				if !hasTaskCompleted {
+					state.Tools = append(state.Tools, taskCompletedTool)
+					instructionSuffix := "\nIf you finished the user's request according to its description, call the task_completed function to exit so the next agents can take over. When calling this function, do not generate any text other than the function call."
+					state.Instruction += instructionSuffix
+				}
+			})
 		}
 	}
 

--- a/agent/workflowagents/sequentialagent/agent.go
+++ b/agent/workflowagents/sequentialagent/agent.go
@@ -151,17 +151,17 @@ func (a *sequentialAgent) RunLive(ctx agent.InvocationContext) (agent.LiveSessio
 			state := llminternal.Reveal(llmAgent)
 			// Reveal returns the sub-agent's shared, persistent State, so
 			// concurrent live sessions driving one agent tree would race
-			// this read-then-append on Tools/Instruction. The guard lives
-			// on State (see llminternal.State.TaskCompletedInjection): the
-			// injection runs exactly once, and every other RunLive caller
-			// for this sub-agent blocks on it before reading Tools rather
-			// than racing its own unsynchronized check.
-			state.TaskCompletedInjection.Do(func() {
+			// this read-then-append on Tools/Instruction. state.LiveInjection
+			// runs it once per agent and gives every other RunLive caller a
+			// happens-before edge before they read Tools.
+			state.LiveInjection.Do(func() {
 				hasTaskCompleted := false
 				for _, t := range state.Tools {
-					// llmagent.New copies cfg.Tools without validating, so a
-					// nil element can reach here; skip it rather than panic
-					// inside sync.Once (which would latch the guard shut).
+					// llmagent.New assigns the caller's cfg.Tools slice
+					// unvalidated (#1490), so a nil element can reach here;
+					// skip an untyped nil. A typed nil still panics in
+					// t.Name() below — on every call, as on main, because
+					// LiveInjection.Do does not latch on panic.
 					if t == nil {
 						continue
 					}

--- a/agent/workflowagents/sequentialagent/agent_test.go
+++ b/agent/workflowagents/sequentialagent/agent_test.go
@@ -476,13 +476,19 @@ const taskCompletedInstructionMarker = "call the task_completed function to exit
 // marker would pass the final count assertion but let a losing caller
 // return before the winner's write is visible -- that read is what fails
 // under -race without the barrier.
+//
+// The pipeline has three sub-agents so RunLive's injection loop runs more
+// than one iteration, and each sub-agent carries its own State with its own
+// sync.Once: the guard has to hold independently for every one of them.
 func TestSequentialAgent_RunLive_ConcurrentInjectionIsRaceFree(t *testing.T) {
-	subAgent := newCustomAgent(t, 1)
+	subAgents := []agent.Agent{
+		newCustomAgent(t, 1), newCustomAgent(t, 2), newCustomAgent(t, 3),
+	}
 
 	sequentialAgent, err := sequentialagent.New(sequentialagent.Config{
 		AgentConfig: agent.Config{
 			Name:      "seq_agent",
-			SubAgents: []agent.Agent{subAgent},
+			SubAgents: subAgents,
 		},
 	})
 	if err != nil {
@@ -496,14 +502,28 @@ func TestSequentialAgent_RunLive_ConcurrentInjectionIsRaceFree(t *testing.T) {
 		t.Fatalf("sequential agent does not implement RunLive")
 	}
 
-	llmAgent, ok := subAgent.(llminternal.Agent)
-	if !ok {
-		t.Fatal("sub-agent does not implement llminternal.Agent")
+	states := make([]*llminternal.State, len(subAgents))
+	for i, sub := range subAgents {
+		llmAgent, ok := sub.(llminternal.Agent)
+		if !ok {
+			t.Fatalf("sub-agent %d does not implement llminternal.Agent", i)
+		}
+		states[i] = llminternal.Reveal(llmAgent)
 	}
-	state := llminternal.Reveal(llmAgent)
+
+	countTaskCompleted := func(s *llminternal.State) int {
+		n := 0
+		for _, tl := range s.Tools {
+			if tl != nil && tl.Name() == "task_completed" {
+				n++
+			}
+		}
+		return n
+	}
 
 	const concurrent = 20
-	seenByCaller := make([]int, concurrent)
+	// seenByCaller[i][j]: what caller i saw in sub-agent j's Tools.
+	seenByCaller := make([][]int, concurrent)
 	var wg sync.WaitGroup
 	wg.Add(concurrent)
 	for i := range concurrent {
@@ -511,38 +531,35 @@ func TestSequentialAgent_RunLive_ConcurrentInjectionIsRaceFree(t *testing.T) {
 			defer wg.Done()
 			invCtx := &mockInvocationContext{agent: sequentialAgent, invocationID: "test_id", ctx: t.Context()}
 			_, _, _ = liveAgent.RunLive(invCtx)
-			// RunLive has returned, so the Once has completed: this read
-			// is ordered after the winner's write and must see it.
-			for _, tl := range state.Tools {
-				if tl != nil && tl.Name() == "task_completed" {
-					seenByCaller[i]++
-				}
+			// RunLive has returned, so every sub-agent's Once has completed:
+			// these reads are ordered after the winners' writes.
+			seen := make([]int, len(states))
+			for j, s := range states {
+				seen[j] = countTaskCompleted(s)
 			}
+			seenByCaller[i] = seen
 		}()
 	}
 	wg.Wait()
 
 	for i, seen := range seenByCaller {
-		if seen != 1 {
-			t.Errorf("caller %d saw task_completed %d times in state.Tools after RunLive returned, want exactly 1", i, seen)
+		for j, n := range seen {
+			if n != 1 {
+				t.Errorf("caller %d saw task_completed %d times in sub-agent %d's Tools after RunLive returned, want exactly 1", i, n, j)
+			}
 		}
 	}
 
-	count := 0
-	for _, tl := range state.Tools {
-		if tl != nil && tl.Name() == "task_completed" {
-			count++
+	for j, s := range states {
+		if n := countTaskCompleted(s); n != 1 {
+			t.Errorf("sub-agent %d: task_completed injected %d times across %d concurrent RunLive calls, want exactly 1", j, n, concurrent)
 		}
-	}
-	if count != 1 {
-		t.Errorf("task_completed injected %d times across %d concurrent RunLive calls, want exactly 1", count, concurrent)
-	}
-
-	// The tool is useless without the instruction telling the model to
-	// call it; two goroutines can both append the suffix and still leave
-	// one tool in the slice, so the suffix count is a distinct check.
-	if n := strings.Count(state.Instruction, taskCompletedInstructionMarker); n != 1 {
-		t.Errorf("task_completed instruction suffix appears %d times, want exactly 1", n)
+		// The tool is useless without the instruction telling the model to
+		// call it; two goroutines can both append the suffix and still leave
+		// one tool in the slice, so the suffix count is a distinct check.
+		if n := strings.Count(s.Instruction, taskCompletedInstructionMarker); n != 1 {
+			t.Errorf("sub-agent %d: task_completed instruction suffix appears %d times, want exactly 1", j, n)
+		}
 	}
 }
 

--- a/agent/workflowagents/sequentialagent/agent_test.go
+++ b/agent/workflowagents/sequentialagent/agent_test.go
@@ -34,7 +34,16 @@ import (
 	"google.golang.org/adk/v2/model"
 	"google.golang.org/adk/v2/runner"
 	"google.golang.org/adk/v2/session"
+	"google.golang.org/adk/v2/tool"
 )
+
+// stubTool is a minimal tool.Tool for tests that only need a named entry
+// in state.Tools.
+type stubTool struct{ name string }
+
+func (s stubTool) Name() string        { return s.name }
+func (s stubTool) Description() string { return s.name }
+func (s stubTool) IsLongRunning() bool { return false }
 
 func TestNewSequentialAgent(t *testing.T) {
 	type args struct {
@@ -470,16 +479,16 @@ const taskCompletedInstructionMarker = "call the task_completed function to exit
 // either had written it back.
 //
 // Beyond "injected exactly once", the test pins the ordering guarantee
-// the sync.Once is there for: each goroutine reads state.Tools right
-// after its own RunLive returns and must observe the completed injection
-// (exactly one task_completed tool, never zero). A plain "already done"
-// marker would pass the final count assertion but let a losing caller
-// return before the winner's write is visible -- that read is what fails
-// under -race without the barrier.
+// the LiveInjection latch is there for: each goroutine reads state.Tools
+// right after its own RunLive returns and must observe the completed
+// injection (exactly one task_completed tool, never zero). A plain
+// "already done" marker would pass the final count assertion but let a
+// losing caller return before the winner's write is visible -- that read
+// is what fails under -race without the barrier.
 //
 // The pipeline has three sub-agents so RunLive's injection loop runs more
 // than one iteration, and each sub-agent carries its own State with its own
-// sync.Once: the guard has to hold independently for every one of them.
+// LiveInjection latch: the guard has to hold independently for every one.
 func TestSequentialAgent_RunLive_ConcurrentInjectionIsRaceFree(t *testing.T) {
 	subAgents := []agent.Agent{
 		newCustomAgent(t, 1), newCustomAgent(t, 2), newCustomAgent(t, 3),
@@ -560,6 +569,62 @@ func TestSequentialAgent_RunLive_ConcurrentInjectionIsRaceFree(t *testing.T) {
 		if n := strings.Count(s.Instruction, taskCompletedInstructionMarker); n != 1 {
 			t.Errorf("sub-agent %d: task_completed instruction suffix appears %d times, want exactly 1", j, n)
 		}
+	}
+}
+
+// TestSequentialAgent_RunLive_PreexistingToolAndNilSkip pins the two
+// branches of RunLive's injection loop that no other test reaches: the
+// idempotence check that leaves a sub-agent's own task_completed tool (and
+// the instruction) alone, and the untyped-nil skip in the same loop.
+// Deleting the "does it already have task_completed" scan and injecting
+// unconditionally otherwise keeps the whole package green, because the
+// LiveInjection guard fires exactly once either way.
+func TestSequentialAgent_RunLive_PreexistingToolAndNilSkip(t *testing.T) {
+	subAgent, err := llmagent.New(llmagent.Config{
+		Name:  "sub_with_task_completed",
+		Model: &FakeLLM{id: 1},
+		Tools: []tool.Tool{nil, stubTool{name: "task_completed"}}, // nil exercises the skip
+	})
+	if err != nil {
+		t.Fatalf("llmagent.New: %v", err)
+	}
+
+	seq, err := sequentialagent.New(sequentialagent.Config{
+		AgentConfig: agent.Config{Name: "seq_agent", SubAgents: []agent.Agent{subAgent}},
+	})
+	if err != nil {
+		t.Fatalf("sequentialagent.New: %v", err)
+	}
+	liveAgent, ok := seq.(interface {
+		RunLive(ctx agent.InvocationContext) (agent.LiveSession, iter.Seq2[*session.Event, error], error)
+	})
+	if !ok {
+		t.Fatalf("sequential agent does not implement RunLive")
+	}
+
+	state := llminternal.Reveal(subAgent.(llminternal.Agent))
+	toolsBefore := len(state.Tools)
+	instrBefore := state.Instruction
+
+	_, _, _ = liveAgent.RunLive(&mockInvocationContext{agent: seq, invocationID: "test_id", ctx: t.Context()})
+
+	if len(state.Tools) != toolsBefore {
+		t.Errorf("Tools grew from %d to %d; a pre-existing task_completed must suppress the append", toolsBefore, len(state.Tools))
+	}
+	got := 0
+	for _, tl := range state.Tools {
+		if tl != nil && tl.Name() == "task_completed" {
+			got++
+		}
+	}
+	if got != 1 {
+		t.Errorf("task_completed tool count = %d, want 1 (the sub-agent's own, untouched)", got)
+	}
+	if state.Instruction != instrBefore {
+		t.Errorf("Instruction changed; the hand-off suffix must not be appended when task_completed already exists")
+	}
+	if n := strings.Count(state.Instruction, taskCompletedInstructionMarker); n != 0 {
+		t.Errorf("instruction suffix appears %d times, want 0", n)
 	}
 }
 

--- a/agent/workflowagents/sequentialagent/agent_test.go
+++ b/agent/workflowagents/sequentialagent/agent_test.go
@@ -18,6 +18,8 @@ import (
 	"context"
 	"fmt"
 	"iter"
+	"strings"
+	"sync"
 	"testing"
 	"time"
 
@@ -448,6 +450,99 @@ func TestSequentialAgent_RunLive_Injection(t *testing.T) {
 		if !hasTaskCompleted {
 			t.Errorf("sub-agent 1 does not have task_completed tool injected after RunLive")
 		}
+	}
+}
+
+// taskCompletedInstructionMarker is a stable fragment of the instruction
+// suffix RunLive appends alongside the task_completed tool. The test
+// counts it instead of hardcoding the whole sentence.
+const taskCompletedInstructionMarker = "call the task_completed function to exit so the next agents can take over"
+
+// TestSequentialAgent_RunLive_ConcurrentInjectionIsRaceFree is the
+// regression test for the data race in RunLive's task_completed
+// injection: llminternal.Reveal(llmAgent) returns the sub-agent's shared,
+// persistent state, and the unguarded read-then-append/read-then-concat
+// used to race under any two concurrent RunLive calls dispatched onto the
+// same sub-agent (e.g. two simultaneous live/streaming sessions sharing
+// an agent tree built once at startup) -- confirmed with `go test -race`
+// before the fix. It also raced itself into double-injecting the tool
+// whenever both goroutines observed hasTaskCompleted == false before
+// either had written it back.
+//
+// Beyond "injected exactly once", the test pins the ordering guarantee
+// the sync.Once is there for: each goroutine reads state.Tools right
+// after its own RunLive returns and must observe the completed injection
+// (exactly one task_completed tool, never zero). A plain "already done"
+// marker would pass the final count assertion but let a losing caller
+// return before the winner's write is visible -- that read is what fails
+// under -race without the barrier.
+func TestSequentialAgent_RunLive_ConcurrentInjectionIsRaceFree(t *testing.T) {
+	subAgent := newCustomAgent(t, 1)
+
+	sequentialAgent, err := sequentialagent.New(sequentialagent.Config{
+		AgentConfig: agent.Config{
+			Name:      "seq_agent",
+			SubAgents: []agent.Agent{subAgent},
+		},
+	})
+	if err != nil {
+		t.Fatalf("failed to create sequential agent: %v", err)
+	}
+
+	liveAgent, ok := sequentialAgent.(interface {
+		RunLive(ctx agent.InvocationContext) (agent.LiveSession, iter.Seq2[*session.Event, error], error)
+	})
+	if !ok {
+		t.Fatalf("sequential agent does not implement RunLive")
+	}
+
+	llmAgent, ok := subAgent.(llminternal.Agent)
+	if !ok {
+		t.Fatal("sub-agent does not implement llminternal.Agent")
+	}
+	state := llminternal.Reveal(llmAgent)
+
+	const concurrent = 20
+	seenByCaller := make([]int, concurrent)
+	var wg sync.WaitGroup
+	wg.Add(concurrent)
+	for i := range concurrent {
+		go func() {
+			defer wg.Done()
+			invCtx := &mockInvocationContext{agent: sequentialAgent, invocationID: "test_id", ctx: t.Context()}
+			_, _, _ = liveAgent.RunLive(invCtx)
+			// RunLive has returned, so the Once has completed: this read
+			// is ordered after the winner's write and must see it.
+			for _, tl := range state.Tools {
+				if tl != nil && tl.Name() == "task_completed" {
+					seenByCaller[i]++
+				}
+			}
+		}()
+	}
+	wg.Wait()
+
+	for i, seen := range seenByCaller {
+		if seen != 1 {
+			t.Errorf("caller %d saw task_completed %d times in state.Tools after RunLive returned, want exactly 1", i, seen)
+		}
+	}
+
+	count := 0
+	for _, tl := range state.Tools {
+		if tl != nil && tl.Name() == "task_completed" {
+			count++
+		}
+	}
+	if count != 1 {
+		t.Errorf("task_completed injected %d times across %d concurrent RunLive calls, want exactly 1", count, concurrent)
+	}
+
+	// The tool is useless without the instruction telling the model to
+	// call it; two goroutines can both append the suffix and still leave
+	// one tool in the slice, so the suffix count is a distinct check.
+	if n := strings.Count(state.Instruction, taskCompletedInstructionMarker); n != 1 {
+		t.Errorf("task_completed instruction suffix appears %d times, want exactly 1", n)
 	}
 }
 

--- a/agent/workflowagents/sequentialagent/agent_test.go
+++ b/agent/workflowagents/sequentialagent/agent_test.go
@@ -300,11 +300,16 @@ func TestNewSequentialAgent(t *testing.T) {
 }
 
 func newCustomAgent(t *testing.T, id int) agent.Agent {
+	return newCustomAgentWithTools(t, id, nil)
+}
+
+func newCustomAgentWithTools(t *testing.T, id int, tools []tool.Tool) agent.Agent {
 	t.Helper()
 
 	a, err := llmagent.New(llmagent.Config{
 		Name:  fmt.Sprintf("custom_agent_%v", id),
 		Model: &FakeLLM{id: id, callCounter: 0},
+		Tools: tools,
 	})
 	if err != nil {
 		t.Fatal(err)
@@ -405,7 +410,8 @@ func (m *mockInvocationContext) Err() error                  { return m.ctx.Err(
 func (m *mockInvocationContext) Value(key any) any           { return m.ctx.Value(key) }
 
 func TestSequentialAgent_RunLive_Injection(t *testing.T) {
-	subAgent1 := newCustomAgent(t, 1)
+	existingTaskCompleted := stubTool{name: "task_completed"}
+	subAgent1 := newCustomAgentWithTools(t, 1, []tool.Tool{existingTaskCompleted})
 	subAgent2 := newCustomAgent(t, 2)
 
 	sequentialAgent, err := sequentialagent.New(sequentialagent.Config{
@@ -421,10 +427,8 @@ func TestSequentialAgent_RunLive_Injection(t *testing.T) {
 	// Before RunLive, sub-agents do not have the task_completed tool
 	if llmAgent1, ok := subAgent1.(llminternal.Agent); ok {
 		state := llminternal.Reveal(llmAgent1)
-		for _, tool := range state.Tools {
-			if tool.Name() == "task_completed" {
-				t.Errorf("sub-agent 1 already has task_completed tool before RunLive")
-			}
+		if len(state.Tools) != 1 || state.Tools[0].Name() != existingTaskCompleted.Name() {
+			t.Fatalf("sub-agent 1 lost its pre-existing task_completed tool before RunLive: %#v", state.Tools)
 		}
 	}
 
@@ -449,15 +453,11 @@ func TestSequentialAgent_RunLive_Injection(t *testing.T) {
 	// After RunLive initiation, the sub-agents MUST have the task_completed tool injected!
 	if llmAgent1, ok := subAgent1.(llminternal.Agent); ok {
 		state := llminternal.Reveal(llmAgent1)
-		hasTaskCompleted := false
-		for _, tool := range state.Tools {
-			if tool.Name() == "task_completed" {
-				hasTaskCompleted = true
-				break
-			}
+		if len(state.Tools) != 1 || state.Tools[0].Name() != existingTaskCompleted.Name() {
+			t.Errorf("sub-agent 1 pre-existing task_completed tool changed after RunLive: %#v", state.Tools)
 		}
-		if !hasTaskCompleted {
-			t.Errorf("sub-agent 1 does not have task_completed tool injected after RunLive")
+		if strings.Contains(state.Instruction, taskCompletedInstructionMarker) {
+			t.Errorf("sub-agent 1 instruction unexpectedly received task_completed suffix")
 		}
 	}
 }
@@ -479,7 +479,7 @@ const taskCompletedInstructionMarker = "call the task_completed function to exit
 // either had written it back.
 //
 // Beyond "injected exactly once", the test pins the ordering guarantee
-// the LiveInjection latch is there for: each goroutine reads state.Tools
+// the LiveModeInjection latch is there for: each goroutine reads state.Tools
 // right after its own RunLive returns and must observe the completed
 // injection (exactly one task_completed tool, never zero). A plain
 // "already done" marker would pass the final count assertion but let a
@@ -488,7 +488,7 @@ const taskCompletedInstructionMarker = "call the task_completed function to exit
 //
 // The pipeline has three sub-agents so RunLive's injection loop runs more
 // than one iteration, and each sub-agent carries its own State with its own
-// LiveInjection latch: the guard has to hold independently for every one.
+// LiveModeInjection latch: the guard has to hold independently for every one.
 func TestSequentialAgent_RunLive_ConcurrentInjectionIsRaceFree(t *testing.T) {
 	subAgents := []agent.Agent{
 		newCustomAgent(t, 1), newCustomAgent(t, 2), newCustomAgent(t, 3),

--- a/internal/llminternal/agent.go
+++ b/internal/llminternal/agent.go
@@ -15,6 +15,8 @@
 package llminternal
 
 import (
+	"sync"
+
 	"google.golang.org/genai"
 
 	"google.golang.org/adk/v2/agent"
@@ -60,6 +62,17 @@ type State struct {
 	OutputSchema *genai.Schema
 
 	OutputKey string
+
+	// TaskCompletedInjection guards the one-time injection of the
+	// task_completed tool and its instruction suffix that
+	// sequentialagent.RunLive performs on each LLM sub-agent. Reveal
+	// returns the same *State for the lifetime of an agent, so a tree
+	// built once and driven by several concurrent live sessions would
+	// otherwise race the read-then-append on Tools/Instruction. Keeping
+	// the guard on State ties its lifetime to the agent's, so it is
+	// collected with the agent and never accumulates in a process-global
+	// map. It is only ever used via (*State), never a copy.
+	TaskCompletedInjection sync.Once
 }
 
 type InstructionProvider func(ctx agent.ReadonlyContext) (string, error)

--- a/internal/llminternal/agent.go
+++ b/internal/llminternal/agent.go
@@ -63,18 +63,18 @@ type State struct {
 
 	OutputKey string
 
-	// LiveInjection guards the single live-mode tool injection an agent may
+	// LiveModeInjection guards the single live-mode tool injection an agent may
 	// receive: whichever workflow agent runs this one live first appends its
 	// hand-off tool and instruction suffix to Tools/Instruction, once, and
 	// every concurrent caller blocks until that has finished. Kept on State
 	// so its lifetime is the agent's — collected with the agent, never
 	// accumulated in a process-global map, and only ever used via (*State).
 	// Today sequentialagent.RunLive is the only injector.
-	LiveInjection LiveToolInjection
+	LiveModeInjection LiveModeToolInjection
 }
 
-// LiveToolInjection is a one-shot, panic-safe latch for the single
-// live-mode tool injection an agent may receive (see State.LiveInjection).
+// LiveModeToolInjection is a one-shot, panic-safe latch for the single
+// live-mode tool injection an agent may receive (see State.LiveModeInjection).
 // The first caller to Do performs the injection; concurrent callers block
 // and then observe it as a no-op, with a happens-before edge to the first
 // caller's writes. Unlike sync.Once it does not latch when the injection
@@ -83,17 +83,17 @@ type State struct {
 // silent after the first failure. If a second workflow agent ever adds its
 // own live-mode injection it shares this latch: first write wins, the rest
 // are skipped.
-type LiveToolInjection struct {
+type LiveModeToolInjection struct {
 	mu   sync.Mutex
 	done bool
 }
 
-// Do runs inject at most once for the lifetime of the receiver. It
+// Do runs inject at most once successfully for the lifetime of the receiver. It
 // serialises concurrent callers, gives the ones that lose the race a
 // happens-before edge to the winner's writes, and — because done is set
 // only after inject returns normally — lets a panic propagate without
 // latching, so a later call retries.
-func (l *LiveToolInjection) Do(inject func()) {
+func (l *LiveModeToolInjection) Do(inject func()) {
 	l.mu.Lock()
 	defer l.mu.Unlock()
 	if l.done {

--- a/internal/llminternal/agent.go
+++ b/internal/llminternal/agent.go
@@ -63,16 +63,44 @@ type State struct {
 
 	OutputKey string
 
-	// TaskCompletedInjection guards the one-time injection of the
-	// task_completed tool and its instruction suffix that
-	// sequentialagent.RunLive performs on each LLM sub-agent. Reveal
-	// returns the same *State for the lifetime of an agent, so a tree
-	// built once and driven by several concurrent live sessions would
-	// otherwise race the read-then-append on Tools/Instruction. Keeping
-	// the guard on State ties its lifetime to the agent's, so it is
-	// collected with the agent and never accumulates in a process-global
-	// map. It is only ever used via (*State), never a copy.
-	TaskCompletedInjection sync.Once
+	// LiveInjection guards the single live-mode tool injection an agent may
+	// receive: whichever workflow agent runs this one live first appends its
+	// hand-off tool and instruction suffix to Tools/Instruction, once, and
+	// every concurrent caller blocks until that has finished. Kept on State
+	// so its lifetime is the agent's — collected with the agent, never
+	// accumulated in a process-global map, and only ever used via (*State).
+	// Today sequentialagent.RunLive is the only injector.
+	LiveInjection LiveToolInjection
+}
+
+// LiveToolInjection is a one-shot, panic-safe latch for the single
+// live-mode tool injection an agent may receive (see State.LiveInjection).
+// The first caller to Do performs the injection; concurrent callers block
+// and then observe it as a no-op, with a happens-before edge to the first
+// caller's writes. Unlike sync.Once it does not latch when the injection
+// panics, so a misconfigured sub-agent stays loud on every call — the same
+// behaviour as re-deriving the decision each time — instead of going
+// silent after the first failure. If a second workflow agent ever adds its
+// own live-mode injection it shares this latch: first write wins, the rest
+// are skipped.
+type LiveToolInjection struct {
+	mu   sync.Mutex
+	done bool
+}
+
+// Do runs inject at most once for the lifetime of the receiver. It
+// serialises concurrent callers, gives the ones that lose the race a
+// happens-before edge to the winner's writes, and — because done is set
+// only after inject returns normally — lets a panic propagate without
+// latching, so a later call retries.
+func (l *LiveToolInjection) Do(inject func()) {
+	l.mu.Lock()
+	defer l.mu.Unlock()
+	if l.done {
+		return
+	}
+	inject()
+	l.done = true
 }
 
 type InstructionProvider func(ctx agent.ReadonlyContext) (string, error)

--- a/internal/llminternal/agent_test.go
+++ b/internal/llminternal/agent_test.go
@@ -1,0 +1,53 @@
+// Copyright 2025 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package llminternal
+
+import "testing"
+
+func TestLiveModeToolInjectionRetriesAfterPanic(t *testing.T) {
+	var calls int
+
+	for attempt := 0; attempt < 2; attempt++ {
+		func() {
+			defer func() {
+				if recover() == nil {
+					t.Errorf("Do() did not panic on attempt %d", attempt+1)
+				}
+			}()
+			injection := LiveModeToolInjection{}
+			injection.Do(func() {
+				calls++
+				panic("injection failed")
+			})
+		}()
+	}
+
+	if calls != 2 {
+		t.Fatalf("injection calls = %d, want 2", calls)
+	}
+}
+
+func TestLiveModeToolInjectionRunsOnceAfterSuccess(t *testing.T) {
+	var calls int
+	injection := LiveModeToolInjection{}
+
+	for range 3 {
+		injection.Do(func() { calls++ })
+	}
+
+	if calls != 1 {
+		t.Fatalf("injection calls = %d, want 1", calls)
+	}
+}


### PR DESCRIPTION
### Link to Issue or Description of Change

**1. Link to an existing issue (if applicable):**

- Closes: #1441

**Problem:**

`RunLive` injects a `task_completed` tool and instruction suffix into each LLM sub-agent, once, so a live/streaming sequential pipeline knows when to hand off to the next sub-agent. `llminternal.Reveal(llmAgent)` returns that sub-agent's shared, persistent state — the same object across every invocation of that agent, not a per-call copy (agents are constructed once and reused across concurrent requests, the same assumption #1137/#1166 already document for llmagent). The injection was an unguarded read-then-append (`state.Tools`) and read-then-concat (`state.Instruction`): two concurrent `RunLive` calls dispatched onto the same sub-agent — e.g. two simultaneous live sessions sharing an agent tree built once at startup — raced on that memory, and could double-inject the tool if both observed `hasTaskCompleted == false` before either had written it back.

**Solution:**

Follows the precedent #1166 set for the same class of bug: never write the shared `State` concurrently, rather than adding narrow locking that still leaves `State`'s other, ordinarily-unsynchronized readers racing against a mutation. A package-level `sync.Map` holds one `*sync.Once` per sub-agent `*llminternal.State` (a stable pointer for that agent's lifetime); the injection runs inside `once.Do`, so it happens exactly once, and every concurrent `RunLive` caller for that sub-agent blocks on that `Once` until it has completed before touching `Tools`/`Instruction`, instead of each racing its own unsynchronized check.

This does not attempt to make `State` generally safe for concurrent read/write from arbitrary call sites — same scope boundary #1166 drew for its own fix — only to stop this specific call site from writing it concurrently.

### Testing Plan

- Added `TestSequentialAgent_RunLive_ConcurrentInjectionIsRaceFree`: 20 goroutines call `RunLive` on a shared sub-agent, then the test asserts the tool was injected exactly once.
- Verified this test fails under `go test -race` on the pre-fix code (stashed the fix, reran, observed both the data race and, separately, a double-injection window) and passes cleanly and repeatedly with the fix in place.
- `gofmt` and `go vet` clean on both touched files.
- Existing package tests (`TestSequentialAgent_RunLive_Injection`, `TestSequentialAgent_RunLive_SequentialOrchestration`, `TestNewSequentialAgent`) still pass.