### PR TITLE
fix: preserve orphan response content during rearrangement

### DIFF
--- a/internal/llminternal/contents_processor.go
+++ b/internal/llminternal/contents_processor.go
@@ -214,11 +214,11 @@ func buildContentsDefaultWithCallSource(agentName, invocationBranch, isolationSc
 	}
 	filtered = processedEvents
 
-	filtered = dropOrphanedFunctionResponses(filtered, allEvents)
+	filtered, orphanRemnants := dropOrphanedFunctionResponses(filtered, allEvents)
 
 	//  src/google/adk/flows/llm_flows/contents.py
 	// 	 - _rearrange_events_for_async_function_response
-	filtered, err := rearrangeEventsForLatestFunctionResponse(filtered)
+	filtered, err := rearrangeEventsForLatestFunctionResponse(filtered, orphanRemnants)
 	if err != nil {
 		return nil, err
 	}
@@ -266,7 +266,9 @@ func eventBelongsToBranch(invocationBranch string, event *session.Event) bool {
 	return utils.EventBelongsToBranch(invocationBranch, event.Branch)
 }
 
-func dropOrphanedFunctionResponses(events, allEvents []*session.Event) []*session.Event {
+// dropOrphanedFunctionResponses also identifies surviving events whose orphaned
+// responses were removed, so later rearrangement preserves their remaining content.
+func dropOrphanedFunctionResponses(events, allEvents []*session.Event) ([]*session.Event, map[*session.Event]bool) {
 	callIDs := make(map[string]struct{})
 	for _, event := range allEvents {
 		for _, call := range utils.FunctionCalls(utils.Content(event)) {
@@ -286,6 +288,7 @@ func dropOrphanedFunctionResponses(events, allEvents []*session.Event) []*sessio
 
 	var orphanedIDs []string
 	result := make([]*session.Event, 0, len(events))
+	orphanRemnants := make(map[*session.Event]bool)
 	for _, event := range events {
 		content := utils.Content(event)
 		if content == nil {
@@ -315,22 +318,21 @@ func dropOrphanedFunctionResponses(events, allEvents []*session.Event) []*sessio
 		cloned.LLMResponse.Content.Parts = parts
 		if len(cloned.LLMResponse.Content.Parts) > 0 {
 			result = append(result, cloned)
+			orphanRemnants[cloned] = true
 		}
 	}
 
 	if len(orphanedIDs) > 0 {
 		log.Printf("adk: dropping function responses with no matching function call: %q", orphanedIDs)
 	}
-	return result
+	return result, orphanRemnants
 }
 
-// rearrangeEventsForLatestFunctionResponse
-// This function only acts if the very last event is a function response.
-// It searches backward for the matching call, deletes all intervening events,
-// and appends a single (merged) response.
-// If the latest function_response is for an async function_call, all events
-// between the initial function_call and the latest function_response will be removed.
-func rearrangeEventsForLatestFunctionResponse(events []*session.Event) ([]*session.Event, error) {
+// rearrangeEventsForLatestFunctionResponse merges responses to the latest event's
+// matching call, dropping intervening non-tool events except orphanRemnants.
+// Unrelated tool events and the content left after pruning their orphaned
+// responses survive; pruning must not change whether that content is retained.
+func rearrangeEventsForLatestFunctionResponse(events []*session.Event, orphanRemnants map[*session.Event]bool) ([]*session.Event, error) {
 	if len(events) < 2 {
 		return events, nil
 	}
@@ -424,6 +426,11 @@ SearchLoop: // A label to allow breaking out of the nested loop
 
 		responses := utils.FunctionResponses(event.Content)
 		if len(responses) == 0 {
+			// Unlike Python's blanket intermediate-event removal, retain content
+			// deliberately preserved when pruning unrelated orphaned responses.
+			if orphanRemnants[event] {
+				resultEvents = append(resultEvents, event)
+			}
 			continue
 		}
 

--- a/internal/llminternal/contents_processor_internal_test.go
+++ b/internal/llminternal/contents_processor_internal_test.go
@@ -41,7 +41,7 @@ func TestDropOrphanedFunctionResponses_LogAndClone(t *testing.T) {
 	want.LLMResponse.Content = genai.NewContentFromText("Keep this", "user")
 	want.LLMResponse.Content.Parts = append(want.LLMResponse.Content.Parts, &genai.Part{Text: "Keep this too"})
 	output := captureLog(t, func() {
-		got := dropOrphanedFunctionResponses([]*session.Event{event}, nil)
+		got, _ := dropOrphanedFunctionResponses([]*session.Event{event}, nil)
 		if diff := cmp.Diff([]*session.Event{&want}, got); diff != "" {
 			t.Errorf("pruned events mismatch (-want +got):\n%s", diff)
 		}

--- a/internal/llminternal/contents_processor_test.go
+++ b/internal/llminternal/contents_processor_test.go
@@ -1451,6 +1451,62 @@ func TestContentsRequestProcessor_Rearrange(t *testing.T) {
 			},
 		},
 		{
+			name: "Rearrangement preserves text sharing an orphaned response part",
+			events: []*session.Event{
+				{Author: agentName, LLMResponse: model.LLMResponse{Content: NewContentFromFunctionCall(fcBasic, "model")}},
+				{Author: "user", LLMResponse: model.LLMResponse{Content: &genai.Content{Role: "user", Parts: []*genai.Part{
+					{Text: "note", FunctionResponse: frOrphaned},
+				}}}},
+				{Author: "user", LLMResponse: model.LLMResponse{Content: NewContentFromFunctionResponse(frBasic, "user")}},
+			},
+			want: []*genai.Content{
+				NewContentFromFunctionCall(fcBasic, "model"),
+				NewContentFromFunctionResponse(frBasic, "user"),
+				genai.NewContentFromText("note", "user"),
+			},
+		},
+		{
+			name: "Rearrangement preserves separate text beside an orphaned response",
+			events: []*session.Event{
+				{Author: agentName, LLMResponse: model.LLMResponse{Content: NewContentFromFunctionCall(fcBasic, "model")}},
+				{Author: "user", LLMResponse: model.LLMResponse{Content: &genai.Content{Role: "user", Parts: []*genai.Part{
+					{Text: "note"}, {FunctionResponse: frOrphaned},
+				}}}},
+				{Author: "user", LLMResponse: model.LLMResponse{Content: NewContentFromFunctionResponse(frBasic, "user")}},
+			},
+			want: []*genai.Content{
+				NewContentFromFunctionCall(fcBasic, "model"),
+				NewContentFromFunctionResponse(frBasic, "user"),
+				genai.NewContentFromText("note", "user"),
+			},
+		},
+		{
+			name: "Rearrangement preserves orphan remnants around unrelated tools",
+			events: []*session.Event{
+				{Author: agentName, LLMResponse: model.LLMResponse{Content: NewContentFromFunctionCall(fcLRO, "model")}},
+				{Author: "user", LLMResponse: model.LLMResponse{Content: NewContentFromFunctionResponse(frLROInter, "user")}},
+				{Author: agentName, LLMResponse: model.LLMResponse{Content: genai.NewContentFromText("Still processing...", "model")}},
+				{Author: "user", LLMResponse: model.LLMResponse{Content: &genai.Content{Role: "user", Parts: []*genai.Part{
+					{Text: "first note", FunctionResponse: frOrphaned},
+				}}}},
+				{Author: agentName, LLMResponse: model.LLMResponse{Content: NewContentFromFunctionCall(fcBasic, "model")}},
+				{Author: "user", LLMResponse: model.LLMResponse{Content: NewContentFromFunctionResponse(frBasic, "user")}},
+				{Author: "user", LLMResponse: model.LLMResponse{Content: &genai.Content{Role: "user", Parts: []*genai.Part{
+					{InlineData: &genai.Blob{MIMEType: "image/png", Data: []byte("image")}, FunctionResponse: frOrphaned},
+				}}}},
+				{Author: "user", LLMResponse: model.LLMResponse{Content: NewContentFromFunctionResponse(frOrphaned, "user")}},
+				{Author: "user", LLMResponse: model.LLMResponse{Content: NewContentFromFunctionResponse(frLROFinal, "user")}},
+			},
+			want: []*genai.Content{
+				NewContentFromFunctionCall(fcLRO, "model"),
+				NewContentFromFunctionResponse(frLROFinal, "user"),
+				genai.NewContentFromText("first note", "user"),
+				NewContentFromFunctionCall(fcBasic, "model"),
+				NewContentFromFunctionResponse(frBasic, "user"),
+				{Role: "user", Parts: []*genai.Part{{InlineData: &genai.Blob{MIMEType: "image/png", Data: []byte("image")}}}},
+			},
+		},
+		{
 			name: "Mid-history mixed content preserves user text",
 			events: []*session.Event{
 				{Author: "user", LLMResponse: model.LLMResponse{Content: genai.NewContentFromText("Before", "user")}},


### PR DESCRIPTION
### Link to Issue or Description of Change

Closes #1540.

When a matched tool response follows an event containing text and an orphaned response, pruning keeps the text but history rearrangement drops it again.

Track events that still have content after orphan pruning and keep them during rearrangement. Other intermediate events keep their existing behavior.

### Behavior change

Text and images left after removing an orphaned response now reach the model when a later matched response triggers rearrangement. For the issue's example, the contents change from `[call:a] [resp:a]` to `[call:a] [resp:a] [text:note]`.

### Testing Plan

Added three cases to `TestContentsRequestProcessor_Rearrange`: a combined text/response part, separate text and response parts, and text/image content around unrelated tool calls. All three fail without the fix, including `Rearrangement_preserves_text_sharing_an_orphaned_response_part`.

Forcing the new condition to always keep intermediate events also fails the existing progress-text tests.

Passed locally:

- `go build -mod=readonly work`
- `go test -race -mod=readonly -count=1 -shuffle=on work`
- `golangci-lint run` (v2.3.1) in both modules
- `go mod tidy -diff` in both modules

Package test output:

```text
ok  google.golang.org/adk/v2/internal/llminternal  2.650s
```

No manual E2E or live-model test was run.

### Checklist

- [x] Read CONTRIBUTING.md.
- [x] Reviewed the full diff.
- [x] Added comments explaining the retention rule.
- [x] Added regression tests and confirmed they fail without the fix.
- [x] New and existing unit tests pass locally.
- [ ] Manually tested end-to-end.

### Additional context

Python's [`_tool_call_rearranger.py:388–400`](https://github.com/google/adk-python/blob/main/src/google/adk/flows/llm_flows/_tool_call_rearranger.py#L388-L400) also removes intermediate events. This fix differs by retaining content that Go's orphan pruning already preserves, as required by #1540.
