### PR TITLE
feat(agent): recover the invocation identity from a plain context

### DIFF
--- a/agent/agent.go
+++ b/agent/agent.go
@@ -24,6 +24,7 @@ import (
 	"google.golang.org/genai"
 
 	"google.golang.org/adk/v2/artifact"
+	"google.golang.org/adk/v2/internal/adkcontext"
 	agentinternal "google.golang.org/adk/v2/internal/agent"
 	"google.golang.org/adk/v2/internal/plugininternal/plugincontext"
 	"google.golang.org/adk/v2/internal/telemetry"
@@ -375,6 +376,7 @@ func runAfterAgentCallbacks(ctx InvocationContext) (*session.Event, error) {
 
 type invocationContext struct {
 	context.Context
+	adkcontext.Marker
 
 	agent     Agent
 	artifacts Artifacts
@@ -427,6 +429,26 @@ func (c *invocationContext) Memory() Memory {
 
 func (c *invocationContext) Session() session.Session {
 	return c.session
+}
+
+// Value implements context.Context, answering the ADK identity key like every
+// other invocation context so a promoted copy and this one cannot disagree. It
+// owns its session, so no session means no identity — never the enclosing
+// invocation's, whose user made no such call.
+func (c *invocationContext) Value(key any) any {
+	if c == nil {
+		return nil
+	}
+	if key == adkcontext.IdentityKey {
+		if id, ok := identityOf(func() session.Session { return c.session }); ok {
+			return id
+		}
+		return nil
+	}
+	if c.Context == nil {
+		return nil
+	}
+	return c.Context.Value(key)
 }
 
 func (c *invocationContext) InvocationID() string {

--- a/agent/callback_context_wrapper.go
+++ b/agent/callback_context_wrapper.go
@@ -22,6 +22,7 @@ import (
 
 	"google.golang.org/genai"
 
+	"google.golang.org/adk/v2/internal/adkcontext"
 	"google.golang.org/adk/v2/memory"
 	"google.golang.org/adk/v2/session"
 	"google.golang.org/adk/v2/tool/toolconfirmation"
@@ -30,6 +31,7 @@ import (
 // callbackContextWrapper is used to emit log entries for unexpected calls - those
 // related to tool-context methods when an agent.Context is used as a callback context.
 type callbackContextWrapper struct {
+	adkcontext.Marker
 	context Context
 }
 
@@ -255,6 +257,12 @@ func (c *callbackContextWrapper) UserID() string {
 
 // Value implements [Context].
 func (c *callbackContextWrapper) Value(key any) any {
+	// Fails closed rather than dereferencing: this is reached from
+	// http.RoundTripper on the caller's goroutine, where net/http does not
+	// recover, and a hand-built wrapper can hold neither.
+	if c == nil || c.context == nil {
+		return nil
+	}
 	return c.context.Value(key)
 }
 

--- a/agent/common_context.go
+++ b/agent/common_context.go
@@ -23,11 +23,188 @@ import (
 	"google.golang.org/genai"
 
 	"google.golang.org/adk/v2/artifact"
+	"google.golang.org/adk/v2/internal/adkcontext"
 	"google.golang.org/adk/v2/memory"
 	"google.golang.org/adk/v2/platform"
 	"google.golang.org/adk/v2/session"
 	"google.golang.org/adk/v2/tool/toolconfirmation"
 )
+
+// Identity is an ADK invocation's identity: the acting user, app name, and
+// session a call belongs to. It is recovered from a plain context.Context via
+// [IdentityFromContext], which reads it off the live session each time rather
+// than caching it.
+//
+// Reading it live is not licence to mutate the session from elsewhere. The
+// lookup runs on whatever goroutine asks — inside an http.RoundTripper, that is
+// the caller's — while [session.Session] states no goroutine-safety requirement
+// on ID, AppName and UserID. A session that rewrites those three after the
+// invocation starts must be safe for concurrent reads, or the credential path
+// races it. ADK's own sessions fix all three at construction.
+type Identity struct {
+	// UserID is the acting end user, as the embedding server put it on the
+	// session. ADK does not authenticate it: anything acting on behalf of this
+	// user — minting a per-user credential, for instance — is trusting the server
+	// to have bound session.UserID to an authenticated principal. ADK's own REST
+	// server takes it from the request body.
+	UserID string
+	// AppName is the app the invocation belongs to.
+	AppName string
+	// SessionID identifies the conversation the invocation belongs to.
+	SessionID string
+}
+
+// identityOf reads an invocation identity from the session getSession returns.
+// It is the one place package agent turns a session into an [Identity], so every
+// context type here answers the identity key the same way.
+//
+// getSession is called inside the recover, not before it: Session() is itself a
+// method on caller-supplied code and can panic on its own.
+func identityOf(getSession func() session.Session) (Identity, bool) {
+	return adkcontext.Recovered(func() Identity {
+		// One Session value, then one call per field: re-reading Session() per
+		// field risks a torn identity, and some context wrappers log on every read.
+		s := getSession()
+		return Identity{UserID: s.UserID(), AppName: s.AppName(), SessionID: s.ID()}
+	})
+}
+
+// IdentityFromContext returns the ADK invocation [Identity] carried by ctx, if
+// present.
+//
+// ADK contexts embed context.Context and register their identity under a private
+// key, so code that only holds a context.Context — for example an
+// http.RoundTripper running deep beneath a tool call, past intermediaries that
+// wrap the context — can recover the acting identity without threading a typed
+// context through every layer.
+//
+// It returns (zero, false) both for a context that does not descend from an ADK
+// context and for an invocation with no readable session. The two are not
+// distinguishable here. ok does not imply a populated Identity either: an
+// invocation whose session carries no user yields an empty UserID, so a caller
+// that needs one must check.
+//
+// An invocation ADK itself built always reports its own user, however a context
+// is derived from it. An [InvocationContext] implemented OUTSIDE the module is
+// where that stops, and one rule covers every way it does.
+//
+// Such a type is a decorator over the invocation it embeds, and Go promotes
+// every method it does not override. Every method on [InvocationContext] and
+// [Context] that RETURNS one of them returns the receiver's own derived copy, so
+// a promoted one hands back the EMBEDDED invocation and the decorator is gone —
+// its session with it. That is not confined to the identity: Session, UserID and
+// AppName then report the enclosing invocation too.
+//
+// Promotion also reaches what a method HANDS BACK, which matters most where the
+// thing handed back carries a user. A decorator that overrides Session but not
+// [Context.Artifacts], [Context.Memory] or [Context.SearchMemory] gets handles
+// built for the enclosing invocation, and those carry AppName, UserID and
+// SessionID as the storage and search keys — SearchMemory by way of the Memory
+// handle it reaches through. So such a context can answer this function with its
+// own user while reading and writing the ENCLOSING user's artifacts and
+// memories.
+//
+// [Context.State], [ReadonlyContext.ReadonlyState] and [Context.Actions] are the
+// same shape by a different route: each resolves through the invocation the
+// context holds rather than through Session, so a promoted one reads and writes
+// the enclosing user's session state, and a promoted Actions accumulates into
+// the event actions that commit to that user's session. Override all six, or
+// accept that only the credential follows the decorator. That behaviour predates
+// the identity key and is unchanged by it — Session, UserID and AppName have
+// always reported the enclosing invocation on the same shape — but a decorator
+// author reading this rule needs to know the credential is not the only thing
+// scoped to a user.
+//
+// So an invocation written outside the module reports its own user only where it
+// answers for itself:
+//
+//   - Derive it — [Promote], [NewContext], [NewToolContext], [NewCallbackContext],
+//     [NewCallbackContextWithArtifactTracking], a readonly context — and the
+//     derived context reports its user, or none at all if it has no readable
+//     session.
+//
+//     Passing it *as the context itself* is different, and what happens depends
+//     on what its own Value does. Leave Value alone and its parent answers, so
+//     the enclosing invocation is reported: the key is unnameable outside the
+//     module, so the decorator cannot claim it. Implement Value and there are two
+//     cases. Answer with something that is not an [Identity] and nothing is
+//     reported. Answer with an [Identity] — built directly, or taken from the
+//     parent's answer and substituted — and that is what this function reports.
+//     Naming the key is required for neither.
+//
+//     Nor is the key itself out of reach, which is worth being exact about
+//     because the internal package's own doc once claimed otherwise. Its TYPE is
+//     unnameable outside the module, but this function hands the key VALUE to
+//     whatever Value implementation ctx provides, so a single call is enough for
+//     that implementation to keep it and later plant an [Identity] under it with
+//     context.WithValue — from a context descending from no invocation at all,
+//     on another goroutine, after the call it observed has ended.
+//
+//     So: this function establishes which invocation a context was DERIVED from,
+//     and it is exactly as trustworthy as every wrapper between it and that
+//     invocation. It is not an authentication boundary and cannot be made into
+//     one — any in-process code that can wrap a context can already lie about
+//     Session and UserID, and a caller needing a guarantee against in-process
+//     code needs a different mechanism.
+//
+//   - Call a context-producing method ON it and it is dropped, promoting or not,
+//     because the promoted method belongs to what it embeds. It must override
+//     every one of them, returning a derived copy of ITSELF. The rule is the
+//     return type, not the list: as of writing that is
+//     [InvocationContext.WithContext] and [InvocationContext.WithICDelta] on
+//     [InvocationContext], plus [Context.WithDelta], [Context.WithAgentContext],
+//     [Context.WithAgentTimeout] and [Context.WithAgentCancel] on [Context].
+//     There is no exception here: a direct call drops it whatever the delta
+//     says, including one carrying no [InvocationContextDelta] at all, because
+//     the promoted method never reaches the decorator to consult the delta.
+//
+//   - Promoting it first shelters it from three of those four. [Promote] holds
+//     the decorator in a commonContext, and WithAgentContext, WithAgentTimeout
+//     and WithAgentCancel re-parent only the context.Context above it, so the
+//     decorator still answers. WithDelta is the exception: it forwards to the
+//     held invocation's WithICDelta, so it drops the decorator through the
+//     promotion, exactly as [PromoteWithDelta] does. Both reach WithICDelta and
+//     neither reaches WithDelta, so overriding WithICDelta alone is enough for
+//     them — it is a direct call on the decorator that WithDelta must also cover.
+//     This is the one place a delta carrying no [InvocationContextDelta] is
+//     genuinely safe: held inside a commonContext, such a delta leaves the
+//     invocation untouched. Held is the operative word, and it is why the
+//     exception belongs here and not above.
+//
+// Two further things a decorator cannot fix by overriding the methods above:
+//
+//   - [Context.WithContext], and [Context.WithAgentContext] it delegates to,
+//     rebind the invocation when handed an [InvocationContext] rather than a
+//     plain context.Context. The result then reports the ARGUMENT's user, by
+//     design and whoever the receiver spoke for. It is the one derivation that
+//     legitimately changes who a context speaks for, so do not hand it another
+//     call's invocation. How MUCH it rebinds then depends on whether the
+//     receiver cached an artifacts handle. Over an invocation that has an
+//     artifact service, a tool or tracking callback context caches one and
+//     carries it across untouched, so the result answers for the argument while
+//     Artifacts() still addresses the receiver's user — the same split as the
+//     promotion case above, reached the other way round. Over an invocation with
+//     none, nothing is cached, Artifacts() falls through to the invocation, and
+//     the rebind takes that with it. Both are pinned, because the second only
+//     became possible when the constructors started returning a nil handle
+//     rather than a wrapper around one.
+//   - [Context.SubScheduler] returns a scheduler, not a context, so the
+//     return-type rule above does not reach it — but the scheduler captured the
+//     context it was built from and derives every child from that. A decorator
+//     that does not override it hands back the embedded context's scheduler, and
+//     workflow.RunNode asks for one on entry, so the whole child subtree then
+//     runs as the enclosing invocation. Overriding SubScheduler does not repair
+//     it, because [DynamicSubScheduler.RunNode] takes no context and the one the
+//     scheduler captured is unexported — so the override has nothing to rebind.
+//     Closing it means changing the workflow engine, not this package.
+//
+// None of this is avoidable by discipline alone — [agent.Run] applies a delta on
+// every run, and the workflow schedulers call WithAgentCancel and
+// WithAgentTimeout on the context a node was handed.
+func IdentityFromContext(ctx context.Context) (Identity, bool) {
+	id, ok := ctx.Value(adkcontext.IdentityKey).(Identity)
+	return id, ok
+}
 
 // In general CommonContext should not be wrapped with contexts not providing agent.Context.
 // It allows to copy&modify context instead of building chains.
@@ -159,6 +336,7 @@ func prepareEventActions(actions *session.EventActions) *session.EventActions {
 // Callbacks and Tools
 type commonContext struct {
 	context.Context
+	adkcontext.Marker
 	invocationContext InvocationContext
 	artifacts         Artifacts
 	actions           *session.EventActions
@@ -344,10 +522,102 @@ func (c *commonContext) UserID() string {
 	return c.invocationContext.Session().UserID()
 }
 
+// Value implements context.Context. For the ADK identity key it returns the
+// [Identity] of the invocation this context speaks for (so [IdentityFromContext]
+// can recover it from a derived context). Every other key delegates to the
+// embedded context, preserving existing behavior.
+//
+// Only the identity key touches the invocation, so no other key is affected by
+// its state, and a session that panics costs the identity, not the process.
+func (c *commonContext) Value(key any) any {
+	if c == nil {
+		return nil
+	}
+	if key == adkcontext.IdentityKey {
+		return c.identity()
+	}
+	if c.Context == nil {
+		return nil
+	}
+	return c.Context.Value(key)
+}
+
+// identity answers the ADK identity key, as an any so it can report "none".
+//
+// A commonContext owns no session, so it speaks for the invocation it wraps, and
+// how it asks depends on whether that invocation is one of the module's own
+// context types.
+//
+// One of ours is asked, and answers for itself. That is what keeps a tool or
+// callback context working: theirs hold no session by design and hand the
+// question down to the invocation underneath.
+//
+// Anything else is read, never asked. An InvocationContext written outside the
+// module embeds the context it was derived from, to inherit cancellation, and
+// cannot override a key it cannot name — so its Value answers with the
+// *enclosing* invocation's identity, a live user who made no such call. Only its
+// own session counts, and a session it cannot produce costs the identity rather
+// than inheriting one. That covers a nil session as well as a broken one: a nil
+// interface is indistinguishable from the session-less view a tool context is,
+// so for a type we do not control the two must fail the same way.
+func (c *commonContext) identity() any {
+	if c.invocationContext == nil {
+		// Speaking for no invocation, it has no acting user of its own, and the
+		// parent it would otherwise pass through to is a different call. No
+		// constructor in this package produces this shape — every one sets the
+		// invocation — so failing closed costs nothing and keeps one rule for the
+		// whole procedure.
+		return nil
+	}
+	if _, ours := c.invocationContext.(adkcontext.Source); ours {
+		return identityFrom(c.invocationContext)
+	}
+	// Method value and call both inside the recover: Session() is caller-supplied
+	// code and invocationContext can be a typed-nil pointer.
+	if id, ok := identityOf(func() session.Session { return c.invocationContext.Session() }); ok {
+		return id
+	}
+	return nil
+}
+
+// identityFrom asks src for the identity key and keeps the answer only if it is
+// an [Identity].
+//
+// Type-asserted rather than merely checked against nil, so a context answering
+// every key does not put a non-Identity under the identity key. That much is
+// defence in depth and not load-bearing on its own: [IdentityFromContext]
+// asserts again, so dropping this one changes what Value returns and not what
+// any caller can observe. Removing it does not fail any test, deliberately —
+// the tests pin the contract, which is that the reader gets nothing.
+//
+// Recovered is load-bearing, and is pinned: src can be a typed-nil pointer or a
+// wrapper holding one, and this runs inside http.RoundTripper on the caller's
+// goroutine, where net/http does not recover.
+func identityFrom(src interface{ Value(any) any }) any {
+	v, _ := adkcontext.Recovered(func() any { return src.Value(adkcontext.IdentityKey) })
+	if id, ok := v.(Identity); ok {
+		return id
+	}
+	return nil
+}
+
 var (
 	_ Context           = (*commonContext)(nil)
 	_ InvocationContext = (*commonContext)(nil)
 	_ ReadonlyContext   = (*commonContext)(nil)
+)
+
+// Every context type in this package that answers the identity key for the
+// invocation it speaks for, asserted rather than left to the [adkcontext.Marker]
+// embed. A type whose only other use of that package is the embed loses the
+// import along with it, so removing it breaks the build for an unrelated reason
+// and reads like a guard while guarding nothing. These fail on the type, which
+// is what was meant.
+var (
+	_ adkcontext.Source = (*commonContext)(nil)
+	_ adkcontext.Source = (*invocationContext)(nil)
+	_ adkcontext.Source = (*toolContextWrapper)(nil)
+	_ adkcontext.Source = (*callbackContextWrapper)(nil)
 )
 
 // --- Tool-context extensions ----------------------------------------------

--- a/agent/common_context_delta.go
+++ b/agent/common_context_delta.go
@@ -16,6 +16,7 @@ package agent
 
 import (
 	"context"
+	"log"
 
 	"google.golang.org/genai"
 )
@@ -46,7 +47,7 @@ func (c *commonContext) WithDelta(d *CommonContextDelta) Context {
 		return c
 	}
 	res := *c
-	res.invocationContext = res.invocationContext.WithICDelta(d.InvocationContextDelta)
+	res.invocationContext = withICDelta(res.invocationContext, d.InvocationContextDelta)
 
 	if d.InvocationContextDelta != nil {
 		if d.InvocationContextDelta.Context != nil {
@@ -78,6 +79,34 @@ func (c *commonContext) WithICDelta(d *InvocationContextDelta) InvocationContext
 		return c
 	}
 	res := *c
-	res.invocationContext = res.invocationContext.WithICDelta(d)
+	res.invocationContext = withICDelta(res.invocationContext, d)
 	return &res
+}
+
+// withICDelta applies d to the invocation this context speaks for, and refuses a
+// nil result.
+//
+// An InvocationContext is free to return nil from WithICDelta, and a partial
+// implementation does: ADK's own ContextMock returns nil from WithContext,
+// WithBranch and WithAgentContext, so the shape is not exotic. Storing that nil
+// leaves a commonContext whose invocation is gone, and most of its accessors —
+// Agent, Branch, Session, UserID among them — dereference it. On the workflow
+// path the scheduler catches the panic and reports it as "node %q panicked",
+// naming the node rather than the cause.
+//
+// Keeping the previous invocation is the better of the two, but it is not free:
+// the delta is gone, so the caller runs on with the previous Agent, Branch and
+// IsolationScope. Nothing else distinguishes that from the delta having been
+// applied, so it is logged. An agent running under the wrong parent is not a
+// quiet kind of wrong.
+func withICDelta(ic InvocationContext, d *InvocationContextDelta) InvocationContext {
+	if ic == nil {
+		return nil
+	}
+	if next := ic.WithICDelta(d); next != nil {
+		return next
+	}
+	log.Printf("agent: %T.WithICDelta returned nil; keeping the previous invocation and "+
+		"discarding the delta, so Agent, Branch and IsolationScope are unchanged", ic)
+	return ic
 }

--- a/agent/common_context_delta.go
+++ b/agent/common_context_delta.go
@@ -19,6 +19,8 @@ import (
 	"log"
 
 	"google.golang.org/genai"
+
+	"google.golang.org/adk/v2/internal/adkcontext"
 )
 
 // CommonContextDelta holds all the changes which should be applied to a new child context based on agent.Context.
@@ -83,30 +85,72 @@ func (c *commonContext) WithICDelta(d *InvocationContextDelta) InvocationContext
 	return &res
 }
 
-// withICDelta applies d to the invocation this context speaks for, and refuses a
-// nil result.
+// withICDelta applies d to the invocation this context speaks for.
 //
-// An InvocationContext is free to return nil from WithICDelta, and a partial
-// implementation does: ADK's own ContextMock returns nil from WithContext,
-// WithBranch and WithAgentContext, so the shape is not exotic. Storing that nil
-// leaves a commonContext whose invocation is gone, and most of its accessors —
-// Agent, Branch, Session, UserID among them — dereference it. On the workflow
-// path the scheduler catches the panic and reports it as "node %q panicked",
-// naming the node rather than the cause.
+// It refuses only a nil result, keeping the original invocation instead. That
+// guard protects the whole [Context] surface rather than the identity in
+// particular: a nil invocation dereferences in most of the accessors on
+// commonContext. The identity itself already fails closed for that shape —
+// commonContext.identity reports nothing when it has no invocation, rather than
+// asking its parent — so this is not what stands between a caller and the
+// enclosing call's user.
 //
-// Keeping the previous invocation is the better of the two, but it is not free:
-// the delta is gone, so the caller runs on with the previous Agent, Branch and
-// IsolationScope. Nothing else distinguishes that from the delta having been
-// applied, so it is logged. An agent running under the wrong parent is not a
-// quiet kind of wrong.
+// It does NOT try to detect the larger problem, which is that an
+// InvocationContext written outside the module inherits WithICDelta by
+// promotion, so the promoted method hands back the invocation it embeds and the
+// decorator — with the session naming its own user — is dropped. Two attempts to
+// catch that from here were measured and both were worse than the disease. Keying
+// on "is the receiver one of ours" refuses the delta for an in-module test double
+// that implements WithICDelta perfectly well. Keying on "did a value that could
+// not answer for itself turn into one that can" misses a decorator whose parent
+// is also from outside the module, and where it does fire it discards the whole
+// delta — so agent.Run then reads Agent, Branch and IsolationScope from the
+// enclosing invocation, or nil-panics when there is no enclosing agent.
+//
+// The defect is in the decorator contract, not here: a type that cannot override
+// WithICDelta cannot survive a delta, and no amount of inspection at this call
+// site reconstructs what it should have returned. It predates the identity key
+// and is documented on IdentityFromContext instead.
 func withICDelta(ic InvocationContext, d *InvocationContextDelta) InvocationContext {
 	if ic == nil {
 		return nil
 	}
+	// A delta with nothing to say about the invocation must not cost an
+	// invocation from outside the module its identity. A promoted WithICDelta
+	// hands back the invocation the decorator embeds whatever the delta says, so
+	// merely asking is what drops the decorator — and entering a workflow does
+	// exactly that, with a CommonContextDelta carrying no InvocationContextDelta
+	// at all (workflow.go sets Path, RunID, OutputForAncestors and SubScheduler).
+	//
+	// "Nothing to say" is emptiness, not a nil pointer. A caller that allocates
+	// the delta and then fills it conditionally hands over an empty one whenever
+	// no condition fires, and keying on nil alone made that one-token neighbour
+	// drop the decorator where the nil case did not.
+	//
+	// Ours are still asked, because for them an empty delta is not a no-op: the
+	// tool and callback wrappers forward to the commonContext they hold, which
+	// returns that inner context, and skipping the call would leave the wrapper
+	// in place with the nil session it reports by design.
+	if _, ours := ic.(adkcontext.Source); d.isZero() && !ours {
+		return ic
+	}
 	if next := ic.WithICDelta(d); next != nil {
 		return next
 	}
+	// Keeping the original beats propagating nil, which breaks most of the
+	// accessors on commonContext. But the delta is gone, so the caller silently
+	// runs with the previous Agent, Branch and IsolationScope — logged because
+	// nothing else distinguishes that from the delta having been applied, and an
+	// agent running under the wrong parent is not a quiet kind of wrong.
 	log.Printf("agent: %T.WithICDelta returned nil; keeping the previous invocation and "+
 		"discarding the delta, so Agent, Branch and IsolationScope are unchanged", ic)
 	return ic
+}
+
+// isZero reports whether d asks for no change to the invocation. A nil delta and
+// an allocated one with every field unset are the same request, and treating
+// them differently is what let an empty delta drop an out-of-module invocation
+// while a nil one preserved it.
+func (d *InvocationContextDelta) isZero() bool {
+	return d == nil || *d == InvocationContextDelta{}
 }

--- a/agent/common_context_delta_test.go
+++ b/agent/common_context_delta_test.go
@@ -19,6 +19,8 @@ import (
 	"log"
 	"strings"
 	"testing"
+
+	"google.golang.org/adk/v2/session"
 )
 
 // nilDeltaInvocation returns nil from WithICDelta rather than a derived
@@ -26,8 +28,10 @@ import (
 // returns nil from WithContext, WithBranch and WithAgentContext.
 type nilDeltaInvocation struct {
 	InvocationContext
+	own session.Session
 }
 
+func (d nilDeltaInvocation) Session() session.Session                            { return d.own }
 func (nilDeltaInvocation) WithICDelta(*InvocationContextDelta) InvocationContext { return nil }
 
 // TestDeltaOnInvocationThatReturnsNil pins that a nil from WithICDelta costs the
@@ -39,8 +43,9 @@ func TestDeltaOnInvocationThatReturnsNil(t *testing.T) {
 		Context: t.Context(),
 		agent:   &agent{name: "parent"},
 		branch:  "parent-branch",
+		session: matrixOwner("enclosing"),
 	}
-	ic := nilDeltaInvocation{InvocationContext: enclosing}
+	ic := nilDeltaInvocation{InvocationContext: enclosing, own: matrixOwner("u")}
 
 	var child Agent = &agent{name: "child"}
 	branch := "child-branch"
@@ -76,6 +81,12 @@ func TestDeltaOnInvocationThatReturnsNil(t *testing.T) {
 			if got := c.Branch(); got != "parent-branch" {
 				t.Errorf("Branch() = %q, want the previous invocation's branch %q", got, "parent-branch")
 			}
+			// Keeping the invocation must not fail open either. A commonContext that
+			// lost its invocation reports no identity, but one that silently adopted
+			// the enclosing invocation would report a user who made no such call.
+			if id, ok := IdentityFromContext(c); !ok || id.UserID != "u" {
+				t.Errorf("IdentityFromContext() = %+v, %v; want the invocation's own user %q", id, ok, "u")
+			}
 		})
 	}
 
@@ -99,25 +110,42 @@ func TestDeltaOnInvocationThatReturnsNil(t *testing.T) {
 	})
 }
 
-// TestDeltaReachesTheInvocation pins that the guard above does not cost a
-// working invocation its delta. A guard that kept the original unconditionally
-// would pass every assertion in the test above.
+// TestDeltaReachesTheInvocation pins that a delta actually lands on the
+// invocation, for a decorated one as much as an ADK one. A guard that kept the
+// original unconditionally would pass every assertion in the test above.
+//
+// It also exists because an attempt to stop a delta dropping an out-of-module
+// decorator did stop it — by discarding the delta wholesale, so agent.Run read
+// Agent, Branch and IsolationScope from the enclosing invocation and nil-panicked
+// where there was no enclosing agent. The identity tests could not see that: they
+// assert who the context speaks for, never what the delta was for. Any future
+// attempt on that problem has to keep this green.
 func TestDeltaReachesTheInvocation(t *testing.T) {
-	ic := &invocationContext{
+	enclosing := &invocationContext{
 		Context: t.Context(),
+		session: matrixOwner("enclosing"),
 		agent:   &agent{name: "parent"},
-		branch:  "parent-branch",
 	}
 	var child Agent = &agent{name: "child"}
 	branch := "child-branch"
-
-	c := PromoteWithDelta(ic, &CommonContextDelta{
-		InvocationContextDelta: &InvocationContextDelta{Agent: &child, Branch: &branch},
-	})
-	if got := c.(InvocationContext).Agent(); got == nil || got.Name() != "child" {
-		t.Errorf("Agent() = %v, want the agent the delta named", got)
+	delta := func() *CommonContextDelta {
+		return &CommonContextDelta{InvocationContextDelta: &InvocationContextDelta{Agent: &child, Branch: &branch}}
 	}
-	if got := c.Branch(); got != branch {
-		t.Errorf("Branch() = %q, want %q", got, branch)
+	for _, tc := range []struct {
+		name string
+		ic   InvocationContext
+	}{
+		{"an ADK invocation", &invocationContext{Context: enclosing, session: matrixOwner("u"), agent: &agent{name: "parent"}}},
+		{"one decorated outside the module", decoratedInvocationValue{InvocationContext: enclosing, own: matrixOwner("u")}},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			ctx := PromoteWithDelta(tc.ic, delta())
+			if got := ctx.(InvocationContext).Agent(); got == nil || got.Name() != "child" {
+				t.Errorf("Agent() = %v, want the agent the delta named", got)
+			}
+			if got := ctx.Branch(); got != branch {
+				t.Errorf("Branch() = %q, want %q", got, branch)
+			}
+		})
 	}
 }

--- a/agent/common_context_delta_test.go
+++ b/agent/common_context_delta_test.go
@@ -1,0 +1,123 @@
+// Copyright 2026 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package agent
+
+import (
+	"bytes"
+	"log"
+	"strings"
+	"testing"
+)
+
+// nilDeltaInvocation returns nil from WithICDelta rather than a derived
+// invocation, the shape a partial implementation takes. ADK's own ContextMock
+// returns nil from WithContext, WithBranch and WithAgentContext.
+type nilDeltaInvocation struct {
+	InvocationContext
+}
+
+func (nilDeltaInvocation) WithICDelta(*InvocationContextDelta) InvocationContext { return nil }
+
+// TestDeltaOnInvocationThatReturnsNil pins that a nil from WithICDelta costs the
+// delta and not the context. Storing the nil leaves a commonContext with no
+// invocation, and Agent() and Branch() dereference it — on the merge base this
+// same input panics.
+func TestDeltaOnInvocationThatReturnsNil(t *testing.T) {
+	enclosing := &invocationContext{
+		Context: t.Context(),
+		agent:   &agent{name: "parent"},
+		branch:  "parent-branch",
+	}
+	ic := nilDeltaInvocation{InvocationContext: enclosing}
+
+	var child Agent = &agent{name: "child"}
+	branch := "child-branch"
+	delta := func() *CommonContextDelta {
+		return &CommonContextDelta{
+			InvocationContextDelta: &InvocationContextDelta{Agent: &child, Branch: &branch},
+		}
+	}
+
+	for _, tc := range []struct {
+		name string
+		ctx  func() Context
+	}{
+		{"PromoteWithDelta", func() Context { return PromoteWithDelta(ic, delta()) }},
+		{"WithDelta", func() Context { return Promote(ic).WithDelta(delta()) }},
+		{"WithICDelta", func() Context {
+			return Promote(ic).WithICDelta(delta().InvocationContextDelta).(Context)
+		}},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			defer func() {
+				if p := recover(); p != nil {
+					t.Fatalf("panicked after a nil WithICDelta: %v", p)
+				}
+			}()
+			c := tc.ctx()
+			// The previous invocation stands, so its agent and branch are what the
+			// caller sees. Asserted rather than merely surviving the call: "does not
+			// panic" would also pass if the accessors started returning zero values.
+			if got := c.(InvocationContext).Agent(); got == nil || got.Name() != "parent" {
+				t.Errorf("Agent() = %v, want the previous invocation's agent %q", got, "parent")
+			}
+			if got := c.Branch(); got != "parent-branch" {
+				t.Errorf("Branch() = %q, want the previous invocation's branch %q", got, "parent-branch")
+			}
+		})
+	}
+
+	// The discard is the cost of keeping the invocation, and nothing in the
+	// assertions above separates it from the delta having been applied. Pinned on
+	// the log, which is the only thing that does.
+	t.Run("the discard is reported", func(t *testing.T) {
+		var buf bytes.Buffer
+		out := log.Writer()
+		log.SetOutput(&buf)
+		t.Cleanup(func() { log.SetOutput(out) })
+
+		c := PromoteWithDelta(ic, delta())
+		if got := c.Branch(); got == branch {
+			t.Fatalf("Branch() = %q, so the delta was applied after all and this test no "+
+				"longer covers what it is named for", got)
+		}
+		if got := buf.String(); !strings.Contains(got, "discarding the delta") {
+			t.Errorf("log = %q, want the discard reported", got)
+		}
+	})
+}
+
+// TestDeltaReachesTheInvocation pins that the guard above does not cost a
+// working invocation its delta. A guard that kept the original unconditionally
+// would pass every assertion in the test above.
+func TestDeltaReachesTheInvocation(t *testing.T) {
+	ic := &invocationContext{
+		Context: t.Context(),
+		agent:   &agent{name: "parent"},
+		branch:  "parent-branch",
+	}
+	var child Agent = &agent{name: "child"}
+	branch := "child-branch"
+
+	c := PromoteWithDelta(ic, &CommonContextDelta{
+		InvocationContextDelta: &InvocationContextDelta{Agent: &child, Branch: &branch},
+	})
+	if got := c.(InvocationContext).Agent(); got == nil || got.Name() != "child" {
+		t.Errorf("Agent() = %v, want the agent the delta named", got)
+	}
+	if got := c.Branch(); got != branch {
+		t.Errorf("Branch() = %q, want %q", got, branch)
+	}
+}

--- a/agent/context_mock.go
+++ b/agent/context_mock.go
@@ -39,6 +39,12 @@ import (
 // Done, Err and Value): those read from the supplied Ctx rather than panicking,
 // so the mock carries a usable context payload. If Ctx is nil they panic like
 // everything else.
+//
+// Value reading from Ctx has a consequence worth knowing when Ctx is a real ADK
+// invocation rather than context.Background(): the mock then reports THAT
+// invocation's identity, not the one its own Session field describes, because it
+// cannot override a key it cannot name. [IdentityFromContext] states the rule and
+// what a decorator must do about it.
 type StrictContextMock struct {
 	// Ctx supplies the values returned by Deadline, Done, Err and Value.
 	Ctx context.Context

--- a/agent/identity_concurrency_test.go
+++ b/agent/identity_concurrency_test.go
@@ -1,0 +1,359 @@
+// Copyright 2026 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package agent
+
+import (
+	"context"
+	"fmt"
+	"strconv"
+	"strings"
+	"sync"
+	"sync/atomic"
+	"testing"
+
+	"google.golang.org/adk/v2/session"
+)
+
+// The identity procedure is read from more than one goroutine by design:
+// IdentityFromContext exists so an http.RoundTripper deep beneath a tool call can
+// recover the acting user, and that runs on whatever goroutine the caller is on.
+// A fanned-out agent adds the other half — several children derived from one
+// parent invocation, read at the same time. Neither shape was covered.
+
+// TestIdentityIsRaceFreeAcrossConcurrentReaders reads one invocation through
+// every derivation at once.
+//
+// The four shapes are the ones a reader actually holds: the invocation itself, a
+// promotion, a fresh context over it, and a derived context.Context that knows
+// nothing about ADK. All four must report the same user, because they all speak
+// for the same invocation.
+func TestIdentityIsRaceFreeAcrossConcurrentReaders(t *testing.T) {
+	parent := &invocationContext{Context: t.Context(), session: matrixOwner("alice")}
+	want := Identity{UserID: "alice", AppName: "app", SessionID: "sid-alice"}
+
+	const readers = 64
+	var wg sync.WaitGroup
+	start := make(chan struct{})
+	errs := make(chan error, readers)
+
+	for i := range readers {
+		wg.Add(1)
+		go func() {
+			defer wg.Done()
+			<-start // release together, so the reads genuinely overlap
+
+			shape := i % 4
+			var ctx context.Context
+			switch shape {
+			case 0:
+				ctx = parent
+			case 1:
+				ctx = Promote(parent)
+			case 2:
+				ctx = NewContext(parent)
+			case 3:
+				ctx = context.WithValue(NewContext(parent), unrelatedKey{}, i)
+			}
+
+			if got, ok := IdentityFromContext(ctx); !ok || got != want {
+				errs <- fmt.Errorf("reader %d (shape %d): IdentityFromContext() = %+v, %v; want %+v, true",
+					i, shape, got, ok, want)
+			}
+		}()
+	}
+
+	close(start)
+	wg.Wait()
+	close(errs)
+	for err := range errs {
+		t.Error(err)
+	}
+}
+
+// generationalInvocation hands out a fresh session per Session() call, every
+// field of it stamped with the same generation number.
+//
+// It is read rather than asked, because embedding the InvocationContext
+// interface promotes only that interface's methods and the marker is not one of
+// them — so this takes the branch that calls Session(), which is the branch under
+// test.
+type generationalInvocation struct {
+	InvocationContext
+	calls atomic.Int64
+}
+
+func (g *generationalInvocation) Session() session.Session {
+	tag := strconv.FormatInt(g.calls.Add(1), 10)
+	return &matrixSession{id: "sid-" + tag, app: "app-" + tag, user: "user-" + tag}
+}
+
+// TestIdentityReadsTheSessionOnceAndNeverTears pins the reason identityOf takes
+// one Session value and then reads three fields off it, rather than calling
+// Session() per field.
+//
+// Its comment says re-reading risks a torn identity and nothing held it to that.
+// A session accessor that returns a different value per call is not exotic: a
+// wrapper rebuilding a view produces one, and llmagent wraps sessions already. If
+// the three fields were read through three calls, an identity could name one
+// user with another's session, and under concurrency it would do so rarely enough
+// to survive review.
+func TestIdentityReadsTheSessionOnceAndNeverTears(t *testing.T) {
+	inv := &generationalInvocation{InvocationContext: &invocationContext{Context: t.Context()}}
+	ctx := Promote(inv)
+
+	if _, ok := IdentityFromContext(ctx); !ok {
+		t.Fatal("IdentityFromContext() reported no identity; the test cannot say anything about tearing")
+	}
+	if got := inv.calls.Load(); got != 1 {
+		t.Errorf("Session() called %d times for one identity read, want 1: each call yields a "+
+			"different session, so reading per field lets one identity mix two of them", got)
+	}
+
+	const readers = 64
+	var wg sync.WaitGroup
+	start := make(chan struct{})
+	errs := make(chan error, readers)
+
+	for i := range readers {
+		wg.Add(1)
+		go func() {
+			defer wg.Done()
+			<-start
+
+			got, ok := IdentityFromContext(ctx)
+			if !ok {
+				errs <- fmt.Errorf("reader %d: IdentityFromContext() reported no identity", i)
+				return
+			}
+			user := strings.TrimPrefix(got.UserID, "user-")
+			app := strings.TrimPrefix(got.AppName, "app-")
+			sid := strings.TrimPrefix(got.SessionID, "sid-")
+			if user != app || user != sid {
+				errs <- fmt.Errorf("reader %d: torn identity %+v — generations user=%s app=%s session=%s",
+					i, got, user, app, sid)
+			}
+		}()
+	}
+
+	close(start)
+	wg.Wait()
+	close(errs)
+	for err := range errs {
+		t.Error(err)
+	}
+}
+
+// swappingSession advances a generation counter on every accessor call, under a
+// mutex, so no access is a data race by construction.
+//
+// It gives the identity read a session that CHANGES between the three accessor
+// calls it makes — which is the shape the contract's read-window clause is about
+// — and it does so without a second goroutine, so nothing depends on the
+// scheduler. It gives ThreadSanitizer nothing of its own to report: every access
+// to the counter goes through the mutex. What TSan sees is the 64 readers below
+// sharing one commonContext.
+type swappingSession struct {
+	session.Session
+	mu  sync.RWMutex
+	gen int
+}
+
+func (s *swappingSession) swap() { s.mu.Lock(); s.gen++; s.mu.Unlock() }
+
+func (s *swappingSession) now() int {
+	s.mu.RLock()
+	defer s.mu.RUnlock()
+	return s.gen
+}
+
+// tag advances the generation and returns the new one, so the three accessor
+// calls inside one identity read see three different sessions BY CONSTRUCTION.
+//
+// The churn is generated by the reader rather than by a separate writer
+// goroutine on purpose. Relying on a writer to land between two accessor calls
+// makes the property scheduler-dependent: measured at GOMAXPROCS=1, no read ever
+// spanned a swap and the control below failed every run.
+func (s *swappingSession) tag() string {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	s.gen++
+	return strconv.Itoa(s.gen)
+}
+
+func (s *swappingSession) ID() string      { return "sid-" + s.tag() }
+func (s *swappingSession) AppName() string { return "app-" + s.tag() }
+func (s *swappingSession) UserID() string  { return "user-" + s.tag() }
+
+// TestIdentityAgainstASessionThatChangesUnderIt pins what the identity read
+// promises against a session that changes between its accessor calls, and what it
+// does not.
+//
+// Promised: every field comes from the window the read spanned. The session
+// advances once per accessor call, so every field must name a generation strictly
+// after the one observed going in and no later than the one observed coming out.
+// A field outside that means the identity was assembled from something other than
+// this session at this moment — a stale cache, a field taken off the wrong
+// session, or two fields transposed. The lower bound is the one that bites: 64
+// readers share the counter, so the upper end is loose, while a cached identity
+// fails the lower end on its second read.
+//
+// Not promised: an atomic snapshot. identityOf binds one Session value and then
+// makes three accessor calls on it, so a swap between the first and the third
+// yields an Identity naming two generations. Holding the value removes the tear
+// across Session() calls, not the tear across field reads, and nothing that keeps
+// session.Session's six-accessor shape can. The bracket tolerates that and still
+// fails a transposition, which a well-formedness check does not.
+func TestIdentityAgainstASessionThatChangesUnderIt(t *testing.T) {
+	sess := &swappingSession{}
+	parent := &invocationContext{Context: t.Context(), session: sess}
+	// One shared context for every reader, unlike the per-goroutine derivations
+	// above: a memo on this commonContext is written by one reader and read by 63.
+	ctx := Promote(parent)
+
+	const readers = 64
+	// No writer goroutine. There was one, and it earned its place only while the
+	// churn came from it. Once the session advanced on every accessor call the
+	// writer stopped contributing to any assertion — measured, the test stays
+	// green with it deleted — and its stated ThreadSanitizer value was already
+	// false, since every access to the counter is mutex-guarded. What TSan does
+	// see is 64 readers sharing one commonContext, each taking the counter's
+	// exclusive lock three times per read.
+	var readersDone sync.WaitGroup
+	errs := make(chan error, readers)
+	// Counts reads where the generation moved across the call. It is a diagnostic,
+	// not an independent assertion: every early return below sends to errs first,
+	// so a short count implies the test is already red. The bracket at the bottom
+	// of the loop is what actually catches a cached identity.
+	var spanned atomic.Int64
+
+	for i := range readers {
+		readersDone.Add(1)
+		go func() {
+			defer readersDone.Done()
+			for range 50 {
+				before := sess.now()
+				got, ok := IdentityFromContext(ctx)
+				after := sess.now()
+				if !ok {
+					errs <- fmt.Errorf("reader %d: IdentityFromContext() reported no identity", i)
+					return
+				}
+				for _, f := range [][2]string{
+					{"UserID", got.UserID}, {"AppName", got.AppName}, {"SessionID", got.SessionID},
+				} {
+					name, want := f[0], map[string]string{"UserID": "user", "AppName": "app", "SessionID": "sid"}[f[0]]
+					prefix, tag, found := strings.Cut(f[1], "-")
+					if !found || prefix != want {
+						errs <- fmt.Errorf("reader %d: %s = %q, want prefix %q — a field read off the wrong accessor looks exactly like this", i, name, f[1], want)
+						return
+					}
+					gen, err := strconv.Atoi(tag)
+					if err != nil {
+						errs <- fmt.Errorf("reader %d: %s = %q, generation %q is not a number", i, name, f[1], tag)
+						return
+					}
+					// Strictly above before: every accessor advances the counter and
+					// then reports the new value, so no field can name the generation
+					// observed going in. At or below after, which the readers share, so
+					// with 64 of them running the window is wide — the bound that bites
+					// is the lower one, and a cached identity trips it at once.
+					if gen <= before || gen > after {
+						errs <- fmt.Errorf("reader %d: %s = %q, generation %d is outside (%d,%d], the window this read spanned",
+							i, name, f[1], gen, before, after)
+						return
+					}
+				}
+				if after > before {
+					spanned.Add(1)
+				}
+			}
+		}()
+	}
+
+	readersDone.Wait()
+	close(errs)
+	for err := range errs {
+		t.Error(err)
+	}
+	// A cross-check on the fixture rather than on the code under test: the session
+	// advances on every accessor call, so a short count means the fixture stopped
+	// churning and the bracket above was measuring nothing. It cannot fail on its
+	// own — a reader that bails sends to errs first — which is why it is worded as
+	// a fixture check and not as the control.
+	if want := int64(readers * 50); spanned.Load() != want {
+		t.Errorf("%d of %d reads saw the generation move; the fixture is meant to advance on "+
+			"every accessor call, so the bracket above was not measuring what it claims",
+			spanned.Load(), want)
+	}
+}
+
+// TestIdentityIsNotCached pins the property the Identity doc states first — that
+// the lookup reads the session each time rather than caching.
+//
+// Nothing else covers it. Every other test builds a context, reads once, and
+// throws it away, so a memo on commonContext guarded by a sync.Once passes all of
+// them and passes -race too: the concurrency tests would see one frozen identity
+// and agree with themselves about it. The consequence would be silent and real,
+// since auth.Transport resolves per request precisely so a credential follows the
+// current session rather than the one the context was born with.
+func TestIdentityIsNotCached(t *testing.T) {
+	sess := &swappingSession{}
+	ctx := Promote(&invocationContext{Context: t.Context(), session: sess})
+
+	first, ok := IdentityFromContext(ctx)
+	if !ok {
+		t.Fatal("IdentityFromContext() reported no identity")
+	}
+	sess.swap()
+	second, ok := IdentityFromContext(ctx)
+	if !ok {
+		t.Fatal("IdentityFromContext() reported no identity after the swap")
+	}
+
+	if second == first {
+		t.Errorf("IdentityFromContext() = %+v both before and after the session changed. "+
+			"The identity is being cached, and the doc says it is read live", first)
+	}
+	// Ahead of the first read, not at any exact generation: the session advances
+	// on every accessor call, so pinning the number here would encode how many
+	// accessors identityOf happens to call rather than the property under test.
+	// All three fields, not just the user. Memoizing AppName and SessionID on the
+	// grounds that they "never change" while reading UserID live passes a
+	// user-only check, and is exactly the half-cached shape the doc forbids.
+	for _, f := range [][3]string{
+		{"UserID", first.UserID, second.UserID},
+		{"AppName", first.AppName, second.AppName},
+		{"SessionID", first.SessionID, second.SessionID},
+	} {
+		if generationOf(t, f[2]) <= generationOf(t, f[1]) {
+			t.Errorf("IdentityFromContext().%s went %q then %q; the second read must see a "+
+				"later session than the first", f[0], f[1], f[2])
+		}
+	}
+}
+
+// generationOf extracts the counter a swappingSession stamped into a field.
+func generationOf(t *testing.T, field string) int {
+	t.Helper()
+	_, tag, found := strings.Cut(field, "-")
+	if !found {
+		t.Fatalf("field %q is not <prefix>-<generation>", field)
+	}
+	n, err := strconv.Atoi(tag)
+	if err != nil {
+		t.Fatalf("field %q has a non-numeric generation: %v", field, err)
+	}
+	return n
+}

--- a/agent/identity_matrix_test.go
+++ b/agent/identity_matrix_test.go
@@ -1,0 +1,1231 @@
+// Copyright 2026 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package agent
+
+import (
+	"context"
+	"go/ast"
+	"go/parser"
+	"go/token"
+	"reflect"
+	"slices"
+	"strings"
+	"testing"
+	"time"
+
+	"google.golang.org/genai"
+
+	"google.golang.org/adk/v2/artifact"
+	"google.golang.org/adk/v2/internal/adkcontext"
+	"google.golang.org/adk/v2/session"
+)
+
+// The identity key is answered by a decision procedure, so it is pinned by a
+// table rather than by cases. Rows are the shapes a session or an invocation can
+// legally take, columns the ways a context is derived from one. Reviewing this
+// procedure a diff at a time found one failing shape per round over five rounds,
+// each fix moving the failure to a neighbouring shape.
+//
+// The policy the table encodes:
+//   - An invocation reports the user of its OWN session, never one it inherited.
+//   - An invocation with no session of its own delegates, which is what a tool or
+//     callback context needs — theirs is nil by design.
+//   - An invocation that cannot answer at all reports nothing. Broken is not
+//     absent, and delegating would hand back a different call's user.
+//   - No shape panics out of Value, and no shape disturbs an unrelated key.
+
+type matrixSession struct {
+	session.Session
+	id, app, user string
+}
+
+func (s *matrixSession) ID() string                { return s.id }
+func (s *matrixSession) AppName() string           { return s.app }
+func (s *matrixSession) UserID() string            { return s.user }
+func (s *matrixSession) State() session.State      { return nil }
+func (s *matrixSession) Events() session.Events    { return nil }
+func (s *matrixSession) LastUpdateTime() time.Time { return time.Time{} }
+
+func matrixOwner(user string) session.Session {
+	return &matrixSession{id: "sid-" + user, app: "app", user: user}
+}
+
+// structSession is a value type, which a six-accessor interface invites and which
+// a reflect-based nil check cannot inspect.
+type structSession struct{ session.Session }
+
+func (structSession) ID() string      { return "sid" }
+func (structSession) AppName() string { return "app" }
+func (structSession) UserID() string  { return "owner" }
+
+// safeNilSession answers without touching its receiver, so a typed-nil one works.
+type safeNilPtrSession struct{ session.Session }
+
+func (*safeNilPtrSession) ID() string      { return "sid" }
+func (*safeNilPtrSession) AppName() string { return "app" }
+func (*safeNilPtrSession) UserID() string  { return "owner" }
+
+// nilWrappingSession promotes its accessors from a nil embedded session, the
+// shape llmagent.newWrappedSession produces for a nil original.
+type nilWrappingSession struct{ session.Session }
+
+// panickingAccessorSession is broken in its own code, not in its nil-ness.
+type panickingAccessorSession struct{ session.Session }
+
+func (panickingAccessorSession) ID() string      { return "sid" }
+func (panickingAccessorSession) AppName() string { return "app" }
+func (panickingAccessorSession) UserID() string  { panic("accessor is not available") }
+
+// panickingSessionInvocation declines to hand over a session at all, as the
+// exported StrictContextMock does.
+type panickingSessionInvocation struct{ InvocationContext }
+
+func (panickingSessionInvocation) Session() session.Session { panic("Session is not available") }
+
+// permissiveInvocationValue answers every key, as a decorator or double might.
+type permissiveInvocationValue struct{ InvocationContext }
+
+func (permissiveInvocationValue) Value(any) any { return "something that is not an Identity" }
+
+// decoratedInvocationValue is the shape written outside this module: embed the
+// invocation you were derived from to inherit cancellation, carry your own
+// session. It cannot override the identity key, because it cannot name it.
+type decoratedInvocationValue struct {
+	InvocationContext
+	own session.Session
+}
+
+func (d decoratedInvocationValue) Session() session.Session { return d.own }
+
+// contextDecorator decorates agent.Context, which is the interface a tool or a
+// workflow node is handed — so it is the shape an author actually writes. It
+// overrides both methods on InvocationContext, which is everything the rule used
+// to name, and is still dropped by the four that Context adds.
+type contextDecorator struct {
+	Context
+	own session.Session
+}
+
+func (d contextDecorator) Session() session.Session                              { return d.own }
+func (d contextDecorator) WithContext(context.Context) InvocationContext         { return d }
+func (d contextDecorator) WithICDelta(*InvocationContextDelta) InvocationContext { return d }
+
+// Two columns deliberately put a value on the chain, so the probe for "an
+// unrelated key is undisturbed" must use a key nothing injects.
+type unrelatedKey struct{}
+
+type probeKey struct{}
+
+// identityColumn is one way of deriving a context from an invocation.
+type identityColumn struct {
+	name string
+	// method is the interface method this column calls on the invocation, empty
+	// for a package function or a plain derivation. TestEveryContextProducingMethodIsTabulated
+	// builds its list of covered methods from this field, so deleting a column
+	// takes the coverage claim with it instead of leaving the guard green.
+	method string
+	// promoted marks a column that calls a context-producing method ON the
+	// invocation. An out-of-module decorator is dropped by its own promoted
+	// method, either before the derivation or inside it.
+	promoted bool
+	// contextOnly marks a column whose method is on Context rather than
+	// InvocationContext. A row that is only the latter reaches it through
+	// Promote, which holds the row rather than replacing it — the path a
+	// workflow scheduler takes on every node — so those rows are exercised
+	// too, and expect their own user rather than wantContextPromoted.
+	contextOnly bool
+	// reachesInvocation marks a contextOnly column that gets at the held
+	// invocation rather than only re-parenting the context.Context above it. Of
+	// the four methods Context adds, only WithDelta does: it forwards to the
+	// invocation's WithICDelta, so promoting first does not shelter a decorator
+	// from being dropped, where for the other three it does.
+	reachesInvocation bool
+	// wantAll overrides every row's expectation, for a column that reparents
+	// onto a fixed invocation and so answers the same whatever the row is.
+	wantAll string
+	of      func(InvocationContext) context.Context
+}
+
+// identityColumns lists the derivations the matrix walks.
+//
+// It is a function so that TestEveryContextProducingMethodIsTabulated can read
+// the method names off the same slice the matrix runs, rather than keeping a
+// second copy that drifts from it. That guard passes a nil enclosing: it reads
+// only the names and never calls of.
+func identityColumns(t *testing.T, enclosing InvocationContext) []identityColumn {
+	t.Helper()
+	return []identityColumn{
+		{name: "the invocation itself", of: func(ic InvocationContext) context.Context { return ic }},
+		{name: "Promote", of: func(ic InvocationContext) context.Context { return Promote(ic) }},
+		{name: "NewContext", of: func(ic InvocationContext) context.Context { return NewContext(ic) }},
+		{name: "NewToolContext", of: func(ic InvocationContext) context.Context { return NewToolContext(ic, "fc", nil, nil) }},
+		{name: "NewCallbackContext", of: func(ic InvocationContext) context.Context { return NewCallbackContext(ic, nil) }},
+		{name: "NewCallbackContextWithArtifactTracking", of: func(ic InvocationContext) context.Context {
+			return NewCallbackContextWithArtifactTracking(ic, nil)
+		}},
+		{name: "reparented onto a carrier of the enclosing invocation", method: "WithContext", of: func(ic InvocationContext) context.Context {
+			return Promote(ic).WithContext(context.WithValue(context.Context(enclosing), unrelatedKey{}, "x"))
+		}},
+		// The same method given an InvocationContext rather than a carrier of
+		// one. WithAgentContext, which WithContext delegates to, then rebinds the
+		// invocation to the argument, so this column answers for the argument
+		// whatever the row is. It is the one derivation that legitimately changes
+		// who the context speaks for, which is why it is pinned rather than left
+		// to the branch coverage of the column above.
+		{name: "reparented onto the enclosing invocation itself", method: "WithContext", wantAll: "enclosing", of: func(ic InvocationContext) context.Context {
+			return Promote(ic).WithContext(enclosing)
+		}},
+		{name: "tool context of a tool context", of: func(ic InvocationContext) context.Context {
+			return NewToolContext(NewToolContext(ic, "a", nil, nil), "b", nil, nil)
+		}},
+		{name: "behind a non-ADK wrapper", of: func(ic InvocationContext) context.Context {
+			return context.WithValue(Promote(ic), unrelatedKey{}, "x")
+		}},
+		// The delta derivations. WithICDelta is on the public InvocationContext
+		// interface, so these columns are as much a way of deriving a context as
+		// the constructors above, and agent.Run takes this exact path on every run.
+		{name: "PromoteWithDelta", method: "WithICDelta", promoted: true, of: func(ic InvocationContext) context.Context {
+			branch := "br"
+			return PromoteWithDelta(ic, &CommonContextDelta{InvocationContextDelta: &InvocationContextDelta{Branch: &branch}})
+		}},
+		// A delta that says nothing about the invocation does not touch it, so this
+		// column is safe where the two below are not.
+		{name: "PromoteWithDelta, nil InvocationContextDelta", of: func(ic InvocationContext) context.Context {
+			return PromoteWithDelta(ic, &CommonContextDelta{})
+		}},
+		// The one-token neighbour of the column above, and it used to answer
+		// differently: keying the shortcut on a nil pointer rather than on
+		// emptiness meant an allocated-but-unset delta reached the invocation and
+		// dropped an out-of-module decorator. A caller that allocates the delta
+		// and fills it conditionally produces exactly this whenever no condition
+		// fires, so the two must agree.
+		{name: "PromoteWithDelta, empty InvocationContextDelta", of: func(ic InvocationContext) context.Context {
+			return PromoteWithDelta(ic, &CommonContextDelta{InvocationContextDelta: &InvocationContextDelta{}})
+		}},
+		{name: "WithICDelta on a promoted context", method: "WithICDelta", promoted: true, of: func(ic InvocationContext) context.Context {
+			branch := "br"
+			return Promote(ic).WithICDelta(&InvocationContextDelta{Branch: &branch})
+		}},
+		// The same method called directly on the invocation rather than on a
+		// commonContext holding it. That is the shape the rule warns about, and
+		// the column above does not reach it: Promote holds the row, so the call
+		// lands on the commonContext.
+		{name: "WithICDelta called on the invocation", method: "WithICDelta", promoted: true, of: func(ic InvocationContext) context.Context {
+			branch := "br"
+			return Promote(ic.WithICDelta(&InvocationContextDelta{Branch: &branch}))
+		}},
+		// WithContext is inherited exactly as WithICDelta is.
+		{name: "WithContext called on the invocation", method: "WithContext", promoted: true, of: func(ic InvocationContext) context.Context {
+			return Promote(ic.WithContext(t.Context()))
+		}},
+		// The four that agent.Context adds.
+		{name: "WithAgentCancel called on the context", method: "WithAgentCancel", promoted: true, contextOnly: true, of: func(ic InvocationContext) context.Context {
+			c, cancel := asContext(ic).WithAgentCancel()
+			t.Cleanup(cancel)
+			return Promote(c)
+		}},
+		{name: "WithAgentTimeout called on the context", method: "WithAgentTimeout", promoted: true, contextOnly: true, of: func(ic InvocationContext) context.Context {
+			c, cancel := asContext(ic).WithAgentTimeout(time.Minute)
+			t.Cleanup(cancel)
+			return Promote(c)
+		}},
+		{name: "WithAgentContext called on the context", method: "WithAgentContext", promoted: true, contextOnly: true, of: func(ic InvocationContext) context.Context {
+			return Promote(asContext(ic).WithAgentContext(t.Context()))
+		}},
+		{name: "WithDelta called on the context", method: "WithDelta", promoted: true, contextOnly: true, reachesInvocation: true, of: func(ic InvocationContext) context.Context {
+			branch := "br"
+			return Promote(asContext(ic).WithDelta(&CommonContextDelta{
+				InvocationContextDelta: &InvocationContextDelta{Branch: &branch},
+			}))
+		}},
+	}
+}
+
+// asContext reaches the Context methods from a row that may only be an
+// InvocationContext. Promoting first holds the row in a commonContext instead of
+// replacing it, so the row still answers for itself — that is what a workflow
+// scheduler does to the context a node was handed. A row that is already a
+// Context is used directly, so its own promoted method runs and a decorator
+// that fails to override it is dropped.
+func asContext(ic InvocationContext) Context {
+	if c, ok := ic.(Context); ok {
+		return c
+	}
+	return Promote(ic)
+}
+
+func TestIdentityDecisionMatrix(t *testing.T) {
+	// Every row is nested under this one, so any cell that reports "enclosing" is
+	// serving a user who made no such call.
+	enclosing := &invocationContext{Context: t.Context(), session: matrixOwner("enclosing")}
+
+	rows := []struct {
+		name string
+		ic   func() InvocationContext
+		want string // "" means no identity, and ok must be false
+		// outsideModule marks an invocation that cannot override the identity key.
+		// The derivations answer for it correctly. Asking it *directly* cannot be
+		// made to, because the parent it embeds serves a key it cannot name. That
+		// is the documented limit of the mechanism, so wantDirect records what the
+		// limit costs rather than skipping the cell and hiding it.
+		outsideModule bool
+		wantDirect    string
+		// wantPromoted is what a context-producing method called ON the invocation
+		// answers. Those methods are inherited by promotion, so for one written
+		// outside the module the promoted method hands back the invocation it
+		// embeds and the decorator is dropped — session and all, not just the
+		// identity. It cannot be repaired from inside the derivation, so it is
+		// asserted rather than assumed. Defaults to want.
+		wantPromoted    string
+		hasWantPromoted bool
+		// wantContextPromoted is the same for the methods Context adds on top of
+		// InvocationContext. A decorator can override one interface's worth and not
+		// the other's, and that is exactly the gap this row set exists to catch.
+		wantContextPromoted    string
+		hasWantContextPromoted bool
+	}{
+		{name: "pointer session", want: "u", ic: func() InvocationContext {
+			return &invocationContext{Context: enclosing, session: matrixOwner("u")}
+		}},
+		{name: "struct-value session", want: "owner", ic: func() InvocationContext {
+			return &invocationContext{Context: enclosing, session: structSession{}}
+		}},
+		{name: "typed-nil with safe accessors", want: "owner", ic: func() InvocationContext {
+			return &invocationContext{Context: enclosing, session: (*safeNilPtrSession)(nil)}
+		}},
+		{name: "no session", ic: func() InvocationContext {
+			return &invocationContext{Context: enclosing}
+		}},
+		{name: "typed-nil session", ic: func() InvocationContext {
+			return &invocationContext{Context: enclosing, session: (*matrixSession)(nil)}
+		}},
+		{name: "session wrapping a nil session", ic: func() InvocationContext {
+			return &invocationContext{Context: enclosing, session: &nilWrappingSession{}}
+		}},
+		{name: "session accessor panics", ic: func() InvocationContext {
+			return &invocationContext{Context: enclosing, session: panickingAccessorSession{}}
+		}},
+		// Read the direct cell here for what it is: "enclosing" because the
+		// promoted Value answers off the embedded invocation and Session() is
+		// never called, not because a panic was contained. Containment is what
+		// every other column on this row asserts — those do reach Session() — and
+		// what the two "accessor panics" rows assert on an in-module invocation.
+		{name: "Session() panics", outsideModule: true, wantDirect: "enclosing", wantPromoted: "enclosing", hasWantPromoted: true, ic: func() InvocationContext {
+			return panickingSessionInvocation{InvocationContext: enclosing}
+		}},
+		// A permissive Value hands back something that is not an Identity, so the
+		// direct cell yields nothing rather than the parent's user.
+		{name: "permissive Value, own session", want: "u", outsideModule: true, ic: func() InvocationContext {
+			return permissiveInvocationValue{InvocationContext: &invocationContext{Context: enclosing, session: matrixOwner("u")}}
+		}},
+		{name: "permissive Value, no session", outsideModule: true, ic: func() InvocationContext {
+			return permissiveInvocationValue{InvocationContext: &invocationContext{Context: enclosing}}
+		}},
+		{name: "decorated outside the module", want: "u", outsideModule: true, wantDirect: "enclosing", wantPromoted: "enclosing", hasWantPromoted: true, ic: func() InvocationContext {
+			return decoratedInvocationValue{InvocationContext: enclosing, own: matrixOwner("u")}
+		}},
+		// The two axes have to be crossed, not just walked. An invocation that owns
+		// a session fails closed on its own, so an unreadable session only reaches
+		// the delegation through a decorator — where inheriting is a live user's
+		// credential minted for someone else's call.
+		{name: "decorated, typed-nil session", outsideModule: true, wantDirect: "enclosing", wantPromoted: "enclosing", hasWantPromoted: true, ic: func() InvocationContext {
+			return decoratedInvocationValue{InvocationContext: enclosing, own: (*matrixSession)(nil)}
+		}},
+		{name: "decorated, session accessor panics", outsideModule: true, wantDirect: "enclosing", wantPromoted: "enclosing", hasWantPromoted: true, ic: func() InvocationContext {
+			return decoratedInvocationValue{InvocationContext: enclosing, own: panickingAccessorSession{}}
+		}},
+		// A nil session field is what a decorator author gets by default, and it is
+		// the shape that used to fail OPEN: a nil interface reads exactly like the
+		// session-less view a tool context is, so the procedure delegated to the
+		// decorator and its parent answered with a live user who made no such call.
+		// Decorating agent.Context rather than agent.InvocationContext. This row
+		// overrides both methods the rule used to name and is still dropped by the
+		// four that Context adds, which is what the promoted columns assert.
+		{
+			name: "decorated agent.Context outside the module", want: "u", outsideModule: true, wantDirect: "enclosing",
+			wantContextPromoted: "enclosing", hasWantContextPromoted: true, ic: func() InvocationContext {
+				return contextDecorator{Context: Promote(enclosing), own: matrixOwner("u")}
+			},
+		},
+		{name: "decorated, nil session", outsideModule: true, wantDirect: "enclosing", wantPromoted: "enclosing", hasWantPromoted: true, ic: func() InvocationContext {
+			return decoratedInvocationValue{InvocationContext: enclosing, own: nil}
+		}},
+	}
+
+	cols := identityColumns(t, enclosing)
+
+	// The four columns on Context reach two different shapes: a row that is
+	// already a Context has the method called on it directly, and a row that is
+	// only an InvocationContext reaches it through Promote. Exactly one row is of
+	// the first shape, so deleting it would silently degrade those columns to
+	// testing the second — no compile error, no failing assertion, eighteen cells
+	// quietly gone. Both shapes must stay represented.
+	var direct, viaPromote int
+	for _, r := range rows {
+		ic := r.ic()
+		_, isCtx := ic.(Context)
+		_, ours := ic.(adkcontext.Source)
+		// Being a Context is not the property that matters — being one written
+		// OUTSIDE the module is. An in-module Context satisfies the first and
+		// tests nothing, which is how this check first passed while the coverage
+		// it stands for was gone.
+		if isCtx && !ours {
+			direct++
+		} else {
+			viaPromote++
+		}
+	}
+	if direct == 0 || viaPromote == 0 {
+		t.Fatalf("rows that are an out-of-module Context = %d, rows reaching the Context "+
+			"columns through Promote = %d; both shapes are needed, and a decorator over "+
+			"agent.Context is the one the promoted columns exist to catch", direct, viaPromote)
+	}
+
+	// The full Identity is compared, not just the user: reading two of the three
+	// fields off the wrong session, or leaving them empty, would otherwise pass
+	// every cell. matrixOwner builds "sid-<user>", while structSession and
+	// safeNilPtrSession answer for a fixed "owner".
+	full := map[string]Identity{
+		"":          {},
+		"u":         {UserID: "u", AppName: "app", SessionID: "sid-u"},
+		"enclosing": {UserID: "enclosing", AppName: "app", SessionID: "sid-enclosing"},
+		"owner":     {UserID: "owner", AppName: "app", SessionID: "sid"},
+	}
+
+	for _, r := range rows {
+		for _, c := range cols {
+			_, isContext := r.ic().(Context)
+			want := r.want
+			switch {
+			case c.wantAll != "":
+				want = c.wantAll
+			case c.name == "the invocation itself" && r.outsideModule:
+				want = r.wantDirect
+			// A contextOnly column calls its method directly on a row that is
+			// already a Context, so a decorator not overriding it is dropped.
+			case c.contextOnly && isContext && r.hasWantContextPromoted:
+				want = r.wantContextPromoted
+			// A row that is only an InvocationContext reaches the same method
+			// through Promote, which holds it rather than replacing it. For three
+			// of the four that shelters the row, which still answers for itself.
+			// For WithDelta it does not, because that one forwards to the held
+			// invocation's WithICDelta and drops a decorator there. Exercising
+			// these rows rather than skipping them is the difference between the
+			// four Context methods being covered by one row and by all of them,
+			// and it is what surfaced that asymmetry.
+			case c.contextOnly && !isContext:
+				if c.reachesInvocation && r.hasWantPromoted {
+					want = r.wantPromoted
+				} else {
+					want = r.want
+				}
+			case c.promoted && r.hasWantPromoted:
+				want = r.wantPromoted
+			}
+			t.Run(r.name+" / "+c.name, func(t *testing.T) {
+				defer func() {
+					if p := recover(); p != nil {
+						t.Fatalf("Value panicked: %v", p)
+					}
+				}()
+				ctx := c.of(r.ic())
+				var got string
+				id, ok := IdentityFromContext(ctx)
+				if ok {
+					got = id.UserID
+				}
+				if got != want {
+					t.Errorf("IdentityFromContext() user = %q, want %q", got, want)
+				}
+				if id != full[want] {
+					t.Errorf("IdentityFromContext() = %+v, want %+v", id, full[want])
+				}
+				// Reported separately from the user: returning a zero Identity where
+				// none exists would satisfy every want:"" row while telling the
+				// provider the invocation has an identity that merely carries no user.
+				if ok != (want != "") {
+					t.Errorf("IdentityFromContext() ok = %v, want %v", ok, want != "")
+				}
+				// An invocation that hijacks every key is answering for itself.
+				if _, hijacks := r.ic().(permissiveInvocationValue); hijacks {
+					return
+				}
+				if v := ctx.Value(probeKey{}); v != nil {
+					t.Errorf("Value(probeKey{}) = %v, want nil: only the identity key reads the session", v)
+				}
+			})
+		}
+	}
+}
+
+// TestEveryContextProducingMethodIsTabulated is the guard on the table itself.
+//
+// Four rounds of review found the identity rule short by a method, and the guard
+// written to stop that carried the same defect one level up: it kept its own copy
+// of the method list, so deleting a matrix column left it green, and it looked
+// only for a method returning a context — which is not where the last one was.
+// Both are fixed here. The covered set is read off the columns, and a method
+// returning any interface must be classified rather than assumed harmless.
+func TestEveryContextProducingMethodIsTabulated(t *testing.T) {
+	cols := identityColumns(t, nil) // nil enclosing: only names are read, of is not called.
+
+	// Covered means a column calls the method ON the invocation. Keying on the
+	// name alone was not enough: three columns name WithContext and only one
+	// calls it on the row, so deleting that one — the path agent.Run takes on
+	// every run — left this green. promoted is exactly the flag for "called on
+	// the row", which is the only shape that exercises the promotion hazard.
+	calledOnTheRow := map[string]bool{}
+	for _, c := range cols {
+		if c.method != "" && c.promoted {
+			calledOnTheRow[c.method] = true
+		}
+	}
+
+	// Deriving from the columns cannot notice a column that is simply gone: nine
+	// of them derive a context through a package function and name no method at
+	// all, and two more share a name with a column that stays. So the set is also
+	// pinned. Unlike the list this test used to keep, this one is not pretending
+	// to be derived — it is a snapshot, and changing the table is meant to fail
+	// here and be updated deliberately.
+	wantColumns := []string{
+		"the invocation itself",
+		"Promote",
+		"NewContext",
+		"NewToolContext",
+		"NewCallbackContext",
+		"NewCallbackContextWithArtifactTracking",
+		"reparented onto a carrier of the enclosing invocation",
+		"reparented onto the enclosing invocation itself",
+		"tool context of a tool context",
+		"behind a non-ADK wrapper",
+		"PromoteWithDelta",
+		"PromoteWithDelta, nil InvocationContextDelta",
+		"PromoteWithDelta, empty InvocationContextDelta",
+		"WithICDelta on a promoted context",
+		"WithICDelta called on the invocation",
+		"WithContext called on the invocation",
+		"WithAgentCancel called on the context",
+		"WithAgentTimeout called on the context",
+		"WithAgentContext called on the context",
+		"WithDelta called on the context",
+	}
+	gotColumns := make([]string, 0, len(cols))
+	for _, c := range cols {
+		gotColumns = append(gotColumns, c.name)
+	}
+	if !slices.Equal(gotColumns, wantColumns) {
+		t.Errorf("the derivation columns changed.\n got: %q\nwant: %q\nA removed column takes "+
+			"real coverage with it and the checks above cannot see it. If the change is "+
+			"deliberate, update wantColumns.", gotColumns, wantColumns)
+	}
+
+	// What a method HANDS BACK can hold a context, or an acting user, just as the
+	// receiver does — and a promoted one hands back the embedded invocation's,
+	// not the decorator's. So every method returning anything but an inert scalar
+	// is classified with the reason. Restricting this to interface returns was
+	// too narrow: a pointer or a slice can carry a context just as well.
+	holdsNothing := map[string]string{
+		"Agent":               "the agent this invocation is running, which carries no user of its own",
+		"Err":                 "cancellation cause",
+		"OutputForAncestors":  "node names",
+		"RequestConfirmation": "reports an error, returns no object",
+		"ResumedInput":        "caller-supplied resume payload",
+		"RunConfig":           "run configuration, shared across the whole run",
+		"ToolConfirmation":    "the confirmation for this one call",
+		"UserContent":         "the prompt content, which carries no identity a credential is minted from",
+		"Value":               "the context value, which is how identity is answered in the first place",
+	}
+	// Returns something scoped to the invocation, but which cannot be used to
+	// reach a context or act as another user.
+	holdsSessionData := map[string]string{
+		"Session": "the session itself, which is what identity is read FROM",
+	}
+	// Returns something that carries the invocation's ACTING USER, so a promoted
+	// one addresses the enclosing user's data even where the identity procedure
+	// answers for the decorator. Not a context drop path, but the same
+	// wrong-user harm by another route, so each must be named in
+	// IdentityFromContext's doc.
+	holdsActingUser := map[string]string{
+		"Artifacts": "an artifact handle carrying AppName/UserID/SessionID, sent as the storage key on every Save, Load and List",
+		"Memory":    "a memory handle carrying AppName/UserID, sent as the search key",
+		// Not merely "a response and an error": it reaches the result by calling
+		// Memory() on the invocation, so a promoted one searches the enclosing
+		// user's memories. Same route as Memory, and it was in holdsSessionData
+		// under a reason that described the return type and not the path to it.
+		"SearchMemory": "searches through the invocation's Memory handle, so it carries that handle's UserID",
+		// Reclassified: the reason strings here used to name the return TYPE, which
+		// is what got Artifacts, Memory and SearchMemory wrong in turn. These three
+		// route through the invocation the context holds, so a promoted one reads
+		// and writes the enclosing user's session state.
+		"State":         "reaches the invocation's Session().State(), so a promoted one writes the enclosing user's state",
+		"ReadonlyState": "reaches the invocation's Session().State(), so a promoted one reads the enclosing user's state",
+		"Actions":       "the event actions of the invocation the context holds, whose StateDelta commits to that user's session",
+	}
+	// Returns something holding a context outright.
+	holdsContext := map[string]string{
+		"SubScheduler": "the scheduler captures the context it was built from and derives every child from it",
+	}
+
+	classified := func(name string) int {
+		var n int
+		for _, m := range []map[string]string{holdsNothing, holdsSessionData, holdsActingUser, holdsContext} {
+			if m[name] != "" {
+				n++
+			}
+		}
+		return n
+	}
+
+	// The bucket has to have a consequence, or this is a spell-check: until now
+	// any of the four satisfied the check, so moving a method between them was
+	// green and only the reason string changed. Both hazardous buckets say a
+	// promoted call reaches the enclosing invocation's data, which is exactly
+	// what IdentityFromContext's rule must warn a decorator author about — so
+	// every name in them has to appear there. Five methods reached that bucket
+	// only because a reviewer caught each one by hand.
+	//
+	// Matched as a doc link rather than as a bare name. A bare substring passes by
+	// accident on any name that is a prefix of another: "Memory" is satisfied by
+	// "SearchMemory" and "State" by "ReadonlyState", so deleting [Context.Memory]
+	// from the rule left this green — measured.
+	rule := identityRuleDoc(t)
+	for _, m := range []map[string]string{holdsActingUser, holdsContext} {
+		for name := range m {
+			if !strings.Contains(rule, "["+name+"]") &&
+				!strings.Contains(rule, "[Context."+name+"]") &&
+				!strings.Contains(rule, "[ReadonlyContext."+name+"]") {
+				t.Errorf("%s is classified as reaching the enclosing invocation's data, and "+
+					"IdentityFromContext's doc never links it. A decorator author reads that "+
+					"doc to decide what they must override.", name)
+			}
+		}
+	}
+
+	ctxType := reflect.TypeOf((*Context)(nil)).Elem()
+	icType := reflect.TypeOf((*InvocationContext)(nil)).Elem()
+	produces := func(m reflect.Method) bool {
+		for i := range m.Type.NumOut() {
+			if out := m.Type.Out(i); out == ctxType || out == icType {
+				return true
+			}
+		}
+		return false
+	}
+	// Kinds that cannot carry a reference to anything. Everything else — a
+	// pointer, a slice, a map, a struct, an interface — must be classified.
+	inert := func(k reflect.Kind) bool {
+		switch k {
+		case reflect.Bool, reflect.String, reflect.Chan, reflect.Func,
+			reflect.Int, reflect.Int8, reflect.Int16, reflect.Int32, reflect.Int64,
+			reflect.Uint, reflect.Uint8, reflect.Uint16, reflect.Uint32, reflect.Uint64,
+			reflect.Float32, reflect.Float64:
+			return true
+		}
+		return false
+	}
+
+	for _, iface := range []reflect.Type{ctxType, icType} {
+		for i := range iface.NumMethod() {
+			m := iface.Method(i)
+			if produces(m) {
+				if !calledOnTheRow[m.Name] {
+					t.Errorf("%s.%s returns a context and no matrix column CALLS IT on the "+
+						"invocation: an invocation written outside the module inherits it by "+
+						"promotion, so it is a way to drop the decorator. Add a column with "+
+						"method: %q and promoted: true, and name it in IdentityFromContext's doc.",
+						iface.Name(), m.Name, m.Name)
+				}
+				continue
+			}
+			if n := classified(m.Name); n > 1 {
+				t.Errorf("%s.%s is classified %d ways; it must be exactly one", iface.Name(), m.Name, n)
+				continue
+			} else if n == 1 {
+				continue
+			}
+			for j := range m.Type.NumOut() {
+				out := m.Type.Out(j)
+				// time.Time is a struct but holds nothing reachable.
+				if inert(out.Kind()) || out == reflect.TypeOf(time.Time{}) {
+					continue
+				}
+				t.Errorf("%s.%s returns %s and is classified nowhere. Decide which it is: "+
+					"holdsContext (a drop path — name it in IdentityFromContext's doc), "+
+					"holdsActingUser (addresses the enclosing user's data — also name it there), "+
+					"holdsSessionData, or holdsNothing. Each entry needs a reason.",
+					iface.Name(), m.Name, out)
+				break
+			}
+		}
+	}
+}
+
+// TestPromotedColumnsActuallyDropADecorator checks what the columns DO, which is
+// the thing four rounds of guards did not.
+//
+// Every guard before this one read the table's own account of itself — a method
+// name, then a name plus a promoted flag, then the list of column names. All of
+// them are labels, and a label is only worth what verifies it: a column whose
+// body was gutted, or one whose promoted flag was simply wrong, satisfied every
+// version while testing nothing. The single row that would have caught it could
+// itself be swapped for an in-module context with the suite green.
+//
+// So this builds its own decorator, owing nothing to the row table, and requires
+// each column marked promoted to actually drop it. A body that no longer calls
+// its method on the invocation now fails here, and so does a mislabelled flag.
+func TestPromotedColumnsActuallyDropADecorator(t *testing.T) {
+	enclosing := &invocationContext{Context: t.Context(), session: matrixOwner("enclosing")}
+
+	var promoted int
+	for _, c := range identityColumns(t, enclosing) {
+		if !c.promoted {
+			continue
+		}
+		promoted++
+		t.Run(c.name, func(t *testing.T) {
+			// Overrides nothing but Session, so every context-producing method on
+			// it is promoted and hands back the invocation it embeds.
+			d := bareContextDecorator{Context: Promote(enclosing), own: matrixOwner("u")}
+			id, ok := IdentityFromContext(c.of(d))
+			if !ok || id.UserID != "enclosing" {
+				t.Errorf("IdentityFromContext() = %q, %v; want \"enclosing\", true.\n"+
+					"This column is marked promoted, which asserts it calls its method ON the "+
+					"invocation, so a decorator overriding nothing must be dropped by it. Either "+
+					"the column body no longer makes that call, or promoted is set wrongly.",
+					id.UserID, ok)
+			}
+		})
+	}
+	// Pinned because "no promoted columns" would make every check above vacuous
+	// and still report success. Eight, not six: three columns reach WithICDelta,
+	// through PromoteWithDelta, on a held invocation, and on one directly.
+	if want := 8; promoted != want {
+		t.Errorf("promoted columns = %d, want %d", promoted, want)
+	}
+}
+
+// TestPromotedColumnsCallTheMethodTheyName closes the half the test above leaves
+// open.
+//
+// Dropping a bare decorator proves a column calls SOME context-producing method
+// on it, not the one its method field names — any two of them are
+// interchangeable there. So the column is run a second time against a decorator
+// overriding exactly the named method and nothing else: if the column really
+// calls it, the override keeps the decorator, and if it calls a different one
+// that method is promoted and the decorator goes. Swapping a column body from
+// WithContext to WithICDelta now fails, where before it left the covered-set
+// claim standing with nothing behind it.
+func TestPromotedColumnsCallTheMethodTheyName(t *testing.T) {
+	enclosing := &invocationContext{Context: t.Context(), session: matrixOwner("enclosing")}
+	var checked int
+	for _, c := range identityColumns(t, enclosing) {
+		if !c.promoted {
+			continue
+		}
+		checked++
+		t.Run(c.name, func(t *testing.T) {
+			d := selectiveDecorator{
+				Context:  Promote(enclosing),
+				own:      matrixOwner("u"),
+				override: c.method,
+			}
+			id, ok := IdentityFromContext(c.of(d))
+			if !ok || id.UserID != "u" {
+				t.Errorf("IdentityFromContext() = %q, %v; want \"u\", true.\n"+
+					"The decorator overrides %s and nothing else, so a column that calls %s "+
+					"must keep it. Getting the enclosing user means this column calls some "+
+					"OTHER context-producing method, and the coverage it is credited with for "+
+					"%s is not real.", id.UserID, ok, c.method, c.method, c.method)
+			}
+		})
+	}
+	// Pinned here too rather than relying on the sibling test's count: a guard
+	// whose non-emptiness lives in another function is one deletion from being
+	// vacuous, which is the failure this file catalogues.
+	if want := 8; checked != want {
+		t.Errorf("promoted columns checked = %d, want %d", checked, want)
+	}
+}
+
+// TestDecoratorAnswersForItselfWhileReadingTheEnclosingUsersData pins the claim
+// the rule makes about Artifacts, Memory and SearchMemory.
+//
+// It was asserted in the doc and in a reason string in the classification map,
+// and nothing checked it. That is the shape of every defect this file exists to
+// catch, so the claim gets a test: one context, answering "u" to the credential
+// path and addressing "enclosing" on the artifact path at the same time.
+func TestDecoratorAnswersForItselfWhileReadingTheEnclosingUsersData(t *testing.T) {
+	enclosing := &invocationContext{
+		Context:   t.Context(),
+		session:   matrixOwner("enclosing"),
+		artifacts: artifactsOf("enclosing"),
+	}
+	// Overrides Session, as the rule instructs, and not Artifacts.
+	d := bareContextDecorator{Context: Promote(enclosing), own: matrixOwner("u")}
+	tc := NewToolContext(d, "fc", nil, nil)
+
+	if id, ok := IdentityFromContext(tc); !ok || id.UserID != "u" {
+		t.Fatalf("IdentityFromContext() = %q, %v; want \"u\", true", id.UserID, ok)
+	}
+	// A tool context wraps the handle for save tracking. The handle underneath is
+	// the one carrying the user.
+	a := tc.Artifacts()
+	if tracked, ok := a.(*trackedArtifacts); ok {
+		a = tracked.Artifacts
+	}
+	got, ok := a.(interface{ owner() string })
+	if !ok {
+		t.Fatalf("Artifacts() = %T, want the test handle", a)
+	}
+	if got.owner() != "enclosing" {
+		t.Errorf("Artifacts() addresses %q, want \"enclosing\"", got.owner())
+	}
+	// Stated as a test rather than left implied: the two disagree, deliberately
+	// and by promotion, and that is what the rule warns a decorator author about.
+}
+
+// TestRebindDoesNotCarryTheArtifactsHandle pins the other half of that split.
+//
+// WithContext given an invocation rebinds who the context speaks for, but an
+// artifacts handle already cached on the receiver is copied across untouched. So
+// the result answers for the argument while Artifacts() still addresses the
+// receiver's user — the same disagreement as the promotion case, reached from
+// the opposite direction, and the rule claims it in prose.
+// TestRebindIsTotalWithNoCachedHandle is the other half, and it only became
+// reachable when the constructors started returning a nil handle for an
+// invocation with no artifact service rather than a wrapper around nil. Before
+// that, artifacts was always non-nil and the split below was unconditional.
+func TestRebindIsTotalWithNoCachedHandle(t *testing.T) {
+	alice := &invocationContext{Context: t.Context(), session: matrixOwner("alice"), artifacts: artifactsOf("alice")}
+	bob := &invocationContext{Context: t.Context(), session: matrixOwner("bob")} // no artifact service
+
+	wrapper, ok := NewToolContext(bob, "fc", nil, nil).(*toolContextWrapper)
+	if !ok {
+		t.Fatalf("NewToolContext() = %T, want *toolContextWrapper", NewToolContext(bob, "fc", nil, nil))
+	}
+	held, ok := wrapper.context.(*commonContext)
+	if !ok {
+		t.Fatalf("the wrapper holds %T, want *commonContext", wrapper.context)
+	}
+	if held.artifacts != nil {
+		t.Fatalf("artifacts = %T, want nil; this test covers the uncached half and the "+
+			"constructors no longer produce it", held.artifacts)
+	}
+
+	rebound, ok := held.WithContext(alice).(*commonContext)
+	if !ok {
+		t.Fatal("WithContext() did not return a *commonContext")
+	}
+	if id, ok := IdentityFromContext(rebound); !ok || id.UserID != "alice" {
+		t.Errorf("IdentityFromContext() = %q, %v; want \"alice\", true", id.UserID, ok)
+	}
+	owner, ok := rebound.Artifacts().(interface{ owner() string })
+	if !ok {
+		t.Fatalf("Artifacts() = %T, want the test handle", rebound.Artifacts())
+	}
+	if got := owner.owner(); got != "alice" {
+		t.Errorf("Artifacts() addresses %q, want \"alice\": with nothing cached the fallback "+
+			"resolves through the rebound invocation, so the rebind is total here", got)
+	}
+}
+
+func TestRebindDoesNotCarryTheArtifactsHandle(t *testing.T) {
+	alice := &invocationContext{Context: t.Context(), session: matrixOwner("alice"), artifacts: artifactsOf("alice")}
+	bob := &invocationContext{Context: t.Context(), session: matrixOwner("bob"), artifacts: artifactsOf("bob")}
+
+	// A callback context is one of the shapes that caches the handle.
+	wrapper, ok := NewCallbackContext(bob, nil).(*callbackContextWrapper)
+	if !ok {
+		t.Fatalf("NewCallbackContext() = %T, want *callbackContextWrapper", NewCallbackContext(bob, nil))
+	}
+	rebound, ok := wrapper.context.WithContext(alice).(*commonContext)
+	if !ok {
+		t.Fatalf("WithContext() did not return a *commonContext")
+	}
+
+	if id, ok := IdentityFromContext(rebound); !ok || id.UserID != "alice" {
+		t.Errorf("IdentityFromContext() = %q, %v; want \"alice\", true", id.UserID, ok)
+	}
+	owner, ok := rebound.Artifacts().(interface{ owner() string })
+	if !ok {
+		t.Fatalf("Artifacts() = %T, want the test handle", rebound.Artifacts())
+	}
+	if got := owner.owner(); got != "bob" {
+		t.Errorf("Artifacts() addresses %q, want \"bob\": the cached handle is expected NOT to "+
+			"follow the rebind, and the rule says so", got)
+	}
+}
+
+// TestAnUnmarkedContextCanAnswerTheKeyItself pins the limit of the mechanism,
+// which the rule used to state backwards.
+//
+// It said a decorator intercepting the key "reports nothing". That is true only
+// when it answers with some other type, which is the only variant the matrix
+// covered. Identity is an ordinary exported struct, so a wrapper can build one
+// and have it reported: the mechanism does not authenticate the value, and
+// supplying one never requires naming the key. Pinned in both directions,
+// because the false half was the half that mattered: a reader of the old
+// sentence would have taken interception for a defence.
+func TestAnUnmarkedContextCanAnswerTheKeyItself(t *testing.T) {
+	enclosing := &invocationContext{Context: t.Context(), session: matrixOwner("enclosing")}
+
+	if id, ok := IdentityFromContext(permissiveInvocationValue{InvocationContext: enclosing}); ok || id != (Identity{}) {
+		t.Errorf("answering with another type: IdentityFromContext() = %+v, %v; "+
+			"want the zero Identity and false", id, ok)
+	}
+	forged := Identity{UserID: "someone else", AppName: "app", SessionID: "s"}
+	id, ok := IdentityFromContext(forgingInvocationValue{InvocationContext: enclosing, id: forged})
+	if !ok || id != forged {
+		t.Errorf("answering with an Identity: IdentityFromContext() = %+v, %v; want %+v, true. "+
+			"The mechanism does not authenticate the value, and the rule must not imply it does.",
+			id, ok, forged)
+	}
+}
+
+// TestTheKeyValueEscapesToAnyContext pins the limit the rule now states, because
+// the rule used to state the opposite.
+//
+// IdentityFromContext hands the key to whatever Value implementation it is given,
+// so one call is enough to capture it — after which an Identity can be planted
+// under it from a context descending from no invocation at all. The type being
+// unnameable does not prevent that: the value is all anyone needs.
+//
+// Pinned as a limit rather than fixed. Value is the only mechanism that reaches
+// through the intermediaries this function exists to see past, so there is no
+// version of it that both works and withholds the key.
+func TestTheKeyValueEscapesToAnyContext(t *testing.T) {
+	var captured any
+	IdentityFromContext(keySniffer{Context: t.Context(), seen: func(k any) { captured = k }})
+	if captured == nil {
+		t.Fatal("the key never reached the context's own Value; if that is now true by " +
+			"design, replace this test with one asserting the stronger property")
+	}
+
+	forged := Identity{UserID: "someone else", AppName: "app", SessionID: "s"}
+	id, ok := IdentityFromContext(context.WithValue(t.Context(), captured, forged))
+	if !ok || id != forged {
+		t.Errorf("IdentityFromContext() = %+v, %v; want %+v, true. The captured key can be "+
+			"replanted, and the rule must keep saying so rather than promising it cannot.",
+			id, ok, forged)
+	}
+}
+
+// keySniffer records the key it is handed and answers nothing.
+type keySniffer struct {
+	context.Context
+	seen func(any)
+}
+
+func (s keySniffer) Value(k any) any {
+	s.seen(k)
+	return nil
+}
+
+// forgingInvocationValue substitutes the identity on its way past without naming
+// the key, which is the shape that actually matters: it forwards keys and swaps
+// only what comes back an Identity. A wrapper answering EVERY key with an
+// Identity would be a far cruder thing and would break its own context, so
+// modelling that instead would suggest forging costs more than it does. Matching
+// on the type is what lets this fixture stay short — it does also catch an
+// Identity stored under some other key, which a real one aiming to be quiet
+// would avoid, and which is beside the point being pinned here.
+type forgingInvocationValue struct {
+	InvocationContext
+	id Identity
+}
+
+func (d forgingInvocationValue) Value(key any) any {
+	v := d.InvocationContext.Value(key)
+	if _, isIdentity := v.(Identity); isIdentity {
+		return d.id
+	}
+	return v
+}
+
+func artifactsOf(user string) Artifacts { return userArtifacts(user) }
+
+// userArtifacts stands in for internal/artifact.Artifacts, which carries
+// AppName/UserID/SessionID and sends them as the storage key.
+type userArtifacts string
+
+func (a userArtifacts) owner() string { return string(a) }
+
+func (a userArtifacts) Save(context.Context, string, *genai.Part) (*artifact.SaveResponse, error) {
+	return nil, nil
+}
+func (a userArtifacts) List(context.Context) (*artifact.ListResponse, error) { return nil, nil }
+func (a userArtifacts) Load(context.Context, string) (*artifact.LoadResponse, error) {
+	return nil, nil
+}
+
+func (a userArtifacts) LoadVersion(context.Context, string, int) (*artifact.LoadResponse, error) {
+	return nil, nil
+}
+
+// selectiveDecorator intercepts exactly one context-producing method and lets
+// every other one promote, so a column can be checked for calling the method it
+// says it calls.
+type selectiveDecorator struct {
+	Context
+	own      session.Session
+	override string
+}
+
+func (d selectiveDecorator) Session() session.Session { return d.own }
+
+func (d selectiveDecorator) WithContext(ctx context.Context) InvocationContext {
+	if d.override == "WithContext" {
+		return d
+	}
+	return d.Context.WithContext(ctx)
+}
+
+func (d selectiveDecorator) WithICDelta(delta *InvocationContextDelta) InvocationContext {
+	if d.override == "WithICDelta" {
+		return d
+	}
+	return d.Context.WithICDelta(delta)
+}
+
+func (d selectiveDecorator) WithDelta(delta *CommonContextDelta) Context {
+	if d.override == "WithDelta" {
+		return d
+	}
+	return d.Context.WithDelta(delta)
+}
+
+func (d selectiveDecorator) WithAgentContext(ctx context.Context) Context {
+	if d.override == "WithAgentContext" {
+		return d
+	}
+	return d.Context.WithAgentContext(ctx)
+}
+
+func (d selectiveDecorator) WithAgentTimeout(timeout time.Duration) (Context, context.CancelFunc) {
+	c, cancel := d.Context.WithAgentTimeout(timeout)
+	if d.override == "WithAgentTimeout" {
+		return d, cancel
+	}
+	return c, cancel
+}
+
+func (d selectiveDecorator) WithAgentCancel() (Context, context.CancelFunc) {
+	c, cancel := d.Context.WithAgentCancel()
+	if d.override == "WithAgentCancel" {
+		return d, cancel
+	}
+	return c, cancel
+}
+
+// bareContextDecorator is the minimum an author writes: embed the context you
+// were handed, carry your own session, override nothing else.
+type bareContextDecorator struct {
+	Context
+	own session.Session
+}
+
+func (d bareContextDecorator) Session() session.Session { return d.own }
+
+// TestIdentityFromAHostileSource pins what a marked context can do to the
+// procedure that asks it.
+//
+// A marked type is asked for the identity rather than read, which is more trust
+// than any other arm extends, so the two shapes that abuse it are the ones worth
+// pinning: answering with the wrong type, and panicking on the way.
+//
+// This catches the recover and NOT the inner type assertion, deliberately and as
+// identityFrom's own doc says — IdentityFromContext asserts again, so removing
+// the inner one changes what Value returns and nothing a caller can observe.
+// Claiming otherwise here would be one more unverified assertion in a file whose
+// whole subject is unverified assertions.
+func TestIdentityFromAHostileSource(t *testing.T) {
+	enclosing := &invocationContext{Context: t.Context(), session: matrixOwner("enclosing")}
+
+	for _, tc := range []struct {
+		name string
+		ic   func() InvocationContext
+	}{{
+		// Answers the identity key with something that is not an Identity.
+		"a source answering with the wrong type",
+		func() InvocationContext { return &junkSource{InvocationContext: enclosing} },
+	}, {
+		// Panics on the way, which for an unmarked context Recovered already
+		// contains. This is the marked path, which asks rather than reads.
+		"a source that panics",
+		func() InvocationContext { return &panickingSource{InvocationContext: enclosing} },
+	}} {
+		t.Run(tc.name, func(t *testing.T) {
+			defer func() {
+				if p := recover(); p != nil {
+					t.Fatalf("identity read panicked out: %v", p)
+				}
+			}()
+			id, ok := IdentityFromContext(Promote(tc.ic()))
+			if ok || id != (Identity{}) {
+				t.Errorf("IdentityFromContext() = %+v, %v; want the zero Identity and false. "+
+					"A context that cannot answer must report nothing, not something taken for "+
+					"an Identity and not the enclosing call's user.", id, ok)
+			}
+		})
+	}
+}
+
+// junkSource carries the marker, so the procedure asks it, and then answers with
+// something that is not an Identity.
+type junkSource struct {
+	InvocationContext
+	adkcontext.Marker
+}
+
+func (*junkSource) Value(any) any { return "not an Identity" }
+
+// panickingSource carries the marker and then fails on the way.
+type panickingSource struct {
+	InvocationContext
+	adkcontext.Marker
+}
+
+func (*panickingSource) Value(any) any { panic("Value is not available") }
+
+// TestPromotedSubSchedulerDropsTheDecorator pins the drop path the guard
+// classifies but cannot tabulate.
+//
+// SubScheduler returns a scheduler, not a context, so no matrix column can call
+// it. The hazard is the same as every other promoted method: a decorator that
+// does not override it hands back the scheduler belonging to what it embeds, and
+// that scheduler derives every child from the context it captured. In
+// workflow.RunNode that is one call — ctx.SubScheduler() — and the whole child
+// subtree then runs as the enclosing invocation.
+func TestPromotedSubSchedulerDropsTheDecorator(t *testing.T) {
+	enclosing := &invocationContext{Context: t.Context(), session: matrixOwner("enclosing")}
+	var theirs DynamicSubScheduler = stubSubScheduler{owner: "enclosing"}
+	base := Promote(enclosing).WithDelta(&CommonContextDelta{SubScheduler: &theirs})
+
+	decorated := contextDecorator{Context: base, own: matrixOwner("u")}
+	if got, ok := decorated.SubScheduler().(stubSubScheduler); !ok || got.owner != "enclosing" {
+		t.Fatalf("SubScheduler() = %#v, want the embedded context's scheduler", decorated.SubScheduler())
+	}
+	// The decorator answers for its own user, and still hands out a scheduler
+	// bound to someone else's invocation. That gap is what the doc must state.
+	if id, ok := IdentityFromContext(Promote(decorated)); !ok || id.UserID != "u" {
+		t.Fatalf("IdentityFromContext() = %q, %v, want \"u\", true", id.UserID, ok)
+	}
+}
+
+type stubSubScheduler struct {
+	DynamicSubScheduler
+	owner string
+}
+
+// TestDeltaDerivationsReachWithICDeltaOnly pins which method the two delta
+// derivations actually call on the invocation.
+//
+// The doc used to claim PromoteWithDelta reaches WithDelta for a Context, so
+// that overriding WithICDelta alone was not enough. It does not: both it and
+// commonContext.WithDelta go through withICDelta, which calls WithICDelta. A
+// decorator overriding only WithICDelta therefore survives both, and the claim
+// sent an author looking for a bug that was not there. Pinned because a
+// statement about which method runs is exactly the kind that drifts unchecked.
+func TestDeltaDerivationsReachWithICDeltaOnly(t *testing.T) {
+	enclosing := &invocationContext{Context: t.Context(), session: matrixOwner("enclosing")}
+	branch := "br"
+	delta := &CommonContextDelta{InvocationContextDelta: &InvocationContextDelta{Branch: &branch}}
+
+	for _, tc := range []struct {
+		name string
+		of   func(Context) context.Context
+	}{
+		{"PromoteWithDelta", func(c Context) context.Context { return PromoteWithDelta(c, delta) }},
+		{"WithDelta on a promoted context", func(c Context) context.Context { return Promote(c).WithDelta(delta) }},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			// Overrides WithICDelta and deliberately not WithDelta.
+			d := icDeltaOnlyDecorator{Context: Promote(enclosing), own: matrixOwner("u")}
+			if id, ok := IdentityFromContext(tc.of(d)); !ok || id.UserID != "u" {
+				t.Errorf("IdentityFromContext() = %q, %v; want \"u\", true: overriding "+
+					"WithICDelta alone should survive this derivation", id.UserID, ok)
+			}
+		})
+	}
+
+	// The counterpart: calling WithDelta directly on the decorator does drop it,
+	// which is why WithDelta is still in the rule.
+	d := icDeltaOnlyDecorator{Context: Promote(enclosing), own: matrixOwner("u")}
+	if id, ok := IdentityFromContext(Promote(d.WithDelta(delta))); !ok || id.UserID != "enclosing" {
+		t.Errorf("IdentityFromContext() = %q, %v; want \"enclosing\", true: a direct "+
+			"WithDelta is promoted from the embedded context and drops the decorator", id.UserID, ok)
+	}
+}
+
+// TestNilInvocationDeltaIsSafeOnlyOnceHeld pins where the nil-delta exception
+// actually holds.
+//
+// The rule used to offer it as a general exception, in the bullet about calling
+// a method directly on the decorator — where it is false. A promoted method
+// never reaches the decorator, so it cannot consult the delta at all, and the
+// decorator is gone whatever the delta says. Held inside a commonContext it is
+// true, because there the delta is inspected before the invocation is touched.
+// An author reading the old wording would have concluded a delta carrying only
+// Path or RunID needed no interception, which is exactly how entering a workflow
+// drops one.
+func TestNilInvocationDeltaIsSafeOnlyOnceHeld(t *testing.T) {
+	enclosing := &invocationContext{Context: t.Context(), session: matrixOwner("enclosing")}
+	path := "n@1"
+	noICDelta := func() *CommonContextDelta { return &CommonContextDelta{Path: &path} }
+
+	d := icDeltaOnlyDecorator{Context: Promote(enclosing), own: matrixOwner("u")}
+	if id, ok := IdentityFromContext(d.WithDelta(noICDelta())); !ok || id.UserID != "enclosing" {
+		t.Errorf("direct WithDelta: IdentityFromContext() = %q, %v; want \"enclosing\", true. "+
+			"A promoted method cannot consult the delta, so an empty one is no shelter.", id.UserID, ok)
+	}
+	if id, ok := IdentityFromContext(Promote(d).WithDelta(noICDelta())); !ok || id.UserID != "u" {
+		t.Errorf("held WithDelta: IdentityFromContext() = %q, %v; want \"u\", true. "+
+			"Held in a commonContext the delta is inspected first, so an empty one "+
+			"leaves the invocation alone.", id.UserID, ok)
+	}
+}
+
+type icDeltaOnlyDecorator struct {
+	Context
+	own session.Session
+}
+
+func (d icDeltaOnlyDecorator) Session() session.Session { return d.own }
+
+func (d icDeltaOnlyDecorator) WithICDelta(*InvocationContextDelta) InvocationContext { return d }
+
+// identityRuleDoc returns IdentityFromContext's doc comment, parsed out of the
+// source rather than copied here — a copy would be one more list to drift, and
+// drift between the rule and what enforces it is the failure this file exists to
+// stop.
+//
+// Parsed with go/parser rather than found by a literal prefix. The prefix version
+// broke on any reword of the sentence it matched, which made the check a brake on
+// editing the very doc it protects.
+func identityRuleDoc(t *testing.T) string {
+	t.Helper()
+	fset := token.NewFileSet()
+	f, err := parser.ParseFile(fset, "common_context.go", nil, parser.ParseComments)
+	if err != nil {
+		t.Fatalf("parsing common_context.go: %v", err)
+	}
+	for _, d := range f.Decls {
+		if fn, ok := d.(*ast.FuncDecl); ok && fn.Name.Name == "IdentityFromContext" && fn.Doc != nil {
+			return fn.Doc.Text()
+		}
+	}
+	t.Fatal("no doc comment found on IdentityFromContext")
+	return ""
+}

--- a/agent/identity_test.go
+++ b/agent/identity_test.go
@@ -1,0 +1,352 @@
+// Copyright 2026 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package agent
+
+import (
+	"bytes"
+	"context"
+	"log"
+	"strings"
+	"testing"
+
+	"google.golang.org/adk/v2/internal/adkcontext"
+	"google.golang.org/adk/v2/session"
+)
+
+// TestInvocationContextIdentityIsOwned pins the guard on the third invocation
+// implementation, the one in this package: it owns its session, so no session
+// means no identity — never the enclosing invocation's, whose user made no such
+// call and whose credential would otherwise be minted for it.
+func TestInvocationContextIdentityIsOwned(t *testing.T) {
+	outer := &invocationContext{Context: t.Context(), session: &identityTestSession{}}
+	if got, ok := IdentityFromContext(outer); !ok || got.UserID != "alice" {
+		t.Fatalf("outer IdentityFromContext() = %+v, %v; want alice", got, ok)
+	}
+
+	nested := &invocationContext{Context: outer} // no session of its own
+	if got, ok := IdentityFromContext(nested); ok {
+		t.Errorf("nested IdentityFromContext() = %+v, true; want no identity", got)
+	}
+	if got := nested.Value(wrapKey{}); got != nil {
+		t.Errorf("nested Value(wrapKey{}) = %v, want nil (unrelated keys still delegate)", got)
+	}
+	// A nil embedded parent must not panic either: Value is a context.Context
+	// method and runs inside an http.RoundTripper.
+	if got := (&invocationContext{}).Value(wrapKey{}); got != nil {
+		t.Errorf("Value(wrapKey{}) with no parent = %v, want nil", got)
+	}
+}
+
+// TestCommonContextWithoutInvocation pins that a commonContext speaking for no
+// invocation reports no identity rather than its parent's. The parent is a
+// different call, so passing its user through would be the same fail-open every
+// other arm of this procedure refuses. A nil parent on top of that must not panic
+// — Value is a context.Context method and runs inside an http.RoundTripper.
+func TestCommonContextWithoutInvocation(t *testing.T) {
+	owner := &invocationContext{Context: t.Context(), session: &identityTestSession{}}
+	c := &commonContext{Context: owner} // no invocationContext
+	if got, ok := IdentityFromContext(c); ok {
+		t.Errorf("IdentityFromContext() = %+v, true; want no identity, not the parent's", got)
+	}
+	if got := (&commonContext{}).Value(adkcontext.IdentityKey); got != nil {
+		t.Errorf("Value(IdentityKey) with no invocation and no parent = %v, want nil", got)
+	}
+	if got := (&commonContext{}).Value(wrapKey{}); got != nil {
+		t.Errorf("Value(wrapKey{}) with no invocation and no parent = %v, want nil", got)
+	}
+}
+
+// TestReadIdentityRecoversPanickingAccessor pins that a session accessor which
+// panics costs the identity and not the process.
+func TestReadIdentityRecoversPanickingAccessor(t *testing.T) {
+	c := &invocationContext{Context: t.Context(), session: panickingSession{}}
+	if got := c.Value(adkcontext.IdentityKey); got != nil {
+		t.Errorf("Value(IdentityKey) = %v, want nil for a session that panics", got)
+	}
+}
+
+// identityTestSession answers the three identity accessors, and
+// panickingSession panics on the first one, the shape a broken third-party
+// session takes.
+type identityTestSession struct{ session.Session }
+
+func (identityTestSession) ID() string      { return "sid-1" }
+func (identityTestSession) AppName() string { return "app-1" }
+func (identityTestSession) UserID() string  { return "alice" }
+
+type panickingSession struct{ session.Session }
+
+func (panickingSession) UserID() string { panic("UserID is not available") }
+
+type wrapKey struct{}
+
+var _ context.Context = (*invocationContext)(nil)
+
+// TestIdentityFromPermissiveInvocation pins that an invocation answering every
+// key with something that is not an [Identity] does not swallow the fallback: a
+// decorator or test double that returns a placeholder for any key would
+// otherwise cost the identity on every outbound request.
+func TestIdentityFromPermissiveInvocation(t *testing.T) {
+	owner := &invocationContext{Context: t.Context(), session: &identityTestSession{}}
+	c := &commonContext{Context: t.Context(), invocationContext: permissiveInvocation{InvocationContext: owner}}
+	got, ok := IdentityFromContext(c)
+	if !ok || got.UserID != "alice" {
+		t.Errorf("IdentityFromContext() = %+v, %v; want the session read to be reached", got, ok)
+	}
+}
+
+// TestIdentityFromDecoratedInvocation pins that an invocation reports its OWN
+// user, not the one it inherited. An InvocationContext written outside this
+// module embeds the context it was derived from, to inherit cancellation, and
+// cannot override a key it cannot name — so its Value answers with the enclosing
+// invocation's identity. Reading its session first is what stops one user's
+// credential being minted for another's call.
+func TestIdentityFromDecoratedInvocation(t *testing.T) {
+	enclosing := &invocationContext{Context: t.Context(), session: &identityTestSession{}} // alice
+	decorated := decoratedInvocation{
+		InvocationContext: enclosing,
+		own:               &otherUserSession{},
+	}
+	for _, tc := range []struct {
+		name string
+		ctx  context.Context
+	}{
+		{"promoted", Promote(decorated)},
+		{"tool context", NewToolContext(decorated, "fc-1", nil, nil)},
+		{"callback context", NewCallbackContext(decorated, nil)},
+	} {
+		id, ok := IdentityFromContext(tc.ctx)
+		if !ok || id.UserID != "bob" {
+			t.Errorf("%s IdentityFromContext() = %+v, %v; want bob, the decorated invocation's own user", tc.name, id, ok)
+		}
+	}
+}
+
+// decoratedInvocation is how an invocation is wrapped outside this module: embed
+// the enclosing one, override the accessors that differ.
+type decoratedInvocation struct {
+	InvocationContext
+	own session.Session
+}
+
+func (d decoratedInvocation) Session() session.Session { return d.own }
+
+type otherUserSession struct{ session.Session }
+
+func (otherUserSession) ID() string      { return "sid-2" }
+func (otherUserSession) AppName() string { return "app-1" }
+func (otherUserSession) UserID() string  { return "bob" }
+
+// permissiveInvocation answers every key, as a decorator or a test double might.
+type permissiveInvocation struct{ InvocationContext }
+
+func (permissiveInvocation) Value(any) any { return "something that is not an Identity" }
+
+// TestIdentityFromBrokenWrapper pins the recover inside identityFrom. The tool and callback wrappers are this package's own types, so
+// the identity procedure trusts them to answer — but a hand-built one can hold a
+// nil inner context, and Value runs inside http.RoundTripper on the caller's
+// goroutine, where net/http does not recover. Losing the identity is the
+// intended cost. Losing the process is not.
+func TestIdentityFromBrokenWrapper(t *testing.T) {
+	for _, tc := range []struct {
+		name string
+		ic   InvocationContext
+	}{
+		{"tool context wrapper with no inner context", &toolContextWrapper{}},
+		{"callback context wrapper with no inner context", &callbackContextWrapper{}},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			defer func() {
+				if p := recover(); p != nil {
+					t.Fatalf("IdentityFromContext panicked: %v", p)
+				}
+			}()
+			if id, ok := IdentityFromContext(Promote(tc.ic)); ok {
+				t.Errorf("IdentityFromContext() = %+v, true; want no identity", id)
+			}
+		})
+	}
+}
+
+// TestIdentityThroughWrapperDoesNotLogPerLookup pins that resolving an identity
+// through a tool or callback context does not call the wrapper's Session().
+// auth.Transport resolves a credential per outbound request, and those wrappers
+// log on every Session() call, so reading the session to find the identity would
+// put one log line on every authenticated request.
+func TestIdentityThroughWrapperDoesNotLogPerLookup(t *testing.T) {
+	var buf bytes.Buffer
+	out := log.Writer()
+	flags := log.Flags()
+	log.SetOutput(&buf)
+	log.SetFlags(0)
+	t.Cleanup(func() { log.SetOutput(out); log.SetFlags(flags) })
+
+	ic := &invocationContext{Context: t.Context(), session: matrixOwner("u")}
+	// A tool context re-derived from a tool context: the outer one's invocation
+	// is the inner wrapper, which is the shape that reads a wrapper's session.
+	toolCtx := NewToolContext(NewToolContext(ic, "a", nil, nil), "b", nil, nil)
+
+	if _, ok := IdentityFromContext(toolCtx); !ok {
+		t.Fatal("IdentityFromContext() ok = false, want the invocation's identity")
+	}
+	if got := buf.String(); strings.Contains(got, "Session()") {
+		t.Errorf("resolving the identity logged %q; it must not read a wrapper's session", got)
+	}
+}
+
+// TestIdentityFromNilContexts pins that a typed-nil receiver costs the identity
+// and not the process. The dispatch trusts a context of ours to answer for
+// itself, and a typed-nil pointer satisfies that interface as readily as a live
+// one — so the guard has to be on the answering side. Value runs inside
+// http.RoundTripper on the caller's goroutine, where net/http does not recover.
+func TestIdentityFromNilContexts(t *testing.T) {
+	for _, tc := range []struct {
+		name string
+		ctx  context.Context
+	}{
+		{"a typed-nil commonContext", (*commonContext)(nil)},
+		{"one wrapping a typed-nil commonContext", &commonContext{invocationContext: (*commonContext)(nil)}},
+		{"one wrapping a typed-nil invocationContext", &commonContext{invocationContext: (*invocationContext)(nil)}},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			defer func() {
+				if p := recover(); p != nil {
+					t.Fatalf("Value panicked: %v", p)
+				}
+			}()
+			if id, ok := IdentityFromContext(tc.ctx); ok {
+				t.Errorf("IdentityFromContext() = %+v, true; want no identity", id)
+			}
+		})
+	}
+}
+
+// TestIdentityFromUserlessSession pins the case the decision matrix cannot
+// express: a session that reads fine and simply carries no user. That must
+// report ok with an empty UserID, not "no identity" — the two reach the
+// credential path as different errors, and only the second means "this is not an
+// agent invocation".
+func TestIdentityFromUserlessSession(t *testing.T) {
+	ic := &invocationContext{Context: t.Context(), session: &matrixSession{id: "sid", app: "app"}}
+	for _, tc := range []struct {
+		name string
+		ctx  context.Context
+	}{
+		{"the invocation itself", ic},
+		{"Promote", Promote(ic)},
+		{"NewToolContext", NewToolContext(ic, "fc", nil, nil)},
+		{"NewCallbackContext", NewCallbackContext(ic, nil)},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			id, ok := IdentityFromContext(tc.ctx)
+			if !ok {
+				t.Fatal("IdentityFromContext() ok = false; a readable session with no user still has an identity")
+			}
+			if want := (Identity{AppName: "app", SessionID: "sid"}); id != want {
+				t.Errorf("IdentityFromContext() = %+v, want %+v", id, want)
+			}
+		})
+	}
+}
+
+// TestIdentityThroughNestedSessionlessContexts pins the marker on commonContext
+// itself. A promoted tool context is a commonContext whose own invocation is a
+// session-less wrapper, so if it could not answer for itself the outer context
+// would read that wrapper's nil session and report no user at all.
+func TestIdentityThroughNestedSessionlessContexts(t *testing.T) {
+	ic := &invocationContext{Context: t.Context(), session: matrixOwner("u")}
+	promotedTool := Promote(NewToolContext(ic, "fc", nil, nil))
+	for _, tc := range []struct {
+		name string
+		ctx  context.Context
+	}{
+		{"callback context over a promoted tool context", NewCallbackContext(promotedTool, nil)},
+		{"tool context over a promoted tool context", NewToolContext(promotedTool, "fc2", nil, nil)},
+		{"context over a promoted tool context", NewContext(promotedTool)},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			id, ok := IdentityFromContext(tc.ctx)
+			if !ok || id.UserID != "u" {
+				t.Errorf("IdentityFromContext() = %+v, %v; want %q", id, ok, "u")
+			}
+		})
+	}
+}
+
+// TestWrapperValueFailsClosed pins that the wrappers' own Value survives a
+// hand-built receiver. Reached through the identity procedure these are already
+// recovered, but a wrapper is a context.Context and anything may call Value on
+// it directly, where nothing recovers.
+func TestWrapperValueFailsClosed(t *testing.T) {
+	type probeKey struct{}
+	for _, tc := range []struct {
+		name string
+		ctx  context.Context
+	}{
+		{"tool wrapper with no inner context", &toolContextWrapper{}},
+		{"callback wrapper with no inner context", &callbackContextWrapper{}},
+		{"typed-nil tool wrapper", (*toolContextWrapper)(nil)},
+		{"typed-nil callback wrapper", (*callbackContextWrapper)(nil)},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			defer func() {
+				if p := recover(); p != nil {
+					t.Fatalf("Value panicked: %v", p)
+				}
+			}()
+			if v := tc.ctx.Value(probeKey{}); v != nil {
+				t.Errorf("Value(probeKey{}) = %v, want nil", v)
+			}
+			if _, ok := IdentityFromContext(tc.ctx); ok {
+				t.Error("IdentityFromContext() ok = true, want no identity")
+			}
+		})
+	}
+}
+
+// TestNilDeltaKeepsTheContextUsable pins that a delta carrying nothing about the
+// invocation leaves a context ADK built exactly as usable as before.
+//
+// It exists because skipping the call for everyone broke that: the tool and
+// callback wrappers do real work for a nil delta — they forward to the
+// commonContext they hold, which hands back that inner context — so keeping the
+// wrapper left a context whose Session() is nil by design, and UserID() panicked.
+func TestNilDeltaKeepsTheContextUsable(t *testing.T) {
+	ic := &invocationContext{Context: t.Context(), session: matrixOwner("u"), agent: &agent{name: "a"}}
+	path := "n@1"
+	for _, tc := range []struct {
+		name string
+		ic   InvocationContext
+	}{
+		{"a tool context re-derived from a tool context", NewToolContext(NewToolContext(ic, "a", nil, nil), "b", nil, nil)},
+		{"a callback context re-derived from a tool context", NewCallbackContext(NewToolContext(ic, "a", nil, nil), nil)},
+		{"a plain invocation", Promote(ic)},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			defer func() {
+				if p := recover(); p != nil {
+					t.Fatalf("panicked after a nil delta: %v", p)
+				}
+			}()
+			c := tc.ic.(Context).WithDelta(&CommonContextDelta{Path: &path})
+			if got := c.UserID(); got != "u" {
+				t.Errorf("UserID() = %q, want %q", got, "u")
+			}
+			if id, ok := IdentityFromContext(c); !ok || id.UserID != "u" {
+				t.Errorf("IdentityFromContext() = %+v, %v; want %q", id, ok, "u")
+			}
+		})
+	}
+}

