### PR TITLE
fix(workflow): restore completed predecessors when resuming joins

### DIFF
--- a/runner/workflow_join_resume_test.go
+++ b/runner/workflow_join_resume_test.go
@@ -1,0 +1,145 @@
+// Copyright 2026 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package runner_test
+
+import (
+	"iter"
+	"reflect"
+	"testing"
+
+	"google.golang.org/genai"
+
+	"google.golang.org/adk/v2/agent"
+	"google.golang.org/adk/v2/agent/workflowagent"
+	"google.golang.org/adk/v2/model"
+	"google.golang.org/adk/v2/runner"
+	"google.golang.org/adk/v2/session"
+	"google.golang.org/adk/v2/workflow"
+)
+
+func joinResumeAgent(t *testing.T, name, output string, interrupt bool) agent.Agent {
+	t.Helper()
+	a, err := agent.New(agent.Config{Name: name, Run: func(ctx agent.InvocationContext) iter.Seq2[*session.Event, error] {
+		return func(yield func(*session.Event, error) bool) {
+			if interrupt {
+				if _, err := workflow.ResumeOrRequestInput(agent.Promote(ctx), func(ev *session.Event) error { yield(ev, nil); return nil }, session.RequestInput{InterruptID: name, Message: "approve"}); err != nil {
+					return
+				}
+				yield(&session.Event{LLMResponse: model.LLMResponse{Content: genai.NewContentFromText(output, genai.RoleModel)}}, nil)
+				return
+			}
+			ev := session.NewEvent(ctx, ctx.InvocationID())
+			ev.Content = genai.NewContentFromText(output, genai.RoleModel)
+			yield(ev, nil)
+		}
+	}})
+	if err != nil {
+		t.Fatal(err)
+	}
+	return a
+}
+
+func TestRunner_WorkflowHITL_AgentJoinResume(t *testing.T) {
+	for _, secondWait := range []bool{false, true} {
+		name := "completed_sibling"
+		if secondWait {
+			name = "two_waiting_siblings"
+		}
+		t.Run(name, func(t *testing.T) { runAgentJoinResume(t, secondWait) })
+	}
+}
+
+func runAgentJoinResume(t *testing.T, secondWait bool) {
+	t.Helper()
+	b := joinResumeAgent(t, "b", "B", true)
+	c := joinResumeAgent(t, "c", "C", secondWait)
+	d := joinResumeAgent(t, "d", "D", false)
+	bNode, err := workflow.NewAgentNode(b, workflow.NodeConfig{})
+	if err != nil {
+		t.Fatal(err)
+	}
+	cNode, err := workflow.NewAgentNode(c, workflow.NodeConfig{})
+	if err != nil {
+		t.Fatal(err)
+	}
+	dNode, err := workflow.NewAgentNode(d, workflow.NodeConfig{})
+	if err != nil {
+		t.Fatal(err)
+	}
+	join := workflow.NewJoinNode("join")
+	root, err := workflowagent.New(workflowagent.Config{Name: "root", SubAgents: []agent.Agent{b, c, d}, Edges: []workflow.Edge{
+		{From: workflow.Start, To: bNode},
+		{From: workflow.Start, To: cNode},
+		{From: bNode, To: join},
+		{From: cNode, To: join},
+		{From: join, To: dNode},
+	}})
+	if err != nil {
+		t.Fatal(err)
+	}
+	svc := session.InMemoryService()
+	r, err := runner.New(runner.Config{AppName: "repro", Agent: root, SessionService: svc, AutoCreateSession: true})
+	if err != nil {
+		t.Fatal(err)
+	}
+	ctx := t.Context()
+	for ev, err := range r.Run(ctx, "u", "s", genai.NewContentFromText("start", genai.RoleUser), agent.RunConfig{}) {
+		if err != nil {
+			t.Fatal(err)
+		}
+		if ev.Author == "d" {
+			t.Fatal("D executed before approval")
+		}
+	}
+	msg := genai.NewContentFromFunctionResponse(workflow.WorkflowInputFunctionCallName, map[string]any{"response": "approved"}, genai.RoleUser)
+	msg.Parts[0].FunctionResponse.ID = "b"
+	wantC := "C"
+	if secondWait {
+		for ev, err := range r.Run(ctx, "u", "s", msg, agent.RunConfig{}) {
+			if err != nil {
+				t.Fatal(err)
+			}
+			if ev.Author == "d" || ev.Output != nil {
+				t.Fatal("join advanced while C still waited")
+			}
+		}
+		msg = resumeContent("c", workflow.WorkflowInputFunctionCallName, "approved C")
+		wantC = "approved C"
+	}
+	var sawD, sawJoin bool
+	for ev, err := range r.Run(ctx, "u", "s", msg, agent.RunConfig{}) {
+		if err != nil {
+			t.Fatal(err)
+		}
+		if ev.Author == "c" {
+			t.Fatal("completed C ran again")
+		}
+		if got, ok := ev.Output.(map[string]any); ok {
+			sawJoin = true
+			if !reflect.DeepEqual(got, map[string]any{"b": "approved", "c": wantC}) {
+				t.Fatalf("join output = %v", got)
+			}
+		}
+		if ev.Author == "d" {
+			sawD = true
+		}
+	}
+	if !sawJoin {
+		t.Fatal("join did not emit predecessor outputs")
+	}
+	if !sawD {
+		t.Fatal("D never executed after approval; completed predecessor must survive rehydration")
+	}
+}

