### PR TITLE
fix(runner): flush buffered live events at EOF

### DIFF
--- a/runner/live_runner_test.go
+++ b/runner/live_runner_test.go
@@ -373,3 +373,82 @@ func TestRunner_RunLive_ChronologicalBuffering(t *testing.T) {
 		t.Errorf("expected second saved event to be function call, but got %v", events.At(1))
 	}
 }
+
+func TestRunner_RunLive_FlushesBufferedToolCallWhenStreamEnds(t *testing.T) {
+	ctx := t.Context()
+	appName, userID, sessionID := "testApp", "testUser", "testSessionEOF"
+
+	sessionService := session.InMemoryService()
+	if _, err := sessionService.Create(ctx, &session.CreateRequest{
+		AppName:   appName,
+		UserID:    userID,
+		SessionID: sessionID,
+	}); err != nil {
+		t.Fatal(err)
+	}
+
+	testAgent := must(agent.New(agent.Config{Name: "test_agent"}))
+	mockLive := &mockLiveAgent{
+		Agent: testAgent,
+		runLiveFn: func(ctx agent.InvocationContext) (agent.LiveSession, iter.Seq2[*session.Event, error], error) {
+			return &dummyLiveSession{}, func(yield func(*session.Event, error) bool) {
+				partial := session.NewEvent(ctx, ctx.InvocationID())
+				partial.LLMResponse.Partial = true
+				partial.LLMResponse.InputTranscription = &genai.Transcription{Text: "book me a "}
+				if !yield(partial, nil) {
+					return
+				}
+
+				call := session.NewEvent(ctx, ctx.InvocationID())
+				call.LLMResponse.Content = &genai.Content{
+					Parts: []*genai.Part{{FunctionCall: &genai.FunctionCall{Name: "book_flight"}}},
+				}
+				yield(call, nil)
+			}, nil
+		},
+	}
+
+	r, err := New(Config{
+		AppName:        appName,
+		Agent:          mockLive,
+		SessionService: sessionService,
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	_, iter, err := r.RunLive(ctx, userID, sessionID, agent.LiveRunConfig{})
+	if err != nil {
+		t.Fatalf("RunLive failed: %v", err)
+	}
+
+	var delivered []*session.Event
+	for event, err := range iter {
+		if err != nil {
+			t.Fatalf("RunLive yielded an error: %v", err)
+		}
+		delivered = append(delivered, event)
+	}
+
+	if len(delivered) != 2 {
+		t.Fatalf("consumer received %d events, want partial transcription and buffered tool call", len(delivered))
+	}
+	if delivered[1].LLMResponse.Content == nil || delivered[1].LLMResponse.Content.Parts[0].FunctionCall == nil {
+		t.Fatalf("consumer did not receive the buffered tool call: %v", delivered[1])
+	}
+
+	got, err := sessionService.Get(ctx, &session.GetRequest{
+		AppName:   appName,
+		UserID:    userID,
+		SessionID: sessionID,
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+	if got.Session.Events().Len() != 1 {
+		t.Fatalf("session persisted %d events, want the buffered tool call", got.Session.Events().Len())
+	}
+	if got.Session.Events().At(0).LLMResponse.Content == nil || got.Session.Events().At(0).LLMResponse.Content.Parts[0].FunctionCall == nil {
+		t.Fatalf("session did not persist the buffered tool call: %v", got.Session.Events().At(0))
+	}
+}

--- a/runner/runner.go
+++ b/runner/runner.go
@@ -1045,6 +1045,20 @@ func (r *Runner) RunLive(ctx context.Context, userID, sessionID string, cfg agen
 				return
 			}
 		}
+
+		// The stream may end while a transcription is in progress. In that
+		// case there is no final transcription event to trigger the flush above.
+		for _, bufferedEvent := range bufferedEvents {
+			if err := r.sessionService.AppendEvent(iCtx, storedSession, bufferedEvent); err != nil {
+				if !yield(nil, fmt.Errorf("failed to add event to session: %w", err)) {
+					return
+				}
+				continue
+			}
+			if !yield(bufferedEvent, nil) {
+				return
+			}
+		}
 	}
 
 	return &runnerLiveSession{


### PR DESCRIPTION
Closes: #1507

## Problem
`Runner.RunLive` buffers tool calls that arrive during a partial transcription. If the live iterator ends before a final transcription event arrives, those calls are silently dropped and never persisted.

## Solution
Flush any remaining buffered events after natural iterator exhaustion, preserving append-before-yield ordering and surfacing append failures through the existing error path. Consumer cancellation and other early-return paths continue to stop without yielding after cancellation.

## Behavior change
On current releases, a live stream ending mid-transcription can lose buffered tool calls. With this fix, the buffered calls are delivered and persisted when the stream naturally ends.

## Testing Plan
- `go test ./runner/ -run TestRunner_RunLive_FlushesBufferedToolCallWhenStreamEnds -count=1 -v`
- `go test ./runner/ -run TestRunner_RunLive_(ChronologicalBuffering|FlushesBufferedToolCallWhenStreamEnds) -count=1 -v`
- `go mod tidy -diff`
- `go build -mod=readonly ./...`
- `go test -race -mod=readonly -count=1 -shuffle=on ./...`
- `golangci-lint run`
- plugin/agentanalytics module build, race tests, tidy check, and lint

The new regression test failed before the source change with only the partial transcription delivered and zero persisted events, then passed with the fix.