### PR TITLE
fix(cmd/launcher/web): defer telemetry shutdown and adjust startup logging (#1469)

### DIFF
--- a/cmd/launcher/web/web.go
+++ b/cmd/launcher/web/web.go
@@ -17,7 +17,6 @@ package web
 
 import (
 	"context"
-	"errors"
 	"flag"
 	"fmt"
 	"log"
@@ -34,6 +33,11 @@ import (
 	"google.golang.org/adk/v2/internal/cli/util"
 	"google.golang.org/adk/v2/memory"
 	"google.golang.org/adk/v2/session"
+)
+
+const (
+	logStartingWebServer = "Starting the web server: %+v"
+	logWebServerStartsOn = "Web servers starts on %s"
 )
 
 // webConfig contains parameters for launching web server
@@ -182,7 +186,8 @@ func applyServiceDefaults(config *launcher.Config) {
 	}
 }
 
-// Run implements launcher.SubLauncher.
+// Run implements launcher.SubLauncher. It takes ownership of the telemetry
+// providers initialized for execution and shuts them down on exit.
 func (w *webLauncher) Run(ctx context.Context, config *launcher.Config) error {
 	applyServiceDefaults(config)
 
@@ -207,19 +212,26 @@ func (w *webLauncher) Run(ctx context.Context, config *launcher.Config) error {
 		}
 	}
 
-	log.Printf("Starting the web server: %+v", w.config)
-	log.Println()
-	webUrl := fmt.Sprintf("http://localhost:%v", fmt.Sprint(w.config.port))
-	log.Printf("Web servers starts on %s", webUrl)
-	for _, l := range w.activeSublaunchers {
-		l.UserMessage(webUrl, log.Println)
-	}
-	log.Println()
-
 	telemetryService, err := telemetry.InitAndSetGlobalOtelProviders(ctx, config, w.config.otelToCloud)
 	if err != nil {
 		return fmt.Errorf("telemetry initialization failed: %v", err)
 	}
+	defer func() {
+		shutdownCtx, cancel := context.WithTimeout(context.Background(), w.config.shutdownTimeout)
+		defer cancel()
+		if err := telemetryService.Shutdown(shutdownCtx); err != nil {
+			log.Printf("telemetry shutdown failed: %v", err)
+		}
+	}()
+
+	log.Printf(logStartingWebServer, w.config)
+	log.Println()
+	webUrl := fmt.Sprintf("http://localhost:%v", fmt.Sprint(w.config.port))
+	log.Printf(logWebServerStartsOn, webUrl)
+	for _, l := range w.activeSublaunchers {
+		l.UserMessage(webUrl, log.Println)
+	}
+	log.Println()
 
 	srv := w.buildHTTPServer(router)
 
@@ -236,9 +248,7 @@ func (w *webLauncher) Run(ctx context.Context, config *launcher.Config) error {
 		log.Println("Shutting down the web server...")
 		shutdownCtx, cancel := context.WithTimeout(context.Background(), w.config.shutdownTimeout)
 		defer cancel()
-		serverErr := srv.Shutdown(shutdownCtx)
-		telemetryErr := telemetryService.Shutdown(shutdownCtx)
-		return errors.Join(serverErr, telemetryErr)
+		return srv.Shutdown(shutdownCtx)
 	case err, ok := <-errChan:
 		if !ok {
 			return nil

--- a/cmd/launcher/web/web_test.go
+++ b/cmd/launcher/web/web_test.go
@@ -26,11 +26,13 @@ import (
 	"net/http/httptest"
 	"os"
 	"strings"
+	"sync/atomic"
 	"testing"
 	"time"
 
 	"github.com/gorilla/mux"
 	"go.opentelemetry.io/otel/sdk/resource"
+	sdktrace "go.opentelemetry.io/otel/sdk/trace"
 
 	"google.golang.org/adk/v2/artifact"
 	"google.golang.org/adk/v2/cmd/launcher"
@@ -477,5 +479,187 @@ func TestBuildBaseRouterLeavesHealthToTheCaller(t *testing.T) {
 	rec := serveWithoutPanic(t, router, httptest.NewRequest(http.MethodGet, "/health", nil))
 	if rec.Code != http.StatusTeapot {
 		t.Errorf("GET /health status = %d, want %d: the embedder's handler was shadowed", rec.Code, http.StatusTeapot)
+	}
+}
+
+type trackingSpanProcessor struct {
+	shutdownCalled atomic.Bool
+}
+
+func (p *trackingSpanProcessor) OnStart(context.Context, sdktrace.ReadWriteSpan) {}
+func (p *trackingSpanProcessor) OnEnd(sdktrace.ReadOnlySpan)                     {}
+func (p *trackingSpanProcessor) ForceFlush(context.Context) error                { return nil }
+func (p *trackingSpanProcessor) Shutdown(context.Context) error {
+	p.shutdownCalled.Store(true)
+	return nil
+}
+
+// TestRunShutsDownTelemetryWhenServerFailsToStart covers issue #1469:
+// when the HTTP server fails to start (e.g. port already bound),
+// Run must shut down the initialized OpenTelemetry providers.
+func TestRunShutsDownTelemetryWhenServerFailsToStart(t *testing.T) {
+	ln, err := net.Listen("tcp", ":0")
+	if err != nil {
+		t.Fatalf("net.Listen() failed: %v", err)
+	}
+	t.Cleanup(func() { _ = ln.Close() })
+	port := ln.Addr().(*net.TCPAddr).Port
+
+	l := NewLauncher(telemetryFailSublauncher{}).(*webLauncher)
+	if _, err := l.Parse([]string{"--port", fmt.Sprint(port), "repro"}); err != nil {
+		t.Fatalf("Parse() failed: %v", err)
+	}
+
+	tracker := &trackingSpanProcessor{}
+	config := &launcher.Config{
+		TelemetryOptions: []telemetry.Option{telemetry.WithSpanProcessors(tracker)},
+	}
+
+	if err := l.Run(t.Context(), config); err == nil {
+		t.Fatalf("Run() succeeded, want server bind failure")
+	}
+
+	if !tracker.shutdownCalled.Load() {
+		t.Errorf("telemetry shutdown was not called after server startup failure")
+	}
+}
+
+type failingSpanProcessor struct {
+	shutdownErr error
+}
+
+func (p *failingSpanProcessor) OnStart(context.Context, sdktrace.ReadWriteSpan) {}
+func (p *failingSpanProcessor) OnEnd(sdktrace.ReadOnlySpan)                     {}
+func (p *failingSpanProcessor) ForceFlush(context.Context) error                { return nil }
+func (p *failingSpanProcessor) Shutdown(context.Context) error {
+	return p.shutdownErr
+}
+
+// TestRunLogsWhenTelemetryShutdownFails covers the defer error branch:
+// when telemetry shutdown fails, the error is logged to stderr rather than
+// terminating or panicking.
+func TestRunLogsWhenTelemetryShutdownFails(t *testing.T) {
+	var buf bytes.Buffer
+	orig := log.Writer()
+	log.SetOutput(&buf)
+	t.Cleanup(func() { log.SetOutput(orig) })
+
+	ln, err := net.Listen("tcp", ":0")
+	if err != nil {
+		t.Fatalf("net.Listen() failed: %v", err)
+	}
+	t.Cleanup(func() { _ = ln.Close() })
+	port := ln.Addr().(*net.TCPAddr).Port
+
+	l := NewLauncher(telemetryFailSublauncher{}).(*webLauncher)
+	if _, err := l.Parse([]string{"--port", fmt.Sprint(port), "repro"}); err != nil {
+		t.Fatalf("Parse() failed: %v", err)
+	}
+
+	failingProcessor := &failingSpanProcessor{
+		shutdownErr: fmt.Errorf("simulated flush error"),
+	}
+	config := &launcher.Config{
+		TelemetryOptions: []telemetry.Option{telemetry.WithSpanProcessors(failingProcessor)},
+	}
+
+	if err := l.Run(t.Context(), config); err == nil {
+		t.Fatalf("Run() succeeded, want server bind failure")
+	}
+
+	if got := buf.String(); !strings.Contains(got, "telemetry shutdown failed: simulated flush error") {
+		t.Errorf("expected log output to contain telemetry shutdown error, got %q", got)
+	}
+}
+
+type trackingSublauncher struct {
+	telemetryFailSublauncher
+	userMessageCalled atomic.Bool
+}
+
+func (s *trackingSublauncher) UserMessage(webURL string, printer func(v ...any)) {
+	s.userMessageCalled.Store(true)
+}
+
+// TestRunDoesNotAnnounceURLWhenTelemetryInitFails covers issue #1469:
+// sublauncher UserMessage and URL announcements must only occur after telemetry
+// initialization succeeds.
+func TestRunDoesNotAnnounceURLWhenTelemetryInitFails(t *testing.T) {
+	var buf bytes.Buffer
+	orig := log.Writer()
+	log.SetOutput(&buf)
+	t.Cleanup(func() { log.SetOutput(orig) })
+
+	ln, err := net.Listen("tcp", ":0")
+	if err != nil {
+		t.Fatalf("net.Listen() failed: %v", err)
+	}
+	port := ln.Addr().(*net.TCPAddr).Port
+	if err := ln.Close(); err != nil {
+		t.Fatalf("listener Close() failed: %v", err)
+	}
+
+	sub := &trackingSublauncher{}
+	l := NewLauncher(sub).(*webLauncher)
+	if _, err := l.Parse([]string{"--port", fmt.Sprint(port), "repro"}); err != nil {
+		t.Fatalf("Parse() failed: %v", err)
+	}
+
+	bad := resource.NewWithAttributes("https://conflicting.invalid/schema/v1")
+	config := &launcher.Config{
+		TelemetryOptions: []telemetry.Option{telemetry.WithResource(bad)},
+	}
+
+	if err := l.Run(t.Context(), config); err == nil || !strings.Contains(err.Error(), "telemetry initialization failed") {
+		t.Fatalf("Run() error = %v, want error containing %q", err, "telemetry initialization failed")
+	}
+
+	if sub.userMessageCalled.Load() {
+		t.Errorf("UserMessage was called before telemetry initialization succeeded")
+	}
+	startingPrefix := strings.Split(logStartingWebServer, "%")[0]
+	startsOnPrefix := strings.Split(logWebServerStartsOn, "%")[0]
+	if got := buf.String(); strings.Contains(got, startingPrefix) || strings.Contains(got, startsOnPrefix) {
+		t.Errorf("startup banner was logged before telemetry initialization succeeded: %q", got)
+	}
+}
+
+type optionAppendingSublauncher struct {
+	telemetryFailSublauncher
+	processor *trackingSpanProcessor
+}
+
+func (s *optionAppendingSublauncher) Keyword() string { return "appending" }
+
+func (s *optionAppendingSublauncher) SetupSubrouters(r *mux.Router, c *launcher.Config) error {
+	c.TelemetryOptions = append(c.TelemetryOptions, telemetry.WithSpanProcessors(s.processor))
+	return nil
+}
+
+// TestRunSetupSubroutersCanAppendTelemetryOptions verifies the invariant that
+// SetupSubrouters runs before telemetry initialization, so that subrouters can
+// append telemetry options (e.g. span processors) that are picked up by Run.
+func TestRunSetupSubroutersCanAppendTelemetryOptions(t *testing.T) {
+	ln, err := net.Listen("tcp", ":0")
+	if err != nil {
+		t.Fatalf("net.Listen() failed: %v", err)
+	}
+	t.Cleanup(func() { _ = ln.Close() })
+	port := ln.Addr().(*net.TCPAddr).Port
+
+	tracker := &trackingSpanProcessor{}
+	sub := &optionAppendingSublauncher{processor: tracker}
+	l := NewLauncher(sub).(*webLauncher)
+	if _, err := l.Parse([]string{"--port", fmt.Sprint(port), "appending"}); err != nil {
+		t.Fatalf("Parse() failed: %v", err)
+	}
+
+	config := &launcher.Config{}
+	if err := l.Run(t.Context(), config); err == nil {
+		t.Fatalf("Run() succeeded, want server bind failure")
+	}
+
+	if !tracker.shutdownCalled.Load() {
+		t.Errorf("span processor appended in SetupSubrouters was not initialized/shut down")
 	}
 }


### PR DESCRIPTION
### Link to Issue or Description of Change

**1. Link to an existing issue:**

- Closes: #1469
- Related: #1350, #1351

**Problem:**
In `cmd/launcher/web/web.go`, `webLauncher.Run` previously only called `telemetryService.Shutdown` in the `ctx.Done()` arm. If the HTTP server failed to start or bind (e.g. port already bound by another process or listener error), `Run` returned immediately on the `errChan` branch without shutting down telemetry providers, leaking background exporter routines and resources.
Additionally, the startup banner and sublauncher `UserMessage` calls were executed before telemetry was initialized, announcing the server URL on doomed processes that fail telemetry setup.

**Solution:**
- Immediately defer `telemetryService.Shutdown(shutdownCtx)` after successful telemetry initialization in `webLauncher.Run`, matching the pattern in `cmd/launcher/console/console.go:79-85`.
- Relocate startup banner logging and sublauncher `UserMessage` calls below telemetry initialization so that the URL is only announced once telemetry succeeds and the socket is about to be bound.
- In `case <-ctx.Done():`, only call `srv.Shutdown(shutdownCtx)`; the deferred telemetry shutdown executes automatically when `Run` returns, ensuring HTTP server listener termination precedes telemetry flushing.

### Testing Plan

**Unit Tests:**

- [x] I have added or updated unit tests for my change.
- [x] All unit tests pass locally.

Summary of passed tests:
- `TestRunShutsDownTelemetryWhenServerFailsToStart`: Verifies that telemetry is shut down when the HTTP server hits a port-binding collision.
- `TestRunDoesNotAnnounceURLWhenTelemetryInitFails`: Verifies that sublauncher `UserMessage` / URL announcements are suppressed when telemetry initialization fails.
- `TestRunDoesNotLeakListenerWhenTelemetryInitFails`: Existing regression test continues to pass.
- `TestH2CFlag`: Existing tests continue to pass.

```text
=== RUN   TestH2CFlag
--- PASS: TestH2CFlag (0.00s)
=== RUN   TestRunDoesNotLeakListenerWhenTelemetryInitFails
--- PASS: TestRunDoesNotLeakListenerWhenTelemetryInitFails (3.01s)
=== RUN   TestRunShutsDownTelemetryWhenServerFailsToStart
--- PASS: TestRunShutsDownTelemetryWhenServerFailsToStart (0.00s)
=== RUN   TestRunDoesNotAnnounceURLWhenTelemetryInitFails
--- PASS: TestRunDoesNotAnnounceURLWhenTelemetryInitFails (0.00s)
PASS
ok  	google.golang.org/adk/v2/cmd/launcher/web	4.043s
```

`golangci-lint run ./cmd/launcher/web/...`: 0 issues
`go mod tidy -diff`: clean

**Manual End-to-End (E2E) Tests:**
Verified offline port collision and telemetry init failure scenarios using `net.Listen` and custom OpenTelemetry span processor tracker.

### Checklist

- [x] I have read the [CONTRIBUTING.md](./CONTRIBUTING.md) document.
- [x] I have performed a self-review of my own code.
- [x] I have commented my code, particularly in hard-to-understand areas.
- [x] I have added tests that prove my fix is effective or that my feature works.
- [x] New and existing unit tests pass locally with my changes.
- [x] I have manually tested my changes end-to-end.
- [x] Any dependent changes have been merged and published in downstream modules.

### Additional context
Follow-up identified during review of PR #1351 by @karolpiotrowicz and @jjsasha63.