### PR TITLE
fix: backport artifact handling fixes (#1390, #1320, #1375)

### DIFF
--- a/agent/callback_context.go
+++ b/agent/callback_context.go
@@ -51,7 +51,7 @@ func NewCallbackContextWithArtifactTracking(ic InvocationContext, actions *sessi
 		Context:           ic,
 		invocationContext: ic,
 		actions:           actions,
-		artifacts:         &trackedArtifacts{Artifacts: ic.Artifacts(), actions: actions},
+		artifacts:         newTrackedArtifacts(ic.Artifacts(), actions),
 	}
 	return cc
 }
@@ -73,7 +73,7 @@ func NewToolContext(ic InvocationContext, functionCallID string, actions *sessio
 		Context:           ic,
 		invocationContext: ic,
 		actions:           actions,
-		artifacts:         &trackedArtifacts{Artifacts: ic.Artifacts(), actions: actions},
+		artifacts:         newTrackedArtifacts(ic.Artifacts(), actions),
 		functionCallID:    functionCallID,
 		toolConfirmation:  confirmation,
 	}
@@ -236,6 +236,17 @@ func (c *callbackContextState) Set(key string, val any) error {
 
 func (c *callbackContextState) All() iter.Seq2[string, any] {
 	return c.ctx.invocationContext.Session().State().All()
+}
+
+// newTrackedArtifacts wraps inner so that each successful Save is recorded
+// into the supplied EventActions.ArtifactDelta. It returns nil when inner is
+// nil so that "no artifact service configured" stays observable (a nil
+// Artifacts) instead of panicking on the first promoted method call.
+func newTrackedArtifacts(inner Artifacts, actions *session.EventActions) Artifacts {
+	if inner == nil {
+		return nil
+	}
+	return &trackedArtifacts{Artifacts: inner, actions: actions}
 }
 
 // trackedArtifacts wraps an Artifacts to record each successful Save into the

--- a/artifact/gcsartifact/gcs_test.go
+++ b/artifact/gcsartifact/gcs_test.go
@@ -202,6 +202,53 @@ func TestSaveZeroByteArtifact(t *testing.T) {
 	}
 }
 
