### PR TITLE
chore(version): bump the tagged version constant to 1.6.1

### DIFF
--- a/internal/version/version.go
+++ b/internal/version/version.go
@@ -15,4 +15,4 @@
 package version
 
 // Version exposes the current ADK Go version, used for llm request tagging
-const Version = "1.6.0"
+const Version = "1.6.1"


### PR DESCRIPTION
## Problem
internal/version.Version reads 1.6.0, the version already tagged as v1.6.0. Left as is, the v1.6.1 release would advertise itself as 1.6.0 in the google-adk/<version> token on Gemini User-Agent and x-goog-api-client headers, as the MCP client version, and as the OpenTelemetry instrumentation version on every trace and log — making its usage indistinguishable from the previous release.

## Summary 
Sets the constant to the version being tagged. Nothing reads or asserts an exact version — model/gemini/gemini_test.go only checks that the google-adk/ and gl-go/ prefixes are present, and no recorded test traffic pins the old string, so replay stays intact.