### PR TITLE
fix(sequentialagent): correct New godoc placement and copy-pasted error string (#1151)

### DIFF
--- a/agent/workflowagents/sequentialagent/agent.go
+++ b/agent/workflowagents/sequentialagent/agent.go
@@ -28,9 +28,8 @@ import (
 	"google.golang.org/adk/tool/functiontool"
 )
 
-// New creates a SequentialAgent.
-//
-// SequentialAgent executes its sub-agents once, in the order they are listed.
+// seqAgent is the agent returned by New; it augments the base agent with the
+// live-mode entry point.
 type seqAgent struct {
 	agent.Agent
 	*agentinternal.State
@@ -41,11 +40,14 @@ func (s *seqAgent) RunLive(ctx agent.InvocationContext) (agent.LiveSession, iter
 	return s.impl.RunLive(ctx)
 }
 
+// New creates a SequentialAgent.
+//
+// SequentialAgent executes its sub-agents once, in the order they are listed.
 // Use the SequentialAgent when you want the execution to occur in a fixed,
 // strict order.
 func New(cfg Config) (agent.Agent, error) {
 	if cfg.AgentConfig.Run != nil {
-		return nil, fmt.Errorf("LoopAgent doesn't allow custom Run implementations")
+		return nil, fmt.Errorf("SequentialAgent doesn't allow custom Run implementations")
 	}
 
 	sequentialAgentImpl := &sequentialAgent{}


### PR DESCRIPTION
Backports #1151 from `main` to `v1`.

Done by hand: the automated replay conflicts. `v1` carries the same two defects as `main` did, in a different arrangement — the `New` godoc is attached to `seqAgent` and `New` is left with an orphaned fragment above it — so the patch context does not match and `git apply`, including `--3way`, rejects hunk 2.

The result is byte-identical to `main` after the module-path rewrite, apart from the pre-existing `agent.Context` / `agent.ToolContext` difference between the branches, which is unrelated to this change.

Carries the `(cherry picked from commit …)` trailer, so the backport tooling recognises #1151 as done and drops it from the queue.

`go build` and `go test ./agent/workflowagents/sequentialagent/` pass.