### PR TITLE
fix(launcher): pin the webui-before-api order, and clarify the adk-web pin

### DIFF
--- a/cmd/launcher/full/full_test.go
+++ b/cmd/launcher/full/full_test.go
@@ -1,0 +1,114 @@
+// Copyright 2025 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package full
+
+import (
+	"fmt"
+	"io"
+	"net"
+	"net/http"
+	"strings"
+	"testing"
+	"time"
+
+	"google.golang.org/adk/v2/agent"
+	"google.golang.org/adk/v2/cmd/launcher"
+	"google.golang.org/adk/v2/cmd/launcher/web"
+	"google.golang.org/adk/v2/cmd/launcher/web/api"
+	"google.golang.org/adk/v2/cmd/launcher/web/webui"
+)
+
+// freePort returns a port nothing is listening on. There is a race between
+// closing the listener and the server binding it, which is why the caller polls
+// rather than assuming the server is up.
+func freePort(t *testing.T) int {
+	t.Helper()
+	ln, err := net.Listen("tcp", "127.0.0.1:0")
+	if err != nil {
+		t.Fatalf("net.Listen() failed: %v", err)
+	}
+	port := ln.Addr().(*net.TCPAddr).Port
+	if err := ln.Close(); err != nil {
+		t.Fatalf("closing the probe listener failed: %v", err)
+	}
+	return port
+}
+
+// TestWebUIOutranksTheAPICatchAll pins the order the sublaunchers are passed to
+// web.NewLauncher in NewLauncher.
+//
+// With an empty path prefix the API sublauncher mounts a catch-all route that
+// matches every path, including /ui/. gorilla/mux serves the first route that
+// matches, so the UI survives only because webui is registered before api.
+// Nothing else enforces that. Swap the two arguments and the entire UI
+// disappears behind the API, with no build or test failure to say so.
+//
+// The assertion is on the served response rather than on the argument order, so
+// it still holds if the mounting changes shape.
+func TestWebUIOutranksTheAPICatchAll(t *testing.T) {
+	port := freePort(t)
+
+	l := web.NewLauncher(webui.NewLauncher(), api.NewLauncher())
+	// An empty API prefix is what makes the two collide. The default /api does
+	// not overlap /ui/, which is why this has never bitten in practice.
+	if _, err := l.Parse([]string{
+		"--port", fmt.Sprint(port),
+		"webui",
+		"api", "--path_prefix", "",
+	}); err != nil {
+		t.Fatalf("Parse() failed: %v", err)
+	}
+
+	rootAgent, err := agent.New(agent.Config{Name: "test_agent", Description: "root agent"})
+	if err != nil {
+		t.Fatalf("agent.New() failed: %v", err)
+	}
+
+	go func() {
+		// Run blocks until the context is done, which t.Context handles at the
+		// end of the test.
+		_ = l.Run(t.Context(), &launcher.Config{AgentLoader: agent.NewSingleLoader(rootAgent)})
+	}()
+
+	url := fmt.Sprintf("http://127.0.0.1:%d/ui/", port)
+	var resp *http.Response
+	deadline := time.Now().Add(10 * time.Second)
+	for time.Now().Before(deadline) {
+		resp, err = http.Get(url)
+		if err == nil {
+			break
+		}
+		time.Sleep(20 * time.Millisecond)
+	}
+	if err != nil {
+		t.Fatalf("GET %s never succeeded: %v", url, err)
+	}
+	defer func() { _ = resp.Body.Close() }()
+
+	body, err := io.ReadAll(resp.Body)
+	if err != nil {
+		t.Fatalf("reading the response failed: %v", err)
+	}
+
+	if resp.StatusCode != http.StatusOK {
+		t.Fatalf("GET /ui/ status = %d, want %d; the API catch-all is shadowing the UI",
+			resp.StatusCode, http.StatusOK)
+	}
+	// The UI serves index.html. The REST catch-all answers with the API
+	// router's own 404 body instead.
+	if !strings.Contains(strings.ToLower(string(body)), "<!doctype html") {
+		t.Errorf("GET /ui/ did not return the UI document; first 120 bytes: %.120q", body)
+	}
+}

--- a/cmd/launcher/full/full_test.go
+++ b/cmd/launcher/full/full_test.go
@@ -25,9 +25,6 @@ import (
 
 	"google.golang.org/adk/v2/agent"
 	"google.golang.org/adk/v2/cmd/launcher"
-	"google.golang.org/adk/v2/cmd/launcher/web"
-	"google.golang.org/adk/v2/cmd/launcher/web/api"
-	"google.golang.org/adk/v2/cmd/launcher/web/webui"
 )
 
 // freePort returns a port nothing is listening on. There is a race between
