### PR TITLE
ci: require a conventional-commit subject on pull requests

### DIFF
--- a/.github/scripts/check-conventional-subject.sh
+++ b/.github/scripts/check-conventional-subject.sh
@@ -1,0 +1,54 @@
+#!/usr/bin/env bash
+# Checks that a subject line is a Conventional Commit whose type is one the
+# Release Please config for this release line actually recognizes.
+#
+# Usage: check-conventional-subject.sh <release-please-config> <what> <subject>
+#
+#   what     what the subject is, quoted back in the error ("PR title", ...)
+#   subject  the line to check; only the first line is considered
+#
+# Why this exists: Release Please derives the next version and the changelog
+# from the conventional-commit subjects that land on the release branch. A
+# subject with no recognized type is not an error there — it is silently
+# dropped, so the change ships while being invisible in the release notes and
+# without moving the version. Merging is the last moment that is cheap to fix.
+#
+# The accepted types come out of the config rather than being repeated here, so
+# this cannot drift from the set that actually shapes the changelog.
+set -euo pipefail
+
+CONFIG="${1:?usage: check-conventional-subject.sh <release-please-config> <what> <subject>}"
+WHAT="${2:?usage: check-conventional-subject.sh <release-please-config> <what> <subject>}"
+SUBJECT="$(printf '%s' "${3-}" | head -n 1)"
+
+# Every type the changelog knows about, hidden sections included: those are
+# legitimate subjects, they just do not show up in the released notes. `revert`
+# is part of the Conventional Commits spec but is not a changelog section, so it
+# has to be added back by hand.
+TYPES="$(jq -r '[.packages["."]["changelog-sections"][].type] | join("|")' "$CONFIG")"
+[ -n "$TYPES" ] || { echo "no changelog-sections in $CONFIG" >&2; exit 1; }
+TYPES="${TYPES}|revert"
+
+# type(optional/scope)!: description
+if printf '%s' "$SUBJECT" | grep -qE "^($TYPES)(\([a-zA-Z0-9._/-]+\))?!?: .+"; then
+  echo "OK ($WHAT): $SUBJECT"
+  exit 0
+fi
+
+cat >&2 <<EOF
+::error title=Not a Conventional Commit::${WHAT}: ${SUBJECT}
+
+The $WHAT must start with a type, an optional scope, and a colon:
+
+  feat: add the thing
+  fix(runner): stop leaking the context
+  docs: correct the example
+  feat!: drop the legacy signature      (breaking change)
+
+Allowed types (from $CONFIG): ${TYPES//|/, }
+
+Only feat, fix and perf move the version. The rest are recorded but neither
+released nor listed. A subject with no type at all is dropped entirely, so the
+change would ship without appearing anywhere in the release notes.
+EOF
+exit 1

--- a/.github/workflows/require-conventional-subject.yml
+++ b/.github/workflows/require-conventional-subject.yml
@@ -1,0 +1,87 @@
+# Rejects pull requests whose landed commit subject would not be a Conventional
+# Commit.
+#
+# Release Please builds the changelog and picks the next version from the
+# conventional-commit subjects on the release branch. A subject with no
+# recognized type is not rejected there, it is silently ignored: the change
+# ships, but it never appears in the release notes and never moves the version.
+# Once merged the subject is history, so this is the last cheap moment to catch
+# it.
+#
+# Two subjects are checked, because either one can be the one that lands. This
+# repository squash-merges with the default "commit or PR title" subject, so a
+# pull request carrying a single commit lands that commit's subject and ignores
+# the PR title entirely; anything larger lands the PR title. Which of the two it
+# will be is not fixed until the merge, and a second push flips it, so both have
+# to hold.
+#
+# To make this block a merge rather than only show up red, add
+# "Require conventional subject" to the required status checks in the branch
+# ruleset.
+name: Require conventional subject
+
+# No workflow_dispatch: there is no pull request to read outside this event.
+on:
+  pull_request:
+    # `edited` is what re-runs the check when someone corrects the title. Without
+    # it a fixed title stays red until an unrelated push.
+    types: [opened, edited, reopened, synchronize]
+    branches: [ "main", "v1" ]
+
+concurrency:
+  group: ${{ github.workflow }}-${{ github.head_ref || github.ref }}
+  cancel-in-progress: true
+
+permissions:
+  contents: read
+  # The commit subjects of a pull request are only reachable through the pulls
+  # API; contents alone gets a 403 there.
+  pull-requests: read
+
+jobs:
+  conventional-subject:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd  # v6.0.2
+        with:
+          # Only the config and the script are read, and no token should linger
+          # on disk for a check that runs on pull requests from forks.
+          sparse-checkout: .github
+          persist-credentials: false
+
+      - name: Select the config for this release line
+        id: line
+        env:
+          BASE_REF: ${{ github.base_ref }}
+        run: |
+          set -euo pipefail
+          if [ "$BASE_REF" = "v1" ]; then
+            config=.github/release-please-config-v1.json
+          else
+            config=.github/release-please-config.json
+          fi
+          echo "config=$config" >> "$GITHUB_OUTPUT"
+
+      - name: Validate the pull request title
+        env:
+          # Through the environment, never interpolated into the script: a title
+          # is attacker controlled, and a `${{ }}` inside run: is substituted
+          # into the shell text before the shell ever sees it.
+          TITLE: ${{ github.event.pull_request.title }}
+          CONFIG: ${{ steps.line.outputs.config }}
+        run: .github/scripts/check-conventional-subject.sh "$CONFIG" "PR title" "$TITLE"
+
+      # Only meaningful for a single-commit pull request: with more than one
+      # commit the individual subjects are folded into the squash body, where
+      # Release Please never reads them.
+      - name: Validate the single commit's subject
+        if: github.event.pull_request.commits == 1
+        env:
+          GH_TOKEN: ${{ github.token }}
+          REPO: ${{ github.repository }}
+          PR: ${{ github.event.pull_request.number }}
+          CONFIG: ${{ steps.line.outputs.config }}
+        run: |
+          set -euo pipefail
+          subject="$(gh api "repos/$REPO/pulls/$PR/commits" --jq '.[0].commit.message' | head -n 1)"
+          .github/scripts/check-conventional-subject.sh "$CONFIG" "commit subject" "$subject"

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -208,7 +208,9 @@ information on using pull requests.
     title, and in the commit subject too on a single-commit PR, where that is
     what lands instead. Release tooling reads the landed subject to pick the
     next version and build the release notes, and silently skips anything with
-    no recognized type.
+    no recognized type. The `Require conventional subject` check enforces this;
+    the types it accepts are the ones listed in
+    `.github/release-please-config.json`.
 -   For bug fixes or features, please provide logs or screenshots after the fix
     is applied to help reviewers better understand the fix.
 -   Please include a `testing plan` section in your PR to talk about how you


### PR DESCRIPTION
_Draft — description pending._