### PR TITLE
fix: backport session service fixes (#1322, #1204, #1237, #1171)

### DIFF
--- a/session/database/service.go
+++ b/session/database/service.go
@@ -380,8 +380,8 @@ func (s *databaseService) applyEvent(ctx context.Context, session *localSession,
 		if storageUpdateTime > sessionUpdateTime {
 			return fmt.Errorf(
 				"stale session error: last update time from request (%s) is older than in database (%s)",
-				time.Unix(0, sessionUpdateTime).Format(time.RFC3339Nano),
-				time.Unix(0, storageUpdateTime).Format(time.RFC3339Nano),
+				time.UnixMicro(sessionUpdateTime).Format(time.RFC3339Nano),
+				time.UnixMicro(storageUpdateTime).Format(time.RFC3339Nano),
 			)
 		}
 

--- a/session/database/service.go
+++ b/session/database/service.go
@@ -109,12 +109,16 @@ func (s *databaseService) Create(ctx context.Context, req *session.CreateRequest
 		// apply state delta
 		if len(appDelta) > 0 {
 			maps.Copy(storageApp.State, appDelta)
+			// Maintain UpdateTime explicitly: an unset time.Time serializes to
+			// a zero datetime that MySQL rejects under strict mode.
+			storageApp.UpdateTime = createdSession.UpdateTime
 			if err := tx.Save(&storageApp).Error; err != nil {
 				return fmt.Errorf("failed to save app state: %w", err)
 			}
 		}
 		if len(userDelta) > 0 {
 			maps.Copy(storageUser.State, userDelta)
+			storageUser.UpdateTime = createdSession.UpdateTime
 			if err := tx.Save(&storageUser).Error; err != nil {
 				return fmt.Errorf("failed to save user state: %w", err)
 			}
@@ -397,12 +401,16 @@ func (s *databaseService) applyEvent(ctx context.Context, session *localSession,
 		// GORM's .Save() method will correctly perform an INSERT or UPDATE.
 		if len(appDelta) > 0 {
 			maps.Copy(storageApp.State, appDelta)
+			// Maintain UpdateTime explicitly (see Create): an unset time.Time
+			// serializes to a zero datetime that MySQL rejects under strict mode.
+			storageApp.UpdateTime = event.Timestamp
 			if err := tx.Save(&storageApp).Error; err != nil {
 				return fmt.Errorf("failed to save app state: %w", err)
 			}
 		}
 		if len(userDelta) > 0 {
 			maps.Copy(storageUser.State, userDelta)
+			storageUser.UpdateTime = event.Timestamp
 			if err := tx.Save(&storageUser).Error; err != nil {
 				return fmt.Errorf("failed to save user state: %w", err)
 			}

--- a/session/database/service_test.go
+++ b/session/database/service_test.go
@@ -51,6 +51,72 @@ func Test_databaseService_CreateUsesProviders(t *testing.T) {
 	}
 }
 
+// TestDatabaseService_StateUpdateTimeIsSet guards against a regression where
+// app_states / user_states rows were saved without ever assigning UpdateTime,
+// leaving a zero time.Time that MySQL rejects under strict mode
+// (Error 1292: Incorrect datetime value: '0000-00-00'). SQLite accepts the
+// zero value, so the guard asserts the column is populated rather than relying
+// on a MySQL-specific write failure.
+func TestDatabaseService_StateUpdateTimeIsSet(t *testing.T) {
+	fixedTime := time.Date(2026, time.July, 19, 17, 33, 48, 0, time.UTC)
+	ctx := platform.WithTimeProvider(t.Context(), func() time.Time { return fixedTime })
+	s := emptyService(t)
+
+	// Create with app:/user: scoped initial state populates both state tables.
+	created, err := s.Create(ctx, &session.CreateRequest{
+		AppName: "app",
+		UserID:  "user",
+		State:   map[string]any{"app:config": "v1", "user:pref": "x"},
+	})
+	if err != nil {
+		t.Fatalf("Create: %v", err)
+	}
+
+	var app storageAppState
+	if err := s.db.First(&app, "app_name = ?", "app").Error; err != nil {
+		t.Fatalf("load app state: %v", err)
+	}
+	if app.UpdateTime.IsZero() {
+		t.Errorf("app_states.update_time is zero after Create; want it populated")
+	}
+
+	var usr storageUserState
+	if err := s.db.First(&usr, "app_name = ? AND user_id = ?", "app", "user").Error; err != nil {
+		t.Fatalf("load user state: %v", err)
+	}
+	if usr.UpdateTime.IsZero() {
+		t.Errorf("user_states.update_time is zero after Create; want it populated")
+	}
+
+	// The AppendEvent path applies app:/user: state deltas separately; it must
+	// also maintain UpdateTime.
+	eventTime := fixedTime.Add(time.Minute)
+	event := &session.Event{
+		ID:        "e1",
+		Author:    "user",
+		Timestamp: eventTime,
+		Actions: session.EventActions{
+			StateDelta: map[string]any{"app:config2": "v2", "user:pref2": "y"},
+		},
+	}
+	if err := s.AppendEvent(ctx, created.Session, event); err != nil {
+		t.Fatalf("AppendEvent: %v", err)
+	}
+
+	if err := s.db.First(&app, "app_name = ?", "app").Error; err != nil {
+		t.Fatalf("reload app state: %v", err)
+	}
+	if app.UpdateTime.IsZero() {
+		t.Errorf("app_states.update_time is zero after AppendEvent; want it populated")
+	}
+	if err := s.db.First(&usr, "app_name = ? AND user_id = ?", "app", "user").Error; err != nil {
+		t.Fatalf("reload user state: %v", err)
+	}
+	if usr.UpdateTime.IsZero() {
+		t.Errorf("user_states.update_time is zero after AppendEvent; want it populated")
+	}
+}
+
 func emptyService(t *testing.T) *databaseService {
 	t.Helper()
 	gormConfig := &gorm.Config{

--- a/session/database/service_test.go
+++ b/session/database/service_test.go
@@ -211,3 +211,64 @@ func TestDatabaseService_AppendEvent_StaleErrorFormatsTimestamps(t *testing.T) {
 		t.Errorf("stale error missing database timestamp %q: %q", wantDatabase, msg)
 	}
 }
+
+// TestDatabaseService_StateUpdateTimeIsSet guards against a regression where
+// app_states / user_states rows were saved without ever assigning UpdateTime,
+// leaving a zero time.Time that MySQL rejects under strict mode
+// (Error 1292: Incorrect datetime value: '0000-00-00'). SQLite accepts the
+// zero value, so the guard asserts the column is populated rather than relying
+// on a MySQL-specific write failure.
+func TestDatabaseService_StateUpdateTimeIsSet(t *testing.T) {
+	fixedTime := time.Date(2026, time.July, 19, 17, 33, 48, 0, time.UTC)
+	ctx := platform.WithTimeProvider(t.Context(), func() time.Time { return fixedTime })
+	s := emptyService(t)
+	// Create with app:/user: scoped initial state populates both state tables.
+	created, err := s.Create(ctx, &session.CreateRequest{
+		AppName: "app",
+		UserID:  "user",
+		State:   map[string]any{"app:config": "v1", "user:pref": "x"},
+	})
+	if err != nil {
+		t.Fatalf("Create: %v", err)
+	}
+	var app storageAppState
+	if err := s.db.First(&app, "app_name = ?", "app").Error; err != nil {
+		t.Fatalf("load app state: %v", err)
+	}
+	if app.UpdateTime.IsZero() {
+		t.Errorf("app_states.update_time is zero after Create; want it populated")
+	}
+	var usr storageUserState
+	if err := s.db.First(&usr, "app_name = ? AND user_id = ?", "app", "user").Error; err != nil {
+		t.Fatalf("load user state: %v", err)
+	}
+	if usr.UpdateTime.IsZero() {
+		t.Errorf("user_states.update_time is zero after Create; want it populated")
+	}
+	// The AppendEvent path applies app:/user: state deltas separately; it must
+	// also maintain UpdateTime.
+	eventTime := fixedTime.Add(time.Minute)
+	event := &session.Event{
+		ID:        "e1",
+		Author:    "user",
+		Timestamp: eventTime,
+		Actions: session.EventActions{
+			StateDelta: map[string]any{"app:config2": "v2", "user:pref2": "y"},
+		},
+	}
+	if err := s.AppendEvent(ctx, created.Session, event); err != nil {
+		t.Fatalf("AppendEvent: %v", err)
+	}
+	if err := s.db.First(&app, "app_name = ?", "app").Error; err != nil {
+		t.Fatalf("reload app state: %v", err)
+	}
+	if app.UpdateTime.IsZero() {
+		t.Errorf("app_states.update_time is zero after AppendEvent; want it populated")
+	}
+	if err := s.db.First(&usr, "app_name = ? AND user_id = ?", "app", "user").Error; err != nil {
+		t.Fatalf("reload user state: %v", err)
+	}
+	if usr.UpdateTime.IsZero() {
+		t.Errorf("user_states.update_time is zero after AppendEvent; want it populated")
+	}
+}

--- a/session/database/service_test.go
+++ b/session/database/service_test.go
@@ -15,6 +15,7 @@
 package database
 
 import (
+	"strings"
 	"testing"
 	"time"
 
@@ -48,72 +49,6 @@ func Test_databaseService_CreateUsesProviders(t *testing.T) {
 	}
 	if got := resp.Session.LastUpdateTime(); !got.Equal(fixedTime) {
 		t.Errorf("LastUpdateTime() = %v, want provider value %v", got, fixedTime)
-	}
-}
-
-// TestDatabaseService_StateUpdateTimeIsSet guards against a regression where
-// app_states / user_states rows were saved without ever assigning UpdateTime,
-// leaving a zero time.Time that MySQL rejects under strict mode
-// (Error 1292: Incorrect datetime value: '0000-00-00'). SQLite accepts the
-// zero value, so the guard asserts the column is populated rather than relying
-// on a MySQL-specific write failure.
-func TestDatabaseService_StateUpdateTimeIsSet(t *testing.T) {
-	fixedTime := time.Date(2026, time.July, 19, 17, 33, 48, 0, time.UTC)
-	ctx := platform.WithTimeProvider(t.Context(), func() time.Time { return fixedTime })
-	s := emptyService(t)
-
-	// Create with app:/user: scoped initial state populates both state tables.
-	created, err := s.Create(ctx, &session.CreateRequest{
-		AppName: "app",
-		UserID:  "user",
-		State:   map[string]any{"app:config": "v1", "user:pref": "x"},
-	})
-	if err != nil {
-		t.Fatalf("Create: %v", err)
-	}
-
-	var app storageAppState
-	if err := s.db.First(&app, "app_name = ?", "app").Error; err != nil {
-		t.Fatalf("load app state: %v", err)
-	}
-	if app.UpdateTime.IsZero() {
-		t.Errorf("app_states.update_time is zero after Create; want it populated")
-	}
-
-	var usr storageUserState
-	if err := s.db.First(&usr, "app_name = ? AND user_id = ?", "app", "user").Error; err != nil {
-		t.Fatalf("load user state: %v", err)
-	}
-	if usr.UpdateTime.IsZero() {
-		t.Errorf("user_states.update_time is zero after Create; want it populated")
-	}
-
-	// The AppendEvent path applies app:/user: state deltas separately; it must
-	// also maintain UpdateTime.
-	eventTime := fixedTime.Add(time.Minute)
-	event := &session.Event{
-		ID:        "e1",
-		Author:    "user",
-		Timestamp: eventTime,
-		Actions: session.EventActions{
-			StateDelta: map[string]any{"app:config2": "v2", "user:pref2": "y"},
-		},
-	}
-	if err := s.AppendEvent(ctx, created.Session, event); err != nil {
-		t.Fatalf("AppendEvent: %v", err)
-	}
-
-	if err := s.db.First(&app, "app_name = ?", "app").Error; err != nil {
-		t.Fatalf("reload app state: %v", err)
-	}
-	if app.UpdateTime.IsZero() {
-		t.Errorf("app_states.update_time is zero after AppendEvent; want it populated")
-	}
-	if err := s.db.First(&usr, "app_name = ? AND user_id = ?", "app", "user").Error; err != nil {
-		t.Fatalf("reload user state: %v", err)
-	}
-	if usr.UpdateTime.IsZero() {
-		t.Errorf("user_states.update_time is zero after AppendEvent; want it populated")
 	}
 }
 
@@ -225,5 +160,54 @@ func TestDatabaseService_AppendEvent_PreservesInputEventTempState(t *testing.T) 
 	}
 	if storedEvent.Actions.StateDelta["sk"] != "v2" {
 		t.Errorf("expected non-temp key sk on stored event, got: %v", storedEvent.Actions.StateDelta)
+	}
+}
+
+// TestDatabaseService_AppendEvent_StaleErrorFormatsTimestamps guards that the
+// stale-session error renders human-readable wall-clock timestamps rather than
+// ~1970 dates. The values compared are UnixMicro() microseconds, so formatting
+// them via time.Unix(0, x) (whose second arg is nanoseconds) is off by 1000x
+// and collapses every real timestamp to 1970-01-2x. See issue #1170.
+func TestDatabaseService_AppendEvent_StaleErrorFormatsTimestamps(t *testing.T) {
+	s := emptyService(t)
+	t0 := time.Date(2026, time.July, 17, 10, 0, 0, 0, time.UTC)
+	createCtx := platform.WithTimeProvider(t.Context(), func() time.Time { return t0 })
+	created, err := s.Create(createCtx, &session.CreateRequest{AppName: "app", UserID: "user"})
+	if err != nil {
+		t.Fatalf("Create: %v", err)
+	}
+	// A second, independent handle on the same session — still pinned at t0.
+	got, err := s.Get(t.Context(), &session.GetRequest{AppName: "app", UserID: "user", SessionID: created.Session.ID()})
+	if err != nil {
+		t.Fatalf("Get: %v", err)
+	}
+	staleHandle := got.Session
+	// Advance the stored session past t0 by appending through the fresh handle.
+	t1 := time.Date(2026, time.July, 17, 11, 0, 0, 0, time.UTC)
+	if err := s.AppendEvent(t.Context(), created.Session, &session.Event{ID: "e1", Author: "agent", Timestamp: t1}); err != nil {
+		t.Fatalf("AppendEvent (fresh handle): %v", err)
+	}
+	// Appending through the stale handle (updatedAt == t0 < stored t1) must fail.
+	err = s.AppendEvent(t.Context(), staleHandle, &session.Event{ID: "e2", Author: "agent", Timestamp: t1})
+	if err == nil {
+		t.Fatal("AppendEvent through stale handle: got nil error, want stale session error")
+	}
+	msg := err.Error()
+	if !strings.Contains(msg, "stale session error") {
+		t.Fatalf("error = %q, want a stale session error", msg)
+	}
+	if strings.Contains(msg, "1970") {
+		t.Errorf("stale error still renders a 1970 timestamp (UnixMicro passed to time.Unix nsec arg): %q", msg)
+	}
+	// Mirror the exact formatting the code uses (UnixMicro -> local time ->
+	// RFC3339Nano) so the assertion is timezone-independent. The request side
+	// is the stale handle's t0; the database side is the advanced t1.
+	wantRequest := time.UnixMicro(t0.UnixMicro()).Format(time.RFC3339Nano)
+	wantDatabase := time.UnixMicro(t1.UnixMicro()).Format(time.RFC3339Nano)
+	if !strings.Contains(msg, wantRequest) {
+		t.Errorf("stale error missing request timestamp %q: %q", wantRequest, msg)
+	}
+	if !strings.Contains(msg, wantDatabase) {
+		t.Errorf("stale error missing database timestamp %q: %q", wantDatabase, msg)
 	}
 }

--- a/session/vertexai/filter_test.go
+++ b/session/vertexai/filter_test.go
@@ -1,0 +1,55 @@
+// Copyright 2025 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package vertexai
+
+import "testing"
+
+func TestQuoteFilterLiteral(t *testing.T) {
+	tests := []struct {
+		name  string
+		input string
+		want  string
+	}{
+		{
+			name:  "plain value",
+			input: "alice",
+			want:  `"alice"`,
+		},
+		{
+			// A double quote in the value must not break out of the literal and
+			// append an OR predicate that would return every user's sessions.
+			name:  "quote injection is neutralized",
+			input: `attacker" OR userId!="`,
+			want:  `"attacker\" OR userId!=\""`,
+		},
+		{
+			name:  "backslash only",
+			input: `\`,
+			want:  `"\\"`,
+		},
+		{
+			name:  "empty string",
+			input: "",
+			want:  `""`,
+		},
+	}
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			if got := quoteFilterLiteral(tc.input); got != tc.want {
+				t.Errorf("quoteFilterLiteral(%q) = %q, want %q", tc.input, got, tc.want)
+			}
+		})
+	}
+}

--- a/session/vertexai/vertexai_client.go
+++ b/session/vertexai/vertexai_client.go
@@ -836,10 +836,18 @@ func createGroundingMetadata(metadata *aiplatformpb.GroundingMetadata) *genai.Gr
 // It uses JSON marshaling as an intermediary step to safely serialize
 // the input data before constructing the *structpb.Struct.
 // Returns an error if any part of the JSON round-trip or conversion fails.
+//
+// A nil value marshals to the JSON literal "null", which structpb rejects.
+// Such a value is treated as an empty Struct, matching structpb.NewStruct(nil)
+// and keeping callers that pass an absent map (for example a function call
+// that takes no arguments) from failing.
 func toStructPB(value any) (*structpb.Struct, error) {
 	data, err := json.Marshal(value)
 	if err != nil {
 		return nil, fmt.Errorf("failed to marshal value: %w", err)
+	}
+	if string(data) == "null" {
+		return &structpb.Struct{}, nil
 	}
 	res := &structpb.Struct{}
 	if err := res.UnmarshalJSON(data); err != nil {

--- a/session/vertexai/vertexai_client.go
+++ b/session/vertexai/vertexai_client.go
@@ -170,6 +170,16 @@ func (c *vertexAiClient) getSession(ctx context.Context, req *session.GetRequest
 	}, nil
 }
 
+// quoteFilterLiteral quotes a value for safe use as a Google AIP-160 filter
+// string literal. Backslashes are escaped first, then double quotes, so that
+// caller-controlled input stays inside the quoted value and cannot inject
+// additional filter predicates. See https://google.aip.dev/160.
+func quoteFilterLiteral(value string) string {
+	escaped := strings.ReplaceAll(value, `\`, `\\`)
+	escaped = strings.ReplaceAll(escaped, `"`, `\"`)
+	return `"` + escaped + `"`
+}
+
 func (c *vertexAiClient) listSessions(ctx context.Context, req *session.ListRequest) ([]session.Session, error) {
 	sessions := make([]session.Session, 0)
 
@@ -188,7 +198,7 @@ func (c *vertexAiClient) listSessions(ctx context.Context, req *session.ListRequ
 		Parent: vertexaiutil.AgentEngineResource(&aeData),
 	}
 	if req.UserID != "" {
-		rpcReq.Filter = fmt.Sprintf("userId=\"%s\"", req.UserID)
+		rpcReq.Filter = "userId=" + quoteFilterLiteral(req.UserID)
 	}
 	it := c.rpcClient.ListSessions(ctx, rpcReq)
 	for {

--- a/session/vertexai/vertexai_test.go
+++ b/session/vertexai/vertexai_test.go
@@ -337,6 +337,29 @@ func TestToStructPB(t *testing.T) {
 			expectError: true,
 		},
 		{
+			// A tool that takes no arguments leaves FunctionCall.Args nil, which
+			// marshals to the JSON literal "null". That must convert to an empty
+			// Struct rather than an error, as structpb.NewStruct(nil) did.
+			name:        "nil map converts to an empty struct",
+			input:       map[string]any(nil),
+			expectError: false,
+			validate: func(t *testing.T, s *structpb.Struct) {
+				if got := len(s.GetFields()); got != 0 {
+					t.Errorf("len(fields) = %d, want 0", got)
+				}
+			},
+		},
+		{
+			name:        "untyped nil converts to an empty struct",
+			input:       nil,
+			expectError: false,
+			validate: func(t *testing.T, s *structpb.Struct) {
+				if got := len(s.GetFields()); got != 0 {
+					t.Errorf("len(fields) = %d, want 0", got)
+				}
+			},
+		},
+		{
 			name: "custom struct representing possible state delta",
 			input: struct {
 				StringValue string
@@ -429,6 +452,38 @@ func TestCreateAiplatformpbContent(t *testing.T) {
 							genai.NewPartFromFunctionCall("tool", map[string]any{
 								"city": "Stockholm",
 							}),
+						},
+						Role: genai.RoleUser,
+					},
+				},
+			},
+			expectError: false,
+		},
+		{
+			// Regression: a tool declaring no parameters yields a FunctionCall
+			// with nil Args. This must persist rather than fail the AppendEvent.
+			name: "function call with nil args",
+			event: &session.Event{
+				LLMResponse: model.LLMResponse{
+					Content: &genai.Content{
+						Parts: []*genai.Part{
+							{FunctionCall: &genai.FunctionCall{ID: "call-1", Name: "get_time"}},
+						},
+						Role: genai.RoleModel,
+					},
+				},
+			},
+			expectError: false,
+		},
+		{
+			// Regression: a tool returning no payload yields a FunctionResponse
+			// with nil Response.
+			name: "function response with nil response",
+			event: &session.Event{
+				LLMResponse: model.LLMResponse{
+					Content: &genai.Content{
+						Parts: []*genai.Part{
+							{FunctionResponse: &genai.FunctionResponse{ID: "call-1", Name: "get_time"}},
 						},
 						Role: genai.RoleUser,
 					},


### PR DESCRIPTION
## Problem

Four defects across the two persistent session services.

- **Stale-session errors render 1970 dates.** The timestamps compared are `UnixMicro()` microseconds, and the error formats them through `time.Unix(0, x)`, whose second argument is nanoseconds. Every real timestamp collapses to a 1970-01-2x date, which makes the error useless for diagnosing which handle is stale.
- **`UpdateTime` is not maintained on app and user state writes** in `session/database`, so a state write leaves the recorded update time behind.
- **`userId` is not quoted in the AIP-160 list filter** in `session/vertexai`. A user ID containing a filter metacharacter breaks the query or changes what it matches.
- **Nil function arguments are mishandled** in `session/vertexai` instead of being treated as an empty struct.

The 1970 formatting bug reproduces on `v1` unmodified:

```
--- FAIL: TestDatabaseService_AppendEvent_StaleErrorFormatsTimestamps
    stale error still renders a 1970 timestamp: "stale session error: last update
    time from request (1970-01-21T15:38:02.4Z) is older than in database
    (1970-01-21T15:38:06Z)"
```

## Summary

Backport of #1322, #1204, #1237 and #1171 to the 1.x maintenance line, applied in upstream order because #1204 and #1237 both touch `session/database/service.go`.

All four source changes are cherry-picked unchanged. One test file needed re-anchoring, and the first attempt at it lost coverage:

- #1237's test hunk sits next to a workflow-event round-trip test covering `NodeInfo`, `RequestedInput`, `Routes` and `IsolationScope`, none of which exist on 1.x, so that surrounding test could not come across.
- Resolving that hunk also removed `TestDatabaseService_StateUpdateTimeIsSet`, which the #1204 cherry-pick had added two commits earlier, leaving the #1204 fix with no coverage on this branch. It is restored verbatim from main in the last commit. With all four `UpdateTime` assignments stripped from `session/database/service.go`, that test fails on all four assertions and nothing else in `./session/...` fails.
