### PR TITLE
Align vertexai session service via ADK REST API with other impl

### DIFF
--- a/session/vertexai/vertexai_client.go
+++ b/session/vertexai/vertexai_client.go
@@ -176,7 +176,7 @@ func (c *vertexAiClient) getSession(ctx context.Context, req *session.GetRequest
 		return nil, fmt.Errorf("%w: %q", session.ErrNotFound, req.SessionID)
 	}
 	if sessRpcResp.UserId != req.UserID {
-		return nil, fmt.Errorf("session %s does not belong to user %s", req.SessionID, req.UserID)
+		return nil, fmt.Errorf("%w: session %s does not belong to user %s", session.ErrNotFound, req.SessionID, req.UserID)
 	}
 
 	return &localSession{


### PR DESCRIPTION
**Problem:**

The following route
```go
		Route{
			Name:        "GetSession",
			Methods:     []string{http.MethodGet},
			Pattern:     "/apps/{app_name}/users/{user_id}/sessions/{session_id}",
			HandlerFunc: r.sessionController.GetSessionHandler,
		},

```

doesn't behave the same for different implementations. 

For VertexAI Session Service the result of getting the session belonging to another user results in HTTP 500. For other implementations: HTTP 404. 

**Solution:**
Aligning the vertexai implementation.

