### PR TITLE
fix(functiontool): wrap non-map results only when they can be marshaled

### DIFF
--- a/tool/functiontool/function.go
+++ b/tool/functiontool/function.go
@@ -16,6 +16,7 @@
 package functiontool
 
 import (
+	"encoding/json"
 	"errors"
 	"fmt"
 	"reflect"
@@ -237,8 +238,15 @@ func (f *functionTool[TArgs, TResults]) Run(ctx agent.Context, args any) (result
 	// functions.py __build_response_event does the following
 	// if not isinstance(function_result, dict):
 	// 		function_result = {'result': function_result}
-	if f.outputSchema != nil {
-		if err1 := f.outputSchema.Validate(output); err1 != nil {
+	// Diverges from the python impl above: a result encoding/json cannot represent
+	// must not be wrapped, because it cannot be sent.
+	if _, mErr := json.Marshal(output); mErr != nil {
+		return nil, mErr
+	}
+	// A schema inferred from TResults describes the type, not what encoding/json
+	// emits for it.
+	if f.cfg.OutputSchema != nil {
+		if err1 := typeutil.ValidateWithJSONSchema(output, f.outputSchema); err1 != nil {
 			return resp, err // if it fails propagate original err.
 		}
 	}

--- a/tool/functiontool/function_test.go
+++ b/tool/functiontool/function_test.go
@@ -19,9 +19,11 @@ import (
 	"errors"
 	"fmt"
 	"iter"
+	"math"
 	"path/filepath"
 	"strings"
 	"testing"
+	"time"
 
 	"github.com/google/go-cmp/cmp"
 	"github.com/google/go-cmp/cmp/cmpopts"
@@ -344,6 +346,238 @@ func TestFunctionTool_ReturnsBasicType(t *testing.T) {
 				t.Errorf("weatherReportTool.Run returned unexpected result (-want +got):\n%s", diff)
 			}
 		})
+	}
+}
+
+func TestFunctionTool_ResultNotRepresentable(t *testing.T) {
+	type Args struct{}
+	for _, tc := range []struct {
+		name       string
+		createTool func() (tool.Tool, error)
+		wantErrMsg string
+	}{
+		{
+			name: "map_holding_nan",
+			createTool: func() (tool.Tool, error) {
+				return functiontool.New(functiontool.Config{
+					Name:        "nan_map_tool",
+					Description: "a tool whose result map holds NaN",
+				}, func(ctx agent.Context, _ Args) (map[string]any, error) {
+					return map[string]any{"score": math.NaN()}, nil
+				})
+			},
+			wantErrMsg: "json: unsupported value: NaN",
+		},
+		{
+			name: "float_infinity",
+			createTool: func() (tool.Tool, error) {
+				return functiontool.New(functiontool.Config{
+					Name:        "inf_float_tool",
+					Description: "a tool returning positive infinity",
+				}, func(ctx agent.Context, _ Args) (float64, error) {
+					return math.Inf(1), nil
+				})
+			},
+			wantErrMsg: "json: unsupported value: +Inf",
+		},
+		{
+			name: "map_holding_channel",
+			createTool: func() (tool.Tool, error) {
+				return functiontool.New(functiontool.Config{
+					Name:        "channel_map_tool",
+					Description: "a tool whose result map holds a channel",
+				}, func(ctx agent.Context, _ Args) (map[string]any, error) {
+					return map[string]any{"ch": make(chan int)}, nil
+				})
+			},
+			wantErrMsg: "json: unsupported type: chan int",
+		},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			tl, err := tc.createTool()
+			if err != nil {
+				t.Fatalf("functiontool.New failed: %v", err)
+			}
+			funcTool, ok := tl.(toolinternal.FunctionTool)
+			if !ok {
+				t.Fatalf("%T does not implement toolinternal.FunctionTool", tl)
+			}
+			got, err := funcTool.Run(createToolContext(t), map[string]any{})
+			if got != nil {
+				t.Errorf("Run returned result %v, want nil", got)
+			}
+			if err == nil {
+				t.Fatalf("Run returned no error, want %q", tc.wantErrMsg)
+			}
+			if err.Error() != tc.wantErrMsg {
+				t.Errorf("Run returned error %q, want %q", err, tc.wantErrMsg)
+			}
+		})
+	}
+}
+
+// objectMarshaler marshals to an object whose key its inferred schema does not
+// describe, so the two disagree even though the value itself is fine.
+type objectMarshaler struct{ N int }
+
+func (objectMarshaler) MarshalJSON() ([]byte, error) { return []byte(`{"other":1}`), nil }
+
+func TestFunctionTool_WrapsNonMapResult(t *testing.T) {
+	type Args struct{}
+	type player struct {
+		Name  string  `json:"name"`
+		Score float64 `json:"score"`
+	}
+	for _, tc := range []struct {
+		name       string
+		createTool func() (tool.Tool, error)
+		want       any
+	}{
+		{
+			name: "slice_of_structs",
+			createTool: func() (tool.Tool, error) {
+				return functiontool.New(functiontool.Config{
+					Name:        "roster_tool",
+					Description: "a tool returning a slice of structs",
+				}, func(ctx agent.Context, _ Args) ([]player, error) {
+					return []player{{Name: "THY", Score: 5.4186}}, nil
+				})
+			},
+			want: []player{{Name: "THY", Score: 5.4186}},
+		},
+		{
+			name: "slice_of_struct_pointers",
+			createTool: func() (tool.Tool, error) {
+				return functiontool.New(functiontool.Config{
+					Name:        "roster_ptr_tool",
+					Description: "a tool returning a slice of struct pointers",
+				}, func(ctx agent.Context, _ Args) ([]*player, error) {
+					return []*player{{Name: "THY", Score: 5.4186}}, nil
+				})
+			},
+			want: []*player{{Name: "THY", Score: 5.4186}},
+		},
+		{
+			name: "struct_marshaling_to_a_string",
+			createTool: func() (tool.Tool, error) {
+				return functiontool.New(functiontool.Config{
+					Name:        "clock_tool",
+					Description: "a tool returning a time",
+				}, func(ctx agent.Context, _ Args) (time.Time, error) {
+					return time.Unix(0, 0).UTC(), nil
+				})
+			},
+			want: time.Unix(0, 0).UTC(),
+		},
+		{
+			name: "struct_marshaling_to_other_keys",
+			createTool: func() (tool.Tool, error) {
+				return functiontool.New(functiontool.Config{
+					Name:        "object_marshaler_tool",
+					Description: "a tool returning a value with its own MarshalJSON",
+				}, func(ctx agent.Context, _ Args) (objectMarshaler, error) {
+					return objectMarshaler{N: 1}, nil
+				})
+			},
+			want: objectMarshaler{N: 1},
+		},
+		{
+			name: "struct_with_configured_output_schema",
+			createTool: func() (tool.Tool, error) {
+				return functiontool.New(functiontool.Config{
+					Name:         "configured_clock_tool",
+					Description:  "a tool returning a time, validated against the configured schema",
+					OutputSchema: &jsonschema.Schema{Type: "string"},
+				}, func(ctx agent.Context, _ Args) (time.Time, error) {
+					return time.Unix(0, 0).UTC(), nil
+				})
+			},
+			want: time.Unix(0, 0).UTC(),
+		},
+		{
+			name: "byte_slice",
+			createTool: func() (tool.Tool, error) {
+				return functiontool.New(functiontool.Config{
+					Name:        "bytes_tool",
+					Description: "a tool returning bytes, which marshal to a base64 string",
+				}, func(ctx agent.Context, _ Args) ([]byte, error) {
+					return []byte("ab"), nil
+				})
+			},
+			want: []byte("ab"),
+		},
+		{
+			name: "raw_message",
+			createTool: func() (tool.Tool, error) {
+				return functiontool.New(functiontool.Config{
+					Name:        "raw_tool",
+					Description: "a tool returning pre-encoded JSON",
+				}, func(ctx agent.Context, _ Args) (json.RawMessage, error) {
+					return json.RawMessage(`{"a":1}`), nil
+				})
+			},
+			want: json.RawMessage(`{"a":1}`),
+		},
+		{
+			name: "nil_struct_pointer",
+			createTool: func() (tool.Tool, error) {
+				return functiontool.New(functiontool.Config{
+					Name:        "absent_tool",
+					Description: "a tool returning no value",
+				}, func(ctx agent.Context, _ Args) (*player, error) {
+					return nil, nil
+				})
+			},
+			want: (*player)(nil),
+		},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			tl, err := tc.createTool()
+			if err != nil {
+				t.Fatalf("functiontool.New failed: %v", err)
+			}
+			funcTool, ok := tl.(toolinternal.FunctionTool)
+			if !ok {
+				t.Fatalf("%T does not implement toolinternal.FunctionTool", tl)
+			}
+			got, err := funcTool.Run(createToolContext(t), map[string]any{})
+			if err != nil {
+				t.Fatalf("Run returned error %v, want nil", err)
+			}
+			if diff := cmp.Diff(tc.want, got["result"]); diff != "" {
+				t.Errorf("Run returned unexpected result (-want +got):\n%s", diff)
+			}
+		})
+	}
+}
+
+func TestFunctionTool_OutputSchemaMismatch(t *testing.T) {
+	type Args struct{}
+	maxLen := 3
+	tl, err := functiontool.New(functiontool.Config{
+		Name:         "short_text_tool",
+		Description:  "a tool whose result must be at most three characters",
+		OutputSchema: &jsonschema.Schema{Type: "string", MaxLength: &maxLen},
+	}, func(ctx agent.Context, _ Args) (string, error) {
+		return "abcdefgh", nil
+	})
+	if err != nil {
+		t.Fatalf("functiontool.New failed: %v", err)
+	}
+	funcTool, ok := tl.(toolinternal.FunctionTool)
+	if !ok {
+		t.Fatalf("%T does not implement toolinternal.FunctionTool", tl)
+	}
+	got, err := funcTool.Run(createToolContext(t), map[string]any{})
+	if got != nil {
+		t.Errorf("Run returned result %v, want nil", got)
+	}
+	wantErrMsg := `validating root: maxLength: "abcdefgh" contains 8 Unicode code points, more than 3`
+	if err == nil {
+		t.Fatalf("Run returned no error, want %q", wantErrMsg)
+	}
+	if err.Error() != wantErrMsg {
+		t.Errorf("Run returned error %q, want %q", err, wantErrMsg)
 	}
 }
 


