### PR TITLE
fix: emit follow-up tool confirmations on resume

### DIFF
--- a/internal/llminternal/request_confirmation_processor.go
+++ b/internal/llminternal/request_confirmation_processor.go
@@ -248,11 +248,28 @@ func RequestConfirmationRequestProcessor(ctx agent.InvocationContext, req *model
 				toolsToResumeConfirmation[callID] = cc.confirmation
 			}
 
-			ev, err := f.handleFunctionCalls(ctx, toolsmap, &model.LLMResponse{
+			response := &model.LLMResponse{
 				Content: &genai.Content{Parts: parts, Role: genai.RoleUser},
-			}, toolsToResumeConfirmation, nil)
-			if !yield(ev, err) {
+			}
+			functionCallEvent := &session.Event{LLMResponse: *response}
+			ev, err := f.handleFunctionCalls(ctx, toolsmap, response, toolsToResumeConfirmation, nil)
+			if err != nil {
+				if !yield(ev, err) {
+					return
+				}
+				continue
+			}
+
+			confirmationEvent := generateRequestConfirmationEvent(ctx, functionCallEvent, ev)
+			if !yield(ev, nil) {
 				return
+			}
+
+			if confirmationEvent != nil {
+				if !yield(confirmationEvent, nil) {
+					return
+				}
+				ctx.EndInvocation()
 			}
 		}
 	}

--- a/internal/llminternal/request_confirmation_processor_test.go
+++ b/internal/llminternal/request_confirmation_processor_test.go
@@ -57,6 +57,30 @@ func (m *mockTool) Run(ctx agent.Context, args any) (map[string]any, error) {
 	return map[string]any{"result": "Mock tool result with test"}, nil
 }
 
+// followUpConfirmationTool requests another confirmation when resumed.
+type followUpConfirmationTool struct {
+	name string
+}
+
+func (t *followUpConfirmationTool) Name() string { return t.name }
+func (t *followUpConfirmationTool) Description() string {
+	return "mock tool requesting follow-up confirmation"
+}
+func (t *followUpConfirmationTool) IsLongRunning() bool { return false }
+func (t *followUpConfirmationTool) Declaration() *genai.FunctionDeclaration {
+	return &genai.FunctionDeclaration{Name: t.name}
+}
+
+func (t *followUpConfirmationTool) Run(ctx agent.Context, _ any) (map[string]any, error) {
+	if ctx.ToolConfirmation() == nil || !ctx.ToolConfirmation().Confirmed {
+		return map[string]any{"error": "tool execution not confirmed"}, nil
+	}
+	if err := ctx.RequestConfirmation("Approve the next operation?", nil); err != nil {
+		return nil, err
+	}
+	return nil, tool.ErrConfirmationRequired
+}
+
 // amountEchoTool is a confirmation-gated tool used by the confirmation-forgery
 // security test. When (and only when) the call is confirmed, it echoes back the
 // "amount" argument it was actually executed with, so the test can assert
@@ -305,6 +329,113 @@ func TestRequestConfirmationRequestProcessor(t *testing.T) {
 				}
 			}
 		})
