### PR TITLE
feat(telemetry): record tool definitions on model requests

### DIFF
--- a/README.md
+++ b/README.md
@@ -50,16 +50,20 @@ go get google.golang.org/adk/v2
 ## 🔭 Telemetry
 
 ADK records tool names, descriptions, and types in `gen_ai.tool.definitions`
-when GenAI content capture is enabled. Tool parameter schemas are excluded by
+when span content capture is enabled. Tool parameter schemas are excluded by
 default because they may contain sensitive application details. To opt in to
-parameter-schema capture, set:
+parameter-schema capture, enable span content capture and set the ADK-specific
+flag:
 
 ```bash
+export OTEL_INSTRUMENTATION_GENAI_CAPTURE_MESSAGE_CONTENT=SPAN_ONLY
 export ADK_INSTRUMENTATION_GENAI_CAPTURE_TOOL_DEFINITION_PARAMETERS=true
 ```
 
-Use this setting only when the captured tool schemas are appropriate for your
-telemetry destination.
+Use `SPAN_AND_EVENT` instead of `SPAN_ONLY` if message content should also be
+recorded in log events. The parameter-capture flag has no effect unless span
+content capture is enabled. Use this setting only when the captured tool
+schemas are appropriate for your telemetry destination.
 
 ## 📖 Docs for AI coding agents
 

--- a/README.md
+++ b/README.md
@@ -47,6 +47,20 @@ To add ADK Go to your project, run:
 go get google.golang.org/adk/v2
 ```
 
+## 🔭 Telemetry
+
+ADK records tool names, descriptions, and types in `gen_ai.tool.definitions`
+when GenAI content capture is enabled. Tool parameter schemas are excluded by
+default because they may contain sensitive application details. To opt in to
+parameter-schema capture, set:
+
+```bash
+export ADK_INSTRUMENTATION_GENAI_CAPTURE_TOOL_DEFINITION_PARAMETERS=true
+```
+
+Use this setting only when the captured tool schemas are appropriate for your
+telemetry destination.
+
 ## 📖 Docs for AI coding agents
 
 [adk.dev/llms.txt](https://adk.dev/llms.txt) is a machine-readable index of the ADK documentation, and [adk.dev/llms-full.txt](https://adk.dev/llms-full.txt) is the same documentation as a single file. Both are generated from [adk-docs](https://github.com/google/adk-docs/) and include the Go API reference and samples, so you can point a coding agent at either one for context:

--- a/README.md
+++ b/README.md
@@ -49,11 +49,12 @@ go get google.golang.org/adk/v2
 
 ## 🔭 Telemetry
 
-ADK records tool names, descriptions, and types in `gen_ai.tool.definitions`
-when span content capture is enabled. Tool parameter schemas are excluded by
-default because they may contain sensitive application details. To opt in to
-parameter-schema capture, enable span content capture and set the ADK-specific
-flag:
+ADK records function tool names, descriptions, and types in
+`gen_ai.tool.definitions` when span content capture is enabled. Provider-native
+tools such as `google_search`, `code_execution`, and `url_context` are not
+currently included. Tool parameter schemas are excluded by default because
+they may contain sensitive application details. To opt in to parameter-schema
+capture, enable span content capture and set the ADK-specific flag:
 
 ```bash
 export OTEL_INSTRUMENTATION_GENAI_CAPTURE_MESSAGE_CONTENT=SPAN_ONLY
