### PR TITLE
feat(artifact): guarantee ArtifactVersion fields across backends

### DIFF
--- a/artifact/gcsartifact/gcs_client.go
+++ b/artifact/gcsartifact/gcs_client.go
@@ -54,6 +54,7 @@ type gcsWriter interface {
 	io.Writer // Provides Write(p []byte) (n int, err error)
 	io.Closer // Provides Close() error
 	SetContentType(string)
+	SetMetadata(map[string]string)
 }
 
 // ---------------------- Wrapper Implementations for Real gcs Types --------------------------------
@@ -144,6 +145,10 @@ func (g *gcsWriterWrapper) Close() error {
 
 func (g *gcsWriterWrapper) SetContentType(cType string) {
 	g.w.ContentType = cType
+}
+
+func (g *gcsWriterWrapper) SetMetadata(metadata map[string]string) {
+	g.w.Metadata = metadata
 }
 
 var (

--- a/artifact/gcsartifact/gcs_client_test.go
+++ b/artifact/gcsartifact/gcs_client_test.go
@@ -21,8 +21,21 @@ import (
 	"testing"
 
 	"cloud.google.com/go/storage"
+	"github.com/google/go-cmp/cmp"
 	"google.golang.org/api/option"
 )
+
+func TestGCSWriterWrapperSetMetadata(t *testing.T) {
+	writer := &storage.Writer{}
+	wrapper := &gcsWriterWrapper{w: writer}
+	want := map[string]string{"key": "value"}
+
+	wrapper.SetMetadata(want)
+
+	if diff := cmp.Diff(want, writer.Metadata); diff != "" {
+		t.Errorf("writer.Metadata mismatch (-want +got):\n%s", diff)
+	}
+}
 
 // TestObjectWrapperIfNotExist checks that the wrapper puts the does-not-exist
 // precondition on the wire. Everything else in this package tests against the

--- a/artifact/gcsartifact/gcs_test.go
+++ b/artifact/gcsartifact/gcs_test.go
@@ -21,6 +21,7 @@ import (
 	"fmt"
 	"io"
 	"io/fs"
+	"maps"
 	"net/http"
 	"slices"
 	"strings"
@@ -62,6 +63,139 @@ func TestGCSArtifactService(t *testing.T) {
 		return newGCSArtifactServiceForTesting("new")
 	}
 	tests.TestArtifactService(t, "GCS", factory)
+}
+
+func TestGCSArtifactVersionFields(t *testing.T) {
+	firstCreateTime := time.Date(2026, time.August, 31, 12, 34, 56, 0, time.UTC)
+	secondCreateTime := firstCreateTime.Add(time.Minute)
+	recreateTime := secondCreateTime.Add(time.Minute)
+
+	for _, tc := range []struct {
+		name          string
+		fileName      string
+		saveSessionID string
+		getSessionID  string
+		uriPrefix     string
+	}{
+		{
+			name:          "session scoped",
+			fileName:      "file.txt",
+			saveSessionID: "session",
+			getSessionID:  "session",
+			uriPrefix:     "gs://bucket/app/user/session/file.txt/",
+		},
+		{
+			name:          "user scoped",
+			fileName:      "user:file.txt",
+			saveSessionID: "save-session",
+			getSessionID:  "irrelevant-session",
+			uriPrefix:     "gs://bucket/app/user/user/user:file.txt/",
+		},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			svc := newGCSServiceForTesting("bucket")
+			fb := svc.bucket.(*fakeBucket)
+			fb.now = func() time.Time { return firstCreateTime }
+			metadata := map[string]any{
+				"string":  "value",
+				"number":  42,
+				"enabled": true,
+			}
+			if _, err := svc.Save(t.Context(), &artifact.SaveRequest{
+				AppName: "app", UserID: "user", SessionID: tc.saveSessionID, FileName: tc.fileName,
+				Part: genai.NewPartFromBytes([]byte("data"), "image/png"), CustomMetadata: metadata,
+			}); err != nil {
+				t.Fatalf("Save(v1) failed: %v", err)
+			}
+			metadata["string"] = "changed after save"
+
+			fb.now = func() time.Time { return secondCreateTime }
+			if _, err := svc.Save(t.Context(), &artifact.SaveRequest{
+				AppName: "app", UserID: "user", SessionID: tc.saveSessionID, FileName: tc.fileName,
+				Part: genai.NewPartFromText("text"),
+			}); err != nil {
+				t.Fatalf("Save(v2) failed: %v", err)
+			}
+
+			latest, err := svc.GetArtifactVersion(t.Context(), &artifact.GetArtifactVersionRequest{
+				AppName: "app", UserID: "user", SessionID: tc.getSessionID, FileName: tc.fileName,
+			})
+			if err != nil {
+				t.Fatalf("GetArtifactVersion(latest) failed: %v", err)
+			}
+			wantLatest := &artifact.ArtifactVersion{
+				Version:        2,
+				CanonicalURI:   tc.uriPrefix + "2",
+				CustomMetadata: map[string]any{},
+				CreateTime:     secondCreateTime,
+				MimeType:       "text/plain",
+			}
+			if diff := cmp.Diff(wantLatest, latest.ArtifactVersion); diff != "" {
+				t.Errorf("GetArtifactVersion(latest) mismatch (-want +got):\n%s", diff)
+			}
+
+			first, err := svc.GetArtifactVersion(t.Context(), &artifact.GetArtifactVersionRequest{
+				AppName: "app", UserID: "user", SessionID: tc.getSessionID, FileName: tc.fileName, Version: 1,
+			})
+			if err != nil {
+				t.Fatalf("GetArtifactVersion(v1) failed: %v", err)
+			}
+			wantFirst := &artifact.ArtifactVersion{
+				Version:      1,
+				CanonicalURI: tc.uriPrefix + "1",
+				CustomMetadata: map[string]any{
+					"string":  "value",
+					"number":  "42",
+					"enabled": "true",
+				},
+				CreateTime: firstCreateTime,
+				MimeType:   "image/png",
+			}
+			if diff := cmp.Diff(wantFirst, first.ArtifactVersion); diff != "" {
+				t.Errorf("GetArtifactVersion(v1) mismatch (-want +got):\n%s", diff)
+			}
+
+			first.ArtifactVersion.CustomMetadata["string"] = "changed after read"
+			again, err := svc.GetArtifactVersion(t.Context(), &artifact.GetArtifactVersionRequest{
+				AppName: "app", UserID: "user", SessionID: tc.getSessionID, FileName: tc.fileName, Version: 1,
+			})
+			if err != nil {
+				t.Fatalf("second GetArtifactVersion(v1) failed: %v", err)
+			}
+			if diff := cmp.Diff(wantFirst, again.ArtifactVersion); diff != "" {
+				t.Errorf("second GetArtifactVersion(v1) mismatch (-want +got):\n%s", diff)
+			}
+
+			if err := svc.Delete(t.Context(), &artifact.DeleteRequest{
+				AppName: "app", UserID: "user", SessionID: tc.getSessionID, FileName: tc.fileName,
+			}); err != nil {
+				t.Fatalf("Delete() failed: %v", err)
+			}
+			fb.now = func() time.Time { return recreateTime }
+			if _, err := svc.Save(t.Context(), &artifact.SaveRequest{
+				AppName: "app", UserID: "user", SessionID: tc.saveSessionID, FileName: tc.fileName,
+				Part: genai.NewPartFromBytes([]byte("new"), "application/octet-stream"),
+			}); err != nil {
+				t.Fatalf("Save(recreated) failed: %v", err)
+			}
+			recreated, err := svc.GetArtifactVersion(t.Context(), &artifact.GetArtifactVersionRequest{
+				AppName: "app", UserID: "user", SessionID: tc.getSessionID, FileName: tc.fileName,
+			})
+			if err != nil {
+				t.Fatalf("GetArtifactVersion(recreated) failed: %v", err)
+			}
+			wantRecreated := &artifact.ArtifactVersion{
+				Version:        1,
+				CanonicalURI:   tc.uriPrefix + "1",
+				CustomMetadata: map[string]any{},
+				CreateTime:     recreateTime,
+				MimeType:       "application/octet-stream",
+			}
+			if diff := cmp.Diff(wantRecreated, recreated.ArtifactVersion); diff != "" {
+				t.Errorf("GetArtifactVersion(recreated) mismatch (-want +got):\n%s", diff)
+			}
+		})
+	}
 }
 
 // TestGCSArtifactServiceConcurrentSave checks that concurrent saves of the same
@@ -148,12 +282,23 @@ func TestSaveExhaustsRetriesOnPersistentConflict(t *testing.T) {
 	svc := newGCSServiceForTesting("errtest")
 	fb := svc.bucket.(*fakeBucket)
 	fb.closeErr = &googleapi.Error{Code: http.StatusPreconditionFailed}
+	wantMetadata := map[string]string{"key": "value"}
+	req := saveReq()
+	req.CustomMetadata = map[string]any{"key": "value"}
 
-	if _, err := svc.Save(t.Context(), saveReq()); !errors.Is(err, ErrVersionConflict) {
+	if _, err := svc.Save(t.Context(), req); !errors.Is(err, ErrVersionConflict) {
 		t.Fatalf("Save() err = %v, want ErrVersionConflict", err)
 	}
 	if got := fb.closeCalls; got != maxSaveAttempts {
 		t.Errorf("write attempts = %d, want %d", got, maxSaveAttempts)
+	}
+	if got := len(fb.metadataCalls); got != maxSaveAttempts {
+		t.Fatalf("SetMetadata calls = %d, want %d", got, maxSaveAttempts)
+	}
+	for i, got := range fb.metadataCalls {
+		if diff := cmp.Diff(wantMetadata, got); diff != "" {
+			t.Errorf("SetMetadata call %d mismatch (-want +got):\n%s", i, diff)
+		}
 	}
 }
 
@@ -319,6 +464,7 @@ func newFakeClient() gcsClient {
 	return &fakeClient{
 		inMemoryBucket: &fakeBucket{
 			blobs: make(map[string]*fakeBlob),
+			now:   time.Now,
 		},
 	}
 }
@@ -332,11 +478,14 @@ func (c *fakeClient) bucket(name string) gcsBucket {
 type fakeBucket struct {
 	mu    sync.Mutex
 	blobs map[string]*fakeBlob
+	now   func() time.Time
 
 	// Test hooks (guarded by mu): closeErr, when set, makes every writer Close
 	// return it (a simulated write failure); closeCalls counts Close calls.
 	closeErr   error
 	closeCalls int
+	// metadataCalls records the metadata set on every write attempt.
+	metadataCalls []map[string]string
 
 	// attrsErr, when set, is returned by every object's attrs() call in place
 	// of the default not-found/found behavior. Used to simulate the GCS
@@ -390,6 +539,8 @@ type fakeBlob struct {
 	exists      bool
 	data        []byte
 	contentType string
+	metadata    map[string]string
+	created     time.Time
 }
 
 // fakeObject is a handle to a fakeBlob, optionally carrying a does-not-exist
@@ -425,7 +576,12 @@ func (o *fakeObject) attrs(ctx context.Context) (*storage.ObjectAttrs, error) {
 	if !b.exists {
 		return nil, storage.ErrObjectNotExist
 	}
-	return &storage.ObjectAttrs{Name: b.name, Created: time.Now(), ContentType: b.contentType}, nil
+	return &storage.ObjectAttrs{
+		Name:        b.name,
+		Created:     b.created,
+		ContentType: b.contentType,
+		Metadata:    maps.Clone(b.metadata),
+	}, nil
 }
 
 // delete removes the object from the in-memory store.
@@ -435,6 +591,9 @@ func (o *fakeObject) delete(ctx context.Context) error {
 	defer b.mu.Unlock()
 	b.exists = false
 	b.data = nil
+	b.contentType = ""
+	b.metadata = nil
+	b.created = time.Time{}
 	return nil
 }
 
@@ -454,9 +613,12 @@ type fakeWriter struct {
 	obj         *fakeObject
 	buffer      *bytes.Buffer
 	contentType string
+	metadata    map[string]string
+	started     bool
 }
 
 func (w *fakeWriter) Write(p []byte) (n int, err error) {
+	w.started = true
 	return w.buffer.Write(p)
 }
 
@@ -464,10 +626,12 @@ func (w *fakeWriter) Write(p []byte) (n int, err error) {
 // that loses the race sees the winner's data and returns HTTP 412 like GCS. A
 // bucket-level closeErr hook lets tests force a write failure.
 func (w *fakeWriter) Close() error {
+	now := time.Now
 	if bkt := w.obj.bucket; bkt != nil {
 		bkt.mu.Lock()
 		bkt.closeCalls++
 		forced := bkt.closeErr
+		now = bkt.now
 		bkt.mu.Unlock()
 		if forced != nil {
 			return forced
@@ -482,13 +646,30 @@ func (w *fakeWriter) Close() error {
 	}
 	b.data = w.buffer.Bytes()
 	b.contentType = w.contentType
+	b.metadata = maps.Clone(w.metadata)
+	b.created = now()
 	b.exists = true
 	return nil
 }
 
 // SetContentType implements the final piece of the interface.
 func (w *fakeWriter) SetContentType(cType string) {
+	if w.started {
+		panic("SetContentType called after Write")
+	}
 	w.contentType = cType
+}
+
+func (w *fakeWriter) SetMetadata(metadata map[string]string) {
+	if w.started {
+		panic("SetMetadata called after Write")
+	}
+	w.metadata = maps.Clone(metadata)
+	if bkt := w.obj.bucket; bkt != nil {
+		bkt.mu.Lock()
+		bkt.metadataCalls = append(bkt.metadataCalls, maps.Clone(metadata))
+		bkt.mu.Unlock()
+	}
 }
 
 // fakeObjectIterator returns attribute snapshots taken at list time.

--- a/artifact/gcsartifact/service.go
+++ b/artifact/gcsartifact/service.go
@@ -134,6 +134,13 @@ func (s *gcsService) Save(ctx context.Context, req *artifact.SaveRequest) (*arti
 		return nil, fmt.Errorf("request validation failed: %w", err)
 	}
 	appName, userID, sessionID, fileName := req.AppName, req.UserID, req.SessionID, req.FileName
+	var customMetadata map[string]string
+	if req.CustomMetadata != nil {
+		customMetadata = make(map[string]string, len(req.CustomMetadata))
+		for key, value := range req.CustomMetadata {
+			customMetadata[key] = fmt.Sprint(value)
+		}
+	}
 
 	var lastErr error
 	for attempt := range maxSaveAttempts {
@@ -150,7 +157,7 @@ func (s *gcsService) Save(ctx context.Context, req *artifact.SaveRequest) (*arti
 
 		blobName := buildBlobName(appName, userID, sessionID, fileName, nextVersion)
 		obj := s.bucket.object(blobName).ifNotExist()
-		err = writeArtifact(ctx, obj, req.Part)
+		err = writeArtifact(ctx, obj, req.Part, customMetadata)
 		if err == nil {
 			return &artifact.SaveResponse{Version: nextVersion}, nil
 		}
@@ -202,13 +209,14 @@ func sleepContext(ctx context.Context, d time.Duration) error {
 
 // writeArtifact streams part to obj. A precondition on obj surfaces as an error
 // from Close, not Write.
-func writeArtifact(ctx context.Context, obj gcsObject, part *genai.Part) (err error) {
+func writeArtifact(ctx context.Context, obj gcsObject, part *genai.Part, metadata map[string]string) (err error) {
 	writer := obj.newWriter(ctx)
 	defer func() {
 		if closeErr := writer.Close(); closeErr != nil && err == nil {
 			err = fmt.Errorf("failed to close blob writer: %w", closeErr)
 		}
 	}()
+	writer.SetMetadata(metadata)
 
 	if part.InlineData != nil {
 		writer.SetContentType(part.InlineData.MIMEType)

--- a/artifact/inmemory.go
+++ b/artifact/inmemory.go
@@ -25,18 +25,28 @@ import (
 	"sort"
 	"strings"
 	"sync"
+	"time"
 
 	"google.golang.org/genai"
 	"rsc.io/omap"
 	"rsc.io/ordered"
+
+	"google.golang.org/adk/v2/platform"
 )
+
+type artifactEntry struct {
+	part           *genai.Part
+	createTime     time.Time
+	customMetadata map[string]any
+	mimeType       string
+}
 
 // inMemoryService is an in-memory implementation of the Service.
 // It is primarily for testing and demonstration purposes.
 type inMemoryService struct {
 	mu sync.RWMutex
 	// ordered(appName, userID, sessionID) -> session
-	artifacts omap.Map[string, *genai.Part]
+	artifacts omap.Map[string, *artifactEntry]
 }
 
 // InMemoryService returns a new in-memory artifact service.
@@ -80,8 +90,8 @@ func (ak *artifactKey) Decode(key string) error {
 // scan returns an iterator over all key-value pairs
 // in the range begin ≤ key ≤ end.
 // TODO: add a concurrent tests.
-func (s *inMemoryService) scan(lo, hi string) iter.Seq2[artifactKey, *genai.Part] {
-	return func(yield func(key artifactKey, val *genai.Part) bool) {
+func (s *inMemoryService) scan(lo, hi string) iter.Seq2[artifactKey, *artifactEntry] {
+	return func(yield func(key artifactKey, val *artifactEntry) bool) {
 		for k, val := range s.artifacts.Scan(lo, hi) {
 			var key artifactKey
 			if err := key.Decode(k); err != nil {
@@ -95,7 +105,7 @@ func (s *inMemoryService) scan(lo, hi string) iter.Seq2[artifactKey, *genai.Part
 	}
 }
 
-func (s *inMemoryService) find(appName, userID, sessionID, fileName string) (int64, *genai.Part, bool) {
+func (s *inMemoryService) find(appName, userID, sessionID, fileName string) (int64, *artifactEntry, bool) {
 	lo := artifactKey{AppName: appName, UserID: userID, SessionID: sessionID, FileName: fileName, Version: math.MaxInt64}.Encode()
 	hi := artifactKey{AppName: appName, UserID: userID, SessionID: sessionID, FileName: fileName, Version: 0}.Encode()
 	for key, val := range s.scan(lo, hi) {
@@ -105,7 +115,7 @@ func (s *inMemoryService) find(appName, userID, sessionID, fileName string) (int
 	return 0, nil, false
 }
 
-func (s *inMemoryService) get(appName, userID, sessionID, fileName string, version int64) (*genai.Part, bool) {
+func (s *inMemoryService) get(appName, userID, sessionID, fileName string, version int64) (*artifactEntry, bool) {
 	key := artifactKey{
 		AppName:   appName,
 		UserID:    userID,
@@ -116,7 +126,7 @@ func (s *inMemoryService) get(appName, userID, sessionID, fileName string, versi
 	return s.artifacts.Get(key)
 }
 
-func (s *inMemoryService) set(appName, userID, sessionID, fileName string, version int64, artifact *genai.Part) {
+func (s *inMemoryService) set(appName, userID, sessionID, fileName string, version int64, entry *artifactEntry) {
 	key := artifactKey{
 		AppName:   appName,
 		UserID:    userID,
@@ -124,7 +134,7 @@ func (s *inMemoryService) set(appName, userID, sessionID, fileName string, versi
 		FileName:  fileName,
 		Version:   version,
 	}.Encode()
-	s.artifacts.Set(key, artifact)
+	s.artifacts.Set(key, entry)
 }
 
 func (s *inMemoryService) delete(appName, userID, sessionID, fileName string, version int64) {
@@ -145,11 +155,19 @@ func (s *inMemoryService) Save(ctx context.Context, req *SaveRequest) (*SaveResp
 		return nil, fmt.Errorf("request validation failed: %w", err)
 	}
 	appName, userID, sessionID, fileName := req.AppName, req.UserID, req.SessionID, req.FileName
-	artifact := req.Part
 	// If file is user scoped, store it under user scope path
 	if fileHasUserNamespace(fileName) {
 		sessionID = userScopedArtifactKey
 	}
+	customMetadata := maps.Clone(req.CustomMetadata)
+	if customMetadata == nil {
+		customMetadata = map[string]any{}
+	}
+	mimeType := "text/plain"
+	if req.Part.InlineData != nil {
+		mimeType = req.Part.InlineData.MIMEType
+	}
+	createTime := platform.Now(ctx)
 
 	s.mu.Lock()
 	defer s.mu.Unlock()
@@ -158,7 +176,12 @@ func (s *inMemoryService) Save(ctx context.Context, req *SaveRequest) (*SaveResp
 	if internalVer, _, ok := s.find(appName, userID, sessionID, fileName); ok {
 		nextVersion = internalVer + 1
 	}
-	s.set(appName, userID, sessionID, fileName, nextVersion, artifact)
+	s.set(appName, userID, sessionID, fileName, nextVersion, &artifactEntry{
+		part:           req.Part,
+		createTime:     createTime,
+		customMetadata: customMetadata,
+		mimeType:       mimeType,
+	})
 	return &SaveResponse{Version: nextVersion}, nil
 }
 
@@ -207,18 +230,18 @@ func (s *inMemoryService) Load(ctx context.Context, req *LoadRequest) (*LoadResp
 	defer s.mu.RUnlock()
 
 	if version > 0 {
-		artifact, ok := s.get(appName, userID, sessionID, fileName, version)
+		entry, ok := s.get(appName, userID, sessionID, fileName, version)
 		if !ok {
 			return nil, fmt.Errorf("artifact not found: %w", fs.ErrNotExist)
 		}
-		return &LoadResponse{Part: artifact}, nil
+		return &LoadResponse{Part: entry.part}, nil
 	}
 	// pick the latest version
-	_, artifact, ok := s.find(appName, userID, sessionID, fileName)
+	_, entry, ok := s.find(appName, userID, sessionID, fileName)
 	if !ok {
 		return nil, fmt.Errorf("artifact not found: %w", fs.ErrNotExist)
 	}
-	return &LoadResponse{Part: artifact}, nil
+	return &LoadResponse{Part: entry.part}, nil
 }
 
 // List implements [artifact.Service]
@@ -292,34 +315,38 @@ func (s *inMemoryService) GetArtifactVersion(ctx context.Context, req *GetArtifa
 		return nil, fmt.Errorf("request validation failed: %w", err)
 	}
 	appName, userID, sessionID, fileName, version := req.AppName, req.UserID, req.SessionID, req.FileName, req.Version
-	if fileHasUserNamespace(fileName) {
+	userScoped := fileHasUserNamespace(fileName)
+	if userScoped {
 		sessionID = userScopedArtifactKey
 	}
 
 	s.mu.RLock()
 	defer s.mu.RUnlock()
 
-	var artifact *genai.Part
+	var entry *artifactEntry
 	var ok bool
 	if version > 0 {
-		artifact, ok = s.get(appName, userID, sessionID, fileName, version)
+		entry, ok = s.get(appName, userID, sessionID, fileName, version)
 	} else {
-		version, artifact, ok = s.find(appName, userID, sessionID, fileName)
+		version, entry, ok = s.find(appName, userID, sessionID, fileName)
 	}
 
 	if !ok {
 		return nil, fmt.Errorf("artifact not found: %w", fs.ErrNotExist)
 	}
 
-	mimeType := "text/plain"
-	if artifact != nil && artifact.InlineData != nil {
-		mimeType = artifact.InlineData.MIMEType
+	canonicalURI := fmt.Sprintf("memory://apps/%s/users/%s/sessions/%s/artifacts/%s/versions/%d", appName, userID, sessionID, fileName, version)
+	if userScoped {
+		canonicalURI = fmt.Sprintf("memory://apps/%s/users/%s/artifacts/%s/versions/%d", appName, userID, fileName, version)
 	}
 
 	return &GetArtifactVersionResponse{
 		ArtifactVersion: &ArtifactVersion{
-			Version:  version,
-			MimeType: mimeType,
+			Version:        version,
+			CanonicalURI:   canonicalURI,
+			CustomMetadata: maps.Clone(entry.customMetadata),
+			CreateTime:     entry.createTime,
+			MimeType:       entry.mimeType,
 		},
 	}, nil
 }

--- a/artifact/inmemory_test.go
+++ b/artifact/inmemory_test.go
@@ -16,9 +16,14 @@ package artifact_test
 
 import (
 	"testing"
+	"time"
+
+	"github.com/google/go-cmp/cmp"
+	"google.golang.org/genai"
 
 	"google.golang.org/adk/v2/artifact"
 	"google.golang.org/adk/v2/internal/artifact/tests"
+	"google.golang.org/adk/v2/platform"
 )
 
 func TestInMemoryArtifactService(t *testing.T) {
@@ -26,4 +31,102 @@ func TestInMemoryArtifactService(t *testing.T) {
 		return artifact.InMemoryService(), nil
 	}
 	tests.TestArtifactService(t, "InMemory", factory)
+}
+
+func TestInMemoryArtifactVersionFields(t *testing.T) {
+	firstCreateTime := time.Date(2026, time.August, 31, 12, 34, 56, 0, time.UTC)
+	secondCreateTime := firstCreateTime.Add(time.Minute)
+	readTime := secondCreateTime.Add(time.Hour)
+
+	for _, tc := range []struct {
+		name          string
+		fileName      string
+		saveSessionID string
+		getSessionID  string
+		uriPrefix     string
+	}{
+		{
+			name:          "session scoped",
+			fileName:      "file.txt",
+			saveSessionID: "session",
+			getSessionID:  "session",
+			uriPrefix:     "memory://apps/app/users/user/sessions/session/artifacts/file.txt/versions/",
+		},
+		{
+			name:          "user scoped",
+			fileName:      "user:file.txt",
+			saveSessionID: "save-session",
+			getSessionID:  "irrelevant-session",
+			uriPrefix:     "memory://apps/app/users/user/artifacts/user:file.txt/versions/",
+		},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			srv := artifact.InMemoryService()
+			metadata := map[string]any{"key": "value", "count": 42, "enabled": true}
+			firstPart := genai.NewPartFromBytes([]byte("data"), "image/png")
+			firstSaveCtx := platform.WithTimeProvider(t.Context(), func() time.Time { return firstCreateTime })
+			if _, err := srv.Save(firstSaveCtx, &artifact.SaveRequest{
+				AppName: "app", UserID: "user", SessionID: tc.saveSessionID, FileName: tc.fileName,
+				Part: firstPart, CustomMetadata: metadata,
+			}); err != nil {
+				t.Fatalf("Save(v1) failed: %v", err)
+			}
+			metadata["key"] = "changed after save"
+			firstPart.InlineData.MIMEType = "application/changed"
+
+			secondSaveCtx := platform.WithTimeProvider(t.Context(), func() time.Time { return secondCreateTime })
+			if _, err := srv.Save(secondSaveCtx, &artifact.SaveRequest{
+				AppName: "app", UserID: "user", SessionID: tc.saveSessionID, FileName: tc.fileName,
+				Part: genai.NewPartFromText("text"),
+			}); err != nil {
+				t.Fatalf("Save(v2) failed: %v", err)
+			}
+
+			readCtx := platform.WithTimeProvider(t.Context(), func() time.Time { return readTime })
+			latest, err := srv.GetArtifactVersion(readCtx, &artifact.GetArtifactVersionRequest{
+				AppName: "app", UserID: "user", SessionID: tc.getSessionID, FileName: tc.fileName,
+			})
+			if err != nil {
+				t.Fatalf("GetArtifactVersion(latest) failed: %v", err)
+			}
+			wantLatest := &artifact.ArtifactVersion{
+				Version:        2,
+				CanonicalURI:   tc.uriPrefix + "2",
+				CustomMetadata: map[string]any{},
+				CreateTime:     secondCreateTime,
+				MimeType:       "text/plain",
+			}
+			if diff := cmp.Diff(wantLatest, latest.ArtifactVersion); diff != "" {
+				t.Errorf("GetArtifactVersion(latest) mismatch (-want +got):\n%s", diff)
+			}
+
+			first, err := srv.GetArtifactVersion(readCtx, &artifact.GetArtifactVersionRequest{
+				AppName: "app", UserID: "user", SessionID: tc.getSessionID, FileName: tc.fileName, Version: 1,
+			})
+			if err != nil {
+				t.Fatalf("GetArtifactVersion(v1) failed: %v", err)
+			}
+			wantFirst := &artifact.ArtifactVersion{
+				Version:        1,
+				CanonicalURI:   tc.uriPrefix + "1",
+				CustomMetadata: map[string]any{"key": "value", "count": 42, "enabled": true},
+				CreateTime:     firstCreateTime,
+				MimeType:       "image/png",
+			}
+			if diff := cmp.Diff(wantFirst, first.ArtifactVersion); diff != "" {
+				t.Errorf("GetArtifactVersion(v1) mismatch (-want +got):\n%s", diff)
+			}
+
+			first.ArtifactVersion.CustomMetadata["key"] = "changed after read"
+			again, err := srv.GetArtifactVersion(readCtx, &artifact.GetArtifactVersionRequest{
+				AppName: "app", UserID: "user", SessionID: tc.getSessionID, FileName: tc.fileName, Version: 1,
+			})
+			if err != nil {
+				t.Fatalf("second GetArtifactVersion(v1) failed: %v", err)
+			}
+			if diff := cmp.Diff(wantFirst, again.ArtifactVersion); diff != "" {
+				t.Errorf("second GetArtifactVersion(v1) mismatch (-want +got):\n%s", diff)
+			}
+		})
+	}
 }

--- a/artifact/service.go
+++ b/artifact/service.go
@@ -64,6 +64,13 @@ type SaveRequest struct {
 
 	// Below are optional fields.
 
+	// CustomMetadata contains caller-defined metadata persisted with the artifact.
+	// Backends with string-only metadata, including GCS, store each value using
+	// its string representation and return it as a string.
+	// The in-memory service shallow-copies the map on save and read; mutable
+	// values stored in it remain shared and must not be mutated after Save.
+	CustomMetadata map[string]any
+
 	// If set, the artifact will be saved with this version.
 	// If unset, a new version will be created.
 	Version int64
@@ -267,6 +274,9 @@ type VersionsResponse struct {
 }
 
 // ArtifactVersion contains metadata describing a specific version of an artifact.
+// Every Service implementation populates all five fields. CustomMetadata is
+// non-nil and empty when no custom metadata was saved. MimeType is the media
+// type recorded when the version was saved.
 type ArtifactVersion struct {
 	Version        int64
 	CanonicalURI   string

--- a/internal/artifact/tests/service_suite.go
+++ b/internal/artifact/tests/service_suite.go
@@ -233,26 +233,28 @@ func testArtifactService_UserScoped(ctx context.Context, t *testing.T, srv artif
 
 	// Save these artifacts for later subtests.
 	testData := []struct {
-		fileName string
-		version  int64
-		artifact *genai.Part
+		fileName  string
+		sessionID string
+		version   int64
+		artifact  *genai.Part
+		metadata  map[string]any
 	}{
 		// file1.
-		{"user:file1", 1, genai.NewPartFromBytes([]byte("file v1"), "text/plain")},
-		{"user:file1", 2, genai.NewPartFromBytes([]byte("file v2"), "text/plain")},
-		{"user:file1", 3, genai.NewPartFromBytes([]byte("file v3"), "text/plain")},
+		{"user:file1", "save-session-1", 1, genai.NewPartFromBytes([]byte("file v1"), "text/plain"), map[string]any{"version": "v1"}},
+		{"user:file1", "save-session-2", 2, genai.NewPartFromBytes([]byte("file v2"), "text/plain"), map[string]any{"version": "v2"}},
+		{"user:file1", "save-session-3", 3, genai.NewPartFromBytes([]byte("file v3"), "text/plain"), map[string]any{"version": "v3"}},
 		// file2.
-		{"file2", 1, genai.NewPartFromBytes([]byte("file v3"), "text/plain")},
+		{"file2", sessionID, 1, genai.NewPartFromBytes([]byte("file v3"), "text/plain"), nil},
 		// file3.
-		{"user:file3", 1, genai.NewPartFromText("file v1")},
+		{"user:file3", "another-save-session", 1, genai.NewPartFromText("file v1"), nil},
 	}
 
 	t.Log("Save file1 and file2")
 	for i, data := range testData {
 		wantVersion := data.version
 		got, err := srv.Save(ctx, &artifact.SaveRequest{
-			AppName: appName, UserID: userID, SessionID: sessionID, FileName: data.fileName,
-			Part: data.artifact,
+			AppName: appName, UserID: userID, SessionID: data.sessionID, FileName: data.fileName,
+			Part: data.artifact, CustomMetadata: data.metadata,
 		})
 		if err != nil || got.Version != wantVersion {
 			t.Errorf("[%d] Save() = (%v, %v), want (%v, nil)", i, got.Version, err, wantVersion)
@@ -310,6 +312,29 @@ func testArtifactService_UserScoped(ctx context.Context, t *testing.T, srv artif
 		}
 	})
 
+	t.Run(fmt.Sprintf("GetArtifactVersion_%s", testSuffix), func(t *testing.T) {
+		for _, tc := range []struct {
+			name         string
+			version      int64
+			wantVersion  int64
+			wantMetadata map[string]any
+		}{
+			{name: "latest", wantVersion: 3, wantMetadata: map[string]any{"version": "v3"}},
+			{name: "specific", version: 2, wantVersion: 2, wantMetadata: map[string]any{"version": "v2"}},
+		} {
+			t.Run(tc.name, func(t *testing.T) {
+				resp, err := srv.GetArtifactVersion(ctx, &artifact.GetArtifactVersionRequest{
+					AppName: appName, UserID: userID, SessionID: "'user' should be used instead", FileName: "user:file1",
+					Version: tc.version,
+				})
+				if err != nil {
+					t.Fatalf("GetArtifactVersion(%d) failed: %v", tc.version, err)
+				}
+				assertArtifactVersion(t, resp.ArtifactVersion, tc.wantVersion, "text/plain", tc.wantMetadata)
+			})
+		}
+	})
+
 	t.Log("Delete user:file1 version 3")
 	if err := srv.Delete(ctx, &artifact.DeleteRequest{
 		AppName: appName, UserID: userID, SessionID: sessionID, FileName: "user:file1",
@@ -317,6 +342,15 @@ func testArtifactService_UserScoped(ctx context.Context, t *testing.T, srv artif
 	}); err != nil {
 		t.Fatalf("Delete(user:file1@v3) failed: %v", err)
 	}
+	t.Run(fmt.Sprintf("GetArtifactVersionAfterDeleteLatest_%s", testSuffix), func(t *testing.T) {
+		resp, err := srv.GetArtifactVersion(ctx, &artifact.GetArtifactVersionRequest{
+			AppName: appName, UserID: userID, SessionID: "another-read-session", FileName: "user:file1",
+		})
+		if err != nil {
+			t.Fatalf("GetArtifactVersion() failed: %v", err)
+		}
+		assertArtifactVersion(t, resp.ArtifactVersion, 2, "text/plain", map[string]any{"version": "v2"})
+	})
 
 	t.Run(fmt.Sprintf("LoadAfterDeleteVersion3_%s", testSuffix), func(t *testing.T) {
 		resp, err := srv.Load(ctx, &artifact.LoadRequest{
@@ -433,15 +467,18 @@ func testArtifactService_GetArtifactVersion(ctx context.Context, t *testing.T, s
 	sessionID := "testsession"
 	fileName := "verfile"
 
-	for i, data := range []*genai.Part{
-		genai.NewPartFromBytes([]byte("v1"), "text/plain"),
-		genai.NewPartFromBytes([]byte("v2"), "text/plain"),
-		genai.NewPartFromBytes([]byte("v3"), "text/plain"),
+	for i, data := range []struct {
+		part     *genai.Part
+		metadata map[string]any
+	}{
+		{genai.NewPartFromBytes([]byte("v1"), "text/plain"), nil},
+		{genai.NewPartFromBytes([]byte("v2"), "image/png"), map[string]any{"version": "v2"}},
+		{genai.NewPartFromText("v3"), map[string]any{"version": "v3"}},
 	} {
 		wantVersion := int64(i + 1)
 		got, err := srv.Save(ctx, &artifact.SaveRequest{
 			AppName: appName, UserID: userID, SessionID: sessionID, FileName: fileName,
-			Part: data,
+			Part: data.part, CustomMetadata: data.metadata,
 		})
 		if err != nil || got.Version != wantVersion {
 			t.Fatalf("[%d] Save() = (%v, %v), want (%v, nil)", i, got.Version, err, wantVersion)
@@ -449,12 +486,15 @@ func testArtifactService_GetArtifactVersion(ctx context.Context, t *testing.T, s
 	}
 
 	for _, tc := range []struct {
-		name        string
-		version     int64
-		wantVersion int64
+		name         string
+		version      int64
+		wantVersion  int64
+		wantMimeType string
+		wantMetadata map[string]any
 	}{
-		{name: "latest", wantVersion: 3},
-		{name: "specific", version: 2, wantVersion: 2},
+		{name: "latest", wantVersion: 3, wantMimeType: "text/plain", wantMetadata: map[string]any{"version": "v3"}},
+		{name: "specific", version: 2, wantVersion: 2, wantMimeType: "image/png", wantMetadata: map[string]any{"version": "v2"}},
+		{name: "empty metadata", version: 1, wantVersion: 1, wantMimeType: "text/plain", wantMetadata: map[string]any{}},
 	} {
 		t.Run(fmt.Sprintf("GetArtifactVersion_%s_%s", tc.name, testSuffix), func(t *testing.T) {
 			resp, err := srv.GetArtifactVersion(ctx, &artifact.GetArtifactVersionRequest{
@@ -463,12 +503,7 @@ func testArtifactService_GetArtifactVersion(ctx context.Context, t *testing.T, s
 			if err != nil {
 				t.Fatalf("GetArtifactVersion(%d) failed: %v", tc.version, err)
 			}
-			if got := resp.ArtifactVersion.Version; got != tc.wantVersion {
-				t.Errorf("GetArtifactVersion(%d).Version = %d, want %d", tc.version, got, tc.wantVersion)
-			}
-			if got := resp.ArtifactVersion.MimeType; got != "text/plain" {
-				t.Errorf("GetArtifactVersion(%d).MimeType = %q, want %q", tc.version, got, "text/plain")
-			}
+			assertArtifactVersion(t, resp.ArtifactVersion, tc.wantVersion, tc.wantMimeType, tc.wantMetadata)
 		})
 	}
 
@@ -490,6 +525,21 @@ func testArtifactService_GetArtifactVersion(ctx context.Context, t *testing.T, s
 	})
 
 	if err := srv.Delete(ctx, &artifact.DeleteRequest{
+		AppName: appName, UserID: userID, SessionID: sessionID, FileName: fileName, Version: 3,
+	}); err != nil {
+		t.Fatalf("Delete(%s@v3) failed: %v", fileName, err)
+	}
+	t.Run(fmt.Sprintf("GetArtifactVersionAfterDeleteLatest_%s", testSuffix), func(t *testing.T) {
+		resp, err := srv.GetArtifactVersion(ctx, &artifact.GetArtifactVersionRequest{
+			AppName: appName, UserID: userID, SessionID: sessionID, FileName: fileName,
+		})
+		if err != nil {
+			t.Fatalf("GetArtifactVersion() failed: %v", err)
+		}
+		assertArtifactVersion(t, resp.ArtifactVersion, 2, "image/png", map[string]any{"version": "v2"})
+	})
+
+	if err := srv.Delete(ctx, &artifact.DeleteRequest{
 		AppName: appName, UserID: userID, SessionID: sessionID, FileName: fileName,
 	}); err != nil {
 		t.Fatalf("Delete(%s) failed: %v", fileName, err)
@@ -502,4 +552,26 @@ func testArtifactService_GetArtifactVersion(ctx context.Context, t *testing.T, s
 			t.Fatalf("GetArtifactVersion() = (%v, %v), want error(%v)", got, err, fs.ErrNotExist)
 		}
 	})
+}
+
+func assertArtifactVersion(t *testing.T, got *artifact.ArtifactVersion, wantVersion int64, wantMimeType string, wantMetadata map[string]any) {
+	t.Helper()
+	if got == nil {
+		t.Fatal("GetArtifactVersion().ArtifactVersion = nil, want non-nil")
+	}
+	if got.Version != wantVersion {
+		t.Errorf("ArtifactVersion.Version = %d, want %d", got.Version, wantVersion)
+	}
+	if got.MimeType != wantMimeType {
+		t.Errorf("ArtifactVersion.MimeType = %q, want %q", got.MimeType, wantMimeType)
+	}
+	if diff := cmp.Diff(wantMetadata, got.CustomMetadata); diff != "" {
+		t.Errorf("ArtifactVersion.CustomMetadata mismatch (-want +got):\n%s", diff)
+	}
+	if got.CanonicalURI == "" {
+		t.Error("ArtifactVersion.CanonicalURI is empty")
+	}
+	if got.CreateTime.IsZero() {
+		t.Error("ArtifactVersion.CreateTime is zero")
+	}
 }


### PR DESCRIPTION
## Summary
- Add `SaveRequest.CustomMetadata` (string-form round-trip on GCS; shallow-copied in-memory) so custom metadata can be persisted.
- Populate all five `ArtifactVersion` fields in both backends (`Version`, `MimeType`, `CanonicalURI`, `CreateTime`, `CustomMetadata`).
- Extend the shared contract suite for `GetArtifactVersion`: assert all five fields, cover `user:`-prefixed filenames, and re-resolve after deleting only the latest version. Add per-backend exact URI/`CreateTime` tests with a stubbed clock.

## Testing plan
- `go test ./artifact/ ./artifact/gcsartifact/ ./internal/artifact/tests/ -count=1` (passed locally)

Fixes #681