### PR TITLE
fix(workflow): make ParallelWorker errors deterministic

### DIFF
--- a/workflow/parallel_worker.go
+++ b/workflow/parallel_worker.go
@@ -15,6 +15,8 @@
 package workflow
 
 import (
+	"context"
+	"errors"
 	"fmt"
 	"iter"
 	"reflect"
@@ -61,7 +63,8 @@ func NewParallelWorker(name string, wrapped Node, maxConcurrency int, cfg NodeCo
 // the ParallelWorker will perform 1 ("a") + 3 ("b" retried) + 1 ("c") = 5 calls in total.
 //
 // If any of the wrapped node executions returns a non-retryable error, the workflow
-// will fail fast, cancel other in-flight workers, and return this first encountered error.
+// will fail fast, cancel other in-flight workers, and return the error from
+// the lowest-index failed input.
 //
 // In case the wrapped node produces more then one output event, they will be
 // aggregated into a list, and the final result will be a multi dimensional list.
@@ -99,16 +102,23 @@ func (n *ParallelWorker) Run(ctx agent.Context, input any) iter.Seq2[*session.Ev
 
 		resCh := make(chan workerResult, nItems)
 
-		// reportFailure cancels the remaining workers. runWorker calls it
-		// synchronously, before releasing its semaphore slot (see below).
+		// reportFailure records the lowest-index worker error and cancels the
+		// remaining workers. runWorker calls it synchronously, before releasing
+		// its semaphore slot (see below).
 		var reportOnce sync.Once
+		var firstErrMu sync.Mutex
 		var firstErr error
-		reportFailure := func(err error) {
-			reportOnce.Do(func() {
+		firstErrIndex := nItems
+		reportFailure := func(index int, err error) {
+			firstErrMu.Lock()
+			if index < firstErrIndex {
+				firstErrIndex = index
 				firstErr = err
-				cancelFunc()
-			})
+			}
+			firstErrMu.Unlock()
+			reportOnce.Do(cancelFunc)
 		}
+		skipped := false
 
 		// Branch isolation: derive a per-item sub-branch so each
 		// worker's wrapped node sees an isolated event history (the
@@ -124,6 +134,7 @@ func (n *ParallelWorker) Run(ctx agent.Context, input any) iter.Seq2[*session.Ev
 				select {
 				case sem <- struct{}{}:
 				case <-workerCtx.Done():
+					skipped = true
 					wg.Done()
 					continue
 				}
@@ -131,6 +142,7 @@ func (n *ParallelWorker) Run(ctx agent.Context, input any) iter.Seq2[*session.Ev
 				// would pick randomly if cancellation raced the send above.
 				select {
 				case <-workerCtx.Done():
+					skipped = true
 					<-sem
 					wg.Done()
 					continue
@@ -139,6 +151,7 @@ func (n *ParallelWorker) Run(ctx agent.Context, input any) iter.Seq2[*session.Ev
 			} else {
 				select {
 				case <-workerCtx.Done():
+					skipped = true
 					wg.Done()
 					continue
 				default:
@@ -165,8 +178,15 @@ func (n *ParallelWorker) Run(ctx agent.Context, input any) iter.Seq2[*session.Ev
 			}
 		}
 
-		if firstErr != nil {
-			yield(nil, firstErr)
+		firstErrMu.Lock()
+		finalErr := firstErr
+		firstErrMu.Unlock()
+		if finalErr == nil && (skipped || ctx.Err() != nil) {
+			finalErr = ctx.Err()
+		}
+
+		if finalErr != nil {
+			yield(nil, finalErr)
 			return
 		}
 
@@ -183,7 +203,7 @@ type workerResult struct {
 	err   error
 }
 
-func (n *ParallelWorker) runWorker(ctx agent.Context, idx int, item any, sem chan struct{}, resCh chan<- workerResult, wg *sync.WaitGroup, reportFailure func(error)) {
+func (n *ParallelWorker) runWorker(ctx agent.Context, idx int, item any, sem chan struct{}, resCh chan<- workerResult, wg *sync.WaitGroup, reportFailure func(int, error)) {
 	defer wg.Done()
 	defer func() {
 		if sem != nil {
@@ -212,21 +232,21 @@ func (n *ParallelWorker) runWorker(ctx agent.Context, idx int, item any, sem cha
 			case <-time.After(delay):
 				continue
 			case <-ctx.Done():
-				// Cancellation while parked in the retry delay is a real
-				// failure too: report it before releasing sem, exactly
-				// like the exhausted-attempts path below. Without this,
-				// firstErr stays nil unless some other worker happens to
-				// report first, so a cancellation landing here can be
-				// silently dropped and the whole run yields success with
-				// a nil output for this item.
-				reportFailure(ctx.Err())
 				resCh <- workerResult{index: idx, err: ctx.Err()}
 				return
 			}
 		}
 
+		// Cancellation caused by another worker's fail-fast signal is not the
+		// error that should be surfaced. The parent context is checked after
+		// all workers drain so external cancellation is still propagated.
+		if errors.Is(runErr, context.Canceled) && ctx.Err() != nil {
+			resCh <- workerResult{index: idx, err: runErr}
+			return
+		}
+
 		// Cannot retry or exhausted attempts: report before releasing sem.
-		reportFailure(runErr)
+		reportFailure(idx, runErr)
 		resCh <- workerResult{index: idx, err: runErr}
 		return
 	}

--- a/workflow/parallel_worker.go
+++ b/workflow/parallel_worker.go
@@ -15,8 +15,6 @@
 package workflow
 
 import (
-	"context"
-	"errors"
 	"fmt"
 	"iter"
 	"reflect"
@@ -102,24 +100,6 @@ func (n *ParallelWorker) Run(ctx agent.Context, input any) iter.Seq2[*session.Ev
 
 		resCh := make(chan workerResult, nItems)
 
-		// reportFailure records the lowest-index worker error and cancels the
-		// remaining workers. runWorker calls it synchronously, before releasing
-		// its semaphore slot (see below).
-		var reportOnce sync.Once
-		var firstErrMu sync.Mutex
-		var firstErr error
-		firstErrIndex := nItems
-		reportFailure := func(index int, err error) {
-			firstErrMu.Lock()
-			if index < firstErrIndex {
-				firstErrIndex = index
-				firstErr = err
-			}
-			firstErrMu.Unlock()
-			reportOnce.Do(cancelFunc)
-		}
-		skipped := false
-
 		// Branch isolation: derive a per-item sub-branch so each
 		// worker's wrapped node sees an isolated event history (the
 		// LLM flow's history filter scopes by branch prefix). Items
@@ -134,7 +114,6 @@ func (n *ParallelWorker) Run(ctx agent.Context, input any) iter.Seq2[*session.Ev
 				select {
 				case sem <- struct{}{}:
 				case <-workerCtx.Done():
-					skipped = true
 					wg.Done()
 					continue
 				}
@@ -142,7 +121,6 @@ func (n *ParallelWorker) Run(ctx agent.Context, input any) iter.Seq2[*session.Ev
 				// would pick randomly if cancellation raced the send above.
 				select {
 				case <-workerCtx.Done():
-					skipped = true
 					<-sem
 					wg.Done()
 					continue
@@ -151,7 +129,6 @@ func (n *ParallelWorker) Run(ctx agent.Context, input any) iter.Seq2[*session.Ev
 			} else {
 				select {
 				case <-workerCtx.Done():
-					skipped = true
 					wg.Done()
 					continue
 				default:
@@ -161,7 +138,7 @@ func (n *ParallelWorker) Run(ctx agent.Context, input any) iter.Seq2[*session.Ev
 			itemBranch := deriveSubBranch(parentBranch, wrappedName+"@"+strconv.Itoa(i+1))
 
 			itemCtx := workerCtx.WithDelta(&agent.CommonContextDelta{InvocationContextDelta: &agent.InvocationContextDelta{Branch: &itemBranch}})
-			go n.runWorker(itemCtx, i, item, sem, resCh, &wg, reportFailure)
+			go n.runWorker(itemCtx, i, item, sem, resCh, &wg, cancelFunc)
 		}
 
 		// Goroutine to close channel when all workers are done
@@ -170,7 +147,13 @@ func (n *ParallelWorker) Run(ctx agent.Context, input any) iter.Seq2[*session.Ev
 			close(resCh)
 		}()
 
+		var finalErr error
+		finalErrIndex := nItems
 		for res := range resCh {
+			if res.err != nil && res.index < finalErrIndex {
+				finalErr = res.err
+				finalErrIndex = res.index
+			}
 			if res.ev != nil {
 				if out, ok := extractOutput(res.ev); ok {
 					outputs[res.index] = out
@@ -178,10 +161,7 @@ func (n *ParallelWorker) Run(ctx agent.Context, input any) iter.Seq2[*session.Ev
 			}
 		}
 
-		firstErrMu.Lock()
-		finalErr := firstErr
-		firstErrMu.Unlock()
-		if finalErr == nil && (skipped || ctx.Err() != nil) {
+		if finalErr == nil && ctx.Err() != nil {
 			finalErr = ctx.Err()
 		}
 
@@ -203,7 +183,7 @@ type workerResult struct {
 	err   error
 }
 
-func (n *ParallelWorker) runWorker(ctx agent.Context, idx int, item any, sem chan struct{}, resCh chan<- workerResult, wg *sync.WaitGroup, reportFailure func(int, error)) {
+func (n *ParallelWorker) runWorker(ctx agent.Context, idx int, item any, sem chan struct{}, resCh chan<- workerResult, wg *sync.WaitGroup, cancelFunc func()) {
 	defer wg.Done()
 	defer func() {
 		if sem != nil {
@@ -232,21 +212,22 @@ func (n *ParallelWorker) runWorker(ctx agent.Context, idx int, item any, sem cha
 			case <-time.After(delay):
 				continue
 			case <-ctx.Done():
-				resCh <- workerResult{index: idx, err: ctx.Err()}
+				resCh <- workerResult{index: idx}
 				return
 			}
 		}
 
-		// Cancellation caused by another worker's fail-fast signal is not the
+		// A cancellation caused by another worker's fail-fast signal is not the
 		// error that should be surfaced. The parent context is checked after
 		// all workers drain so external cancellation is still propagated.
-		if errors.Is(runErr, context.Canceled) && ctx.Err() != nil {
-			resCh <- workerResult{index: idx, err: runErr}
+		if ctx.Err() != nil {
+			resCh <- workerResult{index: idx}
 			return
 		}
 
-		// Cannot retry or exhausted attempts: report before releasing sem.
-		reportFailure(idx, runErr)
+		// Cannot retry or exhausted attempts: cancel before releasing sem and
+		// report the failure through the result channel.
+		cancelFunc()
 		resCh <- workerResult{index: idx, err: runErr}
 		return
 	}

--- a/workflow/parallel_worker_test.go
+++ b/workflow/parallel_worker_test.go
@@ -30,6 +30,8 @@ import (
 	sdktrace "go.opentelemetry.io/otel/sdk/trace"
 	"go.opentelemetry.io/otel/sdk/trace/tracetest"
 	"google.golang.org/genai"
+	grpcCodes "google.golang.org/grpc/codes"
+	grpcStatus "google.golang.org/grpc/status"
 
 	"google.golang.org/adk/v2/agent"
 	"google.golang.org/adk/v2/internal/telemetry"
@@ -429,42 +431,52 @@ func TestParallelWorker_FailFast(t *testing.T) {
 }
 
 func TestParallelWorker_LowestIndexErrorWins(t *testing.T) {
-	wrapped := NewFunctionNode("out_of_order_failures", func(ctx agent.Context, input int) (int, error) {
-		if input == 0 {
-			// Wait for the higher-index worker to report its error and cancel
-			// this worker, then return a distinct error anyway.
-			<-ctx.Done()
-			return 0, errors.New("error 0")
-		}
-		return 0, errors.New("error 1")
-	}, defaultNodeConfig)
+	for range 20 {
+		// Both workers return independent errors. Neither error is caused by
+		// fail-fast cancellation. Disable cancellation for this test so both
+		// results reach the aggregation loop; fail-fast cancellation is covered
+		// by the tests below.
+		wrapped := NewFunctionNode("independent_failures", func(ctx agent.Context, input int) (int, error) {
+			return 0, fmt.Errorf("error %d", input)
+		}, defaultNodeConfig)
 
-	pw, err := NewParallelWorker("parallel", wrapped, 0, defaultNodeConfig)
-	if err != nil {
-		t.Fatal(err)
-	}
-
-	exCtx := agent.NewContext(newMockCtx(t))
-	var gotErr error
-	for _, err := range pw.Run(exCtx, []any{0, 1}) {
+		pw, err := NewParallelWorker("parallel", wrapped, 0, defaultNodeConfig)
 		if err != nil {
-			gotErr = err
+			t.Fatal(err)
 		}
-	}
 
-	if gotErr == nil {
-		t.Fatal("expected error, got nil")
-	}
-	if gotErr.Error() != "error 0" {
-		t.Errorf("expected lowest-index error %q, got %q", "error 0", gotErr)
+		exCtx := &nonCancellingAgentContext{Context: agent.NewContext(newMockCtx(t))}
+		var gotErr error
+		for _, err := range pw.Run(exCtx, []any{0, 1}) {
+			if err != nil {
+				gotErr = err
+			}
+		}
+
+		if gotErr == nil {
+			t.Fatal("expected error, got nil")
+		}
+		if gotErr.Error() != "error 0" {
+			t.Fatalf("expected lowest-index error %q, got %q", "error 0", gotErr)
+		}
 	}
 }
 
-func TestParallelWorker_FailFastCancellationDoesNotMaskError(t *testing.T) {
+// nonCancellingAgentContext isolates result ordering tests from fail-fast
+// cancellation. The cancellation behavior itself is covered separately.
+type nonCancellingAgentContext struct {
+	agent.Context
+}
+
+func (c *nonCancellingAgentContext) WithAgentCancel() (agent.Context, context.CancelFunc) {
+	return c.Context, func() {}
+}
+
+func TestParallelWorker_FailFastGRPCCancellationDoesNotMaskError(t *testing.T) {
 	wrapped := NewFunctionNode("failure_with_cancellation", func(ctx agent.Context, input int) (int, error) {
 		if input == 0 {
 			<-ctx.Done()
-			return 0, ctx.Err()
+			return 0, grpcStatus.Error(grpcCodes.Canceled, "context canceled")
 		}
 		return 0, errors.New("error 1")
 	}, defaultNodeConfig)

--- a/workflow/parallel_worker_test.go
+++ b/workflow/parallel_worker_test.go
@@ -428,6 +428,126 @@ func TestParallelWorker_FailFast(t *testing.T) {
 	}
 }
 
+func TestParallelWorker_LowestIndexErrorWins(t *testing.T) {
+	wrapped := NewFunctionNode("out_of_order_failures", func(ctx agent.Context, input int) (int, error) {
+		if input == 0 {
+			// Wait for the higher-index worker to report its error and cancel
+			// this worker, then return a distinct error anyway.
+			<-ctx.Done()
+			return 0, errors.New("error 0")
+		}
+		return 0, errors.New("error 1")
+	}, defaultNodeConfig)
+
+	pw, err := NewParallelWorker("parallel", wrapped, 0, defaultNodeConfig)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	exCtx := agent.NewContext(newMockCtx(t))
+	var gotErr error
+	for _, err := range pw.Run(exCtx, []any{0, 1}) {
+		if err != nil {
+			gotErr = err
+		}
+	}
+
+	if gotErr == nil {
+		t.Fatal("expected error, got nil")
+	}
+	if gotErr.Error() != "error 0" {
+		t.Errorf("expected lowest-index error %q, got %q", "error 0", gotErr)
+	}
+}
+
+func TestParallelWorker_FailFastCancellationDoesNotMaskError(t *testing.T) {
+	wrapped := NewFunctionNode("failure_with_cancellation", func(ctx agent.Context, input int) (int, error) {
+		if input == 0 {
+			<-ctx.Done()
+			return 0, ctx.Err()
+		}
+		return 0, errors.New("error 1")
+	}, defaultNodeConfig)
+
+	pw, err := NewParallelWorker("parallel", wrapped, 0, defaultNodeConfig)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	exCtx := agent.NewContext(newMockCtx(t))
+	var gotErr error
+	for _, err := range pw.Run(exCtx, []any{0, 1}) {
+		if err != nil {
+			gotErr = err
+		}
+	}
+
+	if gotErr == nil {
+		t.Fatal("expected error, got nil")
+	}
+	if gotErr.Error() != "error 1" {
+		t.Errorf("expected worker error %q, got %q", "error 1", gotErr)
+	}
+}
+
+func TestParallelWorker_CancelDuringDispatch(t *testing.T) {
+	started := make(chan struct{})
+	release := make(chan struct{})
+	var startOnce sync.Once
+
+	wrapped := NewFunctionNode("slow_success", func(ctx agent.Context, input int) (int, error) {
+		startOnce.Do(func() { close(started) })
+		// Deliberately ignore cancellation so the test isolates the dispatch
+		// path and verifies that skipped items still fail the run.
+		<-release
+		return input, nil
+	}, defaultNodeConfig)
+
+	pw, err := NewParallelWorker("parallel", wrapped, 1, defaultNodeConfig)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	ctx, cancel := context.WithCancel(t.Context())
+	defer cancel()
+	exCtx := agent.NewContext(&MockInvocationContext{Context: ctx})
+
+	done := make(chan struct{})
+	var gotErr error
+	var hasFinalResult bool
+	go func() {
+		for ev, err := range pw.Run(exCtx, []any{1, 2, 3, 4}) {
+			if err != nil {
+				gotErr = err
+			}
+			if _, ok := extractOutput(ev); ok {
+				hasFinalResult = true
+			}
+		}
+		close(done)
+	}()
+
+	<-started
+	cancel()
+	close(release)
+
+	select {
+	case <-done:
+	case <-time.After(2 * time.Second):
+		t.Fatal("timeout waiting for cancellation during dispatch")
+	}
+
+	if gotErr == nil {
+		t.Fatal("expected context.Canceled, got nil")
+	}
+	if !errors.Is(gotErr, context.Canceled) {
+		t.Errorf("expected context.Canceled, got %v", gotErr)
+	}
+	if hasFinalResult {
+		t.Error("expected no final result after cancellation during dispatch")
+	}
+}
+
 func TestParallelWorker_CancelDuringExecution(t *testing.T) {
 	blockCh := make(chan struct{})
 	startedCh := make(chan struct{}, 2)


### PR DESCRIPTION
### Link to Issue or Description of Change

**1. Link to an existing issue (if applicable):**

- Closes: #1481

**Problem:**

`workflow.ParallelWorker` can surface different errors for the same input depending on goroutine completion order. It can also report success with nil output entries when the caller cancels while items are waiting to be dispatched.

**Solution:**

- Track worker failures by input index and return the lowest-index failure after workers drain.
- Keep fail-fast cancellation for remaining workers.
- Ignore secondary `context.Canceled` errors caused by internal fail-fast cancellation so they do not mask the original worker failure.
- Record skipped items during dispatch and propagate the parent context error instead of emitting a partial successful result.
- Add regression tests for out-of-order failures, fail-fast cancellation, and cancellation during bounded dispatch.

### Testing Plan

**Unit Tests:**

- `go test ./workflow/...`
- `go test -race ./workflow/...`
- `go vet ./workflow/...`
- `go test -race ./workflow/ -run '^TestParallelWorker_' -count=20`

**Manual End-to-End (E2E) Tests:**

Not applicable. This change is isolated to the workflow execution and unit-test coverage.

### Checklist

- [x] I have read the CONTRIBUTING.md document.
- [x] I have performed a self-review of my own code.
- [x] I have added tests that prove my fix is effective.
- [x] The affected workflow unit tests pass locally.

### Additional context

The implementation keeps the documented `maxConcurrency` semantics and existing goroutine-drain behavior unchanged.
