### PR TITLE
fix(session): snapshot events under read lock in database and vertexa…

### DIFF
--- a/session/database/session.go
+++ b/session/database/session.go
@@ -18,6 +18,7 @@ import (
 	"fmt"
 	"iter"
 	"maps"
+	"slices"
 	"strings"
 	"sync"
 	"time"
@@ -58,7 +59,11 @@ func (s *localSession) State() session.State {
 }
 
 func (s *localSession) Events() session.Events {
-	return events(s.events)
+	s.mu.RLock()
+	defer s.mu.RUnlock()
+
+	// Return a snapshot so callers can iterate without holding the session lock.
+	return events(slices.Clone(s.events))
 }
 
 func (s *localSession) LastUpdateTime() time.Time {

--- a/session/database/session_test.go
+++ b/session/database/session_test.go
@@ -1,0 +1,88 @@
+// Copyright 2025 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package database
+
+import (
+	"fmt"
+	"runtime"
+	"sync"
+	"testing"
+
+	"google.golang.org/adk/v2/session"
+)
+
+func TestLocalSessionEventsSnapshot(t *testing.T) {
+	first := &session.Event{ID: "first"}
+	s := &localSession{events: []*session.Event{first}}
+	snapshot := s.Events()
+
+	// Replacing a slot must not change a previously returned history snapshot.
+	s.mu.Lock()
+	s.events[0] = &session.Event{ID: "replacement"}
+	s.mu.Unlock()
+	if err := s.appendEvent(&session.Event{ID: "second"}); err != nil {
+		t.Fatal(err)
+	}
+	if got := snapshot.Len(); got != 1 {
+		t.Fatalf("snapshot.Len() = %d, want 1", got)
+	}
+	if got := snapshot.At(0); got != first {
+		t.Errorf("snapshot.At(0) = %v, want original event %v", got, first)
+	}
+	for event := range snapshot.All() {
+		if event != first {
+			t.Errorf("snapshot.All() yielded %v, want original event %v", event, first)
+		}
+	}
+}
+
+func TestLocalSessionEventsConcurrentAppend(t *testing.T) {
+	const count = 1000
+	s := &localSession{}
+	start := make(chan struct{})
+	var wg sync.WaitGroup
+	wg.Add(1)
+	go func() {
+		defer wg.Done()
+		<-start
+		for i := range count {
+			if err := s.appendEvent(&session.Event{ID: fmt.Sprint(i)}); err != nil {
+				t.Errorf("appendEvent: %v", err)
+				return
+			}
+			runtime.Gosched()
+		}
+	}()
+	close(start)
+	for range count {
+		snapshot := s.Events()
+		n := 0
+		for event := range snapshot.All() {
+			if event == nil || event.ID != fmt.Sprint(n) {
+				t.Errorf("snapshot event %d = %v, want ID %q", n, event, fmt.Sprint(n))
+				break
+			}
+			n++
+		}
+		if n != snapshot.Len() {
+			t.Errorf("snapshot iteration count = %d, want %d", n, snapshot.Len())
+		}
+		runtime.Gosched()
+	}
+	wg.Wait()
+	if got := s.Events().Len(); got != count {
+		t.Errorf("final event count = %d, want %d", got, count)
+	}
+}

--- a/session/vertexai/session.go
+++ b/session/vertexai/session.go
@@ -18,6 +18,7 @@ import (
 	"fmt"
 	"iter"
 	"maps"
+	"slices"
 	"strings"
 	"sync"
 	"time"
@@ -58,7 +59,11 @@ func (s *localSession) State() session.State {
 }
 
 func (s *localSession) Events() session.Events {
-	return events(s.events)
+	s.mu.RLock()
+	defer s.mu.RUnlock()
+
+	// Return a snapshot so callers can iterate without holding the session lock.
+	return events(slices.Clone(s.events))
 }
 
 func (s *localSession) LastUpdateTime() time.Time {

--- a/session/vertexai/session_test.go
+++ b/session/vertexai/session_test.go
@@ -1,0 +1,88 @@
+// Copyright 2025 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package vertexai
+
+import (
+	"fmt"
+	"runtime"
+	"sync"
+	"testing"
+
+	"google.golang.org/adk/v2/session"
+)
+
+func TestLocalSessionEventsSnapshot(t *testing.T) {
+	first := &session.Event{ID: "first"}
+	s := &localSession{events: []*session.Event{first}}
+	snapshot := s.Events()
+
+	// Replacing a slot must not change a previously returned history snapshot.
+	s.mu.Lock()
+	s.events[0] = &session.Event{ID: "replacement"}
+	s.mu.Unlock()
+	if err := s.appendEvent(&session.Event{ID: "second"}); err != nil {
+		t.Fatal(err)
+	}
+	if got := snapshot.Len(); got != 1 {
+		t.Fatalf("snapshot.Len() = %d, want 1", got)
+	}
+	if got := snapshot.At(0); got != first {
+		t.Errorf("snapshot.At(0) = %v, want original event %v", got, first)
+	}
+	for event := range snapshot.All() {
+		if event != first {
+			t.Errorf("snapshot.All() yielded %v, want original event %v", event, first)
+		}
+	}
+}
+
+func TestLocalSessionEventsConcurrentAppend(t *testing.T) {
+	const count = 1000
+	s := &localSession{}
+	start := make(chan struct{})
+	var wg sync.WaitGroup
+	wg.Add(1)
+	go func() {
+		defer wg.Done()
+		<-start
+		for i := range count {
+			if err := s.appendEvent(&session.Event{ID: fmt.Sprint(i)}); err != nil {
+				t.Errorf("appendEvent: %v", err)
+				return
+			}
+			runtime.Gosched()
+		}
+	}()
+	close(start)
+	for range count {
+		snapshot := s.Events()
+		n := 0
+		for event := range snapshot.All() {
+			if event == nil || event.ID != fmt.Sprint(n) {
+				t.Errorf("snapshot event %d = %v, want ID %q", n, event, fmt.Sprint(n))
+				break
+			}
+			n++
+		}
+		if n != snapshot.Len() {
+			t.Errorf("snapshot iteration count = %d, want %d", n, snapshot.Len())
+		}
+		runtime.Gosched()
+	}
+	wg.Wait()
+	if got := s.Events().Len(); got != count {
+		t.Errorf("final event count = %d, want %d", got, count)
+	}
+}


### PR DESCRIPTION
### Link to Issue or Description of Change

Closes #1553.

**Problem:** Concurrent history reads and event appends race on the `localSession.events` slice header in the database and Vertex AI session backends.

**Solution:** Acquire the session read lock and clone the event slice inside `Events()`. The lock is released before callers iterate over the returned snapshot. Both backends receive focused race and snapshot-isolation regression tests.

### Behavior change

Concurrent calls to `Events()` and event appends now synchronize access to the history slice. A returned history has its own backing array. This is a shallow snapshot: event objects remain shared, and concurrent mutation of their fields is outside this fix. Snapshot creation is O(n) in the number of events. No public API or dependencies change.

### Testing Plan

- `go test -race -mod=readonly ./session/database ./session/vertexai -run TestLocalSessionEvents -count=10` passed for both backends.
- Both new tests failed on the unmodified source: `TestLocalSessionEventsConcurrentAppend` reported a data race, and `TestLocalSessionEventsSnapshot` observed the replaced event through the old snapshot.
- Using Go overlays to remove only the read lock reproduced the race in both backends. Removing only the clone made the snapshot test fail in both backends.
- `go build -mod=readonly ./...`, `golangci-lint run` (v2.3.1), and `go mod tidy -diff` passed in both the root module and `plugin/agentanalytics`.
- `go test -race -mod=readonly -count=1 -shuffle=on ./...` passed in `plugin/agentanalytics`. In the root module, 82 packages passed, but the existing Vertex AI service suite blocked while constructing the gRPC client; it was interrupted after approximately 217 seconds to collect stacks.
- The unmodified upstream source at `49224b6f762988234bc8933ed344eb4d3979b44e`, tested through a Go overlay, also timed out after 30 seconds in `Test_vertexaiService/Create/full_key` in `grpc.DialContext`, before reaching `Events()`. Full-suite validation therefore remains incomplete on this host.

Focused result:

```text
ok  google.golang.org/adk/v2/session/database  8.703s
ok  google.golang.org/adk/v2/session/vertexai  9.166s
```

**Manual E2E:** No live Vertex AI or model calls were used. The concurrent test drives the actual local session append/read methods; the existing database service suite passed. No claim of live-cloud E2E validation is made.

### Checklist

- [x] I have read the contribution guide.
- [x] I have performed a self-review of the change.
- [x] I have added tests that fail without the fix.
- [ ] All existing unit tests pass locally (Vertex AI gRPC test blocker described above).
- [ ] Live end-to-end validation completed.
