### PR TITLE
fix(mcptoolset): report non-text-only tool results instead of dropping them

### DIFF
--- a/tool/mcptoolset/set_test.go
+++ b/tool/mcptoolset/set_test.go
@@ -849,21 +849,55 @@ func TestMCPTool_EmptyTextResponse(t *testing.T) {
 }
 
 // TestMCPTool_NonTextOnlyResponse covers the gap left by #1353: an empty text
-// result is a valid success, but only when the server sent nothing. A result
-// carrying just an image, audio, resource link or embedded resource also
-// accumulates no text, and reporting that as {"output": ""} hands the model an
-// empty map while discarding the entire payload.
+// result is a valid success, but only when there was no other content to lose.
+// A result carrying just an image, audio, resource link or embedded resource
+// also accumulates no text, and reporting that as {"output": ""} hands the
+// model an empty string while discarding the entire payload.
+//
+// The mixed case is the control. A non-text block alongside real text must
+// still succeed, which pins the textResponse.Len() == 0 half of the condition:
+// without it, every result carrying a non-text block would error.
+//
+// TODO(#1401): the mixed case still drops its non-text block silently (#1391).
+// When #1401 renders those blocks, this whole test goes away with the guard.
 func TestMCPTool_NonTextOnlyResponse(t *testing.T) {
 	tests := []struct {
-		name    string
-		content mcp.Content
+		name       string
+		content    []mcp.Content
+		wantErr    bool
+		wantOutput string
 	}{
-		{"image", &mcp.ImageContent{MIMEType: "image/png", Data: []byte{0x89, 0x50, 0x4e, 0x47}}},
-		{"audio", &mcp.AudioContent{MIMEType: "audio/wav", Data: []byte{0x52, 0x49, 0x46, 0x46}}},
-		{"resource link", &mcp.ResourceLink{URI: "file:///tmp/report.pdf", Name: "report.pdf"}},
-		{"embedded resource", &mcp.EmbeddedResource{
-			Resource: &mcp.ResourceContents{URI: "file:///tmp/data.bin", MIMEType: "application/octet-stream", Blob: []byte{0x00, 0x01}},
-		}},
+		{
+			name:    "image only",
+			content: []mcp.Content{&mcp.ImageContent{MIMEType: "image/png", Data: []byte{0x89, 0x50, 0x4e, 0x47}}},
+			wantErr: true,
+		},
+		{
+			name:    "audio only",
+			content: []mcp.Content{&mcp.AudioContent{MIMEType: "audio/wav", Data: []byte{0x52, 0x49, 0x46, 0x46}}},
+			wantErr: true,
+		},
+		{
+			name:    "resource link only",
+			content: []mcp.Content{&mcp.ResourceLink{URI: "file:///tmp/report.pdf", Name: "report.pdf"}},
+			wantErr: true,
+		},
+		{
+			name: "embedded resource only",
+			content: []mcp.Content{&mcp.EmbeddedResource{
+				Resource: &mcp.ResourceContents{URI: "file:///tmp/data.bin", MIMEType: "application/octet-stream", Blob: []byte{0x00, 0x01}},
+			}},
+			wantErr: true,
+		},
+		{
+			name: "text alongside non-text still succeeds",
+			content: []mcp.Content{
+				&mcp.TextContent{Text: "caption"},
+				&mcp.ImageContent{MIMEType: "image/png", Data: []byte{0x89, 0x50, 0x4e, 0x47}},
+			},
+			wantErr:    false,
+			wantOutput: "caption",
+		},
 	}
 
 	for _, tt := range tests {
@@ -871,9 +905,9 @@ func TestMCPTool_NonTextOnlyResponse(t *testing.T) {
 			clientTransport, serverTransport := mcp.NewInMemoryTransports()
 
 			server := mcp.NewServer(&mcp.Implementation{Name: "test_server", Version: "v1.0.0"}, nil)
-			mcp.AddTool(server, &mcp.Tool{Name: "non_text_tool", Description: "returns only non-text content"}, func(ctx context.Context, req *mcp.CallToolRequest, args any) (*mcp.CallToolResult, any, error) {
+			mcp.AddTool(server, &mcp.Tool{Name: "non_text_tool", Description: "returns non-text content"}, func(ctx context.Context, req *mcp.CallToolRequest, args any) (*mcp.CallToolResult, any, error) {
 				return &mcp.CallToolResult{
-					Content: []mcp.Content{tt.content},
+					Content: tt.content,
 				}, nil, nil
 			})
 			if _, err := server.Connect(t.Context(), serverTransport, nil); err != nil {
@@ -909,8 +943,24 @@ func TestMCPTool_NonTextOnlyResponse(t *testing.T) {
 			}
 
 			res, err := fnTool.Run(tc, map[string]any{})
+
+			if !tt.wantErr {
+				if err != nil {
+					t.Fatalf("Run() returned %v, want success", err)
+				}
+				if res["output"] != tt.wantOutput {
+					t.Fatalf("Run() output = %q, want %q", res["output"], tt.wantOutput)
+				}
+				return
+			}
+
 			if err == nil {
-				t.Fatalf("Expected Run to report the dropped content, got output=%q", res["output"])
+				t.Fatalf("Run() succeeded with output=%q, want an error reporting the dropped content", res["output"])
+			}
+			// Pin the identity of the error: a transport failure, or the
+			// pre-#1353 "no text content" error, must not satisfy this case.
+			if want := `tool "non_text_tool" returned only non-text content`; !strings.Contains(err.Error(), want) {
+				t.Fatalf("Run() error = %q, want it to contain %q", err.Error(), want)
 			}
 		})
 	}

--- a/tool/mcptoolset/set_test.go
+++ b/tool/mcptoolset/set_test.go
@@ -847,3 +847,71 @@ func TestMCPTool_EmptyTextResponse(t *testing.T) {
 		t.Fatalf("Expected output to be empty string, got: %v", res["output"])
 	}
 }
+
+// TestMCPTool_NonTextOnlyResponse covers the gap left by #1353: an empty text
+// result is a valid success, but only when the server sent nothing. A result
+// carrying just an image, audio, resource link or embedded resource also
+// accumulates no text, and reporting that as {"output": ""} hands the model an
+// empty map while discarding the entire payload.
+func TestMCPTool_NonTextOnlyResponse(t *testing.T) {
+	tests := []struct {
+		name    string
+		content mcp.Content
+	}{
+		{"image", &mcp.ImageContent{MIMEType: "image/png", Data: []byte{0x89, 0x50, 0x4e, 0x47}}},
+		{"audio", &mcp.AudioContent{MIMEType: "audio/wav", Data: []byte{0x52, 0x49, 0x46, 0x46}}},
+		{"resource link", &mcp.ResourceLink{URI: "file:///tmp/report.pdf", Name: "report.pdf"}},
+		{"embedded resource", &mcp.EmbeddedResource{
+			Resource: &mcp.ResourceContents{URI: "file:///tmp/data.bin", MIMEType: "application/octet-stream", Blob: []byte{0x00, 0x01}},
+		}},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			clientTransport, serverTransport := mcp.NewInMemoryTransports()
+
+			server := mcp.NewServer(&mcp.Implementation{Name: "test_server", Version: "v1.0.0"}, nil)
+			mcp.AddTool(server, &mcp.Tool{Name: "non_text_tool", Description: "returns only non-text content"}, func(ctx context.Context, req *mcp.CallToolRequest, args any) (*mcp.CallToolResult, any, error) {
+				return &mcp.CallToolResult{
+					Content: []mcp.Content{tt.content},
+				}, nil, nil
+			})
+			if _, err := server.Connect(t.Context(), serverTransport, nil); err != nil {
+				t.Fatal(err)
+			}
+
+			ts, err := mcptoolset.New(mcptoolset.Config{
+				Transport: clientTransport,
+			})
+			if err != nil {
+				t.Fatalf("Failed to create MCP tool set: %v", err)
+			}
+
+			tools, err := ts.Tools(icontext.NewReadonlyContext(
+				icontext.NewInvocationContext(
+					t.Context(),
+					icontext.InvocationContextParams{},
+				),
+			))
+			if err != nil {
+				t.Fatalf("Failed to get tools: %v", err)
+			}
+			if len(tools) != 1 {
+				t.Fatalf("Expected 1 tool, got %d", len(tools))
+			}
+
+			toolCtx := icontext.NewInvocationContext(t.Context(), icontext.InvocationContextParams{})
+			tc := agent.NewToolContext(toolCtx, "", nil, nil)
+
+			fnTool, ok := tools[0].(toolinternal.FunctionTool)
+			if !ok {
+				t.Fatalf("Expected tool to implement toolinternal.FunctionTool")
+			}
+
+			res, err := fnTool.Run(tc, map[string]any{})
+			if err == nil {
+				t.Fatalf("Expected Run to report the dropped content, got output=%q", res["output"])
+			}
+		})
+	}
+}

