### PR TITLE
test(agentanalytics): cover the retry that opens a fresh stream

### DIFF
--- a/plugin/agentanalytics/batch_processor_test.go
+++ b/plugin/agentanalytics/batch_processor_test.go
@@ -19,14 +19,19 @@ import (
 	"errors"
 	"fmt"
 	"io"
+	"net"
 	"strings"
 	"sync/atomic"
 	"testing"
 	"time"
 
+	bqstorage "cloud.google.com/go/bigquery/storage/apiv1"
 	storagepb "cloud.google.com/go/bigquery/storage/apiv1/storagepb"
+	"google.golang.org/api/option"
 	statuspb "google.golang.org/genproto/googleapis/rpc/status"
+	"google.golang.org/grpc"
 	"google.golang.org/grpc/codes"
+	"google.golang.org/grpc/credentials/insecure"
 	"google.golang.org/grpc/status"
 )
 
@@ -411,5 +416,47 @@ func TestStreamWriter_SendError(t *testing.T) {
 				t.Errorf("error %q does not contain %q", err.Error(), tt.wantErrMsg)
 			}
 		})
+	}
+}
+
+func TestStreamWriter_RetryOpensAFreshStream(t *testing.T) {
+	ctx := context.Background()
+
+	lis, err := net.Listen("tcp", "localhost:0")
+	if err != nil {
+		t.Fatalf("listen: %v", err)
+	}
+	gSrv := grpc.NewServer()
+	storagepb.RegisterBigQueryWriteServer(gSrv, &fakeBigQueryWriteServer{})
+	go func() { _ = gSrv.Serve(lis) }()
+	t.Cleanup(gSrv.Stop)
+
+	conn, err := grpc.NewClient(lis.Addr().String(), grpc.WithTransportCredentials(insecure.NewCredentials()))
+	if err != nil {
+		t.Fatalf("dial: %v", err)
+	}
+	t.Cleanup(func() { _ = conn.Close() })
+
+	writeClient, err := bqstorage.NewBigQueryWriteClient(ctx, option.WithGRPCConn(conn))
+	if err != nil {
+		t.Fatalf("write client: %v", err)
+	}
+
+	config := DefaultConfig()
+	config.RetryConfig.MaxRetries = 1
+
+	bp, err := NewBatchProcessor(ctx, writeClient, "projects/p/datasets/d/tables/t/_default", config)
+	if err != nil {
+		t.Fatalf("NewBatchProcessor: %v", err)
+	}
+
+	dead := &mockStream{sendErr: io.EOF, recvErr: io.EOF}
+	bp.streamWriter.stream = dead
+
+	if err := bp.writeBatch(ctx, []map[string]any{{"event_type": "retry_probe"}}); err != nil {
+		t.Errorf("attempt 1 did not open a fresh stream: %v", err)
+	}
+	if got := atomic.LoadInt32(&dead.sendCount); got != 1 {
+		t.Errorf("the aborted stream was reused: Send called %d times on it, want 1", got)
 	}
 }


### PR DESCRIPTION
### Link to Issue or Description of Change

**1. Link to an existing issue (if applicable):**

- Related: #1318

**Problem:**

`streamWriter.append` clears `s.stream` when a send fails, so the next attempt opens a fresh stream. Nothing covers that: no test in the package reaches a second attempt, and instrumenting the retry loop shows the `attempt > 0` branch running zero times across the package suite. Moving `s.stream = nil` out of the send-error branch to just before the terminal `return` leaves the package green, and every retry then reuses the aborted stream.

**Solution:**

The test drives the first attempt into the real `AppendRows` call. The package already contains what that requires: `bigquery_agent_analytics_plugin_test.go:227` builds a real `grpc.Server`, and `:239` a real `*bqstorage.BigQueryWriteClient` over it. Seeding `streamWriter.stream` with a mock that always fails and setting `MaxRetries: 1` makes the first attempt fail on the mock and the second open a real stream. No production change.

The test is the one karolpiotrowicz wrote while reviewing #1318.

### Behavior change

**What behaves differently for someone already on the current release?**

Nothing. The change is test-only.

### Testing Plan

**Unit Tests:**

- [x] All unit tests pass locally.

**With your source change reverted and your tests kept, which test fails?**

There is no source change to revert. The equivalent check is the mutation above: with `s.stream = nil` moved to just before the terminal `return`, every other test in the package passes and only `TestStreamWriter_RetryOpensAFreshStream` fails, with `the aborted stream was reused: Send called 2 times on it, want 1`.

Passed locally:

```
$ cd plugin/agentanalytics
$ go build -mod=readonly ./...
$ go test -mod=readonly -count=1 -shuffle=on ./...
ok  	google.golang.org/adk/plugin/agentanalytics	3.048s
$ golangci-lint run --config ../../.golangci.yml
0 issues.
$ go mod tidy -diff
```

**Manual End-to-End (E2E) Tests:**

N/A

### Checklist

- [x] I have read the [CONTRIBUTING.md](./CONTRIBUTING.md) document.
- [x] I have performed a self-review of my own code.
- [x] I have commented my code, particularly in hard-to-understand areas.
- [x] I have added tests that prove my fix is effective or that my feature works.
- [x] New and existing unit tests pass locally with my changes.
- [ ] I have manually tested my changes end-to-end.
- [x] Any dependent changes have been merged and published in downstream modules.
