### PR TITLE
fix(launcher/api): serve run_live through the API mount again

### DIFF
--- a/cmd/launcher/web/api/api.go
+++ b/cmd/launcher/web/api/api.go
@@ -228,7 +228,12 @@ func (w *redirectRewriter) Unwrap() http.ResponseWriter { return w.ResponseWrite
 func (w *redirectRewriter) Hijack() (net.Conn, *bufio.ReadWriter, error) {
 	h, ok := w.ResponseWriter.(http.Hijacker)
 	if !ok {
-		return nil, nil, fmt.Errorf("redirectRewriter: underlying %T is not an http.Hijacker", w.ResponseWriter)
+		// Wrapping the sentinel keeps errors.Is(err, http.ErrNotSupported)
+		// true. http.ResponseController finds this method before it follows
+		// Unwrap, so without the wrap this type would silently change that
+		// answer from true to false for everything underneath it.
+		return nil, nil, fmt.Errorf("redirectRewriter: underlying %T is not an http.Hijacker: %w",
+			w.ResponseWriter, http.ErrNotSupported)
 	}
 	return h.Hijack()
 }

--- a/cmd/launcher/web/api/api.go
+++ b/cmd/launcher/web/api/api.go
@@ -16,8 +16,10 @@
 package api
 
 import (
+	"bufio"
 	"flag"
 	"fmt"
+	"net"
 	"net/http"
 	"net/url"
 	"strings"
@@ -214,6 +216,22 @@ func (w *redirectRewriter) Flush() {
 // Unwrap lets http.ResponseController reach the real writer, which the SSE
 // handler needs for SetWriteDeadline.
 func (w *redirectRewriter) Unwrap() http.ResponseWriter { return w.ResponseWriter }
+
+// Hijack lets /run_live take over the connection for its WebSocket upgrade.
+//
+// gorilla/websocket type-asserts the ResponseWriter to http.Hijacker directly
+// and does not consult Unwrap, so a wrapper that omits this method turns every
+// upgrade into a 500. Only the prefixed mount wraps the writer, which is why
+// the failure shows on the default /api path and not on an empty prefix.
+//
+// Anything else that wraps a ResponseWriter here has to forward this too.
+func (w *redirectRewriter) Hijack() (net.Conn, *bufio.ReadWriter, error) {
+	h, ok := w.ResponseWriter.(http.Hijacker)
+	if !ok {
+		return nil, nil, fmt.Errorf("redirectRewriter: underlying %T is not an http.Hijacker", w.ResponseWriter)
+	}
+	return h.Hijack()
+}
 
 // rewriteRedirects re-adds pathPrefix to a redirect written below the mount.
 //

--- a/cmd/launcher/web/api/api_test.go
+++ b/cmd/launcher/web/api/api_test.go
@@ -23,6 +23,7 @@ import (
 	"testing"
 
 	"github.com/gorilla/mux"
+	"github.com/gorilla/websocket"
 	"google.golang.org/genai"
 
 	"google.golang.org/adk/v2/agent"
@@ -469,6 +470,59 @@ func TestSetupSubroutersServesRealRESTAPI(t *testing.T) {
 			}
 			if got := rec.Header().Get("Allow"); got != "GET, HEAD" {
 				t.Errorf("Allow = %q, want %q", got, "GET, HEAD")
+			}
+		})
+	}
+}
+
+// TestWebSocketUpgradeThroughMount covers /run_live, which takes over the
+// connection instead of writing a response.
+//
+// The prefixed mount wraps the ResponseWriter to rewrite redirects, and
+// gorilla/websocket type-asserts that writer to http.Hijacker directly rather
+// than following Unwrap. A wrapper missing Hijack therefore turns every
+// upgrade into a 500, on the default /api prefix but not on an empty one.
+// httptest.NewServer is used rather than a recorder because only a real
+// connection can be hijacked.
+func TestWebSocketUpgradeThroughMount(t *testing.T) {
+	for _, prefix := range []string{"/api", ""} {
+		t.Run("prefix="+prefix, func(t *testing.T) {
+			upgrader := websocket.Upgrader{}
+			echo := http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+				conn, err := upgrader.Upgrade(w, r, nil)
+				if err != nil {
+					// Upgrade has already written the error response.
+					return
+				}
+				defer func() { _ = conn.Close() }()
+				_ = conn.WriteMessage(websocket.TextMessage, []byte("live"))
+			})
+
+			router := mux.NewRouter().StrictSlash(true)
+			inner := mux.NewRouter().StrictSlash(true)
+			inner.Path("/run_live").Handler(echo)
+			registerAPIRoutes(router, prefix, inner)
+
+			srv := httptest.NewServer(router)
+			defer srv.Close()
+
+			url := "ws" + strings.TrimPrefix(srv.URL, "http") + prefix + "/run_live"
+			conn, resp, err := websocket.DefaultDialer.Dial(url, nil)
+			if err != nil {
+				status := "no response"
+				if resp != nil {
+					status = resp.Status
+				}
+				t.Fatalf("Dial(%s) error = %v (%s), want a successful upgrade", url, err, status)
+			}
+			defer func() { _ = conn.Close() }()
+
+			_, msg, err := conn.ReadMessage()
+			if err != nil {
+				t.Fatalf("ReadMessage() error = %v, want the server's frame", err)
+			}
+			if got := string(msg); got != "live" {
+				t.Errorf("ReadMessage() = %q, want %q", got, "live")
 			}
 		})
 	}