--- a/tool/mcptoolset/tool.go
+++ b/tool/mcptoolset/tool.go
@@ -166,11 +166,17 @@ func (t *mcpTool) Run(ctx agent.Context, args any) (map[string]any, error) {
 		}
 	}
 
-	// An empty result is valid per the MCP spec (#1352), but only when the
-	// server actually sent nothing. Non-text blocks are not yet rendered, so
-	// reporting them as an empty success would hide the whole payload.
+	// A result that yields no text is a valid success (#1352) when there was no
+	// other content to lose: nothing at all, or only empty text blocks. When the
+	// text is empty because every block was non-text, returning {"output": ""}
+	// would report success while discarding the whole payload, so fail loudly
+	// instead.
+	//
+	// TODO(#1401): remove once non-text blocks are rendered rather than skipped.
+	// That also covers the mixed case this deliberately leaves alone, where a
+	// non-text block accompanies real text and is still dropped silently (#1391).
 	if textResponse.Len() == 0 && droppedNonText {
-		return nil, errors.New("tool response contains only non-text content, which is not yet supported")
+		return nil, fmt.Errorf("tool %q returned only non-text content, which is not yet supported", t.name)
 	}
 
 	return map[string]any{

--- a/tool/mcptoolset/tool.go
+++ b/tool/mcptoolset/tool.go
@@ -152,16 +152,25 @@ func (t *mcpTool) Run(ctx agent.Context, args any) (map[string]any, error) {
 	}
 
 	textResponse := strings.Builder{}
+	droppedNonText := false
 
 	for _, c := range res.Content {
 		textContent, ok := c.(*mcp.TextContent)
 		if !ok {
+			droppedNonText = true
 			continue
 		}
 
 		if _, err := textResponse.WriteString(textContent.Text); err != nil {
 			return nil, fmt.Errorf("failed to write text response: %w", err)
 		}
+	}
+
+	// An empty result is valid per the MCP spec (#1352), but only when the
+	// server actually sent nothing. Non-text blocks are not yet rendered, so
+	// reporting them as an empty success would hide the whole payload.
+	if textResponse.Len() == 0 && droppedNonText {
+		return nil, errors.New("tool response contains only non-text content, which is not yet supported")
 	}
 
 	return map[string]any{


### PR DESCRIPTION
### Link to Issue or Description of Change

Follow-up to #1353, which removed the `no text content in tool response` guard so that an empty text result is a valid success (#1352). That guard was also the only thing catching results that carry no text because all their content is non-text.

Adjacent to #1391 but does not close it — see below.

### Problem

`mcpTool.Run` collects text by skipping every block that is not a `*mcp.TextContent`. With the guard gone, a tool result holding only an image, audio, resource link or embedded resource accumulates no text and returns `{"output": ""}` with no error. The call is reported as successful and the entire payload is discarded.

Four of the five `mcp.Content` types are affected. Before #1353 these failed loudly; they now fail silently, which is the worse of the two.

### Solution

Track whether a non-text block was skipped, and return an error when that happened and no text was collected. A result with no content, or with only empty text blocks, still succeeds with `{"output": ""}`, so the #1352 fix is preserved. A non-text block alongside real text also still succeeds, unchanged.

This is deliberately a stopgap. #1401 renders non-text blocks properly and removes this branch when it lands; the guard and the test both carry a `TODO(#1401)`.

### What this does not fix

#1391 covers the mixed shape as well: a file body returned as an `EmbeddedResource` next to a status-line `TextContent`. That still drops the resource silently, before and after this change, because text was collected. Fixing it means rendering the blocks, which is #1401's job. This PR only restores the signal for the all-non-text case.

### Effect on callers

In the LLM flow the error becomes a `{"error": ...}` function response and the turn continues, so the model is told the content was dropped instead of being handed an empty string.

An MCP tool can also sit in a workflow graph via `workflow.NewToolNode`, where the error aborts the node rather than continuing. That is a harder failure than before, and intentional: the node was previously completing on empty data.

### Testing Plan

- [x] Unit test added: `TestMCPTool_NonTextOnlyResponse` in `tool/mcptoolset/set_test.go`, covering image, audio, resource link and embedded resource, plus a mixed text-and-image control that must still succeed.
- [x] All four non-text-only subtests fail on current `main` and pass with this change.
- [x] Mutation-checked both halves of the new condition. Dropping either conjunct, or removing the guard entirely, fails the suite.
- [x] `TestMCPTool_EmptyTextResponse` from #1353 still passes, so empty text remains a valid success.
- [x] Verification commands pass:
  ```text
  go test -race -count=1 ./tool/mcptoolset/...
  go vet ./tool/mcptoolset/...
  gofmt -l tool/mcptoolset/
  ```

### Checklist

- [x] I have read the [CONTRIBUTING.md](./CONTRIBUTING.md) document.
- [x] I have performed a self-review of my own code.
- [x] I have commented my code, particularly in hard-to-understand areas.
- [x] I have added tests that prove my fix is effective or that my feature works.
- [x] New and existing unit tests pass locally with my changes.
- [ ] I have manually tested my changes end-to-end.
- [x] Any dependent changes have been merged and published in downstream modules.
