### PR TITLE
fix(internal): match the copyright skip list against slash-separated paths (#1394)

### DIFF
--- a/internal/style_test.go
+++ b/internal/style_test.go
@@ -62,7 +62,7 @@ func TestCopyrightHeader(t *testing.T) {
 			return err
 		}
 		if info.IsDir() {
-			if ignore[path] {
+			if ignore[filepath.ToSlash(path)] {
 				return filepath.SkipDir
 			}
 			return nil


### PR DESCRIPTION
Backports #1394 from `main` to `v1`. The automatic backport reported a conflict on that PR, so this is the change applied by hand.

## Problem

`TestCopyrightHeader` keys its skip list with forward slashes and looks it up with the path `filepath.Walk` supplies, which uses the OS separator. On Windows that path is `internal\httprr`, so it matches no key, the vendored tree is walked, and the test fails on the files it is meant to skip.

All four entries are inert on Windows. Only `internal/httprr` exists in the tree today, so it is the only one that surfaces. CI runs on Linux, where the separator matches the keys, which is why this has never been caught on this branch.

## Summary

`ignore[path]` becomes `ignore[filepath.ToSlash(path)]` in `internal/style_test.go`. `ToSlash` is a no-op on Linux and macOS, so CI behaviour on `v1` is unchanged.

It did not replay because #1394 touched two files, and `internal/httprr_directives_test.go` does not exist on `v1`, so half the patch had no target. This carries the `internal/style_test.go` half only, byte for byte as it landed on `main`: the blob hashes are the same pair on both branches, `75ac3b1..5abb5e1`.

The dropped hunk is not wanted here. It normalized the same lookup in `TestHTTPRecordDirectivesPartitionCassettes`, which #1394 described as latent rather than live even on `main`, and there is nothing on this branch for it to apply to.

## Testing Plan

Reproduced on this branch first rather than assuming the `main` diagnosis carried over. On `v1` at `cb29818`, unmodified:

```
$ go test ./internal/ -run TestCopyrightHeader -count=1
--- FAIL: TestCopyrightHeader (3.81s)
    style_test.go:78: file "internal\httprr\rr.go" does not have the copyright header
    style_test.go:78: file "internal\httprr\rr_test.go" does not have the copyright header
FAIL
FAIL	google.golang.org/adk/internal	4.091s
```

With the change:

```
$ go test ./internal/ -run TestCopyrightHeader -count=1
ok  	google.golang.org/adk/internal	0.396s

$ go test ./internal/ -count=1
ok  	google.golang.org/adk/internal	0.346s

$ go test -race ./internal/ -count=1
ok  	google.golang.org/adk/internal	1.520s

$ gofmt -l internal/style_test.go
(no output)

$ go vet ./internal/
(no output)

$ go mod tidy -diff
(no output, exit 0)
```

No new test is added: `TestCopyrightHeader` is itself the test, and there is no portable way to assert the Windows path behaviour from a Linux runner, because on Linux `filepath.Walk` already yields forward slashes and the bug cannot occur.

These runs are on Windows, which is the only platform where the failure exists. I have not run the full module on this branch.