@@ -61,8 +62,11 @@ export ADK_INSTRUMENTATION_GENAI_CAPTURE_TOOL_DEFINITION_PARAMETERS=true
 ```
 
 Use `SPAN_AND_EVENT` instead of `SPAN_ONLY` if message content should also be
-recorded in log events. The parameter-capture flag has no effect unless span
-content capture is enabled. Use this setting only when the captured tool
+recorded in log events. A value of `true` is retained for backward compatibility
+and is equivalent to `EVENT_ONLY`; it does not enable content attributes on
+spans. Use `SPAN_ONLY` or `SPAN_AND_EVENT` when recording tool definitions or
+parameter schemas on spans. The parameter-capture flag has no effect unless
+span content capture is enabled. Use this setting only when the captured tool
 schemas are appropriate for your telemetry destination.
 
 ## 📖 Docs for AI coding agents

--- a/README.md
+++ b/README.md
@@ -69,6 +69,12 @@ parameter schemas on spans. The parameter-capture flag has no effect unless
 span content capture is enabled. Use this setting only when the captured tool
 schemas are appropriate for your telemetry destination.
 
+Each content attribute is limited to 60 KiB (61,440 bytes). When parameter
+capture is enabled and the complete tool definition does not fit, ADK retries
+with the tool name, description, and type while omitting the parameter schemas.
+If that metadata-only representation is also too large, the
+`gen_ai.tool.definitions` attribute is omitted.
+
 ## 📖 Docs for AI coding agents
 
 [adk.dev/llms.txt](https://adk.dev/llms.txt) is a machine-readable index of the ADK documentation, and [adk.dev/llms-full.txt](https://adk.dev/llms-full.txt) is the same documentation as a single file. Both are generated from [adk-docs](https://github.com/google/adk-docs/) and include the Go API reference and samples, so you can point a coding agent at either one for context:

--- a/internal/telemetry/functionaltest/agent_telemetry_schema_test.go
+++ b/internal/telemetry/functionaltest/agent_telemetry_schema_test.go
@@ -38,6 +38,10 @@ import (
 // records or elides it for privacy.
 const captureMessageContentEnvVar = "OTEL_INSTRUMENTATION_GENAI_CAPTURE_MESSAGE_CONTENT"
 
+// captureToolDefinitionParametersEnvVar controls the explicit input-schema
+// capture opt-in used by the telemetry package.
+const captureToolDefinitionParametersEnvVar = "ADK_INSTRUMENTATION_GENAI_CAPTURE_TOOL_DEFINITION_PARAMETERS"
+
 // TestTelemetrySchema_AgentWithTool runs the canonical
 // "llmagent with one FunctionTool" scenario end-to-end and asserts
 // the emitted span+log tree matches the expected shape exactly.
@@ -76,6 +80,9 @@ func TestTelemetrySchema_AgentWithTool(t *testing.T) {
 			} else {
 				t.Setenv(captureMessageContentEnvVar, "")
 			}
+			// Keep this end-to-end test independent of a developer's local
+			// tool-schema capture setting.
+			t.Setenv(captureToolDefinitionParametersEnvVar, "")
 			telemetry.ApplyEnv()
 
 			// Install in-memory tracer + logger so the test sees

--- a/internal/telemetry/functionaltest/agent_telemetry_schema_test.go
+++ b/internal/telemetry/functionaltest/agent_telemetry_schema_test.go
@@ -83,6 +83,9 @@ func TestTelemetrySchema_AgentWithTool(t *testing.T) {
 
 	for _, tc := range tests {
 		t.Run(tc.name, func(t *testing.T) {
+			// Register before t.Setenv so environment restoration runs before
+			// ApplyEnv refreshes the package-level telemetry settings.
+			t.Cleanup(telemetry.ApplyEnv)
 			if tc.captureContent {
 				// Spans have to be named: a truthy value means log records only.
 				t.Setenv(captureMessageContentEnvVar, "SPAN_AND_EVENT")

--- a/internal/telemetry/functionaltest/agent_telemetry_schema_test.go
+++ b/internal/telemetry/functionaltest/agent_telemetry_schema_test.go
@@ -56,19 +56,28 @@ const captureToolDefinitionParametersEnvVar = "ADK_INSTRUMENTATION_GENAI_CAPTURE
 // adk-python/tests/unittests/telemetry/test_functional.py.
 func TestTelemetrySchema_AgentWithTool(t *testing.T) {
 	tests := []struct {
-		name           string
-		captureContent bool
-		want           *telemetrytest.SpanDigest
+		name              string
+		captureContent    bool
+		captureParameters bool
+		want              *telemetrytest.SpanDigest
 	}{
 		{
-			name:           "elided",
-			captureContent: false,
-			want:           telemetrytestcase.AgentWithToolCase,
+			name:              "elided",
+			captureContent:    false,
+			captureParameters: false,
+			want:              telemetrytestcase.AgentWithToolCase,
 		},
 		{
-			name:           "capture_content",
-			captureContent: true,
-			want:           telemetrytestcase.AgentWithToolCaptureContentCase,
+			name:              "capture_content",
+			captureContent:    true,
+			captureParameters: false,
+			want:              telemetrytestcase.AgentWithToolCaptureContentCase,
+		},
+		{
+			name:              "capture_content_and_tool_parameters",
+			captureContent:    true,
+			captureParameters: true,
+			want:              telemetrytestcase.AgentWithToolCaptureContentAndParametersCase,
 		},
 	}
 
@@ -82,7 +91,11 @@ func TestTelemetrySchema_AgentWithTool(t *testing.T) {
 			}
 			// Keep this end-to-end test independent of a developer's local
 			// tool-schema capture setting.
-			t.Setenv(captureToolDefinitionParametersEnvVar, "")
+			if tc.captureParameters {
+				t.Setenv(captureToolDefinitionParametersEnvVar, "true")
+			} else {
+				t.Setenv(captureToolDefinitionParametersEnvVar, "")
+			}
 			telemetry.ApplyEnv()
 
 			// Install in-memory tracer + logger so the test sees

--- a/internal/telemetry/genaimessages.go
+++ b/internal/telemetry/genaimessages.go
@@ -119,14 +119,13 @@ type toolResponsePart struct {
 }
 
 // functionToolDefinition is the representation used by the GenAI semantic
-// conventions for a function declaration. Description and parameters are kept
-// as explicit fields so their absence is distinguishable from an empty value
-// in the recorded JSON.
+// conventions for a function declaration. Description is always emitted, while
+// parameters are included only when explicitly enabled.
 type functionToolDefinition struct {
-	Name        string `json:"name"`
-	Description string `json:"description"`
-	Parameters  any    `json:"parameters"`
-	Type        string `json:"type"`
+	Name        string          `json:"name"`
+	Description string          `json:"description"`
+	Parameters  json.RawMessage `json:"parameters,omitempty"`
+	Type        string          `json:"type"`
 }
 
 // toolDefinitions converts the function declarations present in the actual
@@ -137,6 +136,7 @@ func toolDefinitions(config *genai.GenerateContentConfig) []functionToolDefiniti
 	if config == nil {
 		return nil
 	}
+	includeParameters := captureToolDefinitionParametersOnSpans()
 	var definitions []functionToolDefinition
 	for _, tool := range config.Tools {
 		if tool == nil {
@@ -146,23 +146,79 @@ func toolDefinitions(config *genai.GenerateContentConfig) []functionToolDefiniti
 			if declaration == nil {
 				continue
 			}
-			parameters := any(declaration.Parameters)
-			if declaration.ParametersJsonSchema != nil {
-				parameters = declaration.ParametersJsonSchema
-			}
-			definitions = append(definitions, functionToolDefinition{
+			definition := functionToolDefinition{
 				Name:        declaration.Name,
 				Description: declaration.Description,
-				Parameters:  parameters,
 				Type:        "function",
-			})
+			}
+			if includeParameters {
+				definition.Parameters = toolDefinitionParameters(declaration)
+			}
+			definitions = append(definitions, definition)
 		}
 	}
 	return definitions
 }
 
-// requestContentAttributes returns the gen_ai.system_instructions and
-// gen_ai.input.messages attributes for req, or nil when content capture is off
+// toolDefinitionParameters returns a valid JSON value for a declaration's
+// parameters. Each declaration is encoded independently so one malformed
+// application-provided schema cannot erase every tool definition on the span.
+func toolDefinitionParameters(declaration *genai.FunctionDeclaration) json.RawMessage {
+	if declaration.Parameters == nil && declaration.ParametersJsonSchema == nil {
+		return json.RawMessage("null")
+	}
+
+	value := any(declaration.Parameters)
+	if declaration.ParametersJsonSchema != nil {
+		value = declaration.ParametersJsonSchema
+	}
+	encoded, err := json.Marshal(value)
+	if err != nil {
+		return json.RawMessage(unserializablePlaceholder)
+	}
+
+	var normalized any
+	if err := json.Unmarshal(encoded, &normalized); err != nil {
+		return json.RawMessage(unserializablePlaceholder)
+	}
+	lowercaseSchemaTypes(normalized)
+	encoded, err = json.Marshal(normalized)
+	if err != nil {
+		return json.RawMessage(unserializablePlaceholder)
+	}
+	return json.RawMessage(encoded)
+}
+
+// lowercaseSchemaTypes converts genai.Schema's protobuf enum spellings to the
+// lowercase type values required by JSON Schema. It also normalizes literal
+// schema maps supplied by callers, including nested schemas.
+func lowercaseSchemaTypes(value any) {
+	switch value := value.(type) {
+	case map[string]any:
+		if typeValue, ok := value["type"]; ok {
+			switch typeValue := typeValue.(type) {
+			case string:
+				value["type"] = strings.ToLower(typeValue)
+			case []any:
+				for i, item := range typeValue {
+					if item, ok := item.(string); ok {
+						typeValue[i] = strings.ToLower(item)
+					}
+				}
+			}
+		}
+		for _, child := range value {
+			lowercaseSchemaTypes(child)
+		}
+	case []any:
+		for _, child := range value {
+			lowercaseSchemaTypes(child)
+		}
+	}
+}
+
+// requestContentAttributes returns the gen_ai.system_instructions,
+// gen_ai.tool.definitions, and gen_ai.input.messages attributes for req, or nil when content capture is off
 // or req carries nothing to record.
 //
 // Content is sensitive and often large, so the semantic conventions require
@@ -426,12 +482,14 @@ func schemaFinishReason(resp *model.LLMResponse, toolCall bool) string {
 
 // appendJSON encodes value and appends it to attrs under key, unless it does
 // not fit. See [maxContentAttributeBytes] for why an oversized attribute is
-// dropped rather than trimmed.
+// dropped rather than trimmed. Values used for tool payloads are encoded
+// independently before they reach this function so one bad payload cannot
+// discard its siblings.
 func appendJSON(attrs []attribute.KeyValue, key attribute.Key, value any) []attribute.KeyValue {
 	encoded, err := json.Marshal(value)
 	if err != nil {
-		// Unreachable: tool payloads are pre-encoded by toolPayload and
-		// everything else is a string or a slice of them.
+		// Callers should pre-encode values whose individual failures must be
+		// isolated, such as tool definition parameters.
 		return attrs
 	}
 	if len(encoded) > maxContentAttributeBytes {

--- a/internal/telemetry/genaimessages.go
+++ b/internal/telemetry/genaimessages.go
@@ -175,7 +175,7 @@ func toolDefinitionParameters(declaration *genai.FunctionDeclaration) json.RawMe
 	}
 
 	value := any(declaration.Parameters)
-	if declaration.ParametersJsonSchema != nil {
+	if declaration.Parameters == nil {
 		value = declaration.ParametersJsonSchema
 	}
 	encoded, err := json.Marshal(value)

--- a/internal/telemetry/genaimessages.go
+++ b/internal/telemetry/genaimessages.go
@@ -31,6 +31,7 @@ var (
 	genAIInputMessages      = attribute.Key("gen_ai.input.messages")
 	genAIOutputMessages     = attribute.Key("gen_ai.output.messages")
 	genAISystemInstructions = attribute.Key("gen_ai.system_instructions")
+	genAIToolDefinitions    = attribute.Key("gen_ai.tool.definitions")
 )
 
 // Part type discriminators and roles defined by the message JSON schemas.
@@ -117,6 +118,49 @@ type toolResponsePart struct {
 	Response json.RawMessage `json:"response"`
 }
 
+// functionToolDefinition is the representation used by the GenAI semantic
+// conventions for a function declaration. Description and parameters are kept
+// as explicit fields so their absence is distinguishable from an empty value
+// in the recorded JSON.
+type functionToolDefinition struct {
+	Name        string `json:"name"`
+	Description string `json:"description"`
+	Parameters  any    `json:"parameters"`
+	Type        string `json:"type"`
+}
+
+// toolDefinitions converts the function declarations present in the actual
+// model request into the gen_ai.tool.definitions representation. Reading the
+// request is important because a Toolset may produce a different set of tools
+// for each model call.
+func toolDefinitions(config *genai.GenerateContentConfig) []functionToolDefinition {
+	if config == nil {
+		return nil
+	}
+	var definitions []functionToolDefinition
+	for _, tool := range config.Tools {
+		if tool == nil {
+			continue
+		}
+		for _, declaration := range tool.FunctionDeclarations {
+			if declaration == nil {
+				continue
+			}
+			parameters := any(declaration.Parameters)
+			if declaration.ParametersJsonSchema != nil {
+				parameters = declaration.ParametersJsonSchema
+			}
+			definitions = append(definitions, functionToolDefinition{
+				Name:        declaration.Name,
+				Description: declaration.Description,
+				Parameters:  parameters,
+				Type:        "function",
+			})
+		}
+	}
+	return definitions
+}
+
 // requestContentAttributes returns the gen_ai.system_instructions and
 // gen_ai.input.messages attributes for req, or nil when content capture is off
 // or req carries nothing to record.
@@ -134,6 +178,9 @@ func requestContentAttributes(req *model.LLMRequest) []attribute.KeyValue {
 		if parts := semconvParts(req.Config.SystemInstruction.Parts); len(parts) > 0 {
 			attrs = appendJSON(attrs, genAISystemInstructions, parts)
 		}
+	}
+	if definitions := toolDefinitions(req.Config); len(definitions) > 0 {
+		attrs = appendJSON(attrs, genAIToolDefinitions, definitions)
 	}
 	if len(req.Contents) > 0 {
 		// Messages MUST be recorded in the order they were sent. A turn whose

--- a/internal/telemetry/genaimessages.go
+++ b/internal/telemetry/genaimessages.go
@@ -35,6 +35,16 @@ var (
 	genAIToolDefinitions    = attribute.Key("gen_ai.tool.definitions")
 )
 
+var genaiTypeNames = map[string]string{
+	string(genai.TypeString):  "string",
+	string(genai.TypeNumber):  "number",
+	string(genai.TypeInteger): "integer",
+	string(genai.TypeBoolean): "boolean",
+	string(genai.TypeArray):   "array",
+	string(genai.TypeObject):  "object",
+	string(genai.TypeNULL):    "null",
+}
+
 // Part type discriminators and roles defined by the message JSON schemas.
 const (
 	partTypeText             = "text"
@@ -189,6 +199,12 @@ func toolDefinitionParameters(declaration *genai.FunctionDeclaration) json.RawMe
 	if err := decoder.Decode(&normalized); err != nil {
 		return json.RawMessage(unserializableSchemaPlaceholder)
 	}
+	switch normalized.(type) {
+	case map[string]any, bool:
+		// JSON Schema draft-07 permits schemas to be objects or booleans.
+	default:
+		return json.RawMessage(unserializableSchemaPlaceholder)
+	}
 	normalizeSchemaTypes(normalized)
 	encoded, err = json.Marshal(normalized)
 	if err != nil {
@@ -227,6 +243,16 @@ func normalizeSchemaNode(value any) {
 					normalizeSchemaNode(schema)
 				}
 			}
+		case "dependencies":
+			// In draft-07 a dependency is either a property-name array or a
+			// schema. Normalize only schema-valued dependencies.
+			if dependencies, ok := child.(map[string]any); ok {
+				for _, dependency := range dependencies {
+					if schema, ok := dependency.(map[string]any); ok {
+						normalizeSchemaNode(schema)
+					}
+				}
+			}
 		case "additionalProperties", "additionalItems", "items", "contains", "not", "if", "then", "else", "propertyNames", "unevaluatedProperties", "unevaluatedItems":
 			normalizeSchemaValue(child)
 		case "allOf", "anyOf", "oneOf", "prefixItems":
@@ -251,15 +277,6 @@ func normalizeSchemaValue(value any) {
 }
 
 func normalizeSchemaTypeValue(value any) (any, bool) {
-	genaiTypeNames := map[string]string{
-		string(genai.TypeString):  "string",
-		string(genai.TypeNumber):  "number",
-		string(genai.TypeInteger): "integer",
-		string(genai.TypeBoolean): "boolean",
-		string(genai.TypeArray):   "array",
-		string(genai.TypeObject):  "object",
-		string(genai.TypeNULL):    "null",
-	}
 	switch value := value.(type) {
 	case string:
 		if normalized, ok := genaiTypeNames[value]; ok {

--- a/internal/telemetry/genaimessages.go
+++ b/internal/telemetry/genaimessages.go
@@ -15,6 +15,7 @@
 package telemetry
 
 import (
+	"bytes"
 	"encoding/base64"
 	"encoding/json"
 	"strings"
@@ -69,6 +70,11 @@ const maxContentAttributeBytes = 60 << 10
 // Tool arguments and responses are filled in by application code and can hold a
 // NaN, an Inf, a func, a chan or a reference cycle.
 const unserializablePlaceholder = `"<unserializable>"`
+
+// unserializableSchemaPlaceholder is a valid JSON Schema used when a tool
+// parameter schema cannot be encoded. Unlike unserializablePlaceholder, this
+// value is used where the semantic convention requires a schema object.
+const unserializableSchemaPlaceholder = `{"type":"object","properties":{"serialization_error":{"type":"string"}}}`
 
 // maxInlineDataBytes bounds one inline payload before base64, which inflates it
 // by a third. A single image would otherwise consume the whole attribute and
@@ -174,46 +180,109 @@ func toolDefinitionParameters(declaration *genai.FunctionDeclaration) json.RawMe
 	}
 	encoded, err := json.Marshal(value)
 	if err != nil {
-		return json.RawMessage(unserializablePlaceholder)
+		return json.RawMessage(unserializableSchemaPlaceholder)
 	}
 
 	var normalized any
-	if err := json.Unmarshal(encoded, &normalized); err != nil {
-		return json.RawMessage(unserializablePlaceholder)
+	decoder := json.NewDecoder(bytes.NewReader(encoded))
+	decoder.UseNumber()
+	if err := decoder.Decode(&normalized); err != nil {
+		return json.RawMessage(unserializableSchemaPlaceholder)
 	}
-	lowercaseSchemaTypes(normalized)
+	normalizeSchemaTypes(normalized)
 	encoded, err = json.Marshal(normalized)
 	if err != nil {
-		return json.RawMessage(unserializablePlaceholder)
+		return json.RawMessage(unserializableSchemaPlaceholder)
 	}
 	return json.RawMessage(encoded)
 }
 
-// lowercaseSchemaTypes converts genai.Schema's protobuf enum spellings to the
-// lowercase type values required by JSON Schema. It also normalizes literal
-// schema maps supplied by callers, including nested schemas.
-func lowercaseSchemaTypes(value any) {
-	switch value := value.(type) {
-	case map[string]any:
-		if typeValue, ok := value["type"]; ok {
-			switch typeValue := typeValue.(type) {
-			case string:
-				value["type"] = strings.ToLower(typeValue)
-			case []any:
-				for i, item := range typeValue {
-					if item, ok := item.(string); ok {
-						typeValue[i] = strings.ToLower(item)
-					}
+// normalizeSchemaTypes converts only genai.Schema's protobuf enum spellings
+// to the lowercase type values required by JSON Schema. It deliberately leaves
+// arbitrary strings in data-bearing fields such as default and examples alone.
+func normalizeSchemaTypes(value any) {
+	normalizeSchemaNode(value)
+}
+
+// normalizeSchemaNode walks only the JSON Schema locations that contain nested
+// schemas. Walking every nested map would also rewrite ordinary instance data
+// under keywords such as default, examples, and dependencies.
+func normalizeSchemaNode(value any) {
+	obj, ok := value.(map[string]any)
+	if !ok {
+		return
+	}
+	if typeValue, ok := obj["type"]; ok {
+		if normalized, keep := normalizeSchemaTypeValue(typeValue); keep {
+			obj["type"] = normalized
+		} else {
+			delete(obj, "type")
+		}
+	}
+	for key, child := range obj {
+		switch key {
+		case "properties", "patternProperties", "dependentSchemas", "definitions", "$defs":
+			if schemas, ok := child.(map[string]any); ok {
+				for _, schema := range schemas {
+					normalizeSchemaNode(schema)
+				}
+			}
+		case "additionalProperties", "additionalItems", "items", "contains", "not", "if", "then", "else", "propertyNames", "unevaluatedProperties", "unevaluatedItems":
+			normalizeSchemaValue(child)
+		case "allOf", "anyOf", "oneOf", "prefixItems":
+			if schemas, ok := child.([]any); ok {
+				for _, schema := range schemas {
+					normalizeSchemaNode(schema)
 				}
 			}
 		}
-		for _, child := range value {
-			lowercaseSchemaTypes(child)
-		}
+	}
+}
+
+func normalizeSchemaValue(value any) {
+	switch value := value.(type) {
+	case map[string]any:
+		normalizeSchemaNode(value)
 	case []any:
-		for _, child := range value {
-			lowercaseSchemaTypes(child)
+		for _, schema := range value {
+			normalizeSchemaNode(schema)
 		}
+	}
+}
+
+func normalizeSchemaTypeValue(value any) (any, bool) {
+	genaiTypeNames := map[string]string{
+		string(genai.TypeString):  "string",
+		string(genai.TypeNumber):  "number",
+		string(genai.TypeInteger): "integer",
+		string(genai.TypeBoolean): "boolean",
+		string(genai.TypeArray):   "array",
+		string(genai.TypeObject):  "object",
+		string(genai.TypeNULL):    "null",
+	}
+	switch value := value.(type) {
+	case string:
+		if normalized, ok := genaiTypeNames[value]; ok {
+			return normalized, true
+		}
+		if value == string(genai.TypeUnspecified) {
+			return nil, false
+		}
+		return value, true
+	case []any:
+		normalized := make([]any, 0, len(value))
+		for _, item := range value {
+			item, keep := normalizeSchemaTypeValue(item)
+			if keep {
+				normalized = append(normalized, item)
+			}
+		}
+		if len(normalized) == 0 {
+			return nil, false
+		}
+		return normalized, true
+	default:
+		return value, true
 	}
 }
 

--- a/internal/telemetry/genaimessages.go
+++ b/internal/telemetry/genaimessages.go
@@ -45,6 +45,16 @@ var genaiTypeNames = map[string]string{
 	string(genai.TypeNULL):    "null",
 }
 
+var jsonSchemaTypeNames = map[string]struct{}{
+	"string":  {},
+	"number":  {},
+	"integer": {},
+	"boolean": {},
+	"array":   {},
+	"object":  {},
+	"null":    {},
+}
+
 // Part type discriminators and roles defined by the message JSON schemas.
 const (
 	partTypeText             = "text"
@@ -217,8 +227,9 @@ func toolDefinitionParameters(declaration *genai.FunctionDeclaration) json.RawMe
 }
 
 // normalizeSchemaTypes normalizes values at actual JSON Schema type locations
-// to the lowercase values required by JSON Schema. It deliberately leaves
-// arbitrary strings in data-bearing fields such as default and examples alone.
+// to the lowercase values required by JSON Schema, dropping invalid values and
+// duplicate union members. It deliberately leaves arbitrary strings in
+// data-bearing fields such as default and examples alone.
 func normalizeSchemaTypes(value any) {
 	normalizeSchemaNode(value)
 }
@@ -282,20 +293,31 @@ func normalizeSchemaValue(value any) {
 func normalizeSchemaTypeValue(value any) (any, bool) {
 	switch value := value.(type) {
 	case string:
-		if value == string(genai.TypeUnspecified) {
+		if strings.EqualFold(value, string(genai.TypeUnspecified)) {
 			return nil, false
 		}
-		if normalized, ok := genaiTypeNames[value]; ok {
-			return normalized, true
+		normalized := strings.ToLower(value)
+		if mapped, ok := genaiTypeNames[value]; ok {
+			return mapped, true
 		}
-		return strings.ToLower(value), true
+		if _, ok := jsonSchemaTypeNames[normalized]; !ok {
+			return nil, false
+		}
+		return normalized, true
 	case []any:
 		normalized := make([]any, 0, len(value))
+		seen := make(map[string]struct{}, len(value))
 		for _, item := range value {
 			item, keep := normalizeSchemaTypeValue(item)
-			if keep {
-				normalized = append(normalized, item)
+			itemString, ok := item.(string)
+			if !keep || !ok {
+				continue
 			}
+			if _, alreadySeen := seen[itemString]; alreadySeen {
+				continue
+			}
+			seen[itemString] = struct{}{}
+			normalized = append(normalized, itemString)
 		}
 		if len(normalized) == 0 {
 			return nil, false

--- a/internal/telemetry/genaimessages.go
+++ b/internal/telemetry/genaimessages.go
@@ -84,7 +84,7 @@ const unserializablePlaceholder = `"<unserializable>"`
 // unserializableSchemaPlaceholder is a valid JSON Schema used when a tool
 // parameter schema cannot be encoded. Unlike unserializablePlaceholder, this
 // value is used where the semantic convention requires a schema object.
-const unserializableSchemaPlaceholder = `{"type":"object","properties":{"serialization_error":{"type":"string"}}}`
+const unserializableSchemaPlaceholder = `{"$comment":"parameters omitted because serialization failed","type":"object"}`
 
 // maxInlineDataBytes bounds one inline payload before base64, which inflates it
 // by a third. A single image would otherwise consume the whole attribute and
@@ -199,6 +199,9 @@ func toolDefinitionParameters(declaration *genai.FunctionDeclaration) json.RawMe
 	if err := decoder.Decode(&normalized); err != nil {
 		return json.RawMessage(unserializableSchemaPlaceholder)
 	}
+	if normalized == nil {
+		return json.RawMessage("null")
+	}
 	switch normalized.(type) {
 	case map[string]any, bool:
 		// JSON Schema draft-07 permits schemas to be objects or booleans.
@@ -213,8 +216,8 @@ func toolDefinitionParameters(declaration *genai.FunctionDeclaration) json.RawMe
 	return json.RawMessage(encoded)
 }
 
-// normalizeSchemaTypes converts only genai.Schema's protobuf enum spellings
-// to the lowercase type values required by JSON Schema. It deliberately leaves
+// normalizeSchemaTypes normalizes values at actual JSON Schema type locations
+// to the lowercase values required by JSON Schema. It deliberately leaves
 // arbitrary strings in data-bearing fields such as default and examples alone.
 func normalizeSchemaTypes(value any) {
 	normalizeSchemaNode(value)
@@ -279,13 +282,13 @@ func normalizeSchemaValue(value any) {
 func normalizeSchemaTypeValue(value any) (any, bool) {
 	switch value := value.(type) {
 	case string:
-		if normalized, ok := genaiTypeNames[value]; ok {
-			return normalized, true
-		}
 		if value == string(genai.TypeUnspecified) {
 			return nil, false
 		}
-		return value, true
+		if normalized, ok := genaiTypeNames[value]; ok {
+			return normalized, true
+		}
+		return strings.ToLower(value), true
 	case []any:
 		normalized := make([]any, 0, len(value))
 		for _, item := range value {
@@ -299,7 +302,7 @@ func normalizeSchemaTypeValue(value any) (any, bool) {
 		}
 		return normalized, true
 	default:
-		return value, true
+		return nil, false
 	}
 }
 
@@ -322,7 +325,14 @@ func requestContentAttributes(req *model.LLMRequest) []attribute.KeyValue {
 		}
 	}
 	if definitions := toolDefinitions(req.Config); len(definitions) > 0 {
+		before := len(attrs)
 		attrs = appendJSON(attrs, genAIToolDefinitions, definitions)
+		if len(attrs) == before && captureToolDefinitionParametersOnSpans() {
+			for i := range definitions {
+				definitions[i].Parameters = nil
+			}
+			attrs = appendJSON(attrs, genAIToolDefinitions, definitions)
+		}
 	}
 	if len(req.Contents) > 0 {
 		// Messages MUST be recorded in the order they were sent. A turn whose

--- a/internal/telemetry/genaimessages_test.go
+++ b/internal/telemetry/genaimessages_test.go
@@ -529,7 +529,29 @@ func TestRequestContentAttributes_ToolDefinitions_ParametersPrecedenceAndMissing
 		},
 	}
 	if diff := cmp.Diff(want, got); diff != "" {
-		t.Errorf("tool definition parameter precedence and absence (-want +got):\\n%s", diff)
+		t.Errorf("tool definition parameter precedence and absence (-want +got):\n%s", diff)
+	}
+}
+
+func TestToolDefinitionParameters_RejectsInvalidSchemaValues(t *testing.T) {
+	tests := []struct {
+		name  string
+		value any
+		want  string
+	}{
+		{name: "boolean schema", value: true, want: "true"},
+		{name: "string", value: "invalid", want: unserializableSchemaPlaceholder},
+		{name: "number", value: 42, want: unserializableSchemaPlaceholder},
+		{name: "array", value: []any{"invalid"}, want: unserializableSchemaPlaceholder},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			declaration := &genai.FunctionDeclaration{ParametersJsonSchema: tc.value}
+			if got := string(toolDefinitionParameters(declaration)); got != tc.want {
+				t.Errorf("toolDefinitionParameters() = %s, want %s", got, tc.want)
+			}
+		})
 	}
 }
 
@@ -542,8 +564,8 @@ func TestToolDefinitionParameters_NormalizesSchemaTypesWithoutChangingData(t *te
 			"properties": map[string]any{
 				"value": map[string]any{
 					"type":     []string{"OBJECT", "null"},
-					"default":  map[string]any{"type": "PRODUCTION", "region": "US-EAST1"},
-					"examples": []any{map[string]any{"type": "STAGING"}},
+					"default":  map[string]any{"type": "OBJECT", "region": "US-EAST1"},
+					"examples": []any{map[string]any{"type": "STRING"}},
 				},
 				"unspecified": map[string]any{
 					"type":        "TYPE_UNSPECIFIED",
@@ -551,7 +573,8 @@ func TestToolDefinitionParameters_NormalizesSchemaTypesWithoutChangingData(t *te
 				},
 			},
 			"dependencies": map[string]any{
-				"type": []string{"billingAddress"},
+				"credit_card":     map[string]any{"type": "OBJECT"},
+				"billing_address": []string{"OBJECT"},
 			},
 		},
 	}
@@ -566,19 +589,20 @@ func TestToolDefinitionParameters_NormalizesSchemaTypesWithoutChangingData(t *te
 		"properties": map[string]any{
 			"value": map[string]any{
 				"type":     []any{"object", "null"},
-				"default":  map[string]any{"type": "PRODUCTION", "region": "US-EAST1"},
-				"examples": []any{map[string]any{"type": "STAGING"}},
+				"default":  map[string]any{"type": "OBJECT", "region": "US-EAST1"},
+				"examples": []any{map[string]any{"type": "STRING"}},
 			},
 			"unspecified": map[string]any{
 				"description": "type is intentionally unspecified",
 			},
 		},
 		"dependencies": map[string]any{
-			"type": []any{"billingAddress"},
+			"credit_card":     map[string]any{"type": "object"},
+			"billing_address": []any{"OBJECT"},
 		},
 	}
 	if diff := cmp.Diff(want, got); diff != "" {
-		t.Errorf("schema normalization (-want +got):\\n%s", diff)
+		t.Errorf("schema normalization (-want +got):\n%s", diff)
 	}
 }
 

--- a/internal/telemetry/genaimessages_test.go
+++ b/internal/telemetry/genaimessages_test.go
@@ -301,6 +301,137 @@ func TestRequestContentAttributes_ToolTurnRole(t *testing.T) {
 	}
 }
 
+func TestRequestContentAttributes_ToolDefinitions(t *testing.T) {
+	captureContent(t)
+
+	req := &model.LLMRequest{
+		Config: &genai.GenerateContentConfig{
+			Tools: []*genai.Tool{
+				{
+					FunctionDeclarations: []*genai.FunctionDeclaration{
+						{
+							Name:        "get_weather",
+							Description: "Gets the weather for a city.",
+							ParametersJsonSchema: map[string]any{
+								"type": "object",
+								"properties": map[string]any{
+									"city": map[string]any{
+										"type":        "string",
+										"description": "The city name.",
+									},
+								},
+								"required": []string{"city"},
+							},
+						},
+						{
+							Name:        "get_time",
+							Description: "Gets the current time for a timezone.",
+						},
+					},
+				},
+			},
+		},
+	}
+
+	key := attribute.Key("gen_ai.tool.definitions")
+	encoded, ok := attrString(requestContentAttributes(req), key)
+	if !ok {
+		t.Fatalf("gen_ai.tool.definitions was not set")
+	}
+
+	var got []map[string]any
+	if err := json.Unmarshal([]byte(encoded), &got); err != nil {
+		t.Fatalf("invalid gen_ai.tool.definitions JSON: %v", err)
+	}
+	want := []map[string]any{
+		{
+			"name":        "get_weather",
+			"description": "Gets the weather for a city.",
+			"parameters": map[string]any{
+				"type": "object",
+				"properties": map[string]any{
+					"city": map[string]any{
+						"type":        "string",
+						"description": "The city name.",
+					},
+				},
+				"required": []any{"city"},
+			},
+			"type": "function",
+		},
+		{
+			"name":        "get_time",
+			"description": "Gets the current time for a timezone.",
+			"parameters":  nil,
+			"type":        "function",
+		},
+	}
+	if diff := cmp.Diff(want, got); diff != "" {
+		t.Errorf("tool definitions (-want +got):\n%s", diff)
+	}
+}
+
+func TestRequestContentAttributes_ToolDefinitions_Parameters(t *testing.T) {
+	captureContent(t)
+
+	req := &model.LLMRequest{
+		Config: &genai.GenerateContentConfig{
+			Tools: []*genai.Tool{{
+				FunctionDeclarations: []*genai.FunctionDeclaration{{
+					Name: "get_weather",
+					Parameters: &genai.Schema{
+						Type: genai.TypeObject,
+						Properties: map[string]*genai.Schema{
+							"city": {Type: genai.TypeString},
+						},
+						Required: []string{"city"},
+					},
+				}},
+			}},
+		},
+	}
+
+	encoded, ok := attrString(requestContentAttributes(req), genAIToolDefinitions)
+	if !ok {
+		t.Fatal("gen_ai.tool.definitions was not set")
+	}
+	var got []map[string]any
+	if err := json.Unmarshal([]byte(encoded), &got); err != nil {
+		t.Fatalf("invalid gen_ai.tool.definitions JSON: %v", err)
+	}
+	want := []map[string]any{{
+		"name":        "get_weather",
+		"description": "",
+		"parameters": map[string]any{
+			"type": "OBJECT",
+			"properties": map[string]any{
+				"city": map[string]any{"type": "STRING"},
+			},
+			"required": []any{"city"},
+		},
+		"type": "function",
+	}}
+	if diff := cmp.Diff(want, got); diff != "" {
+		t.Errorf("tool definitions with Parameters (-want +got):\n%s", diff)
+	}
+}
+
+func TestRequestContentAttributes_ToolDefinitionsRespectsCapture(t *testing.T) {
+	t.Setenv(captureMessageContentEnvVar, "")
+	ApplyEnv()
+
+	req := &model.LLMRequest{
+		Config: &genai.GenerateContentConfig{
+			Tools: []*genai.Tool{{
+				FunctionDeclarations: []*genai.FunctionDeclaration{{Name: "get_weather"}},
+			}},
+		},
+	}
+	if _, ok := attrString(requestContentAttributes(req), genAIToolDefinitions); ok {
+		t.Fatal("gen_ai.tool.definitions was set while content capture was disabled")
+	}
+}
+
 func TestRequestContentAttributes_SystemInstructions(t *testing.T) {
 	captureContent(t)
 

--- a/internal/telemetry/genaimessages_test.go
+++ b/internal/telemetry/genaimessages_test.go
@@ -460,13 +460,129 @@ func TestRequestContentAttributes_ToolDefinitions_ParametersFailureIsolated(t *t
 	if got[0]["parameters"].(map[string]any)["properties"].(map[string]any)["value"].(map[string]any)["type"] != "string" {
 		t.Fatalf("nested schema type was not normalized: %#v", got[0])
 	}
-	if got[1]["name"] != "bad_tool" || got[1]["parameters"] != unserializablePlaceholderValueForTest() {
+	if got[1]["name"] != "bad_tool" {
 		t.Fatalf("bad tool was not isolated: %#v", got[1])
+	}
+	wantPlaceholder := map[string]any{
+		"type": "object",
+		"properties": map[string]any{
+			"serialization_error": map[string]any{"type": "string"},
+		},
+	}
+	if diff := cmp.Diff(wantPlaceholder, got[1]["parameters"]); diff != "" {
+		t.Errorf("invalid parameters placeholder (-want +got):\n%s", diff)
 	}
 }
 
-func unserializablePlaceholderValueForTest() string {
-	return "<unserializable>"
+func TestRequestContentAttributes_ToolDefinitions_ParametersPrecedenceAndMissing(t *testing.T) {
+	captureToolDefinitionParameters(t)
+
+	req := &model.LLMRequest{
+		Config: &genai.GenerateContentConfig{
+			Tools: []*genai.Tool{{
+				FunctionDeclarations: []*genai.FunctionDeclaration{
+					{
+						Name:       "both_parameters",
+						Parameters: &genai.Schema{Type: genai.TypeObject},
+						ParametersJsonSchema: map[string]any{
+							"type": "STRING",
+						},
+					},
+					{Name: "no_parameters"},
+				},
+			}},
+		},
+	}
+
+	encoded, ok := attrString(requestContentAttributes(req), genAIToolDefinitions)
+	if !ok {
+		t.Fatal("gen_ai.tool.definitions was not set")
+	}
+	var got []map[string]any
+	if err := json.Unmarshal([]byte(encoded), &got); err != nil {
+		t.Fatalf("invalid gen_ai.tool.definitions JSON: %v", err)
+	}
+	want := []map[string]any{
+		{
+			"name":        "both_parameters",
+			"description": "",
+			"parameters":  map[string]any{"type": "string"},
+			"type":        "function",
+		},
+		{
+			"name":        "no_parameters",
+			"description": "",
+			"parameters":  nil,
+			"type":        "function",
+		},
+	}
+	if diff := cmp.Diff(want, got); diff != "" {
+		t.Errorf("tool definition parameter precedence and absence (-want +got):\\n%s", diff)
+	}
+}
+
+func TestToolDefinitionParameters_NormalizesSchemaTypesWithoutChangingData(t *testing.T) {
+	captureToolDefinitionParameters(t)
+
+	declaration := &genai.FunctionDeclaration{
+		ParametersJsonSchema: map[string]any{
+			"type": "OBJECT",
+			"properties": map[string]any{
+				"value": map[string]any{
+					"type":     []string{"OBJECT", "null"},
+					"default":  map[string]any{"type": "PRODUCTION", "region": "US-EAST1"},
+					"examples": []any{map[string]any{"type": "STAGING"}},
+				},
+				"unspecified": map[string]any{
+					"type":        "TYPE_UNSPECIFIED",
+					"description": "type is intentionally unspecified",
+				},
+			},
+			"dependencies": map[string]any{
+				"type": []string{"billingAddress"},
+			},
+		},
+	}
+
+	encoded := toolDefinitionParameters(declaration)
+	var got map[string]any
+	if err := json.Unmarshal(encoded, &got); err != nil {
+		t.Fatalf("invalid parameters JSON: %v", err)
+	}
+	want := map[string]any{
+		"type": "object",
+		"properties": map[string]any{
+			"value": map[string]any{
+				"type":     []any{"object", "null"},
+				"default":  map[string]any{"type": "PRODUCTION", "region": "US-EAST1"},
+				"examples": []any{map[string]any{"type": "STAGING"}},
+			},
+			"unspecified": map[string]any{
+				"description": "type is intentionally unspecified",
+			},
+		},
+		"dependencies": map[string]any{
+			"type": []any{"billingAddress"},
+		},
+	}
+	if diff := cmp.Diff(want, got); diff != "" {
+		t.Errorf("schema normalization (-want +got):\\n%s", diff)
+	}
+}
+
+func TestToolDefinitionParameters_PreservesLargeNumbers(t *testing.T) {
+	captureToolDefinitionParameters(t)
+
+	declaration := &genai.FunctionDeclaration{
+		ParametersJsonSchema: map[string]any{
+			"type":    "object",
+			"maximum": int64(9223372036854775807),
+		},
+	}
+	encoded := toolDefinitionParameters(declaration)
+	if !strings.Contains(string(encoded), `"maximum":9223372036854775807`) {
+		t.Fatalf("large integer lost precision in parameters: %s", encoded)
+	}
 }
 
 func TestRequestContentAttributes_ToolDefinitionsRespectsCapture(t *testing.T) {

--- a/internal/telemetry/genaimessages_test.go
+++ b/internal/telemetry/genaimessages_test.go
@@ -44,6 +44,15 @@ func captureContent(t *testing.T) {
 	// Spans have to be asked for by name. A truthy value means log records
 	// only, which is what the variable meant before spans could carry content.
 	t.Setenv(captureMessageContentEnvVar, "SPAN_AND_EVENT")
+	t.Setenv(captureToolDefinitionParametersEnvVar, "")
+	ApplyEnv()
+}
+
+// captureToolDefinitionParameters turns on the explicit input-schema opt-in for one test.
+func captureToolDefinitionParameters(t *testing.T) {
+	t.Helper()
+	captureContent(t)
+	t.Setenv(captureToolDefinitionParametersEnvVar, "true")
 	ApplyEnv()
 }
 
@@ -333,8 +342,7 @@ func TestRequestContentAttributes_ToolDefinitions(t *testing.T) {
 		},
 	}
 
-	key := attribute.Key("gen_ai.tool.definitions")
-	encoded, ok := attrString(requestContentAttributes(req), key)
+	encoded, ok := attrString(requestContentAttributes(req), genAIToolDefinitions)
 	if !ok {
 		t.Fatalf("gen_ai.tool.definitions was not set")
 	}
@@ -347,22 +355,11 @@ func TestRequestContentAttributes_ToolDefinitions(t *testing.T) {
 		{
 			"name":        "get_weather",
 			"description": "Gets the weather for a city.",
-			"parameters": map[string]any{
-				"type": "object",
-				"properties": map[string]any{
-					"city": map[string]any{
-						"type":        "string",
-						"description": "The city name.",
-					},
-				},
-				"required": []any{"city"},
-			},
-			"type": "function",
+			"type":        "function",
 		},
 		{
 			"name":        "get_time",
 			"description": "Gets the current time for a timezone.",
-			"parameters":  nil,
 			"type":        "function",
 		},
 	}
@@ -372,7 +369,7 @@ func TestRequestContentAttributes_ToolDefinitions(t *testing.T) {
 }
 
 func TestRequestContentAttributes_ToolDefinitions_Parameters(t *testing.T) {
-	captureContent(t)
+	captureToolDefinitionParameters(t)
 
 	req := &model.LLMRequest{
 		Config: &genai.GenerateContentConfig{
@@ -403,9 +400,9 @@ func TestRequestContentAttributes_ToolDefinitions_Parameters(t *testing.T) {
 		"name":        "get_weather",
 		"description": "",
 		"parameters": map[string]any{
-			"type": "OBJECT",
+			"type": "object",
 			"properties": map[string]any{
-				"city": map[string]any{"type": "STRING"},
+				"city": map[string]any{"type": "string"},
 			},
 			"required": []any{"city"},
 		},
@@ -416,8 +413,65 @@ func TestRequestContentAttributes_ToolDefinitions_Parameters(t *testing.T) {
 	}
 }
 
+func TestRequestContentAttributes_ToolDefinitions_ParametersFailureIsolated(t *testing.T) {
+	captureToolDefinitionParameters(t)
+
+	req := &model.LLMRequest{
+		Config: &genai.GenerateContentConfig{
+			Tools: []*genai.Tool{{
+				FunctionDeclarations: []*genai.FunctionDeclaration{
+					{
+						Name:        "good_tool",
+						Description: "A valid tool.",
+						ParametersJsonSchema: map[string]any{
+							"type": "OBJECT",
+							"properties": map[string]any{
+								"value": map[string]any{"type": "STRING"},
+							},
+						},
+					},
+					{
+						Name:        "bad_tool",
+						Description: "An invalid tool.",
+						ParametersJsonSchema: map[string]any{
+							"type":    "object",
+							"invalid": func() {},
+						},
+					},
+				},
+			}},
+		},
+	}
+
+	encoded, ok := attrString(requestContentAttributes(req), genAIToolDefinitions)
+	if !ok {
+		t.Fatal("gen_ai.tool.definitions was not set")
+	}
+	var got []map[string]any
+	if err := json.Unmarshal([]byte(encoded), &got); err != nil {
+		t.Fatalf("invalid gen_ai.tool.definitions JSON: %v", err)
+	}
+	if len(got) != 2 {
+		t.Fatalf("got %d tool definitions, want 2: %s", len(got), encoded)
+	}
+	if got[0]["name"] != "good_tool" || got[0]["parameters"].(map[string]any)["type"] != "object" {
+		t.Fatalf("good tool was not preserved and normalized: %#v", got[0])
+	}
+	if got[0]["parameters"].(map[string]any)["properties"].(map[string]any)["value"].(map[string]any)["type"] != "string" {
+		t.Fatalf("nested schema type was not normalized: %#v", got[0])
+	}
+	if got[1]["name"] != "bad_tool" || got[1]["parameters"] != unserializablePlaceholderValueForTest() {
+		t.Fatalf("bad tool was not isolated: %#v", got[1])
+	}
+}
+
+func unserializablePlaceholderValueForTest() string {
+	return "<unserializable>"
+}
+
 func TestRequestContentAttributes_ToolDefinitionsRespectsCapture(t *testing.T) {
 	t.Setenv(captureMessageContentEnvVar, "")
+	t.Setenv(captureToolDefinitionParametersEnvVar, "true")
 	ApplyEnv()
 
 	req := &model.LLMRequest{

--- a/internal/telemetry/genaimessages_test.go
+++ b/internal/telemetry/genaimessages_test.go
@@ -489,6 +489,12 @@ func TestRequestContentAttributes_ToolDefinitions_ParametersPrecedenceAndMissing
 						},
 					},
 					{Name: "no_parameters"},
+					{
+						Name: "json_schema_only",
+						ParametersJsonSchema: map[string]any{
+							"type": "STRING",
+						},
+					},
 				},
 			}},
 		},
@@ -506,13 +512,19 @@ func TestRequestContentAttributes_ToolDefinitions_ParametersPrecedenceAndMissing
 		{
 			"name":        "both_parameters",
 			"description": "",
-			"parameters":  map[string]any{"type": "string"},
+			"parameters":  map[string]any{"type": "object"},
 			"type":        "function",
 		},
 		{
 			"name":        "no_parameters",
 			"description": "",
 			"parameters":  nil,
+			"type":        "function",
+		},
+		{
+			"name":        "json_schema_only",
+			"description": "",
+			"parameters":  map[string]any{"type": "string"},
 			"type":        "function",
 		},
 	}

--- a/internal/telemetry/genaimessages_test.go
+++ b/internal/telemetry/genaimessages_test.go
@@ -41,6 +41,9 @@ const cloudTraceAttributeValueLimit = 64 * 1024
 // captureContent turns on the message content opt-in for one test.
 func captureContent(t *testing.T) {
 	t.Helper()
+	// ApplyEnv copies the environment into package-level settings, so restore
+	// those settings after t.Setenv restores the environment for the next test.
+	t.Cleanup(ApplyEnv)
 	// Spans have to be asked for by name. A truthy value means log records
 	// only, which is what the variable meant before spans could carry content.
 	t.Setenv(captureMessageContentEnvVar, "SPAN_AND_EVENT")
@@ -464,10 +467,8 @@ func TestRequestContentAttributes_ToolDefinitions_ParametersFailureIsolated(t *t
 		t.Fatalf("bad tool was not isolated: %#v", got[1])
 	}
 	wantPlaceholder := map[string]any{
-		"type": "object",
-		"properties": map[string]any{
-			"serialization_error": map[string]any{"type": "string"},
-		},
+		"$comment": "parameters omitted because serialization failed",
+		"type":     "object",
 	}
 	if diff := cmp.Diff(wantPlaceholder, got[1]["parameters"]); diff != "" {
 		t.Errorf("invalid parameters placeholder (-want +got):\n%s", diff)
@@ -533,6 +534,140 @@ func TestRequestContentAttributes_ToolDefinitions_ParametersPrecedenceAndMissing
 	}
 }
 
+func TestRequestContentAttributes_ToolDefinitions_ParameterCaptureSizeFallback(t *testing.T) {
+	newDeclaration := func(description, propertyDescription string) *genai.FunctionDeclaration {
+		return &genai.FunctionDeclaration{
+			Name:        "get_weather",
+			Description: description,
+			ParametersJsonSchema: map[string]any{
+				"type": "object",
+				"properties": map[string]any{
+					"city": map[string]any{
+						"type":        "string",
+						"description": propertyDescription,
+					},
+				},
+			},
+		}
+	}
+
+	tests := []struct {
+		name              string
+		captureParameters bool
+		declaration       *genai.FunctionDeclaration
+		wantAttribute     bool
+		wantParameters    bool
+	}{
+		{
+			name:              "parameters omitted by default",
+			captureParameters: false,
+			declaration:       newDeclaration("Gets the weather.", "parameters are not captured"),
+			wantAttribute:     true,
+			wantParameters:    false,
+		},
+		{
+			name:              "parameters included when they fit",
+			captureParameters: true,
+			declaration:       newDeclaration("Gets the weather.", ""),
+			wantAttribute:     true,
+			wantParameters:    true,
+		},
+		{
+			name:              "parameters omitted when the complete definition is too large",
+			captureParameters: true,
+			declaration:       newDeclaration("Gets the weather.", strings.Repeat("x", maxContentAttributeBytes)),
+			wantAttribute:     true,
+			wantParameters:    false,
+		},
+		{
+			name:              "attribute omitted when metadata is too large",
+			captureParameters: true,
+			declaration:       newDeclaration(strings.Repeat("x", maxContentAttributeBytes), ""),
+			wantAttribute:     false,
+			wantParameters:    false,
+		},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			if tc.captureParameters {
+				captureToolDefinitionParameters(t)
+			} else {
+				captureContent(t)
+			}
+
+			req := &model.LLMRequest{
+				Config: &genai.GenerateContentConfig{
+					Tools: []*genai.Tool{{FunctionDeclarations: []*genai.FunctionDeclaration{tc.declaration}}},
+				},
+			}
+			encoded, ok := attrString(requestContentAttributes(req), genAIToolDefinitions)
+			if !tc.wantAttribute {
+				if ok {
+					t.Errorf("gen_ai.tool.definitions = %d bytes, want attribute omitted", len(encoded))
+				}
+				return
+			}
+			if !ok {
+				t.Fatal("gen_ai.tool.definitions was not set")
+			}
+
+			var got []map[string]any
+			if err := json.Unmarshal([]byte(encoded), &got); err != nil {
+				t.Fatalf("invalid gen_ai.tool.definitions JSON: %v", err)
+			}
+			if len(got) != 1 {
+				t.Fatalf("got %d tool definitions, want 1: %s", len(got), encoded)
+			}
+			_, hasParameters := got[0]["parameters"]
+			if hasParameters != tc.wantParameters {
+				t.Errorf("parameters present = %t, want %t: %s", hasParameters, tc.wantParameters, encoded)
+			}
+			if got[0]["name"] != "get_weather" || got[0]["type"] != "function" {
+				t.Errorf("metadata was not preserved: %#v", got[0])
+			}
+		})
+	}
+}
+
+func TestToolDefinitionParameters_PreservesNull(t *testing.T) {
+	tests := []struct {
+		name        string
+		declaration *genai.FunctionDeclaration
+	}{
+		{
+			name:        "both fields empty",
+			declaration: &genai.FunctionDeclaration{},
+		},
+		{
+			name: "raw message null",
+			declaration: &genai.FunctionDeclaration{
+				ParametersJsonSchema: json.RawMessage("null"),
+			},
+		},
+		{
+			name: "typed nil pointer",
+			declaration: &genai.FunctionDeclaration{
+				ParametersJsonSchema: (*genai.Schema)(nil),
+			},
+		},
+		{
+			name: "typed nil map",
+			declaration: &genai.FunctionDeclaration{
+				ParametersJsonSchema: map[string]any(nil),
+			},
+		},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			if got := string(toolDefinitionParameters(tc.declaration)); got != "null" {
+				t.Errorf("toolDefinitionParameters() = %s, want null", got)
+			}
+		})
+	}
+}
+
 func TestToolDefinitionParameters_RejectsInvalidSchemaValues(t *testing.T) {
 	tests := []struct {
 		name  string
@@ -571,6 +706,21 @@ func TestToolDefinitionParameters_NormalizesSchemaTypesWithoutChangingData(t *te
 					"type":        "TYPE_UNSPECIFIED",
 					"description": "type is intentionally unspecified",
 				},
+				"mixed_case": map[string]any{
+					"type": "Object",
+				},
+				"union_with_invalid_members": map[string]any{
+					"type": []any{"String", 42, "BOOLEAN", nil},
+				},
+				"invalid_type": map[string]any{
+					"type": 42,
+				},
+				"null_type": map[string]any{
+					"type": nil,
+				},
+				"empty_union": map[string]any{
+					"type": []any{42, nil},
+				},
 			},
 			"dependencies": map[string]any{
 				"credit_card":     map[string]any{"type": "OBJECT"},
@@ -595,6 +745,15 @@ func TestToolDefinitionParameters_NormalizesSchemaTypesWithoutChangingData(t *te
 			"unspecified": map[string]any{
 				"description": "type is intentionally unspecified",
 			},
+			"mixed_case": map[string]any{
+				"type": "object",
+			},
+			"union_with_invalid_members": map[string]any{
+				"type": []any{"string", "boolean"},
+			},
+			"invalid_type": map[string]any{},
+			"null_type":    map[string]any{},
+			"empty_union":  map[string]any{},
 		},
 		"dependencies": map[string]any{
 			"credit_card":     map[string]any{"type": "object"},
@@ -622,6 +781,7 @@ func TestToolDefinitionParameters_PreservesLargeNumbers(t *testing.T) {
 }
 
 func TestRequestContentAttributes_ToolDefinitionsRespectsCapture(t *testing.T) {
+	t.Cleanup(ApplyEnv)
 	t.Setenv(captureMessageContentEnvVar, "")
 	t.Setenv(captureToolDefinitionParametersEnvVar, "true")
 	ApplyEnv()
@@ -668,6 +828,7 @@ func TestRequestContentAttributes_SystemInstructions(t *testing.T) {
 // --- Opt-in ------------------------------------------------------------
 
 func TestContentAttributes_OptInIsOffByDefault(t *testing.T) {
+	t.Cleanup(ApplyEnv)
 	t.Setenv(captureMessageContentEnvVar, "")
 	ApplyEnv()
 
@@ -1085,7 +1246,9 @@ func TestContentCaptureModes(t *testing.T) {
 		{"span_and_event", true, true},
 	} {
 		t.Run(tc.env, func(t *testing.T) {
+			t.Cleanup(ApplyEnv)
 			t.Setenv(captureMessageContentEnvVar, tc.env)
+			t.Setenv(captureToolDefinitionParametersEnvVar, "")
 			ApplyEnv()
 			if got := getGenAICaptureMessageContent(); got != tc.inLogs {
 				t.Errorf("content in log records = %v, want %v", got, tc.inLogs)
@@ -1103,6 +1266,7 @@ func TestContentCaptureModes(t *testing.T) {
 // span capture behind that value would have started shipping full conversations
 // to a tracing backend nobody opted into.
 func TestTruthyValueDoesNotPutContentOnSpans(t *testing.T) {
+	t.Cleanup(ApplyEnv)
 	t.Setenv(captureMessageContentEnvVar, "true")
 	ApplyEnv()
 

--- a/internal/telemetry/genaimessages_test.go
+++ b/internal/telemetry/genaimessages_test.go
@@ -535,14 +535,14 @@ func TestRequestContentAttributes_ToolDefinitions_ParametersPrecedenceAndMissing
 }
 
 func TestRequestContentAttributes_ToolDefinitions_ParameterCaptureSizeFallback(t *testing.T) {
-	newDeclaration := func(description, propertyDescription string) *genai.FunctionDeclaration {
+	newDeclaration := func(name, description, propertyDescription string) *genai.FunctionDeclaration {
 		return &genai.FunctionDeclaration{
-			Name:        "get_weather",
+			Name:        name,
 			Description: description,
 			ParametersJsonSchema: map[string]any{
 				"type": "object",
 				"properties": map[string]any{
-					"city": map[string]any{
+					"value": map[string]any{
 						"type":        "string",
 						"description": propertyDescription,
 					},
@@ -551,40 +551,52 @@ func TestRequestContentAttributes_ToolDefinitions_ParameterCaptureSizeFallback(t
 		}
 	}
 
+	declarations := func(propertyDescription string) []*genai.FunctionDeclaration {
+		return []*genai.FunctionDeclaration{
+			newDeclaration("get_weather", "Gets the weather.", propertyDescription),
+			newDeclaration("get_time", "Gets the current time.", propertyDescription),
+		}
+	}
+
 	tests := []struct {
 		name              string
 		captureParameters bool
-		declaration       *genai.FunctionDeclaration
+		declarations      []*genai.FunctionDeclaration
 		wantAttribute     bool
 		wantParameters    bool
+		wantSameAsOptOut  bool
 	}{
 		{
 			name:              "parameters omitted by default",
 			captureParameters: false,
-			declaration:       newDeclaration("Gets the weather.", "parameters are not captured"),
+			declarations:      declarations("parameters are not captured"),
 			wantAttribute:     true,
 			wantParameters:    false,
 		},
 		{
 			name:              "parameters included when they fit",
 			captureParameters: true,
-			declaration:       newDeclaration("Gets the weather.", ""),
+			declarations:      declarations(""),
 			wantAttribute:     true,
 			wantParameters:    true,
 		},
 		{
 			name:              "parameters omitted when the complete definition is too large",
 			captureParameters: true,
-			declaration:       newDeclaration("Gets the weather.", strings.Repeat("x", maxContentAttributeBytes)),
+			declarations:      declarations(strings.Repeat("x", maxContentAttributeBytes)),
 			wantAttribute:     true,
 			wantParameters:    false,
+			wantSameAsOptOut:  true,
 		},
 		{
 			name:              "attribute omitted when metadata is too large",
 			captureParameters: true,
-			declaration:       newDeclaration(strings.Repeat("x", maxContentAttributeBytes), ""),
-			wantAttribute:     false,
-			wantParameters:    false,
+			declarations: []*genai.FunctionDeclaration{
+				newDeclaration("get_weather", strings.Repeat("x", maxContentAttributeBytes), ""),
+				newDeclaration("get_time", "Gets the current time.", ""),
+			},
+			wantAttribute:  false,
+			wantParameters: false,
 		},
 	}
 
@@ -598,7 +610,7 @@ func TestRequestContentAttributes_ToolDefinitions_ParameterCaptureSizeFallback(t
 
 			req := &model.LLMRequest{
 				Config: &genai.GenerateContentConfig{
-					Tools: []*genai.Tool{{FunctionDeclarations: []*genai.FunctionDeclaration{tc.declaration}}},
+					Tools: []*genai.Tool{{FunctionDeclarations: tc.declarations}},
 				},
 			}
 			encoded, ok := attrString(requestContentAttributes(req), genAIToolDefinitions)
@@ -611,20 +623,35 @@ func TestRequestContentAttributes_ToolDefinitions_ParameterCaptureSizeFallback(t
 			if !ok {
 				t.Fatal("gen_ai.tool.definitions was not set")
 			}
+			if tc.wantSameAsOptOut {
+				t.Setenv(captureToolDefinitionParametersEnvVar, "")
+				ApplyEnv()
+				withoutParameters, withoutParametersOK := attrString(requestContentAttributes(req), genAIToolDefinitions)
+				if !withoutParametersOK {
+					t.Fatal("gen_ai.tool.definitions was not set with parameter capture disabled")
+				}
+				if encoded != withoutParameters {
+					t.Errorf("parameter-capture fallback differs from opt-out value:\nwith opt-in:  %s\nwith opt-out: %s", encoded, withoutParameters)
+				}
+			}
 
 			var got []map[string]any
 			if err := json.Unmarshal([]byte(encoded), &got); err != nil {
 				t.Fatalf("invalid gen_ai.tool.definitions JSON: %v", err)
 			}
-			if len(got) != 1 {
-				t.Fatalf("got %d tool definitions, want 1: %s", len(got), encoded)
+			if len(got) != len(tc.declarations) {
+				t.Fatalf("got %d tool definitions, want %d: %s", len(got), len(tc.declarations), encoded)
 			}
-			_, hasParameters := got[0]["parameters"]
-			if hasParameters != tc.wantParameters {
-				t.Errorf("parameters present = %t, want %t: %s", hasParameters, tc.wantParameters, encoded)
-			}
-			if got[0]["name"] != "get_weather" || got[0]["type"] != "function" {
-				t.Errorf("metadata was not preserved: %#v", got[0])
+			for i, declaration := range tc.declarations {
+				if got[i]["name"] != declaration.Name ||
+					got[i]["description"] != declaration.Description ||
+					got[i]["type"] != "function" {
+					t.Errorf("tool %d metadata was not preserved: %#v", i, got[i])
+				}
+				_, hasParameters := got[i]["parameters"]
+				if hasParameters != tc.wantParameters {
+					t.Errorf("tool %d parameters present = %t, want %t: %s", i, hasParameters, tc.wantParameters, encoded)
+				}
 			}
 		})
 	}
@@ -701,6 +728,11 @@ func TestToolDefinitionParameters_NormalizesSchemaTypesWithoutChangingData(t *te
 					"type":     []string{"OBJECT", "null"},
 					"default":  map[string]any{"type": "OBJECT", "region": "US-EAST1"},
 					"examples": []any{map[string]any{"type": "STRING"}},
+					"items":    map[string]any{"type": "STRING"},
+					"anyOf": []any{
+						map[string]any{"type": "OBJECT"},
+						map[string]any{"type": "String"},
+					},
 				},
 				"unspecified": map[string]any{
 					"type":        "TYPE_UNSPECIFIED",
@@ -710,13 +742,25 @@ func TestToolDefinitionParameters_NormalizesSchemaTypesWithoutChangingData(t *te
 					"type": "Object",
 				},
 				"union_with_invalid_members": map[string]any{
-					"type": []any{"String", 42, "BOOLEAN", nil},
+					"type": []any{"String", 42, "BOOLEAN", nil, "STRING"},
+				},
+				"nested_type_array": map[string]any{
+					"type": []any{[]any{"STRING"}},
+				},
+				"unknown_type": map[string]any{
+					"type": "Widget",
+				},
+				"empty_type": map[string]any{
+					"type": "",
 				},
 				"invalid_type": map[string]any{
 					"type": 42,
 				},
 				"null_type": map[string]any{
 					"type": nil,
+				},
+				"lowercase_unspecified": map[string]any{
+					"type": "type_unspecified",
 				},
 				"empty_union": map[string]any{
 					"type": []any{42, nil},
@@ -741,6 +785,11 @@ func TestToolDefinitionParameters_NormalizesSchemaTypesWithoutChangingData(t *te
 				"type":     []any{"object", "null"},
 				"default":  map[string]any{"type": "OBJECT", "region": "US-EAST1"},
 				"examples": []any{map[string]any{"type": "STRING"}},
+				"items":    map[string]any{"type": "string"},
+				"anyOf": []any{
+					map[string]any{"type": "object"},
+					map[string]any{"type": "string"},
+				},
 			},
 			"unspecified": map[string]any{
 				"description": "type is intentionally unspecified",
@@ -751,9 +800,13 @@ func TestToolDefinitionParameters_NormalizesSchemaTypesWithoutChangingData(t *te
 			"union_with_invalid_members": map[string]any{
 				"type": []any{"string", "boolean"},
 			},
-			"invalid_type": map[string]any{},
-			"null_type":    map[string]any{},
-			"empty_union":  map[string]any{},
+			"nested_type_array":     map[string]any{},
+			"unknown_type":          map[string]any{},
+			"empty_type":            map[string]any{},
+			"invalid_type":          map[string]any{},
+			"null_type":             map[string]any{},
+			"lowercase_unspecified": map[string]any{},
+			"empty_union":           map[string]any{},
 		},
 		"dependencies": map[string]any{
 			"credit_card":     map[string]any{"type": "object"},

--- a/internal/telemetry/logger.go
+++ b/internal/telemetry/logger.go
@@ -36,6 +36,12 @@ import (
 // https://opentelemetry.io/docs/specs/semconv/registry/attributes/gen-ai/.
 const captureMessageContentEnvVar = "OTEL_INSTRUMENTATION_GENAI_CAPTURE_MESSAGE_CONTENT"
 
+// captureToolDefinitionParametersEnvVar controls whether tool input schemas
+// are included in gen_ai.tool.definitions. Tool names, types, and descriptions
+// remain captured with message content; parameters require this additional
+// opt-in because schemas can be large or contain sensitive details.
+const captureToolDefinitionParametersEnvVar = "ADK_INSTRUMENTATION_GENAI_CAPTURE_TOOL_DEFINITION_PARAMETERS"
+
 // contentCaptureMode says which signals may carry message content.
 //
 // The variable was a boolean here before spans could carry content, and
@@ -54,8 +60,9 @@ const (
 )
 
 var (
-	captureMode contentCaptureMode = captureNone
-	once        sync.Once
+	captureMode                            contentCaptureMode = captureNone
+	captureToolDefinitionParametersEnabled bool
+	once                                   sync.Once
 )
 
 func parseContentCaptureMode(s string) contentCaptureMode {
@@ -273,11 +280,21 @@ func contentToJSONLikeValue(c *genai.Content) any {
 	return m
 }
 
-// ApplyEnv reads OTEL_INSTRUMENTATION_GENAI_CAPTURE_MESSAGE_CONTENT. It accepts
-// EVENT_ONLY, SPAN_ONLY and SPAN_AND_EVENT, and treats "1" or "true" as
-// EVENT_ONLY for back-compatibility. Anything else records no content.
+// ApplyEnv reads the content-capture environment variables. It accepts
+// EVENT_ONLY, SPAN_ONLY and SPAN_AND_EVENT for message content, and treats
+// "1" or "true" as EVENT_ONLY for back-compatibility. Tool parameters require
+// a separate explicit opt-in.
 func ApplyEnv() {
 	captureMode = parseContentCaptureMode(os.Getenv(captureMessageContentEnvVar))
+	captureToolDefinitionParametersEnabled = evalsToTrue(os.Getenv(captureToolDefinitionParametersEnvVar))
+}
+
+// captureToolDefinitionParametersOnSpans reports whether input schemas may be
+// included in gen_ai.tool.definitions. The overall content-capture gate is
+// checked separately by the caller.
+func captureToolDefinitionParametersOnSpans() bool {
+	contentCapture()
+	return captureToolDefinitionParametersEnabled
 }
 
 func evalsToTrue(s string) bool {

--- a/internal/telemetry/telemetry.go
+++ b/internal/telemetry/telemetry.go
@@ -86,9 +86,9 @@ type StartGenerateContentSpanParams struct {
 	ModelName string
 	// InvocationID is the ID of the invocation.
 	InvocationID string
-	// Request is the request about to be sent to the model. It is used only
-	// to record the opt-in gen_ai.input.messages and
-	// gen_ai.system_instructions attributes, and may be nil.
+	// Request is the request about to be sent to the model. It is used to
+	// record the opt-in gen_ai.input.messages, gen_ai.system_instructions, and
+	// gen_ai.tool.definitions attributes, and may be nil.
 	Request *model.LLMRequest
 }
 

--- a/internal/telemetry/telemetrytestcase/agent_with_tool_capture_content.go
+++ b/internal/telemetry/telemetrytestcase/agent_with_tool_capture_content.go
@@ -27,6 +27,11 @@ const systemInstructionsJSON = `[{"type":"text","content":"you are helpful\n\n` 
 
 const toolDefinitionsJSON = `[{"name":"some_tool","description":"A sample tool.","type":"function"}]`
 
+const toolDefinitionsWithParametersJSON = `[{"name":"some_tool","description":"A sample tool.",` +
+	`"parameters":{"additionalProperties":false,"properties":{"arg1":{"type":"string"}},` +
+	`"required":["arg1"],"type":"object"},` +
+	`"type":"function"}]`
+
 // AgentWithToolCaptureContentCase is the expected root span for
 // the same scenario as [AgentWithToolCase] but with content capture
 // enabled, via OTEL_INSTRUMENTATION_GENAI_CAPTURE_MESSAGE_CONTENT env var.
@@ -191,4 +196,37 @@ var AgentWithToolCaptureContentCase = &telemetrytest.SpanDigest{
 			},
 		},
 	},
