### PR TITLE
fix(session/inmemory): holding sess.mu accross the eventCopy creation in AppendEvent

### DIFF
--- a/session/inmemory.go
+++ b/session/inmemory.go
@@ -227,6 +227,8 @@ func (s *inMemoryService) AppendEvent(ctx context.Context, curSession Session, e
 	}
 
 	// update the in-memory session
+	// Keep the session locked until eventCopy clones the action maps. Otherwise,
+	// concurrent Session.Events readers can mutate them, potentially causing a data race.
 	sess.mu.Lock()
 	defer sess.mu.Unlock()
 	if err := sess.appendEvent(event); err != nil {
@@ -458,6 +460,8 @@ func trimTempDeltaState(event *Event) *Event {
 	}
 
 	// Create a copy of the event to avoid mutating the original.
+	// The live session exposes this event through Session.Events. Clone its
+	// remaining action maps so they are not shared with the caller's event.
 	eventCopy := *event
 	eventCopy.Actions.StateDelta = filteredStateDelta
 	eventCopy.Actions.ArtifactDelta = maps.Clone(event.Actions.ArtifactDelta)

--- a/session/inmemory.go
+++ b/session/inmemory.go
@@ -227,8 +227,6 @@ func (s *inMemoryService) AppendEvent(ctx context.Context, curSession Session, e
 	}
 
 	// update the in-memory session
-	sess.mu.Lock()
-	defer sess.mu.Unlock()
 	if err := sess.appendEvent(event); err != nil {
 		return fmt.Errorf("fail to set state on appendEvent: %w", err)
 	}
@@ -365,6 +363,8 @@ func (s *session) appendEvent(event *Event) error {
 		return nil
 	}
 
+	s.mu.Lock()
+	defer s.mu.Unlock()
 	if err := updateSessionState(s, event); err != nil {
 		return fmt.Errorf("error on appendEvent: %w", err)
 	}
@@ -462,9 +462,6 @@ func trimTempDeltaState(event *Event) *Event {
 	eventCopy.Actions.StateDelta = filteredStateDelta
 	eventCopy.Actions.ArtifactDelta = maps.Clone(event.Actions.ArtifactDelta)
 	eventCopy.Actions.RequestedToolConfirmations = maps.Clone(event.Actions.RequestedToolConfirmations)
-	eventCopy.Actions.Compaction = event.Actions.Compaction.clone()
-	eventCopy.LongRunningToolIDs = slices.Clone(event.LongRunningToolIDs)
-	eventCopy.Routes = slices.Clone(event.Routes)
 
 	return &eventCopy
 }

--- a/session/inmemory.go
+++ b/session/inmemory.go
@@ -227,6 +227,8 @@ func (s *inMemoryService) AppendEvent(ctx context.Context, curSession Session, e
 	}
 
 	// update the in-memory session
+	sess.mu.Lock()
+	defer sess.mu.Unlock()
 	if err := sess.appendEvent(event); err != nil {
 		return fmt.Errorf("fail to set state on appendEvent: %w", err)
 	}
@@ -363,8 +365,6 @@ func (s *session) appendEvent(event *Event) error {
 		return nil
 	}
 
-	s.mu.Lock()
-	defer s.mu.Unlock()
 	if err := updateSessionState(s, event); err != nil {
 		return fmt.Errorf("error on appendEvent: %w", err)
 	}

--- a/session/inmemory.go
+++ b/session/inmemory.go
@@ -227,6 +227,8 @@ func (s *inMemoryService) AppendEvent(ctx context.Context, curSession Session, e
 	}
 
 	// update the in-memory session
+	sess.mu.Lock()
+	defer sess.mu.Unlock()
 	if err := sess.appendEvent(event); err != nil {
 		return fmt.Errorf("fail to set state on appendEvent: %w", err)
 	}
@@ -363,9 +365,6 @@ func (s *session) appendEvent(event *Event) error {
 		return nil
 	}
 
-	s.mu.Lock()
-	defer s.mu.Unlock()
-
 	if err := updateSessionState(s, event); err != nil {
 		return fmt.Errorf("error on appendEvent: %w", err)
 	}
@@ -461,6 +460,11 @@ func trimTempDeltaState(event *Event) *Event {
 	// Create a copy of the event to avoid mutating the original.
 	eventCopy := *event
 	eventCopy.Actions.StateDelta = filteredStateDelta
+	eventCopy.Actions.ArtifactDelta = maps.Clone(event.Actions.ArtifactDelta)
+	eventCopy.Actions.RequestedToolConfirmations = maps.Clone(event.Actions.RequestedToolConfirmations)
+	eventCopy.Actions.Compaction = event.Actions.Compaction.clone()
+	eventCopy.LongRunningToolIDs = slices.Clone(event.LongRunningToolIDs)
+	eventCopy.Routes = slices.Clone(event.Routes)
 
 	return &eventCopy
 }

--- a/session/inmemory_test.go
+++ b/session/inmemory_test.go
@@ -327,3 +327,45 @@ func TestArtifactDeltaRace(t *testing.T) {
 	close(stop)
 	<-done
 }
+
+// When No temporary state delta key exist, trimTempDeltaState return exact event
+// So, events published into sess.events shares actions maps with concurrent Session.Event() readers,
+// which may be read or cloned by AppendEvent casuing race condition.
+func TestArtifactDeltaRaceNoTemp(t *testing.T) {
+	svc := session.InMemoryService()
+	cr, _ := svc.Create(t.Context(), &session.CreateRequest{AppName: "app", UserID: "u"})
+	live := cr.Session
+	stop := make(chan struct{})
+	done := make(chan struct{})
+	go func() {
+		defer close(done)
+		for {
+			select {
+			case <-stop:
+				return
+			default:
+			}
+			evs := live.Events()
+			if n := evs.Len(); n > 0 {
+				if e := evs.At(n - 1); e != nil && e.Actions.ArtifactDelta != nil {
+					e.Actions.ArtifactDelta["injected"] = 1
+				}
+			}
+		}
+	}()
+	for i := range 20000 {
+		ev := &session.Event{
+			ID:        fmt.Sprintf("e%d", i),
+			Timestamp: time.Now(),
+			Actions: session.EventActions{
+				StateDelta:    map[string]any{"k": i},
+				ArtifactDelta: map[string]int64{"a": int64(i)},
+			},
+		}
+		if err := svc.AppendEvent(t.Context(), live, ev); err != nil {
+			t.Fatal(err)
+		}
+	}
+	close(stop)
+	<-done
+}

--- a/session/inmemory_test.go
+++ b/session/inmemory_test.go
@@ -15,6 +15,7 @@
 package session_test
 
 import (
+	"fmt"
 	"strings"
 	"sync"
 	"sync/atomic"
@@ -286,4 +287,43 @@ func TestInMemoryService_AppendEvent_CopiesCompaction(t *testing.T) {
 	if txt := stored.CompactedContent.Parts[0].Text; txt != "summary" {
 		t.Errorf("stored summary = %q, want %q: the caller rewrote the stored content", txt, "summary")
 	}
+}
+
+func TestArtifactDeltaRace(t *testing.T) {
+	svc := session.InMemoryService()
+	cr, _ := svc.Create(t.Context(), &session.CreateRequest{AppName: "app", UserID: "u"})
+	live := cr.Session
+	stop := make(chan struct{})
+	done := make(chan struct{})
+	go func() {
+		defer close(done)
+		for {
+			select {
+			case <-stop:
+				return
+			default:
+			}
+			evs := live.Events()
+			if n := evs.Len(); n > 0 {
+				if e := evs.At(n - 1); e != nil && e.Actions.ArtifactDelta != nil {
+					e.Actions.ArtifactDelta["injected"] = 1
+				}
+			}
+		}
+	}()
+	for i := range 20000 {
+		ev := &session.Event{
+			ID:        fmt.Sprintf("e%d", i),
+			Timestamp: time.Now(),
+			Actions: session.EventActions{
+				StateDelta:    map[string]any{"temp:t": i, "k": i},
+				ArtifactDelta: map[string]int64{"a": int64(i)},
+			},
+		}
+		if err := svc.AppendEvent(t.Context(), live, ev); err != nil {
+			t.Fatal(err)
+		}
+	}
+	close(stop)
+	<-done
 }


### PR DESCRIPTION
### Link to Issue or Description of Change

**1. Link to an existing issue (if applicable):**

- Closes: #1560 

**Problem:**
`inMemoryService.AppendEvent` can race with callers that read the live session through `Session.Events()` and mutate an event’s action maps. When `trimTempDeltaState` removes temporary state, it shallow-copies the event and retains references to mutable fields such as ArtifactDelta and RequestedToolConfirmations.So, the event published into `sess.events` shares `ArtifactDelta` and `RequestedToolConfirmations` with the caller's event. The live session can therefore expose an event whose maps are exactly the one being read or cloned by AppendEvent.

**Solution:**
Move the session lock from `sess.appendEvent` to `inMemoryService.AppendEvent` and hold it for the full append operation. This prevents Events() from exposing the newly appended live event until AppendEvent has finished reading or cloning event's actions maps.
When temporary state is removed by `trimTempDeltaState`, cloned the remaining mutable action maps (`ArtifactDelta` and `RequestedToolConfirmations`).So, the event published into `sess.events` do not share Actions maps with the caller's event.

### Behavior change
`AppendEvent` now prevents concurrent `Session.Events()` readers from observing a newly appended event until its maps have been copied, avoiding fatal error `concurrent map clone and map write`.
`sess.appendEvent` now holds independent action maps when creating eventCopy,  preventing concurrent `Session.Events()` readers from mutating maps that `AppendEvent` is still cloning.

### Testing Plan

- [x] Added `TestArtifactDeltaRace` and `TestArtifactDeltaRaceNoTemp`, which appends events while another goroutine retrieves the newest live event and writes its `ArtifactDelta`

**Unit Tests:**

- [x] All unit tests pass locally.

**With your source change reverted and your tests kept, which test fails?**
`TestArtifactDeltaRace` and `TestArtifactDeltaRaceNoTemp` in `session/inmemory_test.go` fails without holding `sess.mu` through eventCopy creation (if `trimTempDeltaState` return eventCopy untouched), reproducing `fatal error: concurrent map clone and map write`.
```
deepak@deepakdhakad:~/adk-go$ go test -count=1 ./session -run TestArtifactDeltaRace -v
=== RUN   TestArtifactDeltaRace
--- PASS: TestArtifactDeltaRace (0.09s)
PASS
ok      google.golang.org/adk/v2/s
deepak@deepakdhakad:~/adk-go$ go test -race -count=1 ./session/
ok      google.golang.org/adk/v2/session        1.459s
deepak@deepakdhakad:~/adk-go$ 
```
### Checklist

- [x] I have read the [CONTRIBUTING.md](https://github.com/google/adk-go/blob/main/CONTRIBUTING.md) document.
- [x] I have performed a self-review of my own code.
- [x] I have commented my code, particularly in hard-to-understand areas.
- [x] I have added tests that prove my fix is effective or that my feature works.
- [x] New and existing unit tests pass locally with my changes.
- [x] I have manually tested my changes end-to-end.