--- a/agent/tool_context_wrapper.go
+++ b/agent/tool_context_wrapper.go
@@ -21,6 +21,7 @@ import (
 
 	"google.golang.org/genai"
 
+	"google.golang.org/adk/v2/internal/adkcontext"
 	"google.golang.org/adk/v2/memory"
 	"google.golang.org/adk/v2/session"
 	"google.golang.org/adk/v2/tool/toolconfirmation"
@@ -29,6 +30,7 @@ import (
 // toolContextWrapper is used to emit log entries for unexpected calls - those
 // related to node-context methods when an agent.Context is used as a tool context.
 type toolContextWrapper struct {
+	adkcontext.Marker
 	context Context
 }
 
@@ -241,6 +243,12 @@ func (c *toolContextWrapper) UserID() string {
 
 // Value implements [Context].
 func (c *toolContextWrapper) Value(key any) any {
+	// Fails closed rather than dereferencing: this is reached from
+	// http.RoundTripper on the caller's goroutine, where net/http does not
+	// recover, and a hand-built wrapper can hold neither.
+	if c == nil || c.context == nil {
+		return nil
+	}
 	return c.context.Value(key)
 }
 

--- a/internal/adkcontext/adkcontext.go
+++ b/internal/adkcontext/adkcontext.go
@@ -1,0 +1,98 @@
+// Copyright 2026 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+// Package adkcontext holds the private context key under which an ADK context
+// registers its invocation identity, so it can be recovered from a derived
+// context.Context via agent.IdentityFromContext. It is a tiny leaf package shared
+// by the agent and internal/context packages to avoid an import cycle.
+package adkcontext
+
+type ctxKey int
+
+// IdentityKey is the context value key for the agent.Identity of an ADK context.
+// Its type is unexported and declared in an internal package, so no code outside
+// the module can declare a key equal to it.
+//
+// That is the whole of the guarantee, and it is narrower than it sounds. Two
+// things it does not prevent, neither of which requires naming the type:
+//
+//   - Reading the identity hands this key to every context.Value implementation
+//     between the reader and the invocation, so one read is enough for a wrapper
+//     to keep the key and later plant an agent.Identity under it, from a context
+//     descending from no invocation at all.
+//   - The payload is an ordinary exported struct, so a wrapper can equally build
+//     one, or substitute the one it saw on its way past.
+//
+// So the identity establishes which invocation a context was DERIVED from, and
+// is trusted only as far as every wrapper in the chain is. It is not an
+// authentication boundary. agent.IdentityFromContext states the full rule, and
+// both limits above are pinned by tests in package agent.
+const IdentityKey ctxKey = 0
+
+// Recovered returns what read produced, and whether it returned at all.
+//
+// It exists for the ADK Value implementations, which read the invocation
+// identity off session.Session — a public interface whose implementations are
+// arbitrary code. A nil session, a typed-nil one whose accessors dereference the
+// receiver, a session wrapping a nil one (the shape llmagent.newWrappedSession
+// produces for a nil original), or a Session() accessor that declines, each panic
+// on the way. A typed-nil whose accessors ignore the receiver does not, and
+// answers normally. Value runs inside
+// http.RoundTripper on the caller's goroutine, where net/http does not recover,
+// so a broken session would take the process down. Reporting no identity instead
+// fails the credential path closed.
+//
+// Nothing partially built escapes: on a panic the zero value is returned. The
+// cost is that a bug inside a caller's accessor surfaces as a missing identity
+// rather than a stack trace — deliberate, since the alternative here is killing
+// the process, and the credential path fails closed either way.
+//
+// It contains a panic, and only a panic. An accessor that calls runtime.Goexit
+// ends the calling goroutine, which no recover can undo, and a runtime throw —
+// "concurrent map read and map write", say, from a session whose accessors read
+// state another goroutine is writing — is not recoverable at all. Both end the
+// process, so the containment this offers is narrower than "a broken session
+// cannot bring us down": it covers a session that panics, not one that is
+// unsafe to read from the goroutine holding the context.
+func Recovered[T any](read func() T) (v T, ok bool) {
+	defer func() {
+		if recover() != nil {
+			var zero T
+			v, ok = zero, false
+		}
+	}()
+	return read(), true
+}
+
+// Source marks a context type that answers [IdentityKey] for the invocation it
+// speaks for, rather than for whatever it happens to be derived from.
+//
+// It is what lets the identity procedure tell one of ADK's own session-less
+// views — a tool context, a callback context, the cancel-scoped context a
+// streaming tool runs under — from an agent.InvocationContext written outside
+// the module. One of ours is asked, because it hands the question down to the
+// invocation underneath. Anything else is only read, because it cannot override
+// a key it cannot name, so its embedded parent would answer with a different
+// call's user.
+//
+// The method comes from embedding [Marker] and this package is internal, so a
+// type outside the module can neither name it nor inherit it, and cannot be
+// mistaken for one of ours.
+type Source interface{ adkIdentitySource() }
+
+// Marker is embedded by the ADK context types that satisfy [Source]. It carries
+// no state.
+type Marker struct{}
+
+func (Marker) adkIdentitySource() {}

--- a/internal/adkcontext/adkcontext_test.go
+++ b/internal/adkcontext/adkcontext_test.go
@@ -1,0 +1,153 @@
+// Copyright 2026 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+// Package adkcontext_test is an external test package on purpose: for method
+// sets it behaves exactly as any package outside this module does, which is the
+// party the trust boundary is meant to exclude. An in-package test could satisfy
+// [adkcontext.Source] with an unexported method of its own and would prove
+// nothing.
+package adkcontext_test
+
+import (
+	"reflect"
+	"slices"
+	"strings"
+	"testing"
+
+	"google.golang.org/adk/v2/internal/adkcontext"
+)
+
+// TestSourceMethodIsUnexported guards the property the whole mechanism rests on.
+//
+// Go satisfies interfaces structurally, and an unexported method name is
+// qualified by its declaring package while an exported one is not. So
+// [adkcontext.Source] excludes outside types only while its single method stays
+// unexported. Rename it and any type anywhere satisfies Source without importing
+// this package — and agent's identity procedure ASKS a Source for the invocation
+// it speaks for, rather than reading its session, which is the one arm that
+// extends real trust.
+//
+// Nothing else checks this. The rename was tried and the entire suite stayed
+// green, and the doc on the internal package invites reading the internal/
+// directory as sufficient on its own, which it is not: internal/ governs who may
+// import, never who may satisfy.
+func TestSourceMethodIsUnexported(t *testing.T) {
+	src := reflect.TypeOf((*adkcontext.Source)(nil)).Elem()
+	if got := src.NumMethod(); got != 1 {
+		t.Fatalf("Source has %d methods, want exactly 1; this test knows how to check one", got)
+	}
+	// PkgPath is empty for an exported method and the declaring package's path
+	// for an unexported one.
+	// The method's OWN package must be internal too, not just the key's. Splitting
+	// the package — Source and Marker public, the key left behind — leaves every
+	// other check here green while letting any type anywhere embed Marker and be
+	// ASKED for an identity. Two holes of this class have already been found by
+	// hand. This is the third, and it is the same one test away.
+	if m := src.Method(0); !slices.Contains(strings.Split(m.PkgPath, "/"), "internal") {
+		t.Errorf("Source.%s is declared in %q, which is importable from anywhere. Any importer "+
+			"could then embed Marker and be taken for one of ADK's own contexts. Keep the "+
+			"marker under internal/.", m.Name, m.PkgPath)
+	}
+	if m := src.Method(0); m.PkgPath == "" {
+		t.Errorf("Source.%s is exported. Any type outside this module can then declare a "+
+			"method of that name and be taken for one of ADK's own contexts, which the "+
+			"identity procedure asks for the user it speaks for instead of reading its "+
+			"session. Keep the method unexported.", m.Name)
+	}
+}
+
+// TestIdentityKeyTypeIsUnnameable guards the other half of the boundary.
+//
+// Source decides who gets ASKED for an identity. The key decides who can PLANT
+// one, and it is trusted by everything rather than by one arm, so it is the
+// stronger of the two properties. It holds only while its type is unexported and
+// declared here: a context key compares by dynamic type as well as value, so an
+// untyped `const IdentityKey = 0`, or an exported `CtxKey`, would let any package
+// forge an identity with context.WithValue(ctx, 0, agent.Identity{...}) and have
+// the credential path mint for it.
+//
+// Measured before writing this: with the constant made untyped the forgery
+// succeeds and the entire suite stays green. That is the same shape as the
+// unexported-method hole above, which also went unnoticed until someone tried
+// the rename.
+func TestIdentityKeyTypeIsUnnameable(t *testing.T) {
+	kt := reflect.TypeOf(adkcontext.IdentityKey)
+	if kt.PkgPath() == "" {
+		t.Fatalf("IdentityKey has type %s, which any package can name and plant with "+
+			"context.WithValue. The identity would then be forgeable by unrelated code.", kt)
+	}
+	if name := kt.Name(); name == "" || name[0] >= 'A' && name[0] <= 'Z' {
+		t.Errorf("IdentityKey's type is %s.%s, which is exported; any package could declare "+
+			"a value of it and plant an identity. Keep the key's type unexported.",
+			kt.PkgPath(), name)
+	}
+	// An unexported type is not enough on its own. IdentityKey is itself
+	// exported, so anything able to IMPORT this package can plant an identity
+	// with it and never name the type at all — the only thing preventing that is
+	// the internal/ element in the path. Both checks above survive moving this
+	// package somewhere public, which is a mechanical rename, so the placement is
+	// asserted too.
+	if !slices.Contains(strings.Split(kt.PkgPath(), "/"), "internal") {
+		t.Errorf("IdentityKey is declared in %s, which is importable from anywhere. The key "+
+			"is exported, so any importer can plant an identity with it, and any importer "+
+			"can embed Marker to be asked for one. Keep this package under internal/.",
+			kt.PkgPath())
+	}
+}
+
+// exportedLookalike is what an outside type would declare to impersonate a
+// Source if the marker method were ever exported.
+type exportedLookalike struct{}
+
+func (exportedLookalike) AdkIdentitySource() {}
+
+// unexportedLookalike declares the real name from a different package. Go treats
+// that as a different method, which is the guarantee under test.
+type unexportedLookalike struct{}
+
+func (unexportedLookalike) adkIdentitySource() {}
+
+func TestALookalikeFromAnotherPackageIsNotASource(t *testing.T) {
+	// Called so the method is a genuine use rather than a suppressed warning: it
+	// has to exist for the assertion below to mean anything, and a linter
+	// directive would only hide the day it stops existing.
+	unexportedLookalike{}.adkIdentitySource()
+
+	for _, tc := range []struct {
+		name string
+		v    any
+	}{
+		{"exported name", exportedLookalike{}},
+		{"the real name, declared elsewhere", unexportedLookalike{}},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			if _, ok := tc.v.(adkcontext.Source); ok {
+				t.Errorf("%T satisfies adkcontext.Source from outside the declaring package, "+
+					"so the trust boundary is open: such a type is asked for the invocation it "+
+					"speaks for rather than read.", tc.v)
+			}
+		})
+	}
+}
+
+// Embedding Marker is the sanctioned way in, and it has to keep working — a
+// guard that also broke the legitimate path would be swapped out rather than
+// fixed.
+type sanctioned struct{ adkcontext.Marker }
+
+func TestEmbeddingMarkerStillSatisfiesSource(t *testing.T) {
+	if _, ok := any(sanctioned{}).(adkcontext.Source); !ok {
+		t.Error("a type embedding adkcontext.Marker does not satisfy adkcontext.Source")
+	}
+}

--- a/internal/context/from_context_test.go
+++ b/internal/context/from_context_test.go
@@ -1,0 +1,442 @@
+// Copyright 2026 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package context_test
+
+import (
+	"context"
+	"testing"
+
+	"google.golang.org/adk/v2/agent"
+	icontext "google.golang.org/adk/v2/internal/context"
+	"google.golang.org/adk/v2/session"
+)
+
+type wrapKey struct{}
+
+// TestIdentityFromContextRecoversIdentity verifies that agent.IdentityFromContext
+// recovers the ADK identity from a context that has been wrapped by non-ADK
+// intermediaries (as jsonrpc2 / net/http do), across the base invocation context,
+// a promoted common context, and a tool context.
+func TestIdentityFromContextRecoversIdentity(t *testing.T) {
+	svc := session.InMemoryService()
+	resp, err := svc.Create(t.Context(), &session.CreateRequest{AppName: "app-1", UserID: "user-42"})
+	if err != nil {
+		t.Fatalf("session Create() error = %v", err)
+	}
+	sessionID := resp.Session.ID()
+	ic := icontext.NewInvocationContext(t.Context(), icontext.InvocationContextParams{Session: resp.Session})
+
+	cases := []struct {
+		name string
+		ctx  context.Context
+	}{
+		{"invocation context", ic},
+		{"promoted common context", agent.Promote(ic)},
+		{"tool context", agent.NewToolContext(ic, "fc-1", nil, nil)},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			// Wrap in non-ADK children so a plain type-assert is erased but the
+			// Value lookup still resolves up the chain.
+			wrapped := context.WithValue(tc.ctx, wrapKey{}, "x")
+			wrapped, cancel := context.WithCancel(wrapped)
+			defer cancel()
+
+			id, ok := agent.IdentityFromContext(wrapped)
+			if !ok {
+				t.Fatal("IdentityFromContext() ok = false, want true")
+			}
+			want := agent.Identity{UserID: "user-42", AppName: "app-1", SessionID: sessionID}
+			if id != want {
+				t.Errorf("IdentityFromContext() = %+v, want %+v", id, want)
+			}
+		})
+	}
+}
+
+func TestIdentityFromContextAbsent(t *testing.T) {
+	if _, ok := agent.IdentityFromContext(t.Context()); ok {
+		t.Error("IdentityFromContext() ok = true for a plain context, want false")
+	}
+}
+
+// TestIdentityFromContextSessionShapes covers the session shapes a
+// [session.Session] implementation can legally take. Several of them used to
+// panic inside Value — a struct value tripped reflect.Value.IsNil, a typed-nil
+// pointer passed an interface-nil check and then dereferenced, and a session
+// wrapping a nil one (llmagent.newWrappedSession's shape for a nil original)
+// panicked in the accessor. Value runs inside an http.RoundTripper, where
+// net/http does not recover. Every context implementation must also agree: two
+// of them answering the identity key differently is its own bug.
+func TestIdentityFromContextSessionShapes(t *testing.T) {
+	cases := []struct {
+		name    string
+		session session.Session
+		want    agent.Identity
+		wantOK  bool
+	}{
+		{
+			name:    "pointer",
+			session: &ptrSession{id: "sid-1", app: "app-1", user: "user-42"},
+			want:    agent.Identity{UserID: "user-42", AppName: "app-1", SessionID: "sid-1"},
+			wantOK:  true,
+		},
+		{
+			name:    "struct value",
+			session: valueSession{id: "sid-1", app: "app-1", user: "user-42"},
+			want:    agent.Identity{UserID: "user-42", AppName: "app-1", SessionID: "sid-1"},
+			wantOK:  true,
+		},
+		{
+			// A typed-nil pointer whose accessors do not dereference is usable.
+			name:    "typed-nil pointer with safe accessors",
+			session: (*safeNilSession)(nil),
+			want:    agent.Identity{UserID: "user-nil", AppName: "app-nil", SessionID: "sid-nil"},
+			wantOK:  true,
+		},
+		{name: "nil", session: nil},
+		{name: "typed-nil pointer", session: (*ptrSession)(nil)},
+		{name: "wrapper over a nil session", session: &wrapperSession{}},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			ic := icontext.NewInvocationContext(t.Context(), icontext.InvocationContextParams{Session: tc.session})
+			for _, ctx := range []struct {
+				name string
+				ctx  context.Context
+			}{
+				{"invocation context", ic},
+				{"promoted common context", agent.Promote(ic)},
+				{"tool context", agent.NewToolContext(ic, "fc-1", nil, nil)},
+			} {
+				id, ok := agent.IdentityFromContext(ctx.ctx)
+				if ok != tc.wantOK || id != tc.want {
+					t.Errorf("IdentityFromContext(%s) = %+v, %v; want %+v, %v", ctx.name, id, ok, tc.want, tc.wantOK)
+				}
+			}
+		})
+	}
+}
+
+// TestIdentityAfterWithContext pins the promoted context's own identity branch.
+// WithContext replaces the embedded parent with a non-ADK context while keeping
+// the invocation — the one shape where delegating to the parent cannot recover
+// the identity, and the reason the branch exists. agent.go does exactly this
+// around a tracing span.
+func TestIdentityAfterWithContext(t *testing.T) {
+	svc := session.InMemoryService()
+	resp, err := svc.Create(t.Context(), &session.CreateRequest{AppName: "app-1", UserID: "user-42"})
+	if err != nil {
+		t.Fatalf("session Create() error = %v", err)
+	}
+	ic := icontext.NewInvocationContext(t.Context(), icontext.InvocationContextParams{Session: resp.Session})
+
+	detached := agent.Promote(ic).WithContext(context.Background())
+	id, ok := agent.IdentityFromContext(detached)
+	want := agent.Identity{UserID: "user-42", AppName: "app-1", SessionID: resp.Session.ID()}
+	if !ok || id != want {
+		t.Errorf("IdentityFromContext(WithContext) = %+v, %v; want %+v, true", id, ok, want)
+	}
+}
+
+// TestValueWithNilEmbeddedContext pins the nil-parent guard:
+// NewCleanToolContextTestOnly builds a context with no embedded parent, so
+// without it every non-identity key is a nil-interface method call.
+func TestValueWithNilEmbeddedContext(t *testing.T) {
+	ic := icontext.NewInvocationContext(t.Context(), icontext.InvocationContextParams{})
+	clean, err := agent.NewCleanToolContextTestOnly(agent.Promote(ic), "fc-1", nil, nil)
+	if err != nil {
+		t.Fatalf("NewCleanToolContextTestOnly() error = %v", err)
+	}
+	if got := clean.Value(wrapKey{}); got != nil {
+		t.Errorf("Value(wrapKey{}) = %v, want nil", got)
+	}
+}
+
+// TestIdentityDoesNotInheritEnclosingInvocation pins that identity resolution
+// fails closed. A nested invocation with no session of its own must not report
+// the enclosing invocation's user: that user's credential would then be minted
+// for a call they never made.
+func TestIdentityDoesNotInheritEnclosingInvocation(t *testing.T) {
+	svc := session.InMemoryService()
+	resp, err := svc.Create(t.Context(), &session.CreateRequest{AppName: "app-1", UserID: "alice"})
+	if err != nil {
+		t.Fatalf("session Create() error = %v", err)
+	}
+	outer := icontext.NewInvocationContext(t.Context(), icontext.InvocationContextParams{Session: resp.Session})
+	if id, ok := agent.IdentityFromContext(outer); !ok || id.UserID != "alice" {
+		t.Fatalf("outer IdentityFromContext() = %+v, %v; want alice", id, ok)
+	}
+
+	nested := icontext.NewInvocationContext(outer, icontext.InvocationContextParams{})
+	for _, tc := range []struct {
+		name string
+		ctx  context.Context
+	}{
+		{"nested invocation", nested},
+		// Promote copies the invocation, so this would resolve through the
+		// nested context's own guard even if the promoted one leaked.
+		{"nested and promoted", agent.Promote(nested)},
+		{"nested tool context", agent.NewToolContext(nested, "fc-1", nil, nil)},
+		// A non-ADK wrapper in between must not restore what the guard refused.
+		{"nested behind a non-ADK wrapper", context.WithValue(nested, wrapKey{}, "x")},
+		// Reparented onto a plain context that happens to carry the enclosing
+		// invocation. The derived context still speaks for the nested invocation,
+		// so the parent must not supply a user that invocation refused.
+		// (WithContext given an InvocationContext is different on the one
+		// implementation that rebinds on it, agent.commonContext, where it
+		// deliberately changes which invocation the context speaks for. The two
+		// wrappers log and return nil instead.)
+		{"nested, reparented onto a plain carrier of the enclosing invocation", agent.Promote(nested).WithContext(context.WithValue(outer, wrapKey{}, "x"))},
+	} {
+		if id, ok := agent.IdentityFromContext(tc.ctx); ok {
+			t.Errorf("%s IdentityFromContext() = %+v, true; want no identity, not the enclosing user", tc.name, id)
+		}
+	}
+}
+
+// TestIdentityThroughSessionlessWrappers pins the other half of that rule: a
+// context that does not own a session — a tool or callback context, whose
+// Session() returns nil by design — must delegate rather than report no
+// identity, or every outbound request from a re-derived tool context fails with
+// ErrNoActingUser.
+func TestIdentityThroughSessionlessWrappers(t *testing.T) {
+	svc := session.InMemoryService()
+	resp, err := svc.Create(t.Context(), &session.CreateRequest{AppName: "app-1", UserID: "user-42"})
+	if err != nil {
+		t.Fatalf("session Create() error = %v", err)
+	}
+	ic := icontext.NewInvocationContext(t.Context(), icontext.InvocationContextParams{Session: resp.Session})
+	want := agent.Identity{UserID: "user-42", AppName: "app-1", SessionID: resp.Session.ID()}
+
+	toolCtx := agent.NewToolContext(ic, "fc-1", nil, nil)
+	callbackCtx := agent.NewCallbackContext(ic, nil)
+	// Each of these has a session-less wrapper as the invocation it speaks for, so
+	// every one exercises the delegation. A context derived directly from ic does
+	// not, and would pass whatever the delegation did.
+	for _, tc := range []struct {
+		name string
+		ctx  context.Context
+	}{
+		{"tool context", toolCtx},
+		{"promoted tool context", agent.Promote(toolCtx)},
+		{"tool context re-derived from a tool context", agent.NewToolContext(toolCtx, "fc-2", nil, nil)},
+		{"callback context re-derived from a tool context", agent.NewCallbackContext(toolCtx, nil)},
+		{"callback context", callbackCtx},
+		{"promoted callback context", agent.Promote(callbackCtx)},
+		{"tool context re-derived from a callback context", agent.NewToolContext(callbackCtx, "fc-3", nil, nil)},
+	} {
+		id, ok := agent.IdentityFromContext(tc.ctx)
+		if !ok || id != want {
+			t.Errorf("%s IdentityFromContext() = %+v, %v; want %+v, true", tc.name, id, ok, want)
+		}
+	}
+}
+
+// TestIdentityFromPanickingSession pins that a session whose Session() accessor
+// itself panics — not only its field accessors — costs the identity and not the
+// process: this runs inside an http.RoundTripper, where net/http does not
+// recover.
+func TestIdentityFromPanickingSession(t *testing.T) {
+	parent := context.WithValue(t.Context(), wrapKey{}, "x")
+	inner := icontext.NewInvocationContext(parent, icontext.InvocationContextParams{})
+	ic := agent.Promote(panickingInvocation{InvocationContext: inner})
+	if id, ok := agent.IdentityFromContext(ic); ok {
+		t.Errorf("IdentityFromContext() = %+v, true; want no identity", id)
+	}
+	// The panic costs the identity and nothing else.
+	if got := ic.Value(wrapKey{}); got != "x" {
+		t.Errorf("Value(wrapKey{}) = %v, want %q", got, "x")
+	}
+}
+
+type panickingInvocation struct{ agent.InvocationContext }
+
+func (panickingInvocation) Session() session.Session { panic("Session() is not supported here") }
+
+// TestValueDelegatesUnknownKeys pins that a session shape that stops the
+// identity lookup does not stop every other key: Value is on the hot path for
+// net/http, tracing and logging keys that have nothing to do with the session.
+func TestValueDelegatesUnknownKeys(t *testing.T) {
+	parent := context.WithValue(t.Context(), wrapKey{}, "x")
+	ic := icontext.NewInvocationContext(parent, icontext.InvocationContextParams{Session: (*ptrSession)(nil)})
+	for _, tc := range []struct {
+		name string
+		ctx  context.Context
+	}{
+		{"invocation context", ic},
+		{"promoted common context", agent.Promote(ic)},
+	} {
+		if got := tc.ctx.Value(wrapKey{}); got != "x" {
+			t.Errorf("%s Value(wrapKey{}) = %v, want %q", tc.name, got, "x")
+		}
+	}
+}
+
+// valueSession and ptrSession embed a nil session.Session for the accessors the
+// identity path never reaches, and read their own fields for the ones it does —
+// so a typed-nil *ptrSession panics on use, as a real session would.
+type valueSession struct {
+	session.Session
+	id, app, user string
+}
+
+func (s valueSession) ID() string      { return s.id }
+func (s valueSession) AppName() string { return s.app }
+func (s valueSession) UserID() string  { return s.user }
+
+type ptrSession struct {
+	session.Session
+	id, app, user string
+}
+
+// wrapperSession is the shape llmagent.newWrappedSession produces for a nil
+// original: non-nil, but every identity accessor is promoted from the nil
+// embedded interface and panics on the first call.
+type wrapperSession struct{ session.Session }
+
+// safeNilSession answers without touching its receiver, so a typed-nil one is
+// still a working session.
+type safeNilSession struct{ session.Session }
+
+func (*safeNilSession) ID() string      { return "sid-nil" }
+func (*safeNilSession) AppName() string { return "app-nil" }
+func (*safeNilSession) UserID() string  { return "user-nil" }
+
+func (s *ptrSession) ID() string      { return s.id }
+func (s *ptrSession) AppName() string { return s.app }
+func (s *ptrSession) UserID() string  { return s.user }
+
+// crossPackageDecorator is the shape written outside package agent: embed the
+// invocation you were derived from, to inherit cancellation, and carry your own
+// session. It cannot override the identity key, because it cannot name it.
+type crossPackageDecorator struct {
+	agent.InvocationContext
+	own session.Session
+}
+
+func (d crossPackageDecorator) Session() session.Session { return d.own }
+
+// TestIdentityDecisionMatrixCrossPackage is the other half of
+// agent.TestIdentityDecisionMatrix. The derivations that live here cannot be
+// tabulated there, because package agent cannot import this one — and the
+// column that was missing is exactly where the defect was: ReadonlyContext
+// embeds the invocation as its own context.Context, so before it answered the
+// key for itself it forwarded, and a decorator's parent replied with a
+// different call's user.
+func TestIdentityDecisionMatrixCrossPackage(t *testing.T) {
+	// The full Identity is compared, not just the user: reading two of the three
+	// fields off the wrong session would otherwise pass every cell, exactly as it
+	// would in the sibling table in package agent.
+	full := map[string]agent.Identity{
+		"":          {},
+		"u":         {UserID: "u", AppName: "app", SessionID: "sid-u"},
+		"enclosing": {UserID: "enclosing", AppName: "app", SessionID: "sid-enclosing"},
+	}
+	enclosingSession := valueSession{id: "sid-enclosing", app: "app", user: "enclosing"}
+	enclosing := icontext.NewInvocationContext(t.Context(), icontext.InvocationContextParams{Session: enclosingSession})
+	own := valueSession{id: "sid-u", app: "app", user: "u"}
+
+	rows := []struct {
+		name          string
+		ic            func() agent.InvocationContext
+		want          string // "" means no identity, and ok must be false
+		outsideModule bool
+	}{
+		{name: "in-module invocation with its own session", want: "u", ic: func() agent.InvocationContext {
+			return icontext.NewInvocationContext(enclosing, icontext.InvocationContextParams{Session: own})
+		}},
+		{name: "in-module invocation with no session", ic: func() agent.InvocationContext {
+			return icontext.NewInvocationContext(enclosing, icontext.InvocationContextParams{})
+		}},
+		{name: "decorated, own session", want: "u", outsideModule: true, ic: func() agent.InvocationContext {
+			return crossPackageDecorator{InvocationContext: enclosing, own: own}
+		}},
+		{name: "decorated, nil session", outsideModule: true, ic: func() agent.InvocationContext {
+			return crossPackageDecorator{InvocationContext: enclosing, own: nil}
+		}},
+		{name: "decorated, typed-nil session", outsideModule: true, ic: func() agent.InvocationContext {
+			return crossPackageDecorator{InvocationContext: enclosing, own: (*ptrSession)(nil)}
+		}},
+		{name: "decorated, session wrapping a nil session", outsideModule: true, ic: func() agent.InvocationContext {
+			return crossPackageDecorator{InvocationContext: enclosing, own: &wrapperSession{}}
+		}},
+	}
+
+	type probeKey struct{}
+	cols := []struct {
+		name    string
+		isDelta bool
+		of      func(agent.InvocationContext) context.Context
+	}{
+		{"NewReadonlyContext", false, func(ic agent.InvocationContext) context.Context {
+			return icontext.NewReadonlyContext(ic)
+		}},
+		{"NewCallbackContext", false, func(ic agent.InvocationContext) context.Context {
+			return icontext.NewCallbackContext(ic)
+		}},
+		{"NewCallbackContextWithDelta", false, func(ic agent.InvocationContext) context.Context {
+			return icontext.NewCallbackContextWithDelta(ic, nil, nil)
+		}},
+		{"readonly context of a callback context", false, func(ic agent.InvocationContext) context.Context {
+			return icontext.NewReadonlyContext(icontext.NewCallbackContext(ic))
+		}},
+		{"behind a non-ADK wrapper", false, func(ic agent.InvocationContext) context.Context {
+			return context.WithValue(icontext.NewReadonlyContext(ic), wrapKey{}, "x")
+		}},
+		// A readonly context over a delta-derived one. WithICDelta is inherited by
+		// promotion, so an invocation from outside the module is dropped by its own
+		// promoted method and the enclosing one answers.
+		{"readonly context over a delta-derived context", true, func(ic agent.InvocationContext) context.Context {
+			branch := "br"
+			return icontext.NewReadonlyContext(agent.PromoteWithDelta(ic,
+				&agent.CommonContextDelta{InvocationContextDelta: &agent.InvocationContextDelta{Branch: &branch}}))
+		}},
+	}
+
+	for _, r := range rows {
+		for _, c := range cols {
+			t.Run(r.name+" / "+c.name, func(t *testing.T) {
+				defer func() {
+					if p := recover(); p != nil {
+						t.Fatalf("Value panicked: %v", p)
+					}
+				}()
+				ctx := c.of(r.ic())
+				want := r.want
+				if c.isDelta && r.outsideModule {
+					want = "enclosing"
+				}
+				var got string
+				id, ok := agent.IdentityFromContext(ctx)
+				if ok {
+					got = id.UserID
+				}
+				if got != want {
+					t.Errorf("IdentityFromContext() user = %q, want %q", got, want)
+				}
+				if ok != (want != "") {
+					t.Errorf("IdentityFromContext() ok = %v, want %v", ok, want != "")
+				}
+				if id != full[want] {
+					t.Errorf("IdentityFromContext() = %+v, want %+v", id, full[want])
+				}
+				if v := ctx.Value(probeKey{}); v != nil {
+					t.Errorf("Value(probeKey{}) = %v, want nil: only the identity key reads the session", v)
+				}
+			})
+		}
+	}
+}

