### PR TITLE
fix: deep-copy interface and array values in LLM requests

### DIFF
--- a/internal/llminternal/base_flow_live_test.go
+++ b/internal/llminternal/base_flow_live_test.go
@@ -171,6 +171,65 @@ func liveConfigProcessor(ctx agent.InvocationContext, req *model.LLMRequest, f *
 	return func(yield func(*session.Event, error) bool) {}
 }
 
+func TestRunLiveCloneErrors(t *testing.T) {
+	for _, source := range []string{"config", "contents"} {
+		t.Run(source, func(t *testing.T) {
+			cyclic := map[string]any{}
+			cyclic["self"] = cyclic
+			ctx, cancel := newLiveInvocationContext(t)
+			defer cancel()
+			state := &State{}
+			service := session.InMemoryService()
+			created, err := service.Create(ctx, &session.CreateRequest{AppName: "test", UserID: "user"})
+			if err != nil {
+				t.Fatal(err)
+			}
+			if source == "config" {
+				state.GenerateContentConfig = &genai.GenerateContentConfig{ResponseJsonSchema: cyclic}
+			} else {
+				ev := &session.Event{
+					Author:      ctx.Agent().Name(),
+					LLMResponse: model.LLMResponse{Content: genai.NewContentFromFunctionCall("lookup", cyclic, "model")},
+				}
+				if err := service.AppendEvent(ctx, created.Session, ev); err != nil {
+					t.Fatal(err)
+				}
+			}
+			ctx = icontext.NewInvocationContext(ctx, icontext.InvocationContextParams{
+				Agent: &mockLLMAgent{Agent: ctx.Agent(), s: state}, Session: created.Session,
+			})
+			f := &Flow{
+				Model: &fakeLiveModel{},
+				RequestProcessors: []func(agent.InvocationContext, *model.LLMRequest, *Flow) iter.Seq2[*session.Event, error]{
+					basicRequestProcessor,
+					ContentsRequestProcessor,
+					// Even a regression that swallows the copy error must not open a connection.
+					func(agent.InvocationContext, *model.LLMRequest, *Flow) iter.Seq2[*session.Event, error] {
+						return func(yield func(*session.Event, error) bool) {
+							yield(nil, errors.New("copy error was not propagated"))
+						}
+					},
+				},
+			}
+			live, events, err := f.RunLive(ctx)
+			if err != nil {
+				t.Fatal(err)
+			}
+			defer func() { _ = live.Close() }()
+			errorsSeen := 0
+			for ev, err := range events {
+				if ev != nil || !errors.Is(err, errCloneDepth) {
+					t.Fatalf("live stream returned (%v, %v), want clone depth error", ev, err)
+				}
+				errorsSeen++
+			}
+			if errorsSeen != 1 {
+				t.Errorf("got %d errors, want 1", errorsSeen)
+			}
+		})
+	}
+}
+
 func TestRunLiveNoGoroutineLeak(t *testing.T) {
 	tests := []struct {
 		name string

--- a/internal/llminternal/basic_processor.go
+++ b/internal/llminternal/basic_processor.go
@@ -15,9 +15,12 @@
 package llminternal
 
 import (
+	"encoding/json"
+	"errors"
 	"fmt"
 	"iter"
 	"reflect"
+	"time"
 
 	"google.golang.org/genai"
 
@@ -38,7 +41,12 @@ func basicRequestProcessor(ctx agent.InvocationContext, req *model.LLMRequest, f
 
 		state := llmAgent.internal()
 
-		req.Config = clone(state.GenerateContentConfig)
+		config, err := clone(state.GenerateContentConfig)
+		if err != nil {
+			yield(nil, fmt.Errorf("clone generation config: %w", err))
+			return
+		}
+		req.Config = config
 		if req.Config == nil {
 			req.Config = &genai.GenerateContentConfig{}
 		}
@@ -60,85 +68,123 @@ func basicRequestProcessor(ctx agent.InvocationContext, req *model.LLMRequest, f
 	}
 }
 
-// clone returns a deep copy of the src.
-// NOTE: this does not work for types with unexported fields.
-func clone[M any](src M) M {
-	val := reflect.ValueOf(src)
-
-	// Handle nil pointers
-	if val.Kind() == reflect.Pointer && val.IsNil() {
+// clone copies src's data containers, with time.Time values copied by value.
+// Inside an empty interface, values with unexported fields are preserved as an
+// independent json.RawMessage instead of retaining references to private state.
+// Other concrete types are preserved. Functions, channels, and unsafe pointers
+// are retained as-is. Unsupported types and excessive nesting return an error.
+func clone[M any](src M) (M, error) {
+	var dst M
+	if err := deepCopy(reflect.ValueOf(&src).Elem(), reflect.ValueOf(&dst).Elem(), 0); err != nil {
 		var zero M
-		return zero
+		return zero, err
 	}
-
-	srcIsPointer := val.Kind() == reflect.Pointer
-
-	// Dereference pointer to get the underlying value
-	if srcIsPointer {
-		val = val.Elem()
-	}
-
-	// Create a new instance of the same type
-	newVal := reflect.New(val.Type()).Elem()
-
-	// Recursively copy fields
-	deepCopy(val, newVal)
-
-	// Return as the original type
-	if srcIsPointer {
-		return newVal.Addr().Interface().(M)
-	}
-	return newVal.Interface().(M)
+	return dst, nil
 }
 
+// maxCloneDepth counts reflection steps, including pointers and interfaces,
+// to bound recursion through cyclic or excessively nested payloads.
+const maxCloneDepth = 1024
+
+var (
+	errCloneDepth      = errors.New("maximum clone depth exceeded")
+	errCloneUnexported = errors.New("cannot clone unexported field")
+)
+
 // deepCopy copies src to dst using reflect.
-func deepCopy(src, dst reflect.Value) {
+func deepCopy(src, dst reflect.Value, depth int) error {
+	if depth > maxCloneDepth {
+		return fmt.Errorf("%w: limit %d (cyclic or excessively nested value)", errCloneDepth, maxCloneDepth)
+	}
 	switch src.Kind() {
 	case reflect.Struct:
 		t := src.Type()
+		if t == reflect.TypeFor[time.Time]() {
+			// time.Time's API supports value copying, including its location data.
+			dst.Set(src)
+			return nil
+		}
 		for i := 0; i < src.NumField(); i++ {
 			if !t.Field(i).IsExported() {
-				panic(fmt.Sprintf("deepCopy: unexported field %q in type %q", t.Field(i).Name, t.Name()))
+				return fmt.Errorf("%w %q in type %v", errCloneUnexported, t.Field(i).Name, t)
 			}
 			// Create a copy of the field and set it on the destination struct
 			fieldCopy := reflect.New(src.Field(i).Type()).Elem()
-			deepCopy(src.Field(i), fieldCopy)
+			if err := deepCopy(src.Field(i), fieldCopy, depth+1); err != nil {
+				return err
+			}
 			dst.Field(i).Set(fieldCopy)
+		}
+	case reflect.Interface:
+		if src.IsNil() {
+			return nil
+		}
+		valueCopy := reflect.New(src.Elem().Type()).Elem()
+		if err := deepCopy(src.Elem(), valueCopy, depth+1); err != nil {
+			if !errors.Is(err, errCloneUnexported) || src.Type().NumMethod() != 0 {
+				return err
+			}
+			// JSON preserves opaque payloads (including custom marshalers) without
+			// exposing private state or rounding numbers through float64.
+			raw, err := json.Marshal(src.Interface())
+			if err != nil {
+				return fmt.Errorf("clone JSON value of type %v: %w", src.Elem().Type(), err)
+			}
+			valueCopy = reflect.ValueOf(json.RawMessage(raw))
+		}
+		dst.Set(valueCopy)
+	case reflect.Array:
+		for i := 0; i < src.Len(); i++ {
+			if err := deepCopy(src.Index(i), dst.Index(i), depth+1); err != nil {
+				return err
+			}
 		}
 	case reflect.Slice:
 		if src.IsNil() {
-			return
+			return nil
 		}
 		dst.Set(reflect.MakeSlice(src.Type(), src.Len(), src.Cap()))
 		for i := 0; i < src.Len(); i++ {
 			// Create a copy of each element and set it in the new slice
 			elemCopy := reflect.New(src.Index(i).Type()).Elem()
-			deepCopy(src.Index(i), elemCopy)
+			if err := deepCopy(src.Index(i), elemCopy, depth+1); err != nil {
+				return err
+			}
 			dst.Index(i).Set(elemCopy)
 		}
 	case reflect.Map:
 		if src.IsNil() {
-			return
+			return nil
 		}
 		dst.Set(reflect.MakeMap(src.Type()))
 		for _, key := range src.MapKeys() {
 			// Create copies of the key and value and set them in the new map
 			keyCopy := reflect.New(key.Type()).Elem()
-			deepCopy(key, keyCopy)
+			if err := deepCopy(key, keyCopy, depth+1); err != nil {
+				return err
+			}
+			if !keyCopy.Comparable() {
+				return fmt.Errorf("cloned map key of type %v is not comparable", key.Type())
+			}
 			valCopy := reflect.New(src.MapIndex(key).Type()).Elem()
-			deepCopy(src.MapIndex(key), valCopy)
+			if err := deepCopy(src.MapIndex(key), valCopy, depth+1); err != nil {
+				return err
+			}
 			dst.SetMapIndex(keyCopy, valCopy)
 		}
 	case reflect.Pointer:
 		if src.IsNil() {
-			return
+			return nil
 		}
 		// Create a new pointer and deep copy the underlying value
 		newPtr := reflect.New(src.Elem().Type())
-		deepCopy(src.Elem(), newPtr.Elem())
+		if err := deepCopy(src.Elem(), newPtr.Elem(), depth+1); err != nil {
+			return err
+		}
 		dst.Set(newPtr)
 	default:
 		// For basic types, direct assignment is sufficient
 		dst.Set(src)
 	}
+	return nil
 }

--- a/internal/llminternal/basic_processor_test.go
+++ b/internal/llminternal/basic_processor_test.go
@@ -15,6 +15,10 @@
 package llminternal
 
 import (
+	"encoding/json"
+	"errors"
+	"math/big"
+	"reflect"
 	"testing"
 
 	"github.com/google/go-cmp/cmp"
@@ -22,8 +26,121 @@ import (
 
 	"google.golang.org/adk/v2/agent"
 	icontext "google.golang.org/adk/v2/internal/context"
+	"google.golang.org/adk/v2/internal/utils"
 	"google.golang.org/adk/v2/model"
 )
+
+func TestBasicRequestProcessor_ConfigIsolation(t *testing.T) {
+	newConfig := func() *genai.GenerateContentConfig {
+		return &genai.GenerateContentConfig{
+			ResponseJsonSchema: map[string]any{
+				"properties": map[string]any{"answer": map[string]any{"type": "string"}},
+			},
+			ResponseSchema: &genai.Schema{
+				Default: map[string]any{"answer": "default"},
+				Example: []string{"example"},
+			},
+			Tools: []*genai.Tool{{FunctionDeclarations: []*genai.FunctionDeclaration{{
+				Name: "lookup",
+				ParametersJsonSchema: map[string]any{
+					"properties": map[string]any{"query": map[string]any{"type": "string"}},
+				},
+			}}}},
+		}
+	}
+	config := newConfig()
+	base, err := agent.New(agent.Config{Name: "testAgent"})
+	if err != nil {
+		t.Fatal(err)
+	}
+	a := &mockLLMAgent{Agent: base, s: &State{GenerateContentConfig: config}}
+	ctx := icontext.NewInvocationContext(t.Context(), icontext.InvocationContextParams{Agent: a})
+	requests := []*model.LLMRequest{{}, {}}
+	for _, req := range requests {
+		for _, err := range basicRequestProcessor(ctx, req, &Flow{}) {
+			if err != nil {
+				t.Fatal(err)
+			}
+		}
+		if !reflect.DeepEqual(req.Config, config) {
+			t.Fatalf("request config = %#v, want %#v", req.Config, config)
+		}
+	}
+	// BeforeModel callbacks can mutate any of these request fields.
+	copied := requests[0].Config
+	copied.ResponseJsonSchema.(map[string]any)["additionalProperties"] = false
+	copied.ResponseJsonSchema.(map[string]any)["properties"].(map[string]any)["answer"].(map[string]any)["type"] = "number"
+	copied.ResponseSchema.Default.(map[string]any)["answer"] = "changed"
+	copied.ResponseSchema.Example.([]string)[0] = "changed"
+	copied.Tools[0].FunctionDeclarations[0].ParametersJsonSchema.(map[string]any)["properties"].(map[string]any)["query"].(map[string]any)["type"] = "number"
+	for name, got := range map[string]*genai.GenerateContentConfig{"agent": config, "other request": requests[1].Config} {
+		if diff := cmp.Diff(newConfig(), got); diff != "" {
+			t.Errorf("%s config mutated (-want +got):\n%s", name, diff)
+		}
+	}
+}
+
+func TestBasicRequestProcessor_JSONSchemaCompatibility(t *testing.T) {
+	type schemaWithCache struct {
+		Type  string `json:"type"`
+		cache string
+	}
+	var deep any = map[string]any{"type": "string"}
+	for range 130 {
+		deep = map[string]any{"type": "array", "items": deep}
+	}
+	for name, schema := range map[string]any{
+		"big integer":   map[string]any{"type": "integer", "minimum": big.NewInt(9007199254740993)},
+		"private cache": &schemaWithCache{Type: "string", cache: "not serialized"},
+		"deep schema":   deep,
+	} {
+		t.Run(name, func(t *testing.T) {
+			base := utils.Must(agent.New(agent.Config{Name: "testAgent"}))
+			a := &mockLLMAgent{Agent: base, s: &State{
+				GenerateContentConfig: &genai.GenerateContentConfig{ResponseJsonSchema: schema},
+			}}
+			ctx := icontext.NewInvocationContext(t.Context(), icontext.InvocationContextParams{Agent: a})
+			req := &model.LLMRequest{}
+			for _, err := range basicRequestProcessor(ctx, req, &Flow{}) {
+				if err != nil {
+					t.Fatal(err)
+				}
+			}
+			want, err := json.Marshal(schema)
+			if err != nil {
+				t.Fatal(err)
+			}
+			got, err := json.Marshal(req.Config.ResponseJsonSchema)
+			if err != nil {
+				t.Fatal(err)
+			}
+			if string(got) != string(want) {
+				t.Errorf("schema JSON = %s, want %s", got, want)
+			}
+		})
+	}
+}
+
+func TestBasicRequestProcessor_ConfigCloneError(t *testing.T) {
+	schema := map[string]any{}
+	schema["self"] = schema
+	base := utils.Must(agent.New(agent.Config{Name: "testAgent"}))
+	a := &mockLLMAgent{Agent: base, s: &State{
+		GenerateContentConfig: &genai.GenerateContentConfig{ResponseJsonSchema: schema},
+	}}
+	ctx := icontext.NewInvocationContext(t.Context(), icontext.InvocationContextParams{Agent: a})
+	req := &model.LLMRequest{}
+	errorsSeen := 0
+	for ev, err := range basicRequestProcessor(ctx, req, &Flow{}) {
+		if ev != nil || !errors.Is(err, errCloneDepth) {
+			t.Fatalf("processor returned (%v, %v), want depth error", ev, err)
+		}
+		errorsSeen++
+	}
+	if errorsSeen != 1 || req.Config != nil {
+		t.Errorf("processor returned %d errors and config %p, want one error and no config", errorsSeen, req.Config)
+	}
+}
 
 // TestBasicRequestProcessor_OutputSchemaPerMode pins how
 // basicRequestProcessor populates LLMRequest.Config.ResponseSchema /

--- a/internal/llminternal/clone_test.go
+++ b/internal/llminternal/clone_test.go
@@ -15,9 +15,22 @@
 package llminternal
 
 import (
+	"encoding/json"
+	"errors"
+	"math/big"
 	"reflect"
+	"strings"
 	"testing"
 )
+
+func mustClone[M any](t *testing.T, value M) M {
+	t.Helper()
+	result, err := clone(value)
+	if err != nil {
+		t.Fatal(err)
+	}
+	return result
+}
 
 func TestClone(t *testing.T) {
 	type testStruct struct {
@@ -72,17 +85,17 @@ func TestClone(t *testing.T) {
 
 	t.Run("pointer", func(t *testing.T) {
 		original := testData()
-		cloned := clone(original)
+		cloned := mustClone(t, original)
 		check(t, original, cloned)
 	})
 	t.Run("value", func(t *testing.T) {
 		original := testData()
-		cloned := clone(*original)
+		cloned := mustClone(t, *original)
 		check(t, original, &cloned)
 	})
 	t.Run("interface", func(t *testing.T) {
 		original := testData()
-		cloned := clone(any(original))
+		cloned := mustClone(t, any(original))
 		typed, ok := cloned.(*testStruct)
 		if !ok {
 			t.Fatalf("clone failed with interface: %v", cloned)
@@ -93,9 +106,75 @@ func TestClone(t *testing.T) {
 
 func TestCloneNil(t *testing.T) {
 	var original *int
-	cloned := clone(original)
+	cloned := mustClone(t, original)
 	if cloned != nil {
 		t.Errorf("clone(nil) = %v, want nil", cloned)
+	}
+}
+
+func TestCloneInterfaceFields(t *testing.T) {
+	type record struct {
+		Values []string
+	}
+	type payload struct {
+		Map      any
+		Slice    any
+		Pointer  any
+		Struct   any
+		Array    any
+		Nested   map[string]any
+		MapArray [1]map[string]string
+	}
+	newPayload := func() payload {
+		return payload{
+			Map:      map[string]string{"key": "original"},
+			Slice:    []string{"original"},
+			Pointer:  &record{Values: []string{"original"}},
+			Struct:   record{Values: []string{"original"}},
+			Array:    [1][]string{{"original"}},
+			Nested:   map[string]any{"items": []any{map[string]any{"key": "original"}}},
+			MapArray: [1]map[string]string{{"key": "original"}},
+		}
+	}
+	original := newPayload()
+	copied := mustClone(t, original)
+	if !reflect.DeepEqual(copied, original) {
+		t.Fatalf("clone() = %#v, want %#v", copied, original)
+	}
+	copied.Map.(map[string]string)["key"] = "changed"
+	copied.Slice.([]string)[0] = "changed"
+	copied.Pointer.(*record).Values[0] = "changed"
+	copied.Struct.(record).Values[0] = "changed"
+	copied.Array.([1][]string)[0][0] = "changed"
+	copied.Nested["items"].([]any)[0].(map[string]any)["key"] = "changed"
+	copied.MapArray[0]["key"] = "changed"
+	if want := newPayload(); !reflect.DeepEqual(original, want) {
+		t.Errorf("mutating clone changed original: got %#v, want %#v", original, want)
+	}
+}
+
+func TestCloneNilInterfaces(t *testing.T) {
+	tests := []struct {
+		name  string
+		value any
+	}{
+		{name: "nil"},
+		{name: "nil pointer", value: (*int)(nil)},
+		{name: "nil map", value: map[string]any(nil)},
+		{name: "nil slice", value: []any(nil)},
+		{name: "empty map", value: map[string]any{}},
+		{name: "empty slice", value: []any{}},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			if got := mustClone(t, tt.value); !reflect.DeepEqual(got, tt.value) {
+				t.Errorf("clone() = %#v (%T), want %#v (%T)", got, got, tt.value, tt.value)
+			}
+			original := struct{ Value any }{Value: tt.value}
+			if got := mustClone(t, original); !reflect.DeepEqual(got, original) {
+				t.Errorf("clone() = %#v, want %#v", got, original)
+			}
+		})
 	}
 }
 
@@ -104,11 +183,159 @@ func TestCloneUnexported(t *testing.T) {
 		s string
 	}
 	original := &testStructUnexported{s: "test"}
+	got, err := clone(original)
+	if !errors.Is(err, errCloneUnexported) {
+		t.Errorf("clone() error = %v, want unexported field rejection", err)
+	}
+	if got != nil {
+		t.Errorf("clone() returned partial result: %#v", got)
+	}
+}
 
-	defer func() {
-		if r := recover(); r == nil {
-			t.Errorf("clone() did not panic on unexported field")
+type cloneTestError struct {
+	Messages []string
+}
+
+func (e *cloneTestError) Error() string { return e.Messages[0] }
+
+func TestCloneNonEmptyInterface(t *testing.T) {
+	original := struct{ Err error }{Err: &cloneTestError{Messages: []string{"original"}}}
+	copied := mustClone(t, original)
+	if !reflect.DeepEqual(copied, original) {
+		t.Fatalf("clone() = %#v, want %#v", copied, original)
+	}
+	copied.Err.(*cloneTestError).Messages[0] = "changed"
+	if got := original.Err.Error(); got != "original" {
+		t.Errorf("original error = %q, want original", got)
+	}
+}
+
+func TestCloneRecursionLimit(t *testing.T) {
+	cyclicMap := map[string]any{}
+	cyclicMap["self"] = cyclicMap
+	cyclicSlice := make([]any, 1)
+	cyclicSlice[0] = cyclicSlice
+	type node struct{ Next *node }
+	cyclicPointer := &node{}
+	cyclicPointer.Next = cyclicPointer
+	var cyclicInterface any
+	cyclicInterface = &cyclicInterface
+	var nested any = "leaf"
+	for i := 0; i <= maxCloneDepth; i++ {
+		nested = []any{nested}
+	}
+	for name, value := range map[string]any{
+		"map cycle":       cyclicMap,
+		"slice cycle":     cyclicSlice,
+		"pointer cycle":   cyclicPointer,
+		"interface cycle": cyclicInterface,
+		"excessive depth": nested,
+	} {
+		t.Run(name, func(t *testing.T) {
+			got, err := clone(value)
+			if !errors.Is(err, errCloneDepth) {
+				t.Errorf("clone() error = %v, want depth limit", err)
+			}
+			if got != nil {
+				t.Fatal("clone() returned partial result")
+			}
+		})
+	}
+}
+
+func TestCloneNestedSharedValue(t *testing.T) {
+	shared := map[string]any{"value": "original"}
+	original := map[string]any{"left": shared, "right": shared}
+	for range 130 {
+		original = map[string]any{"nested": original}
+	}
+	copied := mustClone(t, original)
+	if !reflect.DeepEqual(copied, original) {
+		t.Fatal("clone changed a deeply nested value")
+	}
+	for range 130 {
+		copied = copied["nested"].(map[string]any)
+	}
+	copied["left"].(map[string]any)["value"] = "changed"
+	copied["right"].(map[string]any)["value"] = "changed"
+	if shared["value"] != "original" {
+		t.Errorf("original shared map changed: %v", shared)
+	}
+}
+
+type cloneTestJSON struct {
+	raw []byte
+	err error
+}
+
+func (v *cloneTestJSON) MarshalJSON() ([]byte, error) { return v.raw, v.err }
+
+func TestCloneOpaqueJSON(t *testing.T) {
+	integer := big.NewInt(9007199254740993)
+	schema := &struct {
+		Type  string `json:"type"`
+		cache []string
+	}{Type: "string", cache: []string{"private"}}
+	custom := &cloneTestJSON{raw: []byte(`{"minimum":9007199254740993}`)}
+	for _, tt := range []struct {
+		name   string
+		value  any
+		mutate func()
+	}{
+		{name: "big integer", value: integer, mutate: func() { integer.SetInt64(0) }},
+		{name: "private cache", value: schema, mutate: func() { schema.Type = "number"; schema.cache[0] = "changed" }},
+		{name: "custom marshaler", value: custom, mutate: func() { custom.raw[0] = ' ' }},
+	} {
+		t.Run(tt.name, func(t *testing.T) {
+			want, err := json.Marshal(tt.value)
+			if err != nil {
+				t.Fatal(err)
+			}
+			original := struct{ Value any }{Value: tt.value}
+			first := mustClone(t, original)
+			second := mustClone(t, original)
+			raw, ok := first.Value.(json.RawMessage)
+			if !ok {
+				t.Fatalf("opaque value type = %T, want json.RawMessage", first.Value)
+			}
+			tt.mutate()
+			if string(raw) != string(want) {
+				t.Errorf("snapshot = %s, want %s", raw, want)
+			}
+			raw[0] = ' '
+			got, err := json.Marshal(second.Value)
+			if err != nil {
+				t.Fatal(err)
+			}
+			if string(got) != string(want) {
+				t.Errorf("other snapshot changed: got %s, want %s", got, want)
+			}
+		})
+	}
+}
+
+func TestCloneOpaqueJSONErrors(t *testing.T) {
+	t.Run("marshal failure", func(t *testing.T) {
+		wantErr := errors.New("marshal failed")
+		original := struct{ Value any }{Value: &cloneTestJSON{err: wantErr}}
+		got, err := clone(original)
+		if !errors.Is(err, wantErr) {
+			t.Errorf("clone() error = %v, want %v", err, wantErr)
 		}
-	}()
-	clone(original)
+		if got.Value != nil {
+			t.Fatal("clone() returned a partial value")
+		}
+	})
+	t.Run("nonempty interface", func(t *testing.T) {
+		original := struct{ Value json.Marshaler }{Value: &cloneTestJSON{raw: []byte(`{}`)}}
+		if _, err := clone(original); !errors.Is(err, errCloneUnexported) {
+			t.Errorf("clone() error = %v, want unexported field rejection", err)
+		}
+	})
+	t.Run("interface map key", func(t *testing.T) {
+		key := struct{ value int }{value: 1}
+		if _, err := clone(map[any]string{key: "value"}); err == nil || !strings.Contains(err.Error(), "not comparable") {
+			t.Errorf("clone() error = %v, want non-comparable key error", err)
+		}
+	})
 }

--- a/internal/llminternal/contents_processor.go
+++ b/internal/llminternal/contents_processor.go
@@ -223,7 +223,10 @@ func buildContentsDefault(agentName, invocationBranch, isolationScope string, ev
 
 	var contents []*genai.Content
 	for _, ev := range filtered {
-		content := clone(utils.Content(ev))
+		content, err := clone(utils.Content(ev))
+		if err != nil {
+			return nil, fmt.Errorf("clone event content: %w", err)
+		}
 		if content == nil {
 			continue
 		}

--- a/internal/llminternal/contents_processor_test.go
+++ b/internal/llminternal/contents_processor_test.go
@@ -31,6 +31,7 @@ import (
 	icontext "google.golang.org/adk/v2/internal/context"
 	"google.golang.org/adk/v2/internal/llminternal"
 	"google.golang.org/adk/v2/internal/utils"
+	"google.golang.org/adk/v2/memory"
 	"google.golang.org/adk/v2/model"
 	"google.golang.org/adk/v2/session"
 	"google.golang.org/adk/v2/tool/toolconfirmation"
@@ -38,6 +39,67 @@ import (
 
 type testModel struct {
 	model.LLM
+}
+
+func TestContentsRequestProcessor_PayloadIsolation(t *testing.T) {
+	const agentName = "testAgent"
+	timestamp := time.Date(2026, time.September, 9, 12, 0, 0, 0, time.FixedZone("test", 3600))
+	newContents := func() []*genai.Content {
+		return []*genai.Content{
+			{Role: "model", Parts: []*genai.Part{{FunctionCall: &genai.FunctionCall{
+				ID: "call-1", Name: "load_memory",
+				Args: map[string]any{"filters": map[string]any{"tags": []string{"original"}}},
+			}}}},
+			{Role: "user", Parts: []*genai.Part{{FunctionResponse: &genai.FunctionResponse{
+				ID: "call-1", Name: "load_memory",
+				Response: map[string]any{
+					"result": map[string]any{"tags": []any{"original"}},
+					// loadmemorytool returns entries directly, including time.Time values.
+					"memories": []memory.Entry{{
+						Timestamp:      timestamp,
+						Content:        genai.NewContentFromText("original", "user"),
+						CustomMetadata: map[string]any{"source": map[string]any{"name": "original"}},
+					}},
+				},
+			}}}},
+		}
+	}
+	original := newContents()
+	var events []*session.Event
+	for _, content := range original {
+		events = append(events, &session.Event{Author: agentName, LLMResponse: model.LLMResponse{Content: content}})
+	}
+	a := utils.Must(llmagent.New(llmagent.Config{Name: agentName, Model: &testModel{}}))
+	ctx := icontext.NewInvocationContext(t.Context(), icontext.InvocationContextParams{
+		Agent: a, Session: &fakeSession{events: events},
+	})
+	requests := []*model.LLMRequest{{}, {}}
+	for _, req := range requests {
+		for _, err := range llminternal.ContentsRequestProcessor(ctx, req, &llminternal.Flow{}) {
+			if err != nil {
+				t.Fatal(err)
+			}
+		}
+		if diff := cmp.Diff(original, req.Contents); diff != "" {
+			t.Fatalf("request contents mismatch (-want +got):\n%s", diff)
+		}
+	}
+	copied := requests[0].Contents
+	copied[0].Parts[0].FunctionCall.Args["filters"].(map[string]any)["tags"].([]string)[0] = "changed"
+	response := copied[1].Parts[0].FunctionResponse.Response
+	response["result"].(map[string]any)["tags"].([]any)[0] = "changed"
+	memories := response["memories"].([]memory.Entry)
+	if memories[0].Timestamp != timestamp {
+		t.Errorf("timestamp = %v, want exact value %v", memories[0].Timestamp, timestamp)
+	}
+	memories[0].Timestamp = timestamp.Add(time.Hour)
+	memories[0].Content.Parts[0].Text = "changed"
+	memories[0].CustomMetadata["source"].(map[string]any)["name"] = "changed"
+	for name, got := range map[string][]*genai.Content{"session": original, "other request": requests[1].Contents} {
+		if diff := cmp.Diff(newContents(), got); diff != "" {
+			t.Errorf("%s contents mutated (-want +got):\n%s", name, diff)
+		}
+	}
 }
 
 // Test behavior around Agent's IncludeContents.


### PR DESCRIPTION
### Description

Fixes #1484.

The clone helper skipped interface and array values, leaving nested maps, slices, and pointers shared with the original data. A BeforeModel callback could therefore modify agent configuration or session history through the request.

### Behavior change

This change copies those values recursively and preserves nil values and time.Time. Clone failures, including cyclic or excessively nested data, are returned through the request processors so Live runs can report the error.

For JSON-compatible values with unexported fields stored in an empty interface, the clone uses an independent json.RawMessage. This preserves the JSON payload and numeric precision, but changes the dynamic Go type visible to callbacks.

### Testing Plan

Added regression tests for nested request mutations, isolation between requests, nil values, JSON payloads, and Live error propagation.

Passed locally after rebasing onto main at d56d1a8:

- `go build -mod=readonly work`
- `go test -race -mod=readonly -count=1 -shuffle=on work`
- `golangci-lint run` with v2.3.1 in both modules
- `go mod tidy -diff` in both modules, with no changes
- `git diff --check`

Selected results from the full test run:

```text
ok  google.golang.org/adk/v2/internal/llminternal  3.000s
ok  google.golang.org/adk/plugin/agentanalytics  4.469s
```

With interface copying removed through a temporary Go overlay, `TestCloneInterfaceFields`, `TestCloneNonEmptyInterface`, `TestBasicRequestProcessor_ConfigIsolation`, and `TestContentsRequestProcessor_PayloadIsolation` fail. Separately removing or altering the array copy, nil handling, JSON fallback, depth limit, and error guards also causes the corresponding tests to fail.

Also ran an offline integration check using llmagent.New, an in-memory session service, and Runner.Run with a fake model that serializes the request config. Big integers, schemas with private cache fields, and a 130-layer schema pass; a cyclic schema returns an iterator error. Runner.RunLive was checked with the same deep schema and a processor that stops before client access. Both checks pass without model traffic.