--- a/cmd/launcher/web/api/api_test.go
+++ b/cmd/launcher/web/api/api_test.go
@@ -15,12 +15,14 @@
 package api
 
 import (
+	"errors"
 	"fmt"
 	"iter"
 	"net/http"
 	"net/http/httptest"
 	"strings"
 	"testing"
+	"time"
 
 	"github.com/gorilla/mux"
 	"github.com/gorilla/websocket"
@@ -517,6 +519,13 @@ func TestWebSocketUpgradeThroughMount(t *testing.T) {
 			}
 			defer func() { _ = conn.Close() }()
 
+			// Without a deadline, an upgrade that succeeds but never sends a
+			// frame hangs until the package timeout, taking every other test in
+			// the package down with it instead of failing this one.
+			if err := conn.SetReadDeadline(time.Now().Add(10 * time.Second)); err != nil {
+				t.Fatalf("SetReadDeadline() error = %v", err)
+			}
+
 			_, msg, err := conn.ReadMessage()
 			if err != nil {
 				t.Fatalf("ReadMessage() error = %v, want the server's frame", err)
@@ -525,5 +534,89 @@ func TestWebSocketUpgradeThroughMount(t *testing.T) {
 				t.Errorf("ReadMessage() = %q, want %q", got, "live")
 			}
 		})
+	}
+}
+
+// TestHijackReportsNotSupported covers the branch taken when the writer
+// underneath the mount cannot be hijacked.
+//
+// The wrapper has to report that as http.ErrNotSupported rather than a bare
+// error, because http.ResponseController finds this method before it follows
+// Unwrap. A caller asking errors.Is(err, http.ErrNotSupported) would otherwise
+// get a different answer purely because the mount is in the way.
+func TestHijackReportsNotSupported(t *testing.T) {
+	// httptest.ResponseRecorder implements no Hijacker, which is the case.
+	w := &redirectRewriter{ResponseWriter: httptest.NewRecorder(), prefix: "/api"}
+
+	conn, brw, err := w.Hijack()
+
+	if err == nil {
+		t.Fatal("Hijack() error = nil, want a failure on a writer that cannot be hijacked")
+	}
+	if conn != nil || brw != nil {
+		t.Errorf("Hijack() = (%v, %v), want both nil alongside the error", conn, brw)
+	}
+	if !errors.Is(err, http.ErrNotSupported) {
+		t.Errorf("Hijack() error = %v, want it to wrap http.ErrNotSupported", err)
+	}
+}
+
+// TestRunLiveUpgradesThroughTheRealMount drives the actual REST server rather
+// than a stub inner router.
+//
+// The stub version proves the mount can carry an upgrade. This proves the
+// endpoint that was broken can. The session does not exist, so the server
+// accepts the upgrade and then closes; what matters is that the handshake
+// completes at all, which is what returned 500 before Hijack was forwarded.
+func TestRunLiveUpgradesThroughTheRealMount(t *testing.T) {
+	agnt, err := agent.New(agent.Config{
+		Name: "HelloWorldAgent",
+		Run: func(ic agent.InvocationContext) iter.Seq2[*session.Event, error] {
+			return func(yield func(*session.Event, error) bool) {}
+		},
+	})
+	if err != nil {
+		t.Fatalf("agent.New() error = %v", err)
+	}
+
+	l := NewLauncher()
+	if _, err := l.Parse([]string{"-path_prefix", "/api"}); err != nil {
+		t.Fatalf("Parse() error = %v", err)
+	}
+	router := mux.NewRouter().StrictSlash(true)
+	if err := l.SetupSubrouters(router, &launcher.Config{
+		AgentLoader:    agent.NewSingleLoader(agnt),
+		SessionService: session.InMemoryService(),
+	}); err != nil {
+		t.Fatalf("SetupSubrouters() error = %v", err)
+	}
+
+	srv := httptest.NewServer(router)
+	defer srv.Close()
+
+	url := "ws" + strings.TrimPrefix(srv.URL, "http") +
+		"/api/run_live?app_name=HelloWorldAgent&user_id=u&session_id=does-not-exist"
+	conn, resp, err := websocket.DefaultDialer.Dial(url, nil)
+	if err != nil {
+		status := "no response"
+		if resp != nil {
+			status = resp.Status
+		}
+		t.Fatalf("Dial(%s) error = %v (%s), want the handshake to complete", url, err, status)
+	}
+	defer func() { _ = conn.Close() }()
+
+	if resp.StatusCode != http.StatusSwitchingProtocols {
+		t.Errorf("handshake status = %d, want %d", resp.StatusCode, http.StatusSwitchingProtocols)
+	}
+
+	// The server closes because the session is missing. Reading that close is
+	// what confirms the connection was live, and the deadline keeps a silent
+	// server from hanging the package.
+	if err := conn.SetReadDeadline(time.Now().Add(10 * time.Second)); err != nil {
+		t.Fatalf("SetReadDeadline() error = %v", err)
+	}
+	if _, _, err := conn.ReadMessage(); err == nil {
+		t.Log("server sent a frame before closing, which is also fine")
 	}
 }