### PR DESCRIPTION
### Link to Issue or Description of Change

**1. Link to an existing issue (if applicable):**

- Closes: #1585

**Problem:**

The guard at `function.go:241` decides whether a result that will not convert to `map[string]any` is wrapped or reported as an error. What it validates is the raw Go value: `Resolved.Validate` refuses a `reflect.Struct` outright at `jsonschema/validate.go:449-451`, sorts floats by fractional part at `jsonschema/util.go:262-266`, and never marshals. Valid results such as `[]SomeStruct` and `time.Time` are therefore reported as failures, while `map[string]any` holding `math.NaN()` is wrapped and returned with a nil error, after which genai discards the marshal error at `models.go:4472` and the call ends in a 404 with an empty body.

**Solution:**

Marshal once before the fallback and return that error when it fails, so a result is wrapped only when it can be sent. Schema validation applies only to a schema supplied through `Config.OutputSchema`.

The inferred schema describes `TResults` rather than what `encoding/json` emits for it, so moving the validation to the JSON form without taking it out of this decision would reject `[]byte`, which emits a base64 string against an array schema, `json.RawMessage`, and a `*SomeStruct` returning nil, which normalizes to `{}` and then hits required. All three work on main and remain supported. `ConvertToWithJSONSchema` is untouched; it has 10 non-test call sites in the repo.

