### PR TITLE
fix(utils): respect Nullable field on nil values during schema validation

### DIFF
--- a/internal/utils/schema_test.go
+++ b/internal/utils/schema_test.go
@@ -47,6 +47,14 @@ func TestMatchType(t *testing.T) {
 			wantErr:   false,
 		},
 		{
+			name:      "nil value nullable",
+			value:     nil,
+			schema:    &genai.Schema{Type: genai.TypeString, Nullable: genai.Ptr(true)},
+			isInput:   true,
+			wantMatch: true,
+			wantErr:   false,
+		},
+		{
 			name:      "string match",
 			value:     "test",
 			schema:    &genai.Schema{Type: genai.TypeString},

--- a/internal/utils/schema_utils.go
+++ b/internal/utils/schema_utils.go
@@ -31,7 +31,7 @@ func matchType(value any, schema *genai.Schema, isInput bool) (bool, error) {
 	}
 
 	if value == nil {
-		return false, nil
+		return schema.Nullable != nil && *schema.Nullable, nil
 	}
 
 	// Convert type to upper case to match the type in the schema.


### PR DESCRIPTION
### Description

When validating a payload against a `genai.Schema`, `matchType` previously returned `false, nil` unconditionally whenever `value == nil`, ignoring the `Nullable` field on the schema.

This change checks whether `schema.Nullable` is set to `true` when `value == nil`. If `Nullable` is `true`, `matchType` returns `true, nil` so that valid nullable fields with nil values pass schema validation.

### Testing

Added unit test `nil value nullable` in `internal/utils/schema_test.go` covering `matchType` with `value: nil` and `schema.Nullable = genai.Ptr(true)`.

Ran:
```
go test -race ./internal/utils/...
```
All tests pass.

### Behavior Changes

Fixes an issue where `nil` was rejected even when the schema explicitly declared `Nullable: true`.