### PR TITLE
fix: backport base flow nil-deref and artifact delta fixes (#1336, #474)

### DIFF
--- a/internal/llminternal/base_flow.go
+++ b/internal/llminternal/base_flow.go
@@ -788,7 +788,14 @@ func (f *Flow) callLLM(ctx agent.InvocationContext, req *model.LLMRequest, state
 		// to help with slicing the billing reports on a per-agent basis.
 
 		// TODO: RunLive mode when invocation_context.run_config.support_cfc is true.
-		useStream := runconfig.FromContext(ctx).StreamingMode == runconfig.StreamingModeSSE
+		// Streaming mode comes from the invocation context's RunConfig rather than
+		// the runconfig context value: agent.Run() may be invoked directly (outside
+		// the runner), in which case no runconfig is stored in the Go context and
+		// runconfig.FromContext returns nil (issue #586).
+		useStream := false
+		if rc := ctx.RunConfig(); rc != nil {
+			useStream = rc.StreamingMode == agent.StreamingModeSSE
+		}
 
 		for resp, err := range generateContent(ctx, f.Model, req, useStream) {
 			if err != nil {

--- a/internal/llminternal/base_flow.go
+++ b/internal/llminternal/base_flow.go
@@ -1382,7 +1382,9 @@ func mergeEventActions(base, other *session.EventActions) *session.EventActions 
 	if other.StateDelta != nil {
 		base.StateDelta = deepMergeMap(base.StateDelta, other.StateDelta)
 	}
-	// TODO add similar logic for state
+	if other.ArtifactDelta != nil {
+		base.ArtifactDelta = mergeArtifactDeltas(base.ArtifactDelta, other.ArtifactDelta)
+	}
 	if other.RequestedToolConfirmations != nil {
 		if base.RequestedToolConfirmations == nil {
 			base.RequestedToolConfirmations = make(map[string]toolconfirmation.ToolConfirmation)
@@ -1390,6 +1392,22 @@ func mergeEventActions(base, other *session.EventActions) *session.EventActions 
 		maps.Copy(base.RequestedToolConfirmations, other.RequestedToolConfirmations)
 	}
 	return base
+}
+
+// mergeArtifactDeltas merges artifact deltas, preferring higher versions.
+// This is a deliberate divergance from adk-python which uses last-write-wins.
+func mergeArtifactDeltas(dst, src map[string]int64) map[string]int64 {
+	if dst == nil {
+		return maps.Clone(src)
+	}
+	for key, value := range src {
+		if dstVal, ok := dst[key]; ok {
+			dst[key] = max(dstVal, value)
+		} else {
+			dst[key] = value
+		}
+	}
+	return dst
 }
 
 func deepMergeMap(dst, src map[string]any) map[string]any {

--- a/internal/llminternal/base_flow_test.go
+++ b/internal/llminternal/base_flow_test.go
@@ -15,7 +15,9 @@
 package llminternal
 
 import (
+	"context"
 	"errors"
+	"iter"
 	"testing"
 
 	"github.com/google/go-cmp/cmp"
@@ -681,5 +683,45 @@ func TestPreprocess_Toolset(t *testing.T) {
 				t.Errorf("preprocess() model = %s, wantModel %s", req.Model, tc.wantModel)
 			}
 		})
+	}
+}
+
+// recordStreamModel is a minimal model.LLM that records the streaming flag it
+// receives, so tests can assert how the flow derived it from the run config.
+type recordStreamModel struct {
+	stream bool
+}
+
+func (m *recordStreamModel) Name() string { return "test-model" }
+
+func (m *recordStreamModel) GenerateContent(_ context.Context, _ *model.LLMRequest, stream bool) iter.Seq2[*model.LLMResponse, error] {
+	m.stream = stream
+	return func(func(*model.LLMResponse, error) bool) {}
+}
+
+// TestCallLLMStreamingModeWithoutContextRunConfig guards against the nil pointer
+// dereference in callLLM when the run config is not present in the Go context
+// (issue #586). agent.Run() can be invoked directly, bypassing the runner, so
+// runconfig.FromContext returns nil; the streaming mode must instead be read
+// from the invocation context's RunConfig().
+func TestCallLLMStreamingModeWithoutContextRunConfig(t *testing.T) {
+	m := &recordStreamModel{}
+	f := &Flow{Model: m}
+
+	// No runconfig is stored in the Go context (as when the runner is bypassed),
+	// but the invocation context carries an SSE RunConfig.
+	ctx := icontext.NewInvocationContext(t.Context(), icontext.InvocationContextParams{
+		RunConfig: &agent.RunConfig{StreamingMode: agent.StreamingModeSSE},
+	})
+
+	req := &model.LLMRequest{}
+	for _, err := range f.callLLM(ctx, req, map[string]any{}, map[string]int64{}) {
+		if err != nil {
+			t.Fatalf("callLLM() error = %v, want nil", err)
+		}
+	}
+
+	if !m.stream {
+		t.Errorf("GenerateContent received stream=%v, want true for SSE streaming mode", m.stream)
 	}
 }

--- a/internal/llminternal/base_flow_test.go
+++ b/internal/llminternal/base_flow_test.go
@@ -536,6 +536,78 @@ func TestMergeEventActions(t *testing.T) {
 			},
 		},
 		{
+			name: "base has artifact delta, other has nil",
+			base: &session.EventActions{
+				ArtifactDelta: map[string]int64{"file1": 1, "file2": 2},
+			},
+			other: &session.EventActions{
+				ArtifactDelta: nil,
+			},
+			want: &session.EventActions{
+				ArtifactDelta: map[string]int64{"file1": 1, "file2": 2},
+			},
+		},
+		{
+			name: "base has nil artifact delta, other has values",
+			base: &session.EventActions{
+				ArtifactDelta: nil,
+			},
+			other: &session.EventActions{
+				ArtifactDelta: map[string]int64{"file1": 1, "file2": 2},
+			},
+			want: &session.EventActions{
+				ArtifactDelta: map[string]int64{"file1": 1, "file2": 2},
+			},
+		},
+		{
+			name: "artifact delta merged with non-overlapping keys",
+			base: &session.EventActions{
+				ArtifactDelta: map[string]int64{"file1": 1, "file2": 2},
+			},
+			other: &session.EventActions{
+				ArtifactDelta: map[string]int64{"file3": 3, "file4": 4},
+			},
+			want: &session.EventActions{
+				ArtifactDelta: map[string]int64{"file1": 1, "file2": 2, "file3": 3, "file4": 4},
+			},
+		},
+		{
+			name: "artifact delta merged with overlapping keys",
+			base: &session.EventActions{
+				ArtifactDelta: map[string]int64{"file1": 1, "file2": 100},
+			},
+			other: &session.EventActions{
+				ArtifactDelta: map[string]int64{"file1": 10, "file2": 10},
+			},
+			want: &session.EventActions{
+				ArtifactDelta: map[string]int64{"file1": 10, "file2": 100},
+			},
+		},
+		{
+			name: "artifact deltas merged with partially overlapping keys",
+			base: &session.EventActions{
+				ArtifactDelta: map[string]int64{"file1": 1, "file2": 100},
+			},
+			other: &session.EventActions{
+				ArtifactDelta: map[string]int64{"file2": 2, "file3": 3},
+			},
+			want: &session.EventActions{
+				ArtifactDelta: map[string]int64{"file1": 1, "file2": 100, "file3": 3},
+			},
+		},
+		{
+			name: "artifact deltas merged with negative version preserved",
+			base: &session.EventActions{
+				ArtifactDelta: nil,
+			},
+			other: &session.EventActions{
+				ArtifactDelta: map[string]int64{"file1": -1},
+			},
+			want: &session.EventActions{
+				ArtifactDelta: map[string]int64{"file1": -1},
+			},
+		},
+		{
 			name: "skip summarization merging - any true wins",
 			base: &session.EventActions{
 				SkipSummarization: false,
@@ -575,18 +647,21 @@ func TestMergeEventActions(t *testing.T) {
 			name: "all fields merged correctly",
 			base: &session.EventActions{
 				StateDelta:        map[string]any{"key1": "value1"},
+				ArtifactDelta:     map[string]int64{"file1": 1},
 				SkipSummarization: false,
 				TransferToAgent:   "agent1",
 				Escalate:          false,
 			},
 			other: &session.EventActions{
 				StateDelta:        map[string]any{"key2": "value2"},
+				ArtifactDelta:     map[string]int64{"file2": 2},
 				SkipSummarization: true,
 				TransferToAgent:   "agent2",
 				Escalate:          true,
 			},
 			want: &session.EventActions{
 				StateDelta:        map[string]any{"key1": "value1", "key2": "value2"},
+				ArtifactDelta:     map[string]int64{"file1": 1, "file2": 2},
 				SkipSummarization: true,
 				TransferToAgent:   "agent2",
 				Escalate:          true,


### PR DESCRIPTION
## Problem

Two defects in `internal/llminternal/base_flow.go`, one a crash and one silent data loss.

- **Nil dereference on streaming mode.** The flow reads the streaming mode off `RunConfig` without guarding the pointer, so a run configured without it panics.
- **Artifact deltas are dropped when tool calls run in parallel.** [`mergeEventActions`](https://github.com/google/adk-go/blob/cb2981844eae0613a90b100d98c32d231607ac69/internal/llminternal/base_flow.go#L1358) merges `StateDelta` and `RequestedToolConfirmations` but never touches `ArtifactDelta` — it still carries the [`// TODO add similar logic for state`](https://github.com/google/adk-go/blob/cb2981844eae0613a90b100d98c32d231607ac69/internal/llminternal/base_flow.go#L1378) placeholder. Merging keeps the first event's actions as the base, so every artifact delta after the first is discarded and those artifact versions never reach the session.

The artifact-delta loss is worse on 1.x than the form reported upstream: 2.x at least picked a winner among the deltas, whereas 1.x has no merge logic for the field at all.

## Summary

Backport of #1336 and #474 to the 1.x maintenance line, both cherry-picked without adaptation.

#474 merges artifact deltas highest-version-wins rather than first-wins. adk-python uses last-write-wins here, and the upstream PR chose highest-version-wins deliberately because it preserves more information.
