### PR TITLE
fix: backport MCP toolset result handling fixes (#1353, #1473, #1401)

### DIFF
--- a/tool/mcptoolset/set_test.go
+++ b/tool/mcptoolset/set_test.go
@@ -845,120 +845,68 @@ func TestMCPTool_EmptyTextResponse(t *testing.T) {
 	}
 }
 
-// TestMCPTool_NonTextOnlyResponse covers the gap left by #1353: an empty text
-// result is a valid success, but only when there was no other content to lose.
-// A result carrying just an image, audio, resource link or embedded resource
-// also accumulates no text, and reporting that as {"output": ""} hands the
-// model an empty string while discarding the entire payload.
-//
-// The mixed case is the control. A non-text block alongside real text must
-// still succeed, which pins the textResponse.Len() == 0 half of the condition:
-// without it, every result carrying a non-text block would error.
-//
-// TODO(#1401): the mixed case still drops its non-text block silently (#1391).
-// When #1401 renders those blocks, this whole test goes away with the guard.
-func TestMCPTool_NonTextOnlyResponse(t *testing.T) {
-	tests := []struct {
-		name       string
-		content    []mcp.Content
-		wantErr    bool
-		wantOutput string
-	}{
-		{
-			name:    "image only",
-			content: []mcp.Content{&mcp.ImageContent{MIMEType: "image/png", Data: []byte{0x89, 0x50, 0x4e, 0x47}}},
-			wantErr: true,
-		},
-		{
-			name:    "audio only",
-			content: []mcp.Content{&mcp.AudioContent{MIMEType: "audio/wav", Data: []byte{0x52, 0x49, 0x46, 0x46}}},
-			wantErr: true,
-		},
-		{
-			name:    "resource link only",
-			content: []mcp.Content{&mcp.ResourceLink{URI: "file:///tmp/report.pdf", Name: "report.pdf"}},
-			wantErr: true,
-		},
-		{
-			name: "embedded resource only",
-			content: []mcp.Content{&mcp.EmbeddedResource{
-				Resource: &mcp.ResourceContents{URI: "file:///tmp/data.bin", MIMEType: "application/octet-stream", Blob: []byte{0x00, 0x01}},
-			}},
-			wantErr: true,
-		},
-		{
-			name: "text alongside non-text still succeeds",
-			content: []mcp.Content{
-				&mcp.TextContent{Text: "caption"},
-				&mcp.ImageContent{MIMEType: "image/png", Data: []byte{0x89, 0x50, 0x4e, 0x47}},
+func TestMCPTool_NonTextContentRoundTrip(t *testing.T) {
+	clientTransport, serverTransport := mcp.NewInMemoryTransports()
+	resourceSize := int64(42)
+
+	server := mcp.NewServer(&mcp.Implementation{Name: "test_server", Version: "v1.0.0"}, nil)
+	mcp.AddTool(server, &mcp.Tool{Name: "content_tool", Description: "returns non-text content"}, func(ctx context.Context, req *mcp.CallToolRequest, args any) (*mcp.CallToolResult, any, error) {
+		return &mcp.CallToolResult{
+			Content: []mcp.Content{
+				&mcp.EmbeddedResource{Resource: &mcp.ResourceContents{
+					URI:      "repo://owner/project/main/file.go",
+					MIMEType: "text/plain",
+					Blob:     []byte("package example\n"),
+				}},
+				&mcp.ResourceLink{
+					URI:      "https://example.com/report.pdf",
+					Name:     "report.pdf",
+					MIMEType: "application/pdf",
+					Size:     &resourceSize,
+				},
+				&mcp.ImageContent{MIMEType: "image/png", Data: []byte{1, 2, 3, 4}},
+				&mcp.AudioContent{MIMEType: "audio/wav", Data: []byte{1, 2, 3}},
 			},
-			wantErr:    false,
-			wantOutput: "caption",
-		},
+		}, nil, nil
+	})
+	_, err := server.Connect(t.Context(), serverTransport, nil)
+	if err != nil {
+		t.Fatal(err)
 	}
 
-	for _, tt := range tests {
-		t.Run(tt.name, func(t *testing.T) {
-			clientTransport, serverTransport := mcp.NewInMemoryTransports()
+	ts, err := mcptoolset.New(mcptoolset.Config{Transport: clientTransport})
+	if err != nil {
+		t.Fatalf("Failed to create MCP tool set: %v", err)
+	}
 
-			server := mcp.NewServer(&mcp.Implementation{Name: "test_server", Version: "v1.0.0"}, nil)
-			mcp.AddTool(server, &mcp.Tool{Name: "non_text_tool", Description: "returns non-text content"}, func(ctx context.Context, req *mcp.CallToolRequest, args any) (*mcp.CallToolResult, any, error) {
-				return &mcp.CallToolResult{
-					Content: tt.content,
-				}, nil, nil
-			})
-			if _, err := server.Connect(t.Context(), serverTransport, nil); err != nil {
-				t.Fatal(err)
-			}
+	tools, err := ts.Tools(icontext.NewReadonlyContext(
+		icontext.NewInvocationContext(t.Context(), icontext.InvocationContextParams{}),
+	))
+	if err != nil {
+		t.Fatalf("Failed to get tools: %v", err)
+	}
+	if len(tools) != 1 {
+		t.Fatalf("Expected 1 tool, got %d", len(tools))
+	}
 
-			ts, err := mcptoolset.New(mcptoolset.Config{
-				Transport: clientTransport,
-			})
-			if err != nil {
-				t.Fatalf("Failed to create MCP tool set: %v", err)
-			}
+	fnTool, ok := tools[0].(toolinternal.FunctionTool)
+	if !ok {
+		t.Fatalf("Expected tool to implement toolinternal.FunctionTool")
+	}
+	toolCtx := icontext.NewInvocationContext(t.Context(), icontext.InvocationContextParams{})
+	got, err := fnTool.Run(agent.NewToolContext(toolCtx, "", nil, nil), map[string]any{})
+	if err != nil {
+		t.Fatalf("Run() failed: %v", err)
+	}
 
-			tools, err := ts.Tools(icontext.NewReadonlyContext(
-				icontext.NewInvocationContext(
-					t.Context(),
-					icontext.InvocationContextParams{},
-				),
-			))
-			if err != nil {
-				t.Fatalf("Failed to get tools: %v", err)
-			}
-			if len(tools) != 1 {
-				t.Fatalf("Expected 1 tool, got %d", len(tools))
-			}
-
-			toolCtx := icontext.NewInvocationContext(t.Context(), icontext.InvocationContextParams{})
-			tc := agent.NewToolContext(toolCtx, "", nil, nil)
-
-			fnTool, ok := tools[0].(toolinternal.FunctionTool)
-			if !ok {
-				t.Fatalf("Expected tool to implement toolinternal.FunctionTool")
-			}
-
-			res, err := fnTool.Run(tc, map[string]any{})
-
-			if !tt.wantErr {
-				if err != nil {
-					t.Fatalf("Run() returned %v, want success", err)
-				}
-				if res["output"] != tt.wantOutput {
-					t.Fatalf("Run() output = %q, want %q", res["output"], tt.wantOutput)
-				}
-				return
-			}
-
-			if err == nil {
-				t.Fatalf("Run() succeeded with output=%q, want an error reporting the dropped content", res["output"])
-			}
-			// Pin the identity of the error: a transport failure, or the
-			// pre-#1353 "no text content" error, must not satisfy this case.
-			if want := `tool "non_text_tool" returned only non-text content`; !strings.Contains(err.Error(), want) {
-				t.Fatalf("Run() error = %q, want it to contain %q", err.Error(), want)
-			}
-		})
+	want := map[string]any{"output": "[MCP embedded resource: " +
+		"uri=\"repo://owner/project/main/file.go\", mimeType=\"text/plain\"]\n" +
+		"package example\n" +
+		"[MCP resource link: uri=\"https://example.com/report.pdf\", mimeType=\"application/pdf\", " +
+		"name=\"report.pdf\", size=42 bytes]\n" +
+		"[MCP image: mimeType=\"image/png\", size=4 bytes]\n" +
+		"[MCP audio: mimeType=\"audio/wav\", size=3 bytes]"}
+	if diff := cmp.Diff(want, got); diff != "" {
+		t.Errorf("Run() result mismatch (-want +got):\n%s", diff)
 	}
 }

--- a/tool/mcptoolset/set_test.go
+++ b/tool/mcptoolset/set_test.go
@@ -844,3 +844,121 @@ func TestMCPTool_EmptyTextResponse(t *testing.T) {
 		t.Fatalf("Expected output to be empty string, got: %v", res["output"])
 	}
 }
+
+// TestMCPTool_NonTextOnlyResponse covers the gap left by #1353: an empty text
+// result is a valid success, but only when there was no other content to lose.
+// A result carrying just an image, audio, resource link or embedded resource
+// also accumulates no text, and reporting that as {"output": ""} hands the
+// model an empty string while discarding the entire payload.
+//
+// The mixed case is the control. A non-text block alongside real text must
+// still succeed, which pins the textResponse.Len() == 0 half of the condition:
+// without it, every result carrying a non-text block would error.
+//
+// TODO(#1401): the mixed case still drops its non-text block silently (#1391).
+// When #1401 renders those blocks, this whole test goes away with the guard.
+func TestMCPTool_NonTextOnlyResponse(t *testing.T) {
+	tests := []struct {
+		name       string
+		content    []mcp.Content
+		wantErr    bool
+		wantOutput string
+	}{
+		{
+			name:    "image only",
+			content: []mcp.Content{&mcp.ImageContent{MIMEType: "image/png", Data: []byte{0x89, 0x50, 0x4e, 0x47}}},
+			wantErr: true,
+		},
+		{
+			name:    "audio only",
+			content: []mcp.Content{&mcp.AudioContent{MIMEType: "audio/wav", Data: []byte{0x52, 0x49, 0x46, 0x46}}},
+			wantErr: true,
+		},
+		{
+			name:    "resource link only",
+			content: []mcp.Content{&mcp.ResourceLink{URI: "file:///tmp/report.pdf", Name: "report.pdf"}},
+			wantErr: true,
+		},
+		{
+			name: "embedded resource only",
+			content: []mcp.Content{&mcp.EmbeddedResource{
+				Resource: &mcp.ResourceContents{URI: "file:///tmp/data.bin", MIMEType: "application/octet-stream", Blob: []byte{0x00, 0x01}},
+			}},
+			wantErr: true,
+		},
+		{
+			name: "text alongside non-text still succeeds",
+			content: []mcp.Content{
+				&mcp.TextContent{Text: "caption"},
+				&mcp.ImageContent{MIMEType: "image/png", Data: []byte{0x89, 0x50, 0x4e, 0x47}},
+			},
+			wantErr:    false,
+			wantOutput: "caption",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			clientTransport, serverTransport := mcp.NewInMemoryTransports()
+
+			server := mcp.NewServer(&mcp.Implementation{Name: "test_server", Version: "v1.0.0"}, nil)
+			mcp.AddTool(server, &mcp.Tool{Name: "non_text_tool", Description: "returns non-text content"}, func(ctx context.Context, req *mcp.CallToolRequest, args any) (*mcp.CallToolResult, any, error) {
+				return &mcp.CallToolResult{
+					Content: tt.content,
+				}, nil, nil
+			})
+			if _, err := server.Connect(t.Context(), serverTransport, nil); err != nil {
+				t.Fatal(err)
+			}
+
+			ts, err := mcptoolset.New(mcptoolset.Config{
+				Transport: clientTransport,
+			})
+			if err != nil {
+				t.Fatalf("Failed to create MCP tool set: %v", err)
+			}
+
+			tools, err := ts.Tools(icontext.NewReadonlyContext(
+				icontext.NewInvocationContext(
+					t.Context(),
+					icontext.InvocationContextParams{},
+				),
+			))
+			if err != nil {
+				t.Fatalf("Failed to get tools: %v", err)
+			}
+			if len(tools) != 1 {
+				t.Fatalf("Expected 1 tool, got %d", len(tools))
+			}
+
+			toolCtx := icontext.NewInvocationContext(t.Context(), icontext.InvocationContextParams{})
+			tc := agent.NewToolContext(toolCtx, "", nil, nil)
+
+			fnTool, ok := tools[0].(toolinternal.FunctionTool)
+			if !ok {
+				t.Fatalf("Expected tool to implement toolinternal.FunctionTool")
+			}
+
+			res, err := fnTool.Run(tc, map[string]any{})
+
+			if !tt.wantErr {
+				if err != nil {
+					t.Fatalf("Run() returned %v, want success", err)
+				}
+				if res["output"] != tt.wantOutput {
+					t.Fatalf("Run() output = %q, want %q", res["output"], tt.wantOutput)
+				}
+				return
+			}
+
+			if err == nil {
+				t.Fatalf("Run() succeeded with output=%q, want an error reporting the dropped content", res["output"])
+			}
+			// Pin the identity of the error: a transport failure, or the
+			// pre-#1353 "no text content" error, must not satisfy this case.
+			if want := `tool "non_text_tool" returned only non-text content`; !strings.Contains(err.Error(), want) {
+				t.Fatalf("Run() error = %q, want it to contain %q", err.Error(), want)
+			}
+		})
+	}
+}

--- a/tool/mcptoolset/set_test.go
+++ b/tool/mcptoolset/set_test.go
@@ -793,3 +793,54 @@ func TestNewToolSet_RequireConfirmationProvider_Validation(t *testing.T) {
 		})
 	}
 }
