### PR TITLE
fix(memory): score, sort and cap in-memory SearchMemory results

### DIFF
--- a/memory/inmemory.go
+++ b/memory/inmemory.go
@@ -17,6 +17,7 @@ package memory
 import (
 	"context"
 	"maps"
+	"slices"
 	"strings"
 	"sync"
 	"time"
@@ -49,6 +50,10 @@ type value struct {
 	// precomputed set of words in the content for simple keyword matching.
 	words map[string]struct{}
 }
+
+// maxSearchResults caps how many memories SearchMemory returns, matching
+// adk-python's _MAX_SEARCH_RESULTS.
+const maxSearchResults = 10
 
 // inMemoryService is an in-memory implementation of Service.
 type inMemoryService struct {
@@ -128,40 +133,79 @@ func (s *inMemoryService) SearchMemory(ctx context.Context, req *SearchRequest) 
 		return res, nil
 	}
 
-	for _, events := range values {
-		for _, e := range events {
-			if checkMapsIntersect(e.words, queryWords) {
-				res.Memories = append(res.Memories, Entry{
+	// Almost any two sentences share a word, so keeping every event that
+	// matches at least one query word keeps most of the store, and callers
+	// such as preloadmemorytool render all of it into the prompt. Score each
+	// event by how many distinct query words it matches and keep the best few.
+	type scoredEntry struct {
+		score int
+		entry Entry
+	}
+
+	var scored []scoredEntry
+
+	// Sessions are held in a map, whose iteration order is randomized, so
+	// visit them in a fixed order to keep equally scored events in a stable
+	// sequence across runs. adk-python gets this from its insertion-ordered
+	// dict; a Go map has no insertion order to preserve, so sort the IDs.
+	for _, sid := range slices.Sorted(maps.Keys(values)) {
+		for _, e := range values[sid] {
+			score := countMapsIntersect(e.words, queryWords)
+			if score == 0 {
+				continue
+			}
+
+			scored = append(scored, scoredEntry{
+				score: score,
+				entry: Entry{
 					ID:             e.id,
 					Content:        e.content,
 					Author:         e.author,
 					Timestamp:      e.timestamp,
 					CustomMetadata: e.customMetadata,
-				})
-			}
+				},
+			})
 		}
+	}
+
+	// Sorting only on the score keeps events that match equally in the order
+	// they were visited.
+	slices.SortStableFunc(scored, func(a, b scoredEntry) int {
+		return b.score - a.score
+	})
+
+	if len(scored) > maxSearchResults {
+		scored = scored[:maxSearchResults]
+	}
+
+	for _, s := range scored {
+		res.Memories = append(res.Memories, s.entry)
 	}
 
 	return res, nil
 }
 
-func checkMapsIntersect(m1, m2 map[string]struct{}) bool {
+// countMapsIntersect returns how many keys the two sets share.
+func countMapsIntersect(m1, m2 map[string]struct{}) int {
 	if len(m1) == 0 || len(m2) == 0 {
-		return false
+		return 0
 	}
 
-	// Iterate over the smaller map.
+	// Iterate over the smaller map. The size of the intersection is the same
+	// either way round.
 	if len(m1) > len(m2) {
 		m1, m2 = m2, m1
 	}
 
+	count := 0
+
 	for k := range m1 {
 		if _, ok := m2[k]; ok {
-			return true
+			count++
 		}
 	}
 
-	return false
+	return count
 }
 
 func extractWords(text string) map[string]struct{} {

--- a/memory/inmemory_test.go
+++ b/memory/inmemory_test.go
@@ -30,6 +30,9 @@ import (
 	"google.golang.org/adk/v2/session"
 )
 
+// maxSearchResultsForTest mirrors the unexported cap in the memory package.
+const maxSearchResultsForTest = 10
+
 func Test_inMemoryService_SearchMemory(t *testing.T) {
 	tests := []struct {
 		name         string
@@ -267,4 +270,111 @@ func Test_inMemoryService_SearchMemory_Concurrent(t *testing.T) {
 		}()
 	}
 	wg.Wait()
+}
+
+// memoryIDs returns the IDs of the returned memories in order. Ordering is
+// meaningful once results are ranked, so these tests compare the sequence
+// directly rather than through the order-insensitive sortMemories transformer.
+func memoryIDs(resp *memory.SearchResponse) []string {
+	ids := make([]string, 0, len(resp.Memories))
+	for _, m := range resp.Memories {
+		ids = append(ids, m.ID)
+	}
+
+	return ids
+}
+
+func Test_inMemoryService_SearchMemory_RanksByMatchCount(t *testing.T) {
+	s := memory.InMemoryService()
+	events := []*session.Event{
+		{ID: "one", LLMResponse: model.LLMResponse{Content: genai.NewContentFromText("quick dog", genai.RoleUser)}},
+		{ID: "three", LLMResponse: model.LLMResponse{Content: genai.NewContentFromText("quick brown fox", genai.RoleUser)}},
+		{ID: "two", LLMResponse: model.LLMResponse{Content: genai.NewContentFromText("quick brown cat", genai.RoleUser)}},
+	}
+	if err := s.AddSessionToMemory(t.Context(), makeSession(t, "app1", "user1", "sess1", events)); err != nil {
+		t.Fatalf("inMemoryService.AddSessionToMemory() error = %v", err)
+	}
+
+	got, err := s.SearchMemory(t.Context(), &memory.SearchRequest{
+		AppName: "app1",
+		UserID:  "user1",
+		Query:   "quick brown fox",
+	})
+	if err != nil {
+		t.Fatalf("inMemoryService.SearchMemory() error = %v", err)
+	}
+
+	want := []string{"three", "two", "one"}
+	if diff := cmp.Diff(want, memoryIDs(got)); diff != "" {
+		t.Errorf("inMemoryService.SearchMemory() order mismatch (-want +got):\n%s", diff)
+	}
+}
+
+func Test_inMemoryService_SearchMemory_CapsResults(t *testing.T) {
+	s := memory.InMemoryService()
+
+	var events []*session.Event
+	for i := range maxSearchResultsForTest + 5 {
+		events = append(events, &session.Event{
+			ID: strconv.Itoa(i),
+			LLMResponse: model.LLMResponse{
+				Content: genai.NewContentFromText("shared "+strconv.Itoa(i), genai.RoleUser),
+			},
+		})
+	}
+
+	if err := s.AddSessionToMemory(t.Context(), makeSession(t, "app1", "user1", "sess1", events)); err != nil {
+		t.Fatalf("inMemoryService.AddSessionToMemory() error = %v", err)
+	}
+
+	got, err := s.SearchMemory(t.Context(), &memory.SearchRequest{
+		AppName: "app1",
+		UserID:  "user1",
+		Query:   "shared",
+	})
+	if err != nil {
+		t.Fatalf("inMemoryService.SearchMemory() error = %v", err)
+	}
+
+	if len(got.Memories) != maxSearchResultsForTest {
+		t.Errorf("inMemoryService.SearchMemory() returned %d memories, want %d",
+			len(got.Memories), maxSearchResultsForTest)
+	}
+}
+
+func Test_inMemoryService_SearchMemory_OrderIsStableAcrossRuns(t *testing.T) {
+	// Sessions are stored in a map, so without a fixed iteration order equally
+	// scored events come back in a different sequence on each call.
+	s := memory.InMemoryService()
+	for i := range 8 {
+		id := strconv.Itoa(i)
+		events := []*session.Event{
+			{ID: id, LLMResponse: model.LLMResponse{Content: genai.NewContentFromText("shared text", genai.RoleUser)}},
+		}
+		if err := s.AddSessionToMemory(t.Context(), makeSession(t, "app1", "user1", "sess"+id, events)); err != nil {
+			t.Fatalf("inMemoryService.AddSessionToMemory() error = %v", err)
+		}
+	}
+
+	req := &memory.SearchRequest{AppName: "app1", UserID: "user1", Query: "shared"}
+
+	first, err := s.SearchMemory(t.Context(), req)
+	if err != nil {
+		t.Fatalf("inMemoryService.SearchMemory() error = %v", err)
+	}
+
+	want := memoryIDs(first)
+	if len(want) != 8 {
+		t.Fatalf("inMemoryService.SearchMemory() returned %d memories, want 8", len(want))
+	}
+
+	for i := range 25 {
+		got, err := s.SearchMemory(t.Context(), req)
+		if err != nil {
+			t.Fatalf("inMemoryService.SearchMemory() error = %v", err)
+		}
+		if diff := cmp.Diff(want, memoryIDs(got)); diff != "" {
+			t.Fatalf("inMemoryService.SearchMemory() order changed on run %d (-first +got):\n%s", i, diff)
+		}
+	}
 }


### PR DESCRIPTION
Fixes #1526. Scoped to Gap 1 of that issue; Gap 2 (the non-ASCII substring
fallback) overlaps with the tokenization work in #1403 and is left for a
separate PR.

### Problem

`InMemoryService.SearchMemory` keeps every event sharing at least one word with
the query, in whatever order the session map happens to iterate.
`checkMapsIntersect` returns on the first shared word, so a single common token
is enough, nothing sorts the result and nothing caps it.

adk-python — the source of truth per CONTRIBUTING — scores each event by how
many distinct query words it matches, sorts descending and returns at most ten.
Its source says why:

> Almost any two sentences share a word, so returning every event that matches
> at least one query word returns most of the store, and callers such as the
> preload_memory tool put all of it in the prompt.

Go does the thing that comment warns against. A query containing "the" or "what"
matches nearly the whole store, and with `preloadmemorytool` registered all of
it is rendered into the prompt.

### Fix

Count the matched query words instead of stopping at the first, sort descending
on that count, and cap at ten (`maxSearchResults`, mirroring
`_MAX_SEARCH_RESULTS`). The sort is stable and reads only the score, so events
matching equally keep the order they were visited in.

Sessions live in a map, which Go iterates in a randomized order, so they are now
visited by sorted ID. Without that the stable sort has nothing stable to
preserve and identical queries return different orders between runs. adk-python
gets this property free from its insertion-ordered dict; a Go map has no
insertion order, so sorted IDs is the closest equivalent.

`checkMapsIntersect` becomes `countMapsIntersect`. It keeps the existing
"iterate the smaller map" optimisation, since the size of an intersection is the
same whichever side you walk.

### Testing plan

Three unit tests, each exercising one of the behaviours that changed. All three
fail on `main` and pass with the fix — the failures are the bug, stated exactly:

```
--- FAIL: Test_inMemoryService_SearchMemory_RanksByMatchCount
    order mismatch (-want +got):
      []string{
    + 	"one",
      	"three",
      	"two",
    - 	"one",
      }
--- FAIL: Test_inMemoryService_SearchMemory_CapsResults
    returned 15 memories, want 10
--- FAIL: Test_inMemoryService_SearchMemory_OrderIsStableAcrossRuns
    order changed on run 0 (-first +got):
      []string{
    - 	"0",
      	"1",
      ... // 3 identical elements
      	"7",
    + 	"0",
      }
```

With the fix applied:

```
$ go test -count=1 ./memory/...
ok  	google.golang.org/adk/v2/memory	0.353s

$ go test -race -count=1 ./memory/...
ok  	google.golang.org/adk/v2/memory	1.453s

$ go vet ./memory/...        # clean
$ gofmt -l memory/           # clean
```

Ordering is meaningful now, so the new tests compare the returned sequence
directly rather than through the existing order-insensitive `sortMemories`
transformer. The pre-existing table test still passes unchanged.

`./tool/...` also passes, covering `preloadmemorytool` and `loadmemorytool`, the
two consumers of `SearchMemory`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
