### PR TITLE
fix: backport base flow and content assembly fixes (#638, #908, #766, #1428)

### DIFF
--- a/internal/llminternal/base_flow.go
+++ b/internal/llminternal/base_flow.go
@@ -15,7 +15,9 @@
 package llminternal
 
 import (
+	"bytes"
 	"context"
+	"encoding/json"
 	"errors"
 	"fmt"
 	"io"
@@ -1059,6 +1061,53 @@ func (c *cancelledToolContext) Value(key any) any {
 	return c.cancelCtx.Value(key)
 }
 
+// displayableToolResultText renders a tool result as text for the case where
+// SkipSummarization suppresses the LLM's own summary of it. It returns
+// ok=false for results that carry nothing worth showing: error responses,
+// and empty or null results such as those from control-flow-only tools
+// (e.g. exitlooptool), which return no meaningful output of their own.
+//
+// Tools that wrap a single plain-text result under a "result" key (the
+// convention used by agenttool) are shown as-is; anything else is rendered
+// as JSON so structured results remain readable.
+func displayableToolResultText(result map[string]any) (string, bool) {
+	if len(result) == 0 {
+		return "", false
+	}
+	if _, isErr := result["error"]; isErr {
+		return "", false
+	}
+	if len(result) == 1 {
+		if v, ok := result["result"]; ok {
+			if v == nil {
+				return "", false
+			}
+			if text, ok := v.(string); ok {
+				return text, text != ""
+			}
+		}
+	}
+	b, err := marshalJSONNoHTMLEscape(result)
+	if err != nil {
+		return "", false
+	}
+	return string(b), true
+}
+
+// marshalJSONNoHTMLEscape is json.Marshal without HTML-escaping the output.
+// json.Marshal escapes '<', '>' and '&' (e.g. a URL's "&" becomes "&"),
+// which is meant for embedding JSON in HTML but only hurts readability of
+// text meant for a chat transcript.
+func marshalJSONNoHTMLEscape(v any) ([]byte, error) {
+	var buf bytes.Buffer
+	enc := json.NewEncoder(&buf)
+	enc.SetEscapeHTML(false)
+	if err := enc.Encode(v); err != nil {
+		return nil, err
+	}
+	return bytes.TrimRight(buf.Bytes(), "\n"), nil
+}
+
 // handleFunctionCalls calls the functions and returns the function response event.
 //
 // TODO: accept filters to include/exclude function calls.
@@ -1183,20 +1232,42 @@ func (f *Flow) handleFunctionCalls(ctx agent.InvocationContext, toolsDict map[st
 				}
 			}
 
+			parts := []*genai.Part{
+				{
+					FunctionResponse: &genai.FunctionResponse{
+						ID:       fnCall.ID,
+						Name:     fnCall.Name,
+						Response: result,
+					},
+				},
+			}
+			// SkipSummarization causes the parent agent loop to terminate on this
+			// event (see session.Event.IsFinalResponse) without the LLM ever
+			// seeing the function response. Since most UIs don't render function
+			// response parts, attach the result as a visible text part so it
+			// isn't silently dropped from the terminal event.
+			//
+			// This only applies to tools that opt in via
+			// SkipSummarizationResultDisplayer (agenttool): SkipSummarization is
+			// also set by tools whose result is an internal detail never meant
+			// for display - e.g. a pending tool confirmation (see
+			// RequestedToolConfirmations above) or a UI/widget tool's
+			// acknowledgement - and those must not have their result leaked into
+			// a visible text part.
+			if actions := toolCtx.Actions(); actions.SkipSummarization {
+				if displayer, ok := curTool.(toolinternal.SkipSummarizationResultDisplayer); ok && displayer.DisplayResultOnSkipSummarization() {
+					if text, ok := displayableToolResultText(result); ok {
+						parts = append(parts, &genai.Part{Text: text})
+					}
+				}
+			}
+
 			// TODO: handle long-running tool.
 			ev := session.NewEventWithContext(ctx, ctx.InvocationID())
 			ev.LLMResponse = model.LLMResponse{
 				Content: &genai.Content{
-					Role: "user",
-					Parts: []*genai.Part{
-						{
-							FunctionResponse: &genai.FunctionResponse{
-								ID:       fnCall.ID,
-								Name:     fnCall.Name,
-								Response: result,
-							},
-						},
-					},
+					Role:  "user",
+					Parts: parts,
 				},
 			}
 			ev.Author = ctx.Agent().Name()

--- a/internal/llminternal/base_flow.go
+++ b/internal/llminternal/base_flow.go
@@ -139,9 +139,13 @@ func (f *Flow) Run(ctx agent.InvocationContext) iter.Seq2[*session.Event, error]
 				return
 			}
 			if lastEvent.LLMResponse.Partial {
-				// We may have reached max token limit during streaming mode.
-				// TODO: handle Partial response in model level. CL 781377328
-				yield(nil, fmt.Errorf("TODO: last event is not final"))
+				// The last event is a partial streaming response. The realistic cause
+				// is a producer that ends a stream without a terminal aggregate (e.g.,
+				// an a2a peer whose stream ends on an appended artifact chunk with no
+				// terminal status). The turn was truncated, not completed, which is
+				// not expected, so we log a warning and return instead of looping again.
+				log.Printf("adk: agent %q (invocation %q): step ended on a partial event from %q; the producer did not close its stream with an aggregated final event, so the turn will not appear in session history",
+					ctx.Agent().Name(), ctx.InvocationID(), lastEvent.Author)
 				return
 			}
 		}

--- a/internal/llminternal/base_flow_test.go
+++ b/internal/llminternal/base_flow_test.go
@@ -434,6 +434,72 @@ func TestCallTool(t *testing.T) {
 	}
 }
 