+// TestNotFoundIsWrappedSentinel checks that Load and GetArtifactVersion
+// recognize storage.ErrObjectNotExist even when the storage client wraps it,
+// which is how cloud.google.com/go/storage actually returns it in production
+// (see storage.formatObjectErr, which always wraps NotFound as
+// fmt.Errorf("%w: %w", ErrObjectNotExist, err)). A caller checking
+// errors.Is(err, fs.ErrNotExist) must still get a match.
+func TestNotFoundIsWrappedSentinel(t *testing.T) {
+	wrapped := fmt.Errorf("%w: %w", storage.ErrObjectNotExist, errors.New("googleapi: Error 404: Not Found"))
+
+	for _, tc := range []struct {
+		name string
+		call func(svc *gcsService) error
+	}{
+		{
+			name: "Load",
+			call: func(svc *gcsService) error {
+				_, err := svc.Load(t.Context(), &artifact.LoadRequest{
+					AppName: "app", UserID: "user", SessionID: "session", FileName: "file",
+					Version: 1,
+				})
+				return err
+			},
+		},
+		{
+			name: "GetArtifactVersion",
+			call: func(svc *gcsService) error {
+				_, err := svc.GetArtifactVersion(t.Context(), &artifact.GetArtifactVersionRequest{
+					AppName: "app", UserID: "user", SessionID: "session", FileName: "file",
+					Version: 1,
+				})
+				return err
+			},
+		},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			svc := newGCSServiceForTesting("wrapped-not-exist")
+			fb := svc.bucket.(*fakeBucket)
+			fb.attrsErr = wrapped
+
+			err := tc.call(svc)
+			if !errors.Is(err, fs.ErrNotExist) {
+				t.Errorf("err = %v, want errors.Is(err, fs.ErrNotExist) = true", err)
+			}
+		})
+	}
+}
+
 // TestBackoffDelayBounds checks the jittered backoff stays within [0, saveRetryMaxDelay].
 func TestBackoffDelayBounds(t *testing.T) {
 	for attempt := range maxSaveAttempts {
@@ -290,6 +337,12 @@ type fakeBucket struct {
 	// return it (a simulated write failure); closeCalls counts Close calls.
 	closeErr   error
 	closeCalls int
+
+	// attrsErr, when set, is returned by every object's attrs() call in place
+	// of the default not-found/found behavior. Used to simulate the GCS
+	// client library's wrapped storage.ErrObjectNotExist (see
+	// TestNotFoundIsWrappedSentinel).
+	attrsErr error
 }
 
 // object returns a handle to the named blob, creating an empty backing store on
@@ -358,6 +411,14 @@ func (o *fakeObject) ifNotExist() gcsObject {
 
 // attrs returns fake attributes for the object.
 func (o *fakeObject) attrs(ctx context.Context) (*storage.ObjectAttrs, error) {
+	if o.bucket != nil {
+		o.bucket.mu.Lock()
+		forced := o.bucket.attrsErr
+		o.bucket.mu.Unlock()
+		if forced != nil {
+			return nil, forced
+		}
+	}
 	b := o.blob
 	b.mu.Lock()
 	defer b.mu.Unlock()

--- a/artifact/gcsartifact/service.go
+++ b/artifact/gcsartifact/service.go
@@ -298,7 +298,7 @@ func (s *gcsService) Load(ctx context.Context, req *artifact.LoadRequest) (_ *ar
 	// Check if the blob exists before trying to read it
 	attrs, err := blob.attrs(ctx)
 	if err != nil {
-		if err == storage.ErrObjectNotExist {
+		if errors.Is(err, storage.ErrObjectNotExist) {
 			return nil, fmt.Errorf("artifact '%s' not found: %w", blobName, fs.ErrNotExist)
 		}
 		return nil, fmt.Errorf("could not get blob attributes: %w", err)
@@ -474,7 +474,7 @@ func (s *gcsService) GetArtifactVersion(ctx context.Context, req *artifact.GetAr
 
 	attrs, err := blob.attrs(ctx)
 	if err != nil {
-		if err == storage.ErrObjectNotExist {
+		if errors.Is(err, storage.ErrObjectNotExist) {
 			return nil, fmt.Errorf("artifact '%s' not found: %w", blobName, fs.ErrNotExist)
 		}
 		return nil, fmt.Errorf("could not get blob attributes: %w", err)

--- a/tool/loadartifactstool/load_artifacts_tool.go
+++ b/tool/loadartifactstool/load_artifacts_tool.go
@@ -162,14 +162,18 @@ func (t *artifactsTool) processLoadArtifactsFunctionCall(ctx agent.ToolContext, 
 	if lastContent == nil || len(lastContent.Parts) == 0 {
 		return nil
 	}
-	firstPart := lastContent.Parts[0]
-	if firstPart.FunctionResponse == nil {
-		return nil
+	var functionResponse *genai.FunctionResponse
+	// Iterate over all parts in the last content turn to find load_artifacts responses.
+	// Note: adk-python only checks parts[0]; scanning all parts is intentional in Go to
+	// support parallel/multi-tool turns where load_artifacts may not be the first part.
+	for _, part := range lastContent.Parts {
+		if part != nil && part.FunctionResponse != nil && part.FunctionResponse.Name == "load_artifacts" {
+			functionResponse = part.FunctionResponse
+			// Keep only the first load_artifacts response if multiple exist in one turn.
+			break
+		}
 	}
-
-	functionResponse := firstPart.FunctionResponse
-
-	if functionResponse.Name != "load_artifacts" {
+	if functionResponse == nil {
 		return nil
 	}
 	artifactNamesRaw, ok := functionResponse.Response["artifact_names"]

--- a/tool/loadartifactstool/load_artifacts_tool.go
+++ b/tool/loadartifactstool/load_artifacts_tool.go
@@ -118,6 +118,9 @@ func (t *artifactsTool) Run(ctx agent.ToolContext, args any) (map[string]any, er
 // ProcessRequest processes the LLM request. It packs the tool, appends initial
 // instructions, and processes any load artifacts function calls.
 func (t *artifactsTool) ProcessRequest(ctx agent.ToolContext, req *model.LLMRequest) error {
+	if ctx.Artifacts() == nil {
+		return fmt.Errorf("load_artifacts tool requires an artifact service to be configured")
+	}
 	if err := toolutils.PackTool(req, t); err != nil {
 		return err
 	}

--- a/tool/loadartifactstool/load_artifacts_tool_test.go
+++ b/tool/loadartifactstool/load_artifacts_tool_test.go
@@ -408,6 +408,95 @@ func TestLoadArtifactsTool_ProcessRequest_NilArtifacts_WithFunctionCall(t *testi
 	}
 }
 
+func TestLoadArtifactsTool_ProcessRequest_Artifacts_MultiPartFunctionResponse(t *testing.T) {
+	otherFR := &genai.FunctionResponse{
+		Name: "other_function",
+		Response: map[string]any{
+			"status": "ok",
+		},
+	}
+	loadArtifactsFR := &genai.FunctionResponse{
+		Name: "load_artifacts",
+		Response: map[string]any{
+			"artifact_names": []string{"doc1.txt"},
+		},
+	}
+
+	tests := []struct {
+		name  string
+		parts []*genai.Part
+	}{
+		{
+			name: "load_artifacts after other function",
+			parts: []*genai.Part{
+				genai.NewPartFromFunctionResponse(otherFR.Name, otherFR.Response),
+				genai.NewPartFromFunctionResponse(loadArtifactsFR.Name, loadArtifactsFR.Response),
+			},
+		},
+		{
+			name: "load_artifacts before other function",
+			parts: []*genai.Part{
+				genai.NewPartFromFunctionResponse(loadArtifactsFR.Name, loadArtifactsFR.Response),
+				genai.NewPartFromFunctionResponse(otherFR.Name, otherFR.Response),
+			},
+		},
+		{
+			name: "nil part alongside load_artifacts",
+			parts: []*genai.Part{
+				nil,
+				genai.NewPartFromFunctionResponse(loadArtifactsFR.Name, loadArtifactsFR.Response),
+			},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			loadArtifactsTool := loadartifactstool.New()
+			tc := createToolContext(t)
+			if _, err := tc.Artifacts().Save(t.Context(), "doc1.txt", &genai.Part{Text: "This is the content of doc1.txt"}); err != nil {
+				t.Fatalf("Failed to save artifact: %v", err)
+			}
+
+			llmRequest := &model.LLMRequest{
+				Contents: []*genai.Content{
+					{
+						Role:  genai.RoleUser,
+						Parts: tt.parts,
+					},
+				},
+			}
+
+			requestProcessor, ok := loadArtifactsTool.(toolinternal.RequestProcessor)
+			if !ok {
+				t.Fatal("loadArtifactsTool does not implement RequestProcessor")
+			}
+
+			err := requestProcessor.ProcessRequest(tc, llmRequest)
+			if err != nil {
+				t.Fatalf("ProcessRequest failed: %v", err)
+			}
+
+			if len(llmRequest.Contents) != 2 {
+				t.Fatalf("Expected 2 contents, but got: %v", len(llmRequest.Contents))
+			}
+
+			appendedContent := llmRequest.Contents[1]
+			if appendedContent.Role != genai.RoleUser {
+				t.Errorf("Appended Content Role: got %v, want %v", appendedContent.Role, genai.RoleUser)
+			}
+			if len(appendedContent.Parts) != 2 {
+				t.Fatalf("Expected 2 parts in appended content, but got: %v", len(appendedContent.Parts))
+			}
+			if appendedContent.Parts[0].Text != "Artifact doc1.txt is:" {
+				t.Errorf("First part of appended content: got %v, want 'Artifact doc1.txt is:'", appendedContent.Parts[0].Text)
+			}
+			if appendedContent.Parts[1].Text != "This is the content of doc1.txt" {
+				t.Errorf("Second part of appended content: got %v, want 'This is the content of doc1.txt'", appendedContent.Parts[1].Text)
+			}
+		})
+	}
+}
+
 func createToolContext(t *testing.T) agent.ToolContext {
 	t.Helper()
 

--- a/tool/loadartifactstool/load_artifacts_tool_test.go
+++ b/tool/loadartifactstool/load_artifacts_tool_test.go
@@ -339,6 +339,75 @@ func TestLoadArtifactsTool_ProcessRequest_Artifacts_OtherFunctionCall(t *testing
 	}
 }
 
+// TestLoadArtifactsTool_ProcessRequest_NilArtifacts verifies that ProcessRequest
+// returns a descriptive error instead of panicking when no artifact service is
+// configured (see https://github.com/google/adk-go/issues/283).
+func TestLoadArtifactsTool_ProcessRequest_NilArtifacts(t *testing.T) {
+	loadArtifactsTool := loadartifactstool.New()
+
+	// Construct a context with no artifact service configured.
+	invocationCtx := icontext.NewInvocationContext(t.Context(), icontext.InvocationContextParams{})
+	tc := agent.NewToolContext(invocationCtx, "", nil, nil)
+
+	requestProcessor, ok := loadArtifactsTool.(toolinternal.RequestProcessor)
+	if !ok {
+		t.Fatal("loadArtifactsTool does not implement RequestProcessor")
+	}
+
+	llmRequest := &model.LLMRequest{}
+	err := requestProcessor.ProcessRequest(tc, llmRequest)
+	if err == nil {
+		t.Fatal("ProcessRequest should return an error when no artifact service is configured, but got nil")
+	}
+	if !strings.Contains(err.Error(), "artifact service") {
+		t.Errorf("error should mention the missing artifact service, got: %v", err)
+	}
+}
+
+// TestLoadArtifactsTool_ProcessRequest_NilArtifacts_WithFunctionCall verifies
+// that the nil-artifact guard in ProcessRequest also covers the
+// processLoadArtifactsFunctionCall path, not only appendInitialInstructions:
+// with a request whose last content is a load_artifacts function response,
+// ProcessRequest must still return the descriptive error instead of panicking
+// on the unguarded ctx.Artifacts() read in that path.
+func TestLoadArtifactsTool_ProcessRequest_NilArtifacts_WithFunctionCall(t *testing.T) {
+	loadArtifactsTool := loadartifactstool.New()
+
+	// Construct a context with no artifact service configured.
+	invocationCtx := icontext.NewInvocationContext(t.Context(), icontext.InvocationContextParams{})
+	tc := agent.NewToolContext(invocationCtx, "", nil, nil)
+
+	functionResponse := &genai.FunctionResponse{
+		Name: "load_artifacts",
+		Response: map[string]any{
+			"artifact_names": []any{"doc1.txt"},
+		},
+	}
+	llmRequest := &model.LLMRequest{
+		Contents: []*genai.Content{
+			{
+				Role: "model",
+				Parts: []*genai.Part{
+					genai.NewPartFromFunctionResponse(functionResponse.Name, functionResponse.Response),
+				},
+			},
+		},
+	}
+
+	requestProcessor, ok := loadArtifactsTool.(toolinternal.RequestProcessor)
+	if !ok {
+		t.Fatal("loadArtifactsTool does not implement RequestProcessor")
+	}
+
+	err := requestProcessor.ProcessRequest(tc, llmRequest)
+	if err == nil {
+		t.Fatal("ProcessRequest should return an error when no artifact service is configured, but got nil")
+	}
+	if !strings.Contains(err.Error(), "artifact service") {
+		t.Errorf("error should mention the missing artifact service, got: %v", err)
+	}
+}
+
 func createToolContext(t *testing.T) agent.ToolContext {
 	t.Helper()
 


### PR DESCRIPTION
## Problem

Three defects in artifact handling, one of them a panic.

- **`load_artifacts` panics when no artifact service is configured.** [`NewCallbackContextWithArtifactTracking`](https://github.com/google/adk-go/blob/cb2981844eae0613a90b100d98c32d231607ac69/agent/callback_context.go#L54) and [`NewToolContext`](https://github.com/google/adk-go/blob/cb2981844eae0613a90b100d98c32d231607ac69/agent/callback_context.go#L76) both wrap `ic.Artifacts()` in a `trackedArtifacts` unconditionally, so a nil service becomes a non-nil wrapper and the first promoted method call dereferences nil. Against `v1` unmodified the guard test panics rather than returning an error:

```
--- FAIL: TestLoadArtifactsTool_ProcessRequest_NilArtifacts
panic: runtime error: invalid memory address or nil pointer dereference
```

- **`load_artifacts` does nothing when combined with other tool calls.** The processor only inspects one function response, so a turn where `load_artifacts` shares a content with another tool response silently loads nothing.
- **`gcsartifact` does not recognize a wrapped `storage.ErrObjectNotExist`,** turning an absent object into an error rather than a miss.

## Summary

Backport of #1390, #1320 and #1375 to the 1.x maintenance line, applied in upstream order — #1320 builds on the guard #1390 introduces.

One adaptation: the nil guard lives in `agent/callback_context.go`, since `agent/common_context.go` is 2.x-only, and `ProcessRequest` takes `agent.ToolContext` rather than the unified `agent.Context`. The behavior is the same — `newTrackedArtifacts` returns nil for a nil inner service, so "no artifact service configured" stays observable, and the tool reports it as an error.