--- a/workflow/persistence.go
+++ b/workflow/persistence.go
@@ -102,6 +102,18 @@ func (w *Workflow) ReconstructRunState(sess session.Session, invocationID string
 	if state == nil {
 		return nil, nil
 	}
+	// Restore completed predecessors as well as interrupted nodes. Join
+	// barriers consult Nodes, not the completed set used to skip replayed
+	// successors, and need the predecessors' outputs after a resume.
+	for name, output := range nodeOutputs {
+		if _, exists := state.Nodes[name]; !exists {
+			ns := &NodeState{Status: NodeCompleted, Output: output}
+			if scan := scans[name]; scan != nil {
+				ns.Branch = scan.branch
+			}
+			state.Nodes[name] = ns
+		}
+	}
 
 	// WAITING nodes have not finished, so Resume must not treat them
 	// as already-run; the rest stay in completed to skip their
@@ -172,7 +184,7 @@ func scanHistory(events session.Events, nodesByName map[string]Node, invocationI
 			continue
 		}
 		s := scanFor(owner)
-		if ev.Output != nil {
+		if _, ok := childEventOutput(ev); ok {
 			s.branch = ev.Branch
 		}
 		for _, id := range ev.LongRunningToolIDs {

--- a/workflow/persistence_test.go
+++ b/workflow/persistence_test.go
@@ -260,3 +260,44 @@ func nodeState(t *testing.T, state *RunState, name string) *NodeState {
 	}
 	return ns
 }
+
+// A completed sibling must retain its output and branch for a join after
+// another node pauses. Historical runs and unfinished siblings must not
+// become completed predecessors of the current invocation.
+func TestReconstructRunState_CompletedJoinPredecessors(t *testing.T) {
+	ask, done, old, streaming := newDummyNode("ask"), newDummyNode("done"), newDummyNode("old"), newDummyNode("streaming")
+	join := NewJoinNode("join")
+	wf, err := New("root", []Edge{{From: Start, To: ask}, {From: Start, To: done}, {From: Start, To: old}, {From: Start, To: streaming}, {From: ask, To: join}, {From: done, To: join}})
+	if err != nil {
+		t.Fatal(err)
+	}
+	for _, messageOutput := range []bool{false, true} {
+		t.Run(map[bool]string{false: "explicit_output", true: "message_output"}[messageOutput], func(t *testing.T) {
+			completed := modelEvent("done", "saved", messageOutput)
+			completed.InvocationID, completed.Branch = "current", "outer@1.done@1"
+			if !messageOutput {
+				completed.Output = "saved"
+			}
+			pending := &session.Event{Author: "ask", InvocationID: "current", Output: "intermediate", LongRunningToolIDs: []string{"approval"}}
+			previous := &session.Event{Author: "old", InvocationID: "previous", Output: "obsolete"}
+			unfinished := modelEvent("streaming", "partial", false)
+			unfinished.InvocationID = "current"
+			state, err := wf.ReconstructRunState(fakeSession{events: sliceEvents{previous, completed, unfinished, pending}}, "current")
+			if err != nil {
+				t.Fatal(err)
+			}
+			ns := nodeState(t, state, "done")
+			if ns.Status != NodeCompleted || ns.Output != "saved" || ns.Branch != completed.Branch {
+				t.Fatalf("completed sibling = %+v", ns)
+			}
+			if nodeState(t, state, "ask").Status != NodeWaiting {
+				t.Fatal("interrupted node was marked completed")
+			}
+			for _, name := range []string{"old", "streaming"} {
+				if _, exists := state.Nodes[name]; exists {
+					t.Fatalf("%s incorrectly restored as completed", name)
+				}
+			}
+		})
+	}
+}


### PR DESCRIPTION
A workflow that pauses B while sibling C completes cannot advance their native join after B is answered: rehydration restores interrupted nodes but omits C from the NodeState map consulted by the barrier. Restore completed nodes with recorded outputs and their branches without overwriting reconstructed waiting/re-entry state. Message-derived outputs retain branch information too.

After this change, the direct-root B/C -> join -> D scenario resumes with both predecessor outputs and executes D without rerunning C. No public API or dependencies change. This addresses the demonstrated join case in #1568; it does not claim to fix every resume scenario in that report.

The runner integration regression is adapted from the #1568 reproduction, with the response ID supplied and the unused variable corrected. Current main dispatches a direct WorkflowAgent root directly; this fix does not change Runner routing. The same regression fails on #1183 (`8d7ca93`), whose adjacent resume changes do not restore this completed predecessor.

Testing:
- Base: main `4e57df4`.
- `go build -mod=readonly work`: passed across both modules.
- `go test -race ./runner ./workflow ./agent/workflowagent -count=1 -timeout=120s`: passed. Covers completed sibling -> join, two separately resumed waiting siblings, outputs/branches, invocation isolation, and preservation of waiting nodes.
- Tests fail with baseline persistence.go supplied via Go overlay: TestRunner_WorkflowHITL_AgentJoinResume/completed_sibling and both TestReconstructRunState_CompletedJoinPredecessors subtests.
- Removing the waiting-state guard, branch restoration, or message-output branch handling causes the relevant regression to fail.
- golangci-lint v2.3.1: 0 issues in root and plugin/agentanalytics. Both `go mod tidy -diff` checks clean.
- Full workspace race run: 87 packages passed; session/vertexai timed out after 120s in Test_vertexaiService/Create/full_key during gRPC initialization. The same case with unmodified production source times out after 20s. Full-suite validation therefore remains incomplete on this host.
- No live model/cloud calls or browser E2E. Runner integration uses real Runner, WorkflowAgent and in-memory sessions with scripted agents.

Behavior was compared with Python's workflow barrier requiring completed predecessor states and its rehydration collecting node outputs; no claim of complete cross-language parity.

AI assistance was used for investigation, implementation and tests.
