### PR TITLE
test(examples): cover image precedence and empty results

### DIFF
--- a/examples/internal/imagegen/imagegen.go
+++ b/examples/internal/imagegen/imagegen.go
@@ -24,15 +24,16 @@ import (
 )
 
 // ImageBytes returns the bytes and MIME type of the first usable image in a
-// generation response. If the response contains no generated images, it returns
-// an error reporting that no images were returned. If the entries contain no
-// usable image data but include RAI filtering reasons, the error includes the
-// first reason that remains non-empty after trimming surrounding whitespace.
+// generation response. A nil response is accepted and returns the same error as
+// a response containing no generated images. If the entries contain no usable
+// image data but include RAI filtering reasons, the error includes the first
+// reason that remains non-empty after trimming surrounding whitespace.
 // Whitespace-only reasons are ignored. Otherwise, an error reports that the
 // entries contain no usable image data.
 //
 // ImageBytes assumes the image is delivered as inline bytes (Image.ImageBytes);
-// an entry carrying only a GCS URI is treated as having no usable image data.
+// zero-length bytes and entries carrying only a GCS URI are treated as having no
+// usable image data.
 //
 // On error, ImageBytes returns nil bytes and an empty MIME type. On success,
 // the returned bytes alias the image data in the SDK response; they are not

--- a/examples/internal/imagegen/imagegen_test.go
+++ b/examples/internal/imagegen/imagegen_test.go
@@ -39,6 +39,13 @@ func TestImageBytes(t *testing.T) {
 			wantErr:  "image generation returned no images",
 		},
 		{
+			name: "empty generated images",
+			response: &genai.GenerateImagesResponse{
+				GeneratedImages: []*genai.GeneratedImage{},
+			},
+			wantErr: "image generation returned no images",
+		},
+		{
 			name: "nil generated image",
 			response: &genai.GenerateImagesResponse{
 				GeneratedImages: []*genai.GeneratedImage{nil},
@@ -118,6 +125,22 @@ func TestImageBytes(t *testing.T) {
 				},
 			},
 			want:     []byte("first image"),
+			wantMIME: "image/jpeg",
+		},
+		{
+			name: "usable image with a filtering reason",
+			response: &genai.GenerateImagesResponse{
+				GeneratedImages: []*genai.GeneratedImage{
+					{
+						Image: &genai.Image{
+							ImageBytes: []byte("image"),
+							MIMEType:   "image/jpeg",
+						},
+						RAIFilteredReason: "filtered",
+					},
+				},
+			},
+			want:     []byte("image"),
 			wantMIME: "image/jpeg",
 		},
 		{


### PR DESCRIPTION
### Link to Issue or Description of Change

Related: #1477. Follow-up to #1478.

Add two `ImageBytes` test cases suggested during review: a non-nil empty image list, and an entry containing both usable image bytes and a filtering reason. Also clarify how nil responses and zero-length image data are handled.

### Behavior change

Nothing. This PR adds tests and documents existing behavior.

### Testing Plan

All tests passed, including the full race test suite. Build, lint (v2.3.1), tidy, and formatting checks passed in both modules.

**With your source change reverted and your tests kept, which test fails?**

None; this PR does not change runtime code. I checked the new tests against two temporary mutations:

- Using a nil check instead of a length check fails `TestImageBytes/empty_generated_images`.
- Rejecting usable bytes when the same entry has a filtering reason fails `TestImageBytes/usable_image_with_a_filtering_reason`.

**Manual End-to-End (E2E) Tests:**

Not applicable; no runtime behavior changes.

### Checklist

- [x] I have read the [CONTRIBUTING.md](https://github.com/google/adk-go/blob/main/CONTRIBUTING.md) document.
- [x] I have performed a self-review of my own code.
- [x] I have commented my code, particularly in hard-to-understand areas.
- [x] I have added tests that prove the documented behavior.
- [x] New and existing unit tests pass locally with my changes.
- [ ] I have manually tested my changes end-to-end. (Not applicable.)
- [ ] Any dependent changes have been merged and published in downstream modules. (Not applicable; no downstream module changes are required.)