--- a/internal/context/invocation_context.go
+++ b/internal/context/invocation_context.go
@@ -20,6 +20,7 @@ import (
 	"google.golang.org/genai"
 
 	"google.golang.org/adk/v2/agent"
+	"google.golang.org/adk/v2/internal/adkcontext"
 	"google.golang.org/adk/v2/platform"
 	"google.golang.org/adk/v2/session"
 )
@@ -55,6 +56,7 @@ func NewInvocationContext(ctx context.Context, params InvocationContextParams) a
 
 type InvocationContext struct {
 	context.Context
+	adkcontext.Marker
 
 	params InvocationContextParams
 }
@@ -121,6 +123,33 @@ func (c *InvocationContext) WithContext(ctx context.Context) agent.InvocationCon
 	return &newCtx
 }
 
+// Value implements context.Context. It returns this invocation's [agent.Identity]
+// for the ADK identity key (so agent.IdentityFromContext can recover it). Every
+// other key delegates to the embedded context, preserving existing behavior.
+//
+// This type owns its session, so the identity key is answered here even when the
+// session cannot be read — with no identity rather than the enclosing
+// invocation's, whose user made no such call and whose credential would
+// otherwise be minted for it.
+func (c *InvocationContext) Value(key any) any {
+	if c == nil {
+		return nil
+	}
+	if key == adkcontext.IdentityKey {
+		if id, ok := adkcontext.Recovered(func() agent.Identity {
+			s := c.params.Session
+			return agent.Identity{UserID: s.UserID(), AppName: s.AppName(), SessionID: s.ID()}
+		}); ok {
+			return id
+		}
+		return nil
+	}
+	if c.Context == nil {
+		return nil
+	}
+	return c.Context.Value(key)
+}
+
 // ResumedInput always returns (nil, false) for the base
 // invocation context. Implementations that carry a resume payload
 // override this method.
