### PR TITLE
fix(examples): validate generated image responses (#1478)

### DIFF
--- a/examples/internal/imagegen/imagegen.go
+++ b/examples/internal/imagegen/imagegen.go
@@ -1,0 +1,63 @@
+// Copyright 2026 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+// Package imagegen contains helpers shared by image generation examples.
+package imagegen
+
+import (
+	"errors"
+	"fmt"
+	"strings"
+
+	"google.golang.org/genai"
+)
+
+// ImageBytes returns the bytes and MIME type of the first usable image in a
+// generation response. If the response contains no generated images, it returns
+// an error reporting that no images were returned. If the entries contain no
+// usable image data but include RAI filtering reasons, the error includes the
+// first reason that remains non-empty after trimming surrounding whitespace.
+// Whitespace-only reasons are ignored. Otherwise, an error reports that the
+// entries contain no usable image data.
+//
+// ImageBytes assumes the image is delivered as inline bytes (Image.ImageBytes);
+// an entry carrying only a GCS URI is treated as having no usable image data.
+//
+// On error, ImageBytes returns nil bytes and an empty MIME type. On success,
+// the returned bytes alias the image data in the SDK response; they are not
+// copied. The MIME type is returned as-is from the response and may be empty,
+// so callers should fall back to a default when it is empty.
+func ImageBytes(response *genai.GenerateImagesResponse) ([]byte, string, error) {
+	if response == nil || len(response.GeneratedImages) == 0 {
+		return nil, "", errors.New("image generation returned no images")
+	}
+
+	var filteredReason string
+	for _, generatedImage := range response.GeneratedImages {
+		if generatedImage == nil {
+			continue
+		}
+		if generatedImage.Image != nil && len(generatedImage.Image.ImageBytes) > 0 {
+			return generatedImage.Image.ImageBytes, generatedImage.Image.MIMEType, nil
+		}
+		if reason := strings.TrimSpace(generatedImage.RAIFilteredReason); filteredReason == "" && reason != "" {
+			filteredReason = reason
+		}
+	}
+
+	if filteredReason != "" {
+		return nil, "", fmt.Errorf("image generation returned no image: %s", filteredReason)
+	}
+	return nil, "", errors.New("image generation returned no usable image data")
+}

--- a/examples/internal/imagegen/imagegen_test.go
+++ b/examples/internal/imagegen/imagegen_test.go
@@ -1,0 +1,158 @@
+// Copyright 2026 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package imagegen
+
+import (
+	"bytes"
+	"testing"
+
+	"google.golang.org/genai"
+)
+
+func TestImageBytes(t *testing.T) {
+	tests := []struct {
+		name     string
+		response *genai.GenerateImagesResponse
+		want     []byte
+		wantMIME string
+		wantErr  string
+	}{
+		{
+			name:    "nil response",
+			wantErr: "image generation returned no images",
+		},
+		{
+			name:     "empty response",
+			response: &genai.GenerateImagesResponse{},
+			wantErr:  "image generation returned no images",
+		},
+		{
+			name: "nil generated image",
+			response: &genai.GenerateImagesResponse{
+				GeneratedImages: []*genai.GeneratedImage{nil},
+			},
+			wantErr: "image generation returned no usable image data",
+		},
+		{
+			name: "first filtering reason",
+			response: &genai.GenerateImagesResponse{
+				GeneratedImages: []*genai.GeneratedImage{
+					{
+						Image:             &genai.Image{},
+						RAIFilteredReason: "blocked",
+					},
+					{RAIFilteredReason: "later reason"},
+				},
+			},
+			wantErr: "image generation returned no image: blocked",
+		},
+		{
+			name: "whitespace filtering reason ignored",
+			response: &genai.GenerateImagesResponse{
+				GeneratedImages: []*genai.GeneratedImage{
+					{RAIFilteredReason: " \t\n "},
+				},
+			},
+			wantErr: "image generation returned no usable image data",
+		},
+		{
+			name: "whitespace reason yields to a later real one",
+			response: &genai.GenerateImagesResponse{
+				GeneratedImages: []*genai.GeneratedImage{
+					{RAIFilteredReason: "   "},
+					{RAIFilteredReason: "  blocked  "},
+				},
+			},
+			wantErr: "image generation returned no image: blocked",
+		},
+		{
+			name: "empty image data",
+			response: &genai.GenerateImagesResponse{
+				GeneratedImages: []*genai.GeneratedImage{
+					{Image: &genai.Image{}},
+				},
+			},
+			wantErr: "image generation returned no usable image data",
+		},
+		{
+			name: "empty but non-nil image bytes with a reason",
+			response: &genai.GenerateImagesResponse{
+				GeneratedImages: []*genai.GeneratedImage{
+					{
+						Image:             &genai.Image{ImageBytes: []byte{}},
+						RAIFilteredReason: "blocked",
+					},
+				},
+			},
+			wantErr: "image generation returned no image: blocked",
+		},
+		{
+			name: "GCS URI without inline image data",
+			response: &genai.GenerateImagesResponse{
+				GeneratedImages: []*genai.GeneratedImage{
+					{Image: &genai.Image{GCSURI: "gs://bucket/image.png"}},
+				},
+			},
+			wantErr: "image generation returned no usable image data",
+		},
+		{
+			name: "first usable image",
+			response: &genai.GenerateImagesResponse{
+				GeneratedImages: []*genai.GeneratedImage{
+					nil,
+					{RAIFilteredReason: "filtered"},
+					{Image: &genai.Image{ImageBytes: []byte("first image"), MIMEType: "image/jpeg"}},
+					{Image: &genai.Image{ImageBytes: []byte("second image")}},
+				},
+			},
+			want:     []byte("first image"),
+			wantMIME: "image/jpeg",
+		},
+		{
+			name: "MIME type omitted by the response",
+			response: &genai.GenerateImagesResponse{
+				GeneratedImages: []*genai.GeneratedImage{
+					{Image: &genai.Image{ImageBytes: []byte("bytes")}},
+				},
+			},
+			want:     []byte("bytes"),
+			wantMIME: "",
+		},
+	}
+
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			got, mime, err := ImageBytes(test.response)
+			if test.wantErr != "" {
+				if err == nil || err.Error() != test.wantErr {
+					t.Fatalf("ImageBytes() error = %v, want %q", err, test.wantErr)
+				}
+				if got != nil || mime != "" {
+					t.Errorf("ImageBytes() = (%q, %q), want (nil, \"\") on error", got, mime)
+				}
+				return
+			}
+			if err != nil {
+				t.Fatalf("ImageBytes() unexpected error: %v", err)
+			}
+			if !bytes.Equal(got, test.want) {
+				t.Errorf("ImageBytes() bytes = %q, want %q", got, test.want)
+			}
+			if mime != test.wantMIME {
+				t.Errorf("ImageBytes() mime = %q, want %q", mime, test.wantMIME)
+			}
+		})
+	}
+}

