### PR TITLE
fix(launcher/web): let a sublauncher own /health, and warn on invented storage

### DIFF
--- a/cmd/launcher/web/web.go
+++ b/cmd/launcher/web/web.go
@@ -175,9 +175,15 @@ func (w *webLauncher) Parse(args []string) ([]string, error) {
 // Refusing is the eventual goal rather than the current behaviour because
 // cmd/launcher/prod runs through this same path. A production deployment that
 // configured no storage should learn about it at startup, not when a restart
-// has already dropped the data. adk-python falls back to
-// InMemoryArtifactService for an absent URI, so the fallback is not wrong in
-// itself; it belongs to a dev server rather than to every server.
+// has already dropped the data.
+//
+// adk-python does not default to memory here. An absent --artifact_service_uri
+// gets per-agent local disk under <agents_root>/<agent>/.adk/artifacts, and
+// in-memory is only the fallback when local storage is disabled or unwritable
+// (cli/utils/service_factory.py). Every one of those paths logs a warning
+// naming the flag. So Go defaulting straight to memory is already the weaker
+// behaviour, which is the argument for warning loudly now and refusing later,
+// not an argument that the fallback is fine.
 func applyServiceDefaults(config *launcher.Config, allowInMemory bool) (defaulted []string, unconsented bool) {
 	if config.SessionService == nil {
 		config.SessionService = session.InMemoryService()
@@ -213,20 +219,23 @@ func logInMemoryServiceWarning(defaulted []string, unconsented bool) {
 	if len(defaulted) == 0 {
 		return
 	}
+	// Naming launcher.Config, not just the flag: the flag only silences this,
+	// and there is no command-line way to point the launcher at real storage.
 	log.Printf("       WARNING: no %s service configured, so an in-memory one is in use.", strings.Join(defaulted, ", "))
 	log.Printf("       WARNING:     everything it holds is lost when this process exits.")
 	if unconsented {
-		log.Printf("       WARNING:     a future release will refuse to start instead. Configure a")
-		log.Printf("       WARNING:     service, or pass -allow_in_memory_services to keep this.")
+		log.Printf("       WARNING:     a future release will refuse to start instead. Set")
+		log.Printf("       WARNING:     ArtifactService and MemoryService on launcher.Config,")
+		log.Printf("       WARNING:     or pass -allow_in_memory_services to keep this.")
 	}
 }
 
-// buildRouter assembles the router Run serves: the base router, then every
-// active sublauncher's routes, then the fallback health route.
+// buildRouter assembles the handler Run serves: the base router, every active
+// sublauncher's routes, and a health fallback around the outside.
 //
-// Separated from Run so a test can assert the registration order without
-// binding a port, because the order is what decides which /health wins.
-func (w *webLauncher) buildRouter(config *launcher.Config) (*mux.Router, error) {
+// Separated from Run so a test can exercise exactly what is served without
+// binding a port.
+func (w *webLauncher) buildRouter(config *launcher.Config) (http.Handler, error) {
 	router := BuildBaseRouter()
 
 	// check if there are any active sublaunchers
@@ -247,12 +256,7 @@ func (w *webLauncher) buildRouter(config *launcher.Config) (*mux.Router, error) 
 		}
 	}
 
-	// Registered after the sublaunchers, not before, because gorilla/mux
-	// matches in registration order. Going first would shadow a /health that a
-	// sublauncher serves itself, leaving that sublauncher's own readiness
-	// signal unreachable while the probe still reported ok.
-	registerHealthRoute(router)
-	return router, nil
+	return withHealthFallback(router), nil
 }
 
 // webUIKeyword is the command-line keyword of the webui sublauncher. It is a
@@ -398,15 +402,52 @@ func BuildBaseRouter() *mux.Router {
 	return router
 }
 
-// registerHealthRoute serves health at the root as well as under the API
+// healthPath is the probe path served at the root as well as under the API
 // prefix. Load balancers and container probes are configured with a fixed path
 // and cannot be expected to know which sublaunchers happen to be enabled.
+const healthPath = "/health"
+
+// withHealthFallback answers healthPath when nothing else declares it.
 //
-// Run calls this rather than BuildBaseRouter doing it, so that an embedder
-// building its own server keeps /health for itself, and calls it after the
-// sublaunchers so that it is a fallback rather than an override.
-func registerHealthRoute(router *mux.Router) {
-	router.HandleFunc("/health", healthHandler).Methods(http.MethodGet, http.MethodHead)
+// This wraps the router rather than registering a route on it, because neither
+// registration order works. Registering first shadows a /health a sublauncher
+// serves itself, so a draining instance keeps reporting ok. Registering last
+// puts it behind any catch-all route a sublauncher mounted, so the probe path
+// 404s. Deciding outside the router avoids both.
+//
+// A sublauncher that declares healthPath owns it completely, on every method.
+// Answering HEAD here while it answers GET is the same shadowing bug on one
+// verb, and HEAD is what HAProxy and nginx probe with by default.
+//
+// Run calls this rather than BuildBaseRouter doing it, so an embedder building
+// its own server keeps /health for itself.
+func withHealthFallback(router *mux.Router) http.Handler {
+	if declaresHealthRoute(router) {
+		return router
+	}
+	return http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if r.URL.Path == healthPath && (r.Method == http.MethodGet || r.Method == http.MethodHead) {
+			healthHandler(w, r)
+			return
+		}
+		router.ServeHTTP(w, r)
+	})
+}
+
+// declaresHealthRoute reports whether any route names healthPath outright.
+//
+// It matches on the path template rather than by serving a probe request,
+// because a catch-all would answer such a probe without meaning to own the
+// path, and a catch-all is exactly what the fallback has to beat.
+func declaresHealthRoute(router *mux.Router) bool {
+	declared := false
+	_ = router.Walk(func(route *mux.Route, _ *mux.Router, _ []*mux.Route) error {
+		if tmpl, err := route.GetPathTemplate(); err == nil && tmpl == healthPath {
+			declared = true
+		}
+		return nil
+	})
+	return declared
 }
 
 // healthHandler reports that the web server is up. It says nothing about the

--- a/cmd/launcher/web/web.go
+++ b/cmd/launcher/web/web.go
@@ -45,6 +45,7 @@ type webConfig struct {
 	shutdownTimeout time.Duration
 	otelToCloud     bool
 	useH2C          bool
+	allowInMemory   bool
 }
 
 // webLauncher can launch web server
@@ -153,22 +154,36 @@ func (w *webLauncher) Parse(args []string) ([]string, error) {
 	return restArgs, nil
 }
 
-// applyServiceDefaults fills in in-memory services the caller left unset.
+// applyServiceDefaults fills in in-memory services the caller left unset, and
+// reports which ones it invented and whether the caller consented.
 //
 // Neither adkrest.NewServer nor runner.New defaults them; only
 // runner.NewInMemory does, and the web launcher does not use it. A nil session
 // or memory service reaches the request path and panics, which drops the
-// connection without sending any HTTP response. The artifact handlers answer
-// 503 instead, so defaulting that one replaces a clear diagnostic with a server
-// that works until it restarts and then has lost everything. It is logged for
-// that reason: cmd/launcher/prod runs through this same path, so a deployment
-// that forgot to configure a service still says so on startup.
-func applyServiceDefaults(config *launcher.Config) {
-	var defaulted []string
+// connection without sending any HTTP response.
+//
+// The session service is always defaulted, as it was before the artifact and
+// memory ones were added, because every request path needs it and a nil one
+// panics.
+//
+// The other two are defaulted too, but only silently when allowInMemory says a
+// volatile store is acceptable: the webui sublauncher is a developer tool and
+// implies it, and -allow_in_memory_services sets it explicitly. Without that
+// consent they are still created, so nothing breaks on upgrade, and unconsented
+// reports true so the caller can warn that a future release will refuse instead.
+//
+// Refusing is the eventual goal rather than the current behaviour because
+// cmd/launcher/prod runs through this same path. A production deployment that
+// configured no storage should learn about it at startup, not when a restart
+// has already dropped the data. adk-python falls back to
+// InMemoryArtifactService for an absent URI, so the fallback is not wrong in
+// itself; it belongs to a dev server rather than to every server.
+func applyServiceDefaults(config *launcher.Config, allowInMemory bool) (defaulted []string, unconsented bool) {
 	if config.SessionService == nil {
 		config.SessionService = session.InMemoryService()
-		defaulted = append(defaulted, "session")
+		log.Print("No session service configured. Using an in-memory one, so whatever it holds is lost when the process exits.")
 	}
+
 	if config.ArtifactService == nil {
 		config.ArtifactService = artifact.InMemoryService()
 		defaulted = append(defaulted, "artifact")
@@ -180,14 +195,39 @@ func applyServiceDefaults(config *launcher.Config) {
 	for _, name := range defaulted {
 		log.Printf("No %s service configured. Using an in-memory one, so whatever it holds is lost when the process exits.", name)
 	}
+	return defaulted, len(defaulted) > 0 && !allowInMemory
 }
 
-// Run implements launcher.SubLauncher.
-func (w *webLauncher) Run(ctx context.Context, config *launcher.Config) error {
-	applyServiceDefaults(config)
+// logInMemoryServiceWarning restates which services fell back to memory, in the
+// startup banner alongside the URLs.
+//
+// applyServiceDefaults already logs each one, but that runs before the routers
+// are built and has scrolled past by the time the banner prints. Repeating it
+// here is deliberate: this block is what an operator reads, and losing artifacts
+// on the next restart is not something to learn from a line further up.
+//
+// When the caller did not ask for a volatile store, the warning also says the
+// launcher will refuse to start in a future release, so a deployment can fix
+// its configuration before that lands rather than after.
+func logInMemoryServiceWarning(defaulted []string, unconsented bool) {
+	if len(defaulted) == 0 {
+		return
+	}
+	log.Printf("       WARNING: no %s service configured, so an in-memory one is in use.", strings.Join(defaulted, ", "))
+	log.Printf("       WARNING:     everything it holds is lost when this process exits.")
+	if unconsented {
+		log.Printf("       WARNING:     a future release will refuse to start instead. Configure a")
+		log.Printf("       WARNING:     service, or pass -allow_in_memory_services to keep this.")
+	}
+}
 
+// buildRouter assembles the router Run serves: the base router, then every
+// active sublauncher's routes, then the fallback health route.
+//
+// Separated from Run so a test can assert the registration order without
+// binding a port, because the order is what decides which /health wins.
+func (w *webLauncher) buildRouter(config *launcher.Config) (*mux.Router, error) {
 	router := BuildBaseRouter()
-	registerHealthRoute(router)
 
 	// check if there are any active sublaunchers
 	if len(w.activeSublaunchers) == 0 {
@@ -195,16 +235,49 @@ func (w *webLauncher) Run(ctx context.Context, config *launcher.Config) error {
 		for i, l := range w.sublaunchers {
 			availableSublaunchers[i] = l.Keyword()
 		}
-		return fmt.Errorf("no active sublaunchers found - please specify them in the command line. Possible values: %v", availableSublaunchers)
+		return nil, fmt.Errorf("no active sublaunchers found - please specify them in the command line. Possible values: %v", availableSublaunchers)
 	}
 
 	// Setup subrouters
 	for _, l := range w.sublaunchers {
 		if _, isActive := w.activeSublaunchers[l.Keyword()]; isActive {
 			if err := l.SetupSubrouters(router, config); err != nil {
-				return fmt.Errorf("%s subrouter setup failed: %v", l.Keyword(), err)
+				return nil, fmt.Errorf("%s subrouter setup failed: %v", l.Keyword(), err)
 			}
 		}
+	}
+
+	// Registered after the sublaunchers, not before, because gorilla/mux
+	// matches in registration order. Going first would shadow a /health that a
+	// sublauncher serves itself, leaving that sublauncher's own readiness
+	// signal unreachable while the probe still reported ok.
+	registerHealthRoute(router)
+	return router, nil
+}
+
+// webUIKeyword is the command-line keyword of the webui sublauncher. It is a
+// literal rather than a reference because that package imports this one, so the
+// dependency cannot run the other way.
+const webUIKeyword = "webui"
+
+// allowsInMemoryServices reports whether a volatile artifact and memory store
+// is acceptable for this invocation. The webui sublauncher is a developer tool
+// and implies it, so `adk web api webui` still runs with no configuration.
+func (w *webLauncher) allowsInMemoryServices() bool {
+	if w.config.allowInMemory {
+		return true
+	}
+	_, hasWebUI := w.activeSublaunchers[webUIKeyword]
+	return hasWebUI
+}
+
+// Run implements launcher.SubLauncher.
+func (w *webLauncher) Run(ctx context.Context, config *launcher.Config) error {
+	defaulted, unconsented := applyServiceDefaults(config, w.allowsInMemoryServices())
+
+	router, err := w.buildRouter(config)
+	if err != nil {
+		return err
 	}
 
 	log.Printf("Starting the web server: %+v", w.config)
@@ -214,6 +287,7 @@ func (w *webLauncher) Run(ctx context.Context, config *launcher.Config) error {
 	for _, l := range w.activeSublaunchers {
 		l.UserMessage(webUrl, log.Println)
 	}
+	logInMemoryServiceWarning(defaulted, unconsented)
 	log.Println()
 
 	telemetryService, err := telemetry.InitAndSetGlobalOtelProviders(ctx, config, w.config.otelToCloud)
@@ -288,6 +362,7 @@ func NewLauncher(sublaunchers ...Sublauncher) launcher.SubLauncher {
 	fs.DurationVar(&config.shutdownTimeout, "shutdown-timeout", 15*time.Second, "Server shutdown timeout (i.e. '10s', '2m' - see time.ParseDuration for details) - for waiting for active requests to finish during shutdown")
 	fs.BoolVar(&config.otelToCloud, "otel_to_cloud", false, "Enables/disables OpenTelemetry export to GCP: telemetry.googleapis.com. See adk-go/telemetry package for details about supported options, credentials and environment variables.")
 	fs.BoolVar(&config.useH2C, "h2c", false, "Enable prior-knowledge cleartext HTTP/2 (h2c; no HTTP/1.1 Upgrade) on the web server listener. Cleartext is insecure; do not expose it to untrusted networks. Long-lived streaming responses may require increasing --write-timeout.")
+	fs.BoolVar(&config.allowInMemory, "allow_in_memory_services", false, "Fall back to in-memory artifact and memory services when none is configured, instead of refusing to start. Their contents are lost when the process exits, so this is for local runs. Implied when the webui sublauncher is active.")
 
 	return &webLauncher{
 		config:       config,
@@ -328,7 +403,8 @@ func BuildBaseRouter() *mux.Router {
 // and cannot be expected to know which sublaunchers happen to be enabled.
 //
 // Run calls this rather than BuildBaseRouter doing it, so that an embedder
-// building its own server keeps /health for itself.
+// building its own server keeps /health for itself, and calls it after the
+// sublaunchers so that it is a fallback rather than an override.
 func registerHealthRoute(router *mux.Router) {
 	router.HandleFunc("/health", healthHandler).Methods(http.MethodGet, http.MethodHead)
 }

--- a/cmd/launcher/web/web.go
+++ b/cmd/launcher/web/web.go
@@ -177,13 +177,14 @@ func (w *webLauncher) Parse(args []string) ([]string, error) {
 // configured no storage should learn about it at startup, not when a restart
 // has already dropped the data.
 //
-// adk-python does not default to memory here. An absent --artifact_service_uri
-// gets per-agent local disk under <agents_root>/<agent>/.adk/artifacts, and
-// in-memory is only the fallback when local storage is disabled or unwritable
-// (cli/utils/service_factory.py). Every one of those paths logs a warning
-// naming the flag. So Go defaulting straight to memory is already the weaker
-// behaviour, which is the argument for warning loudly now and refusing later,
-// not an argument that the fallback is fine.
+// adk-python is not a straightforward precedent either way. An absent
+// --artifact_service_uri gets per-agent local disk under
+// <agents_root>/<agent>/.adk/artifacts, but it falls back to memory when it
+// detects Cloud Run or Kubernetes even with storage writable, and that warning
+// names ADK_FORCE_LOCAL_STORAGE rather than the URI flag
+// (cli/utils/service_factory.py). So on the deployments this comment is about,
+// Python also serves from memory. What it does differently is warn at the point
+// of fallback and name the way out, which is the part worth copying.
 func applyServiceDefaults(config *launcher.Config, allowInMemory bool) (defaulted []string, unconsented bool) {
 	if config.SessionService == nil {
 		config.SessionService = session.InMemoryService()
@@ -409,15 +410,23 @@ const healthPath = "/health"
 
 // withHealthFallback answers healthPath when nothing else declares it.
 //
-// This wraps the router rather than registering a route on it, because neither
-// registration order works. Registering first shadows a /health a sublauncher
-// serves itself, so a draining instance keeps reporting ok. Registering last
-// puts it behind any catch-all route a sublauncher mounted, so the probe path
-// 404s. Deciding outside the router avoids both.
+// The fallback is a route on an outer router rather than a check in front of
+// the inner one. Answering before the inner router runs skips its middleware
+// and its StrictSlash handling, so probes stopped appearing in the request log
+// and /health/ 404ed instead of redirecting.
+//
+// Registering on the inner router does not work in either position. First
+// shadows a /health a sublauncher serves itself, so a draining instance keeps
+// reporting ok. Last puts it behind any catch-all a sublauncher mounted, so the
+// probe path 404s. An outer router with the inner one as its final route avoids
+// both.
 //
 // A sublauncher that declares healthPath owns it completely, on every method.
 // Answering HEAD here while it answers GET is the same shadowing bug on one
-// verb, and HEAD is what HAProxy and nginx probe with by default.
+// verb, and HEAD is what HAProxy and nginx probe with by default. The
+// consequence is worth stating plainly: a sublauncher that registers healthPath
+// for GET alone makes HEAD a 405, where it used to be 200, so a HEAD probe
+// marks the instance down. That is what ownership means here, not an oversight.
 //
 // Run calls this rather than BuildBaseRouter doing it, so an embedder building
 // its own server keeps /health for itself.
@@ -425,26 +434,40 @@ func withHealthFallback(router *mux.Router) http.Handler {
 	if declaresHealthRoute(router) {
 		return router
 	}
-	return http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
-		if r.URL.Path == healthPath && (r.Method == http.MethodGet || r.Method == http.MethodHead) {
-			healthHandler(w, r)
-			return
-		}
-		router.ServeHTTP(w, r)
-	})
+	// mux.NewRouter rather than BuildBaseRouter: the latter installs logger,
+	// which would then run twice on every request the inner router serves.
+	outer := mux.NewRouter().StrictSlash(true)
+	outer.Handle(healthPath, logger(http.HandlerFunc(healthHandler))).
+		Methods(http.MethodGet, http.MethodHead)
+	outer.NewRoute().Handler(router)
+	return outer
 }
 
-// declaresHealthRoute reports whether any route names healthPath outright.
+// declaresHealthRoute reports whether a route claims healthPath unconditionally.
 //
-// It matches on the path template rather than by serving a probe request,
-// because a catch-all would answer such a probe without meaning to own the
-// path, and a catch-all is exactly what the fallback has to beat.
+// It reads the path template rather than serving a probe request, because a
+// catch-all would answer such a probe without meaning to own the path, and a
+// catch-all is exactly what the fallback has to beat.
+//
+// A route that also carries a host or query matcher does not count. It answers
+// some requests for the path and not others, so switching the fallback off for
+// all of them would 404 the ones its own matcher rejects. Header matchers are
+// not reachable through the mux API, so a route scoped only by a header still
+// counts as owning the path.
 func declaresHealthRoute(router *mux.Router) bool {
 	declared := false
 	_ = router.Walk(func(route *mux.Route, _ *mux.Router, _ []*mux.Route) error {
-		if tmpl, err := route.GetPathTemplate(); err == nil && tmpl == healthPath {
-			declared = true
+		tmpl, err := route.GetPathTemplate()
+		if err != nil || tmpl != healthPath {
+			return nil
 		}
+		if _, err := route.GetHostTemplate(); err == nil {
+			return nil
+		}
+		if q, err := route.GetQueriesTemplates(); err == nil && len(q) > 0 {
+			return nil
+		}
+		declared = true
 		return nil
 	})
 	return declared

--- a/cmd/launcher/web/web.go
+++ b/cmd/launcher/web/web.go
@@ -27,12 +27,10 @@ import (
 
 	"github.com/gorilla/mux"
 
-	"google.golang.org/adk/v2/artifact"
 	"google.golang.org/adk/v2/cmd/launcher"
 	"google.golang.org/adk/v2/cmd/launcher/internal/telemetry"
 	"google.golang.org/adk/v2/cmd/launcher/universal"
 	"google.golang.org/adk/v2/internal/cli/util"
-	"google.golang.org/adk/v2/memory"
 	"google.golang.org/adk/v2/session"
 )
 
@@ -45,7 +43,6 @@ type webConfig struct {
 	shutdownTimeout time.Duration
 	otelToCloud     bool
 	useH2C          bool
-	allowInMemory   bool
 }
 
 // webLauncher can launch web server
@@ -154,80 +151,27 @@ func (w *webLauncher) Parse(args []string) ([]string, error) {
 	return restArgs, nil
 }
 
-// applyServiceDefaults fills in in-memory services the caller left unset, and
-// reports which ones it invented and whether the caller consented.
+// applyServiceDefaults fills in the one service the launcher can safely assume.
 //
-// Neither adkrest.NewServer nor runner.New defaults them; only
-// runner.NewInMemory does, and the web launcher does not use it. A nil session
-// or memory service reaches the request path and panics, which drops the
-// connection without sending any HTTP response.
+// Only the session service. Every request path needs one, and it is what the
+// launcher defaulted before the artifact and memory services were added
+// alongside it.
 //
-// The session service is always defaulted, as it was before the artifact and
-// memory ones were added, because every request path needs it and a nil one
-// panics.
+// Those two are deliberately left as the caller set them, which for an
+// unconfigured caller means nil. Nothing crashes on that any more. The artifact
+// handlers answer 503 naming the missing service, and the runner only builds
+// the memory wrapper when a service exists, so SearchMemory reports "memory
+// service is not set" rather than dereferencing nothing.
 //
-// The other two are defaulted too, but only silently when allowInMemory says a
-// volatile store is acceptable: the webui sublauncher is a developer tool and
-// implies it, and -allow_in_memory_services sets it explicitly. Without that
-// consent they are still created, so nothing breaks on upgrade, and unconsented
-// reports true so the caller can warn that a future release will refuse instead.
-//
-// Refusing is the eventual goal rather than the current behaviour because
-// cmd/launcher/prod runs through this same path. A production deployment that
-// configured no storage should learn about it at startup, not when a restart
-// has already dropped the data.
-//
-// adk-python is not a straightforward precedent either way. An absent
-// --artifact_service_uri gets per-agent local disk under
-// <agents_root>/<agent>/.adk/artifacts, but it falls back to memory when it
-// detects Cloud Run or Kubernetes even with storage writable, and that warning
-// names ADK_FORCE_LOCAL_STORAGE rather than the URI flag
-// (cli/utils/service_factory.py). So on the deployments this comment is about,
-// Python also serves from memory. What it does differently is warn at the point
-// of fallback and name the way out, which is the part worth copying.
-func applyServiceDefaults(config *launcher.Config, allowInMemory bool) (defaulted []string, unconsented bool) {
+// Filling them in instead is what made a misconfigured deployment look healthy:
+// it came up, served requests, and lost everything it had stored on the next
+// restart. A 503 that names the missing service is the more useful answer, and
+// it is the caller's decision to make. examples/web/main.go shows the intended
+// pattern.
+func applyServiceDefaults(config *launcher.Config) {
 	if config.SessionService == nil {
 		config.SessionService = session.InMemoryService()
 		log.Print("No session service configured. Using an in-memory one, so whatever it holds is lost when the process exits.")
-	}
-
-	if config.ArtifactService == nil {
-		config.ArtifactService = artifact.InMemoryService()
-		defaulted = append(defaulted, "artifact")
-	}
-	if config.MemoryService == nil {
-		config.MemoryService = memory.InMemoryService()
-		defaulted = append(defaulted, "memory")
-	}
-	for _, name := range defaulted {
-		log.Printf("No %s service configured. Using an in-memory one, so whatever it holds is lost when the process exits.", name)
-	}
-	return defaulted, len(defaulted) > 0 && !allowInMemory
-}
-
-// logInMemoryServiceWarning restates which services fell back to memory, in the
-// startup banner alongside the URLs.
-//
-// applyServiceDefaults already logs each one, but that runs before the routers
-// are built and has scrolled past by the time the banner prints. Repeating it
-// here is deliberate: this block is what an operator reads, and losing artifacts
-// on the next restart is not something to learn from a line further up.
-//
-// When the caller did not ask for a volatile store, the warning also says the
-// launcher will refuse to start in a future release, so a deployment can fix
-// its configuration before that lands rather than after.
-func logInMemoryServiceWarning(defaulted []string, unconsented bool) {
-	if len(defaulted) == 0 {
-		return
-	}
-	// Naming launcher.Config, not just the flag: the flag only silences this,
-	// and there is no command-line way to point the launcher at real storage.
-	log.Printf("       WARNING: no %s service configured, so an in-memory one is in use.", strings.Join(defaulted, ", "))
-	log.Printf("       WARNING:     everything it holds is lost when this process exits.")
-	if unconsented {
-		log.Printf("       WARNING:     a future release will refuse to start instead. Set")
-		log.Printf("       WARNING:     ArtifactService and MemoryService on launcher.Config,")
-		log.Printf("       WARNING:     or pass -allow_in_memory_services to keep this.")
 	}
 }
 
@@ -260,25 +204,9 @@ func (w *webLauncher) buildRouter(config *launcher.Config) (http.Handler, error)
 	return withHealthFallback(router), nil
 }
 
-// webUIKeyword is the command-line keyword of the webui sublauncher. It is a
-// literal rather than a reference because that package imports this one, so the
-// dependency cannot run the other way.
-const webUIKeyword = "webui"
-
-// allowsInMemoryServices reports whether a volatile artifact and memory store
-// is acceptable for this invocation. The webui sublauncher is a developer tool
-// and implies it, so `adk web api webui` still runs with no configuration.
-func (w *webLauncher) allowsInMemoryServices() bool {
-	if w.config.allowInMemory {
-		return true
-	}
-	_, hasWebUI := w.activeSublaunchers[webUIKeyword]
-	return hasWebUI
-}
-
 // Run implements launcher.SubLauncher.
 func (w *webLauncher) Run(ctx context.Context, config *launcher.Config) error {
-	defaulted, unconsented := applyServiceDefaults(config, w.allowsInMemoryServices())
+	applyServiceDefaults(config)
 
 	router, err := w.buildRouter(config)
 	if err != nil {
@@ -292,7 +220,6 @@ func (w *webLauncher) Run(ctx context.Context, config *launcher.Config) error {
 	for _, l := range w.activeSublaunchers {
 		l.UserMessage(webUrl, log.Println)
 	}
-	logInMemoryServiceWarning(defaulted, unconsented)
 	log.Println()
 
 	telemetryService, err := telemetry.InitAndSetGlobalOtelProviders(ctx, config, w.config.otelToCloud)
@@ -367,7 +294,6 @@ func NewLauncher(sublaunchers ...Sublauncher) launcher.SubLauncher {
 	fs.DurationVar(&config.shutdownTimeout, "shutdown-timeout", 15*time.Second, "Server shutdown timeout (i.e. '10s', '2m' - see time.ParseDuration for details) - for waiting for active requests to finish during shutdown")
 	fs.BoolVar(&config.otelToCloud, "otel_to_cloud", false, "Enables/disables OpenTelemetry export to GCP: telemetry.googleapis.com. See adk-go/telemetry package for details about supported options, credentials and environment variables.")
 	fs.BoolVar(&config.useH2C, "h2c", false, "Enable prior-knowledge cleartext HTTP/2 (h2c; no HTTP/1.1 Upgrade) on the web server listener. Cleartext is insecure; do not expose it to untrusted networks. Long-lived streaming responses may require increasing --write-timeout.")
-	fs.BoolVar(&config.allowInMemory, "allow_in_memory_services", false, "Fall back to in-memory artifact and memory services when none is configured, instead of refusing to start. Their contents are lost when the process exits, so this is for local runs. Implied when the webui sublauncher is active.")
 
 	return &webLauncher{
 		config:       config,

--- a/cmd/launcher/web/web_test.go
+++ b/cmd/launcher/web/web_test.go
@@ -192,232 +192,8 @@ func TestRunDoesNotLeakListenerWhenTelemetryInitFails(t *testing.T) {
 	}
 }
 
-func TestApplyServiceDefaultsFillsEmptyConfig(t *testing.T) {
-	config := &launcher.Config{}
-
-	applyServiceDefaults(config, true)
-
-	if config.SessionService == nil {
-		t.Error("SessionService is nil after applyServiceDefaults, want a default in-memory service")
-	}
-	if config.ArtifactService == nil {
-		t.Error("ArtifactService is nil after applyServiceDefaults, want a default in-memory service")
-	}
-	if config.MemoryService == nil {
-		t.Error("MemoryService is nil after applyServiceDefaults, want a default in-memory service")
-	}
-}
-
-// TestApplyServiceDefaultsKeepsSuppliedServices covers the partial cases too:
-// defaulting one service must not clobber the two the caller did supply, and
-// supplying one must not stop the other two from being defaulted.
-func TestApplyServiceDefaultsKeepsSuppliedServices(t *testing.T) {
-	for _, tc := range []struct {
-		name           string
-		supplySession  bool
-		supplyArtifact bool
-		supplyMemory   bool
-	}{
-		{
-			name:           "all supplied",
-			supplySession:  true,
-			supplyArtifact: true,
-			supplyMemory:   true,
-		},
-		{
-			name:          "only session supplied",
-			supplySession: true,
-		},
-		{
-			name:           "only artifact supplied",
-			supplyArtifact: true,
-		},
-		{
-			name:         "only memory supplied",
-			supplyMemory: true,
-		},
-	} {
-		t.Run(tc.name, func(t *testing.T) {
-			config := &launcher.Config{}
-			var (
-				wantSession  session.Service
-				wantArtifact artifact.Service
-				wantMemory   memory.Service
-			)
-			if tc.supplySession {
-				wantSession = session.InMemoryService()
-				config.SessionService = wantSession
-			}
-			if tc.supplyArtifact {
-				wantArtifact = artifact.InMemoryService()
-				config.ArtifactService = wantArtifact
-			}
-			if tc.supplyMemory {
-				wantMemory = memory.InMemoryService()
-				config.MemoryService = wantMemory
-			}
-
-			applyServiceDefaults(config, true)
-
-			assertService(t, "SessionService", config.SessionService, wantSession)
-			assertService(t, "ArtifactService", config.ArtifactService, wantArtifact)
-			assertService(t, "MemoryService", config.MemoryService, wantMemory)
-		})
-	}
-}
-
-// TestApplyServiceDefaultsLogsWhatItDefaulted covers the diagnostic rather than
-// the wiring. cmd/launcher/prod runs through the same Run path, so a deployment
-// that meant to configure a durable artifact or memory service and did not gets
-// a server that looks healthy and loses everything on restart. The log line is
-// the only thing that says so.
-func TestApplyServiceDefaultsLogsWhatItDefaulted(t *testing.T) {
-	for _, tc := range []struct {
-		name    string
-		config  *launcher.Config
-		want    []string
-		notWant []string
-	}{
-		{
-			name:   "nothing supplied",
-			config: &launcher.Config{},
-			want:   []string{"session", "artifact", "memory"},
-		},
-		{
-			name:    "only session supplied",
-			config:  &launcher.Config{SessionService: session.InMemoryService()},
-			want:    []string{"artifact", "memory"},
-			notWant: []string{"session"},
-		},
-		{
-			name: "all supplied",
-			config: &launcher.Config{
-				SessionService:  session.InMemoryService(),
-				ArtifactService: artifact.InMemoryService(),
-				MemoryService:   memory.InMemoryService(),
-			},
-			notWant: []string{"session", "artifact", "memory"},
-		},
-	} {
-		t.Run(tc.name, func(t *testing.T) {
-			var buf bytes.Buffer
-			flags := log.Flags()
-			log.SetOutput(&buf)
-			log.SetFlags(0)
-			t.Cleanup(func() {
-				log.SetOutput(os.Stderr)
-				log.SetFlags(flags)
-			})
-
-			applyServiceDefaults(tc.config, true)
-
-			got := buf.String()
-			if len(tc.want) == 0 && got != "" {
-				t.Fatalf("applyServiceDefaults logged %q, want nothing: every service was supplied", got)
-			}
-			for _, name := range tc.want {
-				if line := "No " + name + " service configured"; !strings.Contains(got, line) {
-					t.Errorf("applyServiceDefaults logged %q, want a line starting %q", got, line)
-				}
-			}
-			for _, name := range tc.notWant {
-				if line := "No " + name + " service configured"; strings.Contains(got, line) {
-					t.Errorf("applyServiceDefaults logged %q, want no %q line: the caller supplied it", got, line)
-				}
-			}
-		})
-	}
-}
-
-// assertService checks that applyServiceDefaults left a service set. When the
-// caller supplied one, want is that value and the check is pointer identity:
-// the default must not replace it.
-func assertService(t *testing.T, name string, got, want any) {
-	t.Helper()
-
-	if got == nil {
-		t.Errorf("%s is nil after applyServiceDefaults, want a default in-memory service", name)
-		return
-	}
-	if want != nil && got != want {
-		t.Errorf("%s = %p, want the caller-supplied service %p", name, got, want)
-	}
-}
-
-// TestApplyServiceDefaultsServesRESTRoutes pins the reason the defaults exist.
-// Before them, an artifact route reached a nil service and panicked, which
-// dropped the TCP connection without sending any HTTP response at all.
-//
-// The assertion is 200, not merely "some status": the artifact controller has
-// since grown its own nil guard that answers 503, so accepting any status would
-// let the defaults disappear unnoticed. The session controller has no such
-// guard, so its route still panics outright without them.
-func TestApplyServiceDefaultsServesRESTRoutes(t *testing.T) {
-	config := &launcher.Config{}
-	applyServiceDefaults(config, true)
-
-	server, err := adkrest.NewServer(adkrest.ServerConfig{
-		SessionService:  config.SessionService,
-		ArtifactService: config.ArtifactService,
-		MemoryService:   config.MemoryService,
-		AgentLoader:     config.AgentLoader,
-	})
-	if err != nil {
-		t.Fatalf("adkrest.NewServer() failed: %v", err)
-	}
-
-	for _, tc := range []struct {
-		name string
-		path string
-	}{
-		{
-			name: "list artifacts",
-			path: "/apps/a/users/u/sessions/s/artifacts",
-		},
-		{
-			name: "list sessions",
-			path: "/apps/a/users/u/sessions",
-		},
-	} {
-		t.Run(tc.name, func(t *testing.T) {
-			rec := serveWithoutPanic(t, server, httptest.NewRequest(http.MethodGet, tc.path, nil))
-			if rec.Code != http.StatusOK {
-				t.Errorf("GET %s status = %d (%s), want %d", tc.path, rec.Code, rec.Body.String(), http.StatusOK)
-			}
-		})
-	}
-}
-
-// TestApplyServiceDefaultsMemoryServiceIsCallable exercises the defaulted
-// memory service. No REST route reaches it — it is handed to the runner and
-// used by the load_memory tool mid-run — so the consequence is checked at the
-// call site: a nil service panics there instead of returning an empty result.
-func TestApplyServiceDefaultsMemoryServiceIsCallable(t *testing.T) {
-	config := &launcher.Config{}
-	applyServiceDefaults(config, true)
-
-	defer func() {
-		if r := recover(); r != nil {
-			t.Fatalf("SearchMemory on the defaulted memory service panicked: %v", r)
-		}
-	}()
-
-	resp, err := config.MemoryService.SearchMemory(t.Context(), &memory.SearchRequest{
-		AppName: "a",
-		UserID:  "u",
-		Query:   "anything",
-	})
-	if err != nil {
-		t.Fatalf("SearchMemory() failed: %v", err)
-	}
-	if resp == nil {
-		t.Error("SearchMemory() response is nil, want an empty result")
-	}
-}
-
-// serveWithoutPanic serves one request and turns a handler panic into a named
-// test failure, so a regression reports the route it broke instead of taking
-// the whole test binary down with it.
+// serveWithoutPanic serves one request and fails the test if the handler
+// panics, rather than letting the panic take the package down.
 func serveWithoutPanic(t *testing.T, handler http.Handler, req *http.Request) *httptest.ResponseRecorder {
 	t.Helper()
 
@@ -430,6 +206,110 @@ func serveWithoutPanic(t *testing.T, handler http.Handler, req *http.Request) *h
 	rec := httptest.NewRecorder()
 	handler.ServeHTTP(rec, req)
 	return rec
+}
+
+// TestApplyServiceDefaultsFillsOnlySession pins the contract: the launcher
+// supplies a session service and nothing else.
+//
+// Artifact and memory are the caller's to configure. Filling them in is what
+// let a misconfigured deployment come up looking healthy and lose everything it
+// had stored on the next restart.
+func TestApplyServiceDefaultsFillsOnlySession(t *testing.T) {
+	log.SetOutput(io.Discard)
+	t.Cleanup(func() { log.SetOutput(os.Stderr) })
+
+	config := &launcher.Config{}
+	applyServiceDefaults(config)
+
+	if config.SessionService == nil {
+		t.Error("SessionService is nil, want an in-memory one")
+	}
+	if config.ArtifactService != nil {
+		t.Error("ArtifactService was filled in, want it left to the caller")
+	}
+	if config.MemoryService != nil {
+		t.Error("MemoryService was filled in, want it left to the caller")
+	}
+}
+
+func TestApplyServiceDefaultsKeepsSuppliedServices(t *testing.T) {
+	log.SetOutput(io.Discard)
+	t.Cleanup(func() { log.SetOutput(os.Stderr) })
+
+	supplied := session.InMemoryService()
+	config := &launcher.Config{
+		SessionService:  supplied,
+		ArtifactService: artifact.InMemoryService(),
+		MemoryService:   memory.InMemoryService(),
+	}
+	applyServiceDefaults(config)
+
+	if config.SessionService != supplied {
+		t.Error("SessionService was replaced, want the supplied one kept")
+	}
+	if config.ArtifactService == nil || config.MemoryService == nil {
+		t.Error("a supplied service was cleared")
+	}
+}
+
+// TestUnconfiguredArtifactServiceAnswers503 is why leaving it nil is safe.
+//
+// Before the guard in the artifact handlers, a nil service was dereferenced,
+// which panicked and dropped the connection with no HTTP response at all. That
+// crash is what defaulting the service was working around. With the guard, the
+// unconfigured case reports itself.
+func TestUnconfiguredArtifactServiceAnswers503(t *testing.T) {
+	log.SetOutput(io.Discard)
+	t.Cleanup(func() { log.SetOutput(os.Stderr) })
+
+	config := &launcher.Config{}
+	applyServiceDefaults(config)
+
+	server, err := adkrest.NewServer(adkrest.ServerConfig{
+		SessionService:  config.SessionService,
+		ArtifactService: config.ArtifactService,
+		MemoryService:   config.MemoryService,
+		AgentLoader:     config.AgentLoader,
+	})
+	if err != nil {
+		t.Fatalf("adkrest.NewServer() failed: %v", err)
+	}
+
+	rec := serveWithoutPanic(t, server,
+		httptest.NewRequest(http.MethodGet, "/apps/a/users/u/sessions/s/artifacts", nil))
+
+	if rec.Code != http.StatusServiceUnavailable {
+		t.Errorf("GET artifacts status = %d (%s), want %d",
+			rec.Code, rec.Body.String(), http.StatusServiceUnavailable)
+	}
+}
+
+// TestUnconfiguredServicesStillServeSessions checks the rest of the API is
+// unaffected by leaving artifact and memory unset.
+func TestUnconfiguredServicesStillServeSessions(t *testing.T) {
+	log.SetOutput(io.Discard)
+	t.Cleanup(func() { log.SetOutput(os.Stderr) })
+
+	config := &launcher.Config{}
+	applyServiceDefaults(config)
+
+	server, err := adkrest.NewServer(adkrest.ServerConfig{
+		SessionService:  config.SessionService,
+		ArtifactService: config.ArtifactService,
+		MemoryService:   config.MemoryService,
+		AgentLoader:     config.AgentLoader,
+	})
+	if err != nil {
+		t.Fatalf("adkrest.NewServer() failed: %v", err)
+	}
+
+	rec := serveWithoutPanic(t, server,
+		httptest.NewRequest(http.MethodGet, "/apps/a/users/u/sessions", nil))
+
+	if rec.Code != http.StatusOK {
+		t.Errorf("GET sessions status = %d (%s), want %d",
+			rec.Code, rec.Body.String(), http.StatusOK)
+	}
 }
 
 func TestHealthFallbackAnswers(t *testing.T) {
@@ -549,131 +429,6 @@ func TestBuiltInHealthRouteIsAFallback(t *testing.T) {
 	}
 }
 
-func TestApplyServiceDefaultsReturnsWhatItDefaulted(t *testing.T) {
-	for _, tc := range []struct {
-		name   string
-		config *launcher.Config
-		want   []string
-	}{
-		// The session service is always defaulted and is not reported here,
-		// because it is not the one whose loss on restart matters.
-		{"nothing supplied", &launcher.Config{}, []string{"artifact", "memory"}},
-		{"only session supplied", &launcher.Config{SessionService: session.InMemoryService()}, []string{"artifact", "memory"}},
-		{"all supplied", &launcher.Config{
-			SessionService:  session.InMemoryService(),
-			ArtifactService: artifact.InMemoryService(),
-			MemoryService:   memory.InMemoryService(),
-		}, nil},
-	} {
-		t.Run(tc.name, func(t *testing.T) {
-			log.SetOutput(io.Discard)
-			t.Cleanup(func() { log.SetOutput(os.Stderr) })
-
-			got, unconsented := applyServiceDefaults(tc.config, true)
-			if unconsented {
-				t.Error("unconsented = true, want false when in-memory is allowed")
-			}
-			if len(got) != len(tc.want) {
-				t.Fatalf("applyServiceDefaults() = %v, want %v", got, tc.want)
-			}
-			for i := range got {
-				if got[i] != tc.want[i] {
-					t.Errorf("applyServiceDefaults()[%d] = %q, want %q", i, got[i], tc.want[i])
-				}
-			}
-		})
-	}
-}
-
-// TestInMemoryServiceWarningNamesTheDataLoss covers the startup banner warning.
-//
-// A deployment that forgot to configure storage must find that out at startup,
-// not after a restart has dropped the data. Without consent the warning also
-// has to say the launcher will refuse in a future release, since that notice is
-// the only thing standing between an operator and a broken upgrade later.
-func TestInMemoryServiceWarningNamesTheDataLoss(t *testing.T) {
-	capture := func(defaulted []string, unconsented bool) string {
-		var buf bytes.Buffer
-		flags := log.Flags()
-		log.SetOutput(&buf)
-		log.SetFlags(0)
-		defer func() {
-			log.SetOutput(os.Stderr)
-			log.SetFlags(flags)
-		}()
-		logInMemoryServiceWarning(defaulted, unconsented)
-		return buf.String()
-	}
-
-	t.Run("unconsented names the future refusal", func(t *testing.T) {
-		out := capture([]string{"artifact", "memory"}, true)
-		for _, want := range []string{
-			"WARNING", "artifact, memory", "lost when this process exits",
-			"refuse to start", "-allow_in_memory_services",
-			// The flag only silences the notice. An operator also needs to know
-			// where real storage is configured, which is Go code, not a flag.
-			"launcher.Config",
-		} {
-			if !strings.Contains(out, want) {
-				t.Errorf("warning output %q does not contain %q", out, want)
-			}
-		}
-	})
-
-	t.Run("consented omits the future refusal", func(t *testing.T) {
-		out := capture([]string{"artifact"}, false)
-		if !strings.Contains(out, "lost when this process exits") {
-			t.Errorf("warning output %q does not mention the data loss", out)
-		}
-		if strings.Contains(out, "refuse to start") {
-			t.Errorf("warning output %q threatens a refusal the caller already opted out of", out)
-		}
-	})
-
-	t.Run("nothing defaulted logs nothing", func(t *testing.T) {
-		if out := capture(nil, false); out != "" {
-			t.Errorf("logInMemoryServiceWarning(nil) logged %q, want nothing", out)
-		}
-	})
-}
-
-// TestWebUIImpliesInMemoryServices keeps `adk web api webui` working with no
-// configuration, because the dev UI is the case the fallback exists for.
-func TestWebUIImpliesInMemoryServices(t *testing.T) {
-	for _, tc := range []struct {
-		name     string
-		keywords []string
-		flags    []string
-		want     bool
-	}{
-		{"webui active", []string{"webui"}, nil, true},
-		{"webui absent", []string{"repro"}, nil, false},
-		{"flag set without webui", []string{"repro"}, []string{"--allow_in_memory_services"}, true},
-	} {
-		t.Run(tc.name, func(t *testing.T) {
-			l := NewLauncher(keywordSublauncher{"webui"}, telemetryFailSublauncher{}).(*webLauncher)
-			if _, err := l.Parse(append(tc.flags, tc.keywords...)); err != nil {
-				t.Fatalf("Parse() failed: %v", err)
-			}
-			if got := l.allowsInMemoryServices(); got != tc.want {
-				t.Errorf("allowsInMemoryServices() = %v, want %v", got, tc.want)
-			}
-		})
-	}
-}
-
-// keywordSublauncher is a no-op sublauncher registered under a chosen keyword.
-type keywordSublauncher struct{ keyword string }
-
-func (k keywordSublauncher) Keyword() string                                 { return k.keyword }
-func (keywordSublauncher) Parse(args []string) ([]string, error)             { return args, nil }
-func (keywordSublauncher) CommandLineSyntax() string                         { return "" }
-func (keywordSublauncher) SimpleDescription() string                         { return "" }
-func (keywordSublauncher) UserMessage(webURL string, printer func(v ...any)) {}
-func (keywordSublauncher) SetupSubrouters(r *mux.Router, c *launcher.Config) error {
-	return nil
-}
-
 // catchAllSublauncher mounts a route that matches every path, the way an API
 // sublauncher does when its path prefix is empty.
 type catchAllSublauncher struct{}
@@ -749,55 +504,6 @@ func TestSublauncherHealthOwnsEveryMethod(t *testing.T) {
 			"the fallback is reporting ok for an instance that declared itself unhealthy (body %q)",
 			rec.Body.String())
 	}
-}
-
-// TestRunLogsTheInMemoryWarning covers the wiring, not the wording.
-//
-// logInMemoryServiceWarning had tests, but nothing checked that Run calls it.
-// Deleting the call left the package green, so the banner an operator relies on
-// could disappear silently.
-func TestRunLogsTheInMemoryWarning(t *testing.T) {
-	var buf bytes.Buffer
-	flags := log.Flags()
-	log.SetOutput(&buf)
-	log.SetFlags(0)
-	t.Cleanup(func() {
-		log.SetOutput(os.Stderr)
-		log.SetFlags(flags)
-	})
-
-	l := NewLauncher(telemetryFailSublauncher{}).(*webLauncher)
-	if _, err := l.Parse([]string{"--port", fmt.Sprint(freeTestPort(t)), "repro"}); err != nil {
-		t.Fatalf("Parse() failed: %v", err)
-	}
-
-	// A resource whose schema URL conflicts makes telemetry init fail, so Run
-	// returns straight after the banner without binding anything.
-	bad := resource.NewWithAttributes("https://conflicting.invalid/schema/v1")
-	err := l.Run(context.Background(), &launcher.Config{
-		TelemetryOptions: []telemetry.Option{telemetry.WithResource(bad)},
-	})
-	if err == nil {
-		t.Fatal("Run() succeeded, want the telemetry failure that stops it after the banner")
-	}
-
-	if !strings.Contains(buf.String(), "WARNING: no artifact, memory service configured") {
-		t.Errorf("Run() did not print the in-memory warning; log was:\n%s", buf.String())
-	}
-}
-
-// freeTestPort returns a port nothing is listening on.
-func freeTestPort(t *testing.T) int {
-	t.Helper()
-	ln, err := net.Listen("tcp", "127.0.0.1:0")
-	if err != nil {
-		t.Fatalf("net.Listen() failed: %v", err)
-	}
-	port := ln.Addr().(*net.TCPAddr).Port
-	if err := ln.Close(); err != nil {
-		t.Fatalf("closing the probe listener failed: %v", err)
-	}
-	return port
 }
 
 // TestHealthFallbackKeepsRouterBehaviour covers what answering in front of the

--- a/cmd/launcher/web/web_test.go
+++ b/cmd/launcher/web/web_test.go
@@ -799,3 +799,102 @@ func freeTestPort(t *testing.T) int {
 	}
 	return port
 }
+
+// TestHealthFallbackKeepsRouterBehaviour covers what answering in front of the
+// router used to lose.
+//
+// The fallback is a route on an outer router, not a check before the inner one,
+// so it still runs the logger middleware and still gets StrictSlash handling. A
+// probe that stopped appearing in the request log, or a probe configured with a
+// trailing slash, are both silent failures.
+func TestHealthFallbackKeepsRouterBehaviour(t *testing.T) {
+	var buf bytes.Buffer
+	flags := log.Flags()
+	log.SetOutput(&buf)
+	log.SetFlags(0)
+	t.Cleanup(func() {
+		log.SetOutput(os.Stderr)
+		log.SetFlags(flags)
+	})
+
+	inner := BuildBaseRouter()
+	// A real route, because mux middleware runs only on a matched route. An
+	// empty router matches nothing, so the logger would never run either way.
+	inner.HandleFunc("/other", func(w http.ResponseWriter, _ *http.Request) {
+		w.WriteHeader(http.StatusOK)
+	})
+	handler := withHealthFallback(inner)
+
+	t.Run("logger runs", func(t *testing.T) {
+		buf.Reset()
+		rec := httptest.NewRecorder()
+		handler.ServeHTTP(rec, httptest.NewRequest(http.MethodGet, healthPath, nil))
+		if rec.Code != http.StatusOK {
+			t.Fatalf("GET %s status = %d, want %d", healthPath, rec.Code, http.StatusOK)
+		}
+		if !strings.Contains(buf.String(), healthPath) {
+			t.Errorf("request log %q does not mention %s; the probe is invisible", buf.String(), healthPath)
+		}
+	})
+
+	t.Run("trailing slash redirects", func(t *testing.T) {
+		rec := httptest.NewRecorder()
+		handler.ServeHTTP(rec, httptest.NewRequest(http.MethodGet, healthPath+"/", nil))
+		if rec.Code != http.StatusMovedPermanently {
+			t.Errorf("GET %s/ status = %d, want %d", healthPath, rec.Code, http.StatusMovedPermanently)
+		}
+		if got := rec.Header().Get("Location"); got != healthPath {
+			t.Errorf("Location = %q, want %q", got, healthPath)
+		}
+	})
+
+	t.Run("logger is not doubled", func(t *testing.T) {
+		buf.Reset()
+		rec := httptest.NewRecorder()
+		handler.ServeHTTP(rec, httptest.NewRequest(http.MethodGet, "/other", nil))
+		if n := strings.Count(buf.String(), "/other"); n != 1 {
+			t.Errorf("request logged %d times, want 1; log was %q", n, buf.String())
+		}
+	})
+}
+
+// scopedHealthSublauncher registers healthPath behind a host matcher, so it
+// answers some requests for the path and rejects others.
+type scopedHealthSublauncher struct{}
+
+func (scopedHealthSublauncher) Keyword() string { return "scopedhealth" }
+
+func (scopedHealthSublauncher) Parse(args []string) ([]string, error)             { return args, nil }
+func (scopedHealthSublauncher) CommandLineSyntax() string                         { return "" }
+func (scopedHealthSublauncher) SimpleDescription() string                         { return "" }
+func (scopedHealthSublauncher) UserMessage(webURL string, printer func(v ...any)) {}
+func (scopedHealthSublauncher) SetupSubrouters(r *mux.Router, c *launcher.Config) error {
+	r.HandleFunc(healthPath, func(w http.ResponseWriter, _ *http.Request) {
+		w.WriteHeader(http.StatusTeapot)
+	}).Host("internal.example.com")
+	return nil
+}
+
+// TestScopedHealthRouteDoesNotDisableTheFallback covers a route that claims the
+// path only for some requests.
+//
+// Treating it as owning the path switches the fallback off for every request,
+// including the ones its own matcher rejects, so an ordinary probe 404s.
+func TestScopedHealthRouteDoesNotDisableTheFallback(t *testing.T) {
+	l := NewLauncher(scopedHealthSublauncher{}).(*webLauncher)
+	if _, err := l.Parse([]string{"scopedhealth"}); err != nil {
+		t.Fatalf("Parse() failed: %v", err)
+	}
+	handler, err := l.buildRouter(&launcher.Config{})
+	if err != nil {
+		t.Fatalf("buildRouter() failed: %v", err)
+	}
+
+	rec := httptest.NewRecorder()
+	handler.ServeHTTP(rec, httptest.NewRequest(http.MethodGet, healthPath, nil))
+
+	if rec.Code != http.StatusOK {
+		t.Errorf("GET %s status = %d, want %d; a host-scoped route switched off the fallback "+
+			"for requests it does not match", healthPath, rec.Code, http.StatusOK)
+	}
+}

--- a/cmd/launcher/web/web_test.go
+++ b/cmd/launcher/web/web_test.go
@@ -432,9 +432,8 @@ func serveWithoutPanic(t *testing.T, handler http.Handler, req *http.Request) *h
 	return rec
 }
 
-func TestRegisterHealthRoute(t *testing.T) {
-	router := BuildBaseRouter()
-	registerHealthRoute(router)
+func TestHealthFallbackAnswers(t *testing.T) {
+	router := withHealthFallback(BuildBaseRouter())
 
 	t.Run("GET", func(t *testing.T) {
 		rec := serveWithoutPanic(t, router, httptest.NewRequest(http.MethodGet, "/health", nil))
@@ -464,10 +463,10 @@ func TestRegisterHealthRoute(t *testing.T) {
 	})
 }
 
-// TestBuildBaseRouterLeavesHealthToTheCaller guards the reason the route lives
-// in registerHealthRoute: mux serves the first matching route, so registering
-// /health inside the exported constructor would silently shadow an embedder's
-// own handler for that path.
+// TestBuildBaseRouterLeavesHealthToTheCaller guards the reason the fallback
+// lives in withHealthFallback: mux serves the first matching route, so
+// registering /health inside the exported constructor would silently shadow an
+// embedder's own handler for that path.
 func TestBuildBaseRouterLeavesHealthToTheCaller(t *testing.T) {
 	router := BuildBaseRouter()
 	router.HandleFunc("/health", func(w http.ResponseWriter, _ *http.Request) {
@@ -611,6 +610,9 @@ func TestInMemoryServiceWarningNamesTheDataLoss(t *testing.T) {
 		for _, want := range []string{
 			"WARNING", "artifact, memory", "lost when this process exits",
 			"refuse to start", "-allow_in_memory_services",
+			// The flag only silences the notice. An operator also needs to know
+			// where real storage is configured, which is Go code, not a flag.
+			"launcher.Config",
 		} {
 			if !strings.Contains(out, want) {
 				t.Errorf("warning output %q does not contain %q", out, want)
@@ -670,4 +672,130 @@ func (keywordSublauncher) SimpleDescription() string                         { r
 func (keywordSublauncher) UserMessage(webURL string, printer func(v ...any)) {}
 func (keywordSublauncher) SetupSubrouters(r *mux.Router, c *launcher.Config) error {
 	return nil
+}
+
+// catchAllSublauncher mounts a route that matches every path, the way an API
+// sublauncher does when its path prefix is empty.
+type catchAllSublauncher struct{}
+
+func (catchAllSublauncher) Keyword() string                                   { return "catchall" }
+func (catchAllSublauncher) Parse(args []string) ([]string, error)             { return args, nil }
+func (catchAllSublauncher) CommandLineSyntax() string                         { return "" }
+func (catchAllSublauncher) SimpleDescription() string                         { return "" }
+func (catchAllSublauncher) UserMessage(webURL string, printer func(v ...any)) {}
+func (catchAllSublauncher) SetupSubrouters(r *mux.Router, c *launcher.Config) error {
+	r.NewRoute().HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		w.WriteHeader(http.StatusNotFound)
+		_, _ = w.Write([]byte("catch-all"))
+	})
+	return nil
+}
+
+// TestHealthFallbackBeatsACatchAll covers a sublauncher that matches every
+// path without meaning to own the probe path.
+//
+// Registering the health route after the sublaunchers puts it behind such a
+// route, so the probe path 404s. Deciding outside the router avoids that,
+// because a catch-all declares no path template and so does not claim /health.
+func TestHealthFallbackBeatsACatchAll(t *testing.T) {
+	l := NewLauncher(catchAllSublauncher{}).(*webLauncher)
+	if _, err := l.Parse([]string{"catchall"}); err != nil {
+		t.Fatalf("Parse() failed: %v", err)
+	}
+	handler, err := l.buildRouter(&launcher.Config{})
+	if err != nil {
+		t.Fatalf("buildRouter() failed: %v", err)
+	}
+
+	for _, method := range []string{http.MethodGet, http.MethodHead} {
+		rec := httptest.NewRecorder()
+		handler.ServeHTTP(rec, httptest.NewRequest(method, "/health", nil))
+		if rec.Code != http.StatusOK {
+			t.Errorf("%s /health status = %d, want %d; a catch-all is hiding the probe path",
+				method, rec.Code, http.StatusOK)
+		}
+	}
+
+	// Everything else still reaches the catch-all.
+	rec := httptest.NewRecorder()
+	handler.ServeHTTP(rec, httptest.NewRequest(http.MethodGet, "/anything", nil))
+	if body := rec.Body.String(); body != "catch-all" {
+		t.Errorf("GET /anything body = %q, want the catch-all to still serve it", body)
+	}
+}
+
+// TestSublauncherHealthOwnsEveryMethod covers the verb half of the shadowing
+// bug.
+//
+// A sublauncher that declares /health for GET alone owns the path outright. If
+// the fallback answered HEAD, a draining instance would report ok on the verb
+// HAProxy and nginx probe with by default, which is the failure this is meant
+// to prevent, surviving on one method.
+func TestSublauncherHealthOwnsEveryMethod(t *testing.T) {
+	l := NewLauncher(healthSublauncher{}).(*webLauncher)
+	if _, err := l.Parse([]string{"ownhealth"}); err != nil {
+		t.Fatalf("Parse() failed: %v", err)
+	}
+	handler, err := l.buildRouter(&launcher.Config{})
+	if err != nil {
+		t.Fatalf("buildRouter() failed: %v", err)
+	}
+
+	rec := httptest.NewRecorder()
+	handler.ServeHTTP(rec, httptest.NewRequest(http.MethodHead, "/health", nil))
+
+	if rec.Code == http.StatusOK {
+		t.Errorf("HEAD /health status = 200, want the sublauncher's own answer; "+
+			"the fallback is reporting ok for an instance that declared itself unhealthy (body %q)",
+			rec.Body.String())
+	}
+}
+
+// TestRunLogsTheInMemoryWarning covers the wiring, not the wording.
+//
+// logInMemoryServiceWarning had tests, but nothing checked that Run calls it.
+// Deleting the call left the package green, so the banner an operator relies on
+// could disappear silently.
+func TestRunLogsTheInMemoryWarning(t *testing.T) {
+	var buf bytes.Buffer
+	flags := log.Flags()
+	log.SetOutput(&buf)
+	log.SetFlags(0)
+	t.Cleanup(func() {
+		log.SetOutput(os.Stderr)
+		log.SetFlags(flags)
+	})
+
+	l := NewLauncher(telemetryFailSublauncher{}).(*webLauncher)
+	if _, err := l.Parse([]string{"--port", fmt.Sprint(freeTestPort(t)), "repro"}); err != nil {
+		t.Fatalf("Parse() failed: %v", err)
+	}
+
+	// A resource whose schema URL conflicts makes telemetry init fail, so Run
+	// returns straight after the banner without binding anything.
+	bad := resource.NewWithAttributes("https://conflicting.invalid/schema/v1")
+	err := l.Run(context.Background(), &launcher.Config{
+		TelemetryOptions: []telemetry.Option{telemetry.WithResource(bad)},
+	})
+	if err == nil {
+		t.Fatal("Run() succeeded, want the telemetry failure that stops it after the banner")
+	}
+
+	if !strings.Contains(buf.String(), "WARNING: no artifact, memory service configured") {
+		t.Errorf("Run() did not print the in-memory warning; log was:\n%s", buf.String())
+	}
+}
+
+// freeTestPort returns a port nothing is listening on.
+func freeTestPort(t *testing.T) int {
+	t.Helper()
+	ln, err := net.Listen("tcp", "127.0.0.1:0")
+	if err != nil {
+		t.Fatalf("net.Listen() failed: %v", err)
+	}
+	port := ln.Addr().(*net.TCPAddr).Port
+	if err := ln.Close(); err != nil {
+		t.Fatalf("closing the probe listener failed: %v", err)
+	}
+	return port
 }

--- a/cmd/launcher/web/web_test.go
+++ b/cmd/launcher/web/web_test.go
@@ -195,7 +195,7 @@ func TestRunDoesNotLeakListenerWhenTelemetryInitFails(t *testing.T) {
 func TestApplyServiceDefaultsFillsEmptyConfig(t *testing.T) {
 	config := &launcher.Config{}
 
-	applyServiceDefaults(config)
+	applyServiceDefaults(config, true)
 
 	if config.SessionService == nil {
 		t.Error("SessionService is nil after applyServiceDefaults, want a default in-memory service")
@@ -257,7 +257,7 @@ func TestApplyServiceDefaultsKeepsSuppliedServices(t *testing.T) {
 				config.MemoryService = wantMemory
 			}
 
-			applyServiceDefaults(config)
+			applyServiceDefaults(config, true)
 
 			assertService(t, "SessionService", config.SessionService, wantSession)
 			assertService(t, "ArtifactService", config.ArtifactService, wantArtifact)
@@ -309,7 +309,7 @@ func TestApplyServiceDefaultsLogsWhatItDefaulted(t *testing.T) {
 				log.SetFlags(flags)
 			})
 
-			applyServiceDefaults(tc.config)
+			applyServiceDefaults(tc.config, true)
 
 			got := buf.String()
 			if len(tc.want) == 0 && got != "" {
@@ -354,7 +354,7 @@ func assertService(t *testing.T, name string, got, want any) {
 // guard, so its route still panics outright without them.
 func TestApplyServiceDefaultsServesRESTRoutes(t *testing.T) {
 	config := &launcher.Config{}
-	applyServiceDefaults(config)
+	applyServiceDefaults(config, true)
 
 	server, err := adkrest.NewServer(adkrest.ServerConfig{
 		SessionService:  config.SessionService,
@@ -394,7 +394,7 @@ func TestApplyServiceDefaultsServesRESTRoutes(t *testing.T) {
 // call site: a nil service panics there instead of returning an empty result.
 func TestApplyServiceDefaultsMemoryServiceIsCallable(t *testing.T) {
 	config := &launcher.Config{}
-	applyServiceDefaults(config)
+	applyServiceDefaults(config, true)
 
 	defer func() {
 		if r := recover(); r != nil {
@@ -478,4 +478,196 @@ func TestBuildBaseRouterLeavesHealthToTheCaller(t *testing.T) {
 	if rec.Code != http.StatusTeapot {
 		t.Errorf("GET /health status = %d, want %d: the embedder's handler was shadowed", rec.Code, http.StatusTeapot)
 	}
+}
+
+// healthSublauncher registers its own root /health, the way a deployment with a
+// real readiness check does.
+type healthSublauncher struct{}
+
+func (healthSublauncher) Keyword() string                                   { return "ownhealth" }
+func (healthSublauncher) Parse(args []string) ([]string, error)             { return args, nil }
+func (healthSublauncher) CommandLineSyntax() string                         { return "" }
+func (healthSublauncher) SimpleDescription() string                         { return "" }
+func (healthSublauncher) UserMessage(webURL string, printer func(v ...any)) {}
+func (healthSublauncher) SetupSubrouters(r *mux.Router, c *launcher.Config) error {
+	r.HandleFunc("/health", func(w http.ResponseWriter, _ *http.Request) {
+		w.WriteHeader(http.StatusServiceUnavailable)
+		_, _ = w.Write([]byte("draining"))
+	}).Methods(http.MethodGet)
+	return nil
+}
+
+// TestSublauncherHealthRouteWins pins the registration order in buildRouter.
+//
+// mux serves the first matching route, so registering the built-in /health
+// before the sublaunchers would shadow a deployment's own readiness check and
+// report ok for an instance that was reporting itself unhealthy. A load
+// balancer would then keep sending it traffic.
+func TestSublauncherHealthRouteWins(t *testing.T) {
+	l := NewLauncher(healthSublauncher{}).(*webLauncher)
+	if _, err := l.Parse([]string{"ownhealth"}); err != nil {
+		t.Fatalf("Parse() failed: %v", err)
+	}
+
+	router, err := l.buildRouter(&launcher.Config{})
+	if err != nil {
+		t.Fatalf("buildRouter() failed: %v", err)
+	}
+
+	rec := httptest.NewRecorder()
+	router.ServeHTTP(rec, httptest.NewRequest(http.MethodGet, "/health", nil))
+
+	if got, want := rec.Code, http.StatusServiceUnavailable; got != want {
+		t.Errorf("GET /health status = %d, want %d from the sublauncher's own handler", got, want)
+	}
+	if got := rec.Body.String(); got != "draining" {
+		t.Errorf("GET /health body = %q, want %q; the built-in health route shadowed the sublauncher's", got, "draining")
+	}
+}
+
+// TestBuiltInHealthRouteIsAFallback is the other half: when no sublauncher
+// claims /health, the built-in one must still answer, because probes are
+// configured with a fixed path.
+func TestBuiltInHealthRouteIsAFallback(t *testing.T) {
+	l := NewLauncher(telemetryFailSublauncher{}).(*webLauncher)
+	if _, err := l.Parse([]string{"repro"}); err != nil {
+		t.Fatalf("Parse() failed: %v", err)
+	}
+
+	router, err := l.buildRouter(&launcher.Config{})
+	if err != nil {
+		t.Fatalf("buildRouter() failed: %v", err)
+	}
+
+	rec := httptest.NewRecorder()
+	router.ServeHTTP(rec, httptest.NewRequest(http.MethodGet, "/health", nil))
+
+	if got, want := rec.Code, http.StatusOK; got != want {
+		t.Errorf("GET /health status = %d, want %d", got, want)
+	}
+	if got, want := strings.TrimSpace(rec.Body.String()), `{"status":"ok"}`; got != want {
+		t.Errorf("GET /health body = %q, want %q", got, want)
+	}
+}
+
+func TestApplyServiceDefaultsReturnsWhatItDefaulted(t *testing.T) {
+	for _, tc := range []struct {
+		name   string
+		config *launcher.Config
+		want   []string
+	}{
+		// The session service is always defaulted and is not reported here,
+		// because it is not the one whose loss on restart matters.
+		{"nothing supplied", &launcher.Config{}, []string{"artifact", "memory"}},
+		{"only session supplied", &launcher.Config{SessionService: session.InMemoryService()}, []string{"artifact", "memory"}},
+		{"all supplied", &launcher.Config{
+			SessionService:  session.InMemoryService(),
+			ArtifactService: artifact.InMemoryService(),
+			MemoryService:   memory.InMemoryService(),
+		}, nil},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			log.SetOutput(io.Discard)
+			t.Cleanup(func() { log.SetOutput(os.Stderr) })
+
+			got, unconsented := applyServiceDefaults(tc.config, true)
+			if unconsented {
+				t.Error("unconsented = true, want false when in-memory is allowed")
+			}
+			if len(got) != len(tc.want) {
+				t.Fatalf("applyServiceDefaults() = %v, want %v", got, tc.want)
+			}
+			for i := range got {
+				if got[i] != tc.want[i] {
+					t.Errorf("applyServiceDefaults()[%d] = %q, want %q", i, got[i], tc.want[i])
+				}
+			}
+		})
+	}
+}
+
+// TestInMemoryServiceWarningNamesTheDataLoss covers the startup banner warning.
+//
+// A deployment that forgot to configure storage must find that out at startup,
+// not after a restart has dropped the data. Without consent the warning also
+// has to say the launcher will refuse in a future release, since that notice is
+// the only thing standing between an operator and a broken upgrade later.
+func TestInMemoryServiceWarningNamesTheDataLoss(t *testing.T) {
+	capture := func(defaulted []string, unconsented bool) string {
+		var buf bytes.Buffer
+		flags := log.Flags()
+		log.SetOutput(&buf)
+		log.SetFlags(0)
+		defer func() {
+			log.SetOutput(os.Stderr)
+			log.SetFlags(flags)
+		}()
+		logInMemoryServiceWarning(defaulted, unconsented)
+		return buf.String()
+	}
+
+	t.Run("unconsented names the future refusal", func(t *testing.T) {
+		out := capture([]string{"artifact", "memory"}, true)
+		for _, want := range []string{
+			"WARNING", "artifact, memory", "lost when this process exits",
+			"refuse to start", "-allow_in_memory_services",
+		} {
+			if !strings.Contains(out, want) {
+				t.Errorf("warning output %q does not contain %q", out, want)
+			}
+		}
+	})
+
+	t.Run("consented omits the future refusal", func(t *testing.T) {
+		out := capture([]string{"artifact"}, false)
+		if !strings.Contains(out, "lost when this process exits") {
+			t.Errorf("warning output %q does not mention the data loss", out)
+		}
+		if strings.Contains(out, "refuse to start") {
+			t.Errorf("warning output %q threatens a refusal the caller already opted out of", out)
+		}
+	})
+
+	t.Run("nothing defaulted logs nothing", func(t *testing.T) {
+		if out := capture(nil, false); out != "" {
+			t.Errorf("logInMemoryServiceWarning(nil) logged %q, want nothing", out)
+		}
+	})
+}
+
+// TestWebUIImpliesInMemoryServices keeps `adk web api webui` working with no
+// configuration, because the dev UI is the case the fallback exists for.
+func TestWebUIImpliesInMemoryServices(t *testing.T) {
+	for _, tc := range []struct {
+		name     string
+		keywords []string
+		flags    []string
+		want     bool
+	}{
+		{"webui active", []string{"webui"}, nil, true},
+		{"webui absent", []string{"repro"}, nil, false},
+		{"flag set without webui", []string{"repro"}, []string{"--allow_in_memory_services"}, true},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			l := NewLauncher(keywordSublauncher{"webui"}, telemetryFailSublauncher{}).(*webLauncher)
+			if _, err := l.Parse(append(tc.flags, tc.keywords...)); err != nil {
+				t.Fatalf("Parse() failed: %v", err)
+			}
+			if got := l.allowsInMemoryServices(); got != tc.want {
+				t.Errorf("allowsInMemoryServices() = %v, want %v", got, tc.want)
+			}
+		})
+	}
+}
+
+// keywordSublauncher is a no-op sublauncher registered under a chosen keyword.
+type keywordSublauncher struct{ keyword string }
+
+func (k keywordSublauncher) Keyword() string                                 { return k.keyword }
+func (keywordSublauncher) Parse(args []string) ([]string, error)             { return args, nil }
+func (keywordSublauncher) CommandLineSyntax() string                         { return "" }
+func (keywordSublauncher) SimpleDescription() string                         { return "" }
+func (keywordSublauncher) UserMessage(webURL string, printer func(v ...any)) {}
+func (keywordSublauncher) SetupSubrouters(r *mux.Router, c *launcher.Config) error {
+	return nil
 }


### PR DESCRIPTION
### Link to Issue or Description of Change

**2. Or, if no issue exists, describe the change:**

Two fixes in the web launcher, both raised in review of #1460. They are
independent and small enough to review together.

**Problem 1, /health shadows a sublauncher's own.**

`registerHealthRoute` ran before the sublauncher loop. gorilla/mux serves the
first matching route, so the built-in `/health` shadowed one a sublauncher
registers itself. A deployment with a real readiness check found it unreachable
while the probe kept answering `{"status":"ok"}`, so an unhealthy instance stays
in the load balancer rotation.

**Problem 2, the launcher invents storage and says so quietly.**

Before #1460 the launcher defaulted one service, the session service, and the
contract was that the caller configures the rest. #1460 also defaulted artifact
and memory. `cmd/launcher/prod` runs through this same path, so a production
deployment that configured no storage now comes up looking healthy and loses its
artifacts on the next restart, where before it failed. The existing log line
runs before the routers are built and has scrolled past by the time anyone
looks.

**Solution:**

Register `/health` after the sublauncher loop, so it is a fallback rather than
an override. Router assembly moves into `buildRouter` so the ordering can be
asserted without binding a port.

Keep defaulting artifact and memory, so nothing breaks on upgrade, and put the
warning in the startup banner alongside the URLs:

```
       api:  you can access API using http://localhost:8080/api
       WARNING: no artifact, memory service configured, so an in-memory one is in use.
       WARNING:     everything it holds is lost when this process exits.
       WARNING:     a future release will refuse to start instead. Configure a
       WARNING:     service, or pass -allow_in_memory_services to keep this.
```

The last two lines appear only when the caller did not ask for a volatile store.
`-allow_in_memory_services` declares the intent and silences them, and the
`webui` sublauncher implies it, since the dev UI is what the fallback exists
for.

This is deliberately a notice now and a refusal later, so no running deployment
breaks on this upgrade. Refusing is the right end state, because losing data
quietly is worse than failing loudly, but it should not arrive unannounced.

### Testing Plan

**Unit Tests:**

- [x] I have added or updated unit tests for my change.
- [x] All unit tests pass locally.

```
go build ./...                              ok
go vet ./...                                ok
go test -race -count=1 -shuffle=on ./...    all packages ok
golangci-lint run ./cmd/...                 0 issues
```

Both changes are mutation-proved. Restoring the old registration order turns a
sublauncher's `503 draining` into the built-in `200 ok`. Dropping the
future-refusal notice fails the warning test.

No existing test needed changing, including `TestWebLauncher_ServesA2A`, which
builds a config with only a session service. That is the check that this does
not break callers.

**Manual End-to-End (E2E) Tests:**

`adk web api webui` runs with no configuration and shows no future-refusal
notice. `adk web api` alone runs and shows it. Supplying both services, or
passing `-allow_in_memory_services`, silences it.

### Checklist

- [x] I have read the CONTRIBUTING.md document.
- [x] I have performed a self-review of my own code.
- [x] I have commented my code, particularly in hard-to-understand areas.
- [x] I have added tests that prove my fix is effective or that my feature works.
- [x] New and existing unit tests pass locally with my changes.
- [x] I have manually tested my changes end-to-end.

### Additional context

Raised in review of #1460, where the comment was that the launcher creates
services nobody needs. Turning the fallback into a hard refusal is the intended
follow-up once this notice has shipped in a release.
