### PR TITLE
fix(exampletool): skip example injection when the invocation has no user content

### DIFF
--- a/tool/exampletool/tool.go
+++ b/tool/exampletool/tool.go
@@ -60,8 +60,12 @@ func (s exampleTool) Description() string {
 
 // ProcessRequest adds the exampleTool examples to the LLM request.
 func (s exampleTool) ProcessRequest(ctx agent.Context, req *model.LLMRequest) error {
-	parts := ctx.UserContent().Parts
-	if len(parts) == 0 || parts[0].Text == "" {
+	userContent := ctx.UserContent()
+	if userContent == nil {
+		return nil
+	}
+	parts := userContent.Parts
+	if len(parts) == 0 || parts[0] == nil || parts[0].Text == "" {
 		return nil
 	}
 

--- a/tool/exampletool/tool_test.go
+++ b/tool/exampletool/tool_test.go
@@ -101,6 +101,22 @@ func TestExampleTool_ProcessRequest(t *testing.T) {
 			wantInstruct: "",
 		},
 		{
+			name:         "NilUserContent",
+			examples:     []*Example{{Input: genai.NewContentFromText("hi", "user"), Output: []*genai.Content{genai.NewContentFromText("hello", "model")}}},
+			userContent:  nil,
+			model:        "gemini-1.5-pro",
+			wantInstruct: "",
+		},
+		{
+			name:     "NilFirstPart",
+			examples: []*Example{{Input: genai.NewContentFromText("hi", "user"), Output: []*genai.Content{genai.NewContentFromText("hello", "model")}}},
+			userContent: &genai.Content{
+				Parts: []*genai.Part{nil},
+			},
+			model:        "gemini-1.5-pro",
+			wantInstruct: "",
+		},
+		{
 			name:     "EmptyUserContentString",
 			examples: []*Example{{Input: genai.NewContentFromText("hi", "user"), Output: []*genai.Content{genai.NewContentFromText("hello", "model")}}},
 			userContent: &genai.Content{


### PR DESCRIPTION
### Link to Issue or Description of Change

**Problem:**

`exampleTool.ProcessRequest` dereferences the invocation's user content without a nil check (`tool/exampletool/tool.go:63`):

```go
parts := ctx.UserContent().Parts
if len(parts) == 0 || parts[0].Text == "" {
```

`agent.Context.UserContent()` is nil on ordinary paths. `Runner.RunLive` builds its invocation context with `UserContent: nil` outright (`runner/runner.go:908`, under the comment "msg is nil for Live run as it's streaming" at `runner/runner.go:861`), and `Runner.Run` passes the caller's message straight through (`runner/runner.go:691`), so `Run(ctx, user, session, nil, cfg)` is nil too. Every tool's `ProcessRequest` runs on every model step through `toolPreprocess` (`internal/llminternal/base_flow.go:786`), so any agent configured with `exampletool` hits it. On the live path that call runs inside a goroutine with no `recover` (`internal/llminternal/base_flow.go:330`), so the panic takes the process down; on the node path it surfaces as `node "agent" panicked: runtime error: invalid memory address or nil pointer dereference`. A nil element in `Parts` panics one line later.

Every other reader in the repo already guards this: `workflow/workflow.go:336`, `tool/preloadmemorytool/tool.go:74-77` (which also guards `Parts[0] == nil`), `examples/agentregistry/a2a/main.go:154`, `examples/workflow/routing/llm/main.go:90`. adk-python guards the same thing in `src/google/adk/examples/example_util.py:111` (`content is not None and content.parts and content.parts[0].text`), so this is a Go-only gap rather than a deliberate divergence.

**Solution:**

Return early when the user content is nil, and treat a nil first part the same way the existing code treats an empty one. Skipping rather than erroring matches the branch directly below, which already treats "no usable first text part" as nothing to do, and matches the Python line above. The `Parts[0] == nil` guard has no Python counterpart because `[]*genai.Part` is a pointer slice in Go; it mirrors `preloadmemorytool`.

The existing table case named `NoUserContent` passes `&genai.Content{Parts: []*genai.Part{}}`, which is never nil. That is why the nil case was missed. The new cases sit beside it rather than renaming it, to keep this change to one concern.

### Behavior change

An agent that uses `exampletool` and runs with no user content, any `RunLive`, or `Run` with a nil message, used to panic, which is process-fatal on the live path and a failed invocation on the node path. It now skips the few-shot injection for that request and the run proceeds. Nothing changes when user content is present.

### Testing Plan

**Unit Tests:**

- [x] All unit tests pass locally.

`go test -race -count=1 ./tool/exampletool/ ./internal/llminternal/ ./runner/` → `ok google.golang.org/adk/v2/tool/exampletool 1.569s`, `ok google.golang.org/adk/v2/internal/llminternal 2.167s`, `ok google.golang.org/adk/v2/runner 1.935s`. The full module loop from `AGENTS.md` (`go mod tidy -diff`, `go build -mod=readonly ./...`, `go test -race -mod=readonly -count=1 -shuffle=on ./...`, `golangci-lint run` v2.3.1) is green in both modules: 88 packages ok, 0 lint issues.

**With your source change reverted and your tests kept, which test fails?**

`TestExampleTool_ProcessRequest/NilUserContent` and `TestExampleTool_ProcessRequest/NilFirstPart`, both with a nil pointer dereference that takes the package binary down. Each guard was also reverted on its own: dropping only `userContent == nil` fails `NilUserContent` at `tool.go:64`, dropping only `parts[0] == nil` fails `NilFirstPart` at `tool.go:68`.

**Manual End-to-End (E2E) Tests:**

An `llmagent` holding this tool, driven through `testutil.NewTestAgentRunner` with `RunContent(t, "s1", nil)` and `testutil.MockModel`, so no live model call. Before the change: `events=0 err=node "agent" panicked: runtime error: invalid memory address or nil pointer dereference`. After: `events=1 err=<nil>`.

### Checklist

- [x] I have read the [CONTRIBUTING.md](https://github.com/google/adk-go/blob/main/CONTRIBUTING.md) document.
- [x] I have performed a self-review of my own code.
- [ ] I have commented my code, particularly in hard-to-understand areas.
- [x] I have added tests that prove my fix is effective or that my feature works.
- [x] New and existing unit tests pass locally with my changes.
- [x] I have manually tested my changes end-to-end.
- [ ] Any dependent changes have been merged and published in downstream modules.

### Additional context

#1390 fixed the same class of crash in `loadartifactstool`, where a nil artifact service was dereferenced instead of reported.
