### PR TITLE
fix: backport A2A peer metadata trust fix (#1226)

### DIFF
--- a/agent/remoteagent/a2a_agent.go
+++ b/agent/remoteagent/a2a_agent.go
@@ -137,6 +137,13 @@ func NewA2A(cfg A2AConfig) (agent.Agent, error) {
 		Description:          cfg.Description,
 		BeforeAgentCallbacks: cfg.BeforeAgentCallbacks,
 		AfterAgentCallbacks:  cfg.AfterAgentCallbacks,
+		// The deprecated package predates AllowTransferToAgent's introduction
+		// (v2 defaults it to false, secure by default, for new callers). This
+		// wrapper sets it to true to preserve this package's pre-existing
+		// behavior for callers who have not migrated to v2 -- changing it out
+		// from under them here would be a silent, breaking behavior change,
+		// not a new default for new code.
+		AllowTransferToAgent: true,
 		ClientProvider: func(ctx context.Context, card *a2av2.AgentCard) (v2.A2AClient, error) {
 			if cfg.ClientFactory == nil {
 				factory := a2aclientv2.NewFactory(

--- a/agent/remoteagent/v2/a2a_agent.go
+++ b/agent/remoteagent/v2/a2a_agent.go
@@ -129,6 +129,22 @@ type A2AConfig struct {
 	// callbacks will be skipped.
 	AfterAgentCallbacks []agent.AfterAgentCallback
 
+	// AllowTransferToAgent controls whether a transfer_to_agent value set by
+	// the remote A2A peer in its response metadata is honored by the local
+	// orchestrator.
+	//
+	// TransferToAgent drives which agent runs next within the caller's own
+	// configured multi-agent tree, so accepting it from a remote peer lets
+	// that peer redirect the local orchestrator's control flow. This
+	// defaults to false (the peer-supplied value is redacted) so that
+	// connecting to an agent you do not fully trust is safe by default. Set
+	// this to true only for closed, trusted deployments that rely on the
+	// remote peer being able to select the next local agent.
+	//
+	// This is applied uniformly after conversion, whether the default
+	// converter or a custom Converter is used.
+	AllowTransferToAgent bool
+
 	// A2APartConverter is a custom converter for converting A2A parts to GenAI parts.
 	// Implementations should generally remember to leverage adka2a.ToGenAiPart for default conversions
 	// nil returns are considered intentionally dropped parts.
@@ -265,6 +281,15 @@ func (a *a2aAgent) run(ctx agent.InvocationContext, cfg A2AConfig) iter.Seq2[*se
 				event, err = cfg.Converter(ctx, req, a2aEvent, a2aErr)
 			} else {
 				event, err = processor.convertToSessionEvent(ctx, a2aEvent, a2aErr)
+			}
+
+			// See toEventActions: TransferToAgent is restored here, after
+			// conversion, only when the caller has opted in via
+			// AllowTransferToAgent.
+			if err == nil && event != nil && a2aEvent != nil && cfg.AllowTransferToAgent {
+				if transferToAgent, ok := adka2a.TransferToAgentFromMeta(a2aEvent.Meta()); ok {
+					event.Actions.TransferToAgent = transferToAgent
+				}
 			}
 
 			if cbResp, cbErr := processor.runAfterA2ARequestCallbacks(ctx, event, err); cbResp != nil || cbErr != nil {

--- a/agent/remoteagent/v2/a2a_agent_test.go
+++ b/agent/remoteagent/v2/a2a_agent_test.go
@@ -222,12 +222,13 @@ func newFinalStatusUpdate(task *a2a.Task, state a2a.TaskState, msgParts ...*a2a.
 
 func TestRemoteAgent_ADK2ADK(t *testing.T) {
 	testCases := []struct {
-		name          string
-		remoteEvents  []*session.Event
-		wantResponses []model.LLMResponse
-		wantEscalate  bool
-		wantTransfer  string
-		noStreaming   bool
+		name                 string
+		remoteEvents         []*session.Event
+		wantResponses        []model.LLMResponse
+		wantEscalate         bool
+		wantTransfer         string
+		allowTransferToAgent bool
+		noStreaming          bool
 	}{
 		{
 			name: "text streaming",
@@ -315,7 +316,8 @@ func TestRemoteAgent_ADK2ADK(t *testing.T) {
 				{Content: genai.NewContentFromText("stop", genai.RoleModel)},
 				{TurnComplete: true},
 			},
-			wantTransfer: "a-2",
+			wantTransfer:         "a-2",
+			allowTransferToAgent: true,
 		},
 		{
 			name: "long-running function call",
@@ -398,7 +400,8 @@ func TestRemoteAgent_ADK2ADK(t *testing.T) {
 						Agent:          newADKEventReplay(t, "root", tc.remoteEvents),
 					},
 				})
-				remoteAgent := newA2ARemoteAgent(t, "a2a", startA2AServer(executor))
+				card := &a2a.AgentCard{SupportedInterfaces: []*a2a.AgentInterface{a2a.NewAgentInterface(startA2AServer(executor).URL, a2a.TransportProtocolJSONRPC)}, Capabilities: a2a.AgentCapabilities{Streaming: true}}
+				remoteAgent := utils.Must(NewA2A(A2AConfig{AgentCard: card, Name: "a2a", AllowTransferToAgent: tc.allowTransferToAgent}))
 
 				mode := agent.StreamingModeSSE
 				if tc.noStreaming {

--- a/server/adka2a/v2/events.go
+++ b/server/adka2a/v2/events.go
@@ -352,7 +352,7 @@ func toEventActions(meta map[string]any) session.EventActions {
 	}
 	var result session.EventActions
 	result.Escalate, _ = meta[metadataEscalateKey].(bool)
-	result.TransferToAgent, _ = meta[metadataTransferToAgentKey].(string)
+	// TransferToAgent intentionally NOT restored from peer metadata.
 	return result
 }
 

--- a/server/adka2a/v2/events_test.go
+++ b/server/adka2a/v2/events_test.go
@@ -69,9 +69,14 @@ func TestToSessionEvent(t *testing.T) {
 					},
 					TurnComplete: true,
 				},
-				Author:  agentName,
-				Branch:  branch,
-				Actions: session.EventActions{Escalate: true, TransferToAgent: "a-2"},
+				Author: agentName,
+				Branch: branch,
+				// TransferToAgent is peer-supplied metadata; this conversion
+				// layer never restores it -- see
+				// TestToSessionEventWithParts_TransferToAgentAlwaysRedacted and
+				// TransferToAgentFromMeta, which a caller uses to restore it
+				// explicitly after making its own trust decision about the peer.
+				Actions: session.EventActions{Escalate: true},
 			},
 		},
 		{
@@ -738,5 +743,50 @@ func TestToSessionEventWithParts_NilResultFiltered(t *testing.T) {
 				}
 			}
 		})
+	}
+}
+
+// TestToSessionEventWithParts_TransferToAgentAlwaysRedacted verifies that a
+// remote A2A peer's transfer_to_agent metadata is never restored by this
+// conversion layer, regardless of caller. A caller that has made its own
+// trust decision about the remote peer restores it explicitly afterwards,
+// using TransferToAgentFromMeta -- see
+// remoteagent.A2AConfig.AllowTransferToAgent.
+func TestToSessionEventWithParts_TransferToAgentAlwaysRedacted(t *testing.T) {
+	branch, agentName := "main", "a2a agent"
+	a2aAgent, err := agent.New(agent.Config{Name: agentName})
+	if err != nil {
+		t.Fatalf("failed to create an agent: %v", err)
+	}
+	ictx := icontext.NewInvocationContext(t.Context(), icontext.InvocationContextParams{Branch: branch, Agent: a2aAgent})
+
+	input := &a2a.Message{
+		Parts: a2a.ContentParts{a2a.NewTextPart("foo")},
+		Metadata: map[string]any{
+			metadataTransferToAgentKey: "a-2",
+			metadataEscalateKey:        true,
+		},
+	}
+
+	got, err := ToSessionEventWithParts(ictx, input, nil)
+	if err != nil {
+		t.Fatalf("ToSessionEventWithParts() error = %v", err)
+	}
+	want := session.EventActions{Escalate: true}
+	if diff := cmp.Diff(want, got.Actions); diff != "" {
+		t.Errorf("Actions wrong result (+got,-want)\ndiff = %s", diff)
+	}
+}
+
+func TestTransferToAgentFromMeta(t *testing.T) {
+	if got, ok := TransferToAgentFromMeta(nil); ok || got != "" {
+		t.Errorf("TransferToAgentFromMeta(nil) = (%q, %v), want (\"\", false)", got, ok)
+	}
+	if got, ok := TransferToAgentFromMeta(map[string]any{}); ok || got != "" {
+		t.Errorf("TransferToAgentFromMeta(empty) = (%q, %v), want (\"\", false)", got, ok)
+	}
+	meta := map[string]any{metadataTransferToAgentKey: "a-2"}
+	if got, ok := TransferToAgentFromMeta(meta); !ok || got != "a-2" {
+		t.Errorf("TransferToAgentFromMeta(meta) = (%q, %v), want (\"a-2\", true)", got, ok)
 	}
 }

--- a/server/adka2a/v2/metadata.go
+++ b/server/adka2a/v2/metadata.go
@@ -168,6 +168,21 @@ func processA2AMeta(a2aEvent a2a.Event, event *session.Event) error {
 	return nil
 }
 
+// TransferToAgentFromMeta extracts the transfer_to_agent value a remote A2A
+// peer set on its response metadata, if present. This value drives the
+// local orchestrator's own control flow (which agent runs next), so
+// [ToSessionEvent] and [ToSessionEventWithParts] never restore it
+// automatically. A caller that has made its own trust decision about the
+// remote peer -- see [remoteagent.A2AConfig.AllowTransferToAgent] -- can use
+// this to restore it explicitly after conversion.
+func TransferToAgentFromMeta(meta map[string]any) (agentName string, ok bool) {
+	if meta == nil {
+		return "", false
+	}
+	agentName, ok = meta[metadataTransferToAgentKey].(string)
+	return agentName, ok
+}
+
 func addMeta(result map[string]any, key string, data any) error {
 	if data == nil {
 		return nil

--- a/server/adka2a/v2/metadata_test.go
+++ b/server/adka2a/v2/metadata_test.go
@@ -30,6 +30,10 @@ func TestMetadataTwoWayConversion(t *testing.T) {
 		name    string
 		event   *session.Event
 		a2aMeta map[string]any
+		// wantAfterProcessA2AMeta overrides event for the processA2AMeta
+		// direction. Needed only when TransferToAgent is set, since that's
+		// never restored from peer metadata (see toEventActions).
+		wantAfterProcessA2AMeta *session.Event
 	}{
 		{
 			name: "error code",
@@ -79,6 +83,8 @@ func TestMetadataTwoWayConversion(t *testing.T) {
 			name:    "actions",
 			event:   &session.Event{Actions: session.EventActions{TransferToAgent: "another", Escalate: true}},
 			a2aMeta: map[string]any{metadataTransferToAgentKey: "another", metadataEscalateKey: true},
+			// processA2AMeta never restores TransferToAgent from peer metadata.
+			wantAfterProcessA2AMeta: &session.Event{Actions: session.EventActions{Escalate: true}},
 		},
 		{
 			name: "composite",
@@ -104,6 +110,23 @@ func TestMetadataTwoWayConversion(t *testing.T) {
 				metadataTransferToAgentKey: "another",
 				metadataEscalateKey:        true,
 			},
+			// processA2AMeta never restores TransferToAgent from peer metadata;
+			// everything else round-trips.
+			wantAfterProcessA2AMeta: &session.Event{
+				LLMResponse: model.LLMResponse{
+					GroundingMetadata: &genai.GroundingMetadata{
+						SourceFlaggingUris: []*genai.GroundingMetadataSourceFlaggingURI{{SourceID: "id1"}},
+					},
+					UsageMetadata: &genai.GenerateContentResponseUsageMetadata{
+						CandidatesTokenCount: 12,
+						ThoughtsTokenCount:   42,
+					},
+					CustomMetadata: map[string]any{
+						"nested": map[string]any{"key": "value"},
+					},
+				},
+				Actions: session.EventActions{Escalate: true},
+			},
 		},
 	}
 
@@ -120,12 +143,20 @@ func TestMetadataTwoWayConversion(t *testing.T) {
 			}
 
 			event := &session.Event{}
+			// processA2AMeta never restores TransferToAgent from peer
+			// metadata (see TransferToAgentFromMeta for how a caller
+			// restores it explicitly, after making its own trust decision
+			// about the remote peer).
 			err = processA2AMeta(&a2a.TaskStatusUpdateEvent{Metadata: meta}, event)
 			if err != nil {
 				t.Errorf("processA2AMeta() error = %v, want nil", err)
 			}
-			if diff := cmp.Diff(tc.event, event); diff != "" {
-				t.Errorf("processA2AMeta() wrong result (+got,-want)\ngot = %v\nwant = %v\ndiff = %s", event, tc.event, diff)
+			want := tc.event
+			if tc.wantAfterProcessA2AMeta != nil {
+				want = tc.wantAfterProcessA2AMeta
+			}
+			if diff := cmp.Diff(want, event); diff != "" {
+				t.Errorf("processA2AMeta() wrong result (+got,-want)\ngot = %v\nwant = %v\ndiff = %s", event, want, diff)
 			}
 		})
 	}


### PR DESCRIPTION
## Problem

`toEventActions()` restores `session.EventActions.TransferToAgent` straight from metadata supplied by a remote A2A peer, with no filtering. A malicious or compromised remote agent can set that metadata on any `Message`, `Task`, `TaskStatusUpdateEvent` or `TaskArtifactUpdateEvent` it returns, and the local orchestrator honours it — redirecting execution to a different agent inside the deployer's own multi-agent tree, bypassing the sequencing the deployer intended.

The 1.x line carries the same unfiltered restore that 2.x did before the fix, so the exposure is identical. adk-python resolved this by excluding `transfer_to_agent` from the set of fields a remote peer may set, on the grounds that it drives the caller's own control flow rather than describing the peer's session.

## Summary

Backport of #1226 to the 1.x maintenance line, cherry-picked with no adaptation — the change applies to `v1` unmodified, covering both the v1 and v2 A2A client packages and the `adka2a/v2` event and metadata paths.