+func TestDisplayableToolResultText(t *testing.T) {
+	tests := []struct {
+		name     string
+		result   map[string]any
+		wantText string
+		wantOK   bool
+	}{
+		{
+			name:   "empty result is not displayable",
+			result: map[string]any{},
+			wantOK: false,
+		},
+		{
+			name:   "error result is not displayable",
+			result: map[string]any{"error": "boom"},
+			wantOK: false,
+		},
+		{
+			name:   "empty string result is not displayable",
+			result: map[string]any{"result": ""},
+			wantOK: false,
+		},
+		{
+			name:   "nil result is not displayable",
+			result: map[string]any{"result": nil},
+			wantOK: false,
+		},
+		{
+			name:     "single plain-text result key is shown as-is",
+			result:   map[string]any{"result": "sub-agent output"},
+			wantText: "sub-agent output",
+			wantOK:   true,
+		},
+		{
+			name:     "non-string result key is rendered as JSON",
+			result:   map[string]any{"result": 42},
+			wantText: `{"result":42}`,
+			wantOK:   true,
+		},
+		{
+			name:     "structured result is rendered as JSON",
+			result:   map[string]any{"status": "ok", "count": 3},
+			wantText: `{"count":3,"status":"ok"}`,
+			wantOK:   true,
+		},
+		{
+			name:     "JSON output is not HTML-escaped",
+			result:   map[string]any{"url": "https://example.com/a&b<c>"},
+			wantText: `{"url":"https://example.com/a&b<c>"}`,
+			wantOK:   true,
+		},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			gotText, gotOK := displayableToolResultText(tc.result)
+			if gotOK != tc.wantOK {
+				t.Fatalf("displayableToolResultText(%v) ok = %v, want %v", tc.result, gotOK, tc.wantOK)
+			}
+			if gotOK && gotText != tc.wantText {
+				t.Errorf("displayableToolResultText(%v) = %q, want %q", tc.result, gotText, tc.wantText)
+			}
+		})
+	}
+}
+
 func TestMergeEventActions(t *testing.T) {
 	tests := []struct {
 		name  string

--- a/internal/llminternal/base_flow_test.go
+++ b/internal/llminternal/base_flow_test.go
@@ -15,9 +15,12 @@
 package llminternal
 
 import (
+	"bytes"
 	"context"
 	"errors"
+	"fmt"
 	"iter"
+	"log"
 	"testing"
 
 	"github.com/google/go-cmp/cmp"
@@ -799,4 +802,156 @@ func TestCallLLMStreamingModeWithoutContextRunConfig(t *testing.T) {
 	if !m.stream {
 		t.Errorf("GenerateContent received stream=%v, want true for SSE streaming mode", m.stream)
 	}
+}
+
+// TestFlowRunPartialLastEvent verifies that Flow.Run does not return an error
+// when the last event from runOneStep has Partial=true.
+// This is a regression test for https://github.com/google/adk-go/issues/600.
+func TestFlowRunPartialLastEvent(t *testing.T) {
+	tests := []struct {
+		name              string
+		modelResponses    []*model.LLMResponse
+		requestProcessors []func(ctx agent.InvocationContext, req *model.LLMRequest, f *Flow) iter.Seq2[*session.Event, error]
+		wantTexts         []string
+		wantLogAuthor     string
+	}{
+		{
+			name: "single partial response completes without error",
+			modelResponses: []*model.LLMResponse{
+				{
+					Content: genai.NewContentFromText("Hello", genai.RoleModel),
+					Partial: true,
+				},
+			},
+			wantTexts:     []string{"Hello"},
+			wantLogAuthor: "test-agent",
+		},
+		{
+			name: "multiple partial responses complete without error",
+			modelResponses: []*model.LLMResponse{
+				{
+					Content: genai.NewContentFromText("Hello", genai.RoleModel),
+					Partial: true,
+				},
+				{
+					Content: genai.NewContentFromText(" World", genai.RoleModel),
+					Partial: true,
+				},
+			},
+			wantTexts:     []string{"Hello", " World"},
+			wantLogAuthor: "test-agent",
+		},
+		{
+			name: "trailing partial from sub-agent completes without error",
+			requestProcessors: []func(ctx agent.InvocationContext, req *model.LLMRequest, f *Flow) iter.Seq2[*session.Event, error]{
+				func(ctx agent.InvocationContext, req *model.LLMRequest, f *Flow) iter.Seq2[*session.Event, error] {
+					return func(yield func(*session.Event, error) bool) {
+						ev := session.NewEventWithContext(ctx, ctx.InvocationID())
+						ev.Author = "sub-agent"
+						ev.LLMResponse = model.LLMResponse{
+							Content: genai.NewContentFromText("I am a sub-agent", genai.RoleModel),
+							Partial: true,
+						}
+						yield(ev, nil)
+					}
+				},
+			},
+			wantTexts:     []string{"I am a sub-agent"},
+			wantLogAuthor: "sub-agent",
+		},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			mockAgent, err := agent.New(agent.Config{Name: "test-agent"})
+			if err != nil {
+				t.Fatal(err)
+			}
+
+			invCtx := icontext.NewInvocationContext(t.Context(), icontext.InvocationContextParams{
+				Agent:     mockAgent,
+				RunConfig: &agent.RunConfig{StreamingMode: agent.StreamingModeSSE},
+			})
+
+			m := &mockModelForTest{
+				name: "test-model",
+				generateContent: func(_ context.Context, _ *model.LLMRequest, _ bool) iter.Seq2[*model.LLMResponse, error] {
+					return func(yield func(*model.LLMResponse, error) bool) {
+						for _, r := range tc.modelResponses {
+							if !yield(r, nil) {
+								return
+							}
+						}
+					}
+				},
+			}
+
+			f := &Flow{
+				Model:             m,
+				RequestProcessors: tc.requestProcessors,
+			}
+
+			var gotTexts []string
+			var gotErr error
+			// Bound the consumer so a regression fails the test instead of hanging it.
+			const safetyLimit = 50
+			eventsCount := 0
+
+			logOutput := captureLog(t, func() {
+				for ev, err := range f.Run(invCtx) {
+					if err != nil {
+						gotErr = err
+						break
+					}
+					eventsCount++
+					if eventsCount > safetyLimit {
+						t.Fatalf("Flow.Run() did not terminate: yielded >%d events", safetyLimit)
+					}
+					if ev != nil && ev.Content != nil {
+						for _, p := range ev.Content.Parts {
+							if p.Text != "" {
+								gotTexts = append(gotTexts, p.Text)
+							}
+						}
+					}
+				}
+			})
+
+			if gotErr != nil {
+				t.Errorf("Flow.Run() returned unexpected error: %v", gotErr)
+			}
+
+			if diff := cmp.Diff(tc.wantTexts, gotTexts); diff != "" {
+				t.Errorf("Flow.Run() text mismatch (-want +got):\n%s", diff)
+			}
+
+			wantLog := fmt.Sprintf("adk: agent %q (invocation %q): step ended on a partial event from %q; the producer did not close its stream with an aggregated final event, so the turn will not appear in session history\n",
+				invCtx.Agent().Name(), invCtx.InvocationID(), tc.wantLogAuthor)
+			if logOutput != wantLog {
+				t.Errorf("Flow.Run() log mismatch:\nwant: %q\ngot:  %q", wantLog, logOutput)
+			}
+		})
+	}
+}
+
+// captureLog redirects the output of the default [log.Logger] for the
+// duration of fn and returns everything that was written to it.
+func captureLog(t *testing.T, fn func()) string {
+	t.Helper()
+	var buf bytes.Buffer
+	origOut := log.Writer()
+	origFlags := log.Flags()
+	origPrefix := log.Prefix()
+	log.SetOutput(&buf)
+	// Reset flags/prefix so the captured output is deterministic and easy to
+	// assert against.
+	log.SetFlags(0)
+	log.SetPrefix("")
+	t.Cleanup(func() {
+		log.SetOutput(origOut)
+		log.SetFlags(origFlags)
+		log.SetPrefix(origPrefix)
+	})
+	fn()
+	return buf.String()
 }

--- a/internal/llminternal/contents_processor.go
+++ b/internal/llminternal/contents_processor.go
@@ -389,7 +389,15 @@ SearchLoop: // A label to allow breaking out of the nested loop
 // pair function calls with their corresponding responses, which is especially
 // useful for histories involving long running tool calls where
 // responses may not have originally been consecutive. It preserves all
-// non-tool-call events (like user messages) in their original order.
+// non-tool-call events (like user messages) in their original order relative
+// to one another. Their position relative to the surrounding tool exchanges
+// can change, because a pair routed to the tail moves past them.
+//
+// Adjacency alone is not enough. When the last event is a function response —
+// a long running tool completing after unrelated tool exchanges were already
+// recorded — pairing it with its much earlier call would bury it mid-history
+// and leave a stale exchange as the final content, which is what the model
+// answers. So the pair(s) answered by the last event are emitted last.
 //
 // It returns a new, correctly ordered slice of events or an error if the
 // history is malformed (e.g., a response is found without a corresponding call).
@@ -410,8 +418,18 @@ func rearrangeEventsForFunctionResponsesInHistory(events []*session.Event) ([]*s
 		}
 	}
 
