### PR TITLE
fix(workflow): suppress retries while draining

### DIFF
--- a/workflow/scheduler.go
+++ b/workflow/scheduler.go
@@ -789,10 +789,10 @@ func (s *scheduler) handleEvent(it eventItem) {
 }
 
 // handleCompletion finalises a node's run: transitions its lifecycle
-// status, removes the live task, and (if scheduleSuccessors is true)
-// schedules its successors. When the consumer is draining (caller
-// stopped or a node failed), pass scheduleSuccessors=false so the
-// workflow does not keep dispatching new nodes after cancellation.
+// status, removes the live task, and (if scheduleNewWork is true)
+// schedules retries or successors. When the consumer is draining (caller
+// stopped or a node failed), pass scheduleNewWork=false so the workflow
+// does not keep dispatching new nodes after cancellation.
 //
 // The returned error is the node's own error (NodeFailed); nil on
 // clean success or sibling cancellation.
@@ -813,7 +813,7 @@ func (s *scheduler) handleEvent(it eventItem) {
 // context cancel, multiple-output, multiple-routing-event,
 // multiple-input-request) does not silently park in NodeWaiting:
 // failures take precedence and surface as NodeFailed.
-func (s *scheduler) handleCompletion(it completionItem, scheduleSuccessors bool) error {
+func (s *scheduler) handleCompletion(it completionItem, scheduleNewWork bool) error {
 	ns := s.state.EnsureNode(it.nodeName)
 	nr := s.runsByName[it.nodeName]
 	// For retryable nodes still delete them from run variables. If the node is retried,
@@ -855,7 +855,7 @@ func (s *scheduler) handleCompletion(it completionItem, scheduleSuccessors bool)
 	}
 	if it.err != nil {
 		currentNode := s.nodesByName[it.nodeName]
-		if currentNode != nil {
+		if scheduleNewWork && currentNode != nil {
 			cfg := currentNode.Config()
 			if cfg.RetryConfig != nil {
 				ns.Attempt = ns.Attempt + 1
@@ -881,7 +881,7 @@ func (s *scheduler) handleCompletion(it completionItem, scheduleSuccessors bool)
 
 	// Happy path: decide between NodeWaiting (an open interrupt) or
 	// NodeCompleted. The waiting branch fires regardless of the
-	// scheduleSuccessors flag — an interrupt that survived the run
+	// scheduleNewWork flag — an interrupt that survived the run
 	// must be observable in RunState even when the consumer is
 	// draining.
 	//
@@ -908,7 +908,7 @@ func (s *scheduler) handleCompletion(it completionItem, scheduleSuccessors bool)
 	// loop-back routing) starts a fresh lifecycle.
 	ns.ResumedInputs = nil
 
-	if !scheduleSuccessors {
+	if !scheduleNewWork {
 		return nil
 	}
 

--- a/workflow/scheduler_test.go
+++ b/workflow/scheduler_test.go
@@ -183,6 +183,42 @@ func TestScheduler_FailedSiblingsCancelled(t *testing.T) {
 	}
 }
 
+// TestScheduler_DrainingDoesNotRetryFailedSibling verifies that a sibling
+// returning its own retryable error after cancellation does not schedule a
+// retry while the workflow is draining.
+func TestScheduler_DrainingDoesNotRetryFailedSibling(t *testing.T) {
+	mockCtx := newSeededMockCtx(t)
+
+	primaryErr := errors.New("primary node failed")
+	siblingErr := errors.New("cancelled sibling failed during cleanup")
+	primary := newErroringNode("primary", primaryErr)
+	var siblingCalls atomic.Int32
+	sibling := NewFunctionNode("sibling", func(ctx agent.Context, _ any) (any, error) {
+		siblingCalls.Add(1)
+		<-ctx.Done()
+		return nil, siblingErr
+	}, NodeConfig{
+		RetryConfig: &RetryConfig{
+			MaxAttempts:   3,
+			InitialDelay:  time.Hour,
+			BackoffFactor: 1.0,
+			ShouldRetry:   func(error) bool { return true },
+		},
+	})
+	w := mustNew(t, []Edge{
+		{From: Start, To: primary},
+		{From: Start, To: sibling},
+	})
+
+	gotErr := drainErr(t, w.Run(mockCtx))
+	if !errors.Is(gotErr, primaryErr) {
+		t.Errorf("Run error = %v, want it to wrap %v", gotErr, primaryErr)
+	}
+	if got := siblingCalls.Load(); got != 1 {
+		t.Errorf("sibling calls = %d, want 1 (draining must suppress retries)", got)
+	}
+}
+
 // TestScheduler_ExternalCancellationFailsRun verifies that cancellation of
 // the workflow's invocation context is surfaced to the caller, rather than
 // being mistaken for scheduler-initiated sibling cancellation.


### PR DESCRIPTION
### Link to Issue or Description of Change

**1. Link to an existing issue (if applicable):**

- Closes: #1511

**Problem:**

When one fan-out branch fails, the scheduler enters draining mode and `cancelAll` clears `retryTimers`. If a cancelled sibling then returns its own retryable error, `handleCompletion` still attempts to schedule a retry. This writes to the nil `retryTimers` map and panics. Reinitializing the map alone would still leave an uncancelled retry timer that could delay shutdown.

**Solution:**

Treat the existing completion flag as permission to schedule any new work, not only successors. While draining, failed siblings are reaped and marked failed without scheduling retries. The flag was renamed from `scheduleSuccessors` to `scheduleNewWork` to document that invariant.

### Behavior change

After a workflow begins draining because a node failed, retryable errors returned by cancelled siblings no longer panic or schedule delayed retries. The workflow terminates with the original failure.

### Testing Plan

**Unit Tests:**

- [x] All unit tests pass locally.
- Added `TestScheduler_DrainingDoesNotRetryFailedSibling`.
- With the source change reverted and the test retained, `TestScheduler_DrainingDoesNotRetryFailedSibling` fails 100% with `panic: assignment to entry in nil map` from `scheduleRetry`.
- `go build -mod=readonly work`
- `go test -race -mod=readonly -count=1 -shuffle=on work`
- `golangci-lint run` in the root module: `0 issues.`
- `golangci-lint run` in `plugin/agentanalytics`: `0 issues.`
- `go mod tidy -diff` in both modules: clean.

**Manual End-to-End (E2E) Tests:**

N/A. The failure is isolated in the workflow scheduler with deterministic nodes and no model or network calls.

### Checklist

- [x] I have read the `CONTRIBUTING.md` document.
- [x] I have performed a self-review of my own code.
- [x] I have commented my code, particularly in hard-to-understand areas.
- [x] I have added tests that prove my fix is effective or that my feature works.
- [x] New and existing unit tests pass locally with my changes.
- [x] I have manually reproduced the failure before applying the fix.
- [x] Any dependent changes have been merged and published in downstream modules, or are not applicable.

### Additional context

The issue was first observed in a nested fan-out/fan-in workflow where one material-processing branch exhausted its retries while two siblings were still running. The regression test reduces that scenario to two deterministic nodes.
