### PR TITLE
fix: backport tool result and content fixes (#696, #1349, #1367)

### DIFF
--- a/internal/llminternal/contents_processor.go
+++ b/internal/llminternal/contents_processor.go
@@ -502,6 +502,13 @@ func buildContentsCurrentTurnContextOnly(agentName, branch string, events []*ses
 	// Find the latest event that starts the current turn and process from there
 	for i := len(events) - 1; i >= 0; i-- {
 		event := events[i]
+		// Events from a sibling branch are not part of this agent's
+		// current turn. In parallel delegations, a sibling may append its
+		// response after this agent's user input; treating that response as
+		// the pivot would slice the input out of the request.
+		if !eventBelongsToBranch(branch, event) {
+			continue
+		}
 		if event.Author == "user" || isOtherAgentReply(agentName, event) {
 			return buildContentsDefault(agentName, branch, events[i:])
 		}

--- a/internal/llminternal/contents_processor_test.go
+++ b/internal/llminternal/contents_processor_test.go
@@ -1166,3 +1166,47 @@ var (
 	_ session.Session = (*fakeSession)(nil)
 	_ session.Events  = (*fakeSession)(nil)
 )
+
+func TestContentsRequestProcessor_IncludeContentsNone_IgnoresSiblingBranchPivot(t *testing.T) {
+	t.Parallel()
+
+	const branch = "coordinator.translator_es"
+	events := []*session.Event{
+		{
+			Author: "user",
+			Branch: branch,
+			LLMResponse: model.LLMResponse{
+				Content: genai.NewContentFromText("good morning", genai.RoleUser),
+			},
+		},
+		{
+			Author: "translator_fr",
+			Branch: "coordinator.translator_fr",
+			LLMResponse: model.LLMResponse{
+				Content: genai.NewContentFromText("Bonjour", genai.RoleModel),
+			},
+		},
+	}
+
+	a := utils.Must(llmagent.New(llmagent.Config{
+		Name:            "translator_es",
+		Model:           &testModel{},
+		IncludeContents: "none",
+	}))
+	ctx := icontext.NewInvocationContext(t.Context(), icontext.InvocationContextParams{
+		Agent:   a,
+		Branch:  branch,
+		Session: &fakeSession{events: events},
+	})
+	req := &model.LLMRequest{}
+	for _, err := range llminternal.ContentsRequestProcessor(ctx, req, &llminternal.Flow{}) {
+		if err != nil {
+			t.Fatalf("contentsRequestProcessor failed: %v", err)
+		}
+	}
+
+	want := []*genai.Content{genai.NewContentFromText("good morning", genai.RoleUser)}
+	if diff := cmp.Diff(want, req.Contents); diff != "" {
+		t.Errorf("contents mismatch (-want +got):\n%s", diff)
+	}
+}

--- a/tool/agenttool/agent_tool.go
+++ b/tool/agenttool/agent_tool.go
@@ -222,7 +222,7 @@ func (t *agentTool) Run(toolCtx agent.ToolContext, args any) (map[string]any, er
 	lastContent := lastEvent.LLMResponse.Content
 	var textParts []string
 	for _, part := range lastContent.Parts {
-		if part != nil && part.Text != "" {
+		if part != nil && part.Text != "" && !part.Thought {
 			textParts = append(textParts, part.Text)
 		}
 	}

--- a/tool/agenttool/agent_tool_test.go
+++ b/tool/agenttool/agent_tool_test.go
@@ -238,6 +238,112 @@ func TestAgentTool_Run_WithoutSchema(t *testing.T) {
 	}
 }
 
+func TestAgentTool_Run_FiltersThoughtParts(t *testing.T) {
+	testLLM := &testutil.MockModel{
+		Responses: []*genai.Content{
+			{
+				Parts: []*genai.Part{
+					{Text: "Let me think about this...", Thought: true},
+					{Text: "", Thought: true}, // edge case: empty text + thought
+					{Text: "The answer is 42"},
+					{Text: "Still reasoning...", Thought: true},
+				},
+				Role: genai.RoleModel,
+			},
+		},
+		StreamResponsesCount: 1,
+	}
+
+	agent := createAgentWithModel(t, nil, nil, testLLM)
+	agentTool := agenttool.New(agent, nil)
+	toolCtx := createToolContext(t, agent)
+	toolImpl, ok := agentTool.(toolinternal.FunctionTool)
+	if !ok {
+		t.Fatal("agentTool does not implement FunctionTool")
+	}
+
+	result, err := toolImpl.Run(toolCtx, map[string]any{"request": "what is the answer?"})
+	if err != nil {
+		t.Fatalf("Run() failed unexpectedly: %v", err)
+	}
+	want := map[string]any{"result": "The answer is 42"}
+	if diff := cmp.Diff(want, result); diff != "" {
+		t.Errorf("Run() result diff (-want +got):\n%s", diff)
+	}
+}
+
+func TestAgentTool_Run_AllThoughtPartsReturnsEmpty(t *testing.T) {
+	testLLM := &testutil.MockModel{
+		Responses: []*genai.Content{
+			{
+				Parts: []*genai.Part{
+					{Text: "Just thinking...", Thought: true},
+				},
+				Role: genai.RoleModel,
+			},
+		},
+		StreamResponsesCount: 1,
+	}
+
+	agent := createAgentWithModel(t, nil, nil, testLLM)
+	agentTool := agenttool.New(agent, nil)
+	toolCtx := createToolContext(t, agent)
+	toolImpl, ok := agentTool.(toolinternal.FunctionTool)
+	if !ok {
+		t.Fatal("agentTool does not implement FunctionTool")
+	}
+
+	result, err := toolImpl.Run(toolCtx, map[string]any{"request": "think only"})
+	if err != nil {
+		t.Fatalf("Run() failed unexpectedly: %v", err)
+	}
+	want := map[string]any{}
+	if diff := cmp.Diff(want, result); diff != "" {
+		t.Errorf("Run() result diff (-want +got):\n%s", diff)
+	}
+}
+
+func TestAgentTool_Run_FiltersThoughtParts_WithOutputSchema(t *testing.T) {
+	outputSchema := &genai.Schema{
+		Type: "OBJECT",
+		Properties: map[string]*genai.Schema{
+			"is_valid": {Type: "BOOLEAN"},
+			"message":  {Type: "STRING"},
+		},
+		Required: []string{"is_valid", "message"},
+	}
+
+	testLLM := &testutil.MockModel{
+		Responses: []*genai.Content{
+			{
+				Parts: []*genai.Part{
+					{Text: "Let me validate the input carefully...", Thought: true},
+					{Text: "{\"is_valid\": true, \"message\": \"success\"}"},
+				},
+				Role: genai.RoleModel,
+			},
+		},
+		StreamResponsesCount: 1,
+	}
+
+	agent := createAgentWithModel(t, nil, outputSchema, testLLM)
+	agentTool := agenttool.New(agent, nil)
+	toolCtx := createToolContext(t, agent)
+	toolImpl, ok := agentTool.(toolinternal.FunctionTool)
+	if !ok {
+		t.Fatal("agentTool does not implement FunctionTool")
+	}
+
+	result, err := toolImpl.Run(toolCtx, map[string]any{"request": "validate"})
+	if err != nil {
+		t.Fatalf("Run() failed unexpectedly: %v", err)
+	}
+	want := map[string]any{"is_valid": true, "message": "success"}
+	if diff := cmp.Diff(want, result); diff != "" {
+		t.Errorf("Run() result diff (-want +got):\n%s", diff)
+	}
+}
+
 func TestAgentTool_Run_EmptyModelResponse(t *testing.T) {
 	testLLM := &testutil.MockModel{
 		Responses: []*genai.Content{

--- a/tool/preloadmemorytool/tool.go
+++ b/tool/preloadmemorytool/tool.go
@@ -123,7 +123,7 @@ func extractText(mem memory.Entry) string {
 
 	var b strings.Builder
 	for _, part := range mem.Content.Parts {
-		if part.Text == "" {
+		if part == nil || part.Text == "" {
 			continue
 		}
 		if b.Len() > 0 {

--- a/tool/preloadmemorytool/tool_test.go
+++ b/tool/preloadmemorytool/tool_test.go
@@ -105,6 +105,28 @@ func TestPreloadMemoryTool_ProcessRequest(t *testing.T) {
 			wantInstruction: false,
 		},
 		{
+			name:        "memories with nil and empty parts",
+			userContent: genai.NewContentFromText("test query", genai.RoleUser),
+			memories: []memory.Entry{
+				{
+					Author:    "user",
+					Timestamp: time.Date(2025, 1, 1, 12, 0, 0, 0, time.UTC),
+					Content: &genai.Content{
+						Parts: []*genai.Part{
+							nil,
+							{Text: "valid memory"},
+							nil,
+							{Text: ""},
+						},
+					},
+				},
+			},
+			wantInstruction: true,
+			wantTextContains: []string{
+				"user: valid memory",
+			},
+		},
+		{
 			name:        "single memory entry",
 			userContent: genai.NewContentFromText("test query", genai.RoleUser),
 			memories: []memory.Entry{


### PR DESCRIPTION
## Problem

Three defects in tool results and request content assembly.

- **A sibling branch can steal the current-turn pivot.** With `IncludeContents: "none"`, the processor walks backwards for the event that starts this agent's turn and accepts any event authored by a user or another agent, without checking the branch. In a parallel delegation a sibling appends its response after this agent's user input, becomes the pivot, and the user's input is sliced out of the request — the agent is asked to answer a question it can no longer see.
- **Thinking parts leak into `agenttool` results,** so a caller receives the sub-agent's reasoning alongside its answer.
- **`preloadmemorytool.extractText` panics on nil parts.**

## Summary

Backport of #696, #1349 and #1367 to the 1.x maintenance line.

Two adaptations, both in #1367. `buildContentsCurrentTurnContextOnly` has no `isolationScope` parameter on 1.x, so the branch check is the only guard added to the pivot loop — 2.x also skips out-of-scope events there, and scope isolation does not exist on this line. The test drops `llmagent.ModeSingleTurn`, which is 2.x-only. `eventBelongsToBranch`, the helper the fix needs, is already present on `v1`.

