### PR TITLE
fix(examples): return an error for missing image data

### DIFF
--- a/examples/vertexai/imagegenerator/main.go
+++ b/examples/vertexai/imagegenerator/main.go
@@ -19,6 +19,7 @@ package main
 
 import (
 	"context"
+	"fmt"
 	"log"
 	"os"
 	"path/filepath"
@@ -139,7 +140,7 @@ func saveImage(ctx agent.Context, input saveImageInput) (saveImageResult, error)
 
 	if resp.Part.InlineData == nil || len(resp.Part.InlineData.Data) == 0 {
 		log.Printf("Artifact '%s' has no inline data", filename)
-		return saveImageResult{}, err
+		return saveImageResult{}, fmt.Errorf("artifact %q has no inline data", filename)
 	}
 
 	// Ensure the filename has a .png extension for the local file.

--- a/examples/vertexai/imagegenerator/main_test.go
+++ b/examples/vertexai/imagegenerator/main_test.go
@@ -1,0 +1,99 @@
+// Copyright 2026 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package main
+
+import (
+	"errors"
+	"io/fs"
+	"testing"
+
+	"google.golang.org/genai"
+
+	"google.golang.org/adk/v2/agent"
+	"google.golang.org/adk/v2/artifact"
+	artifactinternal "google.golang.org/adk/v2/internal/artifact"
+)
+
+type saveImageContext struct {
+	agent.StrictContextMock
+	artifacts agent.Artifacts
+}
+
+func (c *saveImageContext) Artifacts() agent.Artifacts {
+	return c.artifacts
+}
+
+func TestSaveImageRejectsMissingInlineData(t *testing.T) {
+	tests := []struct {
+		name string
+		part *genai.Part
+	}{
+		{
+			name: "nil inline data",
+			part: genai.NewPartFromText("not image data"),
+		},
+		{
+			name: "empty inline data",
+			part: &genai.Part{InlineData: &genai.Blob{MIMEType: "image/png"}},
+		},
+	}
+
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			artifacts := &artifactinternal.Artifacts{
+				Service:   artifact.InMemoryService(),
+				AppName:   "test-app",
+				UserID:    "test-user",
+				SessionID: "test-session",
+			}
+			if _, err := artifacts.Save(t.Context(), "image.png", test.part); err != nil {
+				t.Fatalf("Save() error = %v", err)
+			}
+			ctx := &saveImageContext{
+				StrictContextMock: agent.NewStrictContextMock(t.Context()),
+				artifacts:         artifacts,
+			}
+
+			got, err := saveImage(ctx, saveImageInput{Filename: "image.png"})
+			if err == nil || err.Error() != `artifact "image.png" has no inline data` {
+				t.Fatalf("saveImage() error = %v, want %q", err, `artifact "image.png" has no inline data`)
+			}
+			if got != (saveImageResult{}) {
+				t.Errorf("saveImage() result = %+v, want zero value", got)
+			}
+		})
+	}
+}
+
+func TestSaveImageReturnsLoadError(t *testing.T) {
+	artifacts := &artifactinternal.Artifacts{
+		Service:   artifact.InMemoryService(),
+		AppName:   "test-app",
+		UserID:    "test-user",
+		SessionID: "test-session",
+	}
+	ctx := &saveImageContext{
+		StrictContextMock: agent.NewStrictContextMock(t.Context()),
+		artifacts:         artifacts,
+	}
+
+	got, err := saveImage(ctx, saveImageInput{Filename: "missing.png"})
+	if !errors.Is(err, fs.ErrNotExist) {
+		t.Fatalf("saveImage() error = %v, want an error matching fs.ErrNotExist", err)
+	}
+	if got != (saveImageResult{}) {
+		t.Errorf("saveImage() result = %+v, want zero value", got)
+	}
+}


### PR DESCRIPTION
### Link to Issue or Description of Change

**1. Link to an existing issue (if applicable):**

- Closes: #1508

**Problem:**

`save_image_locally` detected artifacts without usable inline data but returned
the stale error value from the preceding successful artifact load. Because that
error was nil, the tool invocation could be treated as successful even though
no image was written.

**Solution:**

Return a descriptive error when the loaded artifact has no `InlineData` or its
inline payload is empty.

Add tests using the in-memory artifact service for both missing-data shapes and
verify that artifact load errors continue to be returned unchanged.

### Behavior change

Calling `save_image_locally` with an artifact that has no usable inline data now
returns a non-nil error instead of an empty result with a nil error.

### Testing Plan

**Unit Tests:**

- [x] All unit tests pass locally.

With the source change reverted, `TestSaveImageRejectsMissingInlineData` fails
for both `nil inline data` and `empty inline data` because `saveImage` returns a
nil error.

Commands completed successfully:

- `go test -race -count=1 ./examples/vertexai/imagegenerator`
- `go build -mod=readonly work`
- `go test -race -mod=readonly -count=1 -shuffle=on work`
- `go vet ./examples/...`
- `golangci-lint run` with the CI-pinned v2.3.1 in both modules
- `go mod tidy -diff` in both modules
- `golangci-lint fmt -d` with the CI-pinned v2.3.1 in both modules

**Manual End-to-End (E2E) Tests:**

Not run. This failure path does not require a live model or API request and is
covered offline using the real in-memory artifact service.

### Checklist

- [x] I have read the `CONTRIBUTING.md` document.
- [x] I have performed a self-review of my own code.
- [x] I have commented my code where necessary.
- [x] I have added tests that prove my fix is effective.
- [x] New and existing unit tests pass locally with my changes.
- [ ] I have manually tested my changes end-to-end.
- [x] Any dependent changes have been merged and published in downstream modules.

### Additional context

This is separate from #1477, which covers validation of image-generation API
responses before saving an artifact. This change concerns loading an existing
artifact in `save_image_locally`.