--- a/examples/vertexai/imagegenerator/main.go
+++ b/examples/vertexai/imagegenerator/main.go
@@ -30,6 +30,7 @@ import (
 	"google.golang.org/adk/artifact"
 	"google.golang.org/adk/cmd/launcher"
 	"google.golang.org/adk/cmd/launcher/full"
+	"google.golang.org/adk/examples/internal/imagegen"
 	"google.golang.org/adk/model/gemini"
 	"google.golang.org/adk/tool"
 	"google.golang.org/adk/tool/functiontool"
@@ -105,12 +106,23 @@ func generateImage(ctx agent.ToolContext, input generateImageInput) (generateIma
 		ctx,
 		"imagen-3.0-generate-002",
 		input.Prompt,
-		&genai.GenerateImagesConfig{NumberOfImages: 1})
+		&genai.GenerateImagesConfig{
+			NumberOfImages:   1,
+			IncludeRAIReason: true,
+		})
 	if err != nil {
 		return generateImageResult{}, err
 	}
 
-	_, err = ctx.Artifacts().Save(ctx, input.Filename, genai.NewPartFromBytes(response.GeneratedImages[0].Image.ImageBytes, "image/png"))
+	imageBytes, mimeType, err := imagegen.ImageBytes(response)
+	if err != nil {
+		return generateImageResult{}, err
+	}
+	if mimeType == "" {
+		mimeType = "image/png" // Imagen emits PNG by default; fall back when the response omits the MIME type.
+	}
+
+	_, err = ctx.Artifacts().Save(ctx, input.Filename, genai.NewPartFromBytes(imageBytes, mimeType))
 	if err != nil {
 		return generateImageResult{}, err
 	}

--- a/examples/web/agents/image_generator.go
+++ b/examples/web/agents/image_generator.go
@@ -24,6 +24,7 @@ import (
 
 	"google.golang.org/adk/agent"
 	"google.golang.org/adk/agent/llmagent"
+	"google.golang.org/adk/examples/internal/imagegen"
 	"google.golang.org/adk/model"
 	"google.golang.org/adk/tool"
 	"google.golang.org/adk/tool/functiontool"
@@ -46,14 +47,26 @@ func generateImage(ctx agent.ToolContext, input generateImageInput) (generateIma
 		ctx,
 		"imagen-3.0-generate-002",
 		input.Prompt,
-		&genai.GenerateImagesConfig{NumberOfImages: 1})
+		&genai.GenerateImagesConfig{
+			NumberOfImages:   1,
+			IncludeRAIReason: true,
+		})
 	if err != nil {
 		return generateImageResult{
 			Status: "fail",
 		}, nil
 	}
 
-	_, err = ctx.Artifacts().Save(ctx, input.Filename, genai.NewPartFromBytes(response.GeneratedImages[0].Image.ImageBytes, "image/png"))
+	imageBytes, mimeType, err := imagegen.ImageBytes(response)
+	if err != nil {
+		// Propagate the error so callers can surface any response filtering reason.
+		return generateImageResult{}, err
+	}
+	if mimeType == "" {
+		mimeType = "image/png" // Imagen emits PNG by default; fall back when the response omits the MIME type.
+	}
+
+	_, err = ctx.Artifacts().Save(ctx, input.Filename, genai.NewPartFromBytes(imageBytes, mimeType))
 	if err != nil {
 		return generateImageResult{
 			Status: "fail",


### PR DESCRIPTION
## Problem

The image generation examples assume the model returned an image. A response carrying no inline data, or one whose part is text rather than image bytes, is written out as a file anyway, so the example produces a corrupt artifact instead of reporting what came back.

## Summary

Backports #1478, which adds an `ImageBytes` helper that validates the response before anything is written. A response with no images, or one whose entries carry no usable image data, returns an error rather than a file. Where the model filtered the request, the error carries the reported reasons, so the example says why nothing came back.

Changes are confined to `examples/`.