+	}
+}
+
+func TestRequestConfirmationRequestProcessorEmitsFollowUpConfirmation(t *testing.T) {
+	const toolName = "follow_up_confirmation_tool"
+
+	tools := []tool.Tool{&followUpConfirmationTool{name: toolName}}
+	agnt, err := llmagent.New(llmagent.Config{
+		Name:  "testAgent",
+		Model: &testModel{},
+		Tools: tools,
+	})
+	if err != nil {
+		t.Fatalf("error creating llmagent: %v", err)
+	}
+
+	originalCall := &genai.FunctionCall{
+		Name: toolName,
+		Args: map[string]any{},
+		ID:   mockFunctionCallID,
+	}
+	userConfirmationJSON, err := json.Marshal(toolconfirmation.ToolConfirmation{Confirmed: true})
+	if err != nil {
+		t.Fatalf("error marshalling user confirmation: %v", err)
+	}
+	events := []*session.Event{
+		{
+			Author: "testAgent",
+			LLMResponse: model.LLMResponse{
+				Content: &genai.Content{Parts: []*genai.Part{{
+					FunctionCall: &genai.FunctionCall{
+						Name: toolconfirmation.FunctionCallName,
+						ID:   mockConfirmationFunctionCallID,
+						Args: map[string]any{
+							"originalFunctionCall": originalCall,
+							"toolConfirmation": toolconfirmation.ToolConfirmation{
+								Hint: "Approve the first operation?",
+							},
+						},
+					},
+				}}},
+			},
+		},
+		{
+			Author: "user",
+			LLMResponse: model.LLMResponse{
+				Content: &genai.Content{Parts: []*genai.Part{{
+					FunctionResponse: &genai.FunctionResponse{
+						Name: toolconfirmation.FunctionCallName,
+						ID:   mockConfirmationFunctionCallID,
+						Response: map[string]any{
+							"response": string(userConfirmationJSON),
+						},
+					},
+				}}},
+			},
+		},
+	}
+	invocationContext := createInvocationContext(t, agnt, &fakeSession{events: events})
+
+	var gotEvents []*session.Event
+	for event, err := range llminternal.RequestConfirmationRequestProcessor(
+		invocationContext,
+		&model.LLMRequest{},
+		&llminternal.Flow{Tools: tools},
+	) {
+		if err != nil {
+			t.Fatalf("RequestConfirmationRequestProcessor() unexpected error: %v", err)
+		}
+		gotEvents = append(gotEvents, event)
+	}
+
+	if got, want := len(gotEvents), 2; got != want {
+		t.Fatalf("RequestConfirmationRequestProcessor() got %d events, want %d", got, want)
+	}
+	responseParts := gotEvents[0].Content.Parts
+	if got, want := len(responseParts), 1; got != want {
+		t.Fatalf("response event got %d parts, want %d", got, want)
+	}
+	if got, want := responseParts[0].FunctionResponse.ID, mockFunctionCallID; got != want {
+		t.Errorf("response function call ID = %q, want %q", got, want)
+	}
+
+	confirmationEvent := gotEvents[1]
+	confirmationCalls := confirmationEvent.Content.Parts
+	if got, want := len(confirmationCalls), 1; got != want {
+		t.Fatalf("follow-up confirmation event got %d parts, want %d", got, want)
+	}
+	followUpCall := confirmationCalls[0].FunctionCall
+	if followUpCall == nil {
+		t.Fatal("follow-up confirmation event has no function call")
+	}
+	if got, want := followUpCall.Name, toolconfirmation.FunctionCallName; got != want {
+		t.Errorf("follow-up function name = %q, want %q", got, want)
+	}
+	if diff := cmp.Diff([]string{followUpCall.ID}, confirmationEvent.LongRunningToolIDs); diff != "" {
+		t.Errorf("follow-up LongRunningToolIDs diff (-want +got):\n%s", diff)
+	}
+	followUpOriginalCall, err := toolconfirmation.OriginalCallFrom(followUpCall)
+	if err != nil {
+		t.Fatalf("extracting follow-up original call: %v", err)
+	}
+	if diff := cmp.Diff(originalCall, followUpOriginalCall); diff != "" {
+		t.Errorf("follow-up original call diff (-want +got):\n%s", diff)
+	}
+	if !invocationContext.Ended() {
+		t.Error("invocation did not end after emitting follow-up confirmation")
 	}
 }
 


### PR DESCRIPTION
### Link to Issue or Description of Change

**1. Link to an existing issue (if applicable):**

- Closes: N/A
- Related: N/A

**2. Or, if no issue exists, describe the change:**

**Problem:**
When a tool is resumed after user confirmation and requests another confirmation, `RequestConfirmationRequestProcessor` preserves the new `RequestedToolConfirmations` on the function-response event but does not generate a new `adk_request_confirmation` event. The invocation then continues to the model instead of pausing for the follow-up decision.

**Solution:**
Generate and yield a confirmation event after resumed function calls, using the same `generateRequestConfirmationEvent` path as normal function-call execution. End the current invocation after emitting the follow-up confirmation so processing waits for the next user response.

### Behavior change

A resumed tool that requests another confirmation now emits a new `adk_request_confirmation` event and pauses the current invocation. Previously, the request remained only in `RequestedToolConfirmations` and execution continued to the model.

Completed tool responses are emitted before the follow-up confirmation event, matching the normal function-call path. Multiple follow-up requests remain aggregated in one event.

### Testing Plan

**Unit Tests:**

- [x] Changed package tests pass locally.

**With your source change reverted and your tests kept, which test fails?**

`TestRequestConfirmationRequestProcessorEmitsFollowUpConfirmation` fails:

```text
RequestConfirmationRequestProcessor() got 1 events, want 2
```

With the fix applied:

```text
ok  google.golang.org/adk/v2/internal/llminternal  1.951s
```

Command:

```text
go test -race -count=1 ./internal/llminternal
```

**Manual End-to-End (E2E) Tests:**

The issue was reproduced with a foreground parent tool that runs a child agent:

1. The child requested confirmation for its first tool call.
2. The user approved it.
3. The resumed parent tool forwarded the approval to the child.
4. The child requested a second confirmation.
5. Before this fix, the function-response event contained `RequestedToolConfirmations`, but no corresponding `adk_request_confirmation` event was emitted and the parent model continued.

### Checklist

- [x] I have read the [CONTRIBUTING.md](./CONTRIBUTING.md) document.
- [x] I have performed a self-review of my own code.
- [x] I have commented my code, particularly in hard-to-understand areas.
- [x] I have added tests that prove my fix is effective or that my feature works.
- [ ] New and existing unit tests pass locally with my changes.
- [x] I have manually tested my changes end-to-end.
- [x] Any dependent changes have been merged and published in downstream modules. (Not applicable; there are no dependent changes.)

### Additional context

This keeps follow-up confirmation behavior consistent with the normal function-call path, which already emits the function response before the generated confirmation request.
