### PR TITLE
feat(model/openaimodel): support image/file input via genai InlineData/FileData parts

### DIFF
--- a/model/openaimodel/request.go
+++ b/model/openaimodel/request.go
@@ -16,6 +16,7 @@ package openaimodel
 
 import (
 	"bytes"
+	"encoding/base64"
 	"encoding/json"
 	"fmt"
 	"sort"
@@ -86,14 +87,15 @@ func buildOpenAIParams(modelName string, req *model.LLMRequest) (responses.Respo
 
 func convertContents(contents []*genai.Content) (responses.ResponseInputParam, error) {
 	var (
-		items     responses.ResponseInputParam
-		tracker   callTracker
-		textParts []string
-		curRole   genai.Role = genai.RoleUser
-		// flushText is a helper function that takes any accumulated text parts
-		// and converts them into a message, then appends it to our items.
-		flushText = func() error {
-			if len(textParts) == 0 {
+		items        responses.ResponseInputParam
+		tracker      callTracker
+		pendingParts []responses.ResponseInputContentUnionParam
+		curRole      genai.Role = genai.RoleUser
+		// flushParts is a helper function that takes any accumulated content
+		// parts (text mixed with images/files, in original order) and converts
+		// them into a message, then appends it to our items.
+		flushParts = func() error {
+			if len(pendingParts) == 0 {
 				return nil
 			}
 			msgRole, err := normalizeRole(curRole)
@@ -102,16 +104,23 @@ func convertContents(contents []*genai.Content) (responses.ResponseInputParam, e
 			}
 			// The Responses API rejects "input_text" for the assistant role, so
 			// a replayed assistant turn goes out as an output message instead.
+			// Output messages only support text content, so an assistant turn
+			// that also carries an image or file part is rejected rather than
+			// silently dropping the non-text parts.
 			if msgRole == responses.EasyInputMessageRoleAssistant {
-				if msg := newOutputMessage(textParts); msg != nil {
+				texts, err := textOnlyParts(pendingParts)
+				if err != nil {
+					return err
+				}
+				if msg := newOutputMessage(texts); msg != nil {
 					items = append(items, responses.ResponseInputItemUnionParam{OfOutputMessage: msg})
 				}
 			} else {
-				if msg := newMessage(msgRole, textParts); msg != nil {
+				if msg := newMessage(msgRole, pendingParts); msg != nil {
 					items = append(items, responses.ResponseInputItemUnionParam{OfMessage: msg})
 				}
 			}
-			textParts = textParts[:0]
+			pendingParts = pendingParts[:0]
 			return nil
 		}
 	)
@@ -126,10 +135,14 @@ func convertContents(contents []*genai.Content) (responses.ResponseInputParam, e
 			case part == nil:
 				continue
 			case part.Text != "":
-				textParts = append(textParts, part.Text)
+				pendingParts = append(pendingParts, newInputTextContent(part.Text))
+			case part.InlineData != nil:
+				pendingParts = append(pendingParts, inlineDataToContent(part.InlineData))
+			case part.FileData != nil:
+				pendingParts = append(pendingParts, fileDataToContent(part.FileData))
 			case part.FunctionCall != nil:
-				// If we encounter a function call, we first flush any accumulated text.
-				if err := flushText(); err != nil {
+				// If we encounter a function call, we first flush any accumulated parts.
+				if err := flushParts(); err != nil {
 					return nil, err
 				}
 				callParam, err := tracker.newFunctionCall(part.FunctionCall)
@@ -138,8 +151,8 @@ func convertContents(contents []*genai.Content) (responses.ResponseInputParam, e
 				}
 				items = append(items, responses.ResponseInputItemUnionParam{OfFunctionCall: callParam})
 			case part.FunctionResponse != nil:
-				// Similarly, for a function response, we flush text before adding the response.
-				if err := flushText(); err != nil {
+				// Similarly, for a function response, we flush parts before adding the response.
+				if err := flushParts(); err != nil {
 					return nil, err
 				}
 				respParam, err := tracker.newFunctionResponse(part.FunctionResponse)
@@ -151,8 +164,8 @@ func convertContents(contents []*genai.Content) (responses.ResponseInputParam, e
 				return nil, fmt.Errorf("openai: unsupported content part %T", part)
 			}
 		}
-		// After processing all parts in a content block, we flush any remaining text.
-		if err := flushText(); err != nil {
+		// After processing all parts in a content block, we flush any remaining parts.
+		if err := flushParts(); err != nil {
 			return nil, err
 		}
 	}
@@ -160,23 +173,110 @@ func convertContents(contents []*genai.Content) (responses.ResponseInputParam, e
 	return items, nil
 }
 
-// newMessage builds an easy input message for an already-normalized role.
-func newMessage(msgRole responses.EasyInputMessageRole, texts []string) *responses.EasyInputMessageParam {
-	if len(texts) == 0 {
+// newInputTextContent wraps a plain text string as an input_text content item.
+func newInputTextContent(text string) responses.ResponseInputContentUnionParam {
+	return responses.ResponseInputContentUnionParam{
+		OfInputText: &responses.ResponseInputTextParam{
+			Text: text,
+			Type: constant.InputText("input_text"),
+		},
+	}
+}
+
+// inlineDataToContent converts a genai.Blob (raw bytes + MIME type) into an
+// OpenAI content item. Image MIME types become an input_image item carrying a
+// base64 data URL; everything else (e.g. application/pdf) becomes an
+// input_file item, mirroring adk-python's
+// _inline_data_part_to_response_content.
+func inlineDataToContent(blob *genai.Blob) responses.ResponseInputContentUnionParam {
+	mimeType := blob.MIMEType
+	if mimeType == "" {
+		mimeType = "application/octet-stream"
+	}
+	dataURL := fmt.Sprintf("data:%s;base64,%s", mimeType, base64.StdEncoding.EncodeToString(blob.Data))
+	if strings.HasPrefix(mimeType, "image/") {
+		return responses.ResponseInputContentUnionParam{
+			OfInputImage: &responses.ResponseInputImageParam{
+				Type:     constant.InputImage("input_image"),
+				Detail:   responses.ResponseInputImageDetailAuto,
+				ImageURL: param.NewOpt(dataURL),
+			},
+		}
+	}
+	filename := blob.DisplayName
+	if filename == "" {
+		filename = "inline_data"
+	}
+	return responses.ResponseInputContentUnionParam{
+		OfInputFile: &responses.ResponseInputFileParam{
+			Type:     constant.InputFile("input_file"),
+			Filename: param.NewOpt(filename),
+			FileData: param.NewOpt(dataURL),
+		},
+	}
+}
+
+// fileDataToContent converts a genai.FileData (remote URI + MIME type) into
+// an OpenAI content item. Image MIME types become an input_image item
+// carrying the URI directly; a URI shaped like an OpenAI file ID ("file-...")
+// is passed through FileID, and every other URI (e.g. an https PDF link)
+// becomes an input_file item carrying FileURL, mirroring adk-python's
+// _file_data_part_to_response_content.
+func fileDataToContent(fd *genai.FileData) responses.ResponseInputContentUnionParam {
+	if strings.HasPrefix(fd.MIMEType, "image/") {
+		return responses.ResponseInputContentUnionParam{
+			OfInputImage: &responses.ResponseInputImageParam{
+				Type:     constant.InputImage("input_image"),
+				Detail:   responses.ResponseInputImageDetailAuto,
+				ImageURL: param.NewOpt(fd.FileURI),
+			},
+		}
+	}
+	if strings.HasPrefix(fd.FileURI, "file-") {
+		return responses.ResponseInputContentUnionParam{
+			OfInputFile: &responses.ResponseInputFileParam{
+				Type:   constant.InputFile("input_file"),
+				FileID: param.NewOpt(fd.FileURI),
+			},
+		}
+	}
+	return responses.ResponseInputContentUnionParam{
+		OfInputFile: &responses.ResponseInputFileParam{
+			Type:    constant.InputFile("input_file"),
+			FileURL: param.NewOpt(fd.FileURI),
+		},
+	}
+}
+
+// textOnlyParts extracts the plain text of a run of content parts, erroring
+// if any part is an image or file: the Responses API's output-message
+// content only supports text (see ResponseOutputMessageContentUnionParam),
+// so a replayed assistant turn carrying media cannot be represented and must
+// fail loudly instead of silently dropping it.
+func textOnlyParts(parts []responses.ResponseInputContentUnionParam) ([]string, error) {
+	texts := make([]string, 0, len(parts))
+	for _, p := range parts {
+		if p.OfInputText == nil {
+			return nil, fmt.Errorf("openai: replayed assistant turn with image/file content is not supported")
+		}
+		texts = append(texts, p.OfInputText.Text)
+	}
+	return texts, nil
+}
+
+// newMessage builds an easy input message for an already-normalized role from
+// a run of content parts that may mix text with images/files, preserving
+// their original order.
+func newMessage(msgRole responses.EasyInputMessageRole, parts []responses.ResponseInputContentUnionParam) *responses.EasyInputMessageParam {
+	if len(parts) == 0 {
 		return nil
 	}
-	contentList := make(responses.ResponseInputMessageContentListParam, 0, len(texts))
-	for _, txt := range texts {
-		if strings.TrimSpace(txt) == "" {
+	contentList := make(responses.ResponseInputMessageContentListParam, 0, len(parts))
+	for _, p := range parts {
+		if p.OfInputText != nil && strings.TrimSpace(p.OfInputText.Text) == "" {
 			continue
 		}
-		textParam := responses.ResponseInputTextParam{
-			Text: txt,
-			Type: constant.InputText("input_text"),
-		}
-		contentList = append(contentList, responses.ResponseInputContentUnionParam{
-			OfInputText: &textParam,
-		})
+		contentList = append(contentList, p)
 	}
 	if len(contentList) == 0 {
 		return nil

--- a/model/openaimodel/request_test.go
+++ b/model/openaimodel/request_test.go
@@ -15,6 +15,7 @@
 package openaimodel
 
 import (
+	"encoding/base64"
 	"encoding/json"
 	"errors"
 	"reflect"
@@ -256,13 +257,215 @@ func TestBuildOpenAIParams_UnsupportedPart(t *testing.T) {
 			{
 				Role: string(genai.RoleUser),
 				Parts: []*genai.Part{
-					{InlineData: &genai.Blob{Data: []byte{0x1}}},
+					{ExecutableCode: &genai.ExecutableCode{Code: "1+1", Language: genai.LanguagePython}},
 				},
 			},
 		},
 	}
 	if _, err := buildOpenAIParams("fallback", req); err == nil {
-		t.Fatalf("expected error for inline data part")
+		t.Fatalf("expected error for executable code part")
+	}
+}
+
+// TestBuildOpenAIParams_InlineDataImage guards that a genai.Part.InlineData
+// image (base64 bytes + MIME type) is converted into an OpenAI
+// responses.ResponseInputImageParam using a base64 data URL, matching
+// adk-python's _inline_data_part_to_response_content.
+func TestBuildOpenAIParams_InlineDataImage(t *testing.T) {
+	pngBytes := []byte{0x89, 0x50, 0x4e, 0x47}
+	req := &model.LLMRequest{
+		Contents: []*genai.Content{
+			{
+				Role: string(genai.RoleUser),
+				Parts: []*genai.Part{
+					{InlineData: &genai.Blob{MIMEType: "image/png", Data: pngBytes}},
+				},
+			},
+		},
+	}
+	params, err := buildOpenAIParams("fallback", req)
+	if err != nil {
+		t.Fatalf("buildOpenAIParams() err = %v", err)
+	}
+	items := params.Input.OfInputItemList
+	if len(items) != 1 || items[0].OfMessage == nil {
+		t.Fatalf("unexpected input items: %+v", items)
+	}
+	content := items[0].OfMessage.Content.OfInputItemContentList
+	if len(content) != 1 || content[0].OfInputImage == nil {
+		t.Fatalf("unexpected message content: %+v", content)
+	}
+	img := content[0].OfInputImage
+	wantURL := "data:image/png;base64," + base64.StdEncoding.EncodeToString(pngBytes)
+	if !img.ImageURL.Valid() || img.ImageURL.Value != wantURL {
+		t.Fatalf("image url = %+v, want %q", img.ImageURL, wantURL)
+	}
+	if got := img.Type; got != constant.InputImage("input_image") {
+		t.Errorf("image type = %q, want input_image", got)
+	}
+}
+
+// TestBuildOpenAIParams_InlineDataNonImageFile guards that non-image
+// InlineData (e.g. a PDF) becomes an input_file item carrying an inline
+// base64 data URL rather than an input_image item.
+func TestBuildOpenAIParams_InlineDataNonImageFile(t *testing.T) {
+	pdfBytes := []byte{0x25, 0x50, 0x44, 0x46}
+	req := &model.LLMRequest{
+		Contents: []*genai.Content{
+			{
+				Role: string(genai.RoleUser),
+				Parts: []*genai.Part{
+					{InlineData: &genai.Blob{MIMEType: "application/pdf", Data: pdfBytes}},
+				},
+			},
+		},
+	}
+	params, err := buildOpenAIParams("fallback", req)
+	if err != nil {
+		t.Fatalf("buildOpenAIParams() err = %v", err)
+	}
+	items := params.Input.OfInputItemList
+	if len(items) != 1 || items[0].OfMessage == nil {
+		t.Fatalf("unexpected input items: %+v", items)
+	}
+	content := items[0].OfMessage.Content.OfInputItemContentList
+	if len(content) != 1 || content[0].OfInputFile == nil {
+		t.Fatalf("unexpected message content: %+v", content)
+	}
+	f := content[0].OfInputFile
+	wantData := "data:application/pdf;base64," + base64.StdEncoding.EncodeToString(pdfBytes)
+	if !f.FileData.Valid() || f.FileData.Value != wantData {
+		t.Fatalf("file data = %+v, want %q", f.FileData, wantData)
+	}
+	if got := f.Type; got != constant.InputFile("input_file") {
+		t.Errorf("file type = %q, want input_file", got)
+	}
+}
+
+// TestBuildOpenAIParams_FileDataImageURI guards that a genai.Part.FileData
+// pointing at a remote image URI is converted into an input_image item that
+// carries the URI directly (no re-encoding).
+func TestBuildOpenAIParams_FileDataImageURI(t *testing.T) {
+	req := &model.LLMRequest{
+		Contents: []*genai.Content{
+			{
+				Role: string(genai.RoleUser),
+				Parts: []*genai.Part{
+					{FileData: &genai.FileData{FileURI: "https://example.com/cat.png", MIMEType: "image/png"}},
+				},
+			},
+		},
+	}
+	params, err := buildOpenAIParams("fallback", req)
+	if err != nil {
+		t.Fatalf("buildOpenAIParams() err = %v", err)
+	}
+	items := params.Input.OfInputItemList
+	if len(items) != 1 || items[0].OfMessage == nil {
+		t.Fatalf("unexpected input items: %+v", items)
+	}
+	content := items[0].OfMessage.Content.OfInputItemContentList
+	if len(content) != 1 || content[0].OfInputImage == nil {
+		t.Fatalf("unexpected message content: %+v", content)
+	}
+	img := content[0].OfInputImage
+	if !img.ImageURL.Valid() || img.ImageURL.Value != "https://example.com/cat.png" {
+		t.Fatalf("image url = %+v, want https://example.com/cat.png", img.ImageURL)
+	}
+}
+
+// TestBuildOpenAIParams_FileDataNonImageURI guards that a genai.Part.FileData
+// pointing at a non-image remote file (e.g. a PDF) becomes an input_file item
+// carrying the URL, and that an OpenAI file-id-shaped URI ("file-...") is
+// routed through FileID instead of FileURL.
+func TestBuildOpenAIParams_FileDataNonImageURI(t *testing.T) {
+	tests := []struct {
+		name       string
+		uri        string
+		wantFileID string
+		wantURL    string
+	}{
+		{name: "http url", uri: "https://example.com/doc.pdf", wantURL: "https://example.com/doc.pdf"},
+		{name: "openai file id", uri: "file-abc123", wantFileID: "file-abc123"},
+	}
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			req := &model.LLMRequest{
+				Contents: []*genai.Content{
+					{
+						Role: string(genai.RoleUser),
+						Parts: []*genai.Part{
+							{FileData: &genai.FileData{FileURI: tc.uri, MIMEType: "application/pdf"}},
+						},
+					},
+				},
+			}
+			params, err := buildOpenAIParams("fallback", req)
+			if err != nil {
+				t.Fatalf("buildOpenAIParams() err = %v", err)
+			}
+			items := params.Input.OfInputItemList
+			if len(items) != 1 || items[0].OfMessage == nil {
+				t.Fatalf("unexpected input items: %+v", items)
+			}
+			content := items[0].OfMessage.Content.OfInputItemContentList
+			if len(content) != 1 || content[0].OfInputFile == nil {
+				t.Fatalf("unexpected message content: %+v", content)
+			}
+			f := content[0].OfInputFile
+			if tc.wantURL != "" {
+				if !f.FileURL.Valid() || f.FileURL.Value != tc.wantURL {
+					t.Fatalf("file url = %+v, want %q", f.FileURL, tc.wantURL)
+				}
+			}
+			if tc.wantFileID != "" {
+				if !f.FileID.Valid() || f.FileID.Value != tc.wantFileID {
+					t.Fatalf("file id = %+v, want %q", f.FileID, tc.wantFileID)
+				}
+			}
+		})
+	}
+}
+
+// TestBuildOpenAIParams_MixedTextAndImagePreservesOrder guards that a single
+// message mixing text and image parts is emitted as ONE message whose
+// content list mixes input_text and input_image items IN PART ORDER, rather
+// than being dropped, erroring, or reordered by the old text-only
+// accumulator.
+func TestBuildOpenAIParams_MixedTextAndImagePreservesOrder(t *testing.T) {
+	pngBytes := []byte{0x89, 0x50, 0x4e, 0x47}
+	req := &model.LLMRequest{
+		Contents: []*genai.Content{
+			{
+				Role: string(genai.RoleUser),
+				Parts: []*genai.Part{
+					{Text: "What is in this image?"},
+					{InlineData: &genai.Blob{MIMEType: "image/png", Data: pngBytes}},
+					{Text: "Answer briefly."},
+				},
+			},
+		},
+	}
+	params, err := buildOpenAIParams("fallback", req)
+	if err != nil {
+		t.Fatalf("buildOpenAIParams() err = %v", err)
+	}
+	items := params.Input.OfInputItemList
+	if len(items) != 1 || items[0].OfMessage == nil {
+		t.Fatalf("expected exactly one message, got: %+v", items)
+	}
+	content := items[0].OfMessage.Content.OfInputItemContentList
+	if len(content) != 3 {
+		t.Fatalf("expected 3 content parts, got %d: %+v", len(content), content)
+	}
+	if content[0].OfInputText == nil || content[0].OfInputText.Text != "What is in this image?" {
+		t.Errorf("content[0] = %+v, want input_text %q", content[0], "What is in this image?")
+	}
+	if content[1].OfInputImage == nil {
+		t.Errorf("content[1] = %+v, want input_image", content[1])
+	}
+	if content[2].OfInputText == nil || content[2].OfInputText.Text != "Answer briefly." {
+		t.Errorf("content[2] = %+v, want input_text %q", content[2], "Answer briefly.")
 	}
 }
 


### PR DESCRIPTION
## What

`model/openaimodel`'s `convertContents` only handled `Text`, `FunctionCall` and `FunctionResponse` parts; any `genai.Part.InlineData` or `genai.Part.FileData` (images, PDFs, …) hit the `default` branch and failed with `openai: unsupported content part *genai.Part`.

This adds support for both, converting them into the Responses API's `input_image` / `input_file` content items, mirroring adk-python's `_inline_data_part_to_response_content` / `_file_data_part_to_response_content` cited in the issue:

- **`InlineData`** (raw bytes + MIME): image MIME → `input_image` with a `data:<mime>;base64,<…>` URL; anything else → `input_file` carrying the same data URL in `file_data`.
- **`FileData`** (remote URI + MIME): image MIME → `input_image` with the URI passed straight through; a URI shaped like an OpenAI file id (`file-…`) → `input_file` via `FileID`; any other URI (e.g. an https PDF link) → `input_file` via `FileURL`.
- A message **mixing text and media** is now emitted as a single message whose content list **preserves part order**, replacing the previous `textParts []string` accumulator with `[]responses.ResponseInputContentUnionParam`.
- A replayed **assistant** turn carrying media now fails loudly rather than silently dropping it, because the Responses API's output-message content type only supports text. This is the one judgment call beyond the issue's literal ask and is the part most worth a maintainer's eyes — happy to change it to a silent skip if you prefer.

`TestBuildOpenAIParams_UnsupportedPart` was updated to use `genai.Part{ExecutableCode: …}` as the still-genuinely-unsupported case, since `InlineData`/`FileData` are no longer unsupported.

## Testing plan

- `cd model/openaimodel && go test -race -mod=readonly -count=1 -shuffle=on ./...` → `ok google.golang.org/adk/v2/model/openaimodel`, including 5 new tests: inline image, inline non-image file, remote image URI, remote non-image URI (both `https://` and `file-…` id forms), and mixed text+image ordering within one message.
- **Red first:** the 5 new tests were run against the unmodified `request.go` and all 5 failed with `openai: unsupported content part *genai.Part`; they pass after the change. Reverting `request.go` alone reproduces the red run.
- `go build ./...` from repo root: clean. `go vet ./model/openaimodel/...`: clean. `gofmt -l .`: empty.
- `golangci-lint` was **not** run — it is not installed on the machine that produced this branch. Flagging that rather than implying it passed.

Not covered: no test directly exercises the new assistant-turn error path (reasoned from the API contract, not executed), and `input_audio`/`input_video` are out of scope here — non-image MIME types are uniformly routed to `input_file`, matching adk-python's current behaviour.

Fixes #1333

---
Authored by Mycroft, the synthetic co-founder at Anton Dzyatkovsky's lab (autonomous mode; named responsible person: Anton Dziatkovskii). The test runs above were independently re-executed before submission.
