### PR TITLE
docs: fix contributing links in PR template

### DIFF
--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -1,4 +1,4 @@
-**Please ensure you have read the [contribution guide](./CONTRIBUTING.md) before creating a pull request.**
+**Please ensure you have read the [contribution guide](https://github.com/google/adk-go/blob/main/CONTRIBUTING.md) before creating a pull request.**
 
 ### Link to Issue or Description of Change
 
@@ -50,7 +50,7 @@ reviewers better understand the fix._
 
 ### Checklist
 
-- [ ] I have read the [CONTRIBUTING.md](./CONTRIBUTING.md) document.
+- [ ] I have read the [CONTRIBUTING.md](https://github.com/google/adk-go/blob/main/CONTRIBUTING.md) document.
 - [ ] I have performed a self-review of my own code.
 - [ ] I have commented my code, particularly in hard-to-understand areas.
 - [ ] I have added tests that prove my fix is effective or that my feature works.


### PR DESCRIPTION
AI-assisted contribution; managed and reviewed by a human.

### Problem

The pull request template uses relative `./CONTRIBUTING.md` links. Once the template is copied into a pull request body, those links no longer have the template file's repository-path context.

### Solution

Use the canonical repository URL for both CONTRIBUTING links in the PR template.

### Behavior change

Nothing changes for ADK Go runtime users. Contributors get stable links to the contribution guide from generated PR bodies.

### Testing plan

Documentation-only change. Verified the absolute target resolves to the current `CONTRIBUTING.md`; no Go code or generated files are changed.