-	// Rebuild the event list
-	var resultEvents []*session.Event
+	// Index of the last event when it is a function response, otherwise -1.
+	// Only a response event's index can appear in callIDToResponseEventIndex,
+	// so leaving this at -1 makes the relocation below a no-op for every
+	// history that does not end on a function response.
+	lastResponseEventIdx := -1
+	if len(utils.FunctionResponses(events[len(events)-1].Content)) > 0 {
+		lastResponseEventIdx = len(events) - 1
+	}
+
+	// Rebuild the event list. tailEvents holds the call/response pair(s)
+	// answered by the last event; it is appended after everything else.
+	var resultEvents, tailEvents []*session.Event
 
 	for _, event := range events {
 		// If the event contains responses, skip it. It will be handled
@@ -424,55 +442,75 @@ func rearrangeEventsForFunctionResponsesInHistory(events []*session.Event) ([]*s
 		if len(calls) == 0 {
 			// This is a regular event (e.g., user message). Just append it.
 			resultEvents = append(resultEvents, event)
+			continue
+		}
+
+		// This is a function call event. The call and its consolidated
+		// response move together as one unit, so the pair holds at most two
+		// events.
+		pair := make([]*session.Event, 0, 2)
+		pair = append(pair, event)
+
+		// Find the unique indices of all corresponding response events.
+		// Using a map[int]struct{} as a set.
+		responseEventIndicesSet := make(map[int]struct{})
+		for _, call := range calls {
+			if index, found := callIDToResponseEventIndex[call.ID]; found {
+				responseEventIndicesSet[index] = struct{}{}
+			}
+		}
+
+		switch len(responseEventIndicesSet) {
+		case 0:
+			// No responses were found for any call in this event. This is
+			// reachable: a long running tool or a deferring ResponseDeferrer
+			// produces a call with no response event of its own.
+		case 1:
+			// A single unique response event, so use it directly.
+			for index := range responseEventIndicesSet { // A trick to get the single key
+				pair = append(pair, events[index])
+			}
+		default:
+			// Multiple response events exist for that function call so we merge them.
+			//
+			// This branch does reach the tail routing below, on well-formed
+			// input. It needs one call event whose siblings are answered by two
+			// different response events, plus pass 1 leaving the history alone:
+			// rearrangeEventsForLatestFunctionResponse returns early when the
+			// event before the last one carries any call the last event
+			// answers, so it merges nothing. CALL(c1,c2) | RESP(c2) | CALL(c3)
+			// | RESP(c1,c3) does both, and CALL(c1,c2) merges here and then
+			// moves to the tail.
+			//
+			// Collect and sort the indices to process events in order.
+			var sortedIndices []int
+			for index := range responseEventIndicesSet {
+				sortedIndices = append(sortedIndices, index)
+			}
+			sort.Ints(sortedIndices)
+
+			// Collect the actual event objects to be merged.
+			eventsToMerge := make([]*session.Event, len(sortedIndices))
+			for i, index := range sortedIndices {
+				eventsToMerge[i] = events[index]
+			}
+
+			// Merge the events into a single response.
+			mergedEvent, err := mergeFunctionResponseEvents(eventsToMerge)
+			if err != nil {
+				return nil, fmt.Errorf("failed to merge response events: %w", err)
+			}
+			pair = append(pair, mergedEvent)
+		}
+
+		if _, answeredByLastEvent := responseEventIndicesSet[lastResponseEventIdx]; answeredByLastEvent {
+			tailEvents = append(tailEvents, pair...)
 		} else {
-			// This is a function call event, append it and search for responses
-			resultEvents = append(resultEvents, event)
-
-			// Find the unique indices of all corresponding response events.
-			// Using a map[int]struct{} as a set.
-			responseEventIndicesSet := make(map[int]struct{})
-			for _, call := range calls {
-				if index, found := callIDToResponseEventIndex[call.ID]; found {
-					responseEventIndicesSet[index] = struct{}{}
-				}
-			}
-
-			// If no responses were found for any calls in this event, continue.
-			if len(responseEventIndicesSet) == 0 {
-				continue
-			}
-
-			// If there's only one unique response event, append it directly.
-			if len(responseEventIndicesSet) == 1 {
-				for index := range responseEventIndicesSet { // A trick to get the single key
-					resultEvents = append(resultEvents, events[index])
-				}
-			} else {
-				// Multiple response events exist for that function call so we merge them.
-				// Collect and sort the indices to process events in order.
-				var sortedIndices []int
-				for index := range responseEventIndicesSet {
-					sortedIndices = append(sortedIndices, index)
-				}
-				sort.Ints(sortedIndices)
-
-				// Collect the actual event objects to be merged.
-				eventsToMerge := make([]*session.Event, len(sortedIndices))
-				for i, index := range sortedIndices {
-					eventsToMerge[i] = events[index]
-				}
-
-				// Merge the events and append the single result.
-				mergedEvent, err := mergeFunctionResponseEvents(eventsToMerge)
-				if err != nil {
-					return nil, fmt.Errorf("failed to merge response events: %w", err)
-				}
-				resultEvents = append(resultEvents, mergedEvent)
-			}
+			resultEvents = append(resultEvents, pair...)
 		}
 	}
 
-	return resultEvents, nil
+	return append(resultEvents, tailEvents...), nil
 }
 
 // mergeFunctionResponseEvents merges a list of function response events into one.

