### PR TITLE
fix(auth): keep the consent URI out of ConsentRequiredError's message

### DIFF
--- a/auth/gcp/client_test.go
+++ b/auth/gcp/client_test.go
@@ -173,8 +173,11 @@ func TestRetrieveCredential(t *testing.T) {
 				if !errors.As(err, &consent) {
 					t.Fatalf("error = %v, want *auth.ConsentRequiredError", err)
 				}
+				// Print the fields, not consent: %v on a *ConsentRequiredError
+				// goes through Error(), which reports neither of them.
 				if consent.AuthURI != tc.wantConsent[0] || consent.Nonce != tc.wantConsent[1] {
-					t.Errorf("consent = %+v, want {authURI:%q nonce:%q}", consent, tc.wantConsent[0], tc.wantConsent[1])
+					t.Errorf("consent = {authURI:%q nonce:%q}, want {authURI:%q nonce:%q}",
+						consent.AuthURI, consent.Nonce, tc.wantConsent[0], tc.wantConsent[1])
 				}
 			case tc.wantErrIs != nil:
 				if !errors.Is(err, tc.wantErrIs) {

--- a/auth/providers.go
+++ b/auth/providers.go
@@ -56,16 +56,28 @@ func (f ProviderFunc) Credential(ctx context.Context) (Credential, error) {
 // before a credential can be issued. Consumers detect it with errors.As.
 type ConsentRequiredError struct {
 	// AuthURI is the URL the end user must visit to grant consent.
+	//
+	// Hand it to that user and to nobody else. It is built by the credentials
+	// service, and a 3-legged authorization URI normally carries the acting user
+	// in a login_hint parameter, so it is not redacted the way service text in
+	// other errors is — the identifier in it is what makes the URL work. Do not
+	// log it, do not put it in a span, and do not serialize this error: every
+	// field is exported, so a json.Marshal of it publishes the URI whatever
+	// Error() says.
 	AuthURI string
 	// Nonce is an opaque value echoed back to correlate the consent response.
+	// Sensitive on the same terms as AuthURI, which embeds it.
 	Nonce string
 	// Key is the credential-store key to resume the flow under.
 	Key string
 }
 
-// Error implements error.
+// Error implements error. It deliberately omits AuthURI: this error becomes a
+// tool's error, which is fed to the model and persisted in the session, and the
+// consent URI carries the state and nonce that bind the credential. Consumers
+// read it off the field.
 func (e *ConsentRequiredError) Error() string {
-	return fmt.Sprintf("auth: interactive consent required (auth_uri=%q)", e.AuthURI)
+	return "auth: interactive consent required"
 }
 
 // StaticToken returns a provider that always yields the given bearer token.

--- a/auth/providers_test.go
+++ b/auth/providers_test.go
@@ -110,8 +110,16 @@ func TestConsentRequiredError(t *testing.T) {
 	if consent.AuthURI != "https://consent.example" {
 		t.Errorf("AuthURI = %q, want %q", consent.AuthURI, "https://consent.example")
 	}
-	if !strings.Contains(err.Error(), "consent.example") {
-		t.Errorf("Error() = %q, want it to mention the auth URI", err.Error())
+	// The message must not carry the URI: it becomes a tool's error, which reaches
+	// the model and the session store, and the URI carries the state and nonce
+	// that bind the credential. Asserted exactly, not just by absence of the URI —
+	// the message has no branches, so a negative check passes for an empty string
+	// too, and this is the only assertion on Error() anywhere.
+	if got, want := consent.Error(), "auth: interactive consent required"; got != want {
+		t.Errorf("Error() = %q, want %q", got, want)
+	}
+	if strings.Contains(err.Error(), "consent.example") {
+		t.Errorf("Error() = %q, want the auth URI kept on the field only", err.Error())
 	}
 }
 

--- a/auth/transport_test.go
+++ b/auth/transport_test.go
@@ -77,6 +77,12 @@ func TestTransportConsentRequiredPropagates(t *testing.T) {
 	if base.called {
 		t.Error("base transport must not be called when consent is required")
 	}
+	// The wrap builds a new message, so keeping the URI out of Error() is not
+	// enough on its own. Asserted exactly rather than by absence of the URI: a
+	// negative check would go vacuous the moment the fixture above changes.
+	if got, want := err.Error(), "auth: resolve credential: auth: interactive consent required"; got != want {
+		t.Errorf("RoundTrip() error = %q, want %q", got, want)
+	}
 }
 
 func TestTransportNilProvider(t *testing.T) {


### PR DESCRIPTION
## Problem

A `*ConsentRequiredError` becomes a tool's error, which is fed back to the model and persisted as a session event. Its message carried `AuthURI`, and that URI carries the `state` and the consent nonce that bind the credential. A 3-legged authorization URI also normally carries the acting user in a `login_hint` parameter, so the message published an end-user identifier as well.

## Summary

`Error()` no longer prints the URI. It stays on the `AuthURI` field, which is how consumers already read it — the only assertion on the message text anywhere in the tree was the one updated here.

`AuthURI` and `Nonce` now say on the field that they go to the acting user and nowhere else: not a log, not a span, and not through `json.Marshal`, which publishes them whatever `Error()` returns. `AuthURI` is deliberately not redacted the way service text is in other errors, because the identifier in it is what makes the URL work.

`apidiff` reports the change as additive, since no signature moved and the message text is not part of what it compares.

---

First of a five-part split of #1173. Nothing is stacked below this one.
