### PR TITLE
fix: backport runner and agent lifecycle fixes (#1061, #1206, #1479)

### DIFF
--- a/agent/llmagent/llmagent.go
+++ b/agent/llmagent/llmagent.go
@@ -448,12 +448,17 @@ func (a *llmAgent) maybeSaveOutputToState(event *session.Event) {
 		// TODO: log "Skipping output save for agent %s: event authored by %s"
 		return
 	}
-	if a.OutputKey != "" && !event.Partial && event.Content != nil && len(event.Content.Parts) > 0 {
+	if a.OutputKey != "" && event.IsFinalResponse() && event.Content != nil && len(event.Content.Parts) > 0 {
 		var sb strings.Builder
+		hasTextPart := false
 		for _, part := range event.Content.Parts {
 			if part.Text != "" && !part.Thought {
+				hasTextPart = true
 				sb.WriteString(part.Text)
 			}
+		}
+		if !hasTextPart {
+			return
 		}
 		result := sb.String()
 

--- a/agent/llmagent/llmagent_saveoutput_test.go
+++ b/agent/llmagent/llmagent_saveoutput_test.go
@@ -83,9 +83,36 @@ func TestLlmAgent_MaybeSaveOutputToState(t *testing.T) {
 			wantStateDelta: map[string]any{},
 		},
 		{
+			name:        "skips function call events",
+			agentConfig: Config{Name: "test_agent", OutputKey: "result"},
+			event:       createTestEvent("test_agent", "", true),
+			customEventParts: []*genai.Part{
+				{FunctionCall: &genai.FunctionCall{ID: "call_1", Name: "read_state"}},
+			},
+			wantStateDelta: map[string]any{},
+		},
+		{
+			name:        "skips function response events",
+			agentConfig: Config{Name: "test_agent", OutputKey: "result"},
+			event:       createTestEvent("test_agent", "", true),
+			customEventParts: []*genai.Part{
+				{FunctionResponse: &genai.FunctionResponse{Name: "read_state", Response: map[string]any{"result": "SECRET_42"}}},
+			},
+			wantStateDelta: map[string]any{},
+		},
+		{
 			name:           "skips when event has no content text",
 			agentConfig:    Config{Name: "test_agent", OutputKey: "result"},
 			event:          createTestEvent("test_agent", "", true),
+			wantStateDelta: map[string]any{},
+		},
+		{
+			name:        "skips thought-only text",
+			agentConfig: Config{Name: "test_agent", OutputKey: "result"},
+			event:       createTestEvent("test_agent", "", true),
+			customEventParts: []*genai.Part{
+				{Text: "hidden thought", Thought: true},
+			},
 			wantStateDelta: map[string]any{},
 		},
 		{

--- a/agent/remoteagent/v2/a2a_agent.go
+++ b/agent/remoteagent/v2/a2a_agent.go
@@ -348,6 +348,20 @@ func (a *a2aAgent) run(ctx agent.InvocationContext, cfg A2AConfig) iter.Seq2[*se
 
 			if event != nil { // an event might be skipped
 				for _, toEmit := range processor.aggregatePartial(ctx, a2aEvent, event) {
+					// aggregatePartial may synthesize a brand-new non-partial
+					// event from buffered partial chunks (the reassembled
+					// artifact). That event has not passed through the
+					// after-callbacks, so run them here. The pass-through `event`
+					// already ran callbacks above; skip it (same pointer) to
+					// avoid invoking callbacks on it twice.
+					if toEmit != event {
+						if cbResp, cbErr := processor.runAfterA2ARequestCallbacks(ctx, toEmit, nil); cbResp != nil || cbErr != nil {
+							if cbErr != nil {
+								return yieldErr(cbErr)
+							}
+							toEmit = cbResp
+						}
+					}
 					if !yield(toEmit, nil) {
 						return false
 					}

--- a/agent/remoteagent/v2/a2a_agent_test.go
+++ b/agent/remoteagent/v2/a2a_agent_test.go
@@ -916,6 +916,83 @@ func TestRemoteAgent_RequestCallbacks(t *testing.T) {
 	}
 }
 
+// TestRemoteAgent_AfterCallbackRunsOnAggregatedArtifact guards that
+// AfterRequestCallbacks run on the non-partial event synthesized from partial
+// artifact chunks (the reassembled artifact), not only on the raw incoming
+// events. Streaming an artifact as Append chunks ending with LastChunk routes
+// through buildNonPartialAggregation, which previously bypassed the callbacks —
+// so a callback that acts only on non-partial events never saw a chunked
+// artifact.
+func TestRemoteAgent_AfterCallbackRunsOnAggregatedArtifact(t *testing.T) {
+	executor := &mockA2AExecutor{
+		executeFn: func(ctx context.Context, execCtx *a2asrv.ExecutorContext) iter.Seq2[a2a.Event, error] {
+			return func(yield func(a2a.Event, error) bool) {
+				first := a2a.NewArtifactEvent(execCtx, a2a.NewTextPart("Hello"))
+				last := a2a.NewArtifactUpdateEvent(execCtx, first.Artifact.ID, a2a.NewTextPart(", world!"))
+				last.Append = true
+				last.LastChunk = true // routes through buildNonPartialAggregation
+				events := []a2a.Event{
+					a2a.NewSubmittedTask(execCtx, a2a.NewMessage(a2a.MessageRoleUser, a2a.NewTextPart("..."))),
+					first,
+					last,
+					a2a.NewStatusUpdateEvent(execCtx, a2a.TaskStateCompleted, nil),
+				}
+				for _, ev := range events {
+					if !yield(ev, nil) {
+						return
+					}
+				}
+			}
+		},
+	}
+	server := startA2AServer(executor)
+	card := &a2a.AgentCard{
+		SupportedInterfaces: []*a2a.AgentInterface{
+			a2a.NewAgentInterface(server.URL, a2a.TransportProtocolJSONRPC),
+		},
+		Capabilities: a2a.AgentCapabilities{Streaming: true},
+	}
+
+	// Record the text of every non-partial event handed to the callback. The
+	// callback deliberately ignores partial chunks, so its metadata can't leak
+	// into the aggregated event via chunk aggregation — only a direct call on
+	// the aggregated event can record it.
+	var nonPartialSeen []string
+	after := []AfterA2ARequestCallback{
+		func(ctx agent.CallbackContext, req *a2a.SendMessageRequest, result *session.Event, err error) (*session.Event, error) {
+			if result != nil && !result.Partial && result.Content != nil && len(result.Content.Parts) > 0 {
+				nonPartialSeen = append(nonPartialSeen, result.Content.Parts[0].Text)
+			}
+			return nil, nil
+		},
+	}
+
+	remoteAgent, err := NewA2A(A2AConfig{
+		Name:                  "a2a",
+		AgentCard:             card,
+		AfterRequestCallbacks: after,
+	})
+	if err != nil {
+		t.Fatalf("NewA2A() error = %v", err)
+	}
+
+	ictx := newInvocationContext(t, []*session.Event{newUserHello()})
+	if _, err := runAndCollect(ictx, remoteAgent); err != nil {
+		t.Fatalf("agent.Run() error = %v", err)
+	}
+
+	found := false
+	for _, txt := range nonPartialSeen {
+		if txt == "Hello, world!" {
+			found = true
+			break
+		}
+	}
+	if !found {
+		t.Errorf("after-callback was not invoked on the aggregated artifact event; non-partial events seen = %v, want to include %q", nonPartialSeen, "Hello, world!")
+	}
+}
+
 func TestRemoteAgent_RequestPayload(t *testing.T) {
 	remoteAgentName, notRemoteAgentName := "a2a", "not-a2a"
 	testCases := []struct {

--- a/runner/live_runner_test.go
+++ b/runner/live_runner_test.go
@@ -19,6 +19,7 @@ import (
 	"iter"
 	"strings"
 	"testing"
+	"time"
 
 	"google.golang.org/genai"
 
@@ -40,6 +41,79 @@ type dummyLiveSession struct{}
 
 func (d *dummyLiveSession) Send(req agent.LiveRequest) error { return nil }
 func (d *dummyLiveSession) Close() error                     { return nil }
+
+func TestRunner_RunLive_NilEventYieldedTerminatesRun(t *testing.T) {
+	ctx := context.Background()
+	appName, userID, sessionID := "testApp", "testUser", "testSessionNilFlood"
+
+	sessionService := session.InMemoryService()
+	_, err := sessionService.Create(ctx, &session.CreateRequest{
+		AppName:   appName,
+		UserID:    userID,
+		SessionID: sessionID,
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	testAgent := must(agent.New(agent.Config{Name: "nil_flood"}))
+	mockLive := &mockLiveAgent{
+		Agent: testAgent,
+		runLiveFn: func(ctx agent.InvocationContext) (agent.LiveSession, iter.Seq2[*session.Event, error], error) {
+			return &dummyLiveSession{}, func(yield func(*session.Event, error) bool) {
+				for {
+					if !yield(nil, nil) {
+						return
+					}
+				}
+			}, nil
+		},
+	}
+
+	r, err := New(Config{
+		AppName:        appName,
+		Agent:          mockLive,
+		SessionService: sessionService,
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	_, iter, err := r.RunLive(ctx, userID, sessionID, agent.LiveRunConfig{})
+	if err != nil {
+		t.Fatalf("RunLive failed: %v", err)
+	}
+
+	type result struct {
+		err        error
+		iterations int
+	}
+	done := make(chan result, 1)
+	go func() {
+		got := result{}
+		for _, err := range iter {
+			got.err = err
+			got.iterations++
+			break
+		}
+		done <- got
+	}()
+
+	select {
+	case got := <-done:
+		if got.iterations != 1 {
+			t.Fatalf("RunLive() iterations = %d, want 1", got.iterations)
+		}
+		if got.err == nil {
+			t.Fatal("RunLive() yielded no error for a nil event")
+		}
+		if !strings.Contains(got.err.Error(), "nil_flood") {
+			t.Fatalf("RunLive() error = %v, want the agent name", got.err)
+		}
+	case <-time.After(time.Second):
+		t.Fatal("RunLive() did not terminate after a nil event")
+	}
+}
 
 func TestRunner_RunLive_Callbacks(t *testing.T) {
 	ctx := context.Background()

--- a/runner/runner.go
+++ b/runner/runner.go
@@ -253,7 +253,10 @@ func (r *Runner) Run(ctx context.Context, userID, sessionID string, msg *genai.C
 			}
 
 			if event == nil {
-				continue
+				err := fmt.Errorf("adk: agent %q yielded a nil event", r.rootAgent.Name())
+				log.Printf("%v", err)
+				yield(nil, err)
+				return
 			}
 
 			// only commit non-partial event to a session service
@@ -461,7 +464,10 @@ func (r *Runner) RunLive(ctx context.Context, userID, sessionID string, cfg agen
 			}
 
 			if event == nil {
-				continue
+				err := fmt.Errorf("adk: agent %q yielded a nil event", agentToRun.Name())
+				log.Printf("%v", err)
+				yield(nil, err)
+				return
 			}
 
 			// Chronological event buffering logic for Live streaming.

--- a/runner/runner_test.go
+++ b/runner/runner_test.go
@@ -21,6 +21,7 @@ import (
 	"iter"
 	"strings"
 	"testing"
+	"time"
 
 	"google.golang.org/genai"
 
@@ -448,14 +449,16 @@ func TestRunner_AutoCreateSession(t *testing.T) {
 	}
 }
 
-func TestRunner_NilEventYieldedDoesNotPanic(t *testing.T) {
-	t.Parallel()
-
+func TestRunner_NilEventYieldedTerminatesRun(t *testing.T) {
 	nilAgent, err := agent.New(agent.Config{
-		Name: "nil_yielder",
+		Name: "nil_flood",
 		Run: func(ctx agent.InvocationContext) iter.Seq2[*session.Event, error] {
 			return func(yield func(*session.Event, error) bool) {
-				yield(nil, nil)
+				for {
+					if !yield(nil, nil) {
+						return
+					}
+				}
 			}
 		},
 	})
@@ -464,28 +467,51 @@ func TestRunner_NilEventYieldedDoesNotPanic(t *testing.T) {
 	}
 
 	sessionService := session.InMemoryService()
+	_, err = sessionService.Create(context.Background(), &session.CreateRequest{
+		AppName:   "test_app",
+		UserID:    "user1",
+		SessionID: "session1",
+	})
+	if err != nil {
+		t.Fatalf("Create() error = %v", err)
+	}
+
 	r, err := New(Config{
-		AppName:           "test_app",
-		Agent:             nilAgent,
-		SessionService:    sessionService,
-		AutoCreateSession: true,
+		AppName:        "test_app",
+		Agent:          nilAgent,
+		SessionService: sessionService,
 	})
 	if err != nil {
 		t.Fatalf("New() error = %v", err)
 	}
 
-	var count int
-	msg := &genai.Content{Parts: []*genai.Part{{Text: "hello"}}}
-	for ev, err := range r.Run(t.Context(), "user1", "session1", msg, agent.RunConfig{}) {
-		if err != nil {
-			t.Errorf("unexpected error: %v", err)
-		}
-		if ev == nil {
-			t.Errorf("unexpected nil event")
-		}
-		count++
+	type result struct {
+		err        error
+		iterations int
 	}
-	if count != 0 {
-		t.Errorf("expected 0 events, got %d", count)
+	done := make(chan result, 1)
+	go func() {
+		got := result{}
+		for _, err := range r.Run(context.Background(), "user1", "session1", genai.NewContentFromText("hello", genai.RoleUser), agent.RunConfig{}) {
+			got.err = err
+			got.iterations++
+			break
+		}
+		done <- got
+	}()
+
+	select {
+	case got := <-done:
+		if got.iterations != 1 {
+			t.Fatalf("Run() iterations = %d, want 1", got.iterations)
+		}
+		if got.err == nil {
+			t.Fatal("Run() yielded no error for a nil event")
+		}
+		if !strings.Contains(got.err.Error(), "nil_flood") {
+			t.Fatalf("Run() error = %v, want the agent name", got.err)
+		}
+	case <-time.After(time.Second):
+		t.Fatal("Run() did not terminate after a nil event")
 	}
 }


### PR DESCRIPTION
## Problem

Three runner and agent lifecycle defects shipped in 2.4.0 and are still present on 1.x.

- An agent yielding a nil event is skipped with `continue`. An agent that yields nil repeatedly, which is what a cancelled live stream does, spins the run loop forever with no error and no way out for the caller.
- A non-text event overwrites `OutputKey`, so a tool call or an artifact event can clobber the text the agent was asked to save.
- After-callbacks do not run on the aggregated artifact event from an A2A peer, so a callback watching for the final aggregate never sees it.

## Summary

Backports #1061, #1206 and #1479, one commit each, in the order they landed on main.

- **#1061** requires a final response carrying a text part before writing to `OutputKey`.
- **#1206** runs after-callbacks on the aggregated artifact event.
- **#1479** turns a nil event into an error naming the agent, logs it and stops the loop, in both `Run` and `RunLive`.

One adaptation: the A2A after-request callback takes `agent.CallbackContext` on 1.x, where main has the unified `agent.Context`.