**Behavior change:** three kinds of result that were reported as failures are now wrapped: a non-map result with a Go struct on its path such as `[]SomeStruct`; a named struct that marshals to something other than an object such as `time.Time`; and a named struct whose `MarshalJSON` emits keys the inferred schema does not describe. A result `encoding/json` cannot represent now returns that marshal error instead of being wrapped, and `callTool` turns that error into `{"error": ...}` at `base_flow.go:1416` rather than failing the run. Everything else is unchanged.

**Parity with adk-python:** `_normalize_tool_result` at `flows/llm_flows/_tool_caller.py:95-99` wraps anything that is not a dict and has no representability check, and Python function tools have no notion of an output schema. The added marshal is a deliberate divergence, since a result rejected by `encoding/json` cannot be sent even once wrapped; the reason is written in the comment on the change.

### Testing Plan

**Unit Tests:**

- [x] Tests for the changed packages pass locally.

`TestFunctionTool_WrapsNonMapResult` covers eight cases: five results that were wrongly rejected, plus `[]byte`, `json.RawMessage` and a `*player` returning nil, which already worked and must keep working. `TestFunctionTool_ResultNotRepresentable` covers NaN, +Inf and a chan. `TestFunctionTool_OutputSchemaMismatch` keeps `Config.OutputSchema` enforced and pins the error it returns.

**With your source change reverted and your tests kept, which test fails?**