@@ -151,3 +180,9 @@ func (c *InvocationContext) WithICDelta(d *agent.InvocationContextDelta) agent.I
 
 	return &res
 }
+
+// Asserted rather than left to the [adkcontext.Marker] embed: a type whose only
+// other use of the package is that embed loses the import along with it, so the
+// build breaks for an unrelated reason and reads like a guard while guarding
+// nothing. This fails on the type, which is what was meant.
+var _ adkcontext.Source = (*InvocationContext)(nil)

--- a/internal/context/readonly_context.go
+++ b/internal/context/readonly_context.go
@@ -20,6 +20,7 @@ import (
 	"google.golang.org/genai"
 
 	"google.golang.org/adk/v2/agent"
+	"google.golang.org/adk/v2/internal/adkcontext"
 	"google.golang.org/adk/v2/session"
 )
 
@@ -33,6 +34,41 @@ func NewReadonlyContext(ctx agent.InvocationContext) agent.ReadonlyContext {
 type ReadonlyContext struct {
 	context.Context
 	InvocationContext agent.InvocationContext
+}
+
+// Value implements context.Context. It answers the ADK identity key for the
+// invocation this context speaks for. Every other key delegates to the embedded
+// context, preserving existing behavior.
+//
+// This type answers the key without carrying [adkcontext.Marker], unlike every
+// other type that does. That is safe only because it is not an
+// [agent.InvocationContext], so it can never sit in the field the identity
+// procedure READS rather than asks — give it those methods and it would need the
+// marker too.
+//
+// The identity key has to be answered here rather than left to the embedded
+// context, even though the two are the same invocation. Forwarding asks that
+// invocation directly, and one implemented outside the agent package cannot
+// override a key it cannot name, so its embedded parent replies — with the
+// enclosing invocation's user, whose credential would then be minted for a call
+// they never made. agent.Promote applies the one identity procedure instead,
+// which reads the invocation's own session and falls back only to a context type
+// agent itself owns. It returns the argument unchanged when it is already one of
+// those, so the copy is made only where it is needed.
+func (c *ReadonlyContext) Value(key any) any {
+	if c == nil {
+		return nil
+	}
+	if key == adkcontext.IdentityKey {
+		if c.InvocationContext == nil {
+			return nil
+		}
+		return agent.Promote(c.InvocationContext).Value(key)
+	}
+	if c.Context == nil {
+		return nil
+	}
+	return c.Context.Value(key)
 }
 
 // AppName implements agent.ReadonlyContext.

--- a/internal/llminternal/base_flow.go
+++ b/internal/llminternal/base_flow.go
@@ -32,6 +32,7 @@ import (
 	"google.golang.org/genai"
 
 	"google.golang.org/adk/v2/agent"
+	"google.golang.org/adk/v2/internal/adkcontext"
 	"google.golang.org/adk/v2/internal/agent/parentmap"
 	"google.golang.org/adk/v2/internal/agent/runconfig"
 	icontext "google.golang.org/adk/v2/internal/context"
@@ -1087,6 +1088,12 @@ Suggested fixes:
 
 type cancelledToolContext struct {
 	agent.Context
+	// Marker: this is one of ADK's own context types, so the identity procedure
+	// asks it rather than reading a session it does not have. Without it the
+	// procedure would fall back to the embedded tool context's Session(), which
+	// is nil by design, and a streaming tool that re-derives its context would
+	// lose the acting user.
+	adkcontext.Marker
 	cancelCtx context.Context
 }
 
@@ -1103,6 +1110,12 @@ func (c *cancelledToolContext) Deadline() (deadline time.Time, ok bool) {
 }
 
 func (c *cancelledToolContext) Value(key any) any {
+	// Fails closed rather than dereferencing: this type carries the identity
+	// marker, so the identity procedure asks it directly, and that ask can arrive
+	// from inside http.RoundTripper where net/http does not recover.
+	if c == nil || c.cancelCtx == nil {
+		return nil
+	}
 	return c.cancelCtx.Value(key)
 }
 
@@ -1579,3 +1592,8 @@ type pluginManager interface {
 	RunAfterToolCallback(ctx agent.Context, t tool.Tool, args, result map[string]any, err error) (map[string]any, error)
 	RunOnToolErrorCallback(ctx agent.Context, t tool.Tool, args map[string]any, err error) (map[string]any, error)
 }
+
+// Asserted rather than left to the [adkcontext.Marker] embed: dropping the embed
+// would also drop the import, breaking the build for an unrelated reason. This
+// fails on the type.
+var _ adkcontext.Source = (*cancelledToolContext)(nil)

--- a/internal/llminternal/identity_test.go
+++ b/internal/llminternal/identity_test.go
@@ -1,0 +1,80 @@
+// Copyright 2026 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package llminternal
+
+import (
+	"bytes"
+	"context"
+	"log"
+	"strings"
+	"testing"
+
+	"google.golang.org/adk/v2/agent"
+	icontext "google.golang.org/adk/v2/internal/context"
+	"google.golang.org/adk/v2/session"
+)
+
+// TestCancelledToolContextKeepsIdentity pins that the context a streaming tool
+// runs under is one of ADK's own, not a foreign decorator.
+//
+// It lives outside package agent and holds no session of its own — its embedded
+// tool context returns nil by design — so without the module marker the identity
+// procedure would read that nil session and report no user. A streaming tool
+// that re-derives its context would then lose the acting user, and a per-user
+// credential could not be minted for it at all.
+func TestCancelledToolContextKeepsIdentity(t *testing.T) {
+	svc := session.InMemoryService()
+	resp, err := svc.Create(t.Context(), &session.CreateRequest{AppName: "app", UserID: "u"})
+	if err != nil {
+		t.Fatalf("session Create() = %v", err)
+	}
+	ic := icontext.NewInvocationContext(t.Context(), icontext.InvocationContextParams{Session: resp.Session})
+	toolCtx := agent.NewToolContext(ic, "fc", nil, nil)
+	cancelCtx, cancel := toolCtx.WithAgentCancel()
+	defer cancel()
+	cancelToolCtx := &cancelledToolContext{Context: toolCtx, cancelCtx: cancelCtx}
+
+	var buf bytes.Buffer
+	out := log.Writer()
+	log.SetOutput(&buf)
+	t.Cleanup(func() { log.SetOutput(out) })
+
+	want := agent.Identity{UserID: "u", AppName: "app", SessionID: resp.Session.ID()}
+	for _, tc := range []struct {
+		name string
+		ctx  context.Context
+	}{
+		{"the cancel-scoped context itself", cancelToolCtx},
+		{"promoted", agent.Promote(cancelToolCtx)},
+		{"a tool context re-derived from it", agent.NewToolContext(cancelToolCtx, "fc2", nil, nil)},
+		{"a callback context re-derived from it", agent.NewCallbackContext(cancelToolCtx, nil)},
+		{"a readonly context over it", icontext.NewReadonlyContext(cancelToolCtx)},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			id, ok := agent.IdentityFromContext(tc.ctx)
+			if !ok {
+				t.Fatalf("IdentityFromContext() ok = false, want the invocation's identity")
+			}
+			if id != want {
+				t.Errorf("IdentityFromContext() = %+v, want %+v", id, want)
+			}
+		})
+	}
+	// Reading the session to find the identity would also log on every lookup,
+	// and auth.Transport resolves a credential per outbound request.
+	if got := buf.String(); strings.Contains(got, "Session()") {
+		t.Errorf("resolving the identity logged %q; it must not read a tool context's session", got)
+	}
+}