@@ -46,54 +43,59 @@ func freePort(t *testing.T) int {
 	return port
 }
 
-// TestWebUIOutranksTheAPICatchAll pins the order the sublaunchers are passed to
-// web.NewLauncher in NewLauncher.
+// TestWebUIOutranksTheAPICatchAll pins the sublauncher order in NewLauncher.
 //
 // With an empty path prefix the API sublauncher mounts a catch-all route that
 // matches every path, including /ui/. gorilla/mux serves the first route that
-// matches, so the UI survives only because webui is registered before api.
-// Nothing else enforces that. Swap the two arguments and the entire UI
-// disappears behind the API, with no build or test failure to say so.
+// matches, so the web UI survives only because NewLauncher passes webui before
+// api. Nothing else enforces that. Swap the two and the entire UI 404s, with no
+// build or test failure to say so.
 //
-// The assertion is on the served response rather than on the argument order, so
-// it still holds if the mounting changes shape.
+// This drives NewLauncher itself rather than assembling an equivalent launcher.
+// The composition in full.go is the thing being pinned, and a test that builds
+// its own launcher asserts only that its own argument order works.
 func TestWebUIOutranksTheAPICatchAll(t *testing.T) {
 	port := freePort(t)
-
-	l := web.NewLauncher(webui.NewLauncher(), api.NewLauncher())
-	// An empty API prefix is what makes the two collide. The default /api does
-	// not overlap /ui/, which is why this has never bitten in practice.
-	if _, err := l.Parse([]string{
-		"--port", fmt.Sprint(port),
-		"webui",
-		"api", "--path_prefix", "",
-	}); err != nil {
-		t.Fatalf("Parse() failed: %v", err)
-	}
 
 	rootAgent, err := agent.New(agent.Config{Name: "test_agent", Description: "root agent"})
 	if err != nil {
 		t.Fatalf("agent.New() failed: %v", err)
 	}
 
+	// Surfaced rather than discarded. A bind failure would otherwise show up as
+	// the 404 below, reporting a regression that did not happen.
+	runErr := make(chan error, 1)
 	go func() {
-		// Run blocks until the context is done, which t.Context handles at the
-		// end of the test.
-		_ = l.Run(t.Context(), &launcher.Config{AgentLoader: agent.NewSingleLoader(rootAgent)})
+		// An empty API prefix is what makes the two collide. The default /api
+		// does not overlap /ui/, which is why this has never bitten in practice.
+		runErr <- NewLauncher().Execute(t.Context(),
+			&launcher.Config{AgentLoader: agent.NewSingleLoader(rootAgent)},
+			[]string{"web", "--port", fmt.Sprint(port), "webui", "api", "--path_prefix", ""})
 	}()
 
+	// Bounded per request, not only across the retry loop. Without this a
+	// server that accepts and never answers hangs until the package timeout,
+	// which CI leaves at the ten minute default.
+	client := &http.Client{Timeout: 2 * time.Second}
 	url := fmt.Sprintf("http://127.0.0.1:%d/ui/", port)
+
 	var resp *http.Response
 	deadline := time.Now().Add(10 * time.Second)
 	for time.Now().Before(deadline) {
-		resp, err = http.Get(url)
+		select {
+		case err := <-runErr:
+			t.Fatalf("launcher.Execute() returned before the server answered: %v", err)
+		default:
+		}
+		r, err := client.Get(url)
 		if err == nil {
+			resp = r
 			break
 		}
 		time.Sleep(20 * time.Millisecond)
 	}
-	if err != nil {
-		t.Fatalf("GET %s never succeeded: %v", url, err)
+	if resp == nil {
+		t.Fatalf("GET %s never answered within the deadline", url)
 	}
 	defer func() { _ = resp.Body.Close() }()
 
@@ -106,8 +108,8 @@ func TestWebUIOutranksTheAPICatchAll(t *testing.T) {
 		t.Fatalf("GET /ui/ status = %d, want %d; the API catch-all is shadowing the UI",
 			resp.StatusCode, http.StatusOK)
 	}
-	// The UI serves index.html. The REST catch-all answers with the API
-	// router's own 404 body instead.
+	// The UI serves index.html. The catch-all answers /ui/ with a plain-text
+	// 404, so this cannot pass by accident.
 	if !strings.Contains(strings.ToLower(string(body)), "<!doctype html") {
 		t.Errorf("GET /ui/ did not return the UI document; first 120 bytes: %.120q", body)
 	}

--- a/scripts/adk-web/Dockerfile
+++ b/scripts/adk-web/Dockerfile
@@ -2,11 +2,10 @@
 FROM node:iron-trixie AS downloader
 RUN apt-get update && apt-get install -y git
 
-# The upstream ref to build. Pass --build-arg ADK_WEB_REF=<sha-or-tag> to move
-# it forward; see scripts/adk-web/README.md for how to bump the pin.
-#
 # The upstream revision to build. A SHA rather than a tag, because upstream can
-# move a tag. 33c3568 is upstream tag v1.0.5, dated 2026-08-26.
+# move a tag. 33c3568 is upstream tag v1.0.5, dated 2026-08-26. Pass
+# --build-arg ADK_WEB_REF=<sha-or-tag> for a one-off build; see
+# scripts/adk-web/README.md for how to move the pin for everyone.
 #
 # Keep it pinned. This used to clone `main` behind a cache-buster, so a refresh
 # built whatever upstream had that day and recorded nothing, which is how a

--- a/scripts/adk-web/Dockerfile
+++ b/scripts/adk-web/Dockerfile
@@ -5,27 +5,18 @@ RUN apt-get update && apt-get install -y git
 # The upstream ref to build. Pass --build-arg ADK_WEB_REF=<sha-or-tag> to move
 # it forward; see scripts/adk-web/README.md for how to bump the pin.
 #
-# This is pinned, and must stay pinned, because the bundle it produces is
-# committed and embedded into the server binary. When this cloned `main`
-# instead, a refresh took whatever upstream had that day. On 2026-06-30 one such
-# refresh (commit 893e4a4, 105 files under distr/ inside a 547-file release)
-# pulled in an upstream change that moved 30 developer API endpoints under a
-# /dev/apps/{app}/ prefix. Nothing in the commit said so, and most of the web UI
-# returned 404 for two months. A floating ref makes a refresh unreviewable: the
-# diff is 8MB of minified JavaScript, so the ref is the only thing a reviewer
-# can actually read.
+# The upstream revision to build. A SHA rather than a tag, because upstream can
+# move a tag. 33c3568 is upstream tag v1.0.5, dated 2026-08-26.
 #
-# Pinning also makes the clone layer cacheable: the same ref must yield the same
-# checkout, so there is deliberately no cache-buster here.
+# Keep it pinned. This used to clone `main` behind a cache-buster, so a refresh
+# built whatever upstream had that day and recorded nothing, which is how a
+# breaking UI change shipped unnoticed and left most of the UI returning 404 for
+# two months.
 #
-# The default is a SHA rather than a tag name, because upstream can move a tag.
-# 33c3568 is upstream tag v1.0.5, dated 2026-08-26.
-# NOTE: the bundle committed in cmd/launcher/web/webui/distr/ was built on
-# 2026-06-30, before this pin existed, and carries no provenance file. The pin
-# below therefore does not describe what is committed today: building at it
-# moves the UI forward rather than reproducing the current bundle. The first
-# refresh is a deliberate version bump; after it, the provenance file written
-# below records exactly what shipped.
+# This pin does NOT describe the bundle committed in
+# cmd/launcher/web/webui/distr/, which predates it. Building here moves the UI
+# forward rather than reproducing what is in the tree. README.md in this
+# directory explains why, and what changes after the first refresh.
 ARG ADK_WEB_REF=33c3568021d129339f52b75352dfc35deaf1bf0d
 
 # `git clone -b` accepts a branch or tag but not a SHA, so clone the repository

--- a/scripts/adk-web/README.md
+++ b/scripts/adk-web/README.md
@@ -28,6 +28,24 @@ A pin does not stop upstream from making breaking changes. It makes a refresh
 reviewable. The diff is 8MB of minified JavaScript that no reviewer can read, so
 the upstream revision range is the only part anyone can actually check.
 
+### The pin does not describe the bundle committed today
+
+Read this before assuming the script reproduces what is in the tree, because it
+does not, yet.
+
+`ADK_WEB_REF` is `33c3568`, upstream tag v1.0.5, dated 2026-08-26. The `distr/`
+directory committed alongside it was built on 2026-06-30, before the pin
+existed, and carries no `adk-web-version.json` to say which revision that was.
+
+So running the script today is a version bump of about two months, not a
+rebuild. That is unavoidable rather than intended: the old floating clone
+recorded nothing, so the revision it fetched cannot be recovered. The first
+refresh settles it. From then on the provenance file records what shipped and
+the script reports the upstream range between builds.
+
+Until that first refresh, read the pin as the revision the next build will use,
+not as the revision the committed bundle came from.
+
 ### What the pin does not cover
 
 `ADK_WEB_REF` pins the source, not the toolchain. The container installs from

--- a/scripts/adk-web/README.md
+++ b/scripts/adk-web/README.md
@@ -30,21 +30,13 @@ the upstream revision range is the only part anyone can actually check.
 
 ### The pin does not describe the bundle committed today
 
-Read this before assuming the script reproduces what is in the tree, because it
-does not, yet.
-
 `ADK_WEB_REF` is `33c3568`, upstream tag v1.0.5, dated 2026-08-26. The `distr/`
-directory committed alongside it was built on 2026-06-30, before the pin
-existed, and carries no `adk-web-version.json` to say which revision that was.
+bundle committed next to it was built on 2026-06-30, before the pin existed.
 
 So running the script today is a version bump of about two months, not a
-rebuild. That is unavoidable rather than intended: the old floating clone
-recorded nothing, so the revision it fetched cannot be recovered. The first
-refresh settles it. From then on the provenance file records what shipped and
-the script reports the upstream range between builds.
-
-Until that first refresh, read the pin as the revision the next build will use,
-not as the revision the committed bundle came from.
+rebuild. Read the pin as the revision the next build will use, not as the one
+the committed bundle came from. The provenance section below covers what
+changes after that first refresh.
 
 ### What the pin does not cover
 


### PR DESCRIPTION
### Link to Issue or Description of Change

**2. Or, if no issue exists, describe the change:**

Two loose ends from review of #1459 and #1460. Neither changes behaviour: one
adds a test, the other is documentation.

**Problem 1, the UI survives on argument order alone.**

`api.NewLauncher()` mounts a catch-all route when its path prefix is empty
(`registerAPIRoutes` uses `router.NewRoute()`), and that matches every path,
including `/ui/`. gorilla/mux serves the first route that matches, so the web UI
is reachable only because `NewLauncher` happens to pass `webui.NewLauncher()`
before `api.NewLauncher()`.

Nothing enforced that. Swapping the two arguments makes the entire UI return
404, and neither the build nor any test says so.

**Problem 2, the adk-web pin is confusing.**

The `Dockerfile` buried its most important caveat at the end of a fifteen-line
comment, which is where a reviewer asked what the whole thing was for.

`ADK_WEB_REF` is `33c3568`, upstream tag v1.0.5 dated 2026-08-26. The `distr/`
bundle committed next to it was built on 2026-06-30, before the pin existed, and
carries no provenance file. So building at the pin moves the UI forward by about
two months rather than reproducing what is in the tree.

**Solution:**

Add `cmd/launcher/full/full_test.go`, which starts the server with an empty API
prefix and asserts `GET /ui/` still returns the UI document. It asserts the
served response rather than the argument order, so it survives the mounting
changing shape.

Cut the Dockerfile comment from 29 lines to 13: lead with what the argument is,
state the gap plainly, and point at the README. Add a section to
`scripts/adk-web/README.md` explaining why the gap cannot be closed
retroactively, and what changes after the first refresh.

### Testing Plan

**Unit Tests:**

- [x] I have added or updated unit tests for my change.
- [x] All unit tests pass locally.

```
go build ./...                                  ok
go vet ./...                                    ok
go test -race -count=1 -shuffle=on ./cmd/...    all packages ok
golangci-lint run ./cmd/launcher/full/          0 issues
```

The ordering test is mutation-proved. Swapping the arguments to
`web.NewLauncher` gives:

```
full_test.go:106: GET /ui/ status = 404, want 200; the API catch-all is shadowing the UI
```

Worth knowing for review: swapping the command-line order instead, `api` before
`webui`, does not fail. Registration order comes from the arguments to
`web.NewLauncher`, not from the command line, so the flags are not what protects
this.

**Manual End-to-End (E2E) Tests:**

`adk web webui api -path_prefix=` serves the UI at `/ui/`. Swap the two
sublaunchers in `cmd/launcher/full/full.go` and it 404s.

### Checklist

- [x] I have read the CONTRIBUTING.md document.
- [x] I have performed a self-review of my own code.
- [x] I have commented my code, particularly in hard-to-understand areas.
- [x] I have added tests that prove my fix is effective or that my feature works.
- [x] New and existing unit tests pass locally with my changes.
- [x] I have manually tested my changes end-to-end.

### Additional context

Follows #1533, #1534 and #1535, which cover the rest of that review.
