### PR TITLE
fix(loadartifactstool): stop double-wrapping the artifact load error

### DIFF
--- a/tool/loadartifactstool/load_artifacts_tool.go
+++ b/tool/loadartifactstool/load_artifacts_tool.go
@@ -209,7 +209,7 @@ func (t *artifactsTool) processLoadArtifactsFunctionCall(ctx agent.Context, req 
 			// Although not used, we need to pass childCtx for early return in case of an error.
 			content, err := t.loadIndividualArtifact(childCtx, artifactsService, artifactName)
 			if err != nil {
-				return fmt.Errorf("failed to load artifact %s: %w", artifactName, err)
+				return err
 			}
 			results[i] = content
 			return nil

--- a/tool/loadartifactstool/load_artifacts_tool_test.go
+++ b/tool/loadartifactstool/load_artifacts_tool_test.go
@@ -15,6 +15,8 @@
 package loadartifactstool_test
 
 import (
+	"errors"
+	"io/fs"
 	"strings"
 	"testing"
 
@@ -492,6 +494,61 @@ func TestLoadArtifactsTool_ProcessRequest_Artifacts_MultiPartFunctionResponse(t 
 			}
 			if appendedContent.Parts[1].Text != "This is the content of doc1.txt" {
 				t.Errorf("Second part of appended content: got %v, want 'This is the content of doc1.txt'", appendedContent.Parts[1].Text)
+			}
+		})
+	}
+}
+
+func TestLoadArtifactsTool_ProcessRequest_LoadError(t *testing.T) {
+	tests := []struct {
+		name          string
+		artifactNames []string
+	}{
+		{
+			name:          "missing artifact",
+			artifactNames: []string{"missing.txt"},
+		},
+		{
+			name:          "missing artifact alongside a saved one",
+			artifactNames: []string{"doc1.txt", "missing.txt"},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			loadArtifactsTool := loadartifactstool.New()
+			tc := createToolContext(t)
+			if _, err := tc.Artifacts().Save(t.Context(), "doc1.txt", &genai.Part{Text: "This is the content of doc1.txt"}); err != nil {
+				t.Fatalf("Failed to save artifact: %v", err)
+			}
+
+			llmRequest := &model.LLMRequest{
+				Contents: []*genai.Content{
+					{
+						Role: genai.RoleUser,
+						Parts: []*genai.Part{
+							genai.NewPartFromFunctionResponse("load_artifacts", map[string]any{
+								"artifact_names": tt.artifactNames,
+							}),
+						},
+					},
+				},
+			}
+
+			requestProcessor, ok := loadArtifactsTool.(toolinternal.RequestProcessor)
+			if !ok {
+				t.Fatal("loadArtifactsTool does not implement RequestProcessor")
+			}
+
+			err := requestProcessor.ProcessRequest(tc, llmRequest)
+			if err == nil {
+				t.Fatal("ProcessRequest should return an error when an artifact cannot be loaded, but got nil")
+			}
+			if got := strings.Count(err.Error(), "failed to load artifact"); got != 1 {
+				t.Errorf("error names the failure %d times, want once: %v", got, err)
+			}
+			if !errors.Is(err, fs.ErrNotExist) {
+				t.Errorf("errors.Is(err, fs.ErrNotExist) = false, want true, got: %v", err)
 			}
 		})
 	}


### PR DESCRIPTION
### Link to Issue or Description of Change

- Related: #866

**Problem:**

`loadIndividualArtifact` already wraps the service error with the artifact name (`tool/loadartifactstool/load_artifacts_tool.go:230`), and its only caller wraps the result again with the same format string (`:212`), so the phrase and the filename reach callers and logs twice: `failed to load artifact report.pdf: failed to load artifact report.pdf: artifact not found: file does not exist`.

**Solution:**

Drop the outer wrap and return the error as it comes back, leaving `failed to load artifact report.pdf: artifact not found: file does not exist`. Either wrap could go, since the inner one is the only caller of `loadIndividualArtifact`; keeping the inner one leaves the message identical for the instruction-loading path in `internal/llminternal/instruction_processor.go:141`, which already reads the same way. #866 is open against this file for unsupported MIME types and its hunks sit at the import block and at `loadIndividualArtifact`'s return, so it neither makes nor conflicts with this change.

### Behavior change

A caller that reads the error text from a failed `load_artifacts` request sees `failed to load artifact <name>` once instead of twice. The wrapped cause is unchanged, so `errors.Is` and `errors.As` behave as before.

### Testing Plan

**Unit Tests:**

- [x] All unit tests pass locally.

`go test -race -count=1 ./tool/loadartifactstool/` → `ok google.golang.org/adk/v2/tool/loadartifactstool 1.339s`. The full module loop from `AGENTS.md` is green in both modules: 88 packages ok, `golangci-lint run` (v2.3.1) 0 issues, `go mod tidy -diff` clean.

**With your source change reverted and your tests kept, which test fails?**

`TestLoadArtifactsTool_ProcessRequest_LoadError`, both cases: `error names the failure 2 times, want once: failed to load artifact missing.txt: failed to load artifact missing.txt: artifact not found: file does not exist`.

**Manual End-to-End (E2E) Tests:**

Covered by the new test, which drives `ProcessRequest` with a real in-memory artifact service and a `load_artifacts` function response naming an artifact that was never saved. No model or network call is involved in this path.

### Checklist

- [x] I have read the [CONTRIBUTING.md](https://github.com/google/adk-go/blob/main/CONTRIBUTING.md) document.
- [x] I have performed a self-review of my own code.
- [ ] I have commented my code, particularly in hard-to-understand areas.
- [x] I have added tests that prove my fix is effective or that my feature works.
- [x] New and existing unit tests pass locally with my changes.
- [x] I have manually tested my changes end-to-end.
- [ ] Any dependent changes have been merged and published in downstream modules.
