### PR TITLE
fix: backport runner and REST server fixes (#1417, #1307)

### DIFF
--- a/runner/runner.go
+++ b/runner/runner.go
@@ -252,6 +252,10 @@ func (r *Runner) Run(ctx context.Context, userID, sessionID string, msg *genai.C
 				}
 			}
 
+			if event == nil {
+				continue
+			}
+
 			// only commit non-partial event to a session service
 			if !event.LLMResponse.Partial {
 				if err := r.sessionService.AppendEvent(ctx, storedSession, event); err != nil {
@@ -454,6 +458,10 @@ func (r *Runner) RunLive(ctx context.Context, userID, sessionID string, cfg agen
 				if modifiedEvent != nil {
 					event = modifiedEvent
 				}
+			}
+
+			if event == nil {
+				continue
 			}
 
 			// Chronological event buffering logic for Live streaming.

--- a/runner/runner_test.go
+++ b/runner/runner_test.go
@@ -447,3 +447,45 @@ func TestRunner_AutoCreateSession(t *testing.T) {
 		})
 	}
 }
+
+func TestRunner_NilEventYieldedDoesNotPanic(t *testing.T) {
+	t.Parallel()
+
+	nilAgent, err := agent.New(agent.Config{
+		Name: "nil_yielder",
+		Run: func(ctx agent.InvocationContext) iter.Seq2[*session.Event, error] {
+			return func(yield func(*session.Event, error) bool) {
+				yield(nil, nil)
+			}
+		},
+	})
+	if err != nil {
+		t.Fatalf("agent.New() error = %v", err)
+	}
+
+	sessionService := session.InMemoryService()
+	r, err := New(Config{
+		AppName:           "test_app",
+		Agent:             nilAgent,
+		SessionService:    sessionService,
+		AutoCreateSession: true,
+	})
+	if err != nil {
+		t.Fatalf("New() error = %v", err)
+	}
+
+	var count int
+	msg := &genai.Content{Parts: []*genai.Part{{Text: "hello"}}}
+	for ev, err := range r.Run(t.Context(), "user1", "session1", msg, agent.RunConfig{}) {
+		if err != nil {
+			t.Errorf("unexpected error: %v", err)
+		}
+		if ev == nil {
+			t.Errorf("unexpected nil event")
+		}
+		count++
+	}
+	if count != 0 {
+		t.Errorf("expected 0 events, got %d", count)
+	}
+}