### PR DESCRIPTION
## Problem

Code that holds only a `context.Context` cannot tell which end user an invocation belongs to. A tool's outbound request reaches an `http.RoundTripper` several layers below the tool call, past jsonrpc2 and net/http wrapping, with the typed ADK context long since erased. Anything acting on behalf of the acting user — minting a per-user credential, for instance — has no way to name them, and threading a typed context through `net/http` is not available.

## Summary

Add `agent.Identity` and `agent.IdentityFromContext`. ADK contexts answer a private key held in `internal/adkcontext`, a module-internal leaf package shared by `agent` and `internal/context` to break the import cycle.

The procedure branches on whether the invocation is one of ADK's own context types, marked by embedding `adkcontext.Marker`. One of ours is asked, because it hands the question down to the invocation underneath — that is what keeps a tool or callback context working, since theirs hold no session by design. Anything else is only read. An `InvocationContext` written outside the module embeds the context it was derived from and cannot override a key it cannot name, so asking it would answer with the enclosing invocation's user: a live user who made no such call.

The read recovers rather than nil-tests. `session.Session` is a public interface of six accessors, so a struct value implements it naturally, a typed-nil pointer survives an interface-nil check, and a session wrapping a nil session panics in the accessor. This runs inside `http.RoundTripper`, where net/http does not recover, so a session that cannot answer costs the identity and not the process.

A delta carrying no change to the invocation no longer reaches `WithICDelta` on an invocation from outside the module. Merely asking is what drops such a decorator, and entering a workflow does exactly that. Ours are still asked, because for them an empty delta is not a no-op.

`IdentityFromContext` establishes which invocation a context was derived from, and is trusted only as far as every wrapper in the chain is. It is not an authentication boundary, and the doc says so at length — including that the key value escapes to every `Value` implementation between the reader and the invocation, so a single read is enough for a wrapper to keep it.

The decision procedure is pinned by a table rather than by cases: rows are the shapes a session or an invocation can take, columns the ways a context is derived from one. Every row is nested under one enclosing invocation, so any cell reporting that user is serving someone who made no such call.

---

Fourth of a five-part split of #1173. Stacked on 1521, and #1173 is stacked on this one.