--- a/internal/llminternal/contents_processor.go
+++ b/internal/llminternal/contents_processor.go
@@ -18,6 +18,7 @@ import (
 	"encoding/json"
 	"fmt"
 	"iter"
+	"log"
 	"reflect"
 	"slices"
 	"sort"
@@ -65,6 +66,10 @@ func ContentsRequestProcessor(ctx agent.InvocationContext, req *model.LLMRequest
 // buildContentsDefault returns the contents for the LLM request by applying
 // filtering, rearrangement, and content processing to the given events.
 func buildContentsDefault(agentName, invocationBranch string, events []*session.Event) ([]*genai.Content, error) {
+	return buildContentsDefaultWithCallSource(agentName, invocationBranch, events, events)
+}
+
+func buildContentsDefaultWithCallSource(agentName, invocationBranch string, events, allEvents []*session.Event) ([]*genai.Content, error) {
 	// parse the events, leaving the contents and the function calls and responses from the current agent.
 	var filtered []*session.Event
 	for _, ev := range events {
@@ -140,6 +145,8 @@ func buildContentsDefault(agentName, invocationBranch string, events []*session.
 	}
 	filtered = processedEvents
 
+	filtered = dropOrphanedFunctionResponses(filtered, allEvents)
+
 	//  src/google/adk/flows/llm_flows/contents.py
 	// 	 - _rearrange_events_for_async_function_response
 	filtered, err := rearrangeEventsForLatestFunctionResponse(filtered)
@@ -184,6 +191,64 @@ func eventBelongsToBranch(invocationBranch string, event *session.Event) bool {
 	// (e.g. agent_0 unexpectedly matching agent_00), require either perfect branch
 	// match, or match prefix with an additional explicit '.'
 	return strings.HasPrefix(invocationBranch, event.Branch+".")
+}
+
+func dropOrphanedFunctionResponses(events, allEvents []*session.Event) []*session.Event {
+	callIDs := make(map[string]struct{})
+	for _, event := range allEvents {
+		for _, call := range utils.FunctionCalls(utils.Content(event)) {
+			if call.ID != "" {
+				callIDs[call.ID] = struct{}{}
+			}
+		}
+	}
+
+	isOrphan := func(part *genai.Part) bool {
+		if part == nil || part.FunctionResponse == nil || part.FunctionResponse.ID == "" {
+			return false
+		}
+		_, found := callIDs[part.FunctionResponse.ID]
+		return !found
+	}
+
+	var orphanedIDs []string
+	result := make([]*session.Event, 0, len(events))
+	for _, event := range events {
+		content := utils.Content(event)
+		if content == nil {
+			result = append(result, event)
+			continue
+		}
+
+		if !slices.ContainsFunc(content.Parts, isOrphan) {
+			result = append(result, event)
+			continue
+		}
+
+		cloned := cloneEvent(event)
+		parts := cloned.LLMResponse.Content.Parts[:0]
+		for _, part := range content.Parts {
+			if isOrphan(part) {
+				orphanedIDs = append(orphanedIDs, part.FunctionResponse.ID)
+				cleaned := *part
+				cleaned.FunctionResponse = nil
+				if reflect.ValueOf(cleaned).IsZero() {
+					continue
+				}
+				part = &cleaned
+			}
+			parts = append(parts, part)
+		}
+		cloned.LLMResponse.Content.Parts = parts
+		if len(cloned.LLMResponse.Content.Parts) > 0 {
+			result = append(result, cloned)
+		}
+	}
+
+	if len(orphanedIDs) > 0 {
+		log.Printf("adk: dropping function responses with no matching function call: %q", orphanedIDs)
+	}
+	return result
 }
 
 // rearrangeEventsForLatestFunctionResponse
@@ -510,7 +575,7 @@ func buildContentsCurrentTurnContextOnly(agentName, branch string, events []*ses
 			continue
 		}
 		if event.Author == "user" || isOtherAgentReply(agentName, event) {
-			return buildContentsDefault(agentName, branch, events[i:])
+			return buildContentsDefaultWithCallSource(agentName, branch, events[i:], events)
 		}
 	}
 	// NOTE: in Python, it returns [] if there is no event authored by a user or another agent,
@@ -610,6 +675,7 @@ func cloneEvent(e *session.Event) *session.Event {
 		Branch:       e.Branch,
 		Author:       e.Author,
 		Actions:      e.Actions,
+		LLMResponse:  e.LLMResponse,
 	}
 
 	// 2. Deep copy the LongRunningToolIDs slice
@@ -618,8 +684,7 @@ func cloneEvent(e *session.Event) *session.Event {
 		copy(newEvent.LongRunningToolIDs, e.LongRunningToolIDs)
 	}
 
-	// TODO check if copy parts is needed
-	// 3. Deep copy the LLMResponse pointer struct and content
+	// Own the parts array so pruning and rearrangement cannot mutate session history.
 	if e.LLMResponse.Content != nil {
 		newEvent.LLMResponse.Content = &genai.Content{
 			Parts: make([]*genai.Part, len(e.LLMResponse.Content.Parts)),

--- a/internal/llminternal/contents_processor_internal_test.go
+++ b/internal/llminternal/contents_processor_internal_test.go
@@ -1,0 +1,51 @@
+// Copyright 2026 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package llminternal
+
+import (
+	"testing"
+
+	"github.com/google/go-cmp/cmp"
+	"google.golang.org/genai"
+
+	"google.golang.org/adk/model"
+	"google.golang.org/adk/session"
+)
+
+func TestDropOrphanedFunctionResponses_LogAndClone(t *testing.T) {
+	event := &session.Event{LLMResponse: model.LLMResponse{
+		ModelVersion: "model-version", FinishReason: genai.FinishReasonStop, TurnComplete: true,
+		Content: &genai.Content{Role: "user", Parts: []*genai.Part{
+			{FunctionResponse: &genai.FunctionResponse{ID: "stale\nforged", Response: map[string]any{"secret": "payload"}}},
+			{Text: "Keep this", FunctionResponse: &genai.FunctionResponse{ID: "other"}},
+			{Text: "Keep this too"},
+		}},
+	}}
+	want := *event
+	want.LLMResponse.Content = genai.NewContentFromText("Keep this", "user")
+	want.LLMResponse.Content.Parts = append(want.LLMResponse.Content.Parts, &genai.Part{Text: "Keep this too"})
+	output := captureLog(t, func() {
+		got := dropOrphanedFunctionResponses([]*session.Event{event}, nil)
+		if diff := cmp.Diff([]*session.Event{&want}, got); diff != "" {
+			t.Errorf("pruned events mismatch (-want +got):\n%s", diff)
+		}
+	})
+	if want := "adk: dropping function responses with no matching function call: [\"stale\\nforged\" \"other\"]\n"; output != want {
+		t.Errorf("log = %q, want %q", output, want)
+	}
+	if len(event.Content.Parts) != 3 || event.Content.Parts[0].FunctionResponse == nil || event.Content.Parts[1].FunctionResponse == nil || event.Content.Parts[2] == nil {
+		t.Fatal("pruning mutated the original event parts")
+	}
+}

--- a/internal/llminternal/contents_processor_test.go
+++ b/internal/llminternal/contents_processor_test.go
@@ -15,6 +15,7 @@
 package llminternal_test
 
 import (
+	"encoding/json"
 	"iter"
 	"slices"
 	"strings"
@@ -816,13 +817,29 @@ func TestContentsRequestProcessor_Rearrange(t *testing.T) {
 		Name:     "orphaned_tool",
 		Response: map[string]any{"error": "no matching call"},
 	}
+	frWithoutID := &genai.FunctionResponse{
+		Name:     "legacy_tool",
+		Response: map[string]any{"result": "ok"},
+	}
+	fcOther := &genai.FunctionCall{
+		ID:   "call_456",
+		Name: "other_tool",
+		Args: map[string]any{"query": "other"},
+	}
+	frOther := &genai.FunctionResponse{
+		ID:       "call_456",
+		Name:     "other_tool",
+		Response: map[string]any{"result": "other"},
+	}
 
 	// --- Test Cases ---
 	testCases := []struct {
-		name    string
-		events  []*session.Event
-		want    []*genai.Content
-		wantErr string // Use string to check for specific error messages
+		name            string
+		events          []*session.Event
+		want            []*genai.Content
+		wantErr         string // Use string to check for specific error messages
+		includeContents llmagent.IncludeContents
+		branch          string // Invocation branch, for cases that need one filtered out.
 	}{
 		{
 			name:   "NilEvent",
@@ -1052,25 +1069,186 @@ func TestContentsRequestProcessor_Rearrange(t *testing.T) {
 			},
 		},
 		{
-			name: "Error on function response without matching call",
+			name: "Orphaned function response without matching call is dropped",
 			events: []*session.Event{
 				{Author: "user", LLMResponse: model.LLMResponse{Content: &genai.Content{Role: "user", Parts: []*genai.Part{{Text: "Regular message"}}}}},
 				{Author: "user", LLMResponse: model.LLMResponse{Content: &genai.Content{Role: "user", Parts: []*genai.Part{{FunctionResponse: frOrphaned}}}}},
 			},
-			want:    nil,
+			want: []*genai.Content{
+				genai.NewContentFromText("Regular message", "user"),
+			},
+		},
+		{
+			name: "Orphaned function response after text reply is dropped",
+			events: []*session.Event{
+				{Author: "user", LLMResponse: model.LLMResponse{Content: genai.NewContentFromText("Hello", "user")}},
+				{Author: agentName, LLMResponse: model.LLMResponse{Content: genai.NewContentFromText("Hi there", "model")}},
+				{Author: "user", LLMResponse: model.LLMResponse{Content: &genai.Content{Role: "user", Parts: []*genai.Part{{FunctionResponse: frOrphaned}}}}},
+			},
+			want: []*genai.Content{
+				genai.NewContentFromText("Hello", "user"),
+				genai.NewContentFromText("Hi there", "model"),
+			},
+		},
+		{
+			name: "Orphaned function response is removed from mixed content",
+			events: []*session.Event{
+				{Author: "user", LLMResponse: model.LLMResponse{Content: genai.NewContentFromText("Hello", "user")}},
+				{Author: agentName, LLMResponse: model.LLMResponse{Content: genai.NewContentFromText("Hi there", "model")}},
+				{Author: "user", LLMResponse: model.LLMResponse{Content: &genai.Content{Role: "user", Parts: []*genai.Part{
+					{Text: "What is the weather?"},
+					{FunctionResponse: frOrphaned},
+				}}}},
+			},
+			want: []*genai.Content{
+				genai.NewContentFromText("Hello", "user"),
+				genai.NewContentFromText("Hi there", "model"),
+				genai.NewContentFromText("What is the weather?", "user"),
+			},
+		},
+		{
+			name: "Orphaned function response sharing a part preserves text",
+			events: []*session.Event{
+				{Author: "user", LLMResponse: model.LLMResponse{Content: genai.NewContentFromText("Hello", "user")}},
+				{Author: agentName, LLMResponse: model.LLMResponse{Content: genai.NewContentFromText("Hi", "model")}},
+				{Author: "user", LLMResponse: model.LLMResponse{Content: &genai.Content{Role: "user", Parts: []*genai.Part{
+					{Text: "What is the weather?", FunctionResponse: frOrphaned},
+				}}}},
+			},
+			want: []*genai.Content{
+				genai.NewContentFromText("Hello", "user"),
+				genai.NewContentFromText("Hi", "model"),
+				genai.NewContentFromText("What is the weather?", "user"),
+			},
+		},
+		{
+			name: "Mid-history mixed content preserves user text",
+			events: []*session.Event{
+				{Author: "user", LLMResponse: model.LLMResponse{Content: genai.NewContentFromText("Before", "user")}},
+				{Author: "user", LLMResponse: model.LLMResponse{Content: &genai.Content{Role: "user", Parts: []*genai.Part{
+					{Text: "My question"}, {FunctionResponse: frOrphaned},
+				}}}},
+				{Author: "user", LLMResponse: model.LLMResponse{Content: genai.NewContentFromText("After", "user")}},
+			},
+			want: []*genai.Content{
+				genai.NewContentFromText("Before", "user"),
+				genai.NewContentFromText("My question", "user"),
+				genai.NewContentFromText("After", "user"),
+			},
+		},
+		{
+			name: "Orphaned function response is removed beside matching response",
+			events: []*session.Event{
+				{Author: agentName, LLMResponse: model.LLMResponse{Content: NewContentFromFunctionCall(fcBasic, "model")}},
+				{Author: "user", LLMResponse: model.LLMResponse{Content: &genai.Content{Role: "user", Parts: []*genai.Part{
+					{FunctionResponse: frBasic},
+					{FunctionResponse: frOrphaned},
+				}}}},
+			},
+			want: []*genai.Content{
+				NewContentFromFunctionCall(fcBasic, "model"),
+				NewContentFromFunctionResponse(frBasic, "user"),
+			},
+		},
+		{
+			name: "Only orphaned function response is dropped",
+			events: []*session.Event{
+				{Author: "user", LLMResponse: model.LLMResponse{Content: NewContentFromFunctionResponse(frOrphaned, "user")}},
+			},
+			want: nil,
+		},
+		{
+			name: "Consecutive orphaned function responses are dropped",
+			events: []*session.Event{
+				{Author: "user", LLMResponse: model.LLMResponse{Content: genai.NewContentFromText("Keep this", "user")}},
+				{Author: "user", LLMResponse: model.LLMResponse{Content: NewContentFromFunctionResponse(frOrphaned, "user")}},
+				{Author: "user", LLMResponse: model.LLMResponse{Content: NewContentFromFunctionResponse(frOrphaned, "user")}},
+			},
+			want: []*genai.Content{
+				genai.NewContentFromText("Keep this", "user"),
+			},
+		},
+		{
+			name: "Mid-history orphaned function response is dropped",
+			events: []*session.Event{
+				{Author: "user", LLMResponse: model.LLMResponse{Content: genai.NewContentFromText("Before", "user")}},
+				{Author: "user", LLMResponse: model.LLMResponse{Content: NewContentFromFunctionResponse(frOrphaned, "user")}},
+				{Author: "user", LLMResponse: model.LLMResponse{Content: genai.NewContentFromText("After", "user")}},
+			},
+			want: []*genai.Content{
+				genai.NewContentFromText("Before", "user"),
+				genai.NewContentFromText("After", "user"),
+			},
+		},
+		{
+			name: "Function response without ID is preserved",
+			events: []*session.Event{
+				{Author: "user", LLMResponse: model.LLMResponse{Content: NewContentFromFunctionResponse(frWithoutID, "user")}},
+			},
+			want: []*genai.Content{
+				NewContentFromFunctionResponse(frWithoutID, "user"),
+			},
+		},
+		{
+			name:   "Function response with filtered matching call remains an error",
+			branch: "main",
+			events: []*session.Event{
+				{Author: "user", LLMResponse: model.LLMResponse{Content: genai.NewContentFromText("Regular message", "user")}},
+				{Author: agentName, Branch: "other", LLMResponse: model.LLMResponse{Content: NewContentFromFunctionCall(fcBasic, "model")}},
+				{Author: "user", LLMResponse: model.LLMResponse{Content: NewContentFromFunctionResponse(frBasic, "user")}},
+			},
 			wantErr: "no function call event found",
+		},
+		{
+			name:            "Current turn retains validation for a call from an earlier turn",
+			includeContents: llmagent.IncludeContentsNone,
+			events: []*session.Event{
+				{Author: agentName, LLMResponse: model.LLMResponse{Content: NewContentFromFunctionCall(fcBasic, "model")}},
+				{Author: "user", LLMResponse: model.LLMResponse{Content: genai.NewContentFromText("Next question", "user")}},
+				{Author: agentName, LLMResponse: model.LLMResponse{Content: NewContentFromFunctionResponse(frBasic, "user")}},
+			},
+			wantErr: "no function call event found",
+		},
+		{
+			name: "Responses for different function call events remain an error",
+			events: []*session.Event{
+				{Author: "user", LLMResponse: model.LLMResponse{Content: genai.NewContentFromText("Run both", "user")}},
+				{Author: agentName, LLMResponse: model.LLMResponse{Content: NewContentFromFunctionCall(fcBasic, "model")}},
+				{Author: agentName, LLMResponse: model.LLMResponse{Content: NewContentFromFunctionCall(fcOther, "model")}},
+				{Author: agentName, LLMResponse: model.LLMResponse{Content: genai.NewContentFromText("Working", "model")}},
+				{Author: "user", LLMResponse: model.LLMResponse{Content: &genai.Content{Role: "user", Parts: []*genai.Part{
+					{FunctionResponse: frBasic},
+					{FunctionResponse: frOther},
+				}}}},
+			},
+			wantErr: "validation failed: last response event has IDs not in the matching call event",
 		},
 	}
 
 	for _, tc := range testCases {
 		t.Run(tc.name, func(t *testing.T) {
+			before, err := json.Marshal(tc.events)
+			if err != nil {
+				t.Fatal(err)
+			}
+			t.Cleanup(func() {
+				after, err := json.Marshal(tc.events)
+				if err != nil {
+					t.Fatal(err)
+				}
+				if string(before) != string(after) {
+					t.Errorf("ContentsRequestProcessor mutated session events (-before +after):\n%s", cmp.Diff(string(before), string(after)))
+				}
+			})
 			testAgent := utils.Must(llmagent.New(llmagent.Config{
-				Name:  agentName,
-				Model: testModel,
+				Name:            agentName,
+				Model:           testModel,
+				IncludeContents: tc.includeContents,
 			}))
 
 			ctx := icontext.NewInvocationContext(t.Context(), icontext.InvocationContextParams{
-				Agent: testAgent,
+				Agent:  testAgent,
+				Branch: tc.branch,
 				Session: &fakeSession{
 					events: tc.events,
 				},

--- a/internal/llminternal/contents_processor_test.go
+++ b/internal/llminternal/contents_processor_test.go
@@ -811,6 +811,39 @@ func TestContentsRequestProcessor_Rearrange(t *testing.T) {
 		Response: map[string]any{"confirmed": false},
 	}
 
+	// Late async completion: a long-running call whose final response arrives
+	// as the latest event, after an unrelated tool exchange.
+	fcAsyncPlan := &genai.FunctionCall{
+		ID:   "async_plan_1",
+		Name: "plan_tool",
+		Args: map[string]any{"feature": "Q"},
+	}
+	frAsyncPlanAck := &genai.FunctionResponse{
+		ID:       "async_plan_1",
+		Name:     "plan_tool",
+		Response: map[string]any{"status": "accepted"},
+	}
+	frAsyncPlanFinal := &genai.FunctionResponse{
+		ID:       "async_plan_1",
+		Name:     "plan_tool",
+		Response: map[string]any{"status": "completed", "plan": "add the flag, then wire it up"},
+	}
+	fcAsyncStatus := &genai.FunctionCall{
+		ID:   "async_status_1",
+		Name: "status_tool",
+		Args: map[string]any{"job": "plan"},
+	}
+	frAsyncStatus := &genai.FunctionResponse{
+		ID:       "async_status_1",
+		Name:     "status_tool",
+		Response: map[string]any{"status": "running", "elapsed": "21s"},
+	}
+	fcAsyncUnanswered := &genai.FunctionCall{
+		ID:   "async_unanswered_1",
+		Name: "notify_tool",
+		Args: map[string]any{"channel": "ops"},
+	}
+
 	// Error Call/Response
 	frOrphaned := &genai.FunctionResponse{
 		ID:       "no_matching_call",
@@ -896,12 +929,76 @@ func TestContentsRequestProcessor_Rearrange(t *testing.T) {
 				{Author: "user", LLMResponse: model.LLMResponse{Content: NewContentFromFunctionResponse(frBasic, "user")}},
 				{Author: "user", LLMResponse: model.LLMResponse{Content: NewContentFromFunctionResponse(frLROFinal, "user")}},
 			},
+			// The unrelated search exchange survives (the property #767
+			// established) but sits before the completion, so the freshest
+			// response is the final content.
 			want: []*genai.Content{
 				genai.NewContentFromText("Run long process and search", "user"),
-				NewContentFromFunctionCall(fcLRO, "model"),
-				NewContentFromFunctionResponse(frLROFinal, "user"),
 				NewContentFromFunctionCall(fcBasic, "model"),
 				NewContentFromFunctionResponse(frBasic, "user"),
+				NewContentFromFunctionCall(fcLRO, "model"),
+				NewContentFromFunctionResponse(frLROFinal, "user"),
+			},
+		},
+		{
+			// Regression test for #1181: the completion of a long-running tool
+			// must stay the final content, not be dragged back next to its much
+			// earlier call while a stale status exchange takes the tail.
+			name: "Late async completion stays the final content",
+			events: []*session.Event{
+				{Author: "user", LLMResponse: model.LLMResponse{Content: genai.NewContentFromText("Plan how to add feature Q", "user")}},
+				{Author: agentName, LLMResponse: model.LLMResponse{Content: NewContentFromFunctionCall(fcAsyncPlan, "model")}},
+				{Author: "user", LLMResponse: model.LLMResponse{Content: NewContentFromFunctionResponse(frAsyncPlanAck, "user")}},
+				{Author: agentName, LLMResponse: model.LLMResponse{Content: genai.NewContentFromText("I dispatched the planning task.", "model")}},
+				{Author: "user", LLMResponse: model.LLMResponse{Content: genai.NewContentFromText("What is the status?", "user")}},
+				{Author: agentName, LLMResponse: model.LLMResponse{Content: NewContentFromFunctionCall(fcAsyncStatus, "model")}},
+				{Author: "user", LLMResponse: model.LLMResponse{Content: NewContentFromFunctionResponse(frAsyncStatus, "user")}},
+				{Author: agentName, LLMResponse: model.LLMResponse{Content: genai.NewContentFromText("Still running.", "model")}},
+				{Author: "user", LLMResponse: model.LLMResponse{Content: NewContentFromFunctionResponse(frAsyncPlanFinal, "user")}},
+			},
+			// Nine events produce five contents. The three text turns between
+			// the async call and its completion — including the user asking
+			// "What is the status?" — are dropped by
+			// rearrangeEventsForLatestFunctionResponse, whose preservation loop
+			// keeps only events carrying calls or responses. That is
+			// pre-existing behavior, identical on main, and not what this row
+			// is testing.
+			want: []*genai.Content{
+				genai.NewContentFromText("Plan how to add feature Q", "user"),
+				NewContentFromFunctionCall(fcAsyncStatus, "model"),
+				NewContentFromFunctionResponse(frAsyncStatus, "user"),
+				NewContentFromFunctionCall(fcAsyncPlan, "model"),
+				NewContentFromFunctionResponse(frAsyncPlanFinal, "user"),
+			},
+		},
+		{
+			// A call that never receives a response is reachable: base_flow
+			// creates no response event for a long-running tool or a deferring
+			// ResponseDeferrer. Such a call has an empty responseEventIndicesSet,
+			// so it is never routed to the tail. It keeps its order relative to
+			// the other events that stay put, which leaves it ahead of the
+			// completed pair that does move to the tail.
+			//
+			// This also changes what the model is asked to do while a call is
+			// pending. On main the contents ended on the unanswered call, a
+			// model turn, so a synthetic "Continue processing..." user turn was
+			// appended. They now end on the real tool result instead:
+			//
+			//	main: user text | CALL(plan) | RESP(plan) | CALL(unanswered) | "Continue processing..."
+			//	now:  user text | CALL(unanswered) | CALL(plan) | RESP(plan)
+			name: "Late async completion stays final with an unanswered call in history",
+			events: []*session.Event{
+				{Author: "user", LLMResponse: model.LLMResponse{Content: genai.NewContentFromText("Plan how to add feature Q", "user")}},
+				{Author: agentName, LLMResponse: model.LLMResponse{Content: NewContentFromFunctionCall(fcAsyncPlan, "model")}},
+				{Author: "user", LLMResponse: model.LLMResponse{Content: NewContentFromFunctionResponse(frAsyncPlanAck, "user")}},
+				{Author: agentName, LLMResponse: model.LLMResponse{Content: NewContentFromFunctionCall(fcAsyncUnanswered, "model")}},
+				{Author: "user", LLMResponse: model.LLMResponse{Content: NewContentFromFunctionResponse(frAsyncPlanFinal, "user")}},
+			},
+			want: []*genai.Content{
+				genai.NewContentFromText("Plan how to add feature Q", "user"),
+				NewContentFromFunctionCall(fcAsyncUnanswered, "model"),
+				NewContentFromFunctionCall(fcAsyncPlan, "model"),
+				NewContentFromFunctionResponse(frAsyncPlanFinal, "user"),
 			},
 		},
 		{

--- a/internal/llminternal/skip_summarization_test.go
+++ b/internal/llminternal/skip_summarization_test.go
@@ -1,0 +1,241 @@
+// Copyright 2026 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package llminternal_test
+
+import (
+	"context"
+	"iter"
+	"testing"
+
+	"google.golang.org/genai"
+
+	"google.golang.org/adk/agent"
+	"google.golang.org/adk/agent/llmagent"
+	"google.golang.org/adk/internal/testutil"
+	"google.golang.org/adk/model"
+	"google.golang.org/adk/runner"
+	"google.golang.org/adk/session"
+	"google.golang.org/adk/tool"
+	"google.golang.org/adk/tool/agenttool"
+	"google.golang.org/adk/tool/functiontool"
+)
+
+// runSkipSummarizationScenario runs rootAgent (backed by a singleCallMockModel
+// that calls toolName once) to completion and returns the collected events.
+func runSkipSummarizationScenario(t *testing.T, rootAgent agent.Agent) []*session.Event {
+	t.Helper()
+
+	sessionService := session.InMemoryService()
+	if _, err := sessionService.Create(t.Context(), &session.CreateRequest{
+		AppName:   "testApp",
+		UserID:    "testUser",
+		SessionID: "testSession",
+	}); err != nil {
+		t.Fatal(err)
+	}
+
+	r, err := runner.New(runner.Config{
+		Agent:          rootAgent,
+		SessionService: sessionService,
+		AppName:        "testApp",
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	it := r.Run(t.Context(), "testUser", "testSession", &genai.Content{
+		Role:  "user",
+		Parts: []*genai.Part{genai.NewPartFromText("go")},
+	}, agent.RunConfig{StreamingMode: agent.StreamingModeSSE})
+
+	var events []*session.Event
+	for ev, err := range it {
+		if err != nil {
+			t.Fatal(err)
+		}
+		events = append(events, ev)
+	}
+	return events
+}
+
+// TestHandleFunctionCalls_SkipSummarization_AgentToolDisplaysResult verifies
+// that when agenttool sets SkipSummarization, the parent agent loop still
+// terminates on the function response event (the flag's documented effect),
+// but the terminal event carries the sub-agent's answer as a visible text
+// part rather than a bare, unrendered FunctionResponse.
+func TestHandleFunctionCalls_SkipSummarization_AgentToolDisplaysResult(t *testing.T) {
+	subAgentModel := &testutil.MockModel{
+		Responses: []*genai.Content{
+			genai.NewContentFromText("sub-agent answer", genai.RoleModel),
+		},
+	}
+	subAgent, err := llmagent.New(llmagent.Config{
+		Name:        "sub_agent",
+		Description: "answers questions",
+		Instruction: "Answer the question.",
+		Model:       subAgentModel,
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	agentTool := agenttool.New(subAgent, &agenttool.Config{SkipSummarization: true})
+
+	rootModel := &singleCallMockModel{
+		toolName: agentTool.Name(),
+		fcID:     "call_1",
+		args:     map[string]any{"request": "what is the answer?"},
+	}
+	rootAgent, err := llmagent.New(llmagent.Config{
+		Name:        "root",
+		Description: "root agent",
+		Instruction: "Delegate to the sub-agent.",
+		Model:       rootModel,
+		Tools:       []tool.Tool{agentTool},
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	events := runSkipSummarizationScenario(t, rootAgent)
+
+	if len(events) != 2 {
+		t.Fatalf("expected 2 events (function call, function response), got %d", len(events))
+	}
+	if rootModel.calls != 1 {
+		t.Errorf("root model called %d times, want 1: SkipSummarization should end the run after the first function response", rootModel.calls)
+	}
+
+	respEvent := events[1]
+	if !respEvent.IsFinalResponse() {
+		t.Errorf("expected function response event to be the final response, IsFinalResponse() = false")
+	}
+
+	var gotFunctionResponse, gotText bool
+	var text string
+	for _, part := range respEvent.Content.Parts {
+		if part.FunctionResponse != nil {
+			gotFunctionResponse = true
+		}
+		if part.Text != "" {
+			gotText = true
+			text = part.Text
+		}
+	}
+	if !gotFunctionResponse {
+		t.Errorf("expected final event to retain the FunctionResponse part")
+	}
+	if !gotText {
+		t.Errorf("expected final event to carry a visible text part with the sub-agent's answer")
+	}
+	if text != "sub-agent answer" {
+		t.Errorf("text part = %q, want %q", text, "sub-agent answer")
+	}
+}
+
+// TestHandleFunctionCalls_SkipSummarization_PlainToolResultNotDisplayed
+// verifies that SkipSummarization set by a tool other than agenttool still
+// ends the parent agent loop, but does NOT get its result surfaced as text.
+// SkipSummarization is also used by UI/widget and pending-confirmation tools
+// to suppress an internal acknowledgement that was never meant to be shown;
+// unconditionally displaying it would leak that payload into the transcript
+// and bypass client-side filters that strip FunctionResponse parts.
+func TestHandleFunctionCalls_SkipSummarization_PlainToolResultNotDisplayed(t *testing.T) {
+	const toolName = "widget_ack"
+
+	widgetTool, err := functiontool.New(functiontool.Config{
+		Name:        toolName,
+		Description: "acknowledges a widget interaction",
+	}, func(ctx agent.ToolContext, _ struct{}) (map[string]string, error) {
+		ctx.Actions().SkipSummarization = true
+		return map[string]string{"status": "ok"}, nil
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	rootModel := &singleCallMockModel{toolName: toolName, fcID: "call_1"}
+	rootAgent, err := llmagent.New(llmagent.Config{
+		Name:        "root",
+		Description: "root agent",
+		Instruction: "Use the widget tool.",
+		Model:       rootModel,
+		Tools:       []tool.Tool{widgetTool},
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	events := runSkipSummarizationScenario(t, rootAgent)
+
+	if len(events) != 2 {
+		t.Fatalf("expected 2 events (function call, function response), got %d", len(events))
+	}
+	if rootModel.calls != 1 {
+		t.Errorf("root model called %d times, want 1: SkipSummarization should end the run after the first function response", rootModel.calls)
+	}
+
+	respEvent := events[1]
+	if !respEvent.IsFinalResponse() {
+		t.Errorf("expected function response event to be the final response, IsFinalResponse() = false")
+	}
+	if len(respEvent.Content.Parts) != 1 || respEvent.Content.Parts[0].FunctionResponse == nil {
+		t.Errorf("expected final event to carry only the FunctionResponse part, got %d parts: %+v", len(respEvent.Content.Parts), respEvent.Content.Parts)
+	}
+}
+
+// singleCallMockModel emits one function call on the first turn and a plain
+// text answer on any turn after it. On main this lives in
+// handle_function_calls_async_test.go; 1.x has no copy, so it is defined here.
+type singleCallMockModel struct {
+	model.LLM
+	toolName string
+	fcID     string
+	// args is passed as the function call's Args; a plain empty map is used
+	// when unset, which is fine for tools that ignore their arguments.
+	args  map[string]any
+	calls int
+}
+
+func (m *singleCallMockModel) Name() string { return "single-call-mock" }
+
+func (m *singleCallMockModel) GenerateContent(ctx context.Context, req *model.LLMRequest, useStream bool) iter.Seq2[*model.LLMResponse, error] {
+	return func(yield func(*model.LLMResponse, error) bool) {
+		m.calls++
+		if m.calls > 1 {
+			yield(&model.LLMResponse{
+				Content: &genai.Content{
+					Parts: []*genai.Part{genai.NewPartFromText("done")},
+					Role:  "model",
+				},
+			}, nil)
+			return
+		}
+		args := m.args
+		if args == nil {
+			args = map[string]any{}
+		}
+		yield(&model.LLMResponse{
+			Content: &genai.Content{
+				Parts: []*genai.Part{{FunctionCall: &genai.FunctionCall{
+					ID:   m.fcID,
+					Name: m.toolName,
+					Args: args,
+				}}},
+				Role: "model",
+			},
+		}, nil)
+	}
+}

--- a/internal/toolinternal/tool.go
+++ b/internal/toolinternal/tool.go
@@ -40,3 +40,17 @@ type StreamingFunctionTool interface {
 type RequestProcessor interface {
 	ProcessRequest(ctx agent.ToolContext, req *model.LLMRequest) error
 }
+
+// SkipSummarizationResultDisplayer is implemented by tools whose result
+// should still be shown to the user as text when SkipSummarization causes
+// the agent loop to end on their function response event.
+//
+// SkipSummarization is set for two opposite reasons: agenttool sets it
+// because the sub-agent already produced the final answer, which is meant to
+// be seen; other tools (UI/widget tools, pending-confirmation flows) set it
+// to suppress an internal acknowledgement that was never meant to be shown.
+// Only tools that implement this interface, with DisplayResultOnSkipSummarization
+// returning true, get their result surfaced as a visible text part.
+type SkipSummarizationResultDisplayer interface {
+	DisplayResultOnSkipSummarization() bool
+}

--- a/tool/agenttool/agent_tool.go
+++ b/tool/agenttool/agent_tool.go
@@ -27,6 +27,7 @@ import (
 	"google.golang.org/adk/agent"
 	"google.golang.org/adk/artifact"
 	"google.golang.org/adk/internal/llminternal"
+	"google.golang.org/adk/internal/toolinternal"
 	"google.golang.org/adk/internal/toolinternal/toolutils"
 	"google.golang.org/adk/internal/utils"
 	"google.golang.org/adk/memory"
@@ -35,6 +36,8 @@ import (
 	"google.golang.org/adk/session"
 	"google.golang.org/adk/tool"
 )
+
+var _ toolinternal.SkipSummarizationResultDisplayer = (*agentTool)(nil)
 
 // agentTool implements a tool that allows an agent to call another agent.
 type agentTool struct {
@@ -77,6 +80,14 @@ func (t *agentTool) Description() string {
 // IsLongRunning implements tool.Tool.
 func (t *agentTool) IsLongRunning() bool {
 	return false
+}
+
+// DisplayResultOnSkipSummarization implements
+// toolinternal.SkipSummarizationResultDisplayer. When SkipSummarization is
+// set, the sub-agent's result is the final answer, not an internal
+// acknowledgement, so it should still be shown to the user.
+func (t *agentTool) DisplayResultOnSkipSummarization() bool {
+	return true
 }
 
 // Declaration returns the function declaration for the wrapped agent.

--- a/tool/agenttool/agent_tool_test.go
+++ b/tool/agenttool/agent_tool_test.go
@@ -369,47 +369,39 @@ func TestAgentTool_Run_EmptyModelResponse(t *testing.T) {
 }
 
 func TestAgentTool_Run_SkipSummarization(t *testing.T) {
-	testLLM := &testutil.MockModel{
-		Responses: []*genai.Content{
-			genai.NewContentFromText("test response", genai.RoleModel),
-		},
-	}
-	agent := createAgentWithModel(t, nil, nil, testLLM)
-	toolCtx := createToolContext(t, agent)
-
-	// Test with skipSummarization = true
-	agentToolSkip := agenttool.New(agent, &agenttool.Config{SkipSummarization: true})
-	actions := toolCtx.Actions()
-	toolImpl, ok := agentToolSkip.(toolinternal.FunctionTool)
-	if !ok {
-		t.Fatal("agentToolSkip does not implement FunctionTool")
-	}
-	_, err := toolImpl.Run(toolCtx, map[string]any{"request": "magic"})
-	if err != nil {
-		t.Fatalf("Run() with skipSummarization=true failed unexpectedly: %v", err)
-	}
-	if !actions.SkipSummarization {
-		t.Errorf("SkipSummarization flag not set when AgentTool was created with skipSummarization=true")
+	tests := []struct {
+		name              string
+		skipSummarization bool
+	}{
+		{name: "skip_summarization_true", skipSummarization: true},
+		{name: "skip_summarization_false", skipSummarization: false},
 	}
 
-	// Test with skipSummarization = false
-	agentToolNoSkip := agenttool.New(agent, &agenttool.Config{SkipSummarization: false})
-	toolImpl, ok = agentToolNoSkip.(toolinternal.FunctionTool)
-	if !ok {
-		t.Fatal("agentToolNoSkip does not implement FunctionTool")
-	}
-	actions.SkipSummarization = false // Reset
-	// Reset mock for the second call
-	testLLM.Responses = []*genai.Content{
-		genai.NewContentFromText("test response", genai.RoleModel),
-	}
-	testLLM.Requests = nil
-	_, err = toolImpl.Run(toolCtx, map[string]any{"request": "magic"})
-	if err != nil {
-		t.Fatalf("Run() with skipSummarization=false failed unexpectedly: %v", err)
-	}
-	if actions.SkipSummarization {
-		t.Errorf("SkipSummarization flag was set when AgentTool was created with skipSummarization=false")
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			testLLM := &testutil.MockModel{
+				Responses: []*genai.Content{
+					genai.NewContentFromText("test response", genai.RoleModel),
+				},
+			}
+			ag := createAgentWithModel(t, nil, nil, testLLM)
+			toolCtx := createToolContext(t, ag)
+
+			agentTool := agenttool.New(ag, &agenttool.Config{SkipSummarization: tt.skipSummarization})
+			toolImpl, ok := agentTool.(toolinternal.FunctionTool)
+			if !ok {
+				t.Fatal("agentTool does not implement FunctionTool")
+			}
+
+			_, err := toolImpl.Run(toolCtx, map[string]any{"request": "magic"})
+			if err != nil {
+				t.Fatalf("Run() failed unexpectedly: %v", err)
+			}
+
+			if got := toolCtx.Actions().SkipSummarization; got != tt.skipSummarization {
+				t.Errorf("SkipSummarization propagated to parent tool context = %v, want %v", got, tt.skipSummarization)
+			}
+		})
 	}
 }
 


### PR DESCRIPTION
## Problem

Four defects in the base flow and content assembly shipped in 2.4.0 and are still present on 1.x.

- A turn whose last event is a partial streaming response fails outright with `TODO: last event is not final`. The realistic cause is a producer that ends a stream without a terminal aggregate, such as an A2A peer whose stream ends on an appended artifact chunk.
- A tool that sets `SkipSummarization` ends the parent agent loop on its function response event. Most UIs do not render function response parts, so an agent tool's answer is dropped from the terminal event even though it is the final answer.
- A function response with no matching function call fails the whole turn instead of being dropped.
- When a long running tool completes after unrelated tool exchanges were already recorded, pairing its response with its much earlier call buries it mid-history and leaves a stale exchange as the final content, which is what the model answers.

## Summary

Backports #638, #908, #766 and #1428, one commit each, in the order they landed on main.

- **#638** logs a warning naming the agent, the invocation and the producer, then returns, so a truncated stream ends the turn instead of failing it.
- **#908** adds an opt-in `SkipSummarizationResultDisplayer` interface. Only tools implementing it get their result surfaced as a visible text part, so a widget acknowledgement or a pending confirmation is not leaked into the transcript while an agent tool's answer still reaches the user.
- **#766** prunes orphaned function responses and logs the dropped IDs. The pruning window sees every event, so a response whose call sits before a narrowed window is not mistaken for an orphan.
- **#1428** emits the call and response pair answered by the last event after everything else, so a late completion stays the final content.

Three adaptations were needed because the branches differ:

- 1.x spells the context-carrying event constructor `session.NewEventWithContext`, where main passes the context to `NewEvent`.
- The tool-side context is `agent.ToolContext` on 1.x rather than the unified `agent.Context`.
- `singleCallMockModel` lives in `handle_function_calls_async_test.go` on main and has no counterpart on 1.x, so it is defined alongside the test that needs it.

Two test cases from #766 are not carried over. One sets `session.Event.IsolationScope` and the other exercises the compaction prompt-token estimator, and neither concept exists on 1.x.