+
+func TestMCPTool_EmptyTextResponse(t *testing.T) {
+	clientTransport, serverTransport := mcp.NewInMemoryTransports()
+
+	server := mcp.NewServer(&mcp.Implementation{Name: "test_server", Version: "v1.0.0"}, nil)
+	mcp.AddTool(server, &mcp.Tool{Name: "empty_tool", Description: "returns empty response"}, func(ctx context.Context, req *mcp.CallToolRequest, args any) (*mcp.CallToolResult, any, error) {
+		return &mcp.CallToolResult{
+			Content: []mcp.Content{&mcp.TextContent{Text: ""}},
+		}, nil, nil
+	})
+	_, err := server.Connect(t.Context(), serverTransport, nil)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	ts, err := mcptoolset.New(mcptoolset.Config{
+		Transport: clientTransport,
+	})
+	if err != nil {
+		t.Fatalf("Failed to create MCP tool set: %v", err)
+	}
+
+	tools, err := ts.Tools(icontext.NewReadonlyContext(
+		icontext.NewInvocationContext(
+			t.Context(),
+			icontext.InvocationContextParams{},
+		),
+	))
+	if err != nil {
+		t.Fatalf("Failed to get tools: %v", err)
+	}
+	if len(tools) != 1 {
+		t.Fatalf("Expected 1 tool, got %d", len(tools))
+	}
+
+	toolCtx := icontext.NewInvocationContext(t.Context(), icontext.InvocationContextParams{})
+	tc := agent.NewToolContext(toolCtx, "", nil, nil)
+
+	fnTool, ok := tools[0].(toolinternal.FunctionTool)
+	if !ok {
+		t.Fatalf("Expected tool to implement toolinternal.FunctionTool")
+	}
+
+	res, err := fnTool.Run(tc, map[string]any{})
+	if err != nil {
+		t.Fatalf("Expected Run to succeed on empty text response, got: %v", err)
+	}
+	if res["output"] != "" {
+		t.Fatalf("Expected output to be empty string, got: %v", res["output"])
+	}
+}

