### PR TITLE
fix: backport artifact and memory fixes (#1528, #1563)

### DIFF
--- a/artifact/gcsartifact/gcs_test.go
+++ b/artifact/gcsartifact/gcs_test.go
@@ -249,6 +249,56 @@ func TestNotFoundIsWrappedSentinel(t *testing.T) {
 	}
 }
 
+// TestGetArtifactVersionCanonicalURI checks the URI handed to a consumer is the
+// gs:// form even though the object also has a MediaLink. MediaLink is an
+// authenticated JSON API download URL: a model given it as the file_uri of a
+// file_data part treats it as a web page and cannot read the object.
+func TestGetArtifactVersionCanonicalURI(t *testing.T) {
+	for _, tc := range []struct {
+		name     string
+		fileName string
+		wantPath string
+	}{
+		{name: "session scoped", fileName: "file", wantPath: "app/user/session/file"},
+		{name: "user namespaced", fileName: "user:file", wantPath: "app/user/user/user:file"},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			svc := newGCSServiceForTesting("demo-bucket")
+			saved, err := svc.Save(t.Context(), &artifact.SaveRequest{
+				AppName: "app", UserID: "user", SessionID: "session", FileName: tc.fileName,
+				Part: genai.NewPartFromBytes([]byte("data"), "text/plain"),
+			})
+			if err != nil {
+				t.Fatalf("Save() failed: %v", err)
+			}
+
+			// The assertion below only distinguishes the two forms while the
+			// stored object actually has a MediaLink to be preferred over, so
+			// pin that rather than leaving it to the fixture.
+			blobName := buildBlobName("app", "user", "session", tc.fileName, saved.Version)
+			attrs, err := svc.bucket.object(blobName).attrs(t.Context())
+			if err != nil {
+				t.Fatalf("attrs() failed: %v", err)
+			}
+			if attrs.MediaLink == "" {
+				t.Fatal("stored object has no MediaLink, so this test cannot detect a regression")
+			}
+
+			resp, err := svc.GetArtifactVersion(t.Context(), &artifact.GetArtifactVersionRequest{
+				AppName: "app", UserID: "user", SessionID: "session", FileName: tc.fileName,
+			})
+			if err != nil {
+				t.Fatalf("GetArtifactVersion() failed: %v", err)
+			}
+
+			want := fmt.Sprintf("gs://demo-bucket/%s/%d", tc.wantPath, saved.Version)
+			if got := resp.ArtifactVersion.CanonicalURI; got != want {
+				t.Errorf("CanonicalURI = %q, want %q", got, want)
+			}
+		})
+	}
+}
+
 // TestBackoffDelayBounds checks the jittered backoff stays within [0, saveRetryMaxDelay].
 func TestBackoffDelayBounds(t *testing.T) {
 	for attempt := range maxSaveAttempts {
@@ -425,7 +475,14 @@ func (o *fakeObject) attrs(ctx context.Context) (*storage.ObjectAttrs, error) {
 	if !b.exists {
 		return nil, storage.ErrObjectNotExist
 	}
-	return &storage.ObjectAttrs{Name: b.name, Created: time.Now(), ContentType: b.contentType}, nil
+	// MediaLink is populated on every object real GCS returns. The fake left it
+	// empty, which hid that CanonicalURI preferred it over the gs:// form.
+	return &storage.ObjectAttrs{
+		Name:        b.name,
+		Created:     time.Now(),
+		ContentType: b.contentType,
+		MediaLink:   "https://storage.googleapis.com/download/storage/v1/b/bucket/o/" + b.name + "?alt=media",
+	}, nil
 }
 
 // delete removes the object from the in-memory store.

--- a/artifact/gcsartifact/service.go
+++ b/artifact/gcsartifact/service.go
@@ -480,12 +480,11 @@ func (s *gcsService) GetArtifactVersion(ctx context.Context, req *artifact.GetAr
 		return nil, fmt.Errorf("could not get blob attributes: %w", err)
 	}
 
-	var canonicalURI string
-	if attrs.MediaLink != "" {
-		canonicalURI = attrs.MediaLink
-	} else {
-		canonicalURI = fmt.Sprintf("gs://%s/%s", s.bucketName, blobName)
-	}
+	// Always the gs:// form, matching adk-python's GCS artifact service. The
+	// object's MediaLink is an authenticated JSON API download URL, which a
+	// consumer handed the URI cannot fetch: a model given it as the file_uri of
+	// a file_data part treats it as a web page and fails to read it.
+	canonicalURI := fmt.Sprintf("gs://%s/%s", s.bucketName, blobName)
 
 	customMeta := make(map[string]any)
 	if attrs.Metadata != nil {

--- a/artifact/service.go
+++ b/artifact/service.go
@@ -267,8 +267,16 @@ type VersionsResponse struct {
 
 // ArtifactVersion contains metadata describing a specific version of an artifact.
 type ArtifactVersion struct {
-	Version        int64
-	CanonicalURI   string
+	Version int64
+
+	// CanonicalURI identifies the stored payload in the scheme native to the
+	// backing store, such as gs:// for Google Cloud Storage. It is an identity,
+	// not a download endpoint: it is what a consumer that understands the
+	// scheme resolves, including a model handed it as the FileURI of a
+	// [genai.Part] FileData. It is not an authenticated HTTP URL, and a service
+	// that has no such scheme may leave it empty.
+	CanonicalURI string
+
 	CustomMetadata map[string]any
 	CreateTime     float64
 	MimeType       string

--- a/memory/inmemory.go
+++ b/memory/inmemory.go
@@ -15,21 +15,28 @@
 package memory
 
 import (
+	"cmp"
 	"context"
 	"maps"
+	"slices"
 	"strings"
 	"sync"
 	"time"
+	"unicode"
 
 	"google.golang.org/genai"
 
 	"google.golang.org/adk/session"
 )
 
+const maxSearchResults = 10
+
 // InMemoryService returns a new in-memory implementation of the memory service. Thread-safe.
+// Searches return at most ten entries, ranked by the number of distinct query
+// words they match. Ties follow session insertion order, then event order.
 func InMemoryService() Service {
 	return &inMemoryService{
-		store: make(map[key]map[sessionID][]value),
+		store: make(map[key]*userMemories),
 	}
 }
 
@@ -48,12 +55,21 @@ type value struct {
 
 	// precomputed set of words in the content for simple keyword matching.
 	words map[string]struct{}
+
+	// Cache an additional lowercase copy of the event text to avoid joining and
+	// lowercasing content parts on each substring search.
+	textLower string
+}
+
+type userMemories struct {
+	sessions     map[sessionID][]value
+	sessionOrder []sessionID
 }
 
 // inMemoryService is an in-memory implementation of Service.
 type inMemoryService struct {
 	mu    sync.RWMutex
-	store map[key]map[sessionID][]value
+	store map[key]*userMemories
 }
 
 func (s *inMemoryService) AddSessionToMemory(ctx context.Context, curSession session.Session) error {
@@ -65,12 +81,14 @@ func (s *inMemoryService) AddSessionToMemory(ctx context.Context, curSession ses
 		}
 
 		words := make(map[string]struct{})
+		var texts []string
 		for _, part := range event.LLMResponse.Content.Parts {
 			if part.Text == "" {
 				continue
 			}
 
 			maps.Copy(words, extractWords(part.Text))
+			texts = append(texts, part.Text)
 		}
 
 		if len(words) == 0 {
@@ -84,6 +102,7 @@ func (s *inMemoryService) AddSessionToMemory(ctx context.Context, curSession ses
 			timestamp:      event.Timestamp,
 			customMetadata: event.CustomMetadata,
 			words:          words,
+			textLower:      strings.ToLower(strings.Join(texts, " ")),
 		})
 	}
 
@@ -97,17 +116,25 @@ func (s *inMemoryService) AddSessionToMemory(ctx context.Context, curSession ses
 
 	v, ok := s.store[k]
 	if !ok {
-		v = map[sessionID][]value{}
+		v = &userMemories{sessions: make(map[sessionID][]value)}
 		s.store[k] = v
 	}
 
 	sid := sessionID(curSession.ID())
-	v[sid] = values
+	// Replacing a session must preserve its position, as in Python's dict.
+	if _, ok := v.sessions[sid]; !ok {
+		v.sessionOrder = append(v.sessionOrder, sid)
+	}
+	v.sessions[sid] = values
 	return nil
 }
 
 func (s *inMemoryService) SearchMemory(ctx context.Context, req *SearchRequest) (*SearchResponse, error) {
-	queryWords := extractWords(req.Query)
+	// A true value allows substring matching for that non-ASCII query word.
+	queryWords := make(map[string]bool)
+	for word := range extractWords(req.Query) {
+		queryWords[word] = strings.IndexFunc(word, func(r rune) bool { return r > unicode.MaxASCII }) >= 0
+	}
 
 	k := key{
 		appName: req.AppName,
@@ -115,6 +142,15 @@ func (s *inMemoryService) SearchMemory(ctx context.Context, req *SearchRequest) 
 	}
 
 	res := &SearchResponse{}
+	if len(queryWords) == 0 {
+		return res, nil
+	}
+
+	type scoredMemory struct {
+		score int
+		entry Entry
+	}
+	var scored []scoredMemory
 
 	// Hold the read lock for the whole scan. AddSessionToMemory writes into the
 	// per-user session map under the write lock, so releasing the lock before
@@ -128,40 +164,39 @@ func (s *inMemoryService) SearchMemory(ctx context.Context, req *SearchRequest) 
 		return res, nil
 	}
 
-	for _, events := range values {
-		for _, e := range events {
-			if checkMapsIntersect(e.words, queryWords) {
-				res.Memories = append(res.Memories, Entry{
-					ID:             e.id,
-					Content:        e.content,
-					Author:         e.author,
-					Timestamp:      e.timestamp,
-					CustomMetadata: e.customMetadata,
+	for _, sid := range values.sessionOrder {
+		for _, e := range values.sessions[sid] {
+			score := 0
+			for word, allowSubstring := range queryWords {
+				if _, ok := e.words[word]; ok || (allowSubstring && strings.Contains(e.textLower, word)) {
+					score++
+				}
+			}
+			if score > 0 {
+				scored = append(scored, scoredMemory{
+					score: score,
+					entry: Entry{
+						ID:             e.id,
+						Content:        e.content,
+						Author:         e.author,
+						Timestamp:      e.timestamp,
+						CustomMetadata: e.customMetadata,
+					},
 				})
 			}
 		}
 	}
 
+	// Common words can match most of the store. Rank all matches before limiting
+	// results so that later, more relevant events can still reach the prompt.
+	slices.SortStableFunc(scored, func(a, b scoredMemory) int {
+		return cmp.Compare(b.score, a.score)
+	})
+	for _, match := range scored[:min(len(scored), maxSearchResults)] {
+		res.Memories = append(res.Memories, match.entry)
+	}
+
 	return res, nil
-}
-
-func checkMapsIntersect(m1, m2 map[string]struct{}) bool {
-	if len(m1) == 0 || len(m2) == 0 {
-		return false
-	}
-
-	// Iterate over the smaller map.
-	if len(m1) > len(m2) {
-		m1, m2 = m2, m1
-	}
-
-	for k := range m1 {
-		if _, ok := m2[k]; ok {
-			return true
-		}
-	}
-
-	return false
 }
 
 func extractWords(text string) map[string]struct{} {

--- a/memory/inmemory_search_test.go
+++ b/memory/inmemory_search_test.go
@@ -1,0 +1,204 @@
+// Copyright 2026 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package memory_test
+
+import (
+	"strconv"
+	"testing"
+	"time"
+
+	"github.com/google/go-cmp/cmp"
+	"google.golang.org/genai"
+
+	"google.golang.org/adk/memory"
+	"google.golang.org/adk/model"
+	"google.golang.org/adk/session"
+)
+
+func Test_inMemoryService_SearchMemory_Ranking(t *testing.T) {
+	for _, tt := range []struct {
+		name  string
+		texts []string
+		query string
+		want  []string
+	}{
+		{
+			name:  "most query words first",
+			texts: []string{"deploy ready", "ready", "deploy status ready", "unrelated"},
+			query: "deploy status ready",
+			want:  []string{"2", "0", "1"},
+		},
+		{
+			name:  "repeated words count once",
+			texts: []string{"ready ready ready", "deploy status", "ready deploy"},
+			query: "READY ready ready deploy status",
+			want:  []string{"1", "2", "0"},
+		},
+		{
+			name:  "token and substring matches count once",
+			texts: []string{"caf\u00e9", "deploy ready", "CAF\u00c9 deploy"},
+			query: "caf\u00e9 deploy ready",
+			want:  []string{"1", "2", "0"},
+		},
+		{
+			name:  "combine token and non ASCII substring scores",
+			texts: []string{"deploy", "\u6211\u559c\u6b22\u673a\u5668\u5b66\u4e60 deploy", "\u6211\u559c\u6b22\u673a\u5668\u5b66\u4e60"},
+			query: "deploy \u673a\u5668\u5b66\u4e60",
+			want:  []string{"1", "0", "2"},
+		},
+		{
+			name:  "empty query",
+			texts: []string{"ready"},
+		},
+		{
+			name:  "no matching words",
+			texts: []string{"ready"},
+			query: "missing",
+		},
+	} {
+		t.Run(tt.name, func(t *testing.T) {
+			s := memory.InMemoryService()
+			var events []*session.Event
+			for i, text := range tt.texts {
+				events = append(events, memoryTextEvent(strconv.Itoa(i), text))
+			}
+			if err := s.AddSessionToMemory(t.Context(), makeSession(t, "app", "user", "session", events)); err != nil {
+				t.Fatal(err)
+			}
+			got, err := s.SearchMemory(t.Context(), &memory.SearchRequest{AppName: "app", UserID: "user", Query: tt.query})
+			if err != nil {
+				t.Fatal(err)
+			}
+			var ids []string
+			for _, entry := range got.Memories {
+				ids = append(ids, entry.ID)
+			}
+			if diff := cmp.Diff(tt.want, ids); diff != "" {
+				t.Errorf("SearchMemory() order mismatch (-want +got):\n%s", diff)
+			}
+		})
+	}
+}
+
+func Test_inMemoryService_SearchMemory_LimitAndSessionOrder(t *testing.T) {
+	s := memory.InMemoryService()
+	// Session IDs and timestamps run backwards so neither can define tie order.
+	for i := 0; i < 12; i++ {
+		var events []*session.Event
+		for j := 0; j < 2; j++ {
+			e := memoryTextEvent(strconv.Itoa(2*i+j), "note about work")
+			e.Timestamp = time.Unix(int64(100-2*i-j), 0)
+			events = append(events, e)
+		}
+		if err := s.AddSessionToMemory(t.Context(), makeSession(t, "app", "user", strconv.Itoa(12-i), events)); err != nil {
+			t.Fatal(err)
+		}
+	}
+	if err := s.AddSessionToMemory(t.Context(), makeSession(t, "app", "user", "best", []*session.Event{
+		memoryTextEvent("best", "backlog note about work"),
+	})); err != nil {
+		t.Fatal(err)
+	}
+
+	want := []string{"best", "0", "1", "2", "3", "4", "5", "6", "7", "8"}
+	for i := 0; i < 20; i++ {
+		got, err := s.SearchMemory(t.Context(), &memory.SearchRequest{AppName: "app", UserID: "user", Query: "work backlog note"})
+		if err != nil {
+			t.Fatal(err)
+		}
+		var ids []string
+		for _, entry := range got.Memories {
+			ids = append(ids, entry.ID)
+		}
+		if diff := cmp.Diff(want, ids); diff != "" {
+			t.Fatalf("SearchMemory() iteration %d mismatch (-want +got):\n%s", i, diff)
+		}
+	}
+}
+
+func Test_inMemoryService_SearchMemory_ReplacedSessionOrder(t *testing.T) {
+	s := memory.InMemoryService()
+	for _, sess := range []session.Session{
+		makeSession(t, "app", "user", "z", []*session.Event{memoryTextEvent("old", "note")}),
+		makeSession(t, "app", "user", "empty", nil),
+		makeSession(t, "app", "user", "a", []*session.Event{memoryTextEvent("last", "note")}),
+		makeSession(t, "app", "user", "z", []*session.Event{memoryTextEvent("replacement", "note")}),
+		makeSession(t, "app", "user", "empty", []*session.Event{memoryTextEvent("middle", "note")}),
+	} {
+		if err := s.AddSessionToMemory(t.Context(), sess); err != nil {
+			t.Fatal(err)
+		}
+	}
+	for i := 0; i < 20; i++ {
+		got, err := s.SearchMemory(t.Context(), &memory.SearchRequest{AppName: "app", UserID: "user", Query: "note"})
+		if err != nil {
+			t.Fatal(err)
+		}
+		var ids []string
+		for _, entry := range got.Memories {
+			ids = append(ids, entry.ID)
+		}
+		if diff := cmp.Diff([]string{"replacement", "middle", "last"}, ids); diff != "" {
+			t.Fatalf("SearchMemory() iteration %d mismatch (-want +got):\n%s", i, diff)
+		}
+	}
+}
+
+func Test_inMemoryService_SearchMemory_NonASCII(t *testing.T) {
+	for _, tt := range []struct {
+		name  string
+		parts []string
+		query string
+		want  int
+	}{
+		{name: "Chinese substring", parts: []string{"\u6211\u559c\u6b22\u673a\u5668\u5b66\u4e60"}, query: "\u673a\u5668\u5b66\u4e60", want: 1},
+		{name: "Chinese no match", parts: []string{"\u6211\u559c\u6b22\u673a\u5668\u5b66\u4e60"}, query: "\u5929\u6c14\u9884\u62a5"},
+		{name: "Japanese substring", parts: []string{"\u79c1\u306e\u540d\u524d\u306f\u592a\u90ce\u3067\u3059"}, query: "\u592a\u90ce", want: 1},
+		{name: "non ASCII case folding", parts: []string{"CAF\u00c9TERIA"}, query: "caf\u00e9", want: 1},
+		{name: "substring in later part", parts: []string{"hello", "\u6211\u559c\u6b22\u673a\u5668\u5b66\u4e60"}, query: "\u673a\u5668\u5b66\u4e60", want: 1},
+		{name: "do not join words across parts", parts: []string{"\u673a\u5668", "\u5b66\u4e60"}, query: "\u673a\u5668\u5b66\u4e60"},
+		{name: "ASCII partial word does not match", parts: []string{"Python"}, query: "thon"},
+		{name: "ASCII token matches", parts: []string{"Python"}, query: "python", want: 1},
+		{name: "empty text", parts: []string{""}, query: "\u673a\u5668"},
+	} {
+		t.Run(tt.name, func(t *testing.T) {
+			s := memory.InMemoryService()
+			e := memoryTextEvent("event", tt.parts...)
+			if err := s.AddSessionToMemory(t.Context(), makeSession(t, "app", "user", "session", []*session.Event{e})); err != nil {
+				t.Fatal(err)
+			}
+			got, err := s.SearchMemory(t.Context(), &memory.SearchRequest{AppName: "app", UserID: "user", Query: tt.query})
+			if err != nil {
+				t.Fatal(err)
+			}
+			if len(got.Memories) != tt.want {
+				t.Fatalf("SearchMemory() returned %d entries, want %d", len(got.Memories), tt.want)
+			}
+		})
+	}
+}
+
+func memoryTextEvent(id string, texts ...string) *session.Event {
+	var parts []*genai.Part
+	for _, text := range texts {
+		parts = append(parts, genai.NewPartFromText(text))
+	}
+	return &session.Event{
+		ID: id,
+		LLMResponse: model.LLMResponse{
+			Content: genai.NewContentFromParts(parts, genai.RoleUser),
+		},
+	}
+}

--- a/memory/inmemory_test.go
+++ b/memory/inmemory_test.go
@@ -237,8 +237,8 @@ func Test_inMemoryService_SearchMemory_Concurrent(t *testing.T) {
 	s := memory.InMemoryService()
 	ctx := t.Context()
 
-	// Seed one session so the per-user map is non-empty while searchers iterate.
-	if err := s.AddSessionToMemory(ctx, makeSession(t, "app1", "user1", "seed", nil)); err != nil {
+	// Seed a matching event so searchers also exercise scoring and sorting.
+	if err := s.AddSessionToMemory(ctx, makeSession(t, "app1", "user1", "seed", []*session.Event{memoryTextEvent("seed", "x")})); err != nil {
 		t.Fatalf("AddSessionToMemory() error = %v", err)
 	}
 
@@ -250,7 +250,7 @@ func Test_inMemoryService_SearchMemory_Concurrent(t *testing.T) {
 			defer wg.Done()
 			for j := 0; j < 50; j++ {
 				id := "s" + strconv.Itoa(i) + "-" + strconv.Itoa(j)
-				if err := s.AddSessionToMemory(ctx, makeSession(t, "app1", "user1", id, nil)); err != nil {
+				if err := s.AddSessionToMemory(ctx, makeSession(t, "app1", "user1", id, []*session.Event{memoryTextEvent(id, "x")})); err != nil {
 					t.Errorf("AddSessionToMemory() error = %v", err)
 					return
 				}


### PR DESCRIPTION
## Problem

Two defects shipped in 2.4.0 and are still present on 1.x.

- In-memory memory search returns every match, unranked and unbounded, and handles a non-ASCII query word the same way as an ASCII one.
- The GCS artifact service returns the object's `MediaLink` as `CanonicalURI` whenever one is set. That is an authenticated JSON API download URL, so a model handed it as the `file_uri` of a `file_data` part treats it as a web page and fails to read it.

## Summary

Backports #1528 and #1563.

- **#1528** ranks results by how many distinct query words they match, caps the result set at ten, and breaks ties by session insertion order then event order. Non-ASCII query words are detected and matched accordingly.
- **#1563** always returns the `gs://` form, matching adk-python's GCS artifact service, and documents what `CanonicalURI` is: an identity in the backing store's native scheme, not a download endpoint.