+}
+
+// AgentWithToolCaptureContentAndParametersCase is the expected root span for
+// the same scenario as [AgentWithToolCaptureContentCase] with tool parameter
+// capture enabled.
+var AgentWithToolCaptureContentAndParametersCase = withToolDefinitions(
+	AgentWithToolCaptureContentCase, toolDefinitionsWithParametersJSON,
+)
+
+// withToolDefinitions makes a shallow copy of the digest tree while replacing
+// the tool-definition attribute on each generate_content span. The nested logs
+// are immutable test data and can be shared safely.
+func withToolDefinitions(base *telemetrytest.SpanDigest, toolDefinitions string) *telemetrytest.SpanDigest {
+	clone := *base
+	clone.Attributes = cloneAttributes(base.Attributes)
+	clone.Children = make([]*telemetrytest.SpanDigest, len(base.Children))
+	for i, child := range base.Children {
+		childClone := *child
+		childClone.Attributes = cloneAttributes(child.Attributes)
+		if childClone.Name == "generate_content mock" {
+			childClone.Attributes["gen_ai.tool.definitions"] = toolDefinitions
+		}
+		clone.Children[i] = &childClone
+	}
+	return &clone
+}
+
+func cloneAttributes(attributes map[string]any) map[string]any {
+	clone := make(map[string]any, len(attributes))
+	for key, value := range attributes {
+		clone[key] = value
+	}
+	return clone
 }

