### PR TITLE
docs: ask the two PR-template questions that catch the most defects

### DIFF
--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -19,6 +19,13 @@ _A clear and concise description of what the problem is._
 _A clear and concise description of what you want to happen and why you choose
 this solution._
 
+### Behavior change
+
+**What behaves differently for someone already on the current release?**
+
+_Write "nothing" if that is the answer. Bug fixes count: a fix that alters an
+observable result is still a behavior change._
+
 ### Testing Plan
 
 _Please describe the tests that you ran to verify your changes. This is required
@@ -26,8 +33,12 @@ for all PRs that are not small documentation or typo fixes._
 
 **Unit Tests:**
 
-- [ ] I have added or updated unit tests for my change.
 - [ ] All unit tests pass locally.
+
+**With your source change reverted and your tests kept, which test fails?**
+
+_Name it. If nothing fails, the tests do not yet cover the change. This is the
+cheapest moment to find that out._
 
 _Please include a summary of passed go test results._
 


### PR DESCRIPTION
### Link to Issue or Description of Change

No linked issue. Companion to #1492, which states the same two checks in `AGENTS.md` and `CONTRIBUTING.md`. Split out so the template change can be argued on its own.

**Problem:**

The two defects that come up most often in review are a test that passes whether or not the change under review is present, and a behavior change the description never mentions. The pull request template is the last thing a contributor sees before submitting, and it asks about neither.

The existing `I have added or updated unit tests for my change` checkbox is ticked by anyone who wrote a test file, whether or not that test would notice the change being reverted. It has no wrong answer, so it cannot catch anything.

**Solution:**

Two prompts, one replaced checkbox, no new CI.

- **"With your source change reverted and your tests kept, which test fails?"** replaces that checkbox. Naming a test requires having watched it fail. A contributor who cannot name one has just discovered their tests do not cover the change, at the cheapest possible moment to discover it.
- **A short Behavior change section**, asking what differs for someone already on the current release, with an explicit instruction to write "nothing" when that is the answer. Requiring the word is the point: silence currently reads the same whether the author weighed the question or never considered it. Bug fixes are called out, since a fix that alters an observable result is still a behavior change.

Both are prompts rather than gates. Nothing enforces them, and that is deliberate at this stage.

### Behavior change

Nothing. This changes the template shown when opening a pull request. No code, no public API, no CI configuration, and no effect on anyone consuming the module.

### Testing Plan

**Unit Tests:**

- [x] All unit tests pass locally.

**With your source change reverted and your tests kept, which test fails?**

None, and none should. The change is a markdown template with no executable behavior, so there is nothing a Go test could pin. Answering the question honestly rather than leaving it blank is the intended use.

**Manual End-to-End (E2E) Tests:**

Rendered the modified template to confirm the headings nest correctly under the existing structure and that the two new prompts read as questions rather than as checkboxes. The diff is seven added lines and one removed, entirely within `.github/pull_request_template.md`.

This pull request description was written using the proposed template, so it doubles as a worked example of both new fields.

### Checklist

- [x] I have read the [CONTRIBUTING.md](./CONTRIBUTING.md) document.
- [x] I have performed a self-review of my own code.
- [x] New and existing unit tests pass locally with my changes.
- [x] I have manually tested my changes end-to-end.
- [ ] I have commented my code, particularly in hard-to-understand areas. Not applicable, documentation only.
- [ ] I have added tests that prove my fix is effective or that my feature works. Not applicable, documentation only.
- [ ] Any dependent changes have been merged and published in downstream modules. None.

### Additional context

The Checklist still carries `I have added tests that prove my fix is effective or that my feature works`, which overlaps the new question. I left it alone to keep this diff to the two changes worth discussing, but it is a reasonable follow-up to drop it.