Eight subtests fail: the three rows of `TestFunctionTool_ResultNotRepresentable`, where `Run` returns a nil error together with a wrapped `map[result:map[score:NaN]]`, `map[result:+Inf]` and `map[result:map[ch:0x...]]`, and the first five rows of `TestFunctionTool_WrapsNonMapResult`, which report `Run returned error ..., want nil`. The remaining three rows and `TestFunctionTool_OutputSchemaMismatch` pass on main and are there as regression guards.

`go test -count=1 -shuffle=on` covers `./tool/...`, `./workflow/...`, `./internal/...`, `./agent/...` and `./model/...`. Two packages are red for reasons unrelated to this change, and are red on unmodified main as well. `internal/telemetry/functionaltest` is red every time: sibling spans sharing a start time are ordered by name at `internal/telemetry/telemetrytest/span_digest.go:134-138`, and this machine's clock granularity puts both cases inside one tick. `TestCompactionE2E` in `agent/llmagent` is red intermittently, 3 times out of 8 on unmodified main and 4 times out of 8 on this branch. `golangci-lint run` and `go mod tidy -diff` are clean for both modules, and `go build ./...` passes.

**Manual End-to-End (E2E) Tests:**

Both backends, Gemini API and Vertex AI, were run once before the fix and once after, on `a59464b`, with `gemini-3.8-flash` and `session.InMemoryService` for the session.

For the valid result that was wrongly rejected, the tool returns `[]player` with two elements scoring 5.4186 and 8.65. Before the fix the model receives the tool error and cannot answer with the roster; after it, both runs receive the data and answer from it.

<details>
<summary>Log</summary>

```
===== gemini, base a59464b =====
backend: BackendGeminiAPI
tool call:   roster_tool map[team:Blue]
tool result: map[error:json: cannot unmarshal array into Go value of type map[string]interface {}]
model: I am unable to list the players and scores for team Blue because the roster tool encountered an error while retrieving the data.
===== gemini, fixed =====
backend: BackendGeminiAPI
tool call:   roster_tool map[team:Blue]
tool result: map[result:[{THY 5.4186} {Bo 8.65}]]
model: Team Blue consists of THY with a score of 5.4186 and Bo with a score of 8.65.
===== vertex, base a59464b =====
backend: BackendVertexAI
tool call:   roster_tool map[team:Blue]
tool result: map[error:json: cannot unmarshal array into Go value of type map[string]interface {}]
tool call:   roster_tool map[team:blue]
tool result: map[error:json: cannot unmarshal array into Go value of type map[string]interface {}]
model: Unable to retrieve the players and scores for team Blue due to a tool error.
===== vertex, fixed =====
backend: BackendVertexAI
tool call:   roster_tool map[team:Blue]
tool result: map[result:[{THY 5.4186} {Bo 8.65}]]
model: Team Blue consists of THY with a score of 5.4186 and Bo with a score of 8.65.
```

</details>

For the unrepresentable result that was wrongly let through, the tool returns `map[string]any{"score": math.NaN()}`. Before the fix both runs end in a 404 whose `Message` is empty and break off; after it, the marshal error reaches the model as `{"error": ...}` and both runs go through.

<details>
<summary>Log</summary>

```
===== gemini, base a59464b =====
backend: BackendGeminiAPI
tool call:   score_tool map[team:Blue]
tool result: map[result:map[score:NaN]]
run error: failed to call model: Error 404, Message: , Status: 404 Not Found, Details: []
===== gemini, fixed =====
backend: BackendGeminiAPI
tool call:   score_tool map[team:Blue]
tool result: map[error:json: unsupported value: NaN]
model: The score for team Blue could not be retrieved because the system returned an invalid value (NaN).
===== vertex, base a59464b =====
backend: BackendVertexAI
tool call:   score_tool map[team:Blue]
tool result: map[result:map[score:NaN]]
run error: failed to call model: Error 404, Message: , Status: 404 Not Found, Details: []
===== vertex, fixed =====
backend: BackendVertexAI
tool call:   score_tool map[team:Blue]
tool result: map[error:json: unsupported value: NaN]
model: The score for team Blue could not be retrieved due to an error.
```

</details>

### Checklist

- [x] I have read the [CONTRIBUTING.md](https://github.com/google/adk-go/blob/main/CONTRIBUTING.md) document.
- [x] I have performed a self-review of my own code.
- [x] I have commented my code, particularly in hard-to-understand areas.
- [x] I have added tests that prove my fix is effective or that my feature works.
- [x] New and existing unit tests pass locally with my changes. See Testing Plan.
- [x] I have manually tested my changes end-to-end.