--- a/internal/telemetry/telemetrytestcase/agent_with_tool_capture_content.go
+++ b/internal/telemetry/telemetrytestcase/agent_with_tool_capture_content.go
@@ -25,6 +25,10 @@ const systemInstructionsJSON = `[{"type":"text","content":"you are helpful\n\n` 
 	`You are an agent. Your internal name is \"some_root_agent\". ` +
 	`The description about you is \"A sample root agent.\"."}]`
 
+const toolDefinitionsJSON = `[{"name":"some_tool","description":"A sample tool.",` +
+	`"parameters":{"type":"object","properties":{"arg1":{"type":"string"}},` +
+	`"required":["arg1"],"additionalProperties":false},"type":"function"}]`
+
 // AgentWithToolCaptureContentCase is the expected root span for
 // the same scenario as [AgentWithToolCase] but with content capture
 // enabled, via OTEL_INSTRUMENTATION_GENAI_CAPTURE_MESSAGE_CONTENT env var.
@@ -47,6 +51,7 @@ var AgentWithToolCaptureContentCase = &telemetrytest.SpanDigest{
 				"gcp.vertex.agent.invocation_id": telemetrytest.PRESENT,
 				"gen_ai.response.finish_reasons": []string{""},
 				"gen_ai.system_instructions":     systemInstructionsJSON,
+				"gen_ai.tool.definitions":        toolDefinitionsJSON,
 				"gen_ai.input.messages":          `[{"role":"user","parts":[{"type":"text","content":"hello"}]}]`,
 				// The mock model reports no finish reason, so the tool call
 				// in the turn decides it: the schema distinguishes a tool
@@ -113,6 +118,7 @@ var AgentWithToolCaptureContentCase = &telemetrytest.SpanDigest{
 				"gcp.vertex.agent.invocation_id": telemetrytest.PRESENT,
 				"gen_ai.response.finish_reasons": []string{""},
 				"gen_ai.system_instructions":     systemInstructionsJSON,
+				"gen_ai.tool.definitions":        toolDefinitionsJSON,
 				// The history now carries all three turns. genai labels the
 				// tool result "user"; the schema calls it "tool".
 				"gen_ai.input.messages": `[{"role":"user","parts":[{"type":"text","content":"hello"}]},` +

--- a/internal/telemetry/telemetrytestcase/agent_with_tool_capture_content.go
+++ b/internal/telemetry/telemetrytestcase/agent_with_tool_capture_content.go
@@ -25,9 +25,7 @@ const systemInstructionsJSON = `[{"type":"text","content":"you are helpful\n\n` 
 	`You are an agent. Your internal name is \"some_root_agent\". ` +
 	`The description about you is \"A sample root agent.\"."}]`
 
-const toolDefinitionsJSON = `[{"name":"some_tool","description":"A sample tool.",` +
-	`"parameters":{"type":"object","properties":{"arg1":{"type":"string"}},` +
-	`"required":["arg1"],"additionalProperties":false},"type":"function"}]`
+const toolDefinitionsJSON = `[{"name":"some_tool","description":"A sample tool.","type":"function"}]`
 
 // AgentWithToolCaptureContentCase is the expected root span for
 // the same scenario as [AgentWithToolCase] but with content capture


### PR DESCRIPTION
## Summary

- record function tool definitions from the actual model request
- emit them through the `gen_ai.tool.definitions` attribute
- preserve both `Parameters` and `ParametersJsonSchema`
- keep tool definition capture behind `OTEL_INSTRUMENTATION_GENAI_CAPTURE_MESSAGE_CONTENT`
- add unit and functional telemetry coverage

## Testing

- `go test ./internal/telemetry/... -count=1`
- `go vet ./internal/telemetry`
- `git diff --check`

Fixes #789