### PR TITLE
fix(memory): normalize punctuation in in-memory search

### DIFF
--- a/memory/inmemory.go
+++ b/memory/inmemory.go
@@ -202,11 +202,14 @@ func (s *inMemoryService) SearchMemory(ctx context.Context, req *SearchRequest) 
 func extractWords(text string) map[string]struct{} {
 	res := make(map[string]struct{})
 
-	for s := range strings.SplitSeq(text, " ") {
-		if s == "" {
+	for _, word := range strings.Fields(text) {
+		cleaned := strings.TrimFunc(word, func(r rune) bool {
+			return !unicode.IsLetter(r) && !unicode.IsNumber(r)
+		})
+		if cleaned == "" {
 			continue
 		}
-		res[strings.ToLower(s)] = struct{}{}
+		res[strings.ToLower(cleaned)] = struct{}{}
 	}
 
 	return res

--- a/memory/inmemory_test.go
+++ b/memory/inmemory_test.go
@@ -91,6 +91,24 @@ func Test_inMemoryService_SearchMemory(t *testing.T) {
 			},
 		},
 		{
+			name: "matches punctuation and non-space whitespace",
+			initSessions: []session.Session{
+				makeSession(t, "app1", "user1", "sess-punctuation", []*session.Event{
+					{LLMResponse: model.LLMResponse{Content: genai.NewContentFromText("Error: connection\ntimeout! Please\tretry.", genai.RoleModel)}},
+				}),
+			},
+			req: &memory.SearchRequest{
+				AppName: "app1",
+				UserID:  "user1",
+				Query:   "error timeout retry",
+			},
+			wantResp: &memory.SearchResponse{
+				Memories: []memory.Entry{
+					{Content: genai.NewContentFromText("Error: connection\ntimeout! Please\tretry.", genai.RoleModel)},
+				},
+			},
+		},
+		{
 			name: "no leakage for different appName",
 			initSessions: []session.Session{
 				makeSession(t, "app1", "user1", "sess3", []*session.Event{


### PR DESCRIPTION
Fixes #569

Normalize in-memory search tokens using Unicode-aware whitespace splitting and trimming of leading/trailing punctuation, while preserving internal punctuation such as hyphens. Adds regression coverage for punctuation, newlines, and tabs.

## Testing plan
- go test ./memory/...
- Verified the punctuation/whitespace regression case fails without the source change and passes with it.