### PR TITLE
chore(version): bump the tagged version constant to 2.4.0

### DIFF
--- a/internal/version/version.go
+++ b/internal/version/version.go
@@ -18,4 +18,4 @@ package version
 //
 // The trailing annotation marks this line for Release Please, which rewrites
 // the value in the release PR. Do not edit it by hand.
-const Version = "2.3.0" // x-release-please-version
+const Version = "2.4.0" // x-release-please-version


### PR DESCRIPTION
Bump version before the release.