--- a/tool/mcptoolset/tool.go
+++ b/tool/mcptoolset/tool.go
@@ -165,10 +165,6 @@ func (t *mcpTool) Run(ctx agent.ToolContext, args any) (map[string]any, error) {
 		}
 	}
 
-	if textResponse.Len() == 0 {
-		return nil, errors.New("no text content in tool response")
-	}
-
 	return map[string]any{
 		"output": textResponse.String(),
 	}, nil

--- a/tool/mcptoolset/tool.go
+++ b/tool/mcptoolset/tool.go
@@ -153,16 +153,31 @@ func (t *mcpTool) Run(ctx agent.ToolContext, args any) (map[string]any, error) {
 	}
 
 	textResponse := strings.Builder{}
+	droppedNonText := false
 
 	for _, c := range res.Content {
 		textContent, ok := c.(*mcp.TextContent)
 		if !ok {
+			droppedNonText = true
 			continue
 		}
 
 		if _, err := textResponse.WriteString(textContent.Text); err != nil {
 			return nil, fmt.Errorf("failed to write text response: %w", err)
 		}
+	}
+
+	// A result that yields no text is a valid success (#1352) when there was no
+	// other content to lose: nothing at all, or only empty text blocks. When the
+	// text is empty because every block was non-text, returning {"output": ""}
+	// would report success while discarding the whole payload, so fail loudly
+	// instead.
+	//
+	// TODO(#1401): remove once non-text blocks are rendered rather than skipped.
+	// That also covers the mixed case this deliberately leaves alone, where a
+	// non-text block accompanies real text and is still dropped silently (#1391).
+	if textResponse.Len() == 0 && droppedNonText {
+		return nil, fmt.Errorf("tool %q returned only non-text content, which is not yet supported", t.name)
 	}
 
 	return map[string]any{

--- a/tool/mcptoolset/tool.go
+++ b/tool/mcptoolset/tool.go
@@ -17,7 +17,9 @@ package mcptoolset
 import (
 	"errors"
 	"fmt"
+	"mime"
 	"strings"
+	"unicode/utf8"
 
 	"github.com/modelcontextprotocol/go-sdk/mcp"
 	"google.golang.org/genai"
@@ -127,20 +129,11 @@ func (t *mcpTool) Run(ctx agent.ToolContext, args any) (map[string]any, error) {
 	}
 
 	if res.IsError {
-		details := strings.Builder{}
-		for _, c := range res.Content {
-			textContent, ok := c.(*mcp.TextContent)
-			if !ok {
-				continue
-			}
-			if _, err := details.WriteString(textContent.Text); err != nil {
-				return nil, fmt.Errorf("failed to write error details: %w", err)
-			}
-		}
+		details := formatMCPContent(res.Content)
 
 		errMsg := "Tool execution failed."
-		if details.Len() > 0 {
-			errMsg += " Details: " + details.String()
+		if details != "" {
+			errMsg += " Details: " + details
 		}
 
 		return nil, errors.New(errMsg)
@@ -152,37 +145,248 @@ func (t *mcpTool) Run(ctx agent.ToolContext, args any) (map[string]any, error) {
 		}, nil
 	}
 
-	textResponse := strings.Builder{}
-	droppedNonText := false
+	content := formatMCPContent(res.Content)
 
-	for _, c := range res.Content {
-		textContent, ok := c.(*mcp.TextContent)
-		if !ok {
-			droppedNonText = true
+	return map[string]any{
+		"output": content,
+	}, nil
+}
+
+type formattedMCPContent struct {
+	text    string
+	isPlain bool
+}
+
+// formatMCPContent renders MCP's ordered content blocks into the text-only
+// response shape supported by FunctionTool.Run.
+func formatMCPContent(contents []mcp.Content) string {
+	formatted := make([]formattedMCPContent, 0, len(contents))
+	for _, content := range contents {
+		block := formattedMCPContent{isPlain: true}
+		switch content := content.(type) {
+		case nil:
+			block.text = "[MCP content: unavailable]"
+			block.isPlain = false
+		case *mcp.TextContent:
+			if content == nil {
+				block.text = "[MCP text content: unavailable]"
+				block.isPlain = false
+			} else {
+				block.text = content.Text
+			}
+		case *mcp.EmbeddedResource:
+			block.text = formatEmbeddedResource(content)
+			block.isPlain = false
+		case *mcp.ResourceLink:
+			block.text = formatResourceLink(content)
+			block.isPlain = false
+		case *mcp.ImageContent:
+			if content == nil {
+				block.text = "[MCP image: unavailable]"
+			} else {
+				block.text = formatMediaContent("image", content.MIMEType, len(content.Data))
+			}
+			block.isPlain = false
+		case *mcp.AudioContent:
+			if content == nil {
+				block.text = "[MCP audio: unavailable]"
+			} else {
+				block.text = formatMediaContent("audio", content.MIMEType, len(content.Data))
+			}
+			block.isPlain = false
+		default:
+			block.text = "[MCP content: unsupported]"
+			block.isPlain = false
+		}
+		formatted = append(formatted, block)
+	}
+
+	var result strings.Builder
+	var previous *formattedMCPContent
+	for i := range formatted {
+		block := &formatted[i]
+		if block.text == "" {
+			continue
+		}
+		if previous != nil && (!previous.isPlain || !block.isPlain) &&
+			!strings.HasSuffix(previous.text, "\n") && !strings.HasPrefix(block.text, "\n") {
+			result.WriteByte('\n')
+		}
+		result.WriteString(block.text)
+		previous = block
+	}
+	return result.String()
+}
+
+func formatEmbeddedResource(content *mcp.EmbeddedResource) string {
+	if content == nil || content.Resource == nil {
+		return "[MCP embedded resource: unavailable]"
+	}
+
+	resource := content.Resource
+	attributes := resourceAttributes(resource.URI, resource.MIMEType)
+	if resource.Text != "" {
+		if len(resource.Blob) > 0 {
+			attributes = append(attributes, fmt.Sprintf("size=%d bytes", len(resource.Blob)))
+		}
+		return formatContentWithBody("embedded resource", attributes, resource.Text)
+	}
+	if text, ok := decodeTextBlob(resource.Blob, resource.MIMEType); ok {
+		return formatContentWithBody("embedded resource", attributes, text)
+	}
+	if len(resource.Blob) > 0 {
+		attributes = append(attributes, fmt.Sprintf("size=%d bytes", len(resource.Blob)))
+	}
+	return formatContentLabel("embedded resource", attributes)
+}
+
+func formatResourceLink(content *mcp.ResourceLink) string {
+	if content == nil {
+		return "[MCP resource link: unavailable]"
+	}
+
+	attributes := resourceAttributes(content.URI, content.MIMEType)
+	if content.Name != "" {
+		attributes = append(attributes, fmt.Sprintf("name=%q", content.Name))
+	}
+	if content.Title != "" {
+		attributes = append(attributes, fmt.Sprintf("title=%q", content.Title))
+	}
+	if content.Description != "" {
+		attributes = append(attributes, fmt.Sprintf("description=%q", content.Description))
+	}
+	if content.Size != nil {
+		attributes = append(attributes, fmt.Sprintf("size=%d bytes", *content.Size))
+	}
+	return formatContentLabel("resource link", attributes)
+}
+
+func formatMediaContent(kind, mimeType string, size int) string {
+	attributes := make([]string, 0, 2)
+	if mimeType != "" {
+		attributes = append(attributes, fmt.Sprintf("mimeType=%q", mimeType))
+	}
+	attributes = append(attributes, fmt.Sprintf("size=%d bytes", size))
+	return formatContentLabel(kind, attributes)
+}
+
+func resourceAttributes(uri, mimeType string) []string {
+	attributes := make([]string, 0, 2)
+	if uri != "" {
+		attributes = append(attributes, fmt.Sprintf("uri=%q", uri))
+	}
+	if mimeType != "" {
+		attributes = append(attributes, fmt.Sprintf("mimeType=%q", mimeType))
+	}
+	return attributes
+}
+
+func formatContentWithBody(kind string, attributes []string, body string) string {
+	return formatContentLabel(kind, attributes) + "\n" + body
+}
+
+func formatContentLabel(kind string, attributes []string) string {
+	if len(attributes) == 0 {
+		return "[MCP " + kind + "]"
+	}
+	return "[MCP " + kind + ": " + strings.Join(attributes, ", ") + "]"
+}
+
+func decodeTextBlob(blob []byte, mimeType string) (string, bool) {
+	if len(blob) == 0 {
+		return "", false
+	}
+
+	declaresCharset := hasMIMECharsetParameter(mimeType)
+	mediaType, params, err := mime.ParseMediaType(mimeType)
+	if err != nil && (!errors.Is(err, mime.ErrInvalidMediaParameter) || declaresCharset) {
+		return "", false
+	}
+	if !isTextMediaType(mediaType) {
+		return "", false
+	}
+
+	charset, parsedCharset := params["charset"]
+	if declaresCharset && !parsedCharset {
+		return "", false
+	}
+	charset = strings.ToLower(charset)
+	switch charset {
+	case "", "utf-8", "utf8":
+		if !utf8.Valid(blob) {
+			return "", false
+		}
+	case "us-ascii", "ascii":
+		for _, b := range blob {
+			if b >= utf8.RuneSelf {
+				return "", false
+			}
+		}
+	default:
+		return "", false
+	}
+	return string(blob), true
+}
+
+func hasMIMECharsetParameter(value string) bool {
+	_, params, ok := strings.Cut(value, ";")
+	if !ok {
+		return false
+	}
+
+	start := 0
+	inQuote := false
+	for i := 0; i <= len(params); i++ {
+		if i != len(params) {
+			switch params[i] {
+			case '\\':
+				if inQuote && i+1 < len(params) {
+					i++
+				}
+				continue
+			case '"':
+				if inQuote {
+					// Validate the complete quoted parameter before trusting its boundaries.
+					if _, _, err := mime.ParseMediaType("text/plain;" + params[start:i+1]); err != nil {
+						return true
+					}
+				} else {
+					_, prefix, ok := strings.Cut(params[start:i], "=")
+					// Only a parameter value may open a quote; other positions are ambiguous.
+					if !ok || strings.TrimSpace(prefix) != "" {
+						return true
+					}
+				}
+				inQuote = !inQuote
+				continue
+			}
+		}
+		if i != len(params) && (params[i] != ';' || inQuote) {
 			continue
 		}
 
-		if _, err := textResponse.WriteString(textContent.Text); err != nil {
-			return nil, fmt.Errorf("failed to write text response: %w", err)
+		parameter := params[start:i]
+		name, _, _ := strings.Cut(parameter, "=")
+		name = strings.ToLower(strings.TrimSpace(name))
+		if name == "charset" || strings.HasPrefix(name, "charset*") {
+			return true
 		}
+		start = i + 1
 	}
+	return inQuote
+}
 
-	// A result that yields no text is a valid success (#1352) when there was no
-	// other content to lose: nothing at all, or only empty text blocks. When the
-	// text is empty because every block was non-text, returning {"output": ""}
-	// would report success while discarding the whole payload, so fail loudly
-	// instead.
-	//
-	// TODO(#1401): remove once non-text blocks are rendered rather than skipped.
-	// That also covers the mixed case this deliberately leaves alone, where a
-	// non-text block accompanies real text and is still dropped silently (#1391).
-	if textResponse.Len() == 0 && droppedNonText {
-		return nil, fmt.Errorf("tool %q returned only non-text content, which is not yet supported", t.name)
+func isTextMediaType(mediaType string) bool {
+	if strings.HasPrefix(mediaType, "text/") || strings.HasSuffix(mediaType, "+json") || strings.HasSuffix(mediaType, "+xml") {
+		return true
 	}
-
-	return map[string]any{
-		"output": textResponse.String(),
-	}, nil
+	switch mediaType {
+	case "application/json", "application/javascript", "application/toml", "application/x-www-form-urlencoded", "application/xml",
+		"application/x-yaml", "application/yaml":
+		return true
+	default:
+		return false
+	}
 }
 
 var (

--- a/tool/mcptoolset/tool_test.go
+++ b/tool/mcptoolset/tool_test.go
@@ -1,0 +1,723 @@
+// Copyright 2026 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package mcptoolset
+
+import (
+	"context"
+	"testing"
+
+	"github.com/google/go-cmp/cmp"
+	"github.com/modelcontextprotocol/go-sdk/mcp"
+
+	"google.golang.org/adk/agent"
+	icontext "google.golang.org/adk/internal/context"
+)
+
+type fixedResultMCPClient struct {
+	result *mcp.CallToolResult
+}
+
+type unsupportedContent struct {
+	mcp.Content
+}
+
+func (c *fixedResultMCPClient) CallTool(context.Context, *mcp.CallToolParams) (*mcp.CallToolResult, error) {
+	return c.result, nil
+}
+
+func (*fixedResultMCPClient) ListTools(context.Context) ([]*mcp.Tool, error) {
+	return nil, nil
+}
+
+func TestMCPToolRunContent(t *testing.T) {
+	resourceSize := int64(1 << 20)
+	tests := []struct {
+		name    string
+		result  *mcp.CallToolResult
+		want    map[string]any
+		wantErr string
+	}{
+		{
+			name: "text only remains compatible",
+			result: &mcp.CallToolResult{Content: []mcp.Content{
+				&mcp.TextContent{Text: "first"},
+				&mcp.TextContent{Text: "second"},
+			}},
+			want: map[string]any{"output": "firstsecond"},
+		},
+		{
+			name: "GitHub file response includes embedded text",
+			result: &mcp.CallToolResult{Content: []mcp.Content{
+				&mcp.TextContent{Text: "successfully downloaded text file"},
+				&mcp.EmbeddedResource{Resource: &mcp.ResourceContents{
+					URI:      "repo://owner/project/main/file.go",
+					MIMEType: "text/plain",
+					Text:     "package example\n",
+				}},
+			}},
+			want: map[string]any{"output": "successfully downloaded text file\n" +
+				"[MCP embedded resource: uri=\"repo://owner/project/main/file.go\", mimeType=\"text/plain\"]\n" +
+				"package example\n"},
+		},
+		{
+			name: "multiline embedded body is separated from following text",
+			result: &mcp.CallToolResult{Content: []mcp.Content{
+				&mcp.EmbeddedResource{Resource: &mcp.ResourceContents{
+					URI:      "file:///multiline.txt",
+					MIMEType: "text/plain",
+					Blob:     []byte("line1\nline2"),
+				}},
+				&mcp.TextContent{Text: "tail"},
+			}},
+			want: map[string]any{"output": "[MCP embedded resource: uri=\"file:///multiline.txt\", " +
+				"mimeType=\"text/plain\"]\nline1\nline2\ntail"},
+		},
+		{
+			name: "embedded text reports an accompanying blob",
+			result: &mcp.CallToolResult{Content: []mcp.Content{
+				&mcp.EmbeddedResource{Resource: &mcp.ResourceContents{
+					URI:      "file:///response.txt",
+					MIMEType: "text/plain",
+					Text:     "caption",
+					Blob:     []byte{1, 2, 3, 4},
+				}},
+			}},
+			want: map[string]any{"output": "[MCP embedded resource: uri=\"file:///response.txt\", " +
+				"mimeType=\"text/plain\", size=4 bytes]\ncaption"},
+		},
+		{
+			name: "text MIME blob is decoded",
+			result: &mcp.CallToolResult{Content: []mcp.Content{
+				&mcp.EmbeddedResource{Resource: &mcp.ResourceContents{
+					URI:      "file:///response.json",
+					MIMEType: "application/problem+json; charset=utf-8",
+					Blob:     []byte(`{"status":"ok"}`),
+				}},
+			}},
+			want: map[string]any{"output": "[MCP embedded resource: uri=\"file:///response.json\", " +
+				"mimeType=\"application/problem+json; charset=utf-8\"]\n{\"status\":\"ok\"}"},
+		},
+		{
+			name: "binary resource is represented by metadata",
+			result: &mcp.CallToolResult{Content: []mcp.Content{
+				&mcp.EmbeddedResource{Resource: &mcp.ResourceContents{
+					URI:      "file:///report.pdf",
+					MIMEType: "application/pdf",
+					Blob:     []byte{1, 2, 3, 4},
+				}},
+			}},
+			want: map[string]any{"output": "[MCP embedded resource: uri=\"file:///report.pdf\", " +
+				"mimeType=\"application/pdf\", size=4 bytes]"},
+		},
+		{
+			name: "empty blob is represented by metadata without size",
+			result: &mcp.CallToolResult{Content: []mcp.Content{
+				&mcp.EmbeddedResource{Resource: &mcp.ResourceContents{
+					URI:      "file:///empty.pdf",
+					MIMEType: "application/pdf",
+					Blob:     []byte{},
+				}},
+			}},
+			want: map[string]any{"output": "[MCP embedded resource: uri=\"file:///empty.pdf\", " +
+				"mimeType=\"application/pdf\"]"},
+		},
+		{
+			name: "empty text blob has no trailing newline",
+			result: &mcp.CallToolResult{Content: []mcp.Content{
+				&mcp.EmbeddedResource{Resource: &mcp.ResourceContents{
+					URI:      "file:///empty.txt",
+					MIMEType: "text/plain",
+					Blob:     []byte{},
+				}},
+			}},
+			want: map[string]any{"output": "[MCP embedded resource: uri=\"file:///empty.txt\", " +
+				"mimeType=\"text/plain\"]"},
+		},
+		{
+			name: "unsupported text charset is represented by metadata",
+			result: &mcp.CallToolResult{Content: []mcp.Content{
+				&mcp.EmbeddedResource{Resource: &mcp.ResourceContents{
+					URI:      "file:///utf16.txt",
+					MIMEType: "text/plain; charset=utf-16",
+					Blob:     []byte("hi"),
+				}},
+			}},
+			want: map[string]any{"output": "[MCP embedded resource: uri=\"file:///utf16.txt\", " +
+				"mimeType=\"text/plain; charset=utf-16\", size=2 bytes]"},
+		},
+		{
+			name: "unsupported extended charset is represented by metadata",
+			result: &mcp.CallToolResult{Content: []mcp.Content{
+				&mcp.EmbeddedResource{Resource: &mcp.ResourceContents{
+					URI:      "file:///utf16-star.txt",
+					MIMEType: "text/plain; charset*=utf-16",
+					Blob:     []byte{0x68, 0x00, 0x69, 0x00},
+				}},
+			}},
+			want: map[string]any{"output": "[MCP embedded resource: uri=\"file:///utf16-star.txt\", " +
+				"mimeType=\"text/plain; charset*=utf-16\", size=4 bytes]"},
+		},
+		{
+			name: "unterminated quoted parameter is represented by metadata",
+			result: &mcp.CallToolResult{Content: []mcp.Content{
+				&mcp.EmbeddedResource{Resource: &mcp.ResourceContents{
+					URI:      "file:///unterminated.txt",
+					MIMEType: `text/plain; name="a; charset=utf-16`,
+					Blob:     []byte{0x68, 0x00, 0x69, 0x00},
+				}},
+			}},
+			want: map[string]any{"output": "[MCP embedded resource: uri=\"file:///unterminated.txt\", " +
+				"mimeType=\"text/plain; name=\\\"a; charset=utf-16\", size=4 bytes]"},
+		},
+		{
+			name: "mid-token quotes are represented by metadata",
+			result: &mcp.CallToolResult{Content: []mcp.Content{
+				&mcp.EmbeddedResource{Resource: &mcp.ResourceContents{
+					URI:      "file:///mid-token.txt",
+					MIMEType: `text/plain; name=a"; charset=utf-16; x="b`,
+					Blob:     []byte{0x68, 0x00, 0x69, 0x00},
+				}},
+			}},
+			want: map[string]any{"output": "[MCP embedded resource: uri=\"file:///mid-token.txt\", " +
+				`mimeType="text/plain; name=a\"; charset=utf-16; x=\"b", size=4 bytes]`},
+		},
+		{
+			name: "quoted charset name is represented by metadata",
+			result: &mcp.CallToolResult{Content: []mcp.Content{
+				&mcp.EmbeddedResource{Resource: &mcp.ResourceContents{
+					URI:      "file:///quoted-name.txt",
+					MIMEType: `text/plain; "charset"=utf-16`,
+					Blob:     []byte{0x68, 0x00, 0x69, 0x00},
+				}},
+			}},
+			want: map[string]any{"output": "[MCP embedded resource: uri=\"file:///quoted-name.txt\", " +
+				`mimeType="text/plain; \"charset\"=utf-16", size=4 bytes]`},
+		},
+		{
+			name: "empty parameter name before quote is represented by metadata",
+			result: &mcp.CallToolResult{Content: []mcp.Content{
+				&mcp.EmbeddedResource{Resource: &mcp.ResourceContents{
+					URI:      "file:///empty-name.txt",
+					MIMEType: `text/plain; ="a; charset=utf-16"`,
+					Blob:     []byte{0x68, 0x00, 0x69, 0x00},
+				}},
+			}},
+			want: map[string]any{"output": "[MCP embedded resource: uri=\"file:///empty-name.txt\", " +
+				`mimeType="text/plain; =\"a; charset=utf-16\"", size=4 bytes]`},
+		},
+		{
+			name: "invalid parameter name before quote is represented by metadata",
+			result: &mcp.CallToolResult{Content: []mcp.Content{
+				&mcp.EmbeddedResource{Resource: &mcp.ResourceContents{
+					URI:      "file:///invalid-name.txt",
+					MIMEType: `text/plain; bad name="a; charset=utf-16"`,
+					Blob:     []byte{0x68, 0x00, 0x69, 0x00},
+				}},
+			}},
+			want: map[string]any{"output": "[MCP embedded resource: uri=\"file:///invalid-name.txt\", " +
+				`mimeType="text/plain; bad name=\"a; charset=utf-16\"", size=4 bytes]`},
+		},
+		{
+			name: "carriage return inside quoted value is represented by metadata",
+			result: &mcp.CallToolResult{Content: []mcp.Content{
+				&mcp.EmbeddedResource{Resource: &mcp.ResourceContents{
+					URI:      "file:///quoted-cr.txt",
+					MIMEType: "text/plain; name=\"a\r; charset=utf-16\"",
+					Blob:     []byte{0x68, 0x00, 0x69, 0x00},
+				}},
+			}},
+			want: map[string]any{"output": "[MCP embedded resource: uri=\"file:///quoted-cr.txt\", " +
+				`mimeType="text/plain; name=\"a\r; charset=utf-16\"", size=4 bytes]`},
+		},
+		{
+			name: "line feed inside quoted value is represented by metadata",
+			result: &mcp.CallToolResult{Content: []mcp.Content{
+				&mcp.EmbeddedResource{Resource: &mcp.ResourceContents{
+					URI:      "file:///quoted-lf.txt",
+					MIMEType: "text/plain; name=\"a\n; charset=utf-16\"",
+					Blob:     []byte{0x68, 0x00, 0x69, 0x00},
+				}},
+			}},
+			want: map[string]any{"output": "[MCP embedded resource: uri=\"file:///quoted-lf.txt\", " +
+				`mimeType="text/plain; name=\"a\n; charset=utf-16\"", size=4 bytes]`},
+		},
+		{
+			name: "charset text inside quoted value does not block decoding",
+			result: &mcp.CallToolResult{Content: []mcp.Content{
+				&mcp.EmbeddedResource{Resource: &mcp.ResourceContents{
+					URI:      "file:///quoted-value.txt",
+					MIMEType: `text/plain; name="foo;charset=utf-16" invalid`,
+					Blob:     []byte("hello"),
+				}},
+			}},
+			want: map[string]any{"output": "[MCP embedded resource: uri=\"file:///quoted-value.txt\", " +
+				`mimeType="text/plain; name=\"foo;charset=utf-16\" invalid"]` + "\nhello"},
+		},
+		{
+			name: "US-ASCII text blob is decoded",
+			result: &mcp.CallToolResult{Content: []mcp.Content{
+				&mcp.EmbeddedResource{Resource: &mcp.ResourceContents{
+					URI:      "file:///ascii.txt",
+					MIMEType: "text/plain; charset=us-ascii",
+					Blob:     []byte("hello"),
+				}},
+			}},
+			want: map[string]any{"output": "[MCP embedded resource: uri=\"file:///ascii.txt\", " +
+				"mimeType=\"text/plain; charset=us-ascii\"]\nhello"},
+		},
+		{
+			name: "ASCII alias text blob is decoded",
+			result: &mcp.CallToolResult{Content: []mcp.Content{
+				&mcp.EmbeddedResource{Resource: &mcp.ResourceContents{
+					URI:      "file:///ascii-alias.txt",
+					MIMEType: "text/plain; charset=ascii",
+					Blob:     []byte("hello"),
+				}},
+			}},
+			want: map[string]any{"output": "[MCP embedded resource: uri=\"file:///ascii-alias.txt\", " +
+				"mimeType=\"text/plain; charset=ascii\"]\nhello"},
+		},
+		{
+			name: "form URL encoded blob is decoded",
+			result: &mcp.CallToolResult{Content: []mcp.Content{
+				&mcp.EmbeddedResource{Resource: &mcp.ResourceContents{
+					URI:      "file:///form.txt",
+					MIMEType: "application/x-www-form-urlencoded",
+					Blob:     []byte("name=alice&active=true"),
+				}},
+			}},
+			want: map[string]any{"output": "[MCP embedded resource: uri=\"file:///form.txt\", " +
+				"mimeType=\"application/x-www-form-urlencoded\"]\nname=alice&active=true"},
+		},
+		{
+			name: "non-ASCII byte is represented by metadata",
+			result: &mcp.CallToolResult{Content: []mcp.Content{
+				&mcp.EmbeddedResource{Resource: &mcp.ResourceContents{
+					URI:      "file:///non-ascii.txt",
+					MIMEType: "text/plain; charset=us-ascii",
+					Blob:     []byte{0x80},
+				}},
+			}},
+			want: map[string]any{"output": "[MCP embedded resource: uri=\"file:///non-ascii.txt\", " +
+				"mimeType=\"text/plain; charset=us-ascii\", size=1 bytes]"},
+		},
+		{
+			name: "malformed charset is represented by metadata",
+			result: &mcp.CallToolResult{Content: []mcp.Content{
+				&mcp.EmbeddedResource{Resource: &mcp.ResourceContents{
+					URI:      "file:///utf16.txt",
+					MIMEType: `text/plain; charset="utf-16`,
+					Blob:     []byte{0x68, 0x00, 0x69, 0x00},
+				}},
+			}},
+			want: map[string]any{"output": "[MCP embedded resource: uri=\"file:///utf16.txt\", " +
+				"mimeType=\"text/plain; charset=\\\"utf-16\", size=4 bytes]"},
+		},
+		{
+			name: "text blob with malformed unrelated parameter is decoded",
+			result: &mcp.CallToolResult{Content: []mcp.Content{
+				&mcp.EmbeddedResource{Resource: &mcp.ResourceContents{
+					URI:      "file:///notes.txt",
+					MIMEType: "text/plain; name=my file.txt",
+					Blob:     []byte("hello"),
+				}},
+			}},
+			want: map[string]any{"output": "[MCP embedded resource: uri=\"file:///notes.txt\", " +
+				"mimeType=\"text/plain; name=my file.txt\"]\nhello"},
+		},
+		{
+			name: "JSON blob with malformed unrelated parameter is decoded",
+			result: &mcp.CallToolResult{Content: []mcp.Content{
+				&mcp.EmbeddedResource{Resource: &mcp.ResourceContents{
+					URI:      "file:///response.json",
+					MIMEType: "application/json; profile=https://example.com/schema",
+					Blob:     []byte(`{"status":"ok"}`),
+				}},
+			}},
+			want: map[string]any{"output": "[MCP embedded resource: uri=\"file:///response.json\", " +
+				"mimeType=\"application/json; profile=https://example.com/schema\"]\n{\"status\":\"ok\"}"},
+		},
+		{
+			name: "charset-like parameter name does not block decoding",
+			result: &mcp.CallToolResult{Content: []mcp.Content{
+				&mcp.EmbeddedResource{Resource: &mcp.ResourceContents{
+					URI:      "file:///notes.txt",
+					MIMEType: "text/plain; x-charset-note=",
+					Blob:     []byte("hello"),
+				}},
+			}},
+			want: map[string]any{"output": "[MCP embedded resource: uri=\"file:///notes.txt\", " +
+				"mimeType=\"text/plain; x-charset-note=\"]\nhello"},
+		},
+		{
+			name: "malformed media type is represented by metadata",
+			result: &mcp.CallToolResult{Content: []mcp.Content{
+				&mcp.EmbeddedResource{Resource: &mcp.ResourceContents{
+					URI:      "file:///invalid.txt",
+					MIMEType: "text/plain extra",
+					Blob:     []byte("hello"),
+				}},
+			}},
+			want: map[string]any{"output": "[MCP embedded resource: uri=\"file:///invalid.txt\", " +
+				"mimeType=\"text/plain extra\", size=5 bytes]"},
+		},
+		{
+			name: "invalid UTF-8 text blob is represented by metadata",
+			result: &mcp.CallToolResult{Content: []mcp.Content{
+				&mcp.EmbeddedResource{Resource: &mcp.ResourceContents{
+					URI:      "file:///invalid.txt",
+					MIMEType: "text/plain",
+					Blob:     []byte{0xc3, 0x28},
+				}},
+			}},
+			want: map[string]any{"output": "[MCP embedded resource: uri=\"file:///invalid.txt\", " +
+				"mimeType=\"text/plain\", size=2 bytes]"},
+		},
+		{
+			name: "resource link includes available metadata",
+			result: &mcp.CallToolResult{Content: []mcp.Content{
+				&mcp.ResourceLink{
+					URI:         "https://example.com/archive.txt",
+					Name:        "archive.txt",
+					Title:       "Archive",
+					Description: "Large text file",
+					MIMEType:    "text/plain",
+					Size:        &resourceSize,
+				},
+			}},
+			want: map[string]any{"output": "[MCP resource link: uri=\"https://example.com/archive.txt\", " +
+				"mimeType=\"text/plain\", name=\"archive.txt\", title=\"Archive\", " +
+				"description=\"Large text file\", size=1048576 bytes]"},
+		},
+		{
+			name: "resource link without metadata uses a plain label",
+			result: &mcp.CallToolResult{Content: []mcp.Content{
+				&mcp.ResourceLink{},
+			}},
+			want: map[string]any{"output": "[MCP resource link]"},
+		},
+		{
+			name: "image and audio are represented in order",
+			result: &mcp.CallToolResult{Content: []mcp.Content{
+				&mcp.TextContent{Text: "media:"},
+				&mcp.ImageContent{MIMEType: "image/png", Data: []byte{1, 2, 3}},
+				&mcp.AudioContent{MIMEType: "audio/wav", Data: []byte{4, 5}},
+				&mcp.TextContent{},
+				&mcp.TextContent{Text: "done"},
+			}},
+			want: map[string]any{"output": "media:\n[MCP image: mimeType=\"image/png\", size=3 bytes]\n" +
+				"[MCP audio: mimeType=\"audio/wav\", size=2 bytes]\ndone"},
+		},
+		{
+			name: "image without MIME type omits MIME metadata",
+			result: &mcp.CallToolResult{Content: []mcp.Content{
+				&mcp.ImageContent{Data: []byte{1, 2}},
+			}},
+			want: map[string]any{"output": "[MCP image: size=2 bytes]"},
+		},
+		{
+			name: "empty leading block does not add a separator",
+			result: &mcp.CallToolResult{Content: []mcp.Content{
+				&mcp.TextContent{},
+				&mcp.ImageContent{MIMEType: "image/png", Data: []byte{1}},
+			}},
+			want: map[string]any{"output": "[MCP image: mimeType=\"image/png\", size=1 bytes]"},
+		},
+		{
+			name: "unsupported content is represented in order",
+			result: &mcp.CallToolResult{Content: []mcp.Content{
+				&mcp.TextContent{Text: "before"},
+				&unsupportedContent{},
+				&mcp.TextContent{Text: "after"},
+			}},
+			want: map[string]any{"output": "before\n[MCP content: unsupported]\nafter"},
+		},
+		{
+			name: "existing newline precedes non-text content",
+			result: &mcp.CallToolResult{Content: []mcp.Content{
+				&mcp.TextContent{Text: "downloaded\n"},
+				&mcp.ResourceLink{URI: "https://example.com/file"},
+			}},
+			want: map[string]any{"output": "downloaded\n" +
+				"[MCP resource link: uri=\"https://example.com/file\"]"},
+		},
+		{
+			name: "existing newline follows non-text content",
+			result: &mcp.CallToolResult{Content: []mcp.Content{
+				&mcp.ImageContent{MIMEType: "image/png", Data: []byte{1}},
+				&mcp.TextContent{Text: "\nnotes"},
+			}},
+			want: map[string]any{"output": "[MCP image: mimeType=\"image/png\", size=1 bytes]\nnotes"},
+		},
+		{
+			name: "structured output takes precedence over mixed content",
+			result: &mcp.CallToolResult{
+				StructuredContent: map[string]any{"sha": "abc123"},
+				Content: []mcp.Content{
+					&mcp.TextContent{Text: "downloaded"},
+					&mcp.EmbeddedResource{Resource: &mcp.ResourceContents{
+						URI:      "repo://owner/project/file.txt",
+						MIMEType: "text/plain",
+						Text:     "file contents",
+					}},
+				},
+			},
+			want: map[string]any{"output": map[string]any{"sha": "abc123"}},
+		},
+		{
+			name: "structured output with text only remains compatible",
+			result: &mcp.CallToolResult{
+				StructuredContent: map[string]any{"status": "ok"},
+				Content:           []mcp.Content{&mcp.TextContent{Text: `{"status":"ok"}`}},
+			},
+			want: map[string]any{"output": map[string]any{"status": "ok"}},
+		},
+		{
+			name: "error response includes non-text details",
+			result: &mcp.CallToolResult{
+				IsError: true,
+				Content: []mcp.Content{
+					&mcp.TextContent{Text: "download failed"},
+					&mcp.ResourceLink{URI: "https://example.com/error", MIMEType: "text/plain"},
+				},
+			},
+			wantErr: "Tool execution failed. Details: download failed\n" +
+				"[MCP resource link: uri=\"https://example.com/error\", mimeType=\"text/plain\"]",
+		},
+		{
+			name: "error response without details omits details suffix",
+			result: &mcp.CallToolResult{
+				IsError: true,
+				Content: []mcp.Content{
+					&mcp.TextContent{},
+				},
+			},
+			wantErr: "Tool execution failed.",
+		},
+		{
+			name:   "nil content returns empty output",
+			result: &mcp.CallToolResult{},
+			want:   map[string]any{"output": ""},
+		},
+		{
+			name: "empty content returns empty output",
+			result: &mcp.CallToolResult{
+				Content: []mcp.Content{},
+			},
+			want: map[string]any{"output": ""},
+		},
+		{
+			name: "all-empty text content returns empty output",
+			result: &mcp.CallToolResult{Content: []mcp.Content{
+				&mcp.TextContent{},
+				&mcp.TextContent{},
+			}},
+			want: map[string]any{"output": ""},
+		},
+		{
+			name: "untyped nil content is unavailable",
+			result: &mcp.CallToolResult{Content: []mcp.Content{
+				nil,
+			}},
+			want: map[string]any{"output": "[MCP content: unavailable]"},
+		},
+		{
+			name: "untyped nil content is separated from following text",
+			result: &mcp.CallToolResult{Content: []mcp.Content{
+				nil,
+				&mcp.TextContent{Text: "after"},
+			}},
+			want: map[string]any{"output": "[MCP content: unavailable]\nafter"},
+		},
+		{
+			name: "typed nil text content is separated from following text",
+			result: &mcp.CallToolResult{Content: []mcp.Content{
+				(*mcp.TextContent)(nil),
+				&mcp.TextContent{Text: "after"},
+			}},
+			want: map[string]any{"output": "[MCP text content: unavailable]\nafter"},
+		},
+		{
+			name: "typed nil content does not panic",
+			result: &mcp.CallToolResult{Content: []mcp.Content{
+				(*mcp.TextContent)(nil),
+				(*mcp.EmbeddedResource)(nil),
+				(*mcp.ResourceLink)(nil),
+				(*mcp.ImageContent)(nil),
+				(*mcp.AudioContent)(nil),
+			}},
+			want: map[string]any{"output": "[MCP text content: unavailable]\n" +
+				"[MCP embedded resource: unavailable]\n" +
+				"[MCP resource link: unavailable]\n" +
+				"[MCP image: unavailable]\n" +
+				"[MCP audio: unavailable]"},
+		},
+		{
+			name: "nil resource does not panic",
+			result: &mcp.CallToolResult{Content: []mcp.Content{
+				&mcp.EmbeddedResource{},
+			}},
+			want: map[string]any{"output": "[MCP embedded resource: unavailable]"},
+		},
+	}
+
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			tool := &mcpTool{
+				name:      "test_tool",
+				mcpClient: &fixedResultMCPClient{result: test.result},
+			}
+			// main passes agent.ContextMock, which 1.x does not have. Its
+			// StrictContextMock would need ToolConfirmation overridden, so use
+			// the real tool context instead, as set_test.go already does.
+			invCtx := icontext.NewInvocationContext(t.Context(), icontext.InvocationContextParams{})
+			got, err := tool.Run(agent.NewToolContext(invCtx, "", nil, nil), map[string]any{})
+			if test.wantErr != "" {
+				if err == nil || err.Error() != test.wantErr {
+					t.Fatalf("Run() error = %v, want %q", err, test.wantErr)
+				}
+				return
+			}
+			if err != nil {
+				t.Fatalf("Run() error = %v", err)
+			}
+			if diff := cmp.Diff(test.want, got); diff != "" {
+				t.Errorf("Run() result mismatch (-want +got):\n%s", diff)
+			}
+		})
+	}
+}
+
+func TestHasMIMECharsetParameter(t *testing.T) {
+	tests := []struct {
+		name     string
+		mimeType string
+		want     bool
+	}{
+		{
+			name:     "extended charset parameter",
+			mimeType: `text/plain; charset*=UTF-16''x; name="a`,
+			want:     true,
+		},
+		{
+			name:     "charset after malformed parameter",
+			mimeType: "text/plain; name=my file.txt; charset=utf-16",
+			want:     true,
+		},
+		{
+			name:     "uppercase charset parameter",
+			mimeType: "text/plain; CHARSET=utf-16; name=a",
+			want:     true,
+		},
+		{
+			name:     "uppercase extended charset after quoted parameter",
+			mimeType: `text/plain; name="a"; CHARSET*=UTF-16`,
+			want:     true,
+		},
+		{
+			name:     "backslash outside quoted parameter",
+			mimeType: `text/plain; \; charset=utf-16`,
+			want:     true,
+		},
+		{
+			name:     "unterminated quoted parameter is ambiguous",
+			mimeType: `text/plain; name="a`,
+			want:     true,
+		},
+		{
+			name:     "mid-token quotes are ambiguous",
+			mimeType: `text/plain; name=a"; charset=utf-16; x="b`,
+			want:     true,
+		},
+		{
+			name:     "quoted charset name is ambiguous",
+			mimeType: `text/plain; "charset"=utf-16`,
+			want:     true,
+		},
+		{
+			name:     "empty parameter name before quote is ambiguous",
+			mimeType: `text/plain; ="a; charset=utf-16"`,
+			want:     true,
+		},
+		{
+			name:     "invalid parameter name before quote is ambiguous",
+			mimeType: `text/plain; bad name="a; charset=utf-16"`,
+			want:     true,
+		},
+		{
+			name:     "carriage return inside quoted value is ambiguous",
+			mimeType: "text/plain; name=\"a\r; charset=utf-16\"",
+			want:     true,
+		},
+		{
+			name:     "line feed inside quoted value is ambiguous",
+			mimeType: "text/plain; name=\"a\n; charset=utf-16\"",
+			want:     true,
+		},
+		{
+			name:     "backslash before carriage return inside quoted value is ambiguous",
+			mimeType: "text/plain; name=\"a\\\r; charset=utf-16\"",
+			want:     true,
+		},
+		{
+			name:     "backslash before line feed inside quoted value is ambiguous",
+			mimeType: "text/plain; name=\"a\\\n; charset=utf-16\"",
+			want:     true,
+		},
+		{
+			name:     "charset text inside quoted value",
+			mimeType: `text/plain; name="foo;charset=utf-16" invalid`,
+			want:     false,
+		},
+		{
+			name:     "whitespace before quoted value",
+			mimeType: "text/plain; name= \t\"foo;charset=utf-16\" invalid",
+			want:     false,
+		},
+		{
+			name:     "quoted value after unrelated parameter",
+			mimeType: `text/plain; name=a; note="foo;charset=utf-16" invalid`,
+			want:     false,
+		},
+		{
+			name:     "equals inside quoted value",
+			mimeType: `text/plain; name="a=b;charset=utf-16" invalid`,
+			want:     false,
+		},
+		{
+			name:     "escaped quote inside quoted value",
+			mimeType: `text/plain; name="a\";charset=utf-16" invalid`,
+			want:     false,
+		},
+		{
+			name:     "extra equals before quote is ambiguous",
+			mimeType: `text/plain; name=a="; charset=utf-16; x="b`,
+			want:     true,
+		},
+		{
+			name:     "quote after closed value is ambiguous",
+			mimeType: `text/plain; name="a""; charset=utf-16; x="b`,
+			want:     true,
+		},
+	}
+
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			if got := hasMIMECharsetParameter(test.mimeType); got != test.want {
+				t.Errorf("hasMIMECharsetParameter(%q) = %v, want %v", test.mimeType, got, test.want)
+			}
+		})
+	}
+}


### PR DESCRIPTION
## Problem

The MCP toolset drops or mangles three kinds of valid tool result on 1.x.

- A tool returning an empty text content is rejected with `no text content in tool response`, even though an empty string is a valid answer.
- A result carrying only non-text content is silently reduced to nothing, so the caller sees an empty output with no indication anything was returned.
- Unstructured non-text content is not rendered at all.

## Summary

Backports #1353, #1473 and #1401, one commit each, in the order they landed on main.

- **#1353** removes the empty-text guard, so a tool that legitimately answers with an empty string is no longer an error.
- **#1473** reports non-text-only results instead of dropping them.
- **#1401** renders non-text unstructured results, including a placeholder for an embedded resource that cannot be read.

One adaptation: main's test builds a tool context with `agent.ContextMock`, which 1.x does not have. The test now constructs a real context with `agent.NewToolContext`, the way the other tests in this package already do.
