### PR TITLE
docs(examples): update launcher documentation

### DIFF
--- a/examples/README.md
+++ b/examples/README.md
@@ -26,7 +26,7 @@ is specified. `web` starts an HTTP server with one or more sublaunchers:
 | `console` | Run the agent interactively in a terminal |
 | `web api` | Serve the ADK REST API |
 | `web a2a` | Serve the agent over A2A |
-| `web webui` | Serve the ADK web interface |
+| `web webui` | Serve the ADK web interface assets; combine it with `api` for a working UI |
 | `web pubsub` | Serve the Pub/Sub trigger endpoint |
 | `web eventarc` | Serve the Eventarc trigger endpoint |
 
@@ -37,7 +37,8 @@ go run ./examples/quickstart console
 go run ./examples/quickstart web api
 ```
 
-Several web sublaunchers can run together:
+The `webui` sublauncher serves the frontend assets only. Combine it with `api`
+to provide the backend routes used by the UI:
 
 ```bash
 go run ./examples/quickstart web api webui

--- a/examples/README.md
+++ b/examples/README.md
@@ -1,27 +1,47 @@
-# ADK GO samples
-This folder hosts examples to test different features. The examples are usually minimal and simplistic to test one or a few scenarios.
+# ADK Go samples
 
+This directory contains minimal examples that demonstrate one or a few ADK
+features.
 
-**Note**: This is different from the [google/adk-samples](https://github.com/google/adk-samples) repo, which hosts more complex e2e samples for customers to use or modify directly.
+These examples differ from the
+[google/adk-samples](https://github.com/google/adk-samples) repository, which
+contains more complete end-to-end samples for customers to use or modify.
 
+## Launcher
 
-# Launcher
-In many examples you can see such lines:
+Many examples use the full launcher:
+
 ```go
 l := full.NewLauncher()
-err = l.ParseAndRun(ctx, config, os.Args[1:], universal.ErrorOnUnparsedArgs)
-if err != nil {
-    log.Fatalf("run failed: %v\n\n%s", err, l.FormatSyntax())
+if err := l.Execute(ctx, config, os.Args[1:]); err != nil {
+    log.Fatalf("Run failed: %v\n\n%s", err, l.CommandLineSyntax())
 }
 ```
 
-it allows to decide, which launching options are supported in the run-time. 
-`full.NewLauncher()` includes all major ways you can run the example:
-* console
-* restapi
-* a2a
-* webui (it can run standalone or with restapi or a2a).
+The first argument selects a launcher. `console` is the default when no launcher
+is specified. `web` starts an HTTP server with one or more sublaunchers:
 
-Run `go run ./example/quickstart/main.go help` for details
+| Command | Description |
+|---|---|
+| `console` | Run the agent interactively in a terminal |
+| `web api` | Serve the ADK REST API |
+| `web a2a` | Serve the agent over A2A |
+| `web webui` | Serve the ADK web interface |
+| `web pubsub` | Serve the Pub/Sub trigger endpoint |
+| `web eventarc` | Serve the Eventarc trigger endpoint |
 
-As an alternative, you may want to use `prod.NewLauncher()` which only builds-in restapi and a2a launchers.
+Run examples from the repository root. For example:
+
+```bash
+go run ./examples/quickstart console
+go run ./examples/quickstart web api
+```
+
+Several web sublaunchers can run together:
+
+```bash
+go run ./examples/quickstart web api webui
+```
+
+For deployments that need fewer server modes, `prod.NewLauncher()` exposes only
+`web api` and `web a2a`.

--- a/examples/multiagent/collaboration/README.md
+++ b/examples/multiagent/collaboration/README.md
@@ -92,11 +92,11 @@ export GOOGLE_API_KEY=...
 go run ./examples/multiagent/collaboration console
 ```
 
-You can also serve it over REST or the web UI; run with `help` for all
-launcher subcommands:
+You can also serve it over the REST API or with the bundled web UI:
 
 ```sh
-go run ./examples/multiagent/collaboration help
+go run ./examples/multiagent/collaboration web api
+go run ./examples/multiagent/collaboration web api webui
 ```
 
 ## See also


### PR DESCRIPTION
### Link to Issue or Description of Change

- Closes #1495

**Problem:**

The example documentation referenced outdated launcher methods, obsolete
launcher names, an invalid repository path, and an unsupported positional
`help` argument.

**Solution:**

- Update the launcher snippet to use `Execute` and `CommandLineSyntax`.
- Document the current `console` and `web` launcher hierarchy.
- Add valid commands for the REST API, A2A, Web UI, Pub/Sub, and Eventarc.
- Correct the quickstart repository path.
- Replace the collaboration example's invalid `help` command with runnable REST
  API and Web UI commands.
- Update the `prod.NewLauncher()` description.

### Testing Plan

**Unit Tests:**

- [ ] I have added or updated unit tests for my change. Documentation only; no
  test changes were required.
- [x] All unit tests pass locally.

Commands run successfully:

- `go build -mod=readonly work`
- `go test -race -mod=readonly -count=1 -shuffle=on work`
- `go vet ./examples/...`
- `golangci-lint run` in both modules
- `go mod tidy -diff` in both modules

**Manual End-to-End (E2E) Tests:**

Verified that both documented web launcher forms pass argument parsing and
register the expected routes:

- `web api`
- `web api webui`

The local sandbox prevented binding a listening socket, so no live HTTP
interaction was performed.

### Checklist

- [x] I have read the `CONTRIBUTING.md` document.
- [x] I have performed a self-review of my own changes.
- [x] No code comments were required because this change only updates documentation.
- [x] New and existing unit tests pass locally with my changes.
- [ ] I have manually tested the changes end-to-end.
- [x] No dependent downstream changes are required.
