### PR TITLE
fix: validate Cloud Run service name before passing it to gcloud

### DIFF
--- a/cmd/adkgo/internal/deploy/cloudrun/cloudrun.go
+++ b/cmd/adkgo/internal/deploy/cloudrun/cloudrun.go
@@ -21,6 +21,7 @@ import (
 	"os/exec"
 	"path"
 	"path/filepath"
+	"regexp"
 	"strconv"
 	"strings"
 	"time"
@@ -83,6 +84,26 @@ type deployCloudRunFlags struct {
 
 var flags deployCloudRunFlags
 
+// serviceNameRE matches the Cloud Run service names gcloud itself accepts:
+// lowercase letters, digits and dashes, starting and ending with a letter or
+// digit, at most 63 characters. Verified against gcloud's own client-side
+// resource-name validation (leading digits are allowed).
+var serviceNameRE = regexp.MustCompile(`^[a-z0-9]([-a-z0-9]{0,61}[a-z0-9])?$`)
+
+// validateServiceName rejects a --service_name value that gcloud would not
+// accept as a Cloud Run service. gcloudDeployToCloudRun and runGcloudProxy place
+// this value in gcloud's positional SERVICE slot; without this check a value
+// beginning with '-' is consumed by gcloud as a flag rather than a service name
+// (argument injection, CWE-88). gcloud honors such an injected flag — including
+// one supplied via --flags-file — and applies it before it aborts on the now
+// empty positional.
+func validateServiceName(name string) error {
+	if !serviceNameRE.MatchString(name) {
+		return fmt.Errorf("invalid --service_name %q: a Cloud Run service name must be 1-63 characters of lowercase letters, digits or dashes and must start and end with a letter or digit", name)
+	}
+	return nil
+}
+
 // cloudrunCmd represents the cloudrun command
 var cloudrunCmd = &cobra.Command{
 	Use:   "cloudrun",
@@ -130,6 +151,15 @@ func (f *deployCloudRunFlags) computeFlags() error {
 		func(p util.Printer) error {
 			if f.cloudRun.debugAPI && !f.cloudRun.api {
 				return fmt.Errorf("cannot enable Debug API without having enabled API")
+			}
+
+			// Validate the service name before any work: it is passed to gcloud
+			// in the positional SERVICE slot by gcloudDeployToCloudRun and
+			// runGcloudProxy, where a '-'-prefixed value would be parsed as a
+			// flag rather than a service name (CWE-88). Checking here also means
+			// a rejected value leaves no temporary directory behind.
+			if err := validateServiceName(f.cloudRun.serviceName); err != nil {
+				return err
 			}
 
 			absp, err := filepath.Abs(flags.source.entryPointPath)

--- a/cmd/adkgo/internal/deploy/cloudrun/cloudrun_test.go
+++ b/cmd/adkgo/internal/deploy/cloudrun/cloudrun_test.go
@@ -1,0 +1,69 @@
+// Copyright 2026 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package cloudrun
+
+import (
+	"strings"
+	"testing"
+)
+
+// resetFlags restores the package-level flags var to a fresh, minimally valid
+// state before each test, since computeFlags reads and writes it directly.
+func resetFlags(t *testing.T, entryPointPath, serviceName string) {
+	t.Helper()
+	flags = deployCloudRunFlags{}
+	flags.source.entryPointPath = entryPointPath
+	flags.build.tempDir = t.TempDir()
+	flags.cloudRun.serviceName = serviceName
+}
+
+func TestComputeFlags_RejectsUnsafeServiceName(t *testing.T) {
+	// serviceName is placed in gcloud's positional SERVICE slot; a leading '-'
+	// would be parsed by gcloud as a flag rather than a service name
+	// (argument injection, CWE-88).
+	for _, name := range []string{
+		"--flags-file=/tmp/evil.yaml", // the injection payload
+		"-s",
+		"-agent",
+		"Agent",                 // uppercase not allowed
+		"agent_name",            // underscore not allowed
+		"agent.name",            // dot not allowed
+		"agent-",                // trailing dash not allowed
+		"",                      // empty
+		strings.Repeat("a", 64), // longer than 63
+	} {
+		resetFlags(t, "main.go", name)
+		if err := flags.computeFlags(); err == nil {
+			t.Errorf("computeFlags() with serviceName %q = nil, want an error", name)
+		}
+	}
+}
+
+func TestComputeFlags_AcceptsValidServiceNames(t *testing.T) {
+	// Every value here is accepted by gcloud's own service-name validation.
+	for _, name := range []string{
+		"my-agent",
+		"a",
+		"9agent",
+		"0abc",
+		"ab--cd",
+		strings.Repeat("a", 63),
+	} {
+		resetFlags(t, "main.go", name)
+		if err := flags.computeFlags(); err != nil {
+			t.Errorf("computeFlags() with valid serviceName %q = %v, want nil", name, err)
+		}
+	}
+}


### PR DESCRIPTION
## What
`cmd/adkgo/internal/deploy/cloudrun` runs `gcloud` twice once to deploy (`gcloudDeployToCloudRun`) and once to start the local authenticating proxy
(`runGcloudProxy`) — and in both invocations the `--service_name` flag value is
placed in gcloud's **positional `SERVICE` slot with no validation**:

```go
params := []string{"run", "deploy", f.cloudRun.serviceName, /* … */}
// and
exec.Command("gcloud", "run", "services", "proxy", f.cloudRun.serviceName, /* … */)
```

Because the value sits in the positional slot, a `--service_name` beginning with
`-` is parsed by gcloud as an **option**, not a service name — argument injection
(CWE-88). For example `--service_name=--flags-file=/path/to/attacker.yaml` is
read by gcloud as a `--flags-file` flag, which lets it pull in an arbitrary set
of further gcloud flags. gcloud honors the injected flag (and applies it, e.g.
setting `--verbosity` or an `--impersonate-service-account` property) before it
aborts on the now-empty positional.

Only `--service_name` has this shape. `--project_name` and `--region` are
operands of `--project`/`--region`; an operand cannot become a flag (gcloud
rejects an option-shaped token there), so they are not affected.

## Fix
Validate the service name in `computeFlags`, before any temp dir is created,
against the rules gcloud itself enforces for a Cloud Run service — lowercase
letters, digits and dashes; start and end with a letter or digit; at most 63
characters:

```go
var serviceNameRE = regexp.MustCompile(`^[a-z0-9]([-a-z0-9]{0,61}[a-z0-9])?$`)
```

An option-shaped value is rejected up front with a clear message, and an
ordinary typo gets a readable error instead of a confusing one from gcloud.
Added `cloudrun_test.go` covering rejected values (including the injection
payload, leading `-`, and out-of-range names) and accepted values.

## Notes
- Surfaced by @karolpiotrowicz while reviewing #1240 as an adjacent issue; kept
  as a separate PR per that review. Thank you.
- Independent of #1240 — no overlap in the changed lines.
- `go build ./cmd/adkgo/...`, `go vet`, `go test ./cmd/adkgo/internal/deploy/cloudrun/`
  and `golangci-lint run` all pass locally.
