### PR TITLE
fix: backport session fixes (#1559, #1458)

### DIFF
--- a/session/database/service.go
+++ b/session/database/service.go
@@ -159,7 +159,9 @@ func (s *databaseService) Get(ctx context.Context, req *session.GetRequest) (*se
 		}).
 		First(&foundSession).Error
 	if err != nil {
-		// For any error including ErrRecordNotFound, return it as a system error.
+		if errors.Is(err, gorm.ErrRecordNotFound) {
+			return nil, fmt.Errorf("%w: %q: %w", session.ErrNotFound, sessionID, err)
+		}
 		return nil, fmt.Errorf("database error while fetching session: %w", err)
 	}
 
@@ -359,16 +361,16 @@ func (s *databaseService) AppendEvent(ctx context.Context, curSession session.Se
 
 // applyEvent fetches the session, validates it, applies state changes from an
 // event, and saves the event atomically.
-func (s *databaseService) applyEvent(ctx context.Context, session *localSession, event *session.Event) error {
+func (s *databaseService) applyEvent(ctx context.Context, sess *localSession, event *session.Event) error {
 	// Wrap database operations in a single transaction.
 	err := s.db.WithContext(ctx).Transaction(func(tx *gorm.DB) error {
 		// Fetch the session object from storage.
 		var storageSess storageSession
-		err := tx.Where(&storageSession{AppName: session.AppName(), UserID: session.UserID(), ID: session.ID()}).
+		err := tx.Where(&storageSession{AppName: sess.AppName(), UserID: sess.UserID(), ID: sess.ID()}).
 			First(&storageSess).Error
 		if err != nil {
 			if errors.Is(err, gorm.ErrRecordNotFound) {
-				return fmt.Errorf("session not found, cannot apply event")
+				return fmt.Errorf("%w: %q, cannot apply event: %w", session.ErrNotFound, sess.ID(), err)
 			}
 			return fmt.Errorf("failed to get session: %w", err)
 		}
@@ -376,7 +378,7 @@ func (s *databaseService) applyEvent(ctx context.Context, session *localSession,
 		// Ensure the session object is not stale.
 		// We use UnixMicro() for microsecond-level precision, matching the Python code.
 		storageUpdateTime := storageSess.UpdateTime.UnixMicro()
-		sessionUpdateTime := session.updatedAt.UnixMicro()
+		sessionUpdateTime := sess.updatedAt.UnixMicro()
 		if storageUpdateTime > sessionUpdateTime {
 			return fmt.Errorf(
 				"stale session error: last update time from request (%s) is older than in database (%s)",
@@ -386,11 +388,11 @@ func (s *databaseService) applyEvent(ctx context.Context, session *localSession,
 		}
 
 		// Fetch App and User states.
-		storageApp, err := fetchStorageAppState(tx, session.AppName())
+		storageApp, err := fetchStorageAppState(tx, sess.AppName())
 		if err != nil {
 			return err
 		}
-		storageUser, err := fetchStorageUserState(tx, session.AppName(), session.UserID())
+		storageUser, err := fetchStorageUserState(tx, sess.AppName(), sess.UserID())
 		if err != nil {
 			return err
 		}
@@ -421,7 +423,7 @@ func (s *databaseService) applyEvent(ctx context.Context, session *localSession,
 		}
 
 		// Create the new event record in the database.
-		storageEv, err := createStorageEvent(session, event)
+		storageEv, err := createStorageEvent(sess, event)
 		if err != nil {
 			return fmt.Errorf("failed to map event to storage model: %w", err)
 		}
@@ -435,7 +437,7 @@ func (s *databaseService) applyEvent(ctx context.Context, session *localSession,
 			return fmt.Errorf("failed to save session state: %w", err)
 		}
 
-		session.updatedAt = storageSess.UpdateTime
+		sess.updatedAt = storageSess.UpdateTime
 
 		return nil // Returning nil commits the transaction.
 	})

--- a/session/database/session.go
+++ b/session/database/session.go
@@ -18,6 +18,7 @@ import (
 	"fmt"
 	"iter"
 	"maps"
+	"slices"
 	"strings"
 	"sync"
 	"time"
@@ -58,7 +59,11 @@ func (s *localSession) State() session.State {
 }
 
 func (s *localSession) Events() session.Events {
-	return events(s.events)
+	s.mu.RLock()
+	defer s.mu.RUnlock()
+
+	// Return a snapshot so callers can iterate without holding the session lock.
+	return events(slices.Clone(s.events))
 }
 
 func (s *localSession) LastUpdateTime() time.Time {

--- a/session/database/session_test.go
+++ b/session/database/session_test.go
@@ -1,0 +1,88 @@
+// Copyright 2025 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package database
+
+import (
+	"fmt"
+	"runtime"
+	"sync"
+	"testing"
+
+	"google.golang.org/adk/session"
+)
+
+func TestLocalSessionEventsSnapshot(t *testing.T) {
+	first := &session.Event{ID: "first"}
+	s := &localSession{events: []*session.Event{first}}
+	snapshot := s.Events()
+
+	// Replacing a slot must not change a previously returned history snapshot.
+	s.mu.Lock()
+	s.events[0] = &session.Event{ID: "replacement"}
+	s.mu.Unlock()
+	if err := s.appendEvent(&session.Event{ID: "second"}); err != nil {
+		t.Fatal(err)
+	}
+	if got := snapshot.Len(); got != 1 {
+		t.Fatalf("snapshot.Len() = %d, want 1", got)
+	}
+	if got := snapshot.At(0); got != first {
+		t.Errorf("snapshot.At(0) = %v, want original event %v", got, first)
+	}
+	for event := range snapshot.All() {
+		if event != first {
+			t.Errorf("snapshot.All() yielded %v, want original event %v", event, first)
+		}
+	}
+}
+
+func TestLocalSessionEventsConcurrentAppend(t *testing.T) {
+	const count = 1000
+	s := &localSession{}
+	start := make(chan struct{})
+	var wg sync.WaitGroup
+	wg.Add(1)
+	go func() {
+		defer wg.Done()
+		<-start
+		for i := range count {
+			if err := s.appendEvent(&session.Event{ID: fmt.Sprint(i)}); err != nil {
+				t.Errorf("appendEvent: %v", err)
+				return
+			}
+			runtime.Gosched()
+		}
+	}()
+	close(start)
+	for range count {
+		snapshot := s.Events()
+		n := 0
+		for event := range snapshot.All() {
+			if event == nil || event.ID != fmt.Sprint(n) {
+				t.Errorf("snapshot event %d = %v, want ID %q", n, event, fmt.Sprint(n))
+				break
+			}
+			n++
+		}
+		if n != snapshot.Len() {
+			t.Errorf("snapshot iteration count = %d, want %d", n, snapshot.Len())
+		}
+		runtime.Gosched()
+	}
+	wg.Wait()
+	if got := s.Events().Len(); got != count {
+		t.Errorf("final event count = %d, want %d", got, count)
+	}
+}

--- a/session/inmemory.go
+++ b/session/inmemory.go
@@ -109,7 +109,7 @@ func (s *inMemoryService) Get(ctx context.Context, req *GetRequest) (*GetRespons
 
 	res, ok := s.sessions.Get(id.Encode())
 	if !ok {
-		return nil, fmt.Errorf("session %+v not found", req.SessionID)
+		return nil, fmt.Errorf("%w: %q", ErrNotFound, req.SessionID)
 	}
 
 	copiedSession := copySessionWithoutStateAndEvents(res)
@@ -215,7 +215,7 @@ func (s *inMemoryService) AppendEvent(ctx context.Context, curSession Session, e
 
 	stored_session, ok := s.sessions.Get(sess.id.Encode())
 	if !ok {
-		return fmt.Errorf("session not found, cannot apply event")
+		return fmt.Errorf("%w: %q, cannot apply event", ErrNotFound, sess.id.sessionID)
 	}
 
 	// update the in-memory session

--- a/session/service.go
+++ b/session/service.go
@@ -16,8 +16,29 @@ package session
 
 import (
 	"context"
+	"errors"
 	"time"
 )
+
+// ErrNotFound reports that the requested session does not exist.
+//
+// Every [Service] implementation wraps it from [Service.Get] and from
+// [Service.AppendEvent] when the session named in the request is absent, so
+// that a caller can tell a missing session from a storage failure:
+//
+//	if errors.Is(err, session.ErrNotFound) { … }
+//
+// No other method reports it, because no other method treats a missing session
+// as a failure: [Service.Delete] is a no-op on one, and [Service.List] returns
+// an empty result. Nor does it cover every error those two methods can return.
+// A request that names a session belonging to another user, one that fails
+// validation, and a backend that is simply unreachable all stay ordinary
+// errors, so errors.Is never reads "not yours", "not valid" or "not working"
+// as "not there".
+//
+// The REST layer relies on this to answer 404 rather than 500. Wrap it first,
+// as fmt.Errorf("%w: …: %w", session.ErrNotFound, err).
+var ErrNotFound = errors.New("session not found")
 
 // Service is a session storage service.
 //

--- a/session/sessiontestsuite/service_suite.go
+++ b/session/sessiontestsuite/service_suite.go
@@ -15,6 +15,7 @@
 package sessiontestsuite
 
 import (
+	"errors"
 	"strconv"
 	"testing"
 	"time"
@@ -378,6 +379,11 @@ func RunServiceTests(t *testing.T, opts SuiteOptions, setup func(t *testing.T) s
 		})
 		if err == nil {
 			t.Errorf("Expected error when getting deleted session")
+		} else if !errors.Is(err, session.ErrNotFound) {
+			// A Service that reports a missing session as a plain error leaves
+			// callers unable to tell it from a storage failure, so the REST
+			// layer answers 500 where it owes the client a 404.
+			t.Errorf("Get(deleted session) error = %v, want an error wrapping session.ErrNotFound", err)
 		}
 
 		if opts.SupportsUserProvidedSessionID {
@@ -436,6 +442,41 @@ func RunServiceTests(t *testing.T, opts SuiteOptions, setup func(t *testing.T) s
 			err := s.AppendEvent(ctx, m, event)
 			if err == nil {
 				t.Errorf("AppendEvent() expected error for non-existent session, got nil")
+			}
+		})
+
+		t.Run("when_session_deleted_returns_ErrNotFound", func(t *testing.T) {
+			s := setup(t)
+			ctx := t.Context()
+
+			created, err := s.Create(ctx, &session.CreateRequest{AppName: testAppName, UserID: "user1"})
+			if err != nil {
+				t.Fatalf("Setup: Create failed: %v", err)
+			}
+			if err := s.Delete(ctx, &session.DeleteRequest{
+				AppName:   testAppName,
+				UserID:    "user1",
+				SessionID: created.Session.ID(),
+			}); err != nil {
+				t.Fatalf("Setup: Delete failed: %v", err)
+			}
+
+			// Unlike the case above, this passes the service a session of its
+			// own type, so it reaches the storage lookup instead of stopping at
+			// a type check. A session can disappear between a caller reading it
+			// and appending to it — the REST UpdateSessionHandler does exactly
+			// that Get-then-append — and the handler owes the client a 404 for
+			// it, which it can only tell from a storage failure by the sentinel.
+			err = s.AppendEvent(ctx, created.Session, &session.Event{
+				ID:           "event1",
+				Author:       "user",
+				InvocationID: "inv1",
+			})
+			if err == nil {
+				t.Fatalf("AppendEvent(deleted session) error = nil, want an error wrapping session.ErrNotFound")
+			}
+			if !errors.Is(err, session.ErrNotFound) {
+				t.Errorf("AppendEvent(deleted session) error = %v, want an error wrapping session.ErrNotFound", err)
 			}
 		})
 

--- a/session/vertexai/delete_ownership_test.go
+++ b/session/vertexai/delete_ownership_test.go
@@ -43,13 +43,48 @@ import (
 type fakeSessions struct {
 	aiplatformpb.UnimplementedSessionServiceServer
 	deletes atomic.Int32
+	// appends counts AppendEvent RPCs, so a test can tell a backend error
+	// apart from a local short-circuit that never reached the server.
+	appends atomic.Int32
 }
 
 func (f *fakeSessions) GetSession(_ context.Context, req *aiplatformpb.GetSessionRequest) (*aiplatformpb.Session, error) {
-	if strings.HasSuffix(req.GetName(), "/sessions/owned") {
+	switch {
+	case strings.HasSuffix(req.GetName(), "/sessions/owned"):
 		return &aiplatformpb.Session{Name: req.GetName(), UserId: "user1", UpdateTime: timestamppb.Now()}, nil
+	// "denied" stands for any backend refusal that is not a missing session.
+	// It must not come back as session.ErrNotFound.
+	case strings.HasSuffix(req.GetName(), "/sessions/denied"):
+		return nil, status.Errorf(codes.PermissionDenied, "caller cannot read %s", req.GetName())
+	default:
+		return nil, status.Errorf(codes.NotFound, "Session %s not found.", req.GetName())
 	}
-	return nil, status.Errorf(codes.NotFound, "Session %s not found.", req.GetName())
+}
+
+func (f *fakeSessions) ListEvents(_ context.Context, req *aiplatformpb.ListEventsRequest) (*aiplatformpb.ListEventsResponse, error) {
+	// Get fetches the session and its events concurrently, so this has to agree
+	// with GetSession about which sessions exist. Leaving it unimplemented lets
+	// a gRPC Unimplemented error win the race and mask the real not-found.
+	switch {
+	case strings.HasSuffix(req.GetParent(), "/sessions/owned"):
+		return &aiplatformpb.ListEventsResponse{}, nil
+	case strings.HasSuffix(req.GetParent(), "/sessions/denied"):
+		return nil, status.Errorf(codes.PermissionDenied, "caller cannot read %s", req.GetParent())
+	default:
+		return nil, status.Errorf(codes.NotFound, "Session %s not found.", req.GetParent())
+	}
+}
+
+func (f *fakeSessions) AppendEvent(_ context.Context, req *aiplatformpb.AppendEventRequest) (*aiplatformpb.AppendEventResponse, error) {
+	f.appends.Add(1)
+	switch {
+	case strings.HasSuffix(req.GetName(), "/sessions/owned"):
+		return &aiplatformpb.AppendEventResponse{}, nil
+	case strings.HasSuffix(req.GetName(), "/sessions/denied"):
+		return nil, status.Errorf(codes.PermissionDenied, "caller cannot write %s", req.GetName())
+	default:
+		return nil, status.Errorf(codes.NotFound, "Session %s not found.", req.GetName())
+	}
 }
 
 func (f *fakeSessions) DeleteSession(_ context.Context, req *aiplatformpb.DeleteSessionRequest) (*longrunningpb.Operation, error) {

--- a/session/vertexai/notfound_test.go
+++ b/session/vertexai/notfound_test.go
@@ -1,0 +1,117 @@
+// Copyright 2026 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package vertexai
+
+import (
+	"errors"
+	"testing"
+
+	"google.golang.org/adk/session"
+)
+
+// The shared suite covers Get and AppendEvent on a missing session for every
+// session.Service, but this package can only run a suite case that has recorded
+// Agent Engine traffic to replay, and recording needs a live backend. These
+// tests pin the same behavior against the in-process fake in
+// delete_ownership_test.go, which needs no network and no recording. They are
+// what service_test.go's casesWithoutReplay points at.
+//
+// They also pin the other half of the contract: an error that is not a missing
+// session must not come back as session.ErrNotFound, or the REST layer answers
+// 404 for a backend failure and the client retries something that will never
+// work.
+
+func TestGet_missingSession_wrapsErrNotFound(t *testing.T) {
+	s, _ := newFakeService(t)
+
+	_, err := s.Get(t.Context(), &session.GetRequest{AppName: "123", UserID: "user1", SessionID: "other"})
+	if err == nil {
+		t.Fatalf("Get(missing session) error = nil, want an error wrapping session.ErrNotFound")
+	}
+	if !errors.Is(err, session.ErrNotFound) {
+		t.Errorf("Get(missing session) error = %v, want an error wrapping session.ErrNotFound", err)
+	}
+}
+
+func TestGet_permissionDenied_isNotErrNotFound(t *testing.T) {
+	s, _ := newFakeService(t)
+
+	_, err := s.Get(t.Context(), &session.GetRequest{AppName: "123", UserID: "user1", SessionID: "denied"})
+	if err == nil {
+		t.Fatalf("Get(unreadable session) error = nil, want a permission error")
+	}
+	if errors.Is(err, session.ErrNotFound) {
+		t.Errorf("Get(unreadable session) error = %v, want an error that is NOT session.ErrNotFound", err)
+	}
+}
+
+// A session that exists but belongs to someone else is not a missing session:
+// reporting it as one would let a caller distinguish "no such session" from
+// "not yours" by probing, and would have the REST layer answer 404 for what is
+// really a refusal.
+func TestGet_wrongUser_isNotErrNotFound(t *testing.T) {
+	s, _ := newFakeService(t)
+
+	_, err := s.Get(t.Context(), &session.GetRequest{AppName: "123", UserID: "user2", SessionID: "owned"})
+	if err == nil {
+		t.Fatalf("Get(other user's session) error = nil, want an ownership error")
+	}
+	if errors.Is(err, session.ErrNotFound) {
+		t.Errorf("Get(other user's session) error = %v, want an error that is NOT session.ErrNotFound", err)
+	}
+}
+
+func TestAppendEvent_missingSession_wrapsErrNotFound(t *testing.T) {
+	s, fake := newFakeService(t)
+
+	sess := &localSession{appName: "123", userID: "user1", sessionID: "other"}
+	err := s.AppendEvent(t.Context(), sess, &session.Event{ID: "e1", Author: "user", InvocationID: "inv1"})
+	if err == nil {
+		t.Fatalf("AppendEvent(missing session) error = nil, want an error wrapping session.ErrNotFound")
+	}
+	if !errors.Is(err, session.ErrNotFound) {
+		t.Errorf("AppendEvent(missing session) error = %v, want an error wrapping session.ErrNotFound", err)
+	}
+	if got := fake.appends.Load(); got != 1 {
+		t.Errorf("AppendEvent RPCs = %d, want 1: the error must come from the backend, not from a local short-circuit", got)
+	}
+}
+
+func TestAppendEvent_permissionDenied_isNotErrNotFound(t *testing.T) {
+	s, _ := newFakeService(t)
+
+	sess := &localSession{appName: "123", userID: "user1", sessionID: "denied"}
+	err := s.AppendEvent(t.Context(), sess, &session.Event{ID: "e1", Author: "user", InvocationID: "inv1"})
+	if err == nil {
+		t.Fatalf("AppendEvent(unwritable session) error = nil, want a permission error")
+	}
+	if errors.Is(err, session.ErrNotFound) {
+		t.Errorf("AppendEvent(unwritable session) error = %v, want an error that is NOT session.ErrNotFound", err)
+	}
+}
+
+// The negative control: an append to a session that is there still succeeds, so
+// a wrap that fired on every error could not pass.
+func TestAppendEvent_existingSession_succeeds(t *testing.T) {
+	s, fake := newFakeService(t)
+
+	sess := &localSession{appName: "123", userID: "user1", sessionID: "owned"}
+	if err := s.AppendEvent(t.Context(), sess, &session.Event{ID: "e1", Author: "user", InvocationID: "inv1"}); err != nil {
+		t.Fatalf("AppendEvent(existing session) error = %v, want nil", err)
+	}
+	if got := fake.appends.Load(); got != 1 {
+		t.Errorf("AppendEvent RPCs = %d, want 1", got)
+	}
+}

--- a/session/vertexai/service_test.go
+++ b/session/vertexai/service_test.go
@@ -56,9 +56,25 @@ func Test_vertexaiService(t *testing.T) {
 	} // VertexAI forbids custom IDs
 	sessiontestsuite.RunServiceTests(t, opts, func(t *testing.T) session.Service {
 		name := strings.ReplaceAll(t.Name(), "/", "_")
+		if _, ok := casesWithoutReplay[name]; ok {
+			t.Skipf("no recorded Agent Engine traffic for %s; see casesWithoutReplay", name)
+		}
 		s, _ := emptyService(t, name, false)
 		return s
 	})
+}
+
+// casesWithoutReplay lists shared-suite cases this package cannot run, keyed by
+// the replay file they would need. Recording one requires a live Agent Engine,
+// so a case added to the suite after the last recording session has no traffic
+// to replay and would fail on the missing file rather than on the behavior.
+//
+// Skipping is not a pass: every entry names where the same behavior is pinned
+// instead, and those tests must stay.
+var casesWithoutReplay = map[string]string{
+	// Pinned offline against the in-process fake backend, by
+	// TestAppendEvent_missingSession_wrapsErrNotFound in notfound_test.go.
+	"Test_vertexaiService_AppendEvent_when_session_deleted_returns_ErrNotFound": "notfound_test.go",
 }
 
 func Test_vertexaiService_AppendEvent_StructuralValidation(t *testing.T) {

--- a/session/vertexai/session.go
+++ b/session/vertexai/session.go
@@ -18,6 +18,7 @@ import (
 	"fmt"
 	"iter"
 	"maps"
+	"slices"
 	"strings"
 	"sync"
 	"time"
@@ -58,7 +59,11 @@ func (s *localSession) State() session.State {
 }
 
 func (s *localSession) Events() session.Events {
-	return events(s.events)
+	s.mu.RLock()
+	defer s.mu.RUnlock()
+
+	// Return a snapshot so callers can iterate without holding the session lock.
+	return events(slices.Clone(s.events))
 }
 
 func (s *localSession) LastUpdateTime() time.Time {

--- a/session/vertexai/session_test.go
+++ b/session/vertexai/session_test.go
@@ -1,0 +1,88 @@
+// Copyright 2025 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package vertexai
+
+import (
+	"fmt"
+	"runtime"
+	"sync"
+	"testing"
+
+	"google.golang.org/adk/session"
+)
+
+func TestLocalSessionEventsSnapshot(t *testing.T) {
+	first := &session.Event{ID: "first"}
+	s := &localSession{events: []*session.Event{first}}
+	snapshot := s.Events()
+
+	// Replacing a slot must not change a previously returned history snapshot.
+	s.mu.Lock()
+	s.events[0] = &session.Event{ID: "replacement"}
+	s.mu.Unlock()
+	if err := s.appendEvent(&session.Event{ID: "second"}); err != nil {
+		t.Fatal(err)
+	}
+	if got := snapshot.Len(); got != 1 {
+		t.Fatalf("snapshot.Len() = %d, want 1", got)
+	}
+	if got := snapshot.At(0); got != first {
+		t.Errorf("snapshot.At(0) = %v, want original event %v", got, first)
+	}
+	for event := range snapshot.All() {
+		if event != first {
+			t.Errorf("snapshot.All() yielded %v, want original event %v", event, first)
+		}
+	}
+}
+
+func TestLocalSessionEventsConcurrentAppend(t *testing.T) {
+	const count = 1000
+	s := &localSession{}
+	start := make(chan struct{})
+	var wg sync.WaitGroup
+	wg.Add(1)
+	go func() {
+		defer wg.Done()
+		<-start
+		for i := range count {
+			if err := s.appendEvent(&session.Event{ID: fmt.Sprint(i)}); err != nil {
+				t.Errorf("appendEvent: %v", err)
+				return
+			}
+			runtime.Gosched()
+		}
+	}()
+	close(start)
+	for range count {
+		snapshot := s.Events()
+		n := 0
+		for event := range snapshot.All() {
+			if event == nil || event.ID != fmt.Sprint(n) {
+				t.Errorf("snapshot event %d = %v, want ID %q", n, event, fmt.Sprint(n))
+				break
+			}
+			n++
+		}
+		if n != snapshot.Len() {
+			t.Errorf("snapshot iteration count = %d, want %d", n, snapshot.Len())
+		}
+		runtime.Gosched()
+	}
+	wg.Wait()
+	if got := s.Events().Len(); got != count {
+		t.Errorf("final event count = %d, want %d", got, count)
+	}
+}

--- a/session/vertexai/vertexai.go
+++ b/session/vertexai/vertexai.go
@@ -72,29 +72,39 @@ func (s *vertexAiService) Get(ctx context.Context, req *session.GetRequest) (*se
 	g, gCtx := errgroup.WithContext(ctx)
 
 	var (
-		sess   *localSession
-		events []*session.Event
+		sess      *localSession
+		events    []*session.Event
+		getErr    error
+		eventsErr error
 	)
 
 	g.Go(func() error {
-		var err error
-		sess, err = s.client.getSession(gCtx, req)
-		if err != nil {
-			return fmt.Errorf("failed to get session: %w", err)
+		sess, getErr = s.client.getSession(gCtx, req)
+		if getErr != nil {
+			return fmt.Errorf("failed to get session: %w", getErr)
 		}
 		return nil
 	})
 
 	g.Go(func() error {
-		var err error
-		events, err = s.client.listSessionEvents(gCtx, req.AppName, req.SessionID, req.After, req.NumRecentEvents)
-		if err != nil {
-			return fmt.Errorf("failed to list session events: %w", err)
+		events, eventsErr = s.client.listSessionEvents(gCtx, req.AppName, req.SessionID, req.After, req.NumRecentEvents)
+		if eventsErr != nil {
+			return fmt.Errorf("failed to list session events: %w", eventsErr)
 		}
 		return nil
 	})
 
 	if err := g.Wait(); err != nil {
+		// Both calls run concurrently against the same session, so a missing
+		// one can surface from either, and whichever loses the race reports the
+		// context cancellation instead. Report the missing session whenever
+		// either call saw it, so callers can rely on
+		// errors.Is(err, session.ErrNotFound).
+		for _, callErr := range []error{getErr, eventsErr} {
+			if callErr != nil && isNotFoundError(callErr) {
+				return nil, fmt.Errorf("%w: %q: %w", session.ErrNotFound, req.SessionID, callErr)
+			}
+		}
 		return nil, err
 	}
 	sess.events = events

--- a/session/vertexai/vertexai_client.go
+++ b/session/vertexai/vertexai_client.go
@@ -17,6 +17,7 @@ package vertexai
 import (
 	"context"
 	"encoding/json"
+	"errors"
 	"fmt"
 	"math"
 	"regexp"
@@ -109,9 +110,13 @@ func (c *vertexAiClient) createSession(ctx context.Context, req *session.CreateR
 }
 
 func isNotFoundError(err error) bool {
-	// status.Code returns codes.Unknown if it's not a gRPC error,
-	// otherwise it returns the specific gRPC code.
-	return status.Code(err) == codes.NotFound
+	// status.Code returns codes.Unknown if it's not a gRPC error, otherwise the
+	// specific gRPC code, and it unwraps, so the first arm still sees a
+	// NOT_FOUND that getSession has wrapped in session.ErrNotFound. The
+	// sentinel arm is therefore redundant for every error the backend
+	// produces; it is kept because it is the only arm that catches
+	// getSession's nil-response guard, which carries no gRPC status.
+	return status.Code(err) == codes.NotFound || errors.Is(err, session.ErrNotFound)
 }
 
 // TODO replace with LRO wait when it's fixed
@@ -151,11 +156,24 @@ func (c *vertexAiClient) getSession(ctx context.Context, req *session.GetRequest
 	}
 	sessRpcResp, err := c.rpcClient.GetSession(ctx, sessRpcReq)
 	if err != nil {
+		// The Agent Engine answers a missing session with NOT_FOUND (HTTP 404).
+		// Get re-wraps this one rung up, because a NOT_FOUND can also surface
+		// from the concurrent ListEvents call, so this wrap is defence in depth
+		// rather than the load-bearing one: dropping it changes no observable
+		// behavior. It stays so that getSession's own contract does not depend
+		// on what its callers do with the error.
+		if status.Code(err) == codes.NotFound {
+			return nil, fmt.Errorf("%w: %q: %w", session.ErrNotFound, req.SessionID, err)
+		}
 		return nil, fmt.Errorf("error fetching session: %w", err)
 	}
 
+	// A nil response with a nil error is not something gRPC can deliver, so
+	// this guard is unreachable and untestable through the client. It stays
+	// because the alternative on an unexpected nil is a panic on the field
+	// reads below.
 	if sessRpcResp == nil {
-		return nil, fmt.Errorf("session %+v not found", req.SessionID)
+		return nil, fmt.Errorf("%w: %q", session.ErrNotFound, req.SessionID)
 	}
 	if sessRpcResp.UserId != req.UserID {
 		return nil, fmt.Errorf("session %s does not belong to user %s", req.SessionID, req.UserID)
@@ -307,6 +325,13 @@ func (c *vertexAiClient) appendEvent(ctx context.Context, appName, sessionID str
 		},
 	})
 	if err != nil {
+		// A session can be deleted between a caller reading it and appending to
+		// it, and the Agent Engine answers that with NOT_FOUND. Report it as
+		// session.ErrNotFound, as getSession does, so AppendEvent keeps the
+		// contract documented on the sentinel.
+		if status.Code(err) == codes.NotFound {
+			return fmt.Errorf("%w: %q, cannot append event: %w", session.ErrNotFound, sessionID, err)
+		}
 		return fmt.Errorf("error appending event: %w", err)
 	}
 


### PR DESCRIPTION
## Problem

Two session defects shipped in 2.4.0 and are still present on 1.x.

- `Events()` on the database and Vertex AI backends returns the live slice without holding the read lock, so a caller iterating a session races any concurrent append.
- A session that does not exist is reported as a generic error. Callers cannot distinguish "no such session" from a backend failure, which leaves every REST layer above guessing between 404 and 500.

## Summary

Backports #1559 and #1458.

- **#1559** takes the read lock and returns a snapshot, so callers can iterate without holding the session lock and without racing an append.
- **#1458** introduces the `session.ErrNotFound` sentinel and returns it from every backend when the session is missing.

Worth a deliberate look: #1458 adds a new exported symbol and changes the error returned on a missing session. That is an API addition on a maintenance branch, so it is the second commit here and can be dropped on its own if we would rather it waited. It is also a prerequisite for the ADK web UI endpoint backport, which needs the sentinel to answer 404 rather than 500.