--- a/server/adkrest/controllers/sessions.go
+++ b/server/adkrest/controllers/sessions.go
@@ -17,6 +17,8 @@ package controllers
 import (
 	"context"
 	"encoding/json"
+	"errors"
+	"io"
 	"net/http"
 
 	"github.com/gorilla/mux"
@@ -46,10 +48,9 @@ func (c *SessionsAPIController) CreateSessionHandler(rw http.ResponseWriter, req
 		return
 	}
 	createSessionRequest := models.CreateSessionRequest{}
-	// No state and no events, fails to decode req.Body failing with "EOF"
-	if req.ContentLength > 0 {
+	if req.Body != nil {
 		err := json.NewDecoder(req.Body).Decode(&createSessionRequest)
-		if err != nil {
+		if err != nil && !errors.Is(err, io.EOF) {
 			http.Error(rw, err.Error(), http.StatusBadRequest)
 			return
 		}

--- a/server/adkrest/sessions_integration_test.go
+++ b/server/adkrest/sessions_integration_test.go
@@ -1,0 +1,187 @@
+// Copyright 2026 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package adkrest_test
+
+import (
+	"encoding/json"
+	"io"
+	"net/http"
+	"net/http/httptest"
+	"slices"
+	"strings"
+	"testing"
+
+	"google.golang.org/adk/server/adkrest"
+	"google.golang.org/adk/session"
+)
+
+// unknownLengthReader hides the underlying reader's size so net/http uses chunked transfer encoding.
+type unknownLengthReader struct {
+	io.Reader
+}
+
+type createSessionResponse struct {
+	State  map[string]any `json:"state"`
+	Events []struct {
+		ID           string `json:"id"`
+		InvocationID string `json:"invocationId"`
+		Author       string `json:"author"`
+	} `json:"events"`
+}
+
+func TestCreateSessionPreservesChunkedBody(t *testing.T) {
+	testServer := newChunkedSessionServer(t)
+	requestBody := unknownLengthReader{strings.NewReader(`{
+		"state":{"theme":"dark"},
+		"events":[{"id":"event-1","invocationId":"invocation-1","author":"user"}]
+	}`)}
+	req, err := http.NewRequestWithContext(
+		t.Context(),
+		http.MethodPost,
+		testServer.URL+"/apps/test-app/users/test-user/sessions/test-session",
+		requestBody,
+	)
+	if err != nil {
+		t.Fatalf("http.NewRequestWithContext() failed: %v", err)
+	}
+	req.Header.Set("Content-Type", "application/json")
+
+	resp, err := testServer.Client().Do(req)
+	if err != nil {
+		t.Fatalf("client.Do() failed: %v", err)
+	}
+	respBody, readErr := io.ReadAll(resp.Body)
+	closeErr := resp.Body.Close()
+	if readErr != nil {
+		t.Fatalf("io.ReadAll(response body) failed: %v", readErr)
+	}
+	if closeErr != nil {
+		t.Fatalf("response body Close() failed: %v", closeErr)
+	}
+	if got, want := resp.StatusCode, http.StatusOK; got != want {
+		t.Fatalf("create session status = %d, want %d; body: %s", got, want, respBody)
+	}
+
+	var got createSessionResponse
+	if err := json.Unmarshal(respBody, &got); err != nil {
+		t.Fatalf("json.Unmarshal(response body) failed: %v; body: %s", err, respBody)
+	}
+	if gotTheme, ok := got.State["theme"].(string); !ok || gotTheme != "dark" {
+		t.Errorf("created session state theme = %v, want dark", got.State["theme"])
+	}
+	if gotCount, want := len(got.Events), 1; gotCount != want {
+		t.Fatalf("created session event count = %d, want %d", gotCount, want)
+	}
+	if gotID, want := got.Events[0].ID, "event-1"; gotID != want {
+		t.Errorf("created session event ID = %q, want %q", gotID, want)
+	}
+	if gotInvocationID, want := got.Events[0].InvocationID, "invocation-1"; gotInvocationID != want {
+		t.Errorf("created session event invocation ID = %q, want %q", gotInvocationID, want)
+	}
+	if gotAuthor, want := got.Events[0].Author, "user"; gotAuthor != want {
+		t.Errorf("created session event author = %q, want %q", gotAuthor, want)
+	}
+}
+
+func TestCreateSessionAllowsEmptyChunkedBody(t *testing.T) {
+	testServer := newChunkedSessionServer(t)
+	req, err := http.NewRequestWithContext(
+		t.Context(),
+		http.MethodPost,
+		testServer.URL+"/apps/test-app/users/test-user/sessions/test-session",
+		unknownLengthReader{strings.NewReader("")},
+	)
+	if err != nil {
+		t.Fatalf("http.NewRequestWithContext() failed: %v", err)
+	}
+	req.TransferEncoding = []string{"chunked"}
+
+	resp, err := testServer.Client().Do(req)
+	if err != nil {
+		t.Fatalf("client.Do() failed: %v", err)
+	}
+	respBody, readErr := io.ReadAll(resp.Body)
+	closeErr := resp.Body.Close()
+	if readErr != nil {
+		t.Fatalf("io.ReadAll(response body) failed: %v", readErr)
+	}
+	if closeErr != nil {
+		t.Fatalf("response body Close() failed: %v", closeErr)
+	}
+	if got, want := resp.StatusCode, http.StatusOK; got != want {
+		t.Fatalf("create session status = %d, want %d; body: %s", got, want, respBody)
+	}
+
+	var got createSessionResponse
+	if err := json.Unmarshal(respBody, &got); err != nil {
+		t.Fatalf("json.Unmarshal(response body) failed: %v; body: %s", err, respBody)
+	}
+	if len(got.State) != 0 {
+		t.Errorf("created session state = %v, want empty state", got.State)
+	}
+	if len(got.Events) != 0 {
+		t.Errorf("created session events = %v, want no events", got.Events)
+	}
+}
+
+func TestCreateSessionRejectsMalformedChunkedBody(t *testing.T) {
+	testServer := newChunkedSessionServer(t)
+	req, err := http.NewRequestWithContext(
+		t.Context(),
+		http.MethodPost,
+		testServer.URL+"/apps/test-app/users/test-user/sessions/test-session",
+		unknownLengthReader{strings.NewReader(`{"state":`)},
+	)
+	if err != nil {
+		t.Fatalf("http.NewRequestWithContext() failed: %v", err)
+	}
+	req.Header.Set("Content-Type", "application/json")
+
+	resp, err := testServer.Client().Do(req)
+	if err != nil {
+		t.Fatalf("client.Do() failed: %v", err)
+	}
+	respBody, readErr := io.ReadAll(resp.Body)
+	closeErr := resp.Body.Close()
+	if readErr != nil {
+		t.Fatalf("io.ReadAll(response body) failed: %v", readErr)
+	}
+	if closeErr != nil {
+		t.Fatalf("response body Close() failed: %v", closeErr)
+	}
+	if got, want := resp.StatusCode, http.StatusBadRequest; got != want {
+		t.Fatalf("create session status = %d, want %d; body: %s", got, want, respBody)
+	}
+}
+
+func newChunkedSessionServer(t *testing.T) *httptest.Server {
+	t.Helper()
+
+	server, err := adkrest.NewServer(adkrest.ServerConfig{
+		SessionService: session.InMemoryService(),
+	})
+	if err != nil {
+		t.Fatalf("adkrest.NewServer() failed: %v", err)
+	}
+	testServer := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if r.ContentLength != -1 || !slices.Contains(r.TransferEncoding, "chunked") {
+			http.Error(w, "test request was not chunked", http.StatusInternalServerError)
+			return
+		}
+		server.ServeHTTP(w, r)
+	}))
+	t.Cleanup(testServer.Close)
+	return testServer
+}


### PR DESCRIPTION
## Problem

Two defects, one a panic reachable from any custom agent.

- **A nil event yielded by an agent panics the runner.** Both [`Run`](https://github.com/google/adk-go/blob/cb2981844eae0613a90b100d98c32d231607ac69/runner/runner.go#L256) and [`RunLive`](https://github.com/google/adk-go/blob/cb2981844eae0613a90b100d98c32d231607ac69/runner/runner.go#L480) dereference the event with no nil check. This is worse on 1.x than it was on 2.x before the fix: 2.x guarded the same expression with `event != nil &&`, whereas 1.x has nothing. Against `v1` unmodified an agent yielding one nil event takes the runner down:

```
--- FAIL: TestRunner_NilEventYieldedDoesNotPanic
panic: runtime error: invalid memory address or nil pointer dereference
```

- **`adkrest` fails to decode chunked create-session request bodies,** so a client that sends the body with `Transfer-Encoding: chunked` cannot create a session.

## Summary

Backport of #1417 and #1307 to the 1.x maintenance line.

One adaptation, in #1417. In `RunLive` the guard goes ahead of the transcription-buffering block rather than immediately before the non-partial check, because that block dereferences the event first on 1.x. In `Run` it sits where upstream put it. #1307 is cherry-picked unchanged.