### PR DESCRIPTION
### Link to Issue or Description of Change

**2. Or, if no issue exists, describe the change:**

**Problem:**

`/run_live` returns 500 on the default `/api` prefix, so WebSocket live run is
broken for anyone using it:

```
websocket: bad handshake (500 Internal Server Error)
websocket: response does not implement http.Hijacker
```

The API mount wraps the `ResponseWriter` in `redirectRewriter`, which re-adds
the prefix to a redirect `Location` and promotes a 301 to a 308 so an unsafe
method is not downgraded to GET. `gorilla/websocket` v1.5.3 type-asserts the
writer to `http.Hijacker` at `server.go:175` and does not consult `Unwrap`, so
the wrapper makes the upgrade impossible. Only the prefixed branch wraps, which
is why an empty prefix still works.

**Solution:**

Forward `Hijack` to the underlying writer. The change is purely additive to
`api.go`: `git diff origin/main` shows zero removed lines, so nothing but
`run_live` changes.

The failure is reported as `http.ErrNotSupported` rather than a bare error,
because `http.ResponseController` finds this method before it follows `Unwrap`.
Without the wrap, this type would silently change the answer to
`errors.Is(err, http.ErrNotSupported)` for everything underneath it.

**An earlier version of this branch took a different approach and it was
wrong.** It deleted the wrapper and normalised the request path so the router
never emitted a redirect. Review found two regressions: it 301'd `GET /api` to
`/`, because an empty path took a fast path unrewritten, and it did not cover a
trailing `%2F`, where the inner router still emits a `StrictSlash` redirect that
only the wrapper restores the prefix to. The wrapper does necessary work, so the
fix completes it rather than removing it.

### Testing Plan

**Unit Tests:**

- [x] I have added or updated unit tests for my change.
- [x] All unit tests pass locally.

```
go build ./...                                             ok
go vet ./...                                               ok
go test -race -count=1 -shuffle=on ./cmd/... ./server/...  all packages ok
golangci-lint run ./cmd/...                                0 issues
```

Three tests:

| Test | What it covers |
| --- | --- |
| `TestWebSocketUpgradeThroughMount` | the mount can carry an upgrade, on `/api` and on an empty prefix as a control |
| `TestRunLiveUpgradesThroughTheRealMount` | the real REST server through the real registration path, so it is `/run_live` that is proved and not a stub |
| `TestHijackReportsNotSupported` | the error branch, which is reachable because `httptest.ResponseRecorder` is not a `Hijacker` |

Mutation-proved. Making the hijack fail while keeping the method present fails
both WebSocket tests with the exact reported 500, and the empty-prefix subtest
stays green as a control. Dropping the sentinel wrap fails the error-branch
test.

Both WebSocket tests set a read deadline, so a regression where the upgrade
succeeds but no frame arrives fails the test rather than hanging the package
until the ten minute default.

**Manual End-to-End (E2E) Tests:**

Run any agent with `adk web api webui`, open the UI, and start a live run. On
`main` the connection fails immediately; with this change it upgrades.

### Checklist

- [x] I have read the CONTRIBUTING.md document.
- [x] I have performed a self-review of my own code.
- [x] I have commented my code, particularly in hard-to-understand areas.
- [x] I have added tests that prove my fix is effective or that my feature works.
- [x] New and existing unit tests pass locally with my changes.
- [x] I have manually tested my changes end-to-end.

### Additional context

This is a regression from #1459, found while reviewing that PR's redirect
wrapper.

**Worth a follow-up, not this PR.** `/run_live` has never been reachable on the
default prefix, so this is the first time its own defences matter.
`websocket.Upgrader{}` is constructed with a nil `CheckOrigin`, which compares
the `Origin` host to the `Host` header, so a DNS-rebound page satisfies it and
WebSocket is exempt from CORS. Go also binds `:8080` on every interface while
the flag help calls it "Localhost port". adk-python runs
`_is_dns_rebinding_request` before accepting and defaults to
`--host 127.0.0.1`. `SetReadLimit`, a post-hijack deadline and any cap on
concurrent live sessions are all absent too. None of that is introduced here,
but this change is what makes it